### PR TITLE
Fixed multicast session name prompt being skipped

### DIFF
--- a/packages/web/lib/fog/BootMenu.class.php
+++ b/packages/web/lib/fog/BootMenu.class.php
@@ -324,7 +324,7 @@ class BootMenu extends FOGBase {
         $Send['joinsession'] = array(
             "#!ipxe",
             "cpuid --ext 29 && set arch x86_64 || set arch i386",
-            "echo -n Please enter the session name to join>",
+            "echo -n Please enter the session name to join> ",
             "read sessname",
             "params",
             'param mac0 ${net0/mac}',


### PR DESCRIPTION
```read sessname``` was being appended to the previous echo command causing "Join Multicast Session" to send the user back to the main menu.