### PR TITLE
RAID Support

### DIFF
--- a/src/buildroot/package/fog/scripts/etc/init.d/S99fog
+++ b/src/buildroot/package/fog/scripts/etc/init.d/S99fog
@@ -10,6 +10,12 @@
 #               Modified for RHS Linux by Damien Neil
 #               Modified for FOG by Chuck Syperski
 #
+if [ "$mdraid" = "true" ]
+then
+    mdadm --assemble --scan
+    mdadm --incremental --run --scan
+fi
+
 if [ -n "$keymap" ]
 then
 	loadkeys $keymap;


### PR DESCRIPTION
Added support for automatic scanning and assembly of raid devices on the clients.
Add "mdraid=true" to kernel command line to activate it.