### PR TITLE
Improved Partition ID Handling

### DIFF
--- a/src/buildroot/package/fog/scripts/bin/fog.download
+++ b/src/buildroot/package/fog/scripts/bin/fog.download
@@ -184,7 +184,6 @@ elif [ "$imgType" == "mpa" ]; then
 fi
 if [ "$imgType" == "n" ]; then
     parts=`fogpartinfo --list-parts $hd 2>/dev/null`;
-    diskLength=`expr length $hd`;
     if [ -f "$win7imgroot/sys.img.000" ] && [[ "$osid" == +([5-7]|9) ]]; then
         if [ "$win7partcnt" == "1" ]; then
             restorePartition "$win7sys";
@@ -218,11 +217,10 @@ if [ "$imgType" == "n" ]; then
     done
 elif [ "$imgType" == "mps" ]; then
     parts=`getValidRestorePartitions $hd 1 $imagePath`;
-    diskLength=`expr length $hd`;
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -o '[0-9]*$'`;
         if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
-            restorePartition "$part" "1" "$imagePath" "$diskLength" "$imgPartitionType";
+            restorePartition "$part" "1" "$imagePath" "$imgPartitionType";
         else
             echo " * Skipping partition $partNum";
         fi
@@ -236,12 +234,11 @@ elif [ "$imgType" == "mpa" ]; then
     intDisk=1;
     for disk in $disks; do
         parts=`getValidRestorePartitions $disk $intDisk $imagePath`;
-        diskLength=`expr length $disk`;
         for part in $parts; do
-            partNum=${part:$diskLength};
+            partNum=`echo $part | grep -o '[0-9]*$'`;
             if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
                 echo " * Processing Partition: $part ($partNum)";
-                restorePartition "$part" "$intDisk" "$imagePath" "$diskLength" "$imgPartitionType";
+                restorePartition "$part" "$intDisk" "$imagePath" "$imgPartitionType";
             else
                 echo " * Skipping partition $partNum";
             fi

--- a/src/buildroot/package/fog/scripts/bin/fog.upload
+++ b/src/buildroot/package/fog/scripts/bin/fog.upload
@@ -111,7 +111,7 @@ if [ -f "/images/.mntcheck" ]; then
             fi
             # All:
             #  save the list of fixed size partitions
-            fixed_size_partitions=`echo $fixed_size_partitions | sed -r 's/[^:0-9]//g' | sed -r 's/^://'`;
+            fixed_size_partitions=`echo $fixed_size_partitions | grep -o '[0-9]\+$'`;
             echo $fixed_size_partitions > "${imagePath}/d1.fixed_size_partitions";
             # Windows 2000/XP, Vista, 7, 8, 8.1, Linux:
             #  Remove pagefile and hibernate file

--- a/src/buildroot/package/fog/scripts/bin/fog.upload
+++ b/src/buildroot/package/fog/scripts/bin/fog.upload
@@ -178,9 +178,8 @@ if [ -f "/images/.mntcheck" ]; then
                 echo " * Now FOG will attempt to upload the image using Partclone.";
                 echo "";
                 parts=`fogpartinfo --list-parts $hd 2>/dev/null`;
-                diskLength=`expr length $hd`;
                 for part in $parts; do
-                    savePartition "$part" "1" "$imagePath" "$diskLength" "$cores" "$imgPartitionType";
+                    savePartition "$part" "1" "$imagePath" "$cores" "$imgPartitionType";
                 done
 
                 dots "Restoring MBR";
@@ -209,9 +208,8 @@ if [ -f "/images/.mntcheck" ]; then
                 savePartitionTablesAndBootLoaders "$hd" "1" "$imagePath" "$osid" "$imgPartitionType";
                 debugPause
                 parts=`fogpartinfo --list-parts $hd 2>/dev/null`;
-                diskLength=`expr length $hd`;
                 for part in $parts; do
-                    savePartition "$part" "1" "$imagePath" "$diskLength" "$cores" "$imgPartitionType";
+                    savePartition "$part" "1" "$imagePath" "$cores" "$imgPartitionType";
                     debugPause;
                 done
                 echo " * Task complete!";
@@ -227,9 +225,8 @@ if [ -f "/images/.mntcheck" ]; then
                     savePartitionTablesAndBootLoaders "$disk" "$intDisk" "$imagePath" "$osid" "$imgPartitionType"
                     debugPause
                     parts=`fogpartinfo --list-parts $disk 2>/dev/null`;
-                    diskLength=`expr length $disk`;
                     for part in $parts; do
-                        savePartition "$part" "$intDisk" "$imagePath" "$diskLength" "$cores" "$imgPartitionType"
+                        savePartition "$part" "$intDisk" "$imagePath" "$cores" "$imgPartitionType"
                         debugPause;
                     done
                 else

--- a/src/buildroot/package/fog/scripts/usr/share/fog/lib/funcs.sh
+++ b/src/buildroot/package/fog/scripts/usr/share/fog/lib/funcs.sh
@@ -67,7 +67,7 @@ expandPartition() {
         return;
     fi
     if [ -n "$fixed_size_partitions" ]; then
-        local partNum=`echo $1 | sed -r 's/^[^0-9]+//g'`;
+        local partNum=`echo $1 | grep -o '[0-9]*$'`;
         is_fixed=`echo $fixed_size_partitions | egrep "(${partNum}|^${partNum}|${partNum}$)" | wc -l`;
         if [ "$is_fixed" == "1" ]; then
             dots "Not expanding ($1) fixed size";
@@ -171,7 +171,7 @@ shrinkPartition() {
     # Save filesystem type information
     echo "$1 $fstype" >> "$2"
     if [ -n "$fixed_size_partitions" ]; then
-        local partNum=`echo $1 | sed -r 's/^[^0-9]+//g'`;
+        local partNum=`echo $1 | grep -o '[0-9]*$'`;
         is_fixed=`echo "$fixed_size_partitions" | egrep ':'${partNum}':|^'${partNum}':|:'${partNum}'$' | wc -l`;
         if [ "$is_fixed" == "1" ]; then
             dots "Not shrinking ($1) fixed size";
@@ -380,12 +380,11 @@ getValidRestorePartitions() {
     local imagePath="$3";
     local valid_parts="";
     local parts=`fogpartinfo --list-parts $drive 2>/dev/null`;
-    local diskLength=`expr length $drive`;
     local part="";
     local partNum="";
     local imgpart="";
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -o '[0-9]*$'`;
         imgpart="$imagePath/d${driveNum}p${partNum}.img*";
         if [ -f $imgpart ]; then
             valid_parts="$valid_parts $part";
@@ -404,11 +403,10 @@ makeAllSwapSystems() {
     local imgPartitionType="$4";
     local parts=`fogpartinfo --list-parts $drive 2>/dev/null`;
     local part="";
-    local diskLength=`expr length $drive`;
     local partNum="";
     local swapuuidfilename=`swapUUIDFileName "$imagePath" "${driveNum}"`;
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -o '[0-9]*$'`;
         if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
             makeSwapSystem "$swapuuidfilename" "$part";
         fi
@@ -1176,15 +1174,14 @@ savePartition() {
     local part="$1";
     local intDisk="$2";
     local imagePath="$3";
-    local diskLength="$4";
-    local cores="$5";
-    local imgPartitionType="$6";
+    local cores="$4";
+    local imgPartitionType="$5";
     local partNum="";
     local fstype="";
     local parttype="";
     local imgpart="";
     local fifoname="/tmp/pigz1";
-    partNum=${part:$diskLength};
+    partNum=`echo $part | grep -o '[0-9]*$'`
     if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
         mkfifo $fifoname;
         echo " * Processing Partition: $part ($partNum)";
@@ -1240,18 +1237,13 @@ restorePartition() {
         local imagePath="$3";
     fi
     if [ -z "$4" ]; then
-        local diskLength="`expr length $hd`";
-    else
-        local diskLength="$4";
-    fi
-    if [ -z "$5" ]; then
         local imgPartitionType="$imgPartitionType";
     else
-        local imgPartitionType="$5";
+        local imgPartitionType="$4";
     fi
     local partNum="";
     local imgpart="";
-    partNum=${part:$diskLength};
+    partNum=`echo $part | grep -o '[0-9]*$'`
 
     echo " * Processing Partition: $part ($partNum)";
     if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then

--- a/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
+++ b/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
@@ -91,10 +91,9 @@ saveAllEBRs() {
     local imagePath="$3";
     local parts=`fogpartinfo --list-parts $drive 2>/dev/null`;
     local part="";
-    local diskLength=`expr length $drive`;
     local partNum="";
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -o '[0-9]*$'`;
         ebrfilename=`EBRFileName "${imagePath}" "${driveNum}" "${partNum}"`;
         saveEBR "$part" "$ebrfilename";
     done
@@ -134,10 +133,9 @@ restoreAllEBRs() {
     local imgPartitionType="$4";
     local parts=`fogpartinfo --list-parts $drive 2>/dev/null`;
     local part="";
-    local diskLength=`expr length $drive`;
     local partNum="";
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -p '[0-9]*$'`;
         if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
             local ebrfilename=`EBRFileName "${imagePath}" "${driveNum}" "${partNum}"`;
             restoreEBR "$part" "$ebrfilename";
@@ -224,7 +222,6 @@ saveAllSwapUUIDs() {
     local imagePath="$3";
     local parts=`fogpartinfo --list-parts $drive 2>/dev/null`;
     local part="";
-    local diskLength=`expr length $drive`;
     local partNum="";
     local swapfilename=`swapUUIDFileName "$imagePath" "$driveNum"`;
     for part in $parts; do
@@ -478,14 +475,13 @@ saveSgdiskPartitions() {
     local filename="$2";
     local parts=`fogpartinfo --list-parts $disk 2>/dev/null`;
     local part="";
-    local diskLength=`expr length $disk`;
     local partNum="";
     rm -f $filename;
     sgdisk -p "$disk" | \
     awk '/^Logical sector size:/{sectorsize=$4;} /Disk identifier \(GUID\):/{diskcode=$4;}  /^First usable sector is/{split($5, a, ",", seps); first=a[1]; last=$10;}  /^Partitions will be aligned on/{split($6, a, "-", seps); boundary=a[1];}  /^ *[0-9]+ +/{partnum=$1; start=$2; end=$3; code=$6; print "part:" partnum ":" start ":" end ":" code;}  END{print "'$disk':" sectorsize ":" diskcode ":" first ":" last ":" boundary}' \
     >> $filename;
     for part in $parts; do
-        partNum=${part:$diskLength};
+        partNum=`echo $part | grep -o '[0-9]*$'`;
 
         sgdisk -i "$partNum" "$disk" | \
         awk '/^Partition GUID code:/{typecode=$4;} /Partition unique GUID:/{partcode=$4;} /^Partition name:/{name=$3; for(i=4;i<=NF;i++) {name = name " " $i}} /^First sector:/{first=$3;} /^Last sector:/{last=$3;} END{print "'$part':" typecode ":" partcode ":" first ":" last ":" name;}' \

--- a/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
+++ b/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
@@ -52,8 +52,8 @@ hasExtendedPartition() {
 # $1 is the name of the partition device (e.g. /dev/sda3)
 partitionHasEBR() {
     local part="$1";
-    local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
+    local part_number=`echo $part | grep -o '[0-9]\+$'`;
+    local disk=`echo $part | sed 's/p\?[0-9]\+$//g'`;
     local part_type=`sfdisk -d "$disk" 2>/dev/null | grep ^$part | awk -F[,=] '{print $6}'`;
     if [ "$part_type" == "5" -o "$part_type" == "f" -o "$part_number" -ge 5 ]; then
         echo "1";
@@ -67,8 +67,8 @@ partitionHasEBR() {
 saveEBR() {
     local part="$1";
     local dstfilename="$2";
-    local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
+    local part_number=`echo $part | grep -o '[0-9]\+$'`;
+    local disk=`echo $part | sed  's/p\?[0-9]\+$//g'`;
     local table_type=`getPartitionTableType "$disk"`;
     if [ "$table_type" != "MBR" ]; then
         return
@@ -93,7 +93,7 @@ saveAllEBRs() {
     local part="";
     local partNum="";
     for part in $parts; do
-        partNum=`echo $part | grep -o '[0-9]*$'`;
+        partNum=`echo $part | grep -o '[0-9]\+$'`;
         ebrfilename=`EBRFileName "${imagePath}" "${driveNum}" "${partNum}"`;
         saveEBR "$part" "$ebrfilename";
     done
@@ -105,8 +105,8 @@ saveAllEBRs() {
 restoreEBR() {
     local part="$1";
     local srcfilename="$2";
-    local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
+    local part_number=`echo $part | grep -o '[0-9]\+$'`;
+    local disk=`echo $part | sed 's/p\?[0-9]\+$//g'`;
     local table_type=`getPartitionTableType "$disk"`;
     if [ "$table_type" != "MBR" ]; then
         return
@@ -135,7 +135,7 @@ restoreAllEBRs() {
     local part="";
     local partNum="";
     for part in $parts; do
-        partNum=`echo $part | grep -p '[0-9]*$'`;
+        partNum=`echo $part | grep -p '[0-9]\+$'`;
         if [ "$imgPartitionType" == "all" -o "$imgPartitionType" == "$partNum" ]; then
             local ebrfilename=`EBRFileName "${imagePath}" "${driveNum}" "${partNum}"`;
             restoreEBR "$part" "$ebrfilename";
@@ -237,7 +237,7 @@ saveAllSwapUUIDs() {
 makeSwapSystem() {
     local uuid="";
     local option="";
-    local disk=`echo $2 | sed -r 's/[0-9]+$//g'`;
+    local disk=`echo $2 | sed 's/p\?[0-9]\+$//g'`;
     local part_type="0";
     local hasgpt=`hasGPT $disk`;
     if [ "$hasgpt" == "1" ]; then
@@ -272,7 +272,7 @@ makeSwapSystem() {
 resizeSfdiskPartition() {
     local part="$1";
     local size="$2";
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
+    local disk=`echo $part | sed  's/p\?[0-9]\+$//g'`;
     local imagePath="$3";
     local tmp_file="/tmp/sfdisk.$$";
     local tmp_file2="/tmp/sfdisk2.$$";
@@ -481,7 +481,7 @@ saveSgdiskPartitions() {
     awk '/^Logical sector size:/{sectorsize=$4;} /Disk identifier \(GUID\):/{diskcode=$4;}  /^First usable sector is/{split($5, a, ",", seps); first=a[1]; last=$10;}  /^Partitions will be aligned on/{split($6, a, "-", seps); boundary=a[1];}  /^ *[0-9]+ +/{partnum=$1; start=$2; end=$3; code=$6; print "part:" partnum ":" start ":" end ":" code;}  END{print "'$disk':" sectorsize ":" diskcode ":" first ":" last ":" boundary}' \
     >> $filename;
     for part in $parts; do
-        partNum=`echo $part | grep -o '[0-9]*$'`;
+        partNum=`echo $part | grep -o '[0-9]\+$'`;
 
         sgdisk -i "$partNum" "$disk" | \
         awk '/^Partition GUID code:/{typecode=$4;} /Partition unique GUID:/{partcode=$4;} /^Partition name:/{name=$3; for(i=4;i<=NF;i++) {name = name " " $i}} /^First sector:/{first=$3;} /^Last sector:/{last=$3;} END{print "'$part':" typecode ":" partcode ":" first ":" last ":" name;}' \
@@ -511,7 +511,7 @@ restoreSgdiskPartitions() {
     fi
 
     for part in $parts; do
-        local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
+        local part_number=`echo $part | grep -o '[0-9]\+$'`;
         local escape_part=`echo "$part" | sed -r 's%/%\\\\/%g'`;
         local partstart=`awk -F: '/^'"$escape_part"':/{print $4;}' $filename`;
         local partend=`awk -F: '/^'"$escape_part"':/{print $5;}' $filename`;
@@ -583,7 +583,7 @@ fillSgdiskWithPartitions() {
     local original_variable=0;
     local original_fixed=$first_start;  # pre-first partition is fixed
     for part in $parts; do
-        local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
+        local part_number=`echo $part | grep -o '[0-9]\+$'`;
         local escape_part=`echo "$part" | sed -r 's%/%\\\\/%g'`;
         local partstart=`awk -F: '/^'"$escape_part"':/{print $4;}' $filename`;
         local partend=`awk -F: '/^'"$escape_part"':/{print $5;}' $filename`;
@@ -614,7 +614,7 @@ fillSgdiskWithPartitions() {
     # find new start, size, end for all partitions, and create them
     local g_start="$first_start";
     for part in $parts; do
-        local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
+        local part_number=`echo $part | grep -o '[0-9]\+$'`;
         local escape_part=`echo "$part" | sed -r 's%/%\\\\/%g'`;
         local partstart=`awk -F: '/^'"$escape_part"':/{print $4;}' $filename`;
         local partend=`awk -F: '/^'"$escape_part"':/{print $5;}' $filename`;
@@ -677,8 +677,8 @@ resizeSgdiskPartition() {
     local part="$1";
     local size="$2";
     local imagePath="$3";
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
-    local part_number=`echo $part | sed -r 's/^[^0-9]+//g'`;
+    local disk=`echo $part | sed 's/p\?[0-9]\+$//g'`;
+    local part_number=`echo $part | grep -o '[0-9]\+$'`;
 
 
     local escape_disk=`echo "$disk" | sed -r 's%/%\\\\/%g'`;
@@ -734,7 +734,7 @@ resizePartition() {
     local part="$1";
     local size="$2";
     local imagePath="$3";
-    local disk=`echo $part | sed -r 's/[0-9]+$//g'`;
+    local disk=`echo $part | sed  's/p\?[0-9]+$//g'`;
     local table_type=`getPartitionTableType "$disk"`;
 
     if [ "$table_type" == "MBR" ]; then


### PR DESCRIPTION
I cleaned up and fixed code for handling partition IDs which now work properly with RAID.

The issue was caused because the name of RAID devices in Linux is in the /dev/md{%d}p{%d} format which caused the image files to be incorrectly named on the server(eg d1pp1).