### PR TITLE
Fixed Host Export

### DIFF
--- a/packages/web/lib/fog/ReportMaker.class.php
+++ b/packages/web/lib/fog/ReportMaker.class.php
@@ -11,7 +11,7 @@ class ReportMaker extends FOGBase {
     public function appendHTML($html){$this->strHTML[] = $html;}
     public function addCSVCell($item){$this->strCSV[] = trim($item);}
     public function endCSVLine() {
-        $this->strLine[] = '"'.implode('","',$this->strCSV).'"';
+        $this->strLine[] = '"'.implode('","',addslashes($this->strCSV)).'"';
         unset($this->strCSV);
     }
     public function setFileName($filename){$this->filename = $filename;}

--- a/packages/web/lib/pages/HostManagementPage.class.php
+++ b/packages/web/lib/pages/HostManagementPage.class.php
@@ -1242,7 +1242,7 @@ class HostManagementPage extends FOGPage {
             $report->addCSVCell(implode('|',(array)$macs));
             $report->addCSVCell($Host->get(name));
             $report->addCSVCell($Host->get(ip));
-            $report->addCSVCell('"'.$Host->get(description).'"');
+            $report->addCSVCell($Host->get(description));
             $report->addCSVCell($Host->get(imageID));
             $this->HookManager->processEvent(HOST_EXPORT_REPORT,array(report=>&$report,Host=>&$Host));
             $report->endCSVLine();


### PR DESCRIPTION
Host export was adding additional quote marks for description, but since all fields are handled as strings this caused errors when the import code did not handle double quote.

Added `addslashes` so that quotes in strings are properly handled.