### PR TITLE
Fixed FOG Services crashing on systemd

### DIFF
--- a/packages/systemd/FOGImageReplicator.service
+++ b/packages/systemd/FOGImageReplicator.service
@@ -15,7 +15,7 @@
 
 [Unit]
 Description=FOGImageReplicator
-After=syslog.target network.target
+After=syslog.target network.target mariadb.service
 
 [Service]
 PrivateTmp=true

--- a/packages/systemd/FOGMulticastManager.service
+++ b/packages/systemd/FOGMulticastManager.service
@@ -15,7 +15,7 @@
 
 [Unit]
 Description=FOGMulticastManager
-After=syslog.target network.target
+After=syslog.target network.target mariadb.service
 
 [Service]
 PrivateTmp=true

--- a/packages/systemd/FOGScheduler.service
+++ b/packages/systemd/FOGScheduler.service
@@ -14,7 +14,7 @@
 
 [Unit]
 Description=FOGScheduler
-After=syslog.target network.target
+After=syslog.target network.target mariadb.service
 
 [Service]
 PrivateTmp=true

--- a/packages/systemd/FOGSnapinReplicator.service
+++ b/packages/systemd/FOGSnapinReplicator.service
@@ -15,7 +15,7 @@
 
 [Unit]
 Description=FOGSnapinReplicator
-After=syslog.target network.target
+After=syslog.target network.target mariadb.service
 
 [Service]
 PrivateTmp=true


### PR DESCRIPTION
FOG services were crashing because they required DB access but were not waiting for MariaDB to start.