### PR TITLE
Support for mixed(BIOS and (U)EFI) environments

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -225,7 +225,7 @@ configureFTP() {
 }
 configureDefaultiPXEfile() {
     find "${tftpdirdst}" ! -type d -exec chmod 644 {} \;
-    echo -e "#!ipxe\ncpuid --ext 29 && set arch x86_64 || set arch i386\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain http://${ipaddress}/${webroot}service/ipxe/boot.php##params" > "${tftpdirdst}/default.ipxe"
+    echo -e "#!ipxe\ncpuid --ext 29 && set arch x86_64 || set arch i386\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain http://${ipaddress}/${webroot}service/ipxe/boot.php##params" > "${tftpdirdst}/default.ipxe"
 }
 configureTFTPandPXE() {
     dots "Setting up and starting TFTP and PXE Servers";

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -2041,3 +2041,8 @@ $this->schema[] = array(
     "UPDATE `".DATABASE_NAME."`.`taskTypes` set `ttIcon`='btc' WHERE `ttID`=23",
     "UPDATE `".DATABASE_NAME."`.`taskTypes` set `ttIcon`='share-alt-square' WHERE `ttID`=24",
 );
+// 192
+$this->schema[] = array(
+    "INSERT INTO `" . DATABASE_NAME ."`.globalSettings(settingKey, settingDesc, settingValue, settingCategory)
+    values('FOG_EFI_BOOT_EXIT_TYPE','The method (U)EFI uses to boot the next boot entry/hard drive.  Most will require exit.','exit','FOG Boot Settings')",
+);

--- a/packages/web/lib/fog/BootMenu.class.php
+++ b/packages/web/lib/fog/BootMenu.class.php
@@ -18,7 +18,20 @@ class BootMenu extends FOGBase {
         $curroot = trim(trim($this->FOGCore->getSetting(FOG_WEB_ROOT),'/'));
         $webroot = '/'.(strlen($curroot) > 1 ? $curroot.'/' : '');
         $this->web = "${webserver}${webroot}";
-        $this->bootexittype = ($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'exit' ? 'exit' : ($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'sanboot' ? 'sanboot --no-describe --drive 0x80' : ($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'grub' ? 'chain -ar http://'.rtrim($this->web,'/').'/service/ipxe/grub.exe --config-file="rootnoverify (hd0);chainloader +1"' : 'exit')));
+
+        $exitTypes = array("exit" => "exit", 
+            "sanboot" => "sanboot --no-describe --drive 0x80",
+            "grub" => 'chain -ar http://'.rtrim($this->web,'/').'/service/ipxe/grub.exe --config-file="rootnoverify (hd0);chainloader +1"');
+        $exitSetting = false;
+
+        if (isset($_REQUEST[platform]) && $_REQUEST[platform] == 'efi') {
+            $exitSetting = $this->FOGCore->getSetting(FOG_EFI_BOOT_EXIT_TYPE);
+        } else {
+            $exitSetting = $this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE);
+        }
+
+        $this->bootexittype = $exitTypes[$exitSetting ? $exitSetting : "exit"];
+
         $ramsize = $this->FOGCore->getSetting(FOG_KERNEL_RAMDISK_SIZE);
         $dns = $this->FOGCore->getSetting(FOG_PXE_IMAGE_DNSADDRESS);
         $keymap = $this->FOGCore->getSetting(FOG_KEYMAP);
@@ -129,6 +142,7 @@ class BootMenu extends FOGBase {
                 "params",
                 'param mac0 ${net0/mac}',
                 'param arch ${arch}',
+                'param platform ${platform}',
                 "param menuAccess 1",
                 "param debug ".($debug ? 1 : 0),
                 'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
@@ -148,6 +162,7 @@ class BootMenu extends FOGBase {
                 "params",
                 'param mac0 ${net0/mac}',
                 'param arch ${arch}',
+                'param platform ${platform}',
                 'param username ${username}',
                 'param password ${password}',
                 "param menuaccess 1",
@@ -247,6 +262,7 @@ class BootMenu extends FOGBase {
             "params",
             'param mac0 ${net0/mac}',
             'param arch ${arch}',
+            'param platform ${platform}',
             "param delconf 1",
             'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
             'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',
@@ -266,6 +282,7 @@ class BootMenu extends FOGBase {
             "params",
             'param mac0 ${net0/mac}',
             'param arch ${arch}',
+            'param platform ${platform}',
             "param aprvconf 1",
             'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
             'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',
@@ -286,6 +303,7 @@ class BootMenu extends FOGBase {
             "params",
             'param mac0 ${net0/mac}',
             'param arch ${arch}',
+            'param platform ${platform}',
             'param key ${key}',
             'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
             'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',
@@ -309,6 +327,7 @@ class BootMenu extends FOGBase {
                 "params",
                 'param mac0 ${net0/mac}',
                 'param arch ${arch}',
+                'param platform ${platform}',
                 "param sessionJoin 1",
                 'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
                 'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',
@@ -330,6 +349,7 @@ class BootMenu extends FOGBase {
             "params",
             'param mac0 ${net0/mac}',
             'param arch ${arch}',
+            'param platform ${platform}',
             'param sessname ${sessname}',
             'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
             'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',

--- a/packages/web/lib/fog/System.class.php
+++ b/packages/web/lib/fog/System.class.php
@@ -7,7 +7,7 @@ class System {
      */
     public function __construct() {
         define('FOG_VERSION', '4406');
-        define('FOG_SCHEMA', 191);
+        define('FOG_SCHEMA', 192);
         define('FOG_BCACHE_VER',12);
         define('FOG_SVN_REVISION', '$Revision: 2868 $');
         define('FOG_SVN_LAST_UPDATE', '$LastChangedDate: 2015-01-01 14:16:56 -0500 (Thu, 01 Jan 2015) $');

--- a/packages/web/lib/pages/FOGConfigurationPage.class.php
+++ b/packages/web/lib/pages/FOGConfigurationPage.class.php
@@ -175,6 +175,7 @@ class FOGConfigurationPage extends FOGPage {
             _('Boot Key Sequence') => $bootKeys,
             _('Menu Timeout (in seconds)').':*' => '<input type="text" name="timeout" value="'.$timeout.'" id="timeout" />',
             _('Exit to Hard Drive Type') => '<select name="bootTypeExit"><option value="sanboot" '.($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'sanboot' ? 'selected="selected"' : '').'>Sanboot style</option><option value="exit" '.($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'exit' ? 'selected="selected"' : '').'>Exit style</option><option value="grub" '.($this->FOGCore->getSetting(FOG_BOOT_EXIT_TYPE) == 'grub' ? 'selected="selected"' : '').'>Grub style</option></select>',
+            _('Exit to Hard Drive Type(EFI)') => '<select name="efiBootTypeExit"><option value="sanboot" '.($this->FOGCore->getSetting(FOG_EFI_BOOT_EXIT_TYPE) == 'sanboot' ? 'selected="selected"' : '').'>Sanboot style</option><option value="exit" '.($this->FOGCore->getSetting(FOG_EFI_BOOT_EXIT_TYPE) == 'exit' ? 'selected="selected"' : '').'>Exit style</option><option value="grub" '.($this->FOGCore->getSetting(FOG_EFI_BOOT_EXIT_TYPE) == 'grub' ? 'selected="selected"' : '').'>Grub style</option></select>',
             '<a href="#" onload="$(\'#advancedTextArea\').hide();" onclick="$(\'#advancedTextArea\').toggle();" id="pxeAdvancedLink">Advanced Configuration Options</a>' => '<div id="advancedTextArea" class="hidden"><div class="lighterText tabbed">Add any custom text you would like included added as part of your <i>default</i> file.</div><textarea rows="5" cols="40" name="adv">'.$advanced.'</textarea></div>',
             '&nbsp;' => '<input type="submit" value="'._('Save PXE MENU').'" />',
         );
@@ -212,6 +213,7 @@ class FOGConfigurationPage extends FOGPage {
                 ->setSetting(FOG_KEY_SEQUENCE,$_REQUEST[keysequence])
                 ->setSetting(FOG_NO_MENU,$_REQUEST[nomenu])
                 ->setSetting(FOG_BOOT_EXIT_TYPE,$_REQUEST[bootTypeExit])
+                ->setSetting(FOG_EFI_BOOT_EXIT_TYPE,$_REQUEST[efiBootTypeExit])
                 ->setSetting(FOG_ADVANCED_MENU_LOGIN,$_REQUEST[advmenulogin])
                 ->setSetting(FOG_PXE_HIDDENMENU_TIMEOUT,$hidetimeout)) throw new Exception(_('PXE Menu update failed'));
             throw new Exception(_('PXE Menu has been updated'));
@@ -608,6 +610,12 @@ class FOGConfigurationPage extends FOGPage {
                     unset($val);
                     $type = '<select name="${service_id}" style="width: 220px" autocomplete="off">'.implode($options).'</select>';
                 } else if ($Service->get(name) == 'FOG_BOOT_EXIT_TYPE') {
+                    $types = array('sanboot','grub','exit');
+                    foreach($types AS $i => &$viewop) $options[] = '<option value="'.$viewop.'" '.($Service->get(value) == $viewop ? 'selected="selected"' : '').'>'.strtoupper($viewop).'</option>';
+                    unset($viewop);
+                    $type = '<select name="${service_id}" style="width: 220px" autocomplete="off">'.implode($options).'</select>';
+                    unset($options);
+                } else if ($Service->get(name) == 'FOG_EFI_BOOT_EXIT_TYPE') {
                     $types = array('sanboot','grub','exit');
                     foreach($types AS $i => &$viewop) $options[] = '<option value="'.$viewop.'" '.($Service->get(value) == $viewop ? 'selected="selected"' : '').'>'.strtoupper($viewop).'</option>';
                     unset($viewop);


### PR DESCRIPTION
Added support for separate boot exit types for BIOS and (U)EFI.

Setting name is "FOG_EFI_BOOT_EXIT_TYPE" and is used to select which exit type should be used  during booting based on platform.

The client sends a new parameter called "platform" which is mapped to the iPXE "platform" setting.(http://ipxe.org/cfg/platform).