### PR TITLE
backup the configs even if one some of the folders is read only

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -998,7 +998,8 @@ configureHttpd() {
         rm -rf "$backupPath/fog_web_$version.BACKUP" >/dev/null 2>&1
     fi
     if [ -d "$webdirdest" ]; then
-        mv "$webdirdest" "$backupPath/fog_web_$version.BACKUP" >/dev/null 2>&1
+        cp -RT "$webdirdest" "$backupPath/fog_web_$version.BACKUP"
+        rm -rf "$webdirdest" >/dev/null 2>&1
     fi
     if [ "$osid" == 2 -a -d "/var/www/fog" ]; then
         rm -rf /var/www/fog >/dev/null 2>&1


### PR DESCRIPTION
I found the problem

I am running fog in a docker container and the mv command was failing
the folder /var/www/fog/service/ipxe/custom is mounted as a docker volume from the host so the content is read/write , but the folder (custom ) cannot be deleted so the "mv" command was failing.

now it does cp and rm instead. I hope you except the change.
