### PR TITLE
Added Interface and Address...

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -507,8 +507,10 @@ while [[ -z $blGo ]]; do
                         echo "   http://${snmysqlhost}/fog"
                         echo
                         echo "   You will need this, write this down!"
-                        echo "   Username: $username"
-                        echo "   Password: $password"
+                        echo "   Username:  $username"
+                        echo "   Password:  $password"
+                        echo "   Interface: $interface"
+                        echo "   Address:   $ipaddress"
                         echo
                     fi
                     ;;


### PR DESCRIPTION
... to the installation-complete output for storage nodes.

At the end of a storage node installation, the installer presents FTP username and password and says to write it down because you need it.

You also need the interface. And displaying it right there at the end would save an extra step for those that know how to get it, and for those that don't know how or don't even know they need it will be more likely to write it down and enter this into the web interface.

It'll just smooth things out more.