### PR TITLE
Add changes for postinstall scripts

### DIFF
--- a/packages/web/lib/fog/hostinfo.class.php
+++ b/packages/web/lib/fog/hostinfo.class.php
@@ -1,0 +1,55 @@
+<?php
+class HostInfo extends FOGBase {
+    protected $macSimple;
+    protected $repFields = array(
+        'hostName' => 'hostname',
+        'hostDesc' => 'hostdesc',
+        'imageOSID' => 'imageosid',
+        'imagePath' => 'imagepath',
+        'hostUseAD' => 'hostusead',
+        'hostADDomain' => 'hostaddomain',
+        'hostADOU' => 'hostadou',
+        'hostProductKey' => 'hostproductkey',
+        'iPrimaryUser' => 'primaryuser',
+        'iOtherTag' => 'othertag',
+        'iOtherTag1' => 'othertag1',
+        'lName' => 'location',
+        'iSysman' => 'sysman',
+        'iSysproduct' => 'sysproduct',
+        'iSysserial' => 'sysserial',
+        'iMbman' => 'mbman',
+        'iMbserial' => 'mbserial',
+        'iMbasset' => 'mbasset',
+        'iMbproductname' => 'mbproductname',
+        'iCaseman' => 'caseman',
+        'iCaseserial' => 'caseserial',
+        'iCaseasset' => 'caseasset',
+    );
+
+    public function __construct($check = false) {
+        parent::__construct();
+
+        self::stripAndDecode($_REQUEST);
+        $this->macSimple = strtolower(str_replace(array(':','-'),':',substr($_REQUEST['mac'],0,20)));
+
+        $query = sprintf("SELECT hostName,hostDesc,imageOSID,imagePath,hostUseAD,hostADDomain,hostADOU,hostProductKey,iPrimaryUser,iOtherTag,iOtherTag1,lName,iSysman,iSysproduct,iSysserial,iMbman,iMbserial,iMbasset,iMbproductname,iCaseman,iCaseserial,iCaseasset FROM (((hostMAC INNER JOIN (hosts LEFT JOIN images ON hosts.hostImage = images.imageID) ON hostMAC.hmHostID = hosts.hostID) LEFT JOIN inventory ON hosts.hostID = inventory.iHostID) LEFT JOIN locationAssoc ON hosts.hostID = locationAssoc.laHostID) LEFT JOIN location ON locationAssoc.laLocationID = location.lID WHERE (hostMAC.hmMAC='%s');", $this->macSimple);
+
+        $tmp = (array)self::$DB->query($query)->fetch('','fetch_all')->get();
+
+        ob_start();
+        header('Content-Type: text/plain');
+        header('Connection: close');
+
+        foreach ((array)$tmp AS $i => &$DataRow) {
+            foreach ((array)$DataRow AS $j => &$DataField) {
+                echo  "export " . $this->repFields[$j] . "=\"" . $DataField . "\"\n";
+                unset($DataField);
+            }
+            unset($DataRow);
+        };
+        flush();
+        ob_flush();
+        ob_end_flush();
+    }
+}
+﻿

--- a/packages/web/lib/fog/sethostname.class.php
+++ b/packages/web/lib/fog/sethostname.class.php
@@ -1,0 +1,34 @@
+<?php
+class SetHostName extends FOGBase {
+    protected $macSimple;
+    protected $newName;
+    protected $oldName;
+
+    public function __construct($check = false) {
+        parent::__construct();
+
+        self::stripAndDecode($_REQUEST);
+        $this->macSimple = strtolower(str_replace(array(':','-'),':',substr($_REQUEST['mac'],0,20)));
+        $this->newName = substr(trim($_REQUEST['newname']," \t\n\r\0"),0,20);
+        $this->oldName = substr(trim($_REQUEST['oldname']," \t\n\r\0"),0,20);
+
+        ob_start();
+        header('Content-Type: text/plain');
+        header('Connection: close');
+
+        if ((strlen($this->newName) > 3) & (strlen($this->oldName) > 0)) {
+            $query = sprintf("UPDATE hosts JOIN hostMAC ON (hostMAC.hmHostID = hosts.hostID) SET hostName='%s' WHERE ( (hostMAC.hmMAC='%s') AND (hostName LIKE '%s') );", $this->newName, $this->macSimple, $this->oldName);
+
+            #echo $query;
+            self::$DB->query($query);
+            echo "OK";
+
+        } else {
+            echo "Fail";
+        }
+        flush();
+        ob_flush();
+        ob_end_flush();
+    }
+}
+﻿

--- a/packages/web/lib/service/hostinfo.php
+++ b/packages/web/lib/service/hostinfo.php
@@ -1,0 +1,4 @@
+<?php
+require_once('../commons/base.inc.php');
+FOGCore::getClass('Hostinfo');
+﻿

--- a/packages/web/lib/service/hostinfo.php
+++ b/packages/web/lib/service/hostinfo.php
@@ -1,4 +1,0 @@
-<?php
-require_once('../commons/base.inc.php');
-FOGCore::getClass('Hostinfo');
-﻿

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -1,0 +1,4 @@
+<?php
+require_once('../commons/base.inc.php');
+FOGCore::getClass('Hostinfo');
+﻿

--- a/packages/web/service/sethostname.php
+++ b/packages/web/service/sethostname.php
@@ -1,0 +1,4 @@
+<?php
+require_once('../commons/base.inc.php');
+FOGCore::getClass('SetHostName');
+﻿


### PR DESCRIPTION
Added two new pages one is for exposing fog database values to the post install scripts to allow more robust post install actions. The second is to allow (re)setting of the target host name from within the fog post install script. The hostinfo.php file requires just a mac address. The sethostname.php file requires the mac address, old host name and new host name to complete successfully. 