### PR TITLE
Add automatic correction of storage node credentials.

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -522,6 +522,7 @@ while [[ -z $blGo ]]; do
                         echo
                     else
                         registerStorageNode
+                        updateStorageNodeCredentials
                         echo
                         echo " * Setup complete"
                         echo
@@ -560,6 +561,7 @@ while [[ -z $blGo ]]; do
                     configureNFS
                     writeUpdateFile
                     linkOptFogDir
+                    updateStorageNodeCredentials
                     echo
                     echo " * Setup complete"
                     echo


### PR DESCRIPTION
This change applies to both the main server and storage nodes.
It queries the DB for the current node's credentials, and compares to what the installer has set in the OS. If they do not match, a banner is displayed informing the user that they will be corrected. Then, they are corrected.