### PR TITLE
Added Surface Pro 4 and Apple Intel Mac DHCP configuration.

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1929,6 +1929,28 @@ configureDHCP() {
             echo "        match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00009\";" >> "$dhcptouse"
             echo "        filename \"ipxe.efi\";" >> "$dhcptouse"
             echo "    }" >> "$dhcptouse"
+            echo "    class \"SURFACE-PRO-4\" {" >> "$dhcptouse"
+            echo "        match if substring(option vendor-class-identifier, 0, 32) = \"PXEClient:Arch:00007:UNDI:003016\";" >> "$dhcptouse"
+            echo "        filename \"ipxe7156.efi\";" >> "$dhcptouse"
+            echo "    }" >> "$dhcptouse"
+            echo "    class \"Apple-Intel-Netboot\" {" >> "$dhcptouse"
+            echo "        match if substring (option vendor-class-identifier, 0, 14) = \"AAPLBSDPC/i386\";" >> "$dhcptouse"
+            echo "        option dhcp-parameter-request-list 1,3,17,43,60;" >> "$dhcptouse"
+            echo "        if (option dhcp-message-type = 8) {" >> "$dhcptouse"
+            echo "            option vendor-class-identifier \"AAPLBSDPC\";" >> "$dhcptouse"
+            echo "            if (substring(option vendor-encapsulated-options, 0, 3) = 01:01:01) {" >> "$dhcptouse"
+            echo "                # BSDP List" >> "$dhcptouse"
+            echo "                option vendor-encapsulated-options 01:01:01:04:02:80:00:07:04:81:00:05:2a:09:0D:81:00:05:2a:08:69:50:58:45:2d:46:4f:47;" >> "$dhcptouse"
+            echo "            }" >> "$dhcptouse"
+            echo "        elsif (substring(option vendor-encapsulated-options, 0, 3) = 01:01:02) {" >> "$dhcptouse"
+            echo "            # BSDP Select" >> "$dhcptouse"
+            echo "            option vendor-encapsulated-options 01:01:02:08:04:81:00:05:2a:82:0a:4e:65:74:42:6f:6f:74:30:30:31;" >> "$dhcptouse"
+            echo "            filename \"ipxe.efi\";" >> "$dhcptouse"
+            echo "            }" >> "$dhcptouse"
+            echo "        }" >> "$dhcptouse"
+            echo "    }" >> "$dhcptouse"
+
+
             echo "}" >> "$dhcptouse"
             case $systemctl in
                 yes)


### PR DESCRIPTION
The Apple stuff uses the stuff that Sebastian made and had in the wiki for "FOG on a MAC" in the "Fancy" section. I've not tried it on a Mac myself, but I know Sebastian has. Also, I did run this configuration on my DHCP server and the dhcpd service was able to restart without issue, so it won't break dhcp.

The Surface pro 4 part uses the only known vendor class identifier - and is likely sub-model specific. I am almost 100% sure it will work correctly for this very specific model, but don't have a surface to play with. I did put the configuration in my DHCP server and it was able to restart without error. One class is better than none, and it will only match to that exact model, and will give pass the name of the only working efi file we have for Surface Pros. We need to try very hard to collect as many vendor IDs for Surface Pros of all models and sub models as possible so that we can have a DHCP class for each, to be able to give the best support for them out-of-the-box for FOG 1.3.0.