### PR TITLE
Fixed ipaddress variable listing @line 336

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -333,7 +333,7 @@ exitcode=$?
 [[ -z $bldhcp ]] && bldhcp=""
 [[ -z $installtype ]] && installtype=""
 [[ -z $interface ]] && interface=$(getFirstGoodInterface)
-[[ -z $ipaddress  ]] && ipaddress=$(/sbin/ip addr show $interface | awk -F'[ /]+' '/global/ {print $3}')
+[[ -z $ipaddress  ]] && ipaddress=$(/sbin/ip addr show $interface | awk -F'[ /]+' '/global/ {print $3}') && ipaddress=$(echo $ipaddress | cut -f 1 -d " ")
 [[ -z $routeraddress ]] && routeraddress=$(/sbin/ip route | awk "/$interface/ && /via/ {print \$3}")
 [[ -z $plainrouter ]] && plainrouter=$routeraddress
 [[ -z $blexports ]] && blexports=1


### PR DESCRIPTION
When running the installer on a machine with multiple 'good' interfaces the function getFirstGoodInterface returns all interfaces, line 336 takes the output of getFirstGoodInterface and uses the awk command to define this variable ($ipaddress) with the resulting string.

which returns a string of ALL IP ADDRESSES delimited by spaces.

further down this variable is used to write to the httpd/conf.d/fog.conf which breaks the installer entirely

my idea is just to cut the resulting variable to just use the first entry in that string, this could also be accomplished by rewriting the getFirstGoodInterface function to actually... get the FIRST good interface.