### PR TITLE
Install php 5.6 by default if dnf isn't present.

### DIFF
--- a/lib/redhat/config.sh
+++ b/lib/redhat/config.sh
@@ -17,7 +17,7 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 command -v dnf >/dev/null 2>&1
-[[ $? -eq 0 ]] && repos="remi" || repos="remi,epel"
+[[ $? -eq 0 ]] && repos="remi" || repos="remi,remi-php56,epel"
 [[ -z $packageQuery ]] && packageQuery="rpm -q \$x"
 case $linuxReleaseName in
     *[Mm][Aa][Gg][Ee][Ii][Aa]*)


### PR DESCRIPTION
This fixes an issue came in at commit number: [af73066572bfbb9108b31fcb01c4b4ac821c4429](https://github.com/FOGProject/fogproject/commit/af73066572bfbb9108b31fcb01c4b4ac821c4429)

That commit fixed the Fedora 22+ installation (uses dnf), but it also altered the installation unnecessarily for other distributions (doesn't use dnf). This fix undoes the changes to the other distributions.