### PR TITLE
Fix hanging upload task

### DIFF
--- a/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
+++ b/src/buildroot/package/fog/scripts/usr/share/fog/lib/partition-funcs.sh
@@ -538,8 +538,8 @@ processSfdisk() {
 getPartitionTableType() {
     local disk="$1"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    local mbr=$(gdisk -l $disk | awk '/^\ *MBR:/{print $2}')
-    local gpt=$(gdisk -l $disk | awk '/^\ *GPT:/{print $2}')
+    local mbr=$(yes '' | gdisk -l $disk | awk '/^\ *MBR:/{print $2}')
+    local gpt=$(yes '' | gdisk -l $disk | awk '/^\ *GPT:/{print $2}')
     local type=""
     local mbrtype=""
     local gpttype=""


### PR DESCRIPTION
We've recently had a problem while capturing images from newer machines. The upload process would hang at the following message :

```sh
* Saving original partition table...
```

I managed to track down the problem to the `getPartitionTableType` function in `partition-funcs.sh`, and more specifically to the following line:

```sh
local mbr=$(gdisk -l $disk | awk '/^\ *MBR:/{print $2}')
```

So I booted with a debug task and ran this command in interactive mode. On normal machines, the program answered as expected. However, on the newer machines, probably due to the fact that both GPT and MBR are present, the command asked a question that the `fog.upload` script never answered.

I fixed the problem by piping `yes ''` into the command so that any question gets answered with the default answer.
