### PR TITLE
Fix detection of systemd under Ubuntu

### DIFF
--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -34,7 +34,7 @@ if [[ $linuxReleaseName == +(*[Bb][Uu][Nn][Tt][Uu]*) ]]; then
                 rm -rf /etc/php* /etc/apache2*
                 echo "Done"
                 dots "Stopping web services"
-                systemctl=$(command -v systemctl)
+                command -v systemctl && systemctl="yes"
                 [[ -z $systemctl ]] && systemctl stop apache2 >/dev/null 2>&1 || service apache2 stop >/dev/null 2>&1
                 [[ ! $? -eq 0 ]] && echo "Failed" || echo "Done"
                 dots "Removing the apache and php packages"


### PR DESCRIPTION
It looks as though the installer expects a value of `"yes"` in the `$systemctl` variable if systemd is configured as the init system. The current implementation in `/lib/ubuntu/config.sh` results in `$systemctl` being assigned the path to `systemctl` (e.g. `/bin/systemctl`) instead, causing later comparisons to fail.

This may have gone unnoticed for some time as it appears both tools can be installed simultaneously. Newer Ubuntu releases don't seem to ship with `sysv-rc-conf` installed, causing enabling the Apache/PHP-FPM services to fail, thus preventing installation.