### PR TITLE
add support for VirtIO / XEN paravirtual devices in getHardDisk (vda xvda)

### DIFF
--- a/src/buildroot/package/fog/scripts/usr/share/fog/lib/funcs.sh
+++ b/src/buildroot/package/fog/scripts/usr/share/fog/lib/funcs.sh
@@ -1234,7 +1234,7 @@ getPartitions() {
 getHardDisk() {
     [[ -n $fdrive ]] && hd=$(echo $fdrive)
     [[ -n $hd ]] && return
-    local devs=$(lsblk -dpno KNAME -I 3,8,9,179,259 | uniq | sort -V)
+    local devs=$(lsblk -dpno KNAME -I 3,8,9,179,202,253,259 | uniq | sort -V)
     disks=$(echo $devs)
     [[ -z $disks ]] && handleError "Cannot find disk on system (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ $1 == true ]] && return


### PR DESCRIPTION
Fixes errors during Capturing / deploying images: "Cannot find disk on system (getHardDisk)"

This error is caused by VirtIO vda devices.

additional information:
https://forums.fogproject.org/topic/9299/issue-virtio-disks-not-found-during-image-capture-deploy