### PR TITLE
ifopen without parameter enumerates the NICs and fails with an

### DIFF
--- a/src/ipxe/src-efi/ipxescript
+++ b/src/ipxe/src-efi/ipxescript
@@ -1,14 +1,13 @@
 #!ipxe
-ifopen
-isset ${net0/mac} && dhcp net0 || goto dhcpnet1
+isset ${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
 echo Received DHCP answer on interface net0 && goto proxycheck
 
 :dhcpnet1
-isset ${net1/mac} && dhcp net1 || goto dhcpnet2
+isset ${net1/mac} && ifopen net1 && dhcp net1 || goto dhcpnet2
 echo Received DHCP answer on interface net1 && goto proxycheck
 
 :dhcpnet2
-isset ${net2/mac} && dhcp net2 || goto dhcpall
+isset ${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
 echo Received DHCP anser on infterface net2 && goto proxycheck
 
 :dhcpall

--- a/src/ipxe/src-efi/ipxescript10sec
+++ b/src/ipxe/src-efi/ipxescript10sec
@@ -1,16 +1,15 @@
 #!ipxe
 echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
 sleep 10
-ifopen
-isset ${net0/mac} && dhcp net0 || goto dhcpnet1
+isset ${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
 echo Received DHCP answer on interface net0 && goto proxycheck
 
 :dhcpnet1
-isset ${net1/mac} && dhcp net1 || goto dhcpnet2
+isset ${net1/mac} && ifopen net1 && dhcp net1 || goto dhcpnet2
 echo Received DHCP answer on interface net1 && goto proxycheck
 
 :dhcpnet2
-isset ${net2/mac} && dhcp net2 || goto dhcpall
+isset ${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
 echo Received DHCP anser on infterface net2 && goto proxycheck
 
 :dhcpall

--- a/src/ipxe/src/ipxescript
+++ b/src/ipxe/src/ipxescript
@@ -1,14 +1,13 @@
 #!ipxe
-ifopen
-isset ${net0/mac} && dhcp net0 || goto dhcpnet1
+isset ${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
 echo Received DHCP answer on interface net0 && goto proxycheck
 
 :dhcpnet1
-isset ${net1/mac} && dhcp net1 || goto dhcpnet2
+isset ${net1/mac} && ifopen net1 && dhcp net1 || goto dhcpnet2
 echo Received DHCP answer on interface net1 && goto proxycheck
 
 :dhcpnet2
-isset ${net2/mac} && dhcp net2 || goto dhcpall
+isset ${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
 echo Received DHCP anser on infterface net2 && goto proxycheck
 
 :dhcpall

--- a/src/ipxe/src/ipxescript10sec
+++ b/src/ipxe/src/ipxescript10sec
@@ -1,16 +1,15 @@
 #!ipxe
 echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
 sleep 10
-ifopen
-isset ${net0/mac} && dhcp net0 || goto dhcpnet1
+isset ${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
 echo Received DHCP answer on interface net0 && goto proxycheck
 
 :dhcpnet1
-isset ${net1/mac} && dhcp net1 || goto dhcpnet2
+isset ${net1/mac} && ifopen net1 && dhcp net1 || goto dhcpnet2
 echo Received DHCP answer on interface net1 && goto proxycheck
 
 :dhcpnet2
-isset ${net2/mac} && dhcp net2 || goto dhcpall
+isset ${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
 echo Received DHCP anser on infterface net2 && goto proxycheck
 
 :dhcpall


### PR DESCRIPTION
input/output error on the WLAN NIC on MacBookPro8,2 and most
probably other platforms. So we need to check (&&) or our script
will fail and exit early.