### PR TITLE
Safely handle all special characters in MySQL password

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1592,34 +1592,34 @@ configureHttpd() {
         dummy=""
         while [[ -z $dummy ]]; do
             echo -n " * Is the MySQL password blank? (Y/n) "
-            read dummy
+            read -r dummy
             case $dummy in
                 [Yy]|[Yy][Ee][Ss]|"")
                     dummy='Y'
                     ;;
                 [Nn]|[Nn][Oo])
                     echo -n " * Enter the MySQL password: "
-                    read -s PASSWORD1
+                    read -rs PASSWORD1
                     echo
                     echo -n " * Re-enter the MySQL password: "
-                    read -s PASSWORD2
+                    read -rs PASSWORD2
                     echo
-                    if [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]]; then
+                    if [[ ! -z $PASSWORD1 && $PASSWORD2 == "$PASSWORD1" ]]; then
                         dbpass=$PASSWORD1
                     else
                         dbpass=""
-                        while ! [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]]; do
+                        while ! [[ ! -z $PASSWORD1 && $PASSWORD2 == "$PASSWORD1" ]]; do
                             echo "Password entries were blank or didn't match!"
                             echo -n " * Enter the MySQL password: "
-                            read -s PASSWORD1
+                            read -rs PASSWORD1
                             echo
                             echo -n " * Re-enter the MySQL password: "
-                            read -s PASSWORD2
+                            read -rs PASSWORD2
                             echo
-                            [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]] && dbpass=$PASSWORD1
+                            [[ ! -z $PASSWORD1 && $PASSWORD2 == "$PASSWORD1" ]] && dbpass=$PASSWORD1
                         done
                     fi
-                    [[ $snmysqlpass != $dbpass ]] && snmysqlpass=$dbpass
+                    [[ $snmysqlpass != "$dbpass" ]] && snmysqlpass=$dbpass
                     ;;
                 *)
                     dummy=""

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1118,6 +1118,7 @@ writeUpdateFile() {
     escinstalltype=$(echo $installtype | sed -e $replace)
     escsnmysqluser=$(echo $snmysqluser | sed -e $replace)
     escsnmysqlpass=$(echo "$snmysqlpass" | sed -e s/\'/\'\"\'\"\'/g)  # replace every ' with '"'"' for full bash escaping
+    sedescsnmysqlpass=$(echo "$escsnmysqlpass" | sed -e 's/[\&/]/\\&/g')  # then prefix every \ & and / with \ for sed escaping
     escsnmysqlhost=$(echo $snmysqlhost | sed -e $replace)
     escinstalllang=$(echo $installlang | sed -e $replace)
     escstorageLocation=$(echo $storageLocation | sed -e $replace)
@@ -1194,7 +1195,7 @@ writeUpdateFile() {
                 sed -i "s/snmysqluser=.*/snmysqluser='$escsnmysqluser'/g" $fogprogramdir/.fogsettings || \
                 echo "snmysqluser='$snmysqluser'" >> $fogprogramdir/.fogsettings
             grep -q "snmysqlpass=" $fogprogramdir/.fogsettings && \
-                sed -i "s/snmysqlpass=.*/snmysqlpass='$escsnmysqlpass'/g" $fogprogramdir/.fogsettings || \
+                sed -i "s/snmysqlpass=.*/snmysqlpass='$sedescsnmysqlpass'/g" $fogprogramdir/.fogsettings || \
                 echo "snmysqlpass='$escsnmysqlpass'" >> $fogprogramdir/.fogsettings
             grep -q "snmysqlhost=" $fogprogramdir/.fogsettings && \
                 sed -i "s/snmysqlhost=.*/snmysqlhost='$escsnmysqlhost'/g" $fogprogramdir/.fogsettings || \

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1607,8 +1607,9 @@ configureHttpd() {
                     if [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]]; then
                         dbpass=$PASSWORD1
                     else
-                        dppass=""
-                        while [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]]; do
+                        dbpass=""
+                        while ! [[ ! -z $PASSWORD1 && $PASSWORD2 == $PASSWORD1 ]]; do
+                            echo "Password entries were blank or didn't match!"
                             echo -n " * Enter the MySQL password: "
                             read -s PASSWORD1
                             echo

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1117,7 +1117,7 @@ writeUpdateFile() {
     escblexports=$(echo $blexports | sed -e $replace)
     escinstalltype=$(echo $installtype | sed -e $replace)
     escsnmysqluser=$(echo $snmysqluser | sed -e $replace)
-    escsnmysqlpass=$(echo $snmysqlpass | sed -e $replace -e "s/[']{1}/'''/g")
+    escsnmysqlpass=$(echo "$snmysqlpass" | sed -e s/\'/\'\"\'\"\'/g)  # replace every ' with '"'"' for full bash escaping
     escsnmysqlhost=$(echo $snmysqlhost | sed -e $replace)
     escinstalllang=$(echo $installlang | sed -e $replace)
     escstorageLocation=$(echo $storageLocation | sed -e $replace)
@@ -1628,12 +1628,12 @@ configureHttpd() {
             esac
         done
     fi
-    options="-s"
-    [[ -n $snmysqlhost ]] && options="$options -h$snmysqlhost"
-    [[ -n $snmysqluser ]] && options="$options -u'$snmysqluser'"
-    [[ -n $snmysqlpass ]] && options="$options -p'$snmysqlpass'"
+    options=("-s")
+    [[ -n $snmysqlhost ]] && options=( "${options[@]}" "--host=$snmysqlhost" )
+    [[ -n $snmysqluser ]] && options=( "${options[@]}" "--user=$snmysqluser" )
+    [[ -n $snmysqlpass ]] && options=( "${options[@]}" "--password=$snmysqlpass" )
     sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
-    mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+    mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
     mysqlver=$(mysql -V |  sed -n 's/.*Distrib[ ]\(\([0-9]\([.]\|\)\)*\).*\([-]\|\)[,].*/\1/p')
     mariadb=$(mysql -V |  sed -n 's/.*Distrib[ ].*[-]\(.*\)[,].*/\1/p')
     vertocheck="5.7"
@@ -1647,17 +1647,17 @@ configureHttpd() {
         case $snmysqlhost in
             127.0.0.1|[Ll][Oo][Cc][Aa][Ll][Hh][Oo][Ss][Tt])
                 sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
-                mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 sql="ALTER USER '$snmysqluser'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
-                mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 sql="ALTER USER '$snmysqluser'@'localhost' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
-                mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 ;;
             *)
                 sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
-                mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 sql="ALTER USER '$snmysqluser'@'$snmysqlhost' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
-                mysql ${options} -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 ;;
         esac
     fi

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1771,6 +1771,8 @@ configureHttpd() {
     dots "Creating config file"
     [[ -z $snmysqlhost ]] && snmysqlhost='localhost'
     [[ -z $snmysqluser ]] && snmysqluser='root'
+    phpescsnmysqlpass="${snmysqlpass//\\/\\\\}";   # Replace every \ with \\ ...
+    phpescsnmysqlpass="${phpescsnmysqlpass//\'/\\\'}"   # and then every ' with \' for full PHP escaping
     echo "<?php
 /**
  * The main configuration FOG uses.
@@ -1821,7 +1823,7 @@ class Config
         define('DATABASE_HOST', '$snmysqlhost');
         define('DATABASE_NAME', 'fog');
         define('DATABASE_USERNAME', '$snmysqluser');
-        define('DATABASE_PASSWORD', \"$snmysqlpass\");
+        define('DATABASE_PASSWORD', '$phpescsnmysqlpass');
     }
     /**
      * Defines the service settings

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1632,6 +1632,7 @@ configureHttpd() {
     [[ -n $snmysqlhost ]] && options=( "${options[@]}" "--host=$snmysqlhost" )
     [[ -n $snmysqluser ]] && options=( "${options[@]}" "--user=$snmysqluser" )
     [[ -n $snmysqlpass ]] && options=( "${options[@]}" "--password=$snmysqlpass" )
+    sqlescsnmysqlpass=$(echo "$snmysqlpass" | sed -e s/\'/\'\'/g)   # Replace every ' with '' for full MySQL escaping
     sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
     mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
     mysqlver=$(mysql -V |  sed -n 's/.*Distrib[ ]\(\([0-9]\([.]\|\)\)*\).*\([-]\|\)[,].*/\1/p')
@@ -1648,15 +1649,15 @@ configureHttpd() {
             127.0.0.1|[Ll][Oo][Cc][Aa][Ll][Hh][Oo][Ss][Tt])
                 sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
                 mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-                sql="ALTER USER '$snmysqluser'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
+                sql="ALTER USER '$snmysqluser'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY '$sqlescsnmysqlpass';"
                 mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-                sql="ALTER USER '$snmysqluser'@'localhost' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
+                sql="ALTER USER '$snmysqluser'@'localhost' IDENTIFIED WITH mysql_native_password BY '$sqlescsnmysqlpass';"
                 mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 ;;
             *)
                 sql="UPDATE mysql.user SET plugin='mysql_native_password' WHERE User='root';"
                 mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-                sql="ALTER USER '$snmysqluser'@'$snmysqlhost' IDENTIFIED WITH mysql_native_password BY '$snmysqlpass';"
+                sql="ALTER USER '$snmysqluser'@'$snmysqlhost' IDENTIFIED WITH mysql_native_password BY '$sqlescsnmysqlpass';"
                 mysql "${options[@]}" -e "$sql" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                 ;;
         esac

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -302,7 +302,7 @@ case $installtype in
             echo "  'FOG Settings' -> "
             echo "  'FOG Storage Nodes' -> "
             echo  -n "  'FOG_STORAGENODE_MYSQLPASS'.  Password: "
-            read snmysqlpass
+            read -r snmysqlpass
             [[ -z $snmysqlpass ]] && echo "Invalid input, please try again."
         done
         ;;


### PR DESCRIPTION
In the current dev-branch, if the user supplies a MySQL password to the installer that contains special characters, the installation fails in various ways.  Depending on the characters present, sometimes failure is obvious immediately upon database schema installation, and sometimes it is less obvious and only seen as a DB lockout after the first FOG upgrade installation due to generational corruption of the stored password.

This pull request adds proper escaping of special characters within the user-provided MySQL password as needed for the four different escaping schemes used by bash, sed, PHP, and MySQL itself.

To test these patches, I used a worst-case-scenario MySQL password of:
`{}It's; ""a" \whacky*/ (''MySQL) \\P@ss\'word![&]`

This password causes the current dev-branch FOG to choke on install.

With these patches, I was able to complete installation and access the FOG server's web GUI without issue.  I then performed two re-installations on top of this existing test installation to simulate two subsequent FOG upgrades.  This was to test for generational password corruption issues.  After both re-installs, I was still able to access the web GUI as expected.  I also verified that the `snmysqlpass` line in `.fogsettings` and the `DATABASE_PASSWORD` defined in `config.class.php` had been generated by the installer with proper escaping and didn't change between re-installations.
