### PR TITLE
Changes to ipxe to allow for arm* architectures

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -420,7 +420,7 @@ configureFTP() {
 }
 configureDefaultiPXEfile() {
     [[ -z $webroot ]] && webroot='/'
-    echo -e "#!ipxe\ncpuid --ext 29 && set arch x86_64 || set arch i386\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nparam sysuuid \${uuid}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain ${httpproto}://$ipaddress${webroot}service/ipxe/boot.php##params" > "$tftpdirdst/default.ipxe"
+    echo -e "#!ipxe\ncpuid --ext 29 && set arch x86_64 || set arch \${buildarch}\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nparam sysuuid \${uuid}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain ${httpproto}://$ipaddress${webroot}service/ipxe/boot.php##params" > "$tftpdirdst/default.ipxe"
 }
 configureTFTPandPXE() {
     dots "Setting up and starting TFTP and PXE Servers"

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -128,6 +128,22 @@ class BootMenu extends FOGBase
         $grubChain = 'chain -ar ${boot-url}/service/ipxe/grub.exe '
             . '--config-file="%s"';
         $sanboot = 'sanboot --no-describe --drive 0x80';
+        $refind = sprintf(
+            'imgfetch ${boot-url}/service/ipxe/refind.conf%s'
+            . 'chain -ar ${boot-url}/service/ipxe/refind.efi',
+            "\n"
+        );
+
+        if(stripos($_REQUEST['arch'], 'arm') !== FALSE){ //user arm boot loaders instead
+            $grubChain = 'chain -ar ${boot-url}/service/ipxe/grub_aa64.exe '
+                . '--config-file="%s"';
+            $refind = sprintf(
+                'imgfetch ${boot-url}/service/ipxe/refind_aa64.conf%s'
+                . 'chain -ar ${boot-url}/service/ipxe/refind_aa64.efi',
+                "\n"
+            );
+        }
+
         $grub = array(
             'basic' => sprintf(
                 $grubChain,
@@ -141,11 +157,6 @@ class BootMenu extends FOGBase
                 $grubChain,
                 'find --set-root /BOOTMGR;chainloader /BOOTMGR"'
             )
-        );
-        $refind = sprintf(
-            'imgfetch ${boot-url}/service/ipxe/refind.conf%s'
-            . 'chain -ar ${boot-url}/service/ipxe/refind.efi',
-            "\n"
         );
         self::$_exitTypes = array(
             'sanboot' => $sanboot,


### PR DESCRIPTION
This assumes that refind_aa64.efi and grub_aa64.exe exist but does not add or build them. This is just a small configuration change to allow the arch to be set as arm* and then change the bootloaders accordingly.