### PR TITLE
Respect FOG_UDPCAST_INTERFACE

### DIFF
--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -42,11 +42,7 @@ class MulticastTask extends FOGService
         if (!$StorageNode->get('isMaster')) {
             return;
         }
-        $Interface = self::getMasterInterface(
-            self::resolveHostname(
-                $StorageNode->get('ip')
-            )
-        );
+        $Interface = self::getSetting('FOG_UDPCAST_INTERFACE');
         unset($StorageNode);
         $Tasks = array();
         $find = array(


### PR DESCRIPTION
Use FOG_UDPCAST_INTERFACE setting for outgoing multicast packets, instead of dynamically finding interface (which does not work well).