### PR TITLE
Adding the remit-hello-interval option in the multicast command

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -3719,3 +3719,9 @@ $this->schema[] = array(
     . " Values are 0 or 1, default is 0.'"
     . " ,'0', 'FOG Quick Registration')"
 );
+// 264
+$this->schema[] = array(
+    "ALTER TABLE `nfsGroupMembers` ADD COLUMN `ngmHelloInterval` "
+    . "VARCHAR(8) AFTER `ngmMaxBitrate`",
+);
+

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -43,6 +43,7 @@ class StorageNode extends FOGController
         'path' => 'ngmRootPath',
         'ftppath' => 'ngmFTPPath',
         'bitrate' => 'ngmMaxBitrate',
+        'helloInterval' => 'ngmHelloInterval',
         'snapinpath' => 'ngmSnapinPath',
         'sslpath' => 'ngmSSLPath',
         'ip' => 'ngmHostname',

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -412,7 +412,7 @@ class StorageManagementPage extends FOGPage
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="bitrate">'
-            . _('Bitrates')
+            . _('Bitrate')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="bitrate" id="bitrate" value="'
             . $bitrate

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -311,6 +311,7 @@ class StorageManagementPage extends FOGPage
         $snapinpath = filter_input(INPUT_POST, 'snapinpath') ?: '/opt/fog/snapins/';
         $sslpath = filter_input(INPUT_POST, 'sslpath') ?: '/opt/fog/snapins/ssl/';
         $bitrate = filter_input(INPUT_POST, 'bitrate');
+        $helloInterval = filter_input(INPUT_POST, 'helloInterval');
         $interface = filter_input(INPUT_POST, 'interface') ?: 'eth0';
         $user = filter_input(INPUT_POST, 'user');
         $pass = filter_input(INPUT_POST, 'pass');
@@ -411,10 +412,17 @@ class StorageManagementPage extends FOGPage
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="bitrate">'
-            . _('Bitrate')
+            . _('Bitrates')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="bitrate" id="bitrate" value="'
             . $bitrate
+            . '" autocomplete="off" class="form-control"/>'
+            . '</div>',
+            '<label for="helloInterval">'
+            . _('Rexmit Hello Interval')
+            . '</label>' => '<div class="input-group">'
+            . '<input type="text" name="helloInterval" id="helloInterval" value="'
+            . $helloInterval
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="interface">'
@@ -513,6 +521,7 @@ class StorageManagementPage extends FOGPage
         $snapinpath = filter_input(INPUT_POST, 'snapinpath');
         $sslpath = filter_input(INPUT_POST, 'sslpath');
         $bitrate = filter_input(INPUT_POST, 'bitrate');
+        $helloInterval = filter_input(INPUT_POST, 'helloInterval');
         self::$HookManager->processEvent('STORAGE_NODE_ADD_POST');
         try {
             if (empty($name)) {
@@ -558,6 +567,7 @@ class StorageManagementPage extends FOGPage
                 ->set('snapinpath', $snapinpath)
                 ->set('sslpath', $sslpath)
                 ->set('bitrate', $bitrate)
+                ->set('helloInterval', $helloInterval)
                 ->set('interface', $interface)
                 ->set('isGraphEnabled', $isgren)
                 ->set('isEnabled', $isen)
@@ -650,6 +660,8 @@ class StorageManagementPage extends FOGPage
             $this->obj->get('sslpath');
         $bitrate = filter_input(INPUT_POST, 'bitrate') ?:
             $this->obj->get('bitrate');
+        $helloInterval = filter_input(INPUT_POST, 'helloInterval') ?:
+            $this->obj->get('helloInterval');
         $interface = filter_input(INPUT_POST, 'interface') ?:
             $this->obj->get('interface');
         $user = filter_input(INPUT_POST, 'user') ?:
@@ -783,6 +795,13 @@ class StorageManagementPage extends FOGPage
             . $bitrate
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
+            '<label for="helloInterval">'
+            . _('Remit Hello Interval')
+            . '</label>' => '<div class="input-group">'
+            . '<input type="text" name="helloInterval" id="helloInterval" value="'
+            . $helloInterval
+            . '" autocomplete="off" class="form-control"/>'
+            . '</div>',
             '<label for="interface">'
             . self::$foglang['Interface']
             . '</label>' => '<div class="input-group">'
@@ -884,6 +903,7 @@ class StorageManagementPage extends FOGPage
         $snapinpath = filter_input(INPUT_POST, 'snapinpath');
         $sslpath = filter_input(INPUT_POST, 'sslpath');
         $bitrate = filter_input(INPUT_POST, 'bitrate');
+        $helloInterval = filter_input(INPUT_POST, 'helloInterval');
         self::$HookManager
             ->processEvent(
                 'STORAGE_NODE_EDIT_POST',
@@ -937,6 +957,7 @@ class StorageManagementPage extends FOGPage
                 ->set('snapinpath', $snapinpath)
                 ->set('sslpath', $sslpath)
                 ->set('bitrate', $bitrate)
+                ->set('helloInterval', $helloInterval)
                 ->set('interface', $interface)
                 ->set('isGraphEnabled', $isgren)
                 ->set('isEnabled', $isen)

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -390,6 +390,22 @@ class MulticastTask extends FOGService
         ->get('bitrate');
     }
     /**
+     * Returns the rexmit hello interval
+     *
+     * @return string
+     */
+    public function getHelloInterval()
+    {
+        return self::getClass(
+            'Image',
+            $this->_MultiSess->get('image')
+        )->getStorageGroup()
+        ->getMasterStorageNode()
+        ->get('helloInterval');
+    }
+
+
+    /**
      * Returns the partition id to be cloned, 0 for all
      *
      * @return int
@@ -455,6 +471,11 @@ class MulticastTask extends FOGService
         }
         $buildcmd = array(
             UDPSENDERPATH,
+            (
+                $this->getHelloInterval() ?
+                sprintf(' --rexmit-hello-interval %s', $this->getHelloInterval()) :
+                null
+            ),
             (
                 $this->getBitrate() ?
                 sprintf(' --max-bitrate %s', $this->getBitrate()) :


### PR DESCRIPTION
Create a little feature to add the possibility to config the remit-hello-interval in the udp-sender commands.
NOTE: require alter the nfsGroupMembers table in the database