### PR TITLE
FIX typo in location and site plugins

### DIFF
--- a/packages/web/lib/plugins/location/hooks/addlocationgroup.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationgroup.hook.php
@@ -150,7 +150,7 @@ class AddLocationGroup extends Hook
             '<label for="updateloc">'
             . _('Make Changes?')
             . '</label>' => '<button type="submit" class="btn btn-info btn-block" '
-            . 'id="updateloc">'
+            . 'id="group-edit">'
             . _('Update')
             . '</button>'
         );

--- a/packages/web/lib/plugins/site/hooks/addsitegroup.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitegroup.hook.php
@@ -144,7 +144,7 @@ class AddSiteGroup extends Hook
             '<label for="updatesite">'
             . _('Make Changes?')
             . '</label>' => '<button type="submit" class="btn btn-info btn-block" '
-            . 'id="updatesite">'
+            . 'id="group-edit">'
             . _('Update')
             . '</button>'
         );


### PR DESCRIPTION
When you update the location or site in the group page, this retrieve a blank page