### PR TITLE
Small cleanups

### DIFF
--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -643,6 +643,7 @@ abstract class FOGService extends FOGBase
                         }
                         if ($localsize == $remotesize) {
                             $localhash = self::getHash($localfilename);
+                            $remotehash = null;
                             if ($avail) {
                                 $remotehash = self::$FOGURLRequests->process(
                                     $hashurl,

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -594,9 +594,17 @@ abstract class FOGService extends FOGBase
                 $filescheck = array_unique(array_merge((array)$localfilescheck, (array)$remotefilescheck));
                 $testavail = -1;
                 $allsynced = true;
+
+                $resp = self::$FOGURLRequests->isAvailable($testip, 1, 80);
+                $avail = true;
+                $testavail = array_filter($resp);
+                $testavail = array_shift($testavail);
+                if (!$testavail) {
+                    $avail = false;
+                }
+
                 foreach ($filescheck as $j => &$filename) {
                     $filesequal = false;
-                    $avail = true;
                     $lindex = array_search($filename, $localfilescheck);
                     $rindex = array_search($filename, $remotefilescheck);
                     $localfilename = sprintf('%s%s%s', $path, "/", $localfilescheck[$lindex]);
@@ -622,12 +630,6 @@ abstract class FOGService extends FOGBase
                         ));
                         self::$FOGFTP->delete($remotefilename);
                     } else {
-                        $resp = self::$FOGURLRequests->isAvailable($testip, 1, 80);
-                        $testavail = array_filter($resp);
-                        $testavail = array_shift($testavail);
-                        if (!$testavail) {
-                            $avail = false;
-                        }
                         $localsize = self::getFilesize($localfilename);
                         if ($avail) {
                             $remotesize = self::$FOGURLRequests->process(


### PR DESCRIPTION
1) Only check if the remote is up once, 

1) Removes the wrong checksum from the logs

example:
```
fogreplicator.log:<snip> File hash mismatch - d1p4.img.026: af318bb1fe4dc3ee6c96e92d6e58d96efe305fc3b24073a91beb1e77a9837fa2 != e0bcb6ab70e1b12a39446a3239f99452c10606b27014c5b386084aff89e3258d
fogreplicator.log:<snip>: File hash mismatch - d1p4.img.027: ccfa2820cc2bf53ea37f770f50f4eb79ef8e73867244b46e41755e691db51034 != e0bcb6ab70e1b12a39446a3239f99452c10606b27014c5b386084aff89e3258d
fogreplicator.log:<snip>: File hash mismatch - d1p4.img.028: cf796e093b860a4354afeb8f4a883d80793f2b06f7883b07ac87185c5070f15f != e0bcb6ab70e1b12a39446a3239f99452c10606b27014c5b386084aff89e3258d
```

where `e0bcb6ab70e1b12a39446a3239f99452c10606b27014c5b386084aff89e3258d` is the hash of a previous file