### PR TITLE
Sanity checking remote file data

### DIFF
--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -647,13 +647,17 @@ abstract class FOGService extends FOGBase
                         if ($localsize == $remotesize) {
                             $localhash = self::getHash($localfilename);
                             if ($avail) {
-                                $remotehash = self::$FOGURLRequests->process(
+                                $rhash = self::$FOGURLRequests->process(
                                     $hashurl,
                                     'POST',
                                     ['file' => base64_encode($remotefilename)]
                                 );
-                                $remotehash = array_shift($remotehash);
-                            } else {
+                                $rhash = array_shift($rhash);
+                                if (strlen($rhash) == 64) {
+                                    $remotehash = $rhash;
+                                }
+                            }
+                            if (is_null($remotehash)) {
                                 if ($localsize < 10485760) {
                                     $remotehash = hash_file('sha256', $ftpstart.$remotefilename);
                                 } else {

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -629,14 +629,19 @@ abstract class FOGService extends FOGBase
                             $avail = false;
                         }
                         $localsize = self::getFilesize($localfilename);
+                        $remotesize = null;
                         if ($avail) {
-                            $remotesize = self::$FOGURLRequests->process(
+                            $rsize = self::$FOGURLRequests->process(
                                 $sizeurl,
                                 'POST',
                                 ['file' => base64_encode($remotefilename)]
                             );
-                            $remotesize = array_shift($remotesize);
-                        } else {
+                            $rsize = array_shift($rsize);
+                            if(is_int($rsize) || $res === "") {
+                                $remotesize = $rsize;
+                            }
+                        }
+                        if (is_null($remotesize)) {
                             $remotesize = self::$FOGFTP->size($remotefilename);
                         }
                         if ($localsize == $remotesize) {


### PR DESCRIPTION
This should fix the issue that when a nas is used as storage node, that fog will continuously try to sync the data
example:
https://forums.fogproject.org/topic/11483/continuous-fog-storage-node-replication-problem/3