### PR TITLE
Fix two typos

### DIFF
--- a/src/ipxe/src/ipxescript
+++ b/src/ipxe/src/ipxescript
@@ -8,7 +8,7 @@ echo Received DHCP answer on interface net1 && goto proxycheck
 
 :dhcpnet2
 isset ${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
-echo Received DHCP anser on infterface net2 && goto proxycheck
+echo Received DHCP answer on interface net2 && goto proxycheck
 
 :dhcpall
 dhcp && goto proxycheck || goto dhcperror


### PR DESCRIPTION
Fix two typos in src/ipxe/src/ipxescript, "anser" and "infterface".