### PR TITLE
Add FOG Analytics 

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -630,6 +630,7 @@ while [[ -z $blGo ]]; do
                     writeUpdateFile
                     linkOptFogDir
                     updateStorageNodeCredentials
+		    setupFogAnalytics
                     echo
                     echo " * Setup complete"
                     echo

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -630,7 +630,7 @@ while [[ -z $blGo ]]; do
                     writeUpdateFile
                     linkOptFogDir
                     updateStorageNodeCredentials
-		    setupFogAnalytics
+                    setupFogAnalytics
                     echo
                     echo " * Setup complete"
                     echo

--- a/utils/FOGAnalytics/report_analytics.sh
+++ b/utils/FOGAnalytics/report_analytics.sh
@@ -21,6 +21,6 @@ echo "payload=${payload}"
 
 
 # Send to reporting endpoint.
-curl -X POST -H "Content-Type: application/json"  -d "${payload}" https://fog-analytics-entries.theworkmans.us:/api/records
+curl -s -X POST -H "Content-Type: application/json"  -d "${payload}" https://fog-analytics-entries.theworkmans.us:/api/records
 
 

--- a/utils/FOGAnalytics/report_analytics.sh
+++ b/utils/FOGAnalytics/report_analytics.sh
@@ -21,6 +21,6 @@ echo "payload=${payload}"
 
 
 # Send to reporting endpoint.
-curl -X POST -H "Content-Type: application/json"  -d "${payload}" https://fog-popularity-entries.theworkmans.us:/api/records
+curl -X POST -H "Content-Type: application/json"  -d "${payload}" https://fog-analytics-entries.theworkmans.us:/api/records
 
 

--- a/utils/FOGAnalytics/report_analytics.sh
+++ b/utils/FOGAnalytics/report_analytics.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Get the OS Name.
+os_name=$(lsb_release -i | cut -d':' -f2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+echo "os_name=${os_name}"
+
+
+# Get the OS version.
+os_version=$(lsb_release -r | cut -d':' -f2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+echo "os_version=${os_version}"
+
+
+# Get the FOG version.
+fog_version=$(cat /var/www/fog/lib/fog/system.class.php | grep FOG_VERSION | cut -d',' -f2 | cut -d"'" -f2)
+echo "fog_version=${fog_version}"
+
+
+# Format payload.
+payload="{\"fog_version\":\"${fog_version}\",\"os_name\":\"${os_name}\",\"os_version\":\"${os_version}\"}"
+echo "payload=${payload}"
+
+
+# Send to reporting endpoint.
+curl -X POST -H "Content-Type: application/json"  -d "${payload}" https://fog-popularity-entries.theworkmans.us:/api/records
+
+


### PR DESCRIPTION
This adds the components needed for FOG Analytics.
The FOG Installer was modified to setup a weekly cronjob. This cron job is created such that a random day, hour, and minute is chosen during installation to create the cron job with. This job runs once per week. If it fails, it is of no consequence to the FOG Server's operation. The cron job collects the following information from the FOG Server:

- FOG Version
- OS Name
- OS Version

This information is then sent to the FOG Analytics API, which records these three things. This information will be used to inform the FOG Developers of what OSs and Versions are out there being used for FOG going into the future such that they can make more-informed decisions for the FOG Project.

After installed, there are some settings for this located at `/opt/fog/analytics/settings` which will allow you to choose the day, hour, and minute, the log file, and the user to run the job as. This file is used by the FOG installer to re-create the cron job upon each installation run.

Discussion is here: https://forums.fogproject.org/topic/14668/popularity-contest