### PR TITLE
Add User=fogproject to systemd unitfiles

### DIFF
--- a/packages/systemd/FOGImageReplicator.service
+++ b/packages/systemd/FOGImageReplicator.service
@@ -22,6 +22,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGImageReplicator/FOGImageReplicator
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGImageSize.service
+++ b/packages/systemd/FOGImageSize.service
@@ -21,6 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGImageSize/FOGImageSize
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGMulticastManager.service
+++ b/packages/systemd/FOGMulticastManager.service
@@ -23,6 +23,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGMulticastManager/FOGMulticastManager
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGPingHosts.service
+++ b/packages/systemd/FOGPingHosts.service
@@ -21,6 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGPingHosts/FOGPingHosts
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGScheduler.service
+++ b/packages/systemd/FOGScheduler.service
@@ -21,6 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGTaskScheduler/FOGTaskScheduler
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGSnapinHash.service
+++ b/packages/systemd/FOGSnapinHash.service
@@ -21,6 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGSnapinHash/FOGSnapinHash
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/systemd/FOGSnapinReplicator.service
+++ b/packages/systemd/FOGSnapinReplicator.service
@@ -22,6 +22,7 @@ Type=simple
 Restart=always
 RestartSec=1
 ExecStart=/usr/bin/env php /opt/fog/service/FOGSnapinReplicator/FOGSnapinReplicator
+User=fogproject
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I have added a "User=fogproject" line to all systemd unit files.
1) The daemons otherwise run with "root" rights. Running daemons, processes in general with root privileges is a security risk and should be avoided if possible.
It seems that in the past they were already running with fogproject ownership (although there was no line as suggested in the systemd unit files), as images were stored on our server with fogproject ownership. – But not always, sometimes in the past they had been saved with root ownership. This means that the responsible process then had run with root rights, as it does now.
2) If the images are stored with root ownership, it is not possible to delete them via the web interface. The images will then be deleted in the database, but not in the /images folder. You have to delete them manually.

We had the problem on CentOS 7.x, as well as now on Debian 10.7.