### PR TITLE
Update config.sh for Debian 11.x (bullseye)

### DIFF
--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -20,6 +20,7 @@
 [[ -z $packageQuery ]] && packageQuery="dpkg -l \$x | grep '^ii'"
 if [[ $linuxReleaseName == +(*[Bb][Ii][Aa][Nn]*) ]]; then
     sysvrcconf="sysv-rc-conf"
+    phpgettext="php-gettext"
     case $OSVersion in
         8)
             php_ver="5"
@@ -31,6 +32,11 @@ if [[ $linuxReleaseName == +(*[Bb][Ii][Aa][Nn]*) ]]; then
         10)
             php_ver="7.3"
             x="*php5* *php7.0*"
+            ;;
+        11)
+            php_ver="7.4"
+            x="*php5* *php7.0* *php7.3*"
+            phpgettext="php-php-gettext"
             ;;
     esac
     old_php=$(eval $packageQuery 2>/dev/null | awk '{print $2}' | tr '\n' ' ')
@@ -105,7 +111,7 @@ case $linuxReleaseName in
             x="mysql-server"
             eval $packageQuery >>$workingdir/error_logs/fog_error_${version}.log 2>&1
             [[ $? -eq 0 ]] && db_packages="mysql-client mysql-server" || db_packages="mariadb-client mariadb-server"
-            packages="apache2 build-essential cpp curl g++ gawk gcc genisoimage git gzip htmldoc isc-dhcp-server isolinux lftp libapache2-mod-fastcgi libapache2-mod-php${php_ver} libc6 libcurl3 liblzma-dev m4 ${db_packages} net-tools nfs-kernel-server openssh-server $phpfpm php-gettext php${php_ver} php${php_ver}-cli php${php_ver}-curl php${php_ver}-gd php${php_ver}-json $phpldap php${php_ver}-mysql php${php_ver}-mysqlnd ${sysvrcconf} tar tftpd-hpa tftp-hpa vsftpd wget xinetd zlib1g"
+            packages="apache2 build-essential cpp curl g++ gawk gcc genisoimage git gzip htmldoc isc-dhcp-server isolinux lftp libapache2-mod-fastcgi libapache2-mod-php${php_ver} libc6 libcurl3 liblzma-dev m4 ${db_packages} net-tools nfs-kernel-server openssh-server $phpfpm $phpgettext php${php_ver} php${php_ver}-cli php${php_ver}-curl php${php_ver}-gd php${php_ver}-json $phpldap php${php_ver}-mysql php${php_ver}-mysqlnd ${sysvrcconf} tar tftpd-hpa tftp-hpa vsftpd wget xinetd zlib1g"
         else
             # make sure we update all the php version numbers with those specified above
             packages=${packages//php[0-9]\.[0-9]/php${php_ver}}


### PR DESCRIPTION
* Debian Bullseye runs PHP 7.4
* php-gettext becomes php-php-gettext in Bullseye