### PR TITLE
Add ability to specify additional TFTP server command line options

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -388,6 +388,7 @@ echo "Done"
 [[ -z $httpproto ]] && httpproto="http"
 [[ -z $armsupport ]] && armsupport=0
 [[ -z $mysqldbname ]] && mysqldbname="fog"
+[[ -z $tftpAdvOpts ]] && tftpAdvOpts=""
 [[ -z $fogpriorconfig ]] && fogpriorconfig="$fogprogramdir/.fogsettings"
 #clearScreen
 if [[ -z $* || $* != +(-h|-?|--help|--uninstall) ]]; then

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -582,7 +582,7 @@ configureTFTPandPXE() {
                 if [[ -f /etc/systemd/system/fog-tftp.service ]]; then
                     mv -fv /etc/systemd/system/fog-tftp.service "/etc/systemd/system/fog-tftp.service.${timestamp}" >>$error_log 2>&1
                 fi
-                echo -e "[Unit]\nDescription=Tftp Server\nRequires=fog-tftp.socket\nDocumentation=man:in.tftpd\n\n[Service]\nExecStart=/usr/sbin/in.tftpd -s ${tftpdirdst}\nStandardInput=socket\n\n[Install]\nAlso=fog-tftp.socket" > /etc/systemd/system/fog-tftp.service
+                echo -e "[Unit]\nDescription=Tftp Server\nRequires=fog-tftp.socket\nDocumentation=man:in.tftpd\n\n[Service]\nExecStart=/usr/sbin/in.tftpd ${tftpAdvOpts:+$tftpAdvOpts }-s ${tftpdirdst}\nStandardInput=socket\n\n[Install]\nAlso=fog-tftp.socket" > /etc/systemd/system/fog-tftp.service
                 diffconfig "/etc/systemd/system/fog-tftp.service"
                 cp -v /usr/lib/systemd/system/tftp.socket /etc/systemd/system/fog-tftp.socket >>$error_log 2>&1
                 systemctl daemon-reload


### PR DESCRIPTION
This PR adds a new setting to `.fogsettings` called `tftpAdvOpts` (for "TFTP Advanced Options") that allows a user to specify additional command line arguments to pass to the TFTP server.  Currently, FOG hard-codes the command line options used to run the TFTP server, and any manual changes that are made to either `/etc/default/tftpd-hpa` or `/etc/xinetd.d/tftp` for these options are clobbered by the installer after each installation/upgrade run.  This new option provides a way to make persistent changes to these options that will survive a FOG upgrade or re-install.  The default value of `tftpAdvOpts` is an empty string, so the TFTP server command line options will not be altered at all unless a user intentionally modifies this setting in `.fogsettings`.

My use case that inspired this new setting is my need to pass `--blocksize 1388` as an extra command line option to the TFTP server.  Our organization PXE-boots some of our devices over a WireGuard tunnel that connects a remote site back to our FOG server at our main office.  The WireGuard tunnel is completely transparent to the client devices, except that the inside of the tunnel has a reduced MTU of 1420.  This is in order to accommodate the network overhead introduced by WireGuard's encapsulation and to prevent unnecessary packet fragmentation on the outside of the tunnel by giving devices inside of the tunnel the information they need to perform their own proper packet sizing or (failing that) packet fragmentation.

While this works for other more modern protocols and smarter devices, unfortunately, most PXE firmware is too simple and brain-stem-like to be able to reassemble fragmented IP packets, so it will silently drop the traffic instead.  Because of this, we have to fix the mismatch at the application level instead of the network level.  The TFTP maximum block size must be reduced in order to fit inside of the WireGuard tunnel's 1420 MTU without fragmenting.  Adding `--blocksize 1388` tells the TFTP server to properly size its application data to fit within the lowered 1420 MTU rather than to generate larger data blocks (and hence larger IP packets) that rely on proper IP fragmentation and reassembly at the network level.
