### PR TITLE
Basic readability changes, and shortening of quite a few lines

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -37,7 +37,7 @@ if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ *linux* ]]; then
     exit 2 # Fail OS Check
 fi 
 
-error_log=$/workingdir/error_logs/fog_error_${version}.log
+error_log=${workingdir}/error_logs/fog_error_${version}.log
 timestamp=$(date +%s)
 backupconfig=""
 . ../lib/common/functions.sh

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -30,6 +30,7 @@ if [[ $? -eq 1 || $(echo $PATH | grep -o "sbin" | wc -l) -lt 2 ]]; then
     echo "of the su command as it is important to load root's environment)."
     exit 1
 fi
+error_log=$/workingdir/error_logs/fog_error_${version}.log
 timestamp=$(date +%s)
 backupconfig=""
 . ../lib/common/functions.sh
@@ -338,27 +339,27 @@ fi
 [[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
 echo "Installing LSB_Release as needed"
 dots "Attempting to get release information"
-command -v lsb_release >$workingdir/error_logs/fog_error_${version}.log 2>&1
+command -v lsb_release >$error_log 2>&1
 exitcode=$?
 if [[ ! $exitcode -eq 0 ]]; then
     case $linuxReleaseName in
         *[Bb][Ii][Aa][Nn]*|*[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*)
-            apt-get -yq install lsb-release >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+            apt-get -yq install lsb-release >>$error_log 2>&1
             ;;
         *[Cc][Ee][Nn][Tt][Oo][Ss]*|*[Rr][Ee][Dd]*[Hh][Aa][Tt]*|*[Ff][Ee][Dd][Oo][Rr][Aa]*)
-            command -v dnf >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+            command -v dnf >>$error_log 2>&1
             exitcode=$?
             case $exitcode in
                 0)
-                    dnf -y install redhat-lsb-core >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                    dnf -y install redhat-lsb-core >>$error_log 2>&1
                     ;;
                 *)
-                    yum -y install redhat-lsb-core >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                    yum -y install redhat-lsb-core >>$error_log 2>&1
                     ;;
             esac
             ;;
         *[Aa][Rr][Cc][Hh]*)
-            pacman -Sy --noconfirm lsb-release >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+            pacman -Sy --noconfirm lsb-release >>$error_log 2>&1
             ;;
     esac
 fi
@@ -428,7 +429,7 @@ esac
 [[ -n $srecreateKeys ]] && recreateKeys=$srecreateKeys
 [[ -n $sarmsupport ]] && armsupport=$sarmsupport
 
-[[ -f $fogpriorconfig ]] && grep -l webroot $fogpriorconfig >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+[[ -f $fogpriorconfig ]] && grep -l webroot $fogpriorconfig >>$error_log 2>&1
 case $? in
     0)
         if [[ -n $webroot ]]; then

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -24,6 +24,7 @@ if [[ ! $EUID -eq 0 ]]; then
     echo "FOG Installation must be run as root user"
     exit 1 # Fail Sudo
 fi
+
 which useradd >/dev/null 2>&1
 if [[ $? -eq 1 || $(echo $PATH | grep -o "sbin" | wc -l) -lt 2 ]]; then
     echo "Please switch to a proper root environment to run the installer!"
@@ -39,6 +40,7 @@ if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ "linux" ]]; then
 fi 
 
 [[ -z $version ]] && version="$(awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php | tr -d '[[:space:]]')"
+[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
 error_log=${workingdir}/error_logs/fog_error_${version}.log
 timestamp=$(date +%s)
 backupconfig=""
@@ -78,6 +80,7 @@ usage() {
     echo -e "\t-A    --arm-support\t\tInstall kernel and initrd for ARM platforms"
     exit 0
 }
+
 optspec="h?odEUHSCKYyXxTPFAf:c:-:W:D:B:s:e:b:N:"
 while getopts "$optspec" o; do
     case $o in
@@ -341,7 +344,7 @@ elif [[ -f /etc/debian_version ]]; then
 fi
 
 linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
-[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
+
 echo "Installing LSB_Release as needed"
 dots "Attempting to get release information"
 command -v lsb_release >$error_log 2>&1
@@ -368,8 +371,8 @@ if [[ ! $exitcode -eq 0 ]]; then
             ;;
     esac
 fi
-[[ -z $OSVersion ]] && OSVersion=$(lsb_release -rs| awk -F'\.' '{print $1}')
-[[ -z $OSMinorVersion ]] && OSMinorVersion=$(lsb_release -rs| awk -F'\.' '{print $2}')
+[[ -z $OSVersion ]] && OSVersion=$(lsb_release -rs| awk -F'.' '{print $1}')
+[[ -z $OSMinorVersion ]] && OSMinorVersion=$(lsb_release -rs| awk -F'.' '{print $2}')
 echo "Done"
 . ../lib/common/config.sh
 [[ -z $dnsaddress ]] && dnsaddress=""

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -33,7 +33,7 @@ if [[ $? -eq 1 || $(echo $PATH | grep -o "sbin" | wc -l) -lt 2 ]]; then
 fi
 
 [[ -z $OS ]] && OS=$(uname -s)
-if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ *linux* ]]; then
+if [[ $(echo "$OS" | tr [:upper:] [:lower:]) =~ *linux* ]]; then
     echo "We do not currently support Installation on non-Linux Operating Systems"
     exit 2 # Fail OS Check
 fi 
@@ -342,7 +342,7 @@ elif [[ -f /etc/debian_version ]]; then
     [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
 fi
 
-$linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
 [[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
 echo "Installing LSB_Release as needed"
 dots "Attempting to get release information"

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -19,6 +19,7 @@
 bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
 cd $bindir
 workingdir=$(pwd)
+
 if [[ ! $EUID -eq 0 ]]; then
     echo "FOG Installation must be run as root user"
     exit 1 # Fail Sudo
@@ -37,6 +38,7 @@ if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ *linux* ]]; then
     exit 2 # Fail OS Check
 fi 
 
+[[ -z $version ]] && version="$(awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php | tr -d '[[:space:]]')"
 error_log=${workingdir}/error_logs/fog_error_${version}.log
 timestamp=$(date +%s)
 backupconfig=""
@@ -326,7 +328,7 @@ while getopts "$optspec" o; do
             ;;
     esac
 done
-[[ -z $version ]] && version="$(awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php | tr -d '[[:space:]]')"
+
 
 
 if [[ -f /etc/os-release ]]; then

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -33,7 +33,7 @@ if [[ $? -eq 1 || $(echo $PATH | grep -o "sbin" | wc -l) -lt 2 ]]; then
 fi
 
 [[ -z $OS ]] && OS=$(uname -s)
-if [[ $(echo "$OS" | tr [:upper:] [:lower:]) =~ *linux* ]]; then
+if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ "linux" ]]; then
     echo "We do not currently support Installation on non-Linux Operating Systems"
     exit 2 # Fail OS Check
 fi 
@@ -328,8 +328,6 @@ while getopts "$optspec" o; do
             ;;
     esac
 done
-
-
 
 if [[ -f /etc/os-release ]]; then
     [[ -z $linuxReleaseName ]] && linuxReleaseName=$(sed -n 's/^NAME=\(.*\)/\1/p' /etc/os-release | tr -d '"')

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -43,7 +43,7 @@ error_log=${workingdir}/error_logs/fog_error_${version}.log
 timestamp=$(date +%s)
 backupconfig=""
 . ../lib/common/functions.sh
-help() {
+usage() {
     echo -e "Usage: $0 [-h?dEUuHSCKYXTFA] [-f <filename>] [-N <databasename>]"
     echo -e "\t\t[-D </directory/to/document/root/>] [-c <ssl-path>]"
     echo -e "\t\t[-W <webroot/to/fog/after/docroot/>] [-B </backup/path/>]"
@@ -84,7 +84,7 @@ while getopts "$optspec" o; do
         -)
             case $OPTARG in
                 help)
-                    help
+                    usage
                     exit 0
                     ;;
                 uninstall)
@@ -133,7 +133,7 @@ while getopts "$optspec" o; do
                 webroot)
                     if [[ $OPTARG != *('/')* ]]; then
                         echo -e "-$OPTARG needs a url path for access either / or /fog for example.\n\n\t\tfor example if you access fog using http://127.0.0.1/ without any trail\n\t\tset the path to /"
-                        help
+                        usage
                         exit 2
                     fi
                     swebroot="${OPTARG}"
@@ -145,14 +145,14 @@ while getopts "$optspec" o; do
                         fogpriorconfig=$OPTARG
                     else
                         echo "--$OPTARG requires file after"
-                        help
+                        usage
                         exit 3
                     fi
                     ;;
                 backuppath)
                     if [[ ! -d $OPTARG ]]; then
                         echo "Path must be an existing directory"
-                        help
+                        usage
                         exit 4
                     fi
                     sbackupPath=$OPTARG
@@ -160,7 +160,7 @@ while getopts "$optspec" o; do
                 startrange)
                     if [[ $(validip $OPTARG) != 0 ]]; then
                         echo "Invalid ip passed"
-                        help
+                        usage
                         exit 5
                     fi
                     sstartrange=$OPTARG
@@ -170,7 +170,7 @@ while getopts "$optspec" o; do
                 endrange)
                     if [[ $(validip $OPTARG) != 0 ]]; then
                         echo "Invalid ip passed"
-                        help
+                        usage
                         exit 6
                     fi
                     sendrange=$OPTARG
@@ -195,14 +195,14 @@ while getopts "$optspec" o; do
                 *)
                     if [[ $OPTERR == 1 && ${optspec:0:1} != : ]]; then
                         echo "Unknown option: --${OPTARG}"
-                        help
+                        usage
                         exit 7
                     fi
                     ;;
             esac
             ;;
         h|'?')
-            help
+            usage
             exit 0
             ;;
         o)
@@ -248,7 +248,7 @@ while getopts "$optspec" o; do
         W)
             if [[ $OPTARG != *('/')* ]]; then
                 echo -e "-$OPTARG needs a url path for access either / or /fog for example.\n\n\t\tfor example if you access fog using http://127.0.0.1/ without any trail\n\t\tset the path to /"
-                help
+                usage
                 exit 2
             fi
             swebroot=$OPTARG
@@ -258,7 +258,7 @@ while getopts "$optspec" o; do
         f)
             if [[ ! -f $OPTARG ]]; then
                 echo "-$OPTARG requires a file to follow"
-                help
+                usage
                 exit 3
             fi
             fogpriorconfig=$OPTARG
@@ -266,7 +266,7 @@ while getopts "$optspec" o; do
         B)
             if [[ ! -d $OPTARG ]]; then
                 echo "Path must be an existing directory"
-                help
+                usage
                 exit 4
             fi
             sbackupPath=$OPTARG
@@ -274,7 +274,7 @@ while getopts "$optspec" o; do
         s)
             if [[ $(validip $OPTARG) != 0 ]]; then
                 echo "Invalid ip passed"
-                help
+                usage
                 exit 5
             fi
             sstartrange=$OPTARG
@@ -284,7 +284,7 @@ while getopts "$optspec" o; do
         e)
             if [[ $(validip $OPTARG) != 0 ]]; then
                 echo "Invalid ip passed"
-                help
+                usage
                 exit 6
             fi
             sendrange=$OPTARG
@@ -309,20 +309,20 @@ while getopts "$optspec" o; do
         N)
             if [[ -z $OPTARG ]]; then
                 echo "Please specify a database name"
-                help
+                usage
                 exit 4
             fi
             smysqldbname=$OPTARG
             ;;
         :)
             echo "Option -$OPTARG requires a value"
-            help
+            usage
             exit 8
             ;;
         *)
             if [[ $OPTERR == 1 && ${optspec:0:1} != : ]]; then
                 echo "Unknown option: -$OPTARG"
-                help
+                usage
                 exit 7
             fi
             ;;

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -28,9 +28,9 @@
 [[ -z $nfsservice ]] && nfsservice="nfs-server nfs-kernel-server nfs"
 [[ -z $sqlclientlist ]] && sqlclientlist="mariadb-client mariadb MariaDB-client mysql"
 [[ -z $sqlserverlist ]] && sqlserverlist="mariadb-galera-server mariadb-server MariaDB-Galera-server MariaDB-server mysql-server"
-command -v systemctl >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+command -v systemctl >>$error_log 2>&1
 exitcode=$?
-ps -p 1 -o comm= | grep systemd >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+ps -p 1 -o comm= | grep systemd >>$error_log 2>&1
 bootcode=$?
 [[ $exitcode -eq 0 && $bootcode -eq 0 && -z $systemctl ]] && systemctl="yes"
 if [[ $systemctl == yes ]]; then
@@ -51,13 +51,13 @@ if [[ $systemctl == yes ]]; then
             ;;
     esac
     if [[ -e $initdpath/mariadb.service ]]; then
-        ln -s $initdpath/{mariadb,mysql}.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-        ln -s $initdpath/{mariadb,mysqld}.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-        ln -s $initdpath/mariadb /etc/systemd/system/mysql.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-        ln -s $initdpath/mariadb /etc/systemd/system/mysqld.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+        ln -s $initdpath/{mariadb,mysql}.service >>$error_log 2>&1
+        ln -s $initdpath/{mariadb,mysqld}.service >>$error_log 2>&1
+        ln -s $initdpath/mariadb /etc/systemd/system/mysql.service >>$error_log 2>&1
+        ln -s $initdpath/mariadb /etc/systemd/system/mysqld.service >>$error_log 2>&1
     elif [[ -e $initdpath/mysqld.service ]]; then
-        ln -s $initdpath/mysql{d,}.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
-        ln -s $initdpath/mysqld.service /etc/systemd/system/mysql.service >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+        ln -s $initdpath/mysql{d,}.service >>$error_log 2>&1
+        ln -s $initdpath/mysqld.service /etc/systemd/system/mysql.service >>$error_log 2>&1
     fi
 else
     initdpath="/etc/init.d"

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -42,8 +42,8 @@ if [[ $systemctl == yes ]]; then
     initdSHfullname="FOGSnapinHash.service"
     initdPHfullname="FOGPingHosts.service"
     initdISfullname="FOGImageSize.service"
-    case $linuxReleaseName in
-        *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Bb][Ii][Aa][Nn]*|*[Mm][Ii][Nn][Tt]*)
+    case $linuxReleaseName_lower in
+        *ubuntu*|*bian*|*mint*)
             initdpath="/lib/systemd/system"
             ;;
         *)
@@ -68,8 +68,8 @@ else
     initdSHfullname="FOGSnapinHash"
     initdPHfullname="FOGPingHosts"
     initdISfullname="FOGImageSize"
-    case $linuxReleaseName in
-        *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Bb][Ii][Aa][Nn]*|*[Mm][Ii][Nn][Tt]*)
+    case $linuxReleaseName_lower in
+        *ubuntu*|*bian*|*mint*)
             initdsrc="../packages/init.d/ubuntu"
             ;;
         *)

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -670,8 +670,8 @@ installPackages() {
             packages="${packages// mod_fastcgi/}"
             packages="${packages// mod_evasive/}"
             packages="${packages// php-mcrypt/}"
-            case $linuxReleaseName in
-                *[Ff][Ee][Dd][Oo][Rr][Aa]*)
+            case $linuxReleaseName_lower in
+                *fedora*)
                     packages="$packages php-json"
                     packages="${packages// mysql / mariadb }" >>$error_log 2>&1
                     packages="${packages// mysql-server / mariadb-server }" >>$error_log 2>&1
@@ -717,12 +717,12 @@ installPackages() {
                     packages="$packages language-pack-${i}";
                 done
             fi
-            case $linuxReleaseName in
-                *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*)
+            case $linuxReleaseName_lower in
+                *ubuntu*|*mint*)
                     if [[ $OSVersion -gt 17 ]]; then
                         packages="${packages// libcurl3 / libcurl4 }">>$error_log 2>&1
                     fi
-                    if [[ $linuxReleaseName == +(*[Uu][Bb][Uu][Nn][Tt][Uu]*) && $OSVersion -ge 18 ]]; then
+                    if [[ $linuxReleaseName_lower == +(*ubuntu*) && $OSVersion -ge 18 ]]; then
                         # Fix missing universe section for Ubuntu 18.04 LIVE
                         LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8' add-apt-repository -y universe >>$error_log 2>&1
                         # check to see if we still have packages from deb.sury.org (a.k.a ondrej) installed and try to clean it up
@@ -742,7 +742,7 @@ installPackages() {
                         addOndrejRepo
                     fi
                     ;;
-                *[Bb][Ii][Aa][Nn]*)
+                *bian*)
                     if [[ $OSVersion -ge 10 ]]; then
                         packages="${packages// libcurl3 / libcurl4 }">>$error_log 2>&1
                         packages="${packages// mysql-client / mariadb-client }">>$error_log 2>&1
@@ -760,7 +760,7 @@ installPackages() {
     dots "Preparing Package Manager"
     $packmanUpdate >>$error_log 2>&1
     if [[ $osid -eq 2 ]]; then
-        if [[ $? != 0 ]] && [[ $linuxReleaseName == +(*[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*) ]]; then
+        if [[ $? != 0 ]] && [[ $linuxReleaseName_lower == +(*ubuntu*|*mint*) ]]; then
             cp /etc/apt/sources.list /etc/apt/sources.list.original_fog_$(date +%s)
             sed -i -e 's/\/\/*archive.ubuntu.com\|\/\/*security.ubuntu.com/\/\/old-releases.ubuntu.com/g' /etc/apt/sources.list
             $packmanUpdate >>$error_log 2>&1
@@ -1116,8 +1116,8 @@ enableInitScript() {
                         dots "Enabling $serviceItem Service"
                         sysv-rc-conf $serviceItem off >>$error_log 2>&1
                         sysv-rc-conf $serviceItem on >>$error_log 2>&1
-                        case $linuxReleaseName in
-                            *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*)
+                        case $linuxReleaseName_lower in
+                            *ubuntu*|*mint*)
                                 /usr/lib/insserv/insserv -r $initdpath/$serviceItem >>$error_log 2>&1
                                 /usr/lib/insserv/insserv -d $initdpath/$serviceItem >>$error_log 2>&1
                                 ;;
@@ -2460,8 +2460,8 @@ downloadfiles() {
     cd $cwd
 }
 configureDHCP() {
-    case $linuxReleaseName in
-        *[Dd][Ee][Bb][Ii][Aa][Nn]*)
+    case $linuxReleaseName_lower in
+        *debian*)
             if [[ $bldhcp -eq 1 ]]; then
                 dots "Setting up and starting DHCP Server (incl. debian 9 fix)"
                 sed -i.fog "s/INTERFACESv4=\"\"/INTERFACESv4=\"$interface\"/g" /etc/default/isc-dhcp-server

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -14,11 +14,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 if [[ $guessdefaults == 1 ]]; then
-    case $linuxReleaseName in
-        *[Ff][Ee][Dd][Oo][Rr][Aa]*|*[Rr][Ee][Dd][Hh][Aa][Tt]*|*[Cc][Ee][Nn][Tt][Oo][Ss]*|*[Mm][Aa][Gg][Ee][Ii][Aa]*)
+    case $linuxReleaseName_lower in
+        *fedora*|*red*hat*|*centos*|*mageia*)
             strSuggestedOS=1
             ;;
-        *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Bb][Ii][Aa][Nn]*|*[Mm][Ii][Nn][Tt]*)
+        *ubuntu*|*bian*|*mint*)
             strSuggestedOS=2
             ;;
         *[Aa][Rr][Cc][Hh]*)

--- a/lib/redhat/config.sh
+++ b/lib/redhat/config.sh
@@ -17,8 +17,8 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 [[ -z $packageQuery ]] && packageQuery="rpm -q \$x"
-case $linuxReleaseName in
-    *[Mm][Aa][Gg][Ee][Ii][Aa]*)
+case $linuxReleaseName_lower in
+    *mageia*)
         [[ -z $packages ]] && packages="apache apache-mod_fcgid apache-mod_php apache-mod_ssl cdrkit-genisoimage curl dhcp-server gcc gcc-c++ git gzip htmldoc lftp m4 make mariadb mariadb-common mariadb-common-core mariadb-core net-tools nfs-utils perl perl-Crypt-PasswdMD5 php-cli php-curl php-fpm php-gd php-gettext php-ldap php-mbstring php-mysqlnd php-pcntl php-pdo php-pdo_mysql tar tftp-server vsftpd wget"
         [[ -z $packageinstaller ]] && packageinstaller="urpmi --auto"
         [[ -z $packagelist ]] && packagelist="urpmq"

--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -18,7 +18,7 @@
 #
 [[ -z $repo ]] && repo="php"
 [[ -z $packageQuery ]] && packageQuery="dpkg -l \$x | grep '^ii'"
-if [[ $linuxReleaseName == +(*[Bb][Ii][Aa][Nn]*) ]]; then
+if [[ $linuxReleaseName_lower == +(*bian*) ]]; then
     sysvrcconf="sysv-rc-conf"
     phpgettext="php-gettext"
     case $OSVersion in
@@ -46,7 +46,7 @@ if [[ $linuxReleaseName == +(*[Bb][Ii][Aa][Nn]*) ]]; then
         [[ $? -ne 0 ]] && echo "Failed" || echo "Done"
         apt-get clean -yq >/dev/null 2>&1
     fi
-elif [[ $linuxReleaseName == +(*[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*) ]]; then
+elif [[ $linuxReleaseName_lower == +(*ubuntu*|*mint*) ]]; then
     DEBIAN_FRONTEND=noninteractive apt-get purge -yq sysv-rc-conf >/dev/null 2>&1
     phpgettext="php-gettext"
     case $OSVersion in
@@ -119,8 +119,8 @@ fi
 [[ -z $phpfpm ]] && phpfpm="php${php_ver}-fpm"
 [[ -z $phpldap ]] && phpldap="php${php_ver}-ldap"
 [[ -z $phpcmd ]] && phpcmd="php"
-case $linuxReleaseName in
-    *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Bb][Ii][Aa][Nn]*|*[Mm][Ii][Nn][Tt]*)
+case $linuxReleaseName_lower in
+    *ubuntu*|*bian*|*mint*)
         if [[ -z $packages ]]; then
             x="mysql-server"
             eval $packageQuery >>$error_log 2>&1

--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -78,7 +78,7 @@ elif [[ $linuxReleaseName == +(*[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Mm][Ii][Nn][Tt]*) ]]
             sysvrcconf="sysv-rc-conf"
             php_ver="7.1"
             x="*php5* *php-5*"
-            eval $packageQuery >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+            eval $packageQuery >>$error_log 2>&1
             if [[ $? -ne 0 ]]; then
                 if [[ $autoaccept != yes ]]; then
                     echo " *** Detected a potential need to reinstall apache and php files."
@@ -123,7 +123,7 @@ case $linuxReleaseName in
     *[Uu][Bb][Uu][Nn][Tt][Uu]*|*[Bb][Ii][Aa][Nn]*|*[Mm][Ii][Nn][Tt]*)
         if [[ -z $packages ]]; then
             x="mysql-server"
-            eval $packageQuery >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+            eval $packageQuery >>$error_log 2>&1
             [[ $? -eq 0 ]] && db_packages="mysql-client mysql-server" || db_packages="mariadb-client mariadb-server"
             packages="apache2 build-essential cpp curl g++ gawk gcc genisoimage git gzip htmldoc isc-dhcp-server isolinux lftp libapache2-mod-fastcgi libapache2-mod-php${php_ver} libc6 libcurl3 liblzma-dev m4 ${db_packages} net-tools nfs-kernel-server openssh-server $phpfpm php-gettext php${php_ver} php${php_ver}-cli php${php_ver}-curl php${php_ver}-gd php${php_ver}-json $phpldap php${php_ver}-mysql php${php_ver}-mysqlnd ${sysvrcconf} tar tftpd-hpa tftp-hpa vsftpd wget zlib1g"
         else


### PR DESCRIPTION
Hello, these are rather simplistic changes, but seeing as this is more of a first commit, I think that's expected. 

The first set of changes is largely just find and replacing the string:
`${workingdir}/error_logs/fog_error_${version}.log` with `$error_log`
Simple, and perhaps silly, but I think it makes a readability difference.

Second, I checked the behavior of `lsb_release` and found that a considerable amount of usage of `awk` wasn't necessary,
Adding `-s` to the options used when retrieving individual attributes gives us an output without a header, which allows us to just directly set the variables.

I changed the function named `help()` to `usage()` which is similarly small, but bash has a built-in called `help`, and it's consistent with the `FOGBackup.sh`

Third, and final of the changes is moving a blanket failure case to the top, which is a test case on the result of `uname -s`. The only distinction between the behavior before and after this change is that 

Sorry that these aren't more substantive changes, but I'm making an earnest attempt to get a real commit in. 
