### PR TITLE
Add kernel version reporting

### DIFF
--- a/utils/reporting/report.sh
+++ b/utils/reporting/report.sh
@@ -1,20 +1,54 @@
 #!/bin/bash
 
+
 # Get the OS Information.
 read -r os_name os_version <<< $(lsb_release -ir | cut -d':' -f2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr '\n' ' ')
+
 
 # Get the FOG Version.
 source /opt/fog/.fogsettings
 system_class_php=${docroot}/${webroot}/lib/fog/system.class.php
 fog_version=$(cat ${system_class_php} | grep FOG_VERSION | cut -d',' -f2 | cut -d"'" -f2)
 
+
+# Get kernel information.
+## Begin building the JSON array to send.
+kernel_versions_info='['
+## Loop over all files where fog kernels are normally stored.
+for filename in ${docroot}/${webroot}/service/ipxe/*; do
+    # Get the absolute paths of each file, for cleaner handling.
+    absolute_path=$(readlink -f ${filename})
+    # Get file information about each file.
+    file_information=$(file --no-pad --brief $absolute_path)
+    # Check if "Linux kernel" is a substring in the file information or not.
+    if [[ "${file_information}" == *"Linux kernel"* ]]; then
+        # Here, we are pretty sure the current file we're looking at is a Linux kernel. Parse the version information.
+        version=$(echo ${file_information} | cut -d, -f2 | sed 's/version*//' | xargs)
+        # If there are any double quotes in this version information, add a backslash in front of them for JSON escaping.
+        version=$(echo $version | sed 's/"/\\"/g')
+        # Wrap the version in double quotes for JSON syntax.
+        version="\"${version}\""
+        # Check if the last character in the kernel_versions_info variable is a double quote. If so, add a leading comma.
+        if [[ "${kernel_versions_info: -1}" == '"' ]]; then
+            version=",${version}"
+        fi
+        # Append version to kernel_versions_info JSON list.
+        kernel_versions_info="${kernel_versions_info}${version}"
+    fi
+done
+# Finish JSON list formatting.
+kernel_versions_info="${kernel_versions_info}]"
+
+
 # Format payload.
-payload='{"fog_version":"'${fog_version}'","os_name":"'${os_name}'","os_version":"'${os_version}'"}'
+payload='{"fog_version":"'${fog_version}'","os_name":"'${os_name}'","os_version":"'${os_version}'","kernel_versions_info":'${kernel_versions_info}'}'
 
 #echo "os_name=${os_name}"
 #echo "os_version=${os_version}"
 #echo "fog_version=${fog_version}"
+#echo "kernel_versions_info=${kernel_versions_info}"
 #echo "payload=${payload}"
+
 
 # Send to reporting endpoint.
 curl -s -X POST -H "Content-Type: application/json" -d "${payload}" https://fog-external-reporting-entries.theworkmans.us:/api/records


### PR DESCRIPTION
FOG Forums thread about this PR: https://forums.fogproject.org/topic/16172/feedback-requested-adding-kernel-info-to-fog-reporting

This adds kernel version reporting to the FOG Reporting system.

## Payload

Sample payload from a test system is below. Only the version information for "Linux kernel" files is returned, and nothing else.

```
{
    "fog_version":"1.5.9.139",
    "os_name":"Debian",
    "os_version":"11",
    "kernel_versions_info":[
        "5.15.19 (buildkite-agent@Tollana) #1 SMP Thu Feb 3 15:10:05 CST 2022",
        "5.15.19 (buildkite-agent@Tollana) #1 SMP Thu Feb 3 15:05:47 CST 2022",
        "2.6.13.1 (mdv@localhost) #1 Tue Sep 13 18:18:41 CST 2005",
        "MEMDISK 3.86 2010-04-01"
    ]
}
```

## How I plan to incorporate the kernel info

I’ll need to add another table to the database (no big deal) with an autonumber column, datetime column, and a version varchar column of 255 length. Any version info over 255 characters would just get chopped. FOG’s kernel version info string is about 68 characters, fyi.

With those three columns, I’ll be able to count the occurrences of each unique kernel version within the last 7 days, and produce graphs to report that much like the other graphs already being made.