### PR TITLE
added -y flag for dnf check-update

### DIFF
--- a/lib/redhat/config.sh
+++ b/lib/redhat/config.sh
@@ -45,7 +45,7 @@ case $linuxReleaseName in
             [[ -z $packageinstaller ]] && packageinstaller="dnf -y install"
             [[ -z $packagelist ]] && packagelist="dnf list"
             [[ -z $packageupdater ]] && packageupdater="dnf -y update"
-            [[ -z $packageUpdate ]] && packmanUpdate="dnf check-update"
+            [[ -z $packageUpdate ]] && packmanUpdate="dnf -y check-update"
             [[ -z $repoenable ]] && repoenable="dnf config-manager --set-enabled"
         else
             [[ -z $packageinstaller ]] && packageinstaller="yum -y install"


### PR DESCRIPTION
Hello,

I noticed a missing `-y` flag when running `dnf check-update` in the install script. Without this flag you cannot use the auto approve flag like  `./installfog.sh -y` on a fresh OS install due to having to accept the GPG key for the Remi repo.

This flag is present in the similar command `yum -y check-update` so I suspect this was just a miss when adding support for DNF unless there's some difference between the yum and dnf versions of this command I'm not aware of.