### PR TITLE
Use array_values() in call_user_func_array to comply with PHP 8

### DIFF
--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -121,7 +121,7 @@ class LDAP extends FOGController
         if (!in_array($func, $nonresourcefuncs)) {
             array_unshift($args, self::$_ldapconn);
         }
-        $ret = call_user_func_array($function, $args);
+        $ret = call_user_func_array($function, array_values($args));
         return $ret;
     }
     /**

--- a/packages/web/lib/router/altorouter.class.php
+++ b/packages/web/lib/router/altorouter.class.php
@@ -142,7 +142,7 @@ class AltoRouter
         // Pass to the map method.
         call_user_func_array(
             array($this, 'map'),
-            $arguments
+            array_values($arguments)
         );
         return $this;
     }
@@ -221,7 +221,7 @@ class AltoRouter
             throw new \Exception($msg);
         }
         foreach ($routes as $route) {
-            call_user_func_array(array($this, 'map'), $route);
+            call_user_func_array(array($this, 'map'), array_values($route));
         }
         return $this;
     }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -348,7 +348,7 @@ class Route extends FOGBase
         ) {
             call_user_func_array(
                 self::$matches['target'],
-                self::$matches['params']
+                array_values(self::$matches['params'])
             );
             return;
         }


### PR DESCRIPTION
The API router doesn't work anymore on PHP 8 [1] because `call_user_func_array` uses the array keys as parameter names [2]. 

The recommended fix is to wrap the parameter array into `array_values()`. 
This is what I did here. 

[1] https://forums.fogproject.org/topic/16370/api-doesn-t-work-in-1-5-9-dev-error-in-route-class-php
[2] https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array

