### PR TITLE
Closes #510

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -549,9 +549,9 @@ while [[ -z $blGo ]]; do
             fi
             if [[ $bldhcp == 0 ]]; then
                 [[ -z $newpackagelist ]] && newpackagelist=""
-                for z in $packages; do
-                    [[ $z != $dhcpname ]] && newpackagelist="$newpackagelist $z"
-                done
+                newpackagelist=( "${packages[@]/$dhcpname}" )
+                newpackagelist=( "${packages[@]/$dhcpd}" )
+                # Additional check for Debian/Ubuntu variants
                 packages="$(echo $newpackagelist)"
             fi
             case $installtype in

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -548,7 +548,6 @@ while [[ -z $blGo ]]; do
             if [[ $bldhcp == 0 ]]; then
                 [[ -z $newpackagelist ]] && newpackagelist=""
                 newpackagelist=( "${packages[@]/$dhcpname}" )
-                # Additional check for Debian/Ubuntu variants
                 packages="$(echo $newpackagelist)"
             fi
             case $installtype in

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -542,15 +542,12 @@ while [[ -z $blGo ]]; do
             checkInternetConnection
             if [[ $ignorehtmldoc -eq 1 ]]; then
                 [[ -z $newpackagelist ]] && newpackagelist=""
-                for z in $packages; do
-                    [[ $z != htmldoc ]] && newpackagelist="$newpackagelist $z"
-                done
+                newpackagelist=( "${packages[@]/$htmldoc}" )
                 packages="$(echo $newpackagelist)"
             fi
             if [[ $bldhcp == 0 ]]; then
                 [[ -z $newpackagelist ]] && newpackagelist=""
                 newpackagelist=( "${packages[@]/$dhcpname}" )
-                newpackagelist=( "${packages[@]/$dhcpd}" )
                 # Additional check for Debian/Ubuntu variants
                 packages="$(echo $newpackagelist)"
             fi

--- a/lib/redhat/config.sh
+++ b/lib/redhat/config.sh
@@ -83,5 +83,5 @@ fi
 [[ -z $dhcpconfigother ]] && dhcpconfigother="/etc/dhcp/dhcpd.conf"
 [[ -z $tftpdirdst ]] && tftpdirdst="/tftpboot"
 [[ -z $ftpconfig ]] && ftpconfig="/etc/vsftpd/vsftpd.conf"
-[[ -z $dhcp ]] && dhcpd="dhcpd"
+[[ -z $dhcpd ]] && dhcpd="dhcpd"
 [[ -z $snapindir ]] && snapindir="/opt/fog/snapins"

--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -74,3 +74,4 @@ fi
 [[ -z $ftpconfig ]] && ftpconfig="/etc/vsftpd.conf"
 [[ -z $snapindir ]] && snapindir="/opt/fog/snapins"
 [[ -z $dhcpd ]] && dhcpd="isc-dhcp-server"
+[[ -z $dhcpname ]] && dhcpname="isc-dhcp-server"


### PR DESCRIPTION
- Tested on fresh Debian Bullseye x64
- Shellchecked for new code (removing `$dhcpname` and `$dhcpd` from `$packages` array)

Install log indicates that `isc-dhcp-server` is NO LONGER being installed. The configuration step is also marked as "Skipped".