### PR TITLE
FIX : Failed to open stream : No such file or directory 

### DIFF
--- a/packages/web/status/bandwidth.php
+++ b/packages/web/status/bandwidth.php
@@ -67,12 +67,14 @@ $interfaces = [];
 // Loop the captured data and set up interfaces
 foreach ($dir_interfaces as &$iface) {
     $operstateFile = "/sys/class/net/$iface/operstate";
-    $content = file_get_contents($operstateFile);
-    $content = trim($content);
-    if ($content !== 'up') {
-        continue;
+    if (file_exists($operstateFile)){
+        $content = file_get_contents($operstateFile);
+        $content = trim($content);
+        if ($content !== 'up') {
+            continue;
+        }
+        $interfaces[] = $iface;
     }
-    $interfaces[] = $iface;
     unset($iface);
 };
 // Check up interfaces to see if our specified device is present


### PR DESCRIPTION
FIX : Failed to open stream : No such file or directory on /sys/class/net/bonding_masters/operstate

```
[Fri Jul 28 19:00:28.798636 2023] [proxy_fcgi:error] [pid 57271] [client 192.168.xx.xx:46878] AH01071: Got error 'PHP message: PHP Warning:  file_get_contents(/sys/class/net/bonding_masters/operstate): Failed to open stream: No such file or directory in /var/www/html/fog/status/bandwidth.php on line 70'
[Fri Jul 28 19:00:30.056885 2023] [proxy_fcgi:error] [pid 113515] [client 192.168.xx.xx:46886] AH01071: Got error 'PHP message: PHP Warning:  file_get_contents(/sys/class/net/bonding_masters/operstate): Failed to open stream: No such file or directory in /var/www/html/fog/status/bandwidth.php on line 70'
[Fri Jul 28 19:00:31.310245 2023] [proxy_fcgi:error] [pid 57268] [client 192.168.xx.xx:46894] AH01071: Got error 'PHP message: PHP Warning:  file_get_contents(/sys/class/net/bonding_masters/operstate): Failed to open stream: No such file or directory in /var/www/html/fog/status/bandwidth.php on line 70'
[Fri Jul 28 19:00:32.570374 2023] [proxy_fcgi:error] [pid 111665] [client 192.168.xx.xx:46896] AH01071: Got error 'PHP message: PHP Warning:  file_get_contents(/sys/class/net/bonding_masters/operstate): Failed to open stream: No such file or directory in /var/www/html/fog/status/bandwidth.php on line 70'

```