### PR TITLE
Add GPU information to host inventory and report (working-1.6)

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4176,3 +4176,8 @@ $this->schema[] = [
     "ALTER TABLE `hosts` ADD COLUMN `hostInfoKey` VARCHAR(255)",
     "ALTER TABLE `hosts` ADD COLUMN `hostInfoLock` BOOLEAN DEFAULT 0"
 ];
+// 292
+$this->schema[] = [
+    "ALTER TABLE `inventory` ADD COLUMN `iGpuvendors` VARCHAR(255) NOT NULL",
+    "ALTER TABLE `inventory` ADD COLUMN `iGpuproducts` VARCHAR(255) NOT NULL"
+];

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -65,7 +65,9 @@ class Inventory extends FOGController
         'caseman' => 'iCaseman',
         'casever' => 'iCasever',
         'caseserial' => 'iCaseserial',
-        'caseasset' => 'iCaseasset'
+        'caseasset' => 'iCaseasset',
+        'gpuvendors' => 'iGpuvendors',
+        'gpuproducts' => 'iGpuproducts'
     ];
     /**
      * The required fields.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,10 +59,10 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2123');
+        define('FOG_VERSION', '1.6.0-beta.2124');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 291);
-        define('FOG_BCACHE_VER', 151);
+        define('FOG_SCHEMA', 292);
+        define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');
     }
 }

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -2961,6 +2961,10 @@ class HostManagement extends FOGPage
         $casever = $Inv->get('caseversion');
         $caseser = $Inv->get('caseserial');
         $caseast = $Inv->get('caseasset');
+        $gpuvendors = $Inv->get('gpuvendors');
+        $gpuproducts = $Inv->get('gpuproducts');
+        $gpuvendorsArray = explode(',', $gpuvendors);
+        $gpuproductsArray = explode(',', $gpuproducts);
 
         $labelClass = 'col-sm-3 control-label';
 
@@ -3481,6 +3485,48 @@ class HostManagement extends FOGPage
                     true
                 )
             ];
+            for ($i = 0; $i < count($gpuvendorsArray); $i++) {
+                $fields[
+                    self::makeLabel(
+                        $labelClass,
+                        'inventory-gpu-vendor-' . $i,
+                        _("GPU-$i Vendor")
+                    )
+                ] = self::makeInput(
+                    'form-control',
+                    'inventory-gpu-vendor-' . $i,
+                    '',
+                    'text',
+                    '',
+                    $gpuvendorsArray[$i],
+                    false,
+                    false,
+                    -1,
+                    -1,
+                    '',
+                    true
+                );
+                $fields[
+                    self::makeLabel(
+                        $labelClass,
+                        'inventory-gpu-product-' . $i,
+                        _("GPU-$i Product")
+                    )
+                ] = self::makeInput(
+                    'form-control',
+                    'inventory-gpu-product-' . $i,
+                    '',
+                    'text',
+                    '',
+                    $gpuproductsArray[$i],
+                    false,
+                    false,
+                    -1,
+                    -1,
+                    '',
+                    true
+                );
+            }
         }
 
         self::$HookManager->processEvent(

--- a/packages/web/lib/reports/inventory_report.report.php
+++ b/packages/web/lib/reports/inventory_report.report.php
@@ -69,6 +69,9 @@ class Inventory_Report extends ReportManagement
             _('Case Version'),
             _('Case Serial'),
             _('Case Asset'),
+            // GPU
+            _('GPU Vendors'),
+            _('GPU Products'),
             // Name of host
             _('Hostname'),
         ];

--- a/packages/web/management/js/fog/report/fog.report.file.js
+++ b/packages/web/management/js/fog/report/fog.report.file.js
@@ -263,8 +263,11 @@
                         {data: 'casever'}, // 24
                         {data: 'caseserial'}, // 25
                         {data: 'caseasset'}, // 26
+                        // GPU
+                        {data: 'gpuvendors'}, // 27
+                        {data: 'gpuproducts'}, // 28
                         // name of host
-                        {data: 'hostname'}, // 27 Not visible
+                        {data: 'hostname'}, // 29 Not visible
                     ],
                     columnDefs: [
                         {targets: [0, 5, 7, 8, 22], visible: true },


### PR DESCRIPTION
These are the changes for working-1.6 to display the GPU information in the hosts page and in inventory reports.