### PR TITLE
#668 access control plugin mass delete infinite loop

### DIFF
--- a/packages/web/lib/plugins/accesscontrol/hooks/accesscontroldeletemassitems.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/accesscontroldeletemassitems.hook.php
@@ -80,14 +80,7 @@ class AccessControlDeleteMassItems extends Hook
                 $arguments['removeItems']['accesscontrolruleassociation'] = [
                     'accesscontrolruleID' => $arguments['itemIDs']
                 ];
-                // no break
-            default:
-                $arguments['removeItems']['accesscontrolassociation'] = [
-                    'accesscontrolID' => $arguments['itemIDs']
-                ];
-                $arguments['removeItems']['accesscontrolruleassociation'] = [
-                    'accesscontrolID' => $arguments['itemIDs']
-                ];
+                break;
         }
     }
 }


### PR DESCRIPTION
Fixes #668 by removing some redundant recursion when deleting access control rules in mass aka from list view.