### PR TITLE
Add a view only description column for mac addresses viewed on the host.

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2161');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '');
+        define('FOG_CHANNEL', '');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -1563,12 +1563,14 @@ class HostManagement extends FOGPage
         );
         $this->headerData = [
             _('MAC Address'),
+            _('Description'),
             _('Primary'),
             _('Ignore Imaging'),
             _('Ignore Client'),
             _('Pending')
         ];
         $this->attributes = [
+            [],
             [],
             ['width' => 16],
             ['width' => 16],

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -219,6 +219,7 @@
         ],
         columns: [
             {data: 'mac'},
+            {data: 'description'},
             {data: 'primary'},
             {data: 'imageIgnore'},
             {data: 'clientIgnore'},
@@ -232,6 +233,13 @@
                     return data;
                 },
                 targets: 0
+            },
+            {
+                responsivePriority: -1,
+                render: function(data, type, row) {
+                    return data;
+                },
+                targets: 1
             },
             {
                 render: function(data, type, row) {
@@ -251,7 +259,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 1
+                targets: 2
             },
             {
                 render: function(data, type, row) {
@@ -270,7 +278,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 2
+                targets: 3
             },
             {
                 render: function(data, type, row) {
@@ -289,7 +297,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 3
+                targets: 4
             },
             {
                 render: function(data, type, row) {
@@ -308,7 +316,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 4
+                targets: 5
             }
         ],
         processing: true,


### PR DESCRIPTION
For users that add mac descriptions via api or database changes, allow those to be viewed in the UI.