### PR TITLE
add mac description column to 1.6

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2161');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '');
+        define('FOG_CHANNEL', '');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '');
-        define('FOG_CHANNEL', '');
+        define('FOG_VERSION', '1.6.0-beta.2163');
+        define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -1563,12 +1563,14 @@ class HostManagement extends FOGPage
         );
         $this->headerData = [
             _('MAC Address'),
+            _('Description'),
             _('Primary'),
             _('Ignore Imaging'),
             _('Ignore Client'),
             _('Pending')
         ];
         $this->attributes = [
+            [],
             [],
             ['width' => 16],
             ['width' => 16],

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -219,6 +219,7 @@
         ],
         columns: [
             {data: 'mac'},
+            {data: 'description'},
             {data: 'primary'},
             {data: 'imageIgnore'},
             {data: 'clientIgnore'},
@@ -232,6 +233,13 @@
                     return data;
                 },
                 targets: 0
+            },
+            {
+                responsivePriority: -1,
+                render: function(data, type, row) {
+                    return data;
+                },
+                targets: 1
             },
             {
                 render: function(data, type, row) {
@@ -251,7 +259,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 1
+                targets: 2
             },
             {
                 render: function(data, type, row) {
@@ -270,7 +278,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 2
+                targets: 3
             },
             {
                 render: function(data, type, row) {
@@ -289,7 +297,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 3
+                targets: 4
             },
             {
                 render: function(data, type, row) {
@@ -308,7 +316,7 @@
                         + '/>'
                         + '</div>';
                 },
-                targets: 4
+                targets: 5
             }
         ],
         processing: true,


### PR DESCRIPTION
The mac description column exists in the database and can be edited via api.
This could later be extended to allow manual editing or the fog client and fos could be extended to grab this information when they add macs in other processes. 

At the moment though, someone could use the FogApi powershell module and run this on each windows host to add descriptions  to the macs of a given computer. 
(Assumes fogapi is already configured/authenticated to the fog server)
```
$fogHost = Get-FogHost
$fogHostMacs = Get-FogHostMacs -hostid $foghost.id;
$fogHostMacs | ForEach-Object {
    $fogmac = $_;
    $netAdapter = Get-NetAdapter -IncludeHidden | Where-Object macaddress -eq $fogmac.mac.replace(":","-");
    if ($Null -ne $netAdapter) {
        $fogMac.description = "$($netAdapter.name) - $($netAdapter.InterfaceDescription)"
        Update-FogObject -type object -coreObject macaddressassociation -jsonData ($fogMac | convertto-json) -IDofObject $fogmac.id
    }
}
```