### PR TITLE
Fix various typos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 Deploy and manage any desktop operating system, anywhere. FOG Project can 
 capture, deploy, and manage Windows, Mac OSX, and various Linux distributions. 
 The community has adopted this security disclosure and response policy to 
-ensure responsibe handle of critical issues.
+ensure responsible handling of critical issues.
 
 ## Supported Versions
 

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -55,7 +55,7 @@ usage() {
     echo -e "\t-d    --no-defaults\t\tDon't guess defaults"
     echo -e "\t-U    --no-upgrade\t\tDon't attempt to upgrade"
     echo -e "\t-H    --no-htmldoc\t\tNo htmldoc, means no PDFs"
-    echo -e "\t-S    --force-https\t\tForce HTTPS for all comunication"
+    echo -e "\t-S    --force-https\t\tForce HTTPS for all communication"
     echo -e "\t-C    --recreate-CA\t\tRecreate the CA Keys"
     echo -e "\t-K    --recreate-keys\t\tRecreate the SSL Keys"
     echo -e "\t-Y -y --autoaccept\t\tAuto accept defaults and install"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1262,11 +1262,11 @@ configureMySql() {
     fi
 
     # If we reach this point it's clear that this install is not setup with
-    # unpriviledged DB users yet and we need to have root DB access now.
+    # unprivileged DB users yet and we need to have root DB access now.
     if [[ $connect_as_root -ne 0 ]]; then
         echo
         echo "   To improve the overall security the installer will create an"
-        echo "   unpriviledged database user account for FOG's database access."
+        echo "   unprivileged database user account for FOG's database access."
         echo "   Please provide the database *root* user password. Be asured"
         echo "   that this password will only be used while the FOG installer"
         echo -n "   is running and won't be stored anywhere: "

--- a/packages/init.d/ubuntu/FOGMulticastManager
+++ b/packages/init.d/ubuntu/FOGMulticastManager
@@ -9,7 +9,7 @@
 # Short-Description: Start/Stop FOGMulticastManager
 # Long-Description: Created by Chuck Syperski
 # Used to stop and start the FOGMulticastManager Service.
-# FOGMulticastManager is used to destribute images through
+# FOGMulticastManager is used to distribute images through
 # Multicast.  Useful to image large amounts of systems simultaneously.
 # It serves this ability only if it's the master node.
 ### END INIT INFO

--- a/packages/systemd/FOGMulticastManager.service
+++ b/packages/systemd/FOGMulticastManager.service
@@ -8,7 +8,7 @@
 # Short-Description: Start/Stop FOGMulticastManager
 # Long-Description: Created by David Fear
 # Used to stop and start the FOGMulticastManager Service.
-# FOGMulticastManager is used to destribute images through
+# FOGMulticastManager is used to distribute images through
 # Multicast.  Useful to image large amounts of systems simultaneously.
 # It serves this ability only if it's the master node.
 ### END INIT INFO

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -4,7 +4,7 @@
  *
  * PHP version 5
  *
- * This file simply is the initator.  It establishes the FOG GUI and system
+ * This file simply is the initiator.  It establishes the FOG GUI and system
  * auto loader functionality.
  *
  * This initiator also creates the sanitization and cleansing needed
@@ -19,7 +19,7 @@
 /**
  * Initiator and FOG Autoloader
  *
- * This file simply is the initator.  It establishes the FOG GUI and system
+ * This file simply is the initiator.  It establishes the FOG GUI and system
  * auto loader functionality.
  *
  * This initiator also creates the sanitization and cleansing needed

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -680,7 +680,7 @@ $this->schema[] = array(
     . "fog host register should be globally active. "
     . "(Valid values are 0 or 1)','1','FOG Client - Host Register'),"
     . "('FOG_CLIENT_PRINTERMANAGER_ENABLED','This setting defines if the "
-    . "fog printer maanger should be globally active. "
+    . "fog printer manager should be globally active. "
     . "(Valid values are 0 or 1)','1','FOG Client - Printer Manager'),"
     . "('FOG_CLIENT_TASKREBOOT_ENABLED','This setting defines if the fog "
     . "task reboot should be globally active. "
@@ -984,7 +984,7 @@ $this->schema[] = array(
     . "fragments that is used to filter out pending mac address requests. "
     . "For example, if you don\'t want to see pending mac address requests "
     . "for VMWare NICs then you could filter by 00:05:69. This filter is "
-    . "comma seperated, and is used like a *starts with* filter.',"
+    . "comma separated, and is used like a *starts with* filter.',"
     . "'','FOG Client - Host Register'),"
     . "('FOG_ADVANCED_STATISTICS','Enable the collection and display of "
     . "advanced statistics. This information WILL be sent to a remote "
@@ -2305,7 +2305,7 @@ $this->schema[] = array(
     . "(`settingKey`, `settingDesc`, `settingValue`, `settingCategory`) "
     . "VALUES "
     . "('FOG_SNAPIN_LIMIT', 'This setting defines the maximum snapins "
-    . "allowed to be assigned to a host. Value of 0 means unlimted.', "
+    . "allowed to be assigned to a host. Value of 0 means unlimited.', "
     . "'0', 'General Settings')",
 );
 // 149
@@ -3688,7 +3688,7 @@ $this->schema[] = array(
     . "(`settingKey`,`settingDesc`,`settingValue`,`settingCategory`) "
     . "VALUES "
     . "('FOG_REAUTH_ON_DELETE',"
-    . "'If deleteing an item, require authentication or not. (Defaults to on)',"
+    . "'If deleting an item, require authentication or not. (Defaults to on)',"
     . "'1','General Settings'),"
     . "('FOG_REAUTH_ON_EXPORT',"
     . "'If exporting, require authentication or not. (Defaults to on)',"

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -40,7 +40,7 @@ abstract class FOGClient extends FOGBase
      * @param bool $encoded         if the data is base64 encoded
      * @param bool $hostnotrequired if the host object is required
      * @param bool $returnmacs      if we should only return macs
-     * @param bool $override        if we are being overriden
+     * @param bool $override        if we are being overridden
      *
      * @return void
      */

--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -186,7 +186,7 @@ class DatabaseManager extends FOGCore
         return self::$DB;
     }
     /**
-     * Get's the schema version as stored in the DB.
+     * Gets the schema version as stored in the DB.
      *
      * @return int
      */

--- a/packages/web/lib/db/mysqldump.class.php
+++ b/packages/web/lib/db/mysqldump.class.php
@@ -1019,7 +1019,7 @@ class CompressBzip2 extends CompressManagerFactory
     public function write($str)
     {
         if (false === ($bytesWritten = bzwrite($this->fileHandler, $str))) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new Exception("Writing to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1057,7 +1057,7 @@ class CompressGzip extends CompressManagerFactory
     public function write($str)
     {
         if (false === ($bytesWritten = gzwrite($this->fileHandler, $str))) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new Exception("Writing to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1088,7 +1088,7 @@ class CompressNone extends CompressManagerFactory
     public function write($str)
     {
         if (false === ($bytesWritten = fwrite($this->fileHandler, $str))) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new Exception("Writing to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -303,7 +303,7 @@ class PDODB extends DatabaseManager
      *
      * @param int    $type      the type of fetching PDO int.
      * @param string $fetchType the type in function calling
-     * @param mixed  $params    any additional parameteres needed.
+     * @param mixed  $params    any additional parameters needed.
      *
      * @throws PDOException
      * @return object
@@ -351,7 +351,7 @@ class PDODB extends DatabaseManager
         return $this;
     }
     /**
-     * Get's the relevante items or item as needed.
+     * Gets the relevante items or item as needed.
      *
      * @param string $field the field to get
      *
@@ -506,7 +506,7 @@ class PDODB extends DatabaseManager
         return self::$_link->quote($data);
     }
     /**
-     * Santizes data passed
+     * Sanitizes data passed
      *
      * @param mixed $data the data to be sanitized
      *

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -351,7 +351,7 @@ class PDODB extends DatabaseManager
         return $this;
     }
     /**
-     * Gets the relevante items or item as needed.
+     * Gets the relevant items or item as needed.
      *
      * @param string $field the field to get
      *

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1420,7 +1420,7 @@ class BootMenu extends FOGBase
         exit;
     }
     /**
-     * Get's a current tasking if any
+     * Gets a current tasking if any
      *
      * @return void
      */

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -73,7 +73,7 @@ class EventManager extends FOGBase
             case 'HookManager':
                 if (!is_array($listener) || count($listener) !== 2) {
                     throw new Exception(
-                        _('Second paramater must be in array(class,function)')
+                        _('Second parameter must be in array(class,function)')
                     );
                 }
                 if (!($listener[0] instanceof Hook)) {
@@ -245,7 +245,7 @@ class EventManager extends FOGBase
             $regext,
             RegexIterator::GET_MATCH
         );
-        // Makes all the returned items into an iteratable array
+        // Makes all the returned items into an iterable array
         $files = iterator_to_array($RegexIterator, false);
         unset(
             $RecursiveDirectoryIterator,

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -198,7 +198,7 @@ abstract class FOGBase
      */
     protected static $FOGPageManager;
     /**
-     * URL Manager | mainly for ajax, and externel getters.
+     * URL Manager | mainly for ajax, and external getters.
      *
      * @var object
      */
@@ -487,7 +487,7 @@ abstract class FOGBase
         return $class;
     }
     /**
-     * Get's the relevant host item.
+     * Gets the relevant host item.
      *
      * @param bool $service         Is this a service request
      * @param bool $encoded         Is this data encoded
@@ -609,7 +609,7 @@ abstract class FOGBase
         return;
     }
     /**
-     * Get's blamed nodes for failures.
+     * Gets blamed nodes for failures.
      *
      * @param Host $Host The host to work with.
      *
@@ -1808,7 +1808,7 @@ abstract class FOGBase
      * Prints the data encrypted as needed.
      *
      * @param string $datatosend the data to send
-     * @param bool   $service    if not a service simpy return
+     * @param bool   $service    if not a service simply return
      * @param array  $array      The non-encoded array data.
      *
      * @return string

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -761,7 +761,7 @@ abstract class FOGController extends FOGBase
         return $this;
     }
     /**
-     * Get's the relevant common key if available.
+     * Gets the relevant common key if available.
      *
      * @param string|array $key the key to get commonized
      *
@@ -1047,7 +1047,7 @@ abstract class FOGController extends FOGBase
      *
      * @param string $assocItem    the assoc item to work from/with
      * @param string $alterItem    the alternate item to work with
-     * @param bool   $implicitCall call class implicitely instead of appending
+     * @param bool   $implicitCall call class implicitly instead of appending
      *                             with association
      *
      * @return object

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -196,7 +196,7 @@ class FOGCron extends FOGBase
      * @param mixed $value     The value to check
      * @param int   $min       The minimum the value can be
      * @param int   $max       The maximum the value can be
-     * @param bool  $extremity Implicitly test extremeties
+     * @param bool  $extremity Implicitly test extremities
      *
      * @return bool
      */

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2013,7 +2013,7 @@ abstract class FOGPage extends FOGBase
         echo '</div>';
         echo '<div class="panel-body">';
         if ($node == 'image') {
-            echo '<div id="deleteHint"><b>Hint: Be aware that deleting image(s) this way won\'t actually remove the data files from your server to prevent from accidential data loss. If you want the image data files removed as well you need to use the "Delete" tab found in the settings of each image.</b></div><div>&nbsp;</div>';
+            echo '<div id="deleteHint"><b>Hint: Be aware that deleting image(s) this way won\'t actually remove the data files from your server to prevent from accidental data loss. If you want the image data files removed as well you need to use the "Delete" tab found in the settings of each image.</b></div><div>&nbsp;</div>';
         }
         echo '<div id="deleteDiv"></div>';
         echo '<form class="form-horizontal" action="'
@@ -2484,7 +2484,7 @@ abstract class FOGPage extends FOGBase
         unset($this->data);
     }
     /**
-     * Get's the adinformation from ajax
+     * Gets the adinformation from ajax
      *
      * @return void
      */

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -48,7 +48,7 @@ class FOGPageManager extends FOGBase
     /**
      * Replaces the variable passed with nicer names
      *
-     * @param string $value the valu
+     * @param string $value the value
      *
      * @return string
      */

--- a/packages/web/lib/fog/fogsubmenu.class.php
+++ b/packages/web/lib/fog/fogsubmenu.class.php
@@ -112,7 +112,7 @@ class FOGSubMenu extends FOGBase
      */
     public $items = array();
     /**
-     * Stores main itesm.
+     * Stores main items.
      *
      * @var array
      */

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -1708,7 +1708,7 @@ class Host extends FOGController
      *
      * @param string $mac the mac to add
      *
-     * @return obect
+     * @return object
      */
     public function addPendMAC($mac)
     {
@@ -2059,7 +2059,7 @@ class Host extends FOGController
      * @param string $ou         the ou to bind to
      * @param string $user       the user to perform join with
      * @param string $pass       the pass to perform join with
-     * @param bool   $override   should the host fields override whats passed
+     * @param bool   $override   should the host fields override what's passed
      * @param bool   $nosave     should we save automatically
      * @param string $legacy     the legacy client ad pass string
      * @param string $productKey the product key for the host to activate

--- a/packages/web/lib/fog/multicastsession.class.php
+++ b/packages/web/lib/fog/multicastsession.class.php
@@ -78,7 +78,7 @@ class MulticastSession extends FOGController
         )
     );
     /**
-     * Get's the session's associated image object.
+     * Gets the session's associated image object.
      *
      * @return object
      */
@@ -87,7 +87,7 @@ class MulticastSession extends FOGController
         return new Image($this->get('image'));
     }
     /**
-     * Get's the session's task state.
+     * Gets the session's task state.
      *
      * @return object
      */

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -294,7 +294,7 @@ class Plugin extends FOGController
         return $this;
     }
     /**
-     * Get's the plugin manager class or plugin's manager class as needed.
+     * Gets the plugin manager class or plugin's manager class as needed.
      *
      * @return object
      */
@@ -314,7 +314,7 @@ class Plugin extends FOGController
         return new $classManager();
     }
     /**
-     * Get's the plugin path.
+     * Gets the plugin path.
      *
      * @return string
      */
@@ -323,7 +323,7 @@ class Plugin extends FOGController
         return $this->_strPath;
     }
     /**
-     * Get's the plugin run point.
+     * Gets the plugin run point.
      *
      * @return string
      */
@@ -332,7 +332,7 @@ class Plugin extends FOGController
         return $this->_strEntryPoint;
     }
     /**
-     * Get's the plugin's icon.
+     * Gets the plugin's icon.
      *
      * @return string
      */
@@ -341,7 +341,7 @@ class Plugin extends FOGController
         return $this->_strIcon;
     }
     /**
-     * Get's the installed status of the plugin.
+     * Gets the installed status of the plugin.
      *
      * @return bool
      */
@@ -352,7 +352,7 @@ class Plugin extends FOGController
         return (bool) $this->_blIsInstalled;
     }
     /**
-     * Get's the active status of the plugin.
+     * Gets the active status of the plugin.
      *
      * @return bool
      */
@@ -363,7 +363,7 @@ class Plugin extends FOGController
         return (bool) $this->_blIsActive;
     }
     /**
-     * Get's the plugin's version.
+     * Gets the plugin's version.
      *
      * @return bool
      */

--- a/packages/web/lib/fog/scheduledtask.class.php
+++ b/packages/web/lib/fog/scheduledtask.class.php
@@ -93,7 +93,7 @@ class ScheduledTask extends FOGController
         return new Image($this->get('imageID'));
     }
     /**
-     * Gets the timer (specific to cron really.
+     * Gets the timer (specific to cron really).
      *
      * @return object.
      */

--- a/packages/web/lib/fog/scheduledtask.class.php
+++ b/packages/web/lib/fog/scheduledtask.class.php
@@ -93,7 +93,7 @@ class ScheduledTask extends FOGController
         return new Image($this->get('imageID'));
     }
     /**
-     * Get's the timer (specific to cron really.
+     * Gets the timer (specific to cron really.
      *
      * @return object.
      */

--- a/packages/web/lib/fog/snapinassociation.class.php
+++ b/packages/web/lib/fog/snapinassociation.class.php
@@ -47,7 +47,7 @@ class SnapinAssociation extends FOGController
         'snapinID',
     );
     /**
-     * Get's the host object.
+     * Gets the host object.
      *
      * @return object
      */
@@ -56,7 +56,7 @@ class SnapinAssociation extends FOGController
         return new Host($this->get('hostID'));
     }
     /**
-     * Get's the snapin object.
+     * Gets the snapin object.
      *
      * @return object
      */

--- a/packages/web/lib/fog/snapingroupassociation.class.php
+++ b/packages/web/lib/fog/snapingroupassociation.class.php
@@ -39,7 +39,7 @@ class SnapinGroupAssociation extends FOGController
         'primary' => 'sgaPrimary',
     );
     /**
-     * The required fiedls
+     * The required fields
      *
      * @var array
      */
@@ -74,7 +74,7 @@ class SnapinGroupAssociation extends FOGController
         )
     );
     /**
-     * Get's the snapin object
+     * Gets the snapin object
      *
      * @return object
      */
@@ -83,7 +83,7 @@ class SnapinGroupAssociation extends FOGController
         return $this->get('snapin');
     }
     /**
-     * Get's the associated storage group.
+     * Gets the associated storage group.
      *
      * @return object
      */

--- a/packages/web/lib/fog/snapintask.class.php
+++ b/packages/web/lib/fog/snapintask.class.php
@@ -111,7 +111,7 @@ class SnapinTask extends FOGController
         return $this->getManager()->cancel($this->get('id'));
     }
     /**
-     * Get's the state object.
+     * Gets the state object.
      *
      * @return object
      */

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -189,7 +189,7 @@ class StorageGroup extends FOGController
         );
     }
     /**
-     * Get's the groups master storage node
+     * Gets the groups master storage node
      *
      * @return object
      */
@@ -230,7 +230,7 @@ class StorageGroup extends FOGController
         return new StorageNode($masternode);
     }
     /**
-     * Get's the optimal storage node
+     * Gets the optimal storage node
      *
      * @return object
      */

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -192,7 +192,7 @@ class StorageNode extends FOGController
         $this->set('logfiles', (array)$paths);
     }
     /**
-     * Get's the storage node snapins, logfiles, and images
+     * Gets the storage node snapins, logfiles, and images
      * in a single multi call rather than three individual calls.
      *
      * @return array

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -102,7 +102,7 @@ class TaskState extends FOGController
         return $checkedInState;
     }
     /**
-     * Gets the literal progres state.
+     * Gets the literal progress state.
      *
      * @return int
      */

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -86,7 +86,7 @@ class BootItem extends Hook
     public function tweakmenu($arguments)
     {
         /**
-         * This is How the menu gets displayed:
+         * This is how the menu gets displayed:
          * 'ipxe' 'head' key's followed by the item.
          */
         if ($arguments['ipxe']['head']) {

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -86,7 +86,7 @@ class BootItem extends Hook
     public function tweakmenu($arguments)
     {
         /**
-         * This is How the menu get's displayed:
+         * This is How the menu gets displayed:
          * 'ipxe' 'head' key's followed by the item.
          */
         if ($arguments['ipxe']['head']) {
@@ -145,7 +145,7 @@ class BootItem extends Hook
                 = 'item --gap -- -------------------------------------';
         }
         /**
-         * The next subset of informations is about the item labels.
+         * The next subset of information is about the item labels.
          * This is pulled from the db so some common values may be like:
          * item-<label-name>  so fog.local has item value of: item-fog.local
          * inside of the item label is an arrayed item of value [0] containing

--- a/packages/web/lib/pages/clientmanagementpage.class.php
+++ b/packages/web/lib/pages/clientmanagementpage.class.php
@@ -76,7 +76,7 @@ class ClientManagementPage extends FOGPage
         );
         // Dash boxes row.
         echo '<div class="row">';
-        // New Client and utilties
+        // New Client and utilities
         echo '<div class="col-xs-4">';
         echo '<div class="panel panel-info">';
         echo '<div class="panel-heading text-center">';

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -191,7 +191,7 @@ class FOGConfigurationPage extends FOGPage
         echo '<div class="panel panel-info">';
         echo '<div class="panel-heading text-center">';
         echo '<h4 class="title">';
-        echo _('GNU Gneral Public License');
+        echo _('GNU General Public License');
         echo '</h4>';
         echo '</div>';
         echo '<div class="panel-body text-justify">';
@@ -201,7 +201,7 @@ class FOGConfigurationPage extends FOGPage
         echo '</div>';
     }
     /**
-     * Returns HTML formated output from kernel/initrd list array.
+     * Returns HTML formatted output from kernel/initrd list array.
      *
      * @param array $kernelOrInitData kernel/initrd list array
      * @param string $type 'kernel' or 'initrd'

--- a/packages/web/lib/pages/groupmanagementpage.class.php
+++ b/packages/web/lib/pages/groupmanagementpage.class.php
@@ -144,7 +144,7 @@ class GroupManagementPage extends FOGPage
         );
         $this->_getHostCommon();
         /**
-         * Lamda function to return data either by list or search.
+         * Lambda function to return data either by list or search.
          *
          * @param object $Group the object to use.
          *

--- a/packages/web/lib/pages/imagemanagementpage.class.php
+++ b/packages/web/lib/pages/imagemanagementpage.class.php
@@ -237,7 +237,7 @@ class ImageManagementPage extends FOGPage
             array('class' => 'col-xs-1')
         );
         /**
-         * Lamda function to return data either by list or search.
+         * Lambda function to return data either by list or search.
          *
          * @param object $Image the object to use.
          *
@@ -774,7 +774,7 @@ class ImageManagementPage extends FOGPage
         exit;
     }
     /**
-     * Diplay image general information.
+     * Display image general information.
      *
      * @return void
      */
@@ -1657,7 +1657,7 @@ class ImageManagementPage extends FOGPage
         echo '</div>';
     }
     /**
-     * Submit the mutlicast form.
+     * Submit the multicast form.
      *
      * @return void
      */
@@ -1756,7 +1756,7 @@ class ImageManagementPage extends FOGPage
         );
     }
     /**
-     * Stops/Cancels the mutlicast session(s).
+     * Stops/Cancels the multicast session(s).
      *
      * @return void
      */

--- a/packages/web/lib/pages/printermanagementpage.class.php
+++ b/packages/web/lib/pages/printermanagementpage.class.php
@@ -123,7 +123,7 @@ class PrinterManagementPage extends FOGPage
             array()
         );
         /**
-         * Lamda function to return data either by list or search.
+         * Lambda function to return data either by list or search.
          *
          * @param object $Image the object to use.
          *

--- a/packages/web/lib/pages/reportmanagementpage.class.php
+++ b/packages/web/lib/pages/reportmanagementpage.class.php
@@ -247,7 +247,7 @@ class ReportManagementPage extends FOGPage
         echo '</h4>';
         echo '</div>';
         echo '<div class="panel-body">';
-        echo _('This section allows you to uploade user')
+        echo _('This section allows you to upload user')
             . ' '
             . _('defined reports that may not be a part of')
             . ' '

--- a/packages/web/lib/pages/schemaupdaterpage.class.php
+++ b/packages/web/lib/pages/schemaupdaterpage.class.php
@@ -22,7 +22,7 @@
 class SchemaUpdaterPage extends FOGPage
 {
     /**
-     * The relavent calling node url
+     * The relevant calling node url
      *
      * @var string
      */

--- a/packages/web/lib/pages/serverinfo.class.php
+++ b/packages/web/lib/pages/serverinfo.class.php
@@ -91,7 +91,7 @@ class ServerInfo extends FOGPage
         $ret = self::$FOGURLRequests->process($url);
         $ret = trim($ret[0]);
         if (!$ret) {
-            echo _('Unable to get server infromation!');
+            echo _('Unable to get server information!');
             echo '</div>';
             echo '</div>';
             echo '</div>';

--- a/packages/web/lib/pages/snapinmanagementpage.class.php
+++ b/packages/web/lib/pages/snapinmanagementpage.class.php
@@ -211,7 +211,7 @@ class SnapinManagementPage extends FOGPage
             array()
         );
         /**
-         * Lamda function to return data either by list or search.
+         * Lambda function to return data either by list or search.
          *
          * @param object $Snapin the object to use.
          *
@@ -393,7 +393,7 @@ class SnapinManagementPage extends FOGPage
             $this->templates
         );
         /**
-         * Title of inital/general element.
+         * Title of initial/general element.
          */
         $this->title = _('New Snapin');
         /**

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -277,7 +277,7 @@ class StorageManagementPage extends FOGPage
         );
     }
     /**
-     * Display createing a new storage node.
+     * Display creating a new storage node.
      *
      * @return void
      */

--- a/packages/web/lib/pages/taskmanagementpage.class.php
+++ b/packages/web/lib/pages/taskmanagementpage.class.php
@@ -125,7 +125,7 @@ class TaskManagementPage extends FOGPage
             ),
         );
         /**
-         * Lamda function to return data either by list or search.
+         * Lambda function to return data either by list or search.
          *
          * @param object $Image the object to use.
          *

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -188,7 +188,7 @@ class LDAP extends FOGController
         $out = array();
         /**
          * Loop the parsed information so we get
-         * the values in a mroe usable and joinable form.
+         * the values in a more usable and joinable form.
          */
         foreach ((array)$parser as $key => &$value) {
             if (false !== strstr($value, '=')) {
@@ -589,7 +589,7 @@ class LDAP extends FOGController
         return $accessLevel;
     }
     /**
-     * Get's the access level
+     * Gets the access level
      *
      * @param string $grpMemAttr the group finder item
      * @param string $userDN     the user dn information

--- a/packages/web/lib/plugins/location/hooks/addlocationhost.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationhost.hook.php
@@ -438,7 +438,7 @@ class AddLocationHost extends Hook
         );
     }
     /**
-     * Adds lcoation to host register.
+     * Adds location to host register.
      *
      * @param mixed $arguments The arguments to change.
      *

--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -237,7 +237,7 @@ class Site extends FOGController
      *
      * @param string $assocItem    the assoc item to work from/with
      * @param string $alterItem    the alternate item to work with
-     * @param bool   $implicitCall call class implicitely instead of appending
+     * @param bool   $implicitCall call class implicitly instead of appending
      *                             with association
      *
      * @return object

--- a/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
@@ -363,7 +363,7 @@ class AddSiteHost extends Hook
      *
      * @param mixed $arguments The arguments to change.
      *
-     * @retrun void
+     * @return void
      */
     public function hostImport($arguments)
     {

--- a/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
+++ b/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
@@ -398,7 +398,7 @@ class SiteManagementPage extends FOGPage
                     )
                 ) {
                     throw new Exception(
-                        _('A site alread exists with this name!')
+                        _('A site already exists with this name!')
                     );
                 }
                 $this->obj

--- a/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
+++ b/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
@@ -460,7 +460,7 @@ class SubnetgroupManagementPage extends FOGPage
             throw new Exception(
                 _('Please enter a valid CIDR subnet.')
                 . ' '
-                . _('Can be a comma seperated list.')
+                . _('Can be a comma separated list.')
             );
         }
         $subnets = preg_replace('/\s+/', '', $subnets);

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1096,7 +1096,7 @@ class Route extends FOGBase
         }
     }
     /**
-     * Get's the json body and sets our vars.
+     * Gets the json body and sets our vars.
      *
      * @param string $class The class to get vars for/from.
      *
@@ -1124,7 +1124,7 @@ class Route extends FOGBase
         return $find;
     }
     /**
-     * Get's current/active tasks.
+     * Gets current/active tasks.
      *
      * @param string $class The class to use.
      *
@@ -1235,7 +1235,7 @@ class Route extends FOGBase
     }
     /**
      * This is a commonizing element so list/search/getinfo
-     * will operate in the same fasion.
+     * will operate in the same fashion.
      *
      * @param string $classname The name of the class.
      * @param object $class     The class to work with.

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -93,7 +93,7 @@ abstract class FOGService extends FOGBase
         }
     }
     /**
-     * Checks if the node runnning this is indeed the master
+     * Checks if the node running this is indeed the master
      *
      * @return array
      */
@@ -231,7 +231,7 @@ abstract class FOGService extends FOGBase
         return;
     }
     /**
-     * Get's the current datetime
+     * Gets the current datetime
      *
      * @return string
      */
@@ -997,7 +997,7 @@ abstract class FOGService extends FOGBase
     /**
      * Gets the pid of the running reference
      *
-     * @param resouce $procRef the reference to check
+     * @param resource $procRef the reference to check
      *
      * @return int
      */

--- a/packages/web/management/js/fog/fog.dashboard.js
+++ b/packages/web/management/js/fog/fog.dashboard.js
@@ -508,7 +508,7 @@ function setupBandwidth() {
         // Fetches our data.
         function fetchData() {
 
-            // When ajax recieves data, this updates the graph.
+            // When ajax receives data, this updates the graph.
             function onDataReceived(series) {
 
                 // Setup our Time elements.
@@ -519,7 +519,7 @@ function setupBandwidth() {
                 // all of our data.
                 $.each(series, function(index, value) {
 
-                    // If the data hasn't been initilized yet, initialize it.
+                    // If the data hasn't been initialized yet, initialize it.
                     if (typeof GraphBandwidthData[index] == 'undefined') {
                         GraphBandwidthData[index] = {};
                         GraphBandwidthData[index].tx = [];
@@ -539,7 +539,7 @@ function setupBandwidth() {
                     // seconds, shift off the array.
                     //
                     // In the past it was just the length of the store, which was
-                    // rather inaccurate. As the data recieved might have taken longer
+                    // rather inaccurate. As the data received might have taken longer
                     // to store, you could end up with a 2 minute time spanning over 4-5
                     // minutes. Imagine how this would play out for 5 minutes, 10 minutes,
                     // 30 minutes, or an hour.

--- a/packages/web/management/js/fog/fog.js
+++ b/packages/web/management/js/fog/fog.js
@@ -508,7 +508,7 @@ $.fn.fogVariable = function(opts) {
     });
     /**
      * If we don't have a hash such as when initially entering
-     * an edit pge, display the first item.
+     * an edit page, display the first item.
      */
     if ($('.tab-content').length > 0) {
         if (location.hash == "") {

--- a/packages/web/management/js/fog/fog.js
+++ b/packages/web/management/js/fog/fog.js
@@ -508,7 +508,7 @@ $.fn.fogVariable = function(opts) {
     });
     /**
      * If we don't have a hash such as when initially entering
-     * an edit pge, dispaly the first item.
+     * an edit pge, display the first item.
      */
     if ($('.tab-content').length > 0) {
         if (location.hash == "") {

--- a/packages/web/service/blame.php
+++ b/packages/web/service/blame.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sets the blame of a storage node thats problematic.
+ * Sets the blame of a storage node that's problematic.
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Sets the blame of a storage node thats problematic.
+ * Sets the blame of a storage node that's problematic.
  *
  * @category Blame
  * @package  FOGProject

--- a/packages/web/service/ipxe/refind.conf
+++ b/packages/web/service/ipxe/refind.conf
@@ -103,7 +103,7 @@ timeout -1
 #font myfont.png
 
 # Use text mode only. When enabled, this option forces rEFInd into text mode.
-# Passing this option a "0" value causes graphics mode to be used. Pasing
+# Passing this option a "0" value causes graphics mode to be used. Passing
 # it no value or any non-0 value causes text mode to be used.
 # Default is to use graphics mode.
 #

--- a/packages/web/service/usercleanup-users.php
+++ b/packages/web/service/usercleanup-users.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Cleans up users only good for Windows XP
+ * Cleans up users; only good for Windows XP
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Cleans up users only good for Windows XP
+ * Cleans up users; only good for Windows XP
  *
  * @category Usercleanup_Users
  * @package  FOGProject

--- a/packages/web/service/usercleanup-users.php
+++ b/packages/web/service/usercleanup-users.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Cleans up users ony good for Windows XP
+ * Cleans up users only good for Windows XP
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Cleans up users ony good for Windows XP
+ * Cleans up users only good for Windows XP
  *
  * @category Usercleanup_Users
  * @package  FOGProject

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Get's files stored as requested
+ * Gets files stored as requested
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Get's files stored as requested
+ * Gets files stored as requested
  *
  * PHP version 5
  *

--- a/packages/web/status/gethash.php
+++ b/packages/web/status/gethash.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Get's hash of file passed.
+ * Gets hash of file passed.
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Get's hash of file passed.
+ * Gets hash of file passed.
  *
  * PHP version 5
  *

--- a/packages/web/status/getsize.php
+++ b/packages/web/status/getsize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Get's size of file passed.
+ * Gets size of file passed.
  *
  * PHP version 5
  *
@@ -11,7 +11,7 @@
  * @link     https://fogproject.org
  */
 /**
- * Get's size of file passed.
+ * Gets size of file passed.
  *
  * PHP version 5
  *


### PR DESCRIPTION
Fixes user-facing and non-user-facing typos.
Found via `codespell -q 3 -S "*.svg,*.min.js,*.min.css.map,./Release Notes.MD,./packages/web/management/languages" -L arry,checkin,datas,incase,indx,infront,onlyonce,parms,serie,startd`