### PR TITLE
fix object operator (site plugin)

### DIFF
--- a/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
@@ -435,7 +435,7 @@ class AddSiteHost extends Hook
      */
     public function hostDestroy($arguments)
     {
-        if (!in_array($this-node, (array)self::$pluginsinstalled)) {
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
             return;
         }
         self::getClass('SiteHostAssociationManager')->destroy(


### PR DESCRIPTION
I found this error on site plugin, it prevents a host from being completely deleted. 

Although the host is no longer displayed in the user interface (probably because the associated MAC addresses have been deleted), the orphaned record still exists in the host table, which prevents the hostname from being reused on another host. 

This only happens when the site plugin is installed.