### PR TITLE
Fix tftp error

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -585,7 +585,7 @@ configureTFTPandPXE() {
                 fi
                 echo -e "[Unit]\nDescription=Tftp Server\nRequires=fog-tftp.socket\nDocumentation=man:in.tftpd\n\n[Service]\nExecStart=/usr/sbin/in.tftpd ${tftpAdvOpts:+$tftpAdvOpts }-s ${tftpdirdst}\nStandardInput=socket\n\n[Install]\nAlso=fog-tftp.socket" > /etc/systemd/system/fog-tftp.service
                 diffconfig "/etc/systemd/system/fog-tftp.service"
-                cp -v /usr/lib/systemd/system/tftp.socket /etc/systemd/system/fog-tftp.socket >>$error_log 2>&1
+                find /usr/lib/systemd/system -maxdepth 1 \( -name "tftp.socket" -o -name "tftpd.socket" \) -exec cp -v {} /etc/systemd/system/fog-tftp.socket \; -quit >>$error_log 2>&1
                 systemctl daemon-reload
                 systemctl is-enabled --quiet fog-tftp.socket && true || systemctl enable fog-tftp.socket >>$error_log 2>&1
                 systemctl is-active --quiet fog-tftp.socket && systemctl stop fog-tftp.socket >>$error_log 2>&1 || true


### PR DESCRIPTION
An error occurs when setting up TFTP server:
```
cp: cannot stat '/usr/lib/systemd/system/tftp.socket': No such file or directory
Failed to enable unit: Unit fog-tftp.socket does not exist
Failed to start fog-tftp.socket: Unit fog-tftp.socket not found.
Unit fog-tftp.socket could not be found.
```
Some distros, such as Arch Linux, no longer use the name `tftp.socket`, but `tftpd.socket` instead.

```
pacman -Ql tftp-hpa | grep socket
tftp-hpa /usr/lib/systemd/system/tftpd.socket
```