### PR TITLE
Add libcurl4t64 support for Debian 13 (Trixie)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -757,6 +757,9 @@ installPackages() {
                         packages="${packages// mysql-client / mariadb-client }">>$error_log 2>&1
                         packages="${packages// mysql-server / mariadb-server }">>$error_log 2>&1
                     fi
+                    if [[ $OSVersion -ge 13 ]]; then
+                        packages="${packages// libcurl4 / libcurl4t64 }"
+                    fi
                     ;;
             esac
             ;;


### PR DESCRIPTION
Debian 13 (Trixie) renamed the libcurl4 package to libcurl4t64, but the FOG installer still checks for libcurl4, causing installation to fail.

This change adds a version check for OS >= 13 and replaces libcurl4 with libcurl4t64 in the package list, similar to how it's already handled for Ubuntu 22.04+.

Fixes installation on Debian 13.