### PR TITLE
fix Queue problems when deploying

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '');
-        define('FOG_CHANNEL', '');
+        define('FOG_VERSION', '691.0-beta.2175');
+        define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2173');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '');
+        define('FOG_CHANNEL', '');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '691.0-beta.2175');
+        define('FOG_VERSION', '691.0-beta.2176');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 293);
         define('FOG_BCACHE_VER', 152);

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -128,7 +128,7 @@ class Task extends TaskType
      */
     public function getInFrontOfHostCount()
     {
-        $count = -1; // -1 because we don't count ourselves
+        $count = -1; // -1 because we don't count ourselves as in front of us in the queue
         $curTime = self::niceDate();
         $MyCheckinTime = self::niceDate($this->get('checkInTime'));
         $myLastCheckin = $curTime->getTimestamp() - $MyCheckinTime->getTimestamp();

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -128,7 +128,7 @@ class Task extends TaskType
      */
     public function getInFrontOfHostCount()
     {
-        $count = 0;
+        $count = -1; // -1 because we don't count ourselves
         $curTime = self::niceDate();
         $MyCheckinTime = self::niceDate($this->get('checkInTime'));
         $myLastCheckin = $curTime->getTimestamp() - $MyCheckinTime->getTimestamp();

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -38,7 +38,7 @@ class TaskQueue extends TaskingElement
             )->set(
                 'checkInTime',
                 self::formatTime('now', 'Y-m-d H:i:s')
-            );
+            )->save();
             // $this->Task
             //     ->set('stateID', self::getCheckedInState())
             //     ->set('checkInTime', self::formatTime('now', 'Y-m-d H:i:s'))
@@ -144,7 +144,7 @@ class TaskQueue extends TaskingElement
                         );
                         throw new Exception($msg);
                     }
-                    if ($groupOpenSlots <= $inFront) {
+                    if ($groupOpenSlots < $inFront) {
                         $msg = sprintf(
                             '%s, %s %d %s.',
                             _('There are open slots'),


### PR DESCRIPTION
Fixes #691 for 1.6 by making sure count of tasks in front of a task don't include itself.