### PR TITLE
Fix Queue problems when deploying

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1673');
+        define('FOG_VERSION', '1.5.10.1676');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -127,7 +127,7 @@ class Task extends TaskType
      */
     public function getInFrontOfHostCount()
     {
-        $count = 0;
+        $count = -1; // -1 because we don't count ourselves as in front of us in the queue
         $curTime = self::niceDate();
         $MyCheckinTime = self::niceDate($this->get('checkInTime'));
         $myLastCheckin = $curTime->getTimestamp() - $MyCheckinTime->getTimestamp();

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -41,7 +41,7 @@ class TaskQueue extends TaskingElement
             )->set(
                 'checkInTime',
                 self::formatTime('now', 'Y-m-d H:i:s')
-            );
+            )->save();
             if (!$this->Task->save()) {
                 throw new Exception(_('Failed to update task'));
             }
@@ -157,7 +157,7 @@ class TaskQueue extends TaskingElement
                         );
                         throw new Exception($msg);
                     }
-                    if ($groupOpenSlots <= $inFront) {
+                    if ($groupOpenSlots < $inFront) {
                         $msg = sprintf(
                             '%s, %s %d %s.',
                             _('There are open slots'),


### PR DESCRIPTION
Fixes #691 make sure we don't count the task itself in the imaging queue. Should prevent miscounts in task queue so that all storage node slots get used in all scenarios