### PR TITLE
hostgetkey store token before save in db and return

### DIFF
--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -36,15 +36,16 @@ try {
         throw new Exception(_('Host token is currently in use'));
     }
     if (!FOGCore::$Host->get('token')) {
+        $newToken = FOGCore::createSecToken();
         FOGCore::getClass('HostManager')->update(
             ['id' => FOGCore::$Host->get('id')],
             '',
             [
-                'token' => FOGCore::createSecToken(),
+                'token' => $newToken,
                 'tokenlock' => true
             ]
         );
-        throw new Exception(FOGCore::$Host->get('token'));
+        throw new Exception($newToken);
     }
     if (FOGCore::$Host->isValid() && !FOGCore::$Host->get('tokenlock')) {
         FOGCore::getClass('HostManager')->update(


### PR DESCRIPTION
I encountered an issue when trying to pull tasks using `fog/service/hostinfo.php`.

In some cases, `fog/status/hostgetkey.php` generates a new token, saves it to the database, but returns an empty string as the token value.
I believe this happens due to a race condition between storing the token in the database and retrieving it for returning.

This change generates the new token before updating the database and reuses it for both the DB update and the return value.
This ensures the function always returns the correct token.