### PR TITLE
Minor grammar fix for multi-select delete.

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1907,7 +1907,7 @@ abstract class FOGPage extends FOGBase
         global $sub;
         global $node;
         $this->title = sprintf(
-            "%s's to remove",
+            "%ss to remove",
             (
                 $this->childClass !== 'Storage' ?
                 $this->childClass :

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1733');
+        define('FOG_VERSION', '1.5.10.1734');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');


### PR DESCRIPTION
This change resolves my only long-term frustration with Fog, the fact that the grammar on the multi-select delete page's title uses a possessive apostrophe where it shouldn't.