### PR TITLE
Update functions.sh for Debian Trixie installation - PHP 8.4

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -845,7 +845,7 @@ installPackages() {
                 done
                 ;;
             php-mysql*)
-                for phpmysql in $(echo php-mysqlnd php-mysql); do
+                for phpmysql in $(echo php-mysql); do
                     eval $packagelist "$phpmysql" >>$error_log 2>&1
                     if [[ $? -eq 0 ]]; then
                         x=$phpmysql


### PR DESCRIPTION
php-mysqlnd removed because it is starting with PHP 8.1 only a virtual package. It is included in php-mysql.