### PR TITLE
Fix Power Management "Perform Immediately" bug.

### DIFF
--- a/packages/web/lib/fog/powermanagement.class.php
+++ b/packages/web/lib/fog/powermanagement.class.php
@@ -110,6 +110,13 @@ class PowerManagement extends FOGController
      */
     public function save()
     {
+        if ($this->get('pmOndemand') == '1') {
+			$this->set('pmMin', date('i'));
+			$this->set('pmHour', date('H'));
+			$this->set('pmDom', date('d'));
+			$this->set('pmMonth', date('m'));
+			$this->set('pmDow', date('w'));
+		}
         parent::save();
         return $this
             ->assocSetter('PowerManagement', 'host', true)


### PR DESCRIPTION
When pmOndemand=1, the backend still requires pmMin/pmHour/etc. This patch populates time fields before save(), preventing "Required database field is empty: min".

Tested on FOG 1.5.x with shutdown and reboot tasks.