### PR TITLE
Change input sanitization to use FILTER_SANITIZE_SPECIAL_CHARS

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -22,7 +22,7 @@ class Initiator
         if (!self::$sanitizeItems) {
             self::$sanitizeItems = function (&$val, $key) {
                 if (is_string($val)) {
-                    $val = filter_var($val, FILTER_SANITIZE_STRING);
+                    $val = filter_var($val, FILTER_SANITIZE_SPECIAL_CHARS);
                 }
                 if (is_array($val)) {
                     array_walk($val, self::$sanitizeItems);
@@ -49,7 +49,7 @@ class Initiator
         ]);
 
         self::setSanitize();
-        $useragent = filter_input(INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_STRING);
+        $useragent = filter_input(INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_SPECIAL_CHARS);
         define('DS', DIRECTORY_SEPARATOR);
         define('BASEPATH', self::_determineBasePath());
 


### PR DESCRIPTION
Fix error in PHP error log on PHP 8.3:

```
PHP Deprecated: Constant FILTER_SANITIZE_STRING is deprecated
```