### PR TITLE
Refactor host validation and save logic

### DIFF
--- a/packages/web/lib/client/registerclient.class.php
+++ b/packages/web/lib/client/registerclient.class.php
@@ -70,6 +70,7 @@ class RegisterClient extends FOGClient implements FOGClientSend
                 'Host',
                 array('name' => $hostname)
             )->load('name');
+            // Host is INVALID or Host IS pending
             if (!(self::$Host->isValid() && !self::$Host->get('pending'))) {
                 if (!self::getClass('Host')->isHostnameSafe($hostname)) {
                     if (!self::$json) {
@@ -85,6 +86,7 @@ class RegisterClient extends FOGClient implements FOGClientSend
                         'description',
                         _('Pending Registration created by FOG_CLIENT')
                     )
+                    ->set('imageID', 0)
                     ->set('pending', (string)1)
                     ->set('enforce', (string)$enforce)
                     ->set(
@@ -96,7 +98,8 @@ class RegisterClient extends FOGClient implements FOGClientSend
                     )
                     ->addPriMAC($PriMAC)
                     ->addAddMAC($MACs);
-                if (!self::$Host->save()) {
+                self::$Host->save();
+                if (!self::$Host->isValid()) {
                     return array('error' => 'db');
                 }
                 return array('complete' => true);


### PR DESCRIPTION
This PR fixes an issue where **FOG Client automatic host registration fails silently** when creating a new pending host (Closes #779).

The failure happens because the database schema defines ``hosts.hostImage`` as ``NOT NULL``, but the auto-registration code attempts to insert ``NULL`` when no image is assigned. As a result, the ``INSERT ... ON DUPLICATE KEY UPDATE`` statement is rejected by MySQL, causing ``Host::save()`` to return without throwing an exception.

## Root Cause

- During auto-registration, hosts are created in a **pending** state.
- No image is assigned at this stage.
- ORM generates:

```sql
hostImage = NULL
```

- Database rejects the insert:

```sql
INSERT INTO `hosts` (`hostName`,`hostDesc`,`hostIP`,`hostImage`,`hostBuilding`,`hostCreateDate`,`hostLastDeploy`,`hostCreateBy`,`hostUseAD`,`hostADDomain`,`hostADOU`,`hostADUser`,`hostADPass`,`hostADPassLegacy`,`hostProductKey`,`hostPrinterLevel`,`hostKernelArgs`,`hostKernel`,`hostDevice`,`hostInit`,`hostPending`,`hostPubKey`,`hostSecToken`,`hostSecTime`,`hostPingCode`,`hostExitBios`,`hostExitEfi`,`hostEnforce`,`hostInfoKey`,`hostInfoLock`) VALUES ('EXAMPLE-18','Pending Registration created by FOG_CLIENT','',NULL,'','2026-02-12 22:36:53','','fog','','','','','','','','','','','','','1','','','','','','','1','','') ON DUPLICATE KEY UPDATE `hostName`=VALUES(`hostName`),`hostDesc`=VALUES(`hostDesc`),`hostIP`=VALUES(`hostIP`),`hostImage`=VALUES(`hostImage`),`hostBuilding`=VALUES(`hostBuilding`),`hostCreateDate`=VALUES(`hostCreateDate`),`hostLastDeploy`=VALUES(`hostLastDeploy`),`hostCreateBy`=VALUES(`hostCreateBy`),`hostUseAD`=VALUES(`hostUseAD`),`hostADDomain`=VALUES(`hostADDomain`),`hostADOU`=VALUES(`hostADOU`),`hostADUser`=VALUES(`hostADUser`),`hostADPass`=VALUES(`hostADPass`),`hostADPassLegacy`=VALUES(`hostADPassLegacy`),`hostProductKey`=VALUES(`hostProductKey`),`hostPrinterLevel`=VALUES(`hostPrinterLevel`),`hostKernelArgs`=VALUES(`hostKernelArgs`),`hostKernel`=VALUES(`hostKernel`),`hostDevice`=VALUES(`hostDevice`),`hostInit`=VALUES(`hostInit`),`hostPending`=VALUES(`hostPending`),`hostPubKey`=VALUES(`hostPubKey`),`hostSecToken`=VALUES(`hostSecToken`),`hostSecTime`=VALUES(`hostSecTime`),`hostPingCode`=VALUES(`hostPingCode`),`hostExitBios`=VALUES(`hostExitBios`),`hostExitEfi`=VALUES(`hostExitEfi`),`hostEnforce`=VALUES(`hostEnforce`),`hostInfoKey`=VALUES(`hostInfoKey`),`hostInfoLock`=VALUES(`hostInfoLock`);
ERROR 1048 (23000): Column 'hostImage' cannot be null
```

- The failure is silent, and the host is never created, even though MACs may still be registered.

## Solution

This PR explicitly sets the host image to ``0`` (No Image) during automatic host creation:

```php
->set('imageID', 0)
```

This issue can be difficult to diagnose because it fails without throwing an exception. Adding the explicit ``imageID = 0`` ensures predictable behavior and aligns auto-registration with existing FOG semantics, where ``0`` represents //no assigned image//, and fully satisfies the database constraint.