### PR TITLE
Fix case of searchDN property in LDAP management

### DIFF
--- a/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
@@ -111,7 +111,7 @@ class LDAPManagementPage extends FOGPage
                 'name' => $LDAP->name,
                 'description' => $LDAP->description,
                 'address' => $LDAP->address,
-                'searchDN' => $LDAP->SearchDN,
+                'searchDN' => $LDAP->searchDN,
                 'port' => $LDAP->port,
                 'userNamAttr' => $LDAP->userNamAttr,
                 'grpMemberAttr' => $LDAP->grpMemberAttr,


### PR DESCRIPTION
Fix PHP error on LDAP Auth:

```
[25-Feb-2026 22:49:16 UTC] PHP Warning:  Undefined property: stdClass::$SearchDN in /var/www/fog/lib/plugins/ldap/pages/ldapmanagementpage.class.php on line 114
```