### PR TITLE
Remove hardcoded ftp port for storage node availability check

### DIFF
--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -148,7 +148,7 @@ class StorageNode extends FOGController
      */
     public function loadOnline()
     {
-        $test = self::$FOGURLRequests->isAvailable($this->get('ip'), '0.1', 21);
+        $test = self::$FOGURLRequests->isAvailable($this->get('ip'), '1');
         $this->set('online', array_shift($test));
     }
     /**


### PR DESCRIPTION
- Fixed a bug introduced in a previous version where port 21 was hardcoded for FTP and use the custom configured FTP port instead.
- Revert to a slightly longer timeout used previously to avoid premature check failures.

This PR is to fix a minor UI bug where storage node disk usage chart used port 21 (hardcoded value) 
<img width="320" height="131" alt="image" src="https://github.com/user-attachments/assets/da06dcfc-d734-4fff-ab04-49b572af3331" />

Whereas the bandwidth graph used our custom ftp port
<img width="85" height="98" alt="image" src="https://github.com/user-attachments/assets/0e33118e-bd49-4544-9535-98e78117ba46" />

I think the bug started somewhere along this version release
https://github.com/FOGProject/fogproject/compare/1.5.10.1698...1.5.10.1721