### PR TITLE
Persistent Groups Manager does not auto create snapin tasks, only assigns the snapins.

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -20,15 +20,22 @@ class Initiator
     private static function setSanitize(): void
     {
         if (!self::$sanitizeItems) {
-            self::$sanitizeItems = function (&$val, $key) {
-                if (is_string($val)) {
-                    $val = filter_var($val, FILTER_SANITIZE_SPECIAL_CHARS);
-                }
+            self::$sanitizeItems = function (&$val, $key): void {
                 if (is_array($val)) {
                     array_walk($val, self::$sanitizeItems);
+                    return;
+                }
+
+                if (is_string($val)) {
+                    $val = trim(str_replace("\0", '', $val));
                 }
             };
         }
+    }
+
+    public static function e(mixed $value): string
+    {
+        return htmlspecialchars((string)($value ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
     public function __construct()

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -378,9 +378,9 @@ abstract class FOGBase
             }
             printf(
                 '<option value="%s"%s>%s</option>',
-                $value,
+                Initiator::e($value),
                 (self::$selected == $value ? ' selected' : ''),
-                $option
+                Initiator::e($option)
             );
         };
         /**

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -302,9 +302,9 @@ class FOGCron extends FOGBase
         ob_start();
         foreach ($specialCrons as $val => &$name) {
             echo '<option value="'
-                . $val
+                . Initiator::e($val)
                 . '">'
-                . $name
+                . Initiator::e($name)
                 . '</option>';
             unset($name);
         }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -963,7 +963,7 @@ abstract class FOGManagerController extends FOGBase
         $id = 0,
         $idField = 'name'
     ) {
-        $idSpecField = 'name';
+        $idSpecField = 'id';
         if (empty($id)) {
             $id = 0;
         }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -910,7 +910,7 @@ abstract class FOGManagerController extends FOGBase
             }
             printf(
                 '<option value="%s"%s>%s</option>',
-                $Object->get('id'),
+                Initiator::e($Object->get('id')),
                 (
                     $matchID == $Object->get('id') ?
                     ' selected' :
@@ -920,11 +920,11 @@ abstract class FOGManagerController extends FOGBase
                         ''
                     )
                 ),
-                sprintf(
+                Initiator::e(sprintf(
                     '%s - (%d)',
                     $Object->get('name'),
                     $Object->get('id')
-                )
+                ))
             );
             unset($Object);
         }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -963,6 +963,7 @@ abstract class FOGManagerController extends FOGBase
         $id = 0,
         $idField = 'name'
     ) {
+        $idSpecField = 'name';
         if (empty($id)) {
             $id = 0;
         }
@@ -973,6 +974,10 @@ abstract class FOGManagerController extends FOGBase
             $idField => $val,
             'id' => $id,
         );
+
+        if (!in_array($idSpecField, array_keys($this->databaseFields))) {
+            $idSpecField = 'id';
+        }
         $query = sprintf(
             $this->existsQueryTemplate,
             $this->databaseTable,
@@ -982,7 +987,7 @@ abstract class FOGManagerController extends FOGBase
             $this->databaseFields[$idField],
             sprintf(':%s', $idField),
             $this->databaseTable,
-            $this->databaseFields[$idField],
+            $this->databaseFields[$idSpecField],
             ':id'
         );
 

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -975,9 +975,6 @@ abstract class FOGManagerController extends FOGBase
             'id' => $id,
         );
 
-        if (!in_array($idSpecField, array_keys($this->databaseFields))) {
-            $idSpecField = 'id';
-        }
         $query = sprintf(
             $this->existsQueryTemplate,
             $this->databaseTable,

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -967,7 +967,7 @@ abstract class FOGPage extends FOGBase
                 $name
             );
             $val = trim($val);
-            $this->dataReplace[] = Intiator::e($val);
+            $this->dataReplace[] = Initiator::e($val);
             unset($val);
         }
     }

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -738,7 +738,7 @@ abstract class FOGPage extends FOGBase
                     $actionbox .= '</label>';
                     $actionbox .= '<div class="col-xs-8">';
                     $actionbox .= '<input type="hidden" name="'
-                        . strtolower($node)
+                        . Initiator::e(strtolower($node))
                         . 'IDArray"/>';
                     $actionbox .= '<button type="submit" class='
                         . '"btn btn-danger btn-block" id="'
@@ -1108,11 +1108,11 @@ abstract class FOGPage extends FOGBase
             $snapins = $snapins->snapins;
             foreach ((array)$snapins as &$Snapin) {
                 echo '<option value="'
-                    . $Snapin->id
+                    . Initiator::e($Snapin->id)
                     . '">';
-                echo $Snapin->name;
+                echo Initiator::e($Snapin->name);
                 echo ' - (';
-                echo $Snapin->id;
+                echo Initiator::e($Snapin->id);
                 echo ')';
                 echo '</option>';
                 unset($Snapin);
@@ -1135,11 +1135,11 @@ abstract class FOGPage extends FOGBase
             $snapins = $snapins->snapins;
             foreach ((array)$snapins as &$Snapin) {
                 echo '<option value="'
-                    . $Snapin->id
+                    . Initiator::e($Snapin->id)
                     . '">';
-                echo $Snapin->name;
+                echo Initiator::e($Snapin->name);
                 echo ' - (';
-                echo $Snapin->id;
+                echo Initiator::e($Snapin->id);
                 echo ')';
                 echo '</option>';
                 unset($Snapin);
@@ -1364,9 +1364,9 @@ abstract class FOGPage extends FOGBase
             ob_start();
             foreach ($specialCrons as $val => &$name) {
                 echo '<option value="'
-                    . $val
+                    . Initiator::e($val)
                     . '">'
-                    . $name
+                    . Initiator::e($name)
                     . '</option>';
                 unset($name);
             }
@@ -1985,7 +1985,7 @@ abstract class FOGPage extends FOGBase
             }
             $this->data[] = array(
                 'field' => '<input type="hidden" value="'
-                . $object->id
+                . Initiator::e($object->id)
                 . '" name="remitems[]"/>',
                 'input' => '<a href="?node='
                 . $node
@@ -2297,13 +2297,13 @@ abstract class FOGPage extends FOGBase
                 }
                 printf(
                     '<option value="%s"%s>%s</option>',
-                    $ou,
+                    Initiator::e($ou),
                     (
                         $optFound === $ou ?
                         ' selected' :
                         ''
                     ),
-                    $ou
+                    Initiator::e($ou)
                 );
             }
             $OUOptions = sprintf(
@@ -2315,7 +2315,7 @@ abstract class FOGPage extends FOGBase
             $OUOptions = sprintf(
                 '<input id="adOU" class="form-control" type="text" name='
                 . '"ou" value="%s" autocomplete="off"/>',
-                $ADOU
+                Initiator::e($ADOU)
             );
         }
         $fields = array(
@@ -2344,7 +2344,7 @@ abstract class FOGPage extends FOGBase
                 . '<input id="adDomain" class="form-control" type="text" '
                 . 'name="domainname" value="%s" autocomplete="off"/>'
                 . '</div>',
-                $ADDomain
+                Initiator::e($ADDomain)
             ),
             sprintf(
                 '<label for="adOU">%s'
@@ -2361,7 +2361,7 @@ abstract class FOGPage extends FOGBase
                 . '<input id="adUsername" class="form-control" type="text" '
                 . 'name="domainuser" value="%s" autocomplete="off"/>'
                 . '</div>',
-                $ADUser
+                Initiator::e($ADUser)
             ),
             sprintf(
                 '<label for="adPassword">%s'
@@ -2373,7 +2373,7 @@ abstract class FOGPage extends FOGBase
                 . '"password" '
                 . 'name="domainpassword" value="%s" autocomplete="off"/>'
                 . '</div>',
-                $ADPass
+                Initiator::e($ADPass)
             ),
             sprintf(
                 '<label for="adPasswordLegacy">%s'
@@ -2387,7 +2387,7 @@ abstract class FOGPage extends FOGBase
                 . 'type="password" name="domainpasswordlegacy" '
                 . 'value="%s" autocomplete="off"/>'
                 . '</div>',
-                $ADPassLegacy
+                Initiator::e($ADPassLegacy)
             ),
             sprintf(
                 '<label for="ensel">'
@@ -2943,7 +2943,7 @@ abstract class FOGPage extends FOGBase
                 . $this->title
                 . '</label>' => '<input type="hidden" name="remitems[]" '
                 . 'value="'
-                . $this->obj->get('id')
+                . Initiator::e($this->obj->get('id'))
                 . '"/>'
                 . '<button type="submit" name="delete" id="delete" '
                 . 'class="btn btn-danger btn-block">'
@@ -4241,8 +4241,8 @@ abstract class FOGPage extends FOGBase
             )
             . '" id="%s" name="%s">'
             . '<option value="">- %s -</option>',
-            $name,
-            $name,
+            Initiator::e($name),
+            Initiator::e($name),
             _('Please select an option')
         );
         foreach ($items as $id => &$item) {
@@ -4250,8 +4250,8 @@ abstract class FOGPage extends FOGBase
                 '<option value="%s"%s>%s</option>',
                 (
                     $useidsel ?
-                    $id :
-                    $item
+                    Initiator::e($id) :
+                    Initiator::e($item)
                 ),
                 (
                     $useidsel ? (

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -966,8 +966,7 @@ abstract class FOGPage extends FOGBase
                 '${%s}',
                 $name
             );
-            $val = trim($val);
-            $this->dataReplace[] = Initiator::e($val);
+            $this->dataReplace[] = $val;
             unset($val);
         }
     }

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -967,7 +967,7 @@ abstract class FOGPage extends FOGBase
                 $name
             );
             $val = trim($val);
-            $this->dataReplace[] = $val;
+            $this->dataReplace[] = Intiator::e($val);
             unset($val);
         }
     }

--- a/packages/web/lib/fog/powermanagementmanager.class.php
+++ b/packages/web/lib/fog/powermanagementmanager.class.php
@@ -119,7 +119,7 @@ class PowerManagementManager extends FOGManagerController
         foreach ((array) $types as $val => &$text) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                trim($val),
+                Initiator::e(trim($val)),
                 (
                     (isset($template) && $template !== false)
                     && trim($template) === trim($val) ?
@@ -130,7 +130,7 @@ class PowerManagementManager extends FOGManagerController
                         ''
                     )
                 ),
-                $text
+                Initiator::e($text)
             );
         }
 

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -218,13 +218,13 @@ class Printer extends FOGController
         foreach ((array)$printerTypes as $short => &$long) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                $short,
+                Initiator::e($short),
                 (
                     filter_input(INPUT_POST, 'printertype') === $short ?
                     ' selected' :
                     ''
                 ),
-                $long
+                Initiator::e($long)
             );
             unset($short, $long);
         }

--- a/packages/web/lib/fog/service.class.php
+++ b/packages/web/lib/fog/service.class.php
@@ -241,13 +241,13 @@ class Service extends FOGController
             }
             $options .= sprintf(
                 '<option value="%s"%s>%s</option>',
-                $value,
+                Initiator::e($value),
                 (
                     strtolower($selected) == $value ?
                     ' selected' :
                     ''
                 ),
-                $show
+                Initiator::e($show)
             );
             unset($viewop);
         }

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -148,7 +148,7 @@ class StorageNode extends FOGController
      */
     public function loadOnline()
     {
-        $test = self::$FOGURLRequests->isAvailable($this->get('ip'), '0.1', 21);
+        $test = self::$FOGURLRequests->isAvailable($this->get('ip'), '1');
         $this->set('online', array_shift($test));
     }
     /**

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1811');
+        define('FOG_VERSION', '1.5.10.1812');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1804');
+        define('FOG_VERSION', '1.5.10.1805');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1805');
+        define('FOG_VERSION', '1.5.10.1806');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1798');
+        define('FOG_VERSION', '1.5.10.1803');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1806');
+        define('FOG_VERSION', '1.5.10.1807');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1807');
+        define('FOG_VERSION', '1.5.10.1808');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1809');
+        define('FOG_VERSION', '1.5.10.1810');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1803');
+        define('FOG_VERSION', '1.5.10.1804');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1810');
+        define('FOG_VERSION', '1.5.10.1811');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1808');
+        define('FOG_VERSION', '1.5.10.1809');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -102,9 +102,9 @@ class TaskType extends FOGController
         foreach ((array) $icons as $name => &$unicode) {
             printf(
                 '<option value="%s"%s> %s</option>',
-                $name,
+                Initiator::e($name),
                 $selected == $name ? ' selected' : '',
-                $name
+                Initiator::e($name)
             );
             unset($unicode, $name);
         }

--- a/packages/web/lib/pages/dashboardpage.class.php
+++ b/packages/web/lib/pages/dashboardpage.class.php
@@ -124,12 +124,12 @@ class DashboardPage extends FOGPage
             unset($ip);
             self::$_nodeOpts[] = sprintf(
                 '<option value="%s" class="fogversion" urlcall="%s">%s%s ()</option>',
-                $StorageNode->id,
+                Initiator::e($StorageNode->id),
                 sprintf(
                     '%sservice/getversion.php',
                     $url
                 ),
-                $StorageNode->name,
+                Initiator::e($StorageNode->name),
                 (
                     $StorageNode->isMaster ?
                     ' *' :
@@ -152,8 +152,8 @@ class DashboardPage extends FOGPage
         foreach ((array)$Groups as &$StorageGroup) {
             self::$_groupOpts .= sprintf(
                 '<option value="%s">%s</option>',
-                $StorageGroup->id,
-                $StorageGroup->name
+                Initiator::e($StorageGroup->id),
+                Initiator::e($StorageGroup->name)
             );
             unset($StorageGroup);
         }
@@ -345,8 +345,8 @@ class DashboardPage extends FOGPage
         printf(
             '<input type="hidden" id="bandwidthUrls" type="hidden" value="%s"/>'
             . '<input type="hidden" id="nodeNames" type="hidden" value="%s"/>',
-            implode(',', self::$_nodeURLs),
-            implode(',', self::$_nodeNames)
+            Initiator::e(implode(',', self::$_nodeURLs)),
+            Initiator::e(implode(',', self::$_nodeNames))
         );
         echo '<div class="panel panel-info">';
         echo '<div class="panel-heading">';

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -401,7 +401,7 @@ class FOGConfigurationPage extends FOGPage
             $formstr;
             echo '">';
             echo '<input type="hidden" name="file" value="';
-            echo $tmpFile;
+            echo Initiator::e($tmpFile);
             echo '"/>';
             echo '<div class="col-xs-4">';
             echo '<label class="control-label" for="dstName">';
@@ -412,7 +412,7 @@ class FOGConfigurationPage extends FOGPage
             echo '<div class="input-group">';
             echo '<input class="form-control" type="text" name="dstName" id='
                 . '"dstName" value="'
-                . $tmpArch
+                . Initiator::e($tmpArch)
                 . '"/>';
             echo '</div>';
             echo '</div>';
@@ -551,7 +551,7 @@ class FOGConfigurationPage extends FOGPage
             $formstr;
             echo '">';
             echo '<input type="hidden" name="file" value="';
-            echo $tmpFile;
+            echo Initiator::e($tmpFile);
             echo '"/>';
             echo '<div class="col-xs-4">';
             echo '<label class="control-label" for="dstName">';
@@ -562,7 +562,7 @@ class FOGConfigurationPage extends FOGPage
             echo '<div class="input-group">';
             echo '<input class="form-control" type="text" name="dstName" id='
                 . '"dstName" value="'
-                . $tmpArch
+                . Initiator::e($tmpArch)
                 . '"/>';
             echo '</div>';
             echo '</div>';
@@ -697,7 +697,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => array(
                 '<div class="input-group">'
                 . '<textarea id="mainColors" name="mainColors" class="form-control">'
-                . $mainColors
+                . Initiator::e($mainColors)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -709,7 +709,7 @@ class FOGConfigurationPage extends FOGPage
             . '<label>' => array(
                 '<div class="input-group">'
                 . '<textarea id="hostValid" class="form-control" name="hostValid">'
-                . $hostValid
+                . Initiator::e($hostValid)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -724,7 +724,7 @@ class FOGConfigurationPage extends FOGPage
                 '<div class="input-group">'
                 . '<textarea name="hostInvalid" class="form-control" id='
                 . '"hostInvalid">'
-                . $hostInvalid
+                . Initiator::e($hostInvalid)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -739,7 +739,7 @@ class FOGConfigurationPage extends FOGPage
                 '<div class="input-group">'
                 . '<textarea id="mainCpairs" name="mainCpairs" class='
                 . '"form-control">'
-                . $mainCpairs
+                . Initiator::e($mainCpairs)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -754,7 +754,7 @@ class FOGConfigurationPage extends FOGPage
                 '<div class="input-group">'
                 . '<textarea class="form-control" id="mainFallback" name='
                 . '"mainFallback">'
-                . $mainFallback
+                . Initiator::e($mainFallback)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -766,7 +766,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => array(
                 '<div class="input-group">'
                 . '<textarea class="form-control" id="hostCPairs" name="hostCpairs">'
-                . $hostCpairs
+                . Initiator::e($hostCpairs)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -781,7 +781,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => array(
                 '<div class="input-group">'
                 . '<input type="text" id="timeout" name="timeout" value="'
-                . $timeout
+                . Initiator::e($timeout)
                 . '" class="form-control"/>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -799,7 +799,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => array(
                 '<div class="input-group">'
                 . '<input type="text" id="bgfile" name="bgfile" value="'
-                . $bgfile
+                . Initiator::e($bgfile)
                 . '" class="form-control"/>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -900,7 +900,7 @@ class FOGConfigurationPage extends FOGPage
                 '<div class="input-group">'
                 . '<input type="text" id="hidetimeout" name="hidetimeout" '
                 . 'value="'
-                . $hideTimeout
+                . Initiator::e($hideTimeout)
                 . '" class="form-control"/>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -1030,7 +1030,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => array(
                 '<div class="input-group">'
                 . '<textarea id="advtext" class="form-control" name="adv">'
-                . $advanced
+                . Initiator::e($advanced)
                 . '</textarea>'
                 . '</div>',
                 '<i class="fa fa-question hand" title="'
@@ -1297,7 +1297,7 @@ class FOGConfigurationPage extends FOGPage
                 . _('Menu Item')
                 . '</label>' => '<div class="input-group">'
                 . '<input type="text" class="form-control" value="'
-                . $Menu->name
+                . Initiator::e($Menu->name)
                 . '" name="menu_item" id="menu_item'
                 . $divTab
                 . '"/>'
@@ -1310,7 +1310,7 @@ class FOGConfigurationPage extends FOGPage
                 . '<textarea name="menu_description" id="menu_description'
                 . $divTab
                 . '" class="form-control">'
-                . $Menu->description
+                . Initiator::e($Menu->description)
                 . '</textarea>'
                 . '</div>',
                 '<label for="menu_params'
@@ -1321,7 +1321,7 @@ class FOGConfigurationPage extends FOGPage
                 . '<textarea name="menu_params" id="menu_params'
                 . $divTab
                 . '" class="form-control">'
-                . $Menu->params
+                . Initiator::e($Menu->params)
                 . '</textarea>'
                 . '</div>',
                 '<label for="menu_options'
@@ -1333,7 +1333,7 @@ class FOGConfigurationPage extends FOGPage
                 . 'menu_options'
                 . $divTab
                 . '" value="'
-                . $Menu->args
+                . Initiator::e($Menu->args)
                 . '" class="form-control"/>'
                 . '</div>',
                 '<label for="menudef'
@@ -1361,7 +1361,7 @@ class FOGConfigurationPage extends FOGPage
                 . _('Hot Key to use')
                 . '</label>' => '<div class="input-group">'
                 . '<input type="text" name="keysequence" value="'
-                . $keySeq
+                . Initiator::e($keySeq)
                 . '" class="form-control" id="menu_hotkey'
                 . $divTab
                 . '"/>'
@@ -1385,7 +1385,7 @@ class FOGConfigurationPage extends FOGPage
                 . _('Make Changes?')
                 . '</label>'
                 . '<input type="hidden" name="menu_id" value="'
-                . $Menu->id
+                . Initiator::e($Menu->id)
                 . '"/>' => '<button name="saveform" type="submit" class="'
                 . 'btn btn-info btn-block" id="menu_id'
                 . $divTab
@@ -1400,7 +1400,7 @@ class FOGConfigurationPage extends FOGPage
                     . _('Delete Menu Item')
                     . '</label>'
                     . '<input type="hidden" name="rmid" value="'
-                    . $Menu->id
+                    . Initiator::e($Menu->id)
                     . '"/>' :
                     ''
                 ) => (
@@ -1646,7 +1646,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="menu_description" id="menu_description'
             . '" class="form-control">'
-            . $menu_desc
+            . Initiator::e($menu_desc)
             . '</textarea>'
             . '</div>',
             '<label for="menu_params">'
@@ -1654,7 +1654,7 @@ class FOGConfigurationPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="menu_params" id="menu_params'
             . '" class="form-control">'
-            . $menu_params
+            . Initiator::e($menu_params)
             . '</textarea>'
             . '</div>',
             '<label for="menu_options">'
@@ -1663,7 +1663,7 @@ class FOGConfigurationPage extends FOGPage
             . '<input type="text" name="menu_options" id="'
             . 'menu_options'
             . '" value="'
-            . $menu_options
+            . Initiator::e($menu_options)
             . '" class="form-control"/>'
             . '</div>',
             '<label for="menudef">'
@@ -1683,7 +1683,7 @@ class FOGConfigurationPage extends FOGPage
             . _('Hot Key to use')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="keysequence" value="'
-            . $menu_key
+            . Initiator::e($menu_key)
             . '" class="form-control" id="menu_hotkey'
             . '"/>'
             . '</div>',
@@ -2457,13 +2457,13 @@ class FOGConfigurationPage extends FOGPage
                 foreach ((array)$vals as $view => &$value) {
                     printf(
                         '<option value="%s"%s>%s</option>',
-                        $value,
+                        Initiator::e($value),
                         (
                             $Service->value == $value ?
                             ' selected' :
                             ''
                         ),
-                        $view
+                        Initiator::e($view)
                     );
                     unset($value);
                 }
@@ -2482,13 +2482,13 @@ class FOGConfigurationPage extends FOGPage
                 foreach ((array)$screens as &$viewop) {
                     printf(
                         '<option value="%s"%s>%s</option>',
-                        strtolower($viewop),
+                        Initiator::e(strtolower($viewop)),
                         (
                             $Service->value == strtolower($viewop) ?
                             ' selected' :
                             ''
                         ),
-                        $viewop
+                        Initiator::e($viewop)
                     );
                     unset($viewop);
                 }
@@ -2510,13 +2510,13 @@ class FOGConfigurationPage extends FOGPage
                 foreach ((array)$duplexTypes as $types => &$val) {
                     printf(
                         '<option value="%s"%s>%s</option>',
-                        $val,
+                        Initiator::e($val),
                         (
                             $Service->value == $val ?
                             ' selected' :
                             ''
                         ),
-                        $types
+                        Initiator::e($types)
                     );
                     unset($val);
                 }
@@ -2547,14 +2547,14 @@ class FOGConfigurationPage extends FOGPage
                 foreach ($langs as $lang => &$humanreadable) {
                     printf(
                         '<option value="%s"%s>%s</option>',
-                        $lang,
+                        Initiator::e($lang),
                         (
                             $locale == $lang
                             || $locale == $foglangt['Language'][$lang] ?
                             ' selected' :
                             ''
                         ),
-                        $humanreadable
+                        Initiator::e($humanreadable)
                     );
                     unset($humanreadable);
                 }
@@ -2625,13 +2625,13 @@ class FOGConfigurationPage extends FOGPage
                     );
                     printf(
                         '<option value="%s"%s>%s [%s %s]</option>',
-                        $tz,
+                        Initiator::e($tz),
                         (
                             $Service->value == $tz ?
                             ' selected' :
                             ''
                         ),
-                        $tz,
+                        Initiator::e($tz),
                         $abbr,
                         $offset
                     );
@@ -3421,14 +3421,14 @@ class FOGConfigurationPage extends FOGPage
                 }
                 printf(
                     '<option value="%s||%s"%s>%s</option>',
-                    base64_encode($ip[$nodename]),
-                    $file,
+                    Initiator::e(base64_encode($ip[$nodename])),
+                    Initiator::e($file),
                     (
                         (isset($_POST['logtype']) && $value == $_POST['logtype']) ?
                         ' selected' :
                         ''
                     ),
-                    $value
+                    Initiator::e($value)
                 );
                 unset($file);
             }
@@ -3449,13 +3449,13 @@ class FOGConfigurationPage extends FOGPage
         foreach ((array)$vals as $i => &$value) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                $value,
+                Initiator::e($value),
                 (
                     (isset($_POST['n']) && $value == $_POST['n']) ?
                     ' selected' :
                     ''
                 ),
-                $value
+                Initiator::e($value)
             );
             unset($value);
         }

--- a/packages/web/lib/pages/groupmanagementpage.class.php
+++ b/packages/web/lib/pages/groupmanagementpage.class.php
@@ -189,7 +189,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" '
             . 'value="'
-            . filter_input(INPUT_POST, 'name')
+            . Initiator::e(filter_input(INPUT_POST, 'name'))
             . '" class="groupname-input form-control" '
             . 'id="name" required/>'
             . '</div>',
@@ -198,7 +198,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" '
             . 'id="description" name="description">'
-            . filter_input(INPUT_POST, 'description')
+            . Initiator::e(filter_input(INPUT_POST, 'description'))
             . '</textarea>'
             . '</div>',
             '<label for="kern">'
@@ -206,7 +206,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="kern" '
             . 'value="'
-            . filter_input(INPUT_POST, 'kern')
+            . Initiator::e(filter_input(INPUT_POST, 'kern'))
             . '" class="groupkern-input form-control" '
             . 'id="kern"/>'
             . '</div>',
@@ -215,7 +215,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="args" '
             . 'value="'
-            . filter_input(INPUT_POST, 'args')
+            . Initiator::e(filter_input(INPUT_POST, 'args'))
             . '" class="groupargs-input form-control" '
             . 'id="args"/>'
             . '</div>',
@@ -224,7 +224,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="dev" '
             . 'value="'
-            . filter_input(INPUT_POST, 'dev')
+            . Initiator::e(filter_input(INPUT_POST, 'dev'))
             . '" class="groupdev-input form-control" '
             . 'id="dev"/>'
             . '</div>',
@@ -467,7 +467,7 @@ class GroupManagementPage extends FOGPage
             . _('Group Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="groupname-input form-control" '
             . 'id="name" required/>'
             . '</div>',
@@ -476,7 +476,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" id="description" '
             . 'name="description">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="productKey">'
@@ -484,7 +484,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input id="productKey" type="text" '
             . 'name="key" value="'
-            . $productKey
+            . Initiator::e($productKey)
             .'" class="form-control"/>'
             . '</div>',
             '<label for="kern">'
@@ -492,7 +492,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="kern" id="kern" '
             . 'class="form-control" value="'
-            . $kern
+            . Initiator::e($kern)
             . '"/>'
             . '</div>',
             '<label for="args">'
@@ -500,7 +500,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' =>'<div class="input-group">'
             . '<input type="text" name="args" id="args" '
             . 'class="form-control" value="'
-            . $args
+            . Initiator::e($args)
             . '"/>'
             . '</div>',
             '<label for="dev">'
@@ -508,7 +508,7 @@ class GroupManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="dev" id="dev" '
             . 'class="form-control" value="'
-            . $dev
+            . Initiator::e($dev)
             . '"/>'
             . '</div>',
             '<label for="bootTypeExit">'
@@ -1236,13 +1236,11 @@ class GroupManagementPage extends FOGPage
                     . '</div>',
                     $Module->shortName,
                     (
-                        ($moduleName[$Module->shortName]
-                        || $moduleName[$Module->shortName])
-                        && $Module->isDefault ?
+                        $moduleName[$Module->shortName] && $Module->isDefault ?
                         ' class="checkboxes" ':
                         ''
                     ),
-                    $Module->id,
+                    Initiator::e($Module->id),
                     (
                         in_array($Module->id, $ModuleOn) ?
                         ' checked' :
@@ -1262,17 +1260,17 @@ class GroupManagementPage extends FOGPage
                     . 'title="%s"></span>'
                     . '</div>'
                     . '%s',
-                    str_replace(
+                    Initiator::e(str_replace(
                         '"',
                         '\"',
                         $Module->description
-                    ),
-                    $note
+                    )),
+                    Initiator::e($note)
                 ),
                 'mod_name' => '<label for="'
-                . $Module->shortName
+                . Initiator::e($Module->shortName)
                 . '">'
-                . $Module->name
+                . Initiator::e($Module->name)
                 . '</label>',
             );
             unset($Module);
@@ -1416,8 +1414,8 @@ class GroupManagementPage extends FOGPage
                     . 'class="form-control"/>'
                     . '</div>',
                     $name,
-                    $name,
-                    $val
+                    Initiator::e($name),
+                    Initiator::e($val)
                 ),
                 'span' => sprintf(
                     '<div class="col-xs-2">'
@@ -1425,7 +1423,7 @@ class GroupManagementPage extends FOGPage
                     . 'data-toggle="tooltip" data-placement="right" '
                     . 'title="%s"></span>'
                     . '</div>',
-                    $get[1]
+                    Initiator::e($get[1])
                 ),
                 'field' => '<label for="'
                 . $name

--- a/packages/web/lib/pages/groupmanagementpage.class.php
+++ b/packages/web/lib/pages/groupmanagementpage.class.php
@@ -152,9 +152,9 @@ class GroupManagementPage extends FOGPage
          */
         self::$returnData = function (&$Group) {
             $this->data[] = array(
-                'id' => $Group->id,
-                'name' => $Group->name,
-                'description' => $Group->description,
+                'id' => Initiator::e($Group->id),
+                'name' => Initiator::e($Group->name),
+                'description' => Initiator::e($Group->description),
                 'count' => $Group->hostcount
             );
             unset($Group);

--- a/packages/web/lib/pages/hostmanagementpage.class.php
+++ b/packages/web/lib/pages/hostmanagementpage.class.php
@@ -295,16 +295,16 @@ class HostManagementPage extends FOGPage
          */
         self::$returnData = function ($Host) {
             $this->data[] = array(
-                'id' => $Host->id,
+                'id' => Initiator::e($Host->id),
                 'deployed' => self::formatTime(
                     $Host->deployed,
                     'Y-m-d H:i:s'
                 ),
-                'host_name' => $Host->name,
-                'host_mac' => $Host->primac,
-                'host_desc' => $Host->description,
-                'image_id' => $Host->imageID,
-                'image_name' => $Host->imagename,
+                'host_name' => Initiator::e($Host->name),
+                'host_mac' => Initiator::e($Host->primac),
+                'host_desc' => Initiator::e($Host->description),
+                'image_id' => Initiator::e($Host->imageID),
+                'image_name' => Initiator::e($Host->imagename),
                 'pingstatus' => $Host->pingstatus,
             );
             unset($Host);

--- a/packages/web/lib/pages/hostmanagementpage.class.php
+++ b/packages/web/lib/pages/hostmanagementpage.class.php
@@ -439,7 +439,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="host" '
             . 'value="'
-            . filter_input(INPUT_POST, 'host')
+            . Initiator::e(filter_input(INPUT_POST, 'host'))
             . '" maxlength="15" '
             . 'class="hostname-input form-control" '
             . 'id="host" required/>'
@@ -451,7 +451,7 @@ class HostManagementPage extends FOGPage
             . '</span>'
             . '<input type="text" name="mac" class="macaddr form-control" '
             . 'id="mac" value="'
-            . filter_input(INPUT_POST, 'mac')
+            . Initiator::e(filter_input(INPUT_POST, 'mac'))
             . '" maxlength="17" required/>'
             . '</div>',
             '<label for="description">'
@@ -459,7 +459,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" '
             . 'id="description" name="description">'
-            . filter_input(INPUT_POST, 'description')
+            . Initiator::e(filter_input(INPUT_POST, 'description'))
             . '</textarea>'
             . '</div>',
             '<label for="productKey">'
@@ -467,7 +467,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input id="productKey" type="text" '
             . 'name="key" value="'
-            . filter_input(INPUT_POST, 'key')
+            . Initiator::e(filter_input(INPUT_POST, 'key'))
             . '" class="form-control"/>'
             . '</div>',
             '<label for="image">'
@@ -484,27 +484,27 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="kern" '
             . 'value="'
-            . filter_input(INPUT_POST, 'kern')
+            . Initiator::e(filter_input(INPUT_POST, 'kern'))
             . '" class="form-control" id="kern"/>'
             . '</div>',
             '<label for="args">'
             . _('Host Kernel Arguments')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="args" id="args" value="'
-            . filter_input(INPUT_POST, 'args')
+            . Initiator::e(filter_input(INPUT_POST, 'args'))
             . '" class="form-control"/>'
             . '</div>',
             '<label for="init">'
             . _('Host Init')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="init" value="'
-            . filter_input(INPUT_POST, 'init')
+            . Initiator::e(filter_input(INPUT_POST, 'init'))
             . '" id="init" class="form-control"/>',
             '<label for="dev">'
             . _('Host Primary Disk')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="dev" value="'
-            . filter_input(INPUT_POST, 'dev')
+            . Initiator::e(filter_input(INPUT_POST, 'dev'))
             . '" id="dev" class="form-control"/>'
             . '</div>',
             '<label for="bootTypeExit">'
@@ -922,7 +922,7 @@ class HostManagementPage extends FOGPage
             echo '<input type="text" class="macaddr additionalMAC form-control" '
                 . 'name="additionalMACs[]" '
                 . 'value="'
-                . $MAC
+                . Initiator::e($MAC)
                 . '" maxlength="17"/>';
             echo '<span class="icon remove-mac fa fa-minus-circle hand '
                 . 'input-group-addon" '
@@ -944,7 +944,7 @@ class HostManagementPage extends FOGPage
             echo '<div class="checkbox">';
             echo '<label>';
             echo '<input type="checkbox" name="igclient[]" value="'
-                . $MAC
+                . Initiator::e($MAC)
                 . '"'
                 . $this->obj->clientMacCheck($MAC)
                 . '/>';
@@ -963,7 +963,7 @@ class HostManagementPage extends FOGPage
             echo '<div class="checkbox">';
             echo '<label>';
             echo '<input type="checkbox" name="igimage[]" value="'
-                . $MAC
+                . Initiator::e($MAC)
                 . '"'
                 . $this->obj->imageMacCheck($MAC)
                 . '/>';
@@ -982,7 +982,7 @@ class HostManagementPage extends FOGPage
             echo '<input type="text" class="macaddr pending-mac form-control" '
                 . 'name="pendingMACs[]" '
                 . 'value="'
-                . $MAC
+                . Initiator::e($MAC)
                 . '" maxlength="17"/>';
             echo '<a class="input-group-addon" href="'
                 . $this->formAction
@@ -1059,7 +1059,7 @@ class HostManagementPage extends FOGPage
             . _('Host Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="host" value="'
-            . $name
+            . Initiator::e($name)
             . '" maxlength="15" class="hostname-input form-control" '
             . 'id="name" required/>'
             . '</div>',
@@ -1071,7 +1071,7 @@ class HostManagementPage extends FOGPage
             . '<input type="text" class="macaddr form-control" '
             . 'name="mac" '
             . 'value="'
-            . $mac
+            . Initiator::e($mac)
             . '" id="mac" '
             . 'maxlength="17" required/>'
             . '<span class="icon add-mac fa fa-plus-circle hand '
@@ -1093,7 +1093,7 @@ class HostManagementPage extends FOGPage
             . '<div class="checkbox">'
             . '<label>'
             . '<input type="checkbox" name="igclient[]" value="'
-            . $mac
+            . Initiator::e($mac)
             . '"'
             . $this->obj->clientMacCheck()
             . '/>'
@@ -1112,7 +1112,7 @@ class HostManagementPage extends FOGPage
             . '<div class="checkbox">'
             . '<label>'
             . '<input type="checkbox" name="igimage[]" value="'
-            . $mac
+            . Initiator::e($mac)
             . '"'
             . $this->obj->imageMacCheck()
             . '/>'
@@ -1139,14 +1139,14 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" id="description" '
             . 'name="description">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="productKey">'
             . _('Host Product Key')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="key" value="'
-            . $productKey
+            . Initiator::e($productKey)
             . '" id="productKey" class="form-control"/>'
             . '</div>',
             '<label for="image">'
@@ -1157,7 +1157,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="kern" id="kern" '
             . 'class="form-control" value="'
-            . $kern
+            . Initiator::e($kern)
             . '"/>'
             . '</div>',
             '<label for="args">'
@@ -1165,7 +1165,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="args" id="args" '
             . 'class="form-control" value="'
-            . $args
+            . Initiator::e($args)
             . '"/>'
             . '</div>',
             '<label for="init">'
@@ -1173,7 +1173,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="init" id="init" '
             . 'class="form-control" value="'
-            . $init
+            . Initiator::e($init)
             . '"/>'
             . '</div>',
             '<label for="dev">'
@@ -1181,7 +1181,7 @@ class HostManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="dev" id="dev" '
             . 'class="form-control" value="'
-            . $dev
+            . Initiator::e($dev)
             . '"/>'
             . '</div>',
             '<label for="bootTypeExit">'
@@ -2092,9 +2092,7 @@ class HostManagementPage extends FOGPage
                     . '</div>',
                     $Module->shortName,
                     (
-                        ($moduleName[$Module->shortName]
-                        || $moduleName[$Module->shortName])
-                        && $Module->isDefault ?
+                        $moduleName[$Module->shortName] && $Module->isDefault ?
                         ' class="checkboxes" ':
                         ''
                     ),
@@ -2244,9 +2242,9 @@ class HostManagementPage extends FOGPage
                     . '<input type="number" id="%s" name="%s" value="%s" '
                     . 'class="form-control"/>'
                     . '</div>',
-                    $name,
-                    $name,
-                    $this->obj->getDispVals($get[0])
+                    Initiator::e($name),
+                    Initiator::e($name),
+                    Initiator::e($this->obj->getDispVals($get[0]))
                 ),
                 'span' => sprintf(
                     '<div class="col-xs-2">'
@@ -2254,12 +2252,12 @@ class HostManagementPage extends FOGPage
                     . 'data-toggle="tooltip" data-placement="right" '
                     . 'title="%s"></span>'
                     . '</div>',
-                    $get[1]
+                    Initiator::e($get[1])
                 ),
                 'field' => '<label for="'
                 . $name
                 . '">'
-                . $get[2]
+                . Initiator::e($get[2])
                 . '</label>',
             );
             unset($get);
@@ -2459,21 +2457,21 @@ class HostManagementPage extends FOGPage
             . _('Primary User')
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" value="'
-            . $puser
+            . Initiator::e($puser)
             . '" name="pu" id="pu"/>'
             . '</div>',
             '<label for="other1"/>'
             . _('Other Tag #1')
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" value="'
-            . $other1
+            . Initiator::e($other1)
             . '" name="other1" id="other1"/>'
             . '</div>',
             '<label for="other2"/>'
             . _('Other Tag #2')
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" value="'
-            . $other2
+            . Initiator::e($other2)
             . '" name="other2" id="other2"/>'
             . '</div>',
             '<label for="updateinv">'

--- a/packages/web/lib/pages/imagemanagementpage.class.php
+++ b/packages/web/lib/pages/imagemanagementpage.class.php
@@ -261,23 +261,23 @@ class ImageManagementPage extends FOGPage
             /**
              * The id.
              */
-            $id = $Image->id;
+            $id = Initiator::e($Image->id);
             /**
              * The name.
              */
-            $name = $Image->name;
+            $name = Initiator::e($Image->name);
             /**
              * The description.
              */
-            $description = $Image->description;
+            $description = Initiator::e($Image->description);
             /**
              * The storage group name.
              */
-            $storageGroup = $Image->storagegroupname;
+            $storageGroup = Initiator::e($Image->storagegroupname);
             /**
              * The os name.
              */
-            $os = $Image->osname;
+            $os = Initiator::e($Image->osname);
             /**
              * If no os is set/found set to not set.
              */
@@ -300,11 +300,11 @@ class ImageManagementPage extends FOGPage
             /**
              * The image type name.
              */
-            $imageType = $Image->imagetypename;
+            $imageType = Initiator::e($Image->imagetypename);
             /**
              * The image partition type name.
              */
-            $imagePartitionType = $Image->imageparttypename;
+            $imagePartitionType = Initiator::e($Image->imageparttypename);
             /**
              * The path.
              */

--- a/packages/web/lib/pages/imagemanagementpage.class.php
+++ b/packages/web/lib/pages/imagemanagementpage.class.php
@@ -570,7 +570,7 @@ class ImageManagementPage extends FOGPage
             . '<input class="form-control imagename-input" type="text" '
             . 'name="name" id="iName" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="description">'
@@ -578,7 +578,7 @@ class ImageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control imagedesc-input" '
             . 'id="description">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>',
             '<label for="storagegroup">'
             . _('Storage Group')
@@ -590,13 +590,13 @@ class ImageManagementPage extends FOGPage
             . _('Image Path')
             . '</label>' => '<div class="input-group">'
             . '<span class="input-group-addon">'
-            . $StorageNode->get('path')
+            . Initiator::e($StorageNode->get('path'))
             . '/'
             . '</span>'
             . '<input type="text" class="form-control imagefile-input" '
             . 'name="file" id="iFile" '
             . 'value="'
-            . $file
+            . Initiator::e($file)
             . '"/>',
             '<label for="imagetype">'
             . _('Image Type')
@@ -628,7 +628,7 @@ class ImageManagementPage extends FOGPage
             . '<div class="input-group">'
             . '<input type="text" name="compress" class="form-control '
             . 'showVal pigz" maxsize="2" value="'
-            . $compression
+            . Initiator::e($compression)
             . '" id="pigzcomp" readonly/>'
             . '</div>'
             . '</div>',
@@ -935,7 +935,7 @@ class ImageManagementPage extends FOGPage
             . '<input class="form-control imagename-input" type="text" '
             . 'name="name" id="iName" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="description">'
@@ -943,7 +943,7 @@ class ImageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control imagedesc-input" '
             . 'id="description">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>',
             '<label for="os">'
             . _('Operating System')
@@ -952,13 +952,13 @@ class ImageManagementPage extends FOGPage
             . _('Image Path')
             . '</label>' => '<div class="input-group">'
             . '<span class="input-group-addon">'
-            . $StorageNode->get('path')
+            . Initiator::e($StorageNode->get('path'))
             . '/'
             . '</span>'
             . '<input type="text" class="form-control imagefile-input" '
             . 'name="file" id="iFile" '
             . 'value="'
-            . $file
+            . Initiator::e($file)
             . '"/>',
             '<label for="imagetype">'
             . _('Image Type')
@@ -1000,7 +1000,7 @@ class ImageManagementPage extends FOGPage
             . '<div class="input-group">'
             . '<input type="text" name="compress" class="form-control '
             . 'showVal pigz" maxsize="2" value="'
-            . $compression
+            . Initiator::e($compression)
             . '" id="pigzcomp" readonly/>'
             . '</div>'
             . '</div>',
@@ -1491,7 +1491,7 @@ class ImageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="name" id="iName" '
             . 'autocomplete="off" value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="iCount">'
@@ -1499,7 +1499,7 @@ class ImageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="number" name="count" id="iCount" '
             . 'autocomplete="off" value="'
-            . $count
+            . Initiator::e($count)
             . '"/>'
             . '</div>',
             '<label for="iTimeout">'
@@ -1510,7 +1510,7 @@ class ImageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="number" name=timeout" '
             . 'id="iTimeout" autocomplete="off" value="'
-            . $timeout
+            . Initiator::e($timeout)
             . '"/>'
             . '</div>',
             '<label for="image">'

--- a/packages/web/lib/pages/pluginmanagementpage.class.php
+++ b/packages/web/lib/pages/pluginmanagementpage.class.php
@@ -144,13 +144,13 @@ class PluginManagementPage extends FOGPage
                 break;
             }
             $this->data[] = array(
-                'type' => self::$_plugintype,
+                'type' => Initiator::e(self::$_plugintype),
                 'encname' => md5($Plugin->name),
-                'id' => (isset($Plugin->id) ? $Plugin->id : ''),
-                'name' => $Plugin->name,
-                'icon' => $Plugin->icon,
-                'desc' => $Plugin->description,
-                'location' => $Plugin->location
+                'id' => (isset($Plugin->id) ? Initiator::e($Plugin->id) : ''),
+                'name' => Initiator::e($Plugin->name),
+                'icon' => Initiator::e($Plugin->icon),
+                'desc' => Initiator::e($Plugin->description),
+                'location' => Initiator::e($Plugin->location)
             );
             unset($Plugin);
         };

--- a/packages/web/lib/pages/printermanagementpage.class.php
+++ b/packages/web/lib/pages/printermanagementpage.class.php
@@ -135,15 +135,15 @@ class PrinterManagementPage extends FOGPage
                 $config = $Printer->config;
             }
             $this->data[] = array(
-                'id' => $Printer->id,
-                'name' => $Printer->name,
-                'config' => $config,
-                'model' => $Printer->model,
-                'port' => $Printer->port,
-                'file' => $Printer->file,
-                'ip' => $Printer->ip,
-                'configFile' => $Printer->configFile,
-                'desc' => $Printer->description
+                'id' => Initiator::e($Printer->id),
+                'name' => Initiator::e($Printer->name),
+                'config' => Initiator::e($config),
+                'model' => Initiator::e($Printer->model),
+                'port' => Initiator::e($Printer->port),
+                'file' => Initiator::e($Printer->file),
+                'ip' => Initiator::e($Printer->ip),
+                'configFile' => Initiator::e($Printer->configFile),
+                'desc' => Initiator::e($Printer->description)
             );
             unset($Printer);
         };

--- a/packages/web/lib/pages/printermanagementpage.class.php
+++ b/packages/web/lib/pages/printermanagementpage.class.php
@@ -245,7 +245,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namenetwork" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -253,7 +253,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="descnetwork" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>'
         );
@@ -285,7 +285,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="nameiprint" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -293,7 +293,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desciprint" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="portiprint">'
@@ -301,7 +301,7 @@ class PrinterManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="port" id="portiprint" '
             . 'value="'
-            . $port
+            . Initiator::e($port)
             . '" class="form-control printerport-input" autocomplete="off" '
             . '/>'
             . '</div>'
@@ -334,7 +334,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namecups" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -342,14 +342,14 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desccups" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="infcups">'
             . _('Printer INF File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="inf" value="'
-            . $inf
+            . Initiator::e($inf)
             . '" id="infcups" class="printerinf-input form-control" '
             . '/>'
             . '</div>',
@@ -357,7 +357,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer IP')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" id="ipcups" class="printerip-input form-control" '
             . '/>'
             . '</div>'
@@ -390,7 +390,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namelocal" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -398,7 +398,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desclocal" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="portlocal">'
@@ -406,7 +406,7 @@ class PrinterManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="port" id="portlocal" '
             . 'value="'
-            . $port
+            . Initiator::e($port)
             . '" class="form-control printerport-input" autocomplete="off" '
             . '/>'
             . '</div>',
@@ -414,7 +414,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer INF File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="inf" value="'
-            . $inf
+            . Initiator::e($inf)
             . '" id="inflocal" class="printerinf-input form-control" '
             . '/>'
             . '</div>',
@@ -422,7 +422,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer IP/Hostname')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" id="iplocal" class="printerip-input form-control" '
             . '/>'
             . '</div>',
@@ -430,7 +430,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Model')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="model" value="'
-            . $model
+            . Initiator::e($model)
             . '" id="modellocal" class="printermodel-input form-control" '
             . '/>'
             . '</div>',
@@ -438,7 +438,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Config File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="configFile" value="'
-            . $configFile
+            . Initiator::e($configFile)
             . '" id="configFilelocal" class="printerconfigfile-input form-control" '
             . '/>'
             . '</div>'
@@ -653,7 +653,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namenetwork" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -661,7 +661,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="descnetwork" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>'
         );
@@ -693,7 +693,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="nameiprint" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -701,7 +701,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desciprint" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="portiprint">'
@@ -709,7 +709,7 @@ class PrinterManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="port" id="portiprint" '
             . 'value="'
-            . $port
+            . Initiator::e($port)
             . '" class="form-control printerport-input" autocomplete="off" '
             . '/>'
             . '</div>'
@@ -742,7 +742,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namecups" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -750,14 +750,14 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desccups" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="infcups">'
             . _('Printer INF File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="inf" value="'
-            . $inf
+            . Initiator::e($inf)
             . '" id="infcups" class="printerinf-input form-control" '
             . '/>'
             . '</div>',
@@ -765,7 +765,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer IP/Hostname')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" id="ipcups" class="printerip-input form-control" '
             . '/>'
             . '</div>'
@@ -798,7 +798,7 @@ class PrinterManagementPage extends FOGPage
             . _('e.g.')
             . ' \\\\printerserver\\printername' => '<div class="input-group">'
             . '<input type="text" name="alias" id="namelocal" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control printername-input" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -806,7 +806,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desclocal" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="portlocal">'
@@ -814,7 +814,7 @@ class PrinterManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="port" id="portlocal" '
             . 'value="'
-            . $port
+            . Initiator::e($port)
             . '" class="form-control printerport-input" autocomplete="off" '
             . '/>'
             . '</div>',
@@ -822,7 +822,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer INF File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="inf" value="'
-            . $inf
+            . Initiator::e($inf)
             . '" id="inflocal" class="printerinf-input form-control" '
             . '/>'
             . '</div>',
@@ -830,7 +830,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer IP')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" id="iplocal" class="printerip-input form-control" '
             . '/>'
             . '</div>',
@@ -838,7 +838,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Model')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="model" value="'
-            . $model
+            . Initiator::e($model)
             . '" id="modellocal" class="printermodel-input form-control" '
             . '/>'
             . '</div>',
@@ -846,7 +846,7 @@ class PrinterManagementPage extends FOGPage
             . _('Printer Config File')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="configFile" value="'
-            . $configFile
+            . Initiator::e($configFile)
             . '" id="configFilelocal" class="printerconfigfile-input form-control" '
             . '/>'
             . '</div>'

--- a/packages/web/lib/pages/processlogin.class.php
+++ b/packages/web/lib/pages/processlogin.class.php
@@ -77,9 +77,9 @@ class ProcessLogin extends FOGPage
         foreach ($foglangt['Language'] as $base => &$lang) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                $base,
+                Initiator::e($base),
                 ($base == $selected ? ' selected' : ''),
-                $lang
+                Initiator::e($lang)
             );
             unset($lang);
         }

--- a/packages/web/lib/pages/serviceconfigurationpage.class.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.class.php
@@ -280,7 +280,7 @@ class ServiceConfigurationPage extends FOGPage
                 . '"/>'
                 . _('Make Changes?')
                 . '</label>' => '<input type="hidden" name="name" value="'
-                . $modNames[$Module->shortName]
+                . Initiator::e($modNames[$Module->shortName])
                 . '"/>'
             );
             array_walk($fields, $this->fieldsToData);
@@ -547,7 +547,7 @@ class ServiceConfigurationPage extends FOGPage
                     . '</label>' => '<div class="input-group">'
                     . '<input type="text" class="form-control" name="width" '
                     . 'value="'
-                    . $x
+                    . Initiator::e($x)
                     . '" id="width"/>'
                     . '</div>',
                     '<label for="height">'
@@ -555,7 +555,7 @@ class ServiceConfigurationPage extends FOGPage
                     . '</label>' => '<div class="input-group">'
                     . '<input type="text" class="form-control" name="height" '
                     . 'value="'
-                    . $y
+                    . Initiator::e($y)
                     . '" id="height"/>'
                     . '</div>',
                     '<label for="refresh">'
@@ -563,7 +563,7 @@ class ServiceConfigurationPage extends FOGPage
                     . '</label>' => '<div class="input-group">'
                     . '<input type="text" class="form-control" name="refresh" '
                     . 'value="'
-                    . $r
+                    . Initiator::e($r)
                     . '" id="refresh"/>'
                     . '</div>',
                     '<label for="updatescreen">'

--- a/packages/web/lib/pages/snapinmanagementpage.class.php
+++ b/packages/web/lib/pages/snapinmanagementpage.class.php
@@ -287,12 +287,12 @@ class SnapinManagementPage extends FOGPage
              * Store the data.
              */
             $this->data[] = array(
-                'id' => $id,
-                'name' => $name,
-                'description' => $description,
-                'file' => $file,
+                'id' => Initiator::e($id),
+                'name' => Initiator::e($name),
+                'description' => Initiator::e($description),
+                'file' => Initiator::e($file),
                 'packtype' => $packtype,
-                'storageGroup' => $storageGroup,
+                'storageGroup' => Initiator::e($storageGroup),
                 'protected' => $protected,
                 'enabled' => $enabled
             );

--- a/packages/web/lib/pages/snapinmanagementpage.class.php
+++ b/packages/web/lib/pages/snapinmanagementpage.class.php
@@ -94,10 +94,10 @@ class SnapinManagementPage extends FOGPage
         foreach (self::$_argTypes as $type => &$cmd) {
             printf(
                 '<option value="%s" rwargs="%s" args="%s">%s</option>',
-                $cmd[0],
-                $cmd[1],
-                $cmd[2],
-                $type
+                Initiator::e($cmd[0]),
+                Initiator::e($cmd[1]),
+                Initiator::e($cmd[2]),
+                Initiator::e($type)
             );
             unset($cmd);
         }
@@ -364,13 +364,13 @@ class SnapinManagementPage extends FOGPage
         foreach ($args as $type => &$cmd) {
             printf(
                 '<option file="%s" args="%s">%s</option>',
-                $cmd[0],
+                Initiator::e($cmd[0]),
                 (
                     isset($cmd[1]) ?
-                    $cmd[1] :
+                    Initiator::e($cmd[1]) :
                     ''
                 ),
-                $type
+                Initiator::e($type)
             );
             unset($cmd);
         }
@@ -507,7 +507,7 @@ class SnapinManagementPage extends FOGPage
             . _('Snapin Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="snapinname-input form-control"/>'
             . '</div>',
             '<label for="desc">'
@@ -515,7 +515,7 @@ class SnapinManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desc" class='
             . '"form-control snapindescription-input">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="storagegroup">'
@@ -571,7 +571,7 @@ class SnapinManagementPage extends FOGPage
             . '</span>' => '<div class="input-group">'
             . '<input type="text" class="snapinrw-input cmdlet1 form-control" '
             . 'name="rw" id="snaprw" value="'
-            . htmlspecialchars($rw, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($rw, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>',
             '<span class="hiddeninitially packnochangerwa">'
@@ -586,7 +586,7 @@ class SnapinManagementPage extends FOGPage
             . '</span>' => '<div class="input-group">'
             . '<input type="text" class="snapinrwa-input cmdlet2 form-control" '
             . 'name="rwa" id="snaprwa" value="'
-            . htmlspecialchars($rwa, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($rwa, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>',
             '<label for="snapinfile">'
@@ -624,7 +624,7 @@ class SnapinManagementPage extends FOGPage
             . '<div class="input-group">'
             . '<input type="text" name="args" id="args" class='
             . '"snapinargs-input cmdlet4 form-control" value="'
-            . htmlspecialchars($args, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($args, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>'
             . '</span>',
@@ -642,7 +642,7 @@ class SnapinManagementPage extends FOGPage
             . '<input type="number" class='
             . '"snapintimeout-input form-control" name="timeout" '
             . 'id="timeout" value="'
-            . $timeout
+            . Initiator::e($timeout)
             . '"/>'
             . '</div>',
             '<label for="toRep">'
@@ -998,7 +998,7 @@ class SnapinManagementPage extends FOGPage
             . _('Snapin Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="snapinname-input form-control"/>'
             . '</div>',
             '<label for="desc">'
@@ -1006,7 +1006,7 @@ class SnapinManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desc" class='
             . '"form-control snapindescription-input">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="snapinpack">'
@@ -1059,7 +1059,7 @@ class SnapinManagementPage extends FOGPage
             . '</span>' => '<div class="input-group">'
             . '<input type="text" class="snapinrw-input cmdlet1 form-control" '
             . 'name="rw" id="snaprw" value="'
-            . htmlspecialchars($rw, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($rw, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>',
             '<span class="hiddeninitially packnochangerwa">'
@@ -1074,7 +1074,7 @@ class SnapinManagementPage extends FOGPage
             . '</span>' => '<div class="input-group">'
             . '<input type="text" class="snapinrwa-input cmdlet2 form-control" '
             . 'name="rwa" id="snaprwa" value="'
-            . htmlspecialchars($rwa, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($rwa, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>',
             '<label for="snapinfile">'
@@ -1092,7 +1092,7 @@ class SnapinManagementPage extends FOGPage
             . '</span>'
             . '</label>'
             . '<input type="text" class="form-control filedisp cmdlet3" value="'
-            . $snapinfileexists
+            . Initiator::e($snapinfileexists)
             . '" readonly/>'
             . '</div>',
             (
@@ -1114,7 +1114,7 @@ class SnapinManagementPage extends FOGPage
             . '<div class="input-group">'
             . '<input type="text" name="args" id="args" class='
             . '"snapinargs-input cmdlet4 form-control" value="'
-            . htmlspecialchars($args, ENT_COMPAT, 'UTF-8', false)
+            . Initiator::e(htmlspecialchars($args, ENT_COMPAT, 'UTF-8', false))
             . '"/>'
             . '</div>'
             . '</span>',
@@ -1142,7 +1142,7 @@ class SnapinManagementPage extends FOGPage
             . '<input type="number" class='
             . '"snapintimeout-input form-control" name="timeout" '
             . 'id="timeout" value="'
-            . $timeout
+            . Initiator::e($timeout)
             . '"/>'
             . '</div>',
             '<label for="toRep">'

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -320,7 +320,7 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['SNName']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="desc">'
@@ -328,28 +328,28 @@ class StorageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desc" autocomplete="off" '
             . 'class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="ip">'
             . self::$foglang['IPAdr']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" id="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="webroot">'
             . _('Web root')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="webroot" id="webroot" value="'
-            . $webroot
+            . Initiator::e($webroot)
             . '" class="form-control" autocomplete="off"/>'
             . '</div>',
             '<label for="maxClients">'
             . self::$foglang['MaxClients']
             . '</div>' => '<div class="input-group">'
             . '<input type="number" name="maxClients" id="maxClients" value="'
-            . $maxClients
+            . Initiator::e($maxClients)
             . '" class="form-control" autocomplete="off" required/>'
             . '</div>',
             '<label for="ismaster">'
@@ -374,7 +374,7 @@ class StorageManagementPage extends FOGPage
             . '" data-toggle="tooltip" data-placement="left"></i>'
             . '<input type="number" name="bandwidth" id="bandwidth" '
             . 'value="'
-            . $bandwidth
+            . Initiator::e($bandwidth)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="storagegroupID">'
@@ -387,49 +387,49 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['ImagePath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="path" id="path" value="'
-            . $path
+            . Initiator::e($path)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="ftppath">'
             . self::$foglang['FTPPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ftppath" id="ftppath" value="'
-            . $ftppath
+            . Initiator::e($ftppath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="snapinpath">'
             . self::$foglang['SnapinPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="snapinpath" id="snapinpath" value="'
-            . $snapinpath
+            . Initiator::e($snapinpath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="sslpath">'
             . self::$foglang['SSLPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="sslpath" id="sslpath" value="'
-            . $sslpath
+            . Initiator::e($sslpath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="bitrate">'
             . _('Bitrate')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="bitrate" id="bitrate" value="'
-            . $bitrate
+            . Initiator::e($bitrate)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="helloInterval">'
             . _('Rexmit Hello Interval')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="helloInterval" id="helloInterval" value="'
-            . $helloInterval
+            . Initiator::e($helloInterval)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="interface">'
             . self::$foglang['Interface']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="interface" id="interface" value="'
-            . $interface
+            . Initiator::e($interface)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="isen">'
@@ -448,14 +448,14 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['ManUser']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="user" id="user" value="'
-            . $user
+            . Initiator::e($user)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="pass">'
             . self::$foglang['ManPass']
             . '</label>' => '<div class="input-group">'
             . '<input type="password" name="pass" id="pass" value="'
-            . $pass
+            . Initiator::e($pass)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="add">'
@@ -697,7 +697,7 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['SNName']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="desc">'
@@ -705,28 +705,28 @@ class StorageManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="desc" autocomplete="off" '
             . 'class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="ip">'
             . self::$foglang['IPAdr']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ip" id="ip" value="'
-            . $ip
+            . Initiator::e($ip)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="webroot">'
             . _('Web root')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="webroot" id="webroot" value="'
-            . $webroot
+            . Initiator::e($webroot)
             . '" class="form-control" autocomplete="off"/>'
             . '</div>',
             '<label for="maxClients">'
             . self::$foglang['MaxClients']
             . '</div>' => '<div class="input-group">'
             . '<input type="number" name="maxClients" id="maxClients" value="'
-            . $maxClients
+            . Initiator::e($maxClients)
             . '" class="form-control" autocomplete="off" required/>'
             . '</div>',
             '<label for="ismaster">'
@@ -751,7 +751,7 @@ class StorageManagementPage extends FOGPage
             . '" data-toggle="tooltip" data-placement="left"></i>'
             . '<input type="number" name="bandwidth" id="bandwidth" '
             . 'value="'
-            . $bandwidth
+            . Initiator::e($bandwidth)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="storagegroupID">'
@@ -764,49 +764,49 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['ImagePath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="path" id="path" value="'
-            . $path
+            . Initiator::e($path)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="ftppath">'
             . self::$foglang['FTPPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ftppath" id="ftppath" value="'
-            . $ftppath
+            . Initiator::e($ftppath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="snapinpath">'
             . self::$foglang['SnapinPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="snapinpath" id="snapinpath" value="'
-            . $snapinpath
+            . Initiator::e($snapinpath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="sslpath">'
             . self::$foglang['SSLPath']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="sslpath" id="sslpath" value="'
-            . $sslpath
+            . Initiator::e($sslpath)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="bitrate">'
             . _('Bitrate')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="bitrate" id="bitrate" value="'
-            . $bitrate
+            . Initiator::e($bitrate)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="helloInterval">'
             . _('Remit Hello Interval')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="helloInterval" id="helloInterval" value="'
-            . $helloInterval
+            . Initiator::e($helloInterval)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="interface">'
             . self::$foglang['Interface']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="interface" id="interface" value="'
-            . $interface
+            . Initiator::e($interface)
             . '" autocomplete="off" class="form-control"/>'
             . '</div>',
             '<label for="isen">'
@@ -828,14 +828,14 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['ManUser']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="user" id="user" value="'
-            . $user
+            . Initiator::e($user)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="pass">'
             . self::$foglang['ManPass']
             . '</label>' => '<div class="input-group">'
             . '<input type="password" name="pass" id="pass" value="'
-            . $pass
+            . Initiator::e($pass)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
             '<label for="update">'
@@ -1037,7 +1037,7 @@ class StorageManagementPage extends FOGPage
             . $this->title
             . '</label>' => '<input type="hidden" name="remitems[]" '
             . 'value="'
-            . $this->obj->get('id')
+            . Initiator::e($this->obj->get('id'))
             . '"/>'
             . '<button type="submit" name="delete" id="delete" '
             . 'class="btn btn-danger btn-block">'
@@ -1236,14 +1236,14 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['SGName']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control" required/>'
             . '</div>',
             '<label for="description">'
             . self::$foglang['SGDesc']
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="description" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="add">'
@@ -1361,14 +1361,14 @@ class StorageManagementPage extends FOGPage
             . self::$foglang['SGName']
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control" autocomplete="off" required/>'
             . '</div>',
             '<label for="description">'
             . self::$foglang['SGDesc']
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="description" class="form-control">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="update">'
@@ -1491,7 +1491,7 @@ class StorageManagementPage extends FOGPage
             . $this->title
             . '</label>' => '<input type="hidden" name="remitems[]" '
             . 'value="'
-            . $this->obj->get('id')
+            . Initiator::e($this->obj->get('id'))
             . '"/>'
             . '<button type="submit" name="delete" id="delete" '
             . 'class="btn btn-danger btn-block">'

--- a/packages/web/lib/pages/taskmanagementpage.class.php
+++ b/packages/web/lib/pages/taskmanagementpage.class.php
@@ -178,15 +178,15 @@ class TaskManagementPage extends FOGPage
             $this->data[] = array(
                 'startedby' => $Task->createdBy,
                 'details_taskforce' => isset($forcetask) ? $forcetask : '',
-                'id' => $Task->id,
-                'name' => $Task->name,
+                'id' => Initiator::e($Task->id),
+                'name' => Initiator::e($Task->name),
                 'time' => self::formatTime(
                     $Task->createdTime,
                     'Y-m-d H:i:s'
                 ),
-                'state' => $Task->state->name,
+                'state' => Initiator::e($Task->state->name),
                 'forced' => $Task->isForced,
-                'type' => $Task->type->name,
+                'type' => Initiator::e($Task->type->name),
                 'elapsed' => isset($Task->timeElapsed) ? $Task->timeElapsed : '',
                 'remains' => isset($Task->timeRemaining) ? $Task->timeRemaining : '',
                 'percent' => isset($Task->pct) ? $Task->pct : '',
@@ -197,19 +197,19 @@ class TaskManagementPage extends FOGPage
                     (isset($Task->name) && $Task->name) ?
                     sprintf(
                         '<div class="task-name">%s</div>',
-                        $Task->name
+                        Initiator::e($Task->name)
                     ) :
                     ''
                 ),
-                'host_id' => isset($Task->host->id) ? $Task->host->id : '',
-                'host_name' => isset($Task->host->name) ? $Task->host->name : '',
-                'host_mac' => isset($Task->host->mac) ? $Task->host->mac : '',
+                'host_id' => isset($Task->host->id) ? Initiator::e($Task->host->id) : '',
+                'host_name' => isset($Task->host->name) ? Initiator::e($Task->host->name) : '',
+                'host_mac' => isset($Task->host->mac) ? Initiator::e($Task->host->mac) : '',
                 'icon_state' => isset($Task->state->icon) ? $Task->state->icon : '',
                 'icon_type' => isset($Task->type->icon) ? $Task->type->icon : '',
-                'state_id' => isset($Task->state->id) ? $Task->state->id : '',
-                'image_name' => isset($Task->image->name) ? $Task->image->name : '',
-                'image_id' => isset($Task->image->id) ? $Task->image->id : '',
-                'node_name' => isset($Task->storagenode->name) ? $Task->storagenode->name : ''
+                'state_id' => isset($Task->state->id) ? Initiator::e($Task->state->id) : '',
+                'image_name' => isset($Task->image->name) ? Initiator::e($Task->image->name) : '',
+                'image_id' => isset($Task->image->id) ? Initiator::e($Task->image->id) : '',
+                'node_name' => isset($Task->storagenode->name) ? Initiator::e($Task->storagenode->name) : ''
             );
             unset($tmpTask, $Task);
         };

--- a/packages/web/lib/pages/usermanagementpage.class.php
+++ b/packages/web/lib/pages/usermanagementpage.class.php
@@ -59,7 +59,7 @@ class UserManagementPage extends FOGPage
             $this->notes = array(
                 _('Friendly Name') => (
                     $this->obj->get('display') ?
-                    $this->obj->get('display') :
+                    Initiator::e($this->obj->get('display')) :
                     _('No friendly name defined')
                 ),
                 self::$foglang['User'] => $this->obj->get('name'),
@@ -134,10 +134,10 @@ class UserManagementPage extends FOGPage
                 return;
             }
             $this->data[] = array(
-                'id' => $User->id,
+                'id' => Initiator::e($User->id),
                 'apiYes' => $User->api ? _('Yes') : _('No'),
-                'name' => $User->name,
-                'friendly' => $User->display
+                'name' => Initiator::e($User->name),
+                'friendly' => Initiator::e($User->display)
             );
             unset($User);
         };

--- a/packages/web/lib/pages/usermanagementpage.class.php
+++ b/packages/web/lib/pages/usermanagementpage.class.php
@@ -181,7 +181,7 @@ class UserManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control username-input" name='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" id="name" required/>'
             . '</div>',
             '<label for="display">'
@@ -190,7 +190,7 @@ class UserManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control friendlyname-input" name="'
             . 'display" value="'
-            . $display
+            . Initiator::e($display)
             . '" autocomplete="off" id="display"/>'
             . '</div>',
             '<label for="password">'
@@ -376,7 +376,7 @@ class UserManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control username-input" name='
             . '"name" value="'
-            . $this->obj->get('name')
+            . Initiator::e($this->obj->get('name'))
             . '" autocomplete="off" id="name" required/>'
             . '</div>',
             '<label for="display">'
@@ -385,7 +385,7 @@ class UserManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control friendlyname-input" name="'
             . 'display" value="'
-            . $this->obj->get('display')
+            . Initiator::e($this->obj->get('display'))
             . '" autocomplete="off" id="display"/>'
             . '</div>',
             '<label for="updategen">'
@@ -559,9 +559,9 @@ class UserManagementPage extends FOGPage
             . '<input type="password" class="'
             . 'form-control token" name="'
             . 'apitoken" id="token" readonly value="'
-            . base64_encode(
+            . Initiator::e(base64_encode(
                 $this->obj->get('token')
-            )
+            ))
             . '"/>'
             . '<div class="input-group-btn">'
             . '<button class="btn btn-warning resettoken" type="button">'

--- a/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
+++ b/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
@@ -345,7 +345,7 @@ class AccessControlManagementPage extends FOGPage
             . _('Role Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" class="form-control" value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="desc">'
@@ -353,7 +353,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" name="description" '
             . 'id="desc">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="add">'
@@ -494,7 +494,7 @@ class AccessControlManagementPage extends FOGPage
             . _('Role Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" class="form-control" value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="desc">'
@@ -502,7 +502,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" name="description" '
             . 'id="desc">'
-            . $desc
+            . Initiator::e($desc)
             . '</textarea>'
             . '</div>',
             '<label for="update">'
@@ -778,7 +778,7 @@ class AccessControlManagementPage extends FOGPage
             }
             $this->data[] = array(
                 'field' => '<input type="hidden" value="'
-                . $object->id
+                . Initiator::e($object->id)
                 . '" name="remitems[]"/>',
                 'input' => '<a href="?node='
                 . $node
@@ -913,7 +913,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control ruletype-input" type='
             . '"text" name="type" id="type" required value="'
-            . $type
+            . Initiator::e($type)
             . '"/>'
             . '</div>',
             '<label for="parent">'
@@ -921,7 +921,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control ruleparent-input" type='
             . '"text" name="parent" id="parent" required value="'
-            . $parent
+            . Initiator::e($parent)
             . '"/>'
             . '</div>',
             '<label for="nodeParent">'
@@ -929,7 +929,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control rulenodeparent-input" '
             . 'type="text" name="nodeParent" id="nodeParent" value="'
-            . $node
+            . Initiator::e($node)
             . '"/>'
             . '</div>',
             '<label for="value">'
@@ -937,7 +937,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control rulevalue-input" '
             . 'type="text" name="value" id="value" required value="'
-            . $value
+            . Initiator::e($value)
             . '"/>'
             . '</div>',
             '<label for="add">'
@@ -1095,7 +1095,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control ruletype-input" type='
             . '"text" name="type" id="type" required value="'
-            . $type
+            . Initiator::e($type)
             . '"/>'
             . '</div>',
             '<label for="parent">'
@@ -1103,7 +1103,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control ruleparent-input" type='
             . '"text" name="parent" id="parent" required value="'
-            . $parent
+            . Initiator::e($parent)
             . '"/>'
             . '</div>',
             '<label for="nodeParent">'
@@ -1111,7 +1111,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control rulenodeparent-input" '
             . 'type="text" name="nodeParent" id="nodeParent" value="'
-            . $node
+            . Initiator::e($node)
             . '"/>'
             . '</div>',
             '<label for="value">'
@@ -1119,7 +1119,7 @@ class AccessControlManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control rulevalue-input" '
             . 'type="text" name="value" id="value" required value="'
-            . $value
+            . Initiator::e($value)
             . '"/>'
             . '</div>',
             '<label for="updaterule">'
@@ -1271,7 +1271,7 @@ class AccessControlManagementPage extends FOGPage
             . $this->title
             . '</label>' => '<input type="hidden" name="remitems[]" '
             . 'value="'
-            . $this->obj->get('id')
+            . Initiator::e($this->obj->get('id'))
             . '"/>'
             . '<button type="submit" name="delete" id="delete" '
             . 'class="btn btn-danger btn-block">'

--- a/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
+++ b/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
@@ -274,9 +274,9 @@ class AccessControlManagementPage extends FOGPage
                 );
             self::$returnData = function (&$AccessControl) {
                 $this->data[] = array(
-                    'id' => $AccessControl->id,
-                    'name' => $AccessControl->name,
-                    'description' => $AccessControl->description,
+                    'id' => Initiator::e($AccessControl->id),
+                    'name' => Initiator::e($AccessControl->name),
+                    'description' => Initiator::e($AccessControl->description),
                     'createdBy' => $AccessControl->createdBy,
                     'createdTime' => $AccessControl->createdTime
                 );
@@ -286,11 +286,11 @@ class AccessControlManagementPage extends FOGPage
         case 'accesscontrolrule':
             self::$returnData = function (&$AccessControlRule) {
                 $this->data[] = array(
-                    'type' => $AccessControlRule->type,
-                    'id' => $AccessControlRule->id,
-                    'value' => $AccessControlRule->value,
-                    'parent' => $AccessControlRule->parent,
-                    'node' => $AccessControlRule->node
+                    'type' => Initiator::e($AccessControlRule->type),
+                    'id' => Initiator::e($AccessControlRule->id),
+                    'value' => Initiator::e($AccessControlRule->value),
+                    'parent' => Initiator::e($AccessControlRule->parent),
+                    'node' => Initiator::e($AccessControlRule->node)
                 );
                 unset($AccessControlRule);
             };

--- a/packages/web/lib/plugins/fileintegrity/pages/fileintegritymanagementpage.class.php
+++ b/packages/web/lib/plugins/fileintegrity/pages/fileintegritymanagementpage.class.php
@@ -86,11 +86,11 @@ class FileIntegrityManagementPage extends FOGPage
          */
         self::$returnData = function (&$FileIntegrity) {
             $this->data[] = array(
-                'checksum' => $FileIntegrity->checksum,
+                'checksum' => Initiator::e($FileIntegrity->checksum),
                 'modtime' => $FileIntegrity->modtime,
-                'storagenodeID' => $FileIntegrity->storagenode->id,
-                'storage_name' => $FileIntegrity->storagenode->name,
-                'file_path' => $FileIntegrity->path,
+                'storagenodeID' => Initiator::e($FileIntegrity->storagenode->id),
+                'storage_name' => Initiator::e($FileIntegrity->storagenode->name),
+                'file_path' => Initiator::e($FileIntegrity->path),
             );
             unset($FileIntegrity);
         };

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
@@ -232,14 +232,14 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="name" name="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('LDAP Server Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="address">'
@@ -247,7 +247,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="address" name="address" '
             . 'value="'
-            . $address
+            . Initiator::e($address)
             . '" required/>'
             . '</div>',
             '<label for="port">'
@@ -266,7 +266,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="searchDN" name='
             . '"searchDN" value="'
-            . $searchDN
+            . Initiator::e($searchDN)
             . '" required/>'
             . '</div>',
             '<label for="grpSearchDN">'
@@ -274,7 +274,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="grpSearchDN" name='
             . '"grpSearchDN" value="'
-            . $grpSearchDN
+            . Initiator::e($grpSearchDN)
             . '"/>'
             . '</div>',
             '<label for="adminGroup">'
@@ -282,7 +282,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="adminGroup" name='
             . '"adminGroup" value="'
-            . $adminGroup
+            . Initiator::e($adminGroup)
             . '"/>'
             . '</div>',
             '<label for="userGroup">'
@@ -290,7 +290,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="userGroup" name='
             . '"userGroup" value="'
-            . $userGroup
+            . Initiator::e($userGroup)
             . '"/>'
             . '</div>',
             '<label for="inittemplate">'
@@ -314,7 +314,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="userNamAttr" name='
             . '"userNamAttr" value="'
-            . $userNamAttr
+            . Initiator::e($userNamAttr)
             . '" required/>'
             . '</div>',
             '<label for="grpMemberAttr">'
@@ -322,7 +322,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="grpMemberAttr" name='
             . '"grpMemberAttr" value="'
-            . $grpMemberAttr
+            . Initiator::e($grpMemberAttr)
             . '"/>'
             . '</div>',
             '<label for="searchScope">'
@@ -333,7 +333,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="bindDN" name="bindDN" '
             . 'value="'
-            . $bindDN
+            . Initiator::e($bindDN)
             . '"/>'
             . '</div>',
             '<label for="bindPwd">'
@@ -341,7 +341,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="password" id="bindPwd" name='
             . '"bindPwd" value="'
-            . $bindPwd
+            . Initiator::e($bindPwd)
             . '"/>'
             . '</div>',
             '<label for="add">'
@@ -695,14 +695,14 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="name" name="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('LDAP Server Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="address">'
@@ -710,7 +710,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="address" name="address" '
             . 'value="'
-            . $address
+            . Initiator::e($address)
             . '" required/>'
             . '</div>',
             '<label for="port">'
@@ -733,7 +733,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="searchDN" name='
             . '"searchDN" value="'
-            . $searchDN
+            . Initiator::e($searchDN)
             . '" required/>'
             . '</div>',
             '<label for="grpSearchDN">'
@@ -741,7 +741,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="grpSearchDN" name='
             . '"grpSearchDN" value="'
-            . $grpSearchDN
+            . Initiator::e($grpSearchDN)
             . '"/>'
             . '</div>',
             '<label for="adminGroup">'
@@ -749,7 +749,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="adminGroup" name='
             . '"adminGroup" value="'
-            . $adminGroup
+            . Initiator::e($adminGroup)
             . '"/>'
             . '</div>',
             '<label for="userGroup">'
@@ -757,7 +757,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="userGroup" name='
             . '"userGroup" value="'
-            . $userGroup
+            . Initiator::e($userGroup)
             . '"/>'
             . '</div>',
             '<label for="inittemplate">'
@@ -781,7 +781,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="userNamAttr" name='
             . '"userNamAttr" value="'
-            . $userNamAttr
+            . Initiator::e($userNamAttr)
             . '" required/>'
             . '</div>',
             '<label for="grpMemberAttr">'
@@ -789,7 +789,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="grpMemberAttr" name='
             . '"grpMemberAttr" value="'
-            . $grpMemberAttr
+            . Initiator::e($grpMemberAttr)
             . '"/>'
             . '</div>',
             '<label for="searchScope">'
@@ -800,7 +800,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="bindDN" name="bindDN" '
             . 'value="'
-            . $bindDN
+            . Initiator::e($bindDN)
             . '"/>'
             . '</div>',
             '<label for="bindPwd">'
@@ -808,7 +808,7 @@ class LDAPManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="password" id="bindPwd" name='
             . '"bindPwd" value="'
-            . $bindPwd
+            . Initiator::e($bindPwd)
             . '"/>'
             . '</div>',
             '<label for="update">'
@@ -1069,14 +1069,14 @@ class LDAPManagementPage extends FOGPage
             . _('User Filter')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="filter" id="filter" class="form-control" value="'
-            . $filter
+            . Initiator::e($filter)
             . '"/>'
             . '</div>',
             '<label for="ports">'
             . _('LDAP Ports')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="ports" id="ports" class="form-control" value="'
-            . $ports
+            . Initiator::e($ports)
             . '"/>'
             . '</div>',
             '<label for="update">'

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
@@ -107,21 +107,21 @@ class LDAPManagementPage extends FOGPage
          */
         self::$returnData = function (&$LDAP) {
             $this->data[] = array(
-                'id' => $LDAP->id,
-                'name' => $LDAP->name,
-                'description' => $LDAP->description,
-                'address' => $LDAP->address,
-                'searchDN' => $LDAP->searchDN,
-                'port' => $LDAP->port,
-                'userNamAttr' => $LDAP->userNamAttr,
-                'grpMemberAttr' => $LDAP->grpMemberAttr,
-                'grpSearchDN' => $LDAP->grpSearchDN,
-                'adminGroup' => $LDAP->adminGroup,
-                'userGroup' => $LDAP->userGroup,
-                'searchScope' => $LDAP->searchScope,
-                'bindDN' => $LDAP->bindDN,
-                'bindPwd' => $LDAP->bindPwd,
-                'useGroupMatch' => $LDAP->useGroupMatch,
+                'id' => Initiator::e($LDAP->id),
+                'name' => Initiator::e($LDAP->name),
+                'description' => Initiator::e($LDAP->description),
+                'address' => Initiator::e($LDAP->address),
+                'searchDN' => Initiator::e($LDAP->searchDN),
+                'port' => Initiator::e($LDAP->port),
+                'userNamAttr' => Initiator::e($LDAP->userNamAttr),
+                'grpMemberAttr' => Initiator::e($LDAP->grpMemberAttr),
+                'grpSearchDN' => Initiator::e($LDAP->grpSearchDN),
+                'adminGroup' => Initiator::e($LDAP->adminGroup),
+                'userGroup' => Initiator::e($LDAP->userGroup),
+                'searchScope' => Initiator::e($LDAP->searchScope),
+                'bindDN' => Initiator::e($LDAP->bindDN),
+                'bindPwd' => Initiator::e($LDAP->bindPwd),
+                'useGroupMatch' => Initiator::e($LDAP->useGroupMatch),
             );
             unset($LDAP);
         };

--- a/packages/web/lib/plugins/location/class/locationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationmanager.class.php
@@ -171,13 +171,13 @@ class LocationManager extends FOGManagerController
         foreach ((array)$protocols as $short => &$long) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                $short,
+                Initiator::e($short),
                 (
                     $preselection === $short ?
                     ' selected' :
                     ''
                 ),
-                $long
+                Initiator::e($long)
             );
             unset($short, $long);
         }

--- a/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
+++ b/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
@@ -176,7 +176,7 @@ class LocationManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control locationname-input" name='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" id="name" required/>'
             . '</div>',
             '<label for="storagegroup">'
@@ -357,7 +357,7 @@ class LocationManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control locationname-input" name='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" id="name" required/>'
             . '</div>',
             '<label for="storagegroup">'

--- a/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
+++ b/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
@@ -110,11 +110,11 @@ class LocationManagementPage extends FOGPage
         self::$returnData = function (&$Location) {
             $sn = empty($Location->storagenode->name) ? '*' : $Location->storagenode->name;
             $this->data[] = array(
-                'id' => $Location->id,
-                'name' => $Location->name,
-                'storageGroup' => $Location->storagegroup->name,
-                'storageNode' => $sn,
-                'storageNodeProtocol' => $Location->protocol,
+                'id' => Initiator::e($Location->id),
+                'name' => Initiator::e($Location->name),
+                'storageGroup' => Initiator::e($Location->storagegroup->name),
+                'storageNode' => Initiator::e($sn),
+                'storageNodeProtocol' => Initiator::e($Location->protocol),
                 'tftp' => $Location->tftp ? _('Yes') : _('No'),
             );
             unset($Location);

--- a/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
+++ b/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
@@ -64,10 +64,30 @@ class PersistentGroupsManager extends FOGManagerController
             FROM `printerAssoc` WHERE `paHostID`=@myTemplateID
             ON DUPLICATE KEY UPDATE `paHostID`=VALUES(`paHostID`),`paPrinterID`=VALUES(`paPrinterID`),`paIsDefault`=VALUES(`paIsDefault`),`paAnon1`=VALUES(`paAnon1`),`paAnon2`=VALUES(`paAnon2`),`paAnon3`=VALUES(`paAnon3`),`paAnon4`=VALUES(`paAnon4`),`paAnon5`=VALUES(`paAnon5`);
 
-        INSERT INTO `snapinAssoc` (`saHostID`,`saSnapinID`)
-            SELECT @myHostID as `saHostID`,`saSnapinID` 
-            FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID
-            ON DUPLICATE KEY UPDATE `saHostID`=VALUES(`saHostID`),`saSnapinID`=VALUES(`saSnapinID`);
+        SET @myDBTest = (SELECT count(`saSnapinID`) FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID LIMIT 1);
+        IF (@myDBTest > 0) THEN
+            INSERT INTO `snapinAssoc` (`saHostID`,`saSnapinID`)
+                SELECT @myHostID as `saHostID`,`saSnapinID` 
+                FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID
+                ON DUPLICATE KEY UPDATE `saHostID`=VALUES(`saHostID`),`saSnapinID`=VALUES(`saSnapinID`);
+
+            -- Check if there's already an active snapin job for this host
+            SET @existingJob = (SELECT `sjID` FROM `snapinJobs` WHERE `sjHostID`=@myHostID AND `sjStateID` IN (1,2) LIMIT 1);
+            
+            IF (@existingJob IS NULL) THEN
+                INSERT INTO `snapinJobs` (`sjHostID`,`sjStateID`,`sjCreateTime`)
+                    VALUES (@myHostID, 1, NOW());
+                SET @mysjID = LAST_INSERT_ID();
+            ELSE
+                SET @mysjID = @existingJob;
+            END IF;
+            
+            -- Add tasks for any snapins that don't already have tasks in this job
+            INSERT INTO `snapinTasks` (`stJobID`,`stState`,`stCheckinDate`,`stSnapinID`)
+                SELECT @mysjID as `stJobID`, 1 as `stState`, NOW() as `stCheckinDate`, `saSnapinID` as `stSnapinID`
+                FROM `snapinAssoc` WHERE `saHostID`=@myHostID
+                AND `saSnapinID` NOT IN (SELECT `stSnapinID` FROM `snapinTasks` WHERE `stJobID`=@mysjID);
+        END IF;
 
         INSERT INTO `moduleStatusByHost` (`msHostID`,`msModuleID`,`msState`)
             SELECT @myHostID as `msHostID`,`msModuleID`,`msState`

--- a/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
+++ b/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
@@ -119,7 +119,7 @@ class PushbulletManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" '
             . 'name="apiToken" id="apiToken" value="'
-            . $value
+            . Initiator::e($value)
             . '"/>'
             . '</div>',
             '<label for="add">'

--- a/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
+++ b/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
@@ -78,9 +78,9 @@ class PushbulletManagementPage extends FOGPage
          */
         self::$returnData = function (&$PushBullet) {
             $this->data[] = array(
-                'name'    => $PushBullet->name,
-                'email'   => $PushBullet->email,
-                'id'      => $PushBullet->id,
+                'name'    => Initiator::e($PushBullet->name),
+                'email'   => Initiator::e($PushBullet->email),
+                'id'      => Initiator::e($PushBullet->id),
             );
             unset($PushBullet);
         };

--- a/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
+++ b/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
@@ -151,7 +151,7 @@ class SiteManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control" '
             . 'id="site" required/>',
             '<label for="description">'
@@ -159,7 +159,7 @@ class SiteManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea class="form-control" '
             . 'id="description" name="description">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="add">'
@@ -294,7 +294,7 @@ class SiteManagementPage extends FOGPage
             . '<input class="form-control sitename-input" type="text" '
             . 'name="name" id="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="description">'
@@ -302,7 +302,7 @@ class SiteManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control sitedesc-input" '
             . 'id="description">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="updategen">'

--- a/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
+++ b/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
@@ -108,9 +108,9 @@ class SiteManagementPage extends FOGPage
          */
         self::$returnData = function (&$Site) {
             $this->data[] = array(
-                'id' => $Site->id,
-                'name' => $Site->name,
-                'description' => $Site->description,
+                'id' => Initiator::e($Site->id),
+                'name' => Initiator::e($Site->name),
+                'description' => Initiator::e($Site->description),
 //                'hosts' => $Site->getHostCount()
                 'hosts' => self::getClass('SiteHostAssociationManager')
                         ->count(

--- a/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
+++ b/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
@@ -131,7 +131,7 @@ class SlackManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" '
             . 'name="apiToken" id="apiToken" value="'
-            . $value
+            . Initiator::e($value)
             . '" required/>'
             . '</div>',
             '<label for="user">'
@@ -139,7 +139,7 @@ class SlackManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" '
             . 'name="user" id="user" value="'
-            . $user
+            . Initiator::e($user)
             . '" required/>'
             . '</div>',
             '<label for="add">'

--- a/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
+++ b/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
@@ -85,10 +85,10 @@ class SlackManagementPage extends FOGPage
                 $Slack->id
             )->call('auth.test');
             $this->data[] = array(
-                'id' => $Slack->id,
-                'team' => $team_name['team'],
-                'createdBy' => $team_name['user'],
-                'name' => $Slack->name,
+                'id' => Initiator::e($Slack->id),
+                'team' => Initiator::e($team_name['team']),
+                'createdBy' => Initiator::e($team_name['user']),
+                'name' => Initiator::e($Slack->name),
             );
             unset($Slack);
         };

--- a/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
+++ b/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
@@ -109,11 +109,11 @@ class SubnetgroupManagementPage extends FOGPage
             );
 
             $this->data[] = array(
-                'id' => $Subnetgroup->id,
-                'groupName' => isset($Group->groups[0]) ? $Group->groups[0]->name : '',
-                'groupID'   => $Subnetgroup->groupID,
-                'subnets' => $Subnetgroup->subnets,
-                'name' => $Subnetgroup->name,
+                'id' => Initiator::e($Subnetgroup->id),
+                'groupName' => isset($Group->groups[0]) ? Initiator::e($Group->groups[0]->name) : '',
+                'groupID'   => Initiator::e($Subnetgroup->groupID),
+                'subnets' => Initiator::e($Subnetgroup->subnets),
+                'name' => Initiator::e($Subnetgroup->name),
             );
             unset($Subnetgroup);
         };

--- a/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
+++ b/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
@@ -160,7 +160,7 @@ class SubnetgroupManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control sgsubnet-input" name='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" id="name" required'
             . '</div>',
           '<label for="subnets">'
@@ -169,7 +169,7 @@ class SubnetgroupManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control sgsubnet-input" name='
             . '"subnets" value="'
-            . $subnets
+            . Initiator::e($subnets)
             . '" autocomplete="off" id="subnets" required'
             . ' placeholder="192.168.1.0/24, 10.1.0.0/16"/>'
             . '</div>',
@@ -343,7 +343,7 @@ class SubnetgroupManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control sgsubnet-input" name='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" autocomplete="off" id="name"/>'
             . '</div>',
           '<label for="subnets">'
@@ -352,7 +352,7 @@ class SubnetgroupManagementPage extends FOGPage
             . '<input type="text" class="'
             . 'form-control sgsubnet-input" name='
             . '"subnets" value="'
-            . $subnets
+            . Initiator::e($subnets)
             . '" autocomplete="off" id="subnets"/>'
             . '</div>',
           '<label for="group">'

--- a/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
@@ -94,8 +94,8 @@ class TaskstateeditManagementPage extends FOGPage
          */
         self::$returnData = function (&$TaskState) {
             $this->data[] = array(
-                'id' => $TaskState->id,
-                'name' => $TaskState->name,
+                'id' => Initiator::e($TaskState->id),
+                'name' => Initiator::e($TaskState->name),
                 'icon' => $TaskState->icon,
             );
             unset($TaskState);

--- a/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
@@ -140,14 +140,14 @@ class TaskstateeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="name" id='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="icon">'
@@ -158,7 +158,7 @@ class TaskstateeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="additional" id='
             . '"additional" value="'
-            . $additional
+            . Initiator::e($additional)
             . '"/>'
             . '</div>',
             '<label for="add">'
@@ -329,14 +329,14 @@ class TaskstateeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="name" id='
             . '"name" value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="icon">'
@@ -347,7 +347,7 @@ class TaskstateeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="additional" id='
             . '"additional" value="'
-            . $additional
+            . Initiator::e($additional)
             . '"/>'
             . '</div>',
             '<label for="update">'

--- a/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
@@ -174,7 +174,7 @@ class TasktypeeditManagementPage extends FOGPage
             . _('Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -182,7 +182,7 @@ class TasktypeeditManagementPage extends FOGPage
             . _('Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="description" class="form-control">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="icon">'
@@ -193,7 +193,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="kernel" id="kernel" '
             . 'value="'
-            . $kernel
+            . Initiator::e($kernel)
             . '"/>'
             . '</div>',
             '<label for="kernargs">'
@@ -201,7 +201,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="kernelargs" id='
             . '"kernargs" value="'
-            . $kernelargs
+            . Initiator::e($kernelargs)
             . '"/>'
             . '</div>',
             '<label for="initrd">'
@@ -209,7 +209,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="initrd" class='
             . '"form-control" id="initrd">'
-            . $initrd
+            . Initiator::e($initrd)
             . '</textarea>'
             . '</div>',
             '<label for="type">'
@@ -217,7 +217,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="type" id='
             . '"type" value="'
-            . $type
+            . Initiator::e($type)
             . '"/>'
             . '</div>',
             '<label for="isAd">'
@@ -450,7 +450,7 @@ class TasktypeeditManagementPage extends FOGPage
             . _('Name')
             . '</label>' => '<div class="input-group">'
             . '<input type="text" name="name" id="name" value="'
-            . $name
+            . Initiator::e($name)
             . '" class="form-control" autocomplete="off" '
             . 'required/>'
             . '</div>',
@@ -458,7 +458,7 @@ class TasktypeeditManagementPage extends FOGPage
             . _('Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" id="description" class="form-control">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="icon">'
@@ -469,7 +469,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="kernel" id="kernel" '
             . 'value="'
-            . $kernel
+            . Initiator::e($kernel)
             . '"/>'
             . '</div>',
             '<label for="kernargs">'
@@ -477,7 +477,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="kernelargs" id='
             . '"kernargs" value="'
-            . $kernelargs
+            . Initiator::e($kernelargs)
             . '"/>'
             . '</div>',
             '<label for="initrd">'
@@ -485,7 +485,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<textarea name="initrd" class='
             . '"form-control" id="initrd">'
-            . $initrd
+            . Initiator::e($initrd)
             . '</textarea>'
             . '</div>',
             '<label for="type">'
@@ -493,7 +493,7 @@ class TasktypeeditManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" name="type" id='
             . '"type" value="'
-            . $type
+            . Initiator::e($type)
             . '"/>'
             . '</div>',
             '<label for="isAd">'

--- a/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
@@ -95,10 +95,10 @@ class TasktypeeditManagementPage extends FOGPage
         self::$returnData = function (&$TaskType) {
             $this->data[] = array(
                 'icon' => $TaskType->icon,
-                'id' => $TaskType->id,
-                'name' => $TaskType->name,
-                'access' => $TaskType->access,
-                'args' => $TaskType->kernelArgs,
+                'id' => Initiator::e($TaskType->id),
+                'name' => Initiator::e($TaskType->name),
+                'access' => Initiator::e($TaskType->access),
+                'args' => Initiator::e($TaskType->kernelArgs),
             );
             unset($TaskType);
         };

--- a/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
+++ b/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
@@ -142,14 +142,14 @@ class WindowsKeyManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="name" name="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('Windows Key Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="productKey">'
@@ -157,7 +157,7 @@ class WindowsKeyManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="productKey" name="key" '
             . 'value="'
-            . $key
+            . Initiator::e($key)
             . '" required/>'
             . '</div>',
             '<label for="add">'
@@ -322,14 +322,14 @@ class WindowsKeyManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="name" name="name" '
             . 'value="'
-            . $name
+            . Initiator::e($name)
             . '" required/>'
             . '</div>',
             '<label for="desc">'
             . _('Windows Key Description')
             . '</label>' => '<div class="input-group">'
             . '<textarea name="description" class="form-control" id="desc">'
-            . $description
+            . Initiator::e($description)
             . '</textarea>'
             . '</div>',
             '<label for="productKey">'
@@ -337,7 +337,7 @@ class WindowsKeyManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control" type="text" id="productKey" name="key" '
             . 'value="'
-            . $key
+            . Initiator::e($key)
             . '" required/>'
             . '</div>',
             '<label for="update">'

--- a/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
+++ b/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
@@ -95,8 +95,8 @@ class WindowsKeyManagementPage extends FOGPage
          */
         self::$returnData = function (&$WindowsKey) {
             $this->data[] = array(
-                'id' => $WindowsKey->id,
-                'name' => $WindowsKey->name
+                'id' => Initiator::e($WindowsKey->id),
+                'name' => Initiator::e($WindowsKey->name),
             );
             unset($WindowsKey);
         };

--- a/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
@@ -120,7 +120,7 @@ class WOLBroadcastManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control wolinput-name" type='
             . '"text" name="name" id="name" required value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="broadcast">'
@@ -128,7 +128,7 @@ class WOLBroadcastManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control wolinput-ip" type='
             . '"text" name="broadcast" id="broadcast" required value="'
-            . $broadcast
+            . Initiator::e($broadcast)
             . '"/>',
             '<label for="add">'
             . _('Create WOL Broadcast?')
@@ -265,7 +265,7 @@ class WOLBroadcastManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control wolinput-name" type='
             . '"text" name="name" id="name" required value="'
-            . $name
+            . Initiator::e($name)
             . '"/>'
             . '</div>',
             '<label for="broadcast">'
@@ -273,7 +273,7 @@ class WOLBroadcastManagementPage extends FOGPage
             . '</label>' => '<div class="input-group">'
             . '<input class="form-control wolinput-ip" type='
             . '"text" name="broadcast" id="broadcast" required value="'
-            . $broadcast
+            . Initiator::e($broadcast)
             . '"/>',
             '<label for="updategen">'
             . _('Make Changes?')

--- a/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
@@ -84,9 +84,9 @@ class WOLBroadcastManagementPage extends FOGPage
          */
         self::$returnData = function (&$WOLBroadcast) {
             $this->data[] = array(
-                'id'    => $WOLBroadcast->id,
-                'name'  => $WOLBroadcast->name,
-                'wol_ip' => $WOLBroadcast->broadcast,
+                'id'    => Initiator::e($WOLBroadcast->id),
+                'name'  => Initiator::e($WOLBroadcast->name),
+                'wol_ip' => Initiator::e($WOLBroadcast->broadcast),
             );
             unset($WOLBroadcast);
         };

--- a/packages/web/lib/reports/history_report.report.php
+++ b/packages/web/lib/reports/history_report.report.php
@@ -70,7 +70,7 @@ class History_Report extends ReportManagementPage
                 . '<input type="text" class="'
                 . 'form-control text-input" name='
                 . '"info" value="'
-                . (isset($info) ? $info : '')
+                . (isset($info) ? Initiator::e($info) : '')
                 . '" autocomplete="off" id="info" />'
                 . '</div>',
                 '<label for="performsearch">'

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5013,8 +5013,8 @@ msgstr "Snapin ajouté !"
 
 msgid "Snapin file is too big, increase post_max_size in php.ini."
 msgstr ""
-"Le fichier Snapin est trop gros, augmentez post_max_size dans le fichier php."
-"ini."
+"Le fichier Snapin est trop gros, augmentez post_max_size dans le fichier "
+"php.ini."
 
 msgid "Snapin is invalid"
 msgstr "Snapin n'est pas valide"


### PR DESCRIPTION
In a test deployment, I noticed that we had to deploy all the snapins through the GUI even though the snapins were assigned to each new host. 

I dug further and found a forum post regarding that same issue that had some sample code written for it.

https://forums.fogproject.org/topic/15084/persistent-groups-snapins-added-to-host-but-not-deployed/33?lang=en-US&page=2

I refined it and implemented it into my current FOG installation that I've been testing out and it has worked on ~30 workstations so far.

I'm new to Git but wanted to hopefully help others that had the same issue. If I need to submit an issue with this, please let me know and I can give more details if needed.