### PR TITLE
Persistent Groups Manager does not auto create snapin tasks, only assigns the snapins.

### DIFF
--- a/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
+++ b/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
@@ -64,10 +64,30 @@ class PersistentGroupsManager extends FOGManagerController
             FROM `printerAssoc` WHERE `paHostID`=@myTemplateID
             ON DUPLICATE KEY UPDATE `paHostID`=VALUES(`paHostID`),`paPrinterID`=VALUES(`paPrinterID`),`paIsDefault`=VALUES(`paIsDefault`),`paAnon1`=VALUES(`paAnon1`),`paAnon2`=VALUES(`paAnon2`),`paAnon3`=VALUES(`paAnon3`),`paAnon4`=VALUES(`paAnon4`),`paAnon5`=VALUES(`paAnon5`);
 
-        INSERT INTO `snapinAssoc` (`saHostID`,`saSnapinID`)
-            SELECT @myHostID as `saHostID`,`saSnapinID` 
-            FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID
-            ON DUPLICATE KEY UPDATE `saHostID`=VALUES(`saHostID`),`saSnapinID`=VALUES(`saSnapinID`);
+        SET @myDBTest = (SELECT count(`saSnapinID`) FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID LIMIT 1);
+        IF (@myDBTest > 0) THEN
+            INSERT INTO `snapinAssoc` (`saHostID`,`saSnapinID`)
+                SELECT @myHostID as `saHostID`,`saSnapinID` 
+                FROM `snapinAssoc` WHERE `saHostID`=@myTemplateID
+                ON DUPLICATE KEY UPDATE `saHostID`=VALUES(`saHostID`),`saSnapinID`=VALUES(`saSnapinID`);
+
+            -- Check if there's already an active snapin job for this host
+            SET @existingJob = (SELECT `sjID` FROM `snapinJobs` WHERE `sjHostID`=@myHostID AND `sjStateID` IN (1,2) LIMIT 1);
+            
+            IF (@existingJob IS NULL) THEN
+                INSERT INTO `snapinJobs` (`sjHostID`,`sjStateID`,`sjCreateTime`)
+                    VALUES (@myHostID, 1, NOW());
+                SET @mysjID = LAST_INSERT_ID();
+            ELSE
+                SET @mysjID = @existingJob;
+            END IF;
+            
+            -- Add tasks for any snapins that don't already have tasks in this job
+            INSERT INTO `snapinTasks` (`stJobID`,`stState`,`stCheckinDate`,`stSnapinID`)
+                SELECT @mysjID as `stJobID`, 1 as `stState`, NOW() as `stCheckinDate`, `saSnapinID` as `stSnapinID`
+                FROM `snapinAssoc` WHERE `saHostID`=@myHostID
+                AND `saSnapinID` NOT IN (SELECT `stSnapinID` FROM `snapinTasks` WHERE `stJobID`=@mysjID);
+        END IF;
 
         INSERT INTO `moduleStatusByHost` (`msHostID`,`msModuleID`,`msState`)
             SELECT @myHostID as `msHostID`,`msModuleID`,`msState`


### PR DESCRIPTION
In a test deployment, I noticed that we had to deploy all the snapins through the GUI even though the snapins were assigned to each new host.

I dug further and found a [forum post](https://forums.fogproject.org/topic/15084/persistent-groups-snapins-added-to-host-but-not-deployed/33?lang=en-US&page=2) regarding that same issue that had some sample code written for it.

I refined it and implemented it into my current FOG installation that I've been testing out and it has worked on ~30 workstations so far.

I'm new to Git but wanted to hopefully help others that had the same issue. If I need to submit an issue with this, please let me know and I can give more details if needed. Please disregard my first pull request that I closed. I accidentally created my fork from stable and not `dev-branch` so multiple files were updated instead of this single change.