### PR TITLE
Fix rfc2307 LDAP group login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,203 @@
+# Interaction rules (apply in every conversation)
+
+1. Don't assume. Don't hide confusion. Surface tradeoffs.
+2. Minimum code that solves the problem. Nothing speculative.
+3. Touch only what you must. Clean up only your own mess.
+4. Define success criteria. Loop until verified.
+
+---
+
+# FOG Project — Claude Context (dev-branch / 1.5.x)
+
+> **Branch note:** This is `dev-branch`, the **1.5.x stable/patches line** (currently `1.5.10`).
+> It is a *different codebase* from `working-1.6` — file naming, layout, and some conventions
+> differ (see below). Do **not** assume 1.6 patterns or file paths apply here. Fixes often need
+> to be ported between the two branches by hand, not merged.
+
+## What This Is
+
+FOG Project is an open-source network imaging and endpoint management system. It allows IT administrators to deploy OS images to computers over PXE boot, manage client hosts, schedule tasks, push snapins (software packages), manage printers, track users, and run background replication/multicast services.
+
+- Primary language: **PHP** (the codebase runs on PHP 8; `commons/init.php` uses typed signatures like `Initiator::e(mixed $value): string`)
+- Frontend: **jQuery + Bootstrap + AdminLTE** (no build step — plain JS served directly)
+- Background services: **PHP CLI daemons**
+- ~128 core `*.class.php` files under `lib/fog/`
+- Version line: **1.5.10** (the pre-commit hook stamps `dev`/`stable` branches with the `Patches` channel)
+
+---
+
+## How this differs from `working-1.6` (read this first)
+
+| Thing | dev-branch (1.5.x) | working-1.6 |
+|------|--------------------|-------------|
+| Page file names | `imagemanagementpage.class.php` (one word, `.class.php`) | `ImageManagement.page.php` |
+| Page class names | `ImageManagementPage` (with `Page` suffix) | `ImageManagement` (no suffix) |
+| ORM array syntax | older `array(...)` in many files | `[...]` short syntax |
+| `declare(strict_types=1)` | **none** in `lib/fog/` | present in newer files |
+| Node routing | `$nodes` allowlist array in `management/index.php` | node→class mapping |
+| Service daemons | no `FOGFileDeleter` | adds `FOGFileDeleter` |
+| `lib/` extra dirs | has `client/`, `reg-task/`, `service/` | reorganized |
+
+When porting a fix from 1.6, expect the target file to have a **different name and class name** here, and the surrounding code to use `array()` and other older idioms.
+
+---
+
+## Directory Structure
+
+```
+fogproject/                     (dev-branch)
+├── bin/                        # installfog.sh installer
+├── lib/                        # Shell library scripts (per-distro functions)
+├── packages/
+│   ├── service/                # PHP CLI background daemons
+│   │   ├── FOGTaskScheduler/
+│   │   ├── FOGImageReplicator/
+│   │   ├── FOGSnapinReplicator/
+│   │   ├── FOGMulticastManager/
+│   │   ├── FOGPingHosts/
+│   │   ├── FOGImageSize/
+│   │   ├── FOGSnapinHash/
+│   │   └── lib/service_lib.php
+│   └── web/                    # The web application
+│       ├── api/                # REST API
+│       ├── client/             # fog-client related files
+│       ├── commons/            # Boot/init files (loaded by ALL entry points)
+│       │   ├── base.inc.php    # Security headers, starts output buffering
+│       │   ├── init.php        # Initiator class: autoloader, session, sanitization
+│       │   ├── schema.php      # DB schema (CREATE TABLE as PHP arrays)
+│       │   └── text.php        # $foglang[] translation strings
+│       ├── lib/
+│       │   ├── fog/            # ~128 core *.class.php files (models, managers, utilities)
+│       │   ├── pages/          # *page.class.php UI page classes (e.g. hostmanagementpage.class.php)
+│       │   ├── hooks/          # *.hook.php hook classes
+│       │   ├── events/         # *.event.php event classes
+│       │   ├── reports/        # *.report.php report classes
+│       │   ├── reg-task/       # registration/task helpers
+│       │   ├── client/         # client-side support
+│       │   ├── db/             # PDODB, DatabaseManager
+│       │   ├── router/         # API routing
+│       │   ├── service/        # service support classes
+│       │   └── plugins/        # plugin directories
+│       └── management/         # Apache/Nginx document root
+│           ├── index.php       # Main UI entry point ($nodes allowlist lives here)
+│           ├── js/fog/         # FOG-specific JS
+│           ├── css/            # Stylesheets + LESS source
+│           └── languages/      # gettext .po/.mo files
+└── src/                        # iPXE / binaries source
+```
+
+---
+
+## PHP Architecture
+
+### Boot Chain
+
+Every entry point (web UI, API, background services) starts the same way:
+
+```
+commons/base.inc.php
+  → commons/init.php (defines Initiator, runs autoloader registration)
+    → new LoadGlobals() (bootstraps $DB, $HookManager, $EventManager, $currentUser)
+```
+
+### Autoloader
+
+No Composer/PSR-4. `Initiator` scans `BASEPATH` with `RecursiveDirectoryIterator` and registers these extensions (`commons/init.php`):
+
+```
+spl_autoload_extensions('.class.php,.page.php,.event.php,.hook.php,.report.php');
+```
+
+**Class name must match the filename** (the page files are lowercase one-word names, e.g. `imagemanagementpage.class.php` → class `ImageManagementPage`).
+
+### Class Hierarchy
+
+```
+FOGBase (abstract)
+├── FOGCore              — static utility methods (getSetting, getClass, etc.)
+├── FOGController        — single-entity ORM base
+│   └── Host, Image, Snapin, StorageNode, etc.
+├── FOGManagerController — collection/query base
+│   └── HostManager, ImageManager, etc.
+├── FOGPage              — UI page base
+│   └── HostManagementPage, ImageManagementPage, etc.
+├── Page                 — HTML shell renderer
+├── Hook                 — base for all hooks
+└── LoadGlobals          — bootstraps globals on construction
+```
+
+### ORM Pattern
+
+Every entity model declares (note the older `array()` syntax):
+```php
+protected $databaseTable = 'hosts';
+protected $databaseFields = array(
+    'id'   => 'hostID',    // friendly name => DB column name
+    'name' => 'hostName',
+);
+```
+
+Access: `$host->get('name')`, `$host->set('name', 'foo')`, `$host->save()`, `$host->load()`, `$host->destroy()`.
+Instantiate with ID to auto-load: `new Host(42)`.
+
+### URL Routing
+
+Driven by `?node=host&sub=list&id=42`. Allowed `node` values are whitelisted in `management/index.php` (the `$nodes` array); `node` maps to the matching `*page.class.php`, and `sub` maps to a method on that class.
+
+### Settings
+
+All app config lives in the `globalSettings` MySQL table:
+- Read: `FOGBase::getSetting('FOG_SETTING_NAME')`
+- Write: `FOGBase::setSetting('FOG_SETTING_NAME', $value)`
+
+### Hook/Event System
+
+```php
+// Register (in hook constructor):
+self::$HookManager->register('EVENT_NAME', array($this, 'methodName'));
+// Fire:
+self::$HookManager->processEvent('EVENT_NAME', array('data' => &$data));
+```
+
+---
+
+## Sanitization and Output
+
+- `Initiator::e($value)` — use when echoing user-controlled data into HTML (htmlspecialchars wrapper).
+- Input reads should use `filter_input(INPUT_GET/POST, 'key', FILTER_*)` rather than raw superglobals.
+- Output runs through an `ob_start` sanitizer.
+- CSRF handled via `csrf.class.php` server-side + token injection client-side.
+
+---
+
+## Coding Conventions
+
+- **Private methods**: single underscore prefix (`_init()`, `_verCheck()`)
+- **PHPDoc**: present on classes and methods
+- **Static globals**: `FOGBase::$HookManager`, `FOGBase::$DB`, etc.
+- **Class instantiation**: prefer `FOGBase::getClass('ClassName')` factory
+- **Translation**: `_('string')` for inline gettext; `$foglang['Key']` for pre-defined strings from `text.php`
+- **Do NOT add `declare(strict_types=1)`** — no file in `lib/fog/` uses it on this branch
+- Match the existing `array()` style in the file you are editing; don't mass-convert to `[]`
+
+---
+
+## Pre-commit hook (IMPORTANT — explains "files I didn't touch" in commits)
+
+`core.hooksPath` is `.githooks/`, so `.githooks/pre-commit` runs on **every** `git commit` (and `pre-merge-commit` delegates to it). It auto-modifies and `git add`s files beyond what you staged — this is expected, not a bug. Do **not** revert these. It does three things:
+
+1. **`updateLanguage()`** — regenerates `management/languages/messages.pot` via `xgettext`, sorts with `msgcat`, then `msgmerge`-updates every `.po`. Adds the whole `languages/` dir. Skipped if those tools aren't installed.
+2. **`psrfix()`** — runs `php-cs-fixer fix packages/web --rules=@PSR2` and **`git add packages/web`** unconditionally. Two consequences: your code may be auto-reformatted to PSR-2, and **any other dirty file under `packages/web/` gets swept into your commit** regardless of what you staged. Commit files outside `packages/web/` (like this `CLAUDE.md`) separately if you need them isolated.
+3. **Version bump** — derives a version from the branch name + commit count and rewrites `FOG_VERSION`/`FOG_CHANNEL` in `packages/web/lib/fog/system.class.php`. On `dev`/`stable` branches the channel is `Patches`. This step also tends to leave a **dangling staged `system.class.php`** bump after the commit; discard it with `git checkout -- packages/web/lib/fog/system.class.php` if you don't want it in the next commit.
+
+---
+
+## What NOT to Do
+
+- Do not add `declare(strict_types=1)`
+- Do not assume 1.6 file names/paths — this branch uses `*page.class.php` and `array()` idioms
+- Do not use raw `$_GET`/`$_POST` — use `filter_input()`
+- Do not echo user data without `Initiator::e()`
+- Do not remove hooks, events, or plugin integration points without explicit confirmation
+- Do not touch `config.class.php` — it's generated and excluded from git
+- Do not commit to `stable` or `master`; this branch (`dev-branch`) is the patches line

--- a/lib/arch/config.sh
+++ b/lib/arch/config.sh
@@ -48,4 +48,7 @@ fi
 [[ -z $ftpxinetd ]] && ftpxinetd="/etc/xinetd.d/vsftpd"
 [[ -z $ftpconfig ]] && ftpconfig="/etc/vsftpd.conf"
 [[ -z $dhcpd ]] && dhcpd="dhcpd4"
+[[ -z $iscservice ]] && iscservice="dhcpd4"
+[[ -z $keapackage ]] && keapackage="kea"
+[[ -z $keaservice ]] && keaservice="kea-dhcp4"
 [[ -z $snapindir ]] && snapindir="/opt/fog/snapins"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -683,6 +683,44 @@ addOndrejRepo() {
     LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8' add-apt-repository -y ppa:ondrej/php >>$error_log 2>&1
     LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8' add-apt-repository -y ppa:ondrej/apache2 >>$error_log 2>&1
 }
+resolveDHCPEngine() {
+    # Decide between Kea and ISC-DHCP for the optional FOG-hosted DHCP service.
+    # Only relevant when FOG is actually building DHCP and the ISC package is
+    # still in the install set (the storage-node and bldhcp=0 paths strip it in
+    # doOSSpecificIncludes before we ever get here). Must run after repo setup
+    # so the Kea availability probe sees enabled repos (e.g. EPEL on RHEL).
+    [[ -z $keaconfig ]] && keaconfig="/etc/kea/kea-dhcp4.conf"
+    [[ $bldhcp -eq 1 ]] || return 0
+    local iscpkg="$dhcpname"
+    [[ -n $iscpkg && $packages == *"$iscpkg"* ]] || return 0
+    # Honor an explicit/persisted choice; an existing install is never switched.
+    dhcpengine="${dhcpengine,,}"
+    if [[ -z $dhcpengine ]]; then
+        x="$iscpkg"
+        eval $packageQuery >>$error_log 2>&1
+        if [[ $? -eq 0 ]]; then
+            # A prior ISC install is left on ISC unless the admin opts in.
+            dhcpengine="isc"
+        elif [[ -n $keapackage ]]; then
+            eval $packagelist "$keapackage" >>$error_log 2>&1
+            [[ $? -eq 0 ]] && dhcpengine="kea" || dhcpengine="isc"
+        else
+            dhcpengine="isc"
+        fi
+    fi
+    if [[ $dhcpengine == kea ]]; then
+        if [[ -z $keapackage || -z $keaservice ]]; then
+            echo " * Kea requested but not available for this OS; using ISC-DHCP"
+            dhcpengine="isc"
+        else
+            packages="${packages//$iscpkg/$keapackage}"
+            dhcpname="$keapackage"
+            dhcpd="$keaservice"
+            dhcpconfig="$keaconfig"
+            dhcpconfigother=""
+        fi
+    fi
+}
 installPackages() {
     [[ $installlang -eq 1 ]] && packages="$packages gettext"
     packages="$packages unzip"
@@ -812,6 +850,7 @@ installPackages() {
         fi
     fi
     errorStat $?
+    resolveDHCPEngine
     packages=$(echo ${packages[@]} | tr ' ' '\n' | sort -u | tr '\n' ' ')
     echo -e " * Packages to be installed:\n\n\t$packages\n\n"
     newPackList=""
@@ -1685,6 +1724,7 @@ writeUpdateFile() {
     escdodhcp=$(echo $dodhcp | sed -e $replace)
     escbldhcp=$(echo $bldhcp | sed -e $replace)
     escdhcpd=$(echo $dhcpd | sed -e $replace)
+    escdhcpengine=$(echo $dhcpengine | sed -e $replace)
     escblexports=$(echo $blexports | sed -e $replace)
     escinstalltype=$(echo $installtype | sed -e $replace)
     escsnmysqlexternal=$(echo $snmysqlexternal | sed -e $replace)
@@ -1759,6 +1799,9 @@ writeUpdateFile() {
             grep -q "dhcpd=" $fogprogramdir/.fogsettings && \
                 sed -i "s/dhcpd=.*/dhcpd='$escdhcpd'/g" $fogprogramdir/.fogsettings || \
                 echo "dhcpd='$dhcpd'" >> $fogprogramdir/.fogsettings
+            grep -q "dhcpengine=" $fogprogramdir/.fogsettings && \
+                sed -i "s/dhcpengine=.*/dhcpengine='$escdhcpengine'/g" $fogprogramdir/.fogsettings || \
+                echo "dhcpengine='$dhcpengine'" >> $fogprogramdir/.fogsettings
             grep -q "blexports=" $fogprogramdir/.fogsettings && \
                 sed -i "s/blexports=.*/blexports='$escblexports'/g" $fogprogramdir/.fogsettings || \
                 echo "blexports='$blexports'" >> $fogprogramdir/.fogsettings
@@ -1866,6 +1909,7 @@ writeUpdateFile() {
             echo "dodhcp='$dodhcp'" >> "$fogprogramdir/.fogsettings"
             echo "bldhcp='$bldhcp'" >> "$fogprogramdir/.fogsettings"
             echo "dhcpd='$dhcpd'" >> "$fogprogramdir/.fogsettings"
+            echo "dhcpengine='$dhcpengine'" >> "$fogprogramdir/.fogsettings"
             echo "blexports='$blexports'" >> "$fogprogramdir/.fogsettings"
             echo "installtype='$installtype'" >> "$fogprogramdir/.fogsettings"
             echo "snmysqlexternal='${snmysqlexternal:-0}'" >> "$fogprogramdir/.fogsettings"
@@ -1914,6 +1958,7 @@ writeUpdateFile() {
         echo "dodhcp='$dodhcp'" >> "$fogprogramdir/.fogsettings"
         echo "bldhcp='$bldhcp'" >> "$fogprogramdir/.fogsettings"
         echo "dhcpd='$dhcpd'" >> "$fogprogramdir/.fogsettings"
+        echo "dhcpengine='$dhcpengine'" >> "$fogprogramdir/.fogsettings"
         echo "blexports='$blexports'" >> "$fogprogramdir/.fogsettings"
         echo "installtype='$installtype'" >> "$fogprogramdir/.fogsettings"
         echo "snmysqlexternal='${snmysqlexternal:-0}'" >> "$fogprogramdir/.fogsettings"
@@ -2560,20 +2605,148 @@ downloadfiles() {
     errorStat $?
     cd $cwd
 }
+_writeKeaConfig() {
+    # $1 = target file, $2 = client-classes block. Reads $interface, $ipaddress,
+    # $network, $cidr, $startrange, $endrange and $optdata from the caller's scope.
+    cat > "$1" <<EOFKEA
+{
+    "Dhcp4": {
+        "interfaces-config": { "interfaces": [ "$interface" ] },
+        "lease-database": { "type": "memfile", "lfc-interval": 3600 },
+        "valid-lifetime": 21600,
+        "max-valid-lifetime": 43200,
+        "next-server": "$ipaddress",
+        "option-data": [
+            { "name": "tftp-server-name", "data": "$ipaddress" }
+        ],
+        "subnet4": [
+            {
+                "id": 1,
+                "subnet": "$network/$cidr",
+                "pools": [ { "pool": "$startrange - $endrange" } ],
+                "option-data": [
+$optdata
+                ]
+            }
+        ],
+        "client-classes": [
+$2
+        ]
+    }
+}
+EOFKEA
+}
+configureKeaDHCP() {
+    local cidr=$(mask2cidr $submask)
+    local target="$dhcpconfig"
+    local tmp="${target}.fogtmp"
+    [[ -d $(dirname "$target") ]] || mkdir -p "$(dirname "$target")" >>$error_log 2>&1
+    [[ -f $target ]] && mv -fv "$target" "${target}.${timestamp}" >>$error_log 2>&1
+    local optdata="                { \"name\": \"subnet-mask\", \"data\": \"$submask\" }"
+    [[ $(validip $routeraddress) -eq 0 ]] && optdata="${optdata},
+                { \"name\": \"routers\", \"data\": \"$routeraddress\" }"
+    [[ $(validip $dnsaddress) -eq 0 ]] && optdata="${optdata},
+                { \"name\": \"domain-name-servers\", \"data\": \"$dnsaddress\" }"
+    # The architecture -> boot-file mapping below intentionally mirrors the ISC
+    # "class" blocks in the ISC branch of configureDHCP(). Keep the two in sync.
+    local baseclasses
+    baseclasses=$(cat <<'EOFCLS'
+        {
+            "name": "FOG-Legacy-BIOS",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00000'",
+            "boot-file-name": "undionly.kkpxe"
+        },
+        {
+            "name": "FOG-UEFI-32-2",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00002'",
+            "boot-file-name": "i386-efi/snponly.efi"
+        },
+        {
+            "name": "FOG-UEFI-32-1",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00006'",
+            "boot-file-name": "i386-efi/snponly.efi"
+        },
+        {
+            "name": "FOG-UEFI-64-1",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
+            "boot-file-name": "snponly.efi"
+        },
+        {
+            "name": "FOG-UEFI-64-2",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00008'",
+            "boot-file-name": "snponly.efi"
+        },
+        {
+            "name": "FOG-UEFI-64-3",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00009'",
+            "boot-file-name": "snponly.efi"
+        },
+        {
+            "name": "FOG-UEFI-ARM64",
+            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00011'",
+            "boot-file-name": "arm64-efi/snponly.efi"
+        },
+        {
+            "name": "FOG-Surface-Pro-4",
+            "test": "substring(option[60].hex,0,32) == 'PXEClient:Arch:00007:UNDI:003016'",
+            "boot-file-name": "snponly.efi"
+        }
+EOFCLS
+)
+    local appleclass
+    appleclass=$(cat <<'EOFAPL'
+        {
+            "name": "FOG-Apple-Intel-Netboot",
+            "test": "substring(option[60].text,0,14) == 'AAPLBSDPC/i386'",
+            "boot-file-name": "snponly.efi",
+            "option-data": [
+                { "code": 43, "csv-format": false, "data": "01:01:01:04:02:80:00:07:04:81:00:05:2a:09:0D:81:00:05:2a:08:69:50:58:45:2d:46:4f:47" }
+            ]
+        }
+EOFAPL
+)
+    # Tier 1: base classes must validate or we refuse to start a broken server.
+    _writeKeaConfig "$target" "$baseclasses"
+    if command -v kea-dhcp4 >/dev/null 2>&1; then
+        if ! kea-dhcp4 -t "$target" >>$error_log 2>&1; then
+            echo "Failed"
+            echo "Kea base configuration failed validation (kea-dhcp4 -t); see $error_log"
+            return 1
+        fi
+        # Tier 2: best-effort Apple BSDP; drop if Kea rejects it.
+        _writeKeaConfig "$tmp" "${baseclasses},
+${appleclass}"
+        if kea-dhcp4 -t "$tmp" >>$error_log 2>&1; then
+            mv -f "$tmp" "$target"
+        else
+            rm -f "$tmp"
+            echo ""
+            echo " * Note: Apple Intel netboot (BSDP) is not supported under Kea and was skipped"
+        fi
+    else
+        echo " * Warning: kea-dhcp4 not found; wrote config without validation" >>$error_log 2>&1
+    fi
+    diffconfig "$target"
+    return 0
+}
 configureDHCP() {
-    case $linuxReleaseName_lower in
-        *debian*)
-            if [[ $bldhcp -eq 1 ]]; then
-                dots "Setting up and starting DHCP Server (incl. fix for Debian)"
-                sed -i.fog "s/INTERFACESv4=\"\"/INTERFACESv4=\"$interface\"/g" /etc/default/isc-dhcp-server
-            else
+    if [[ $bldhcp -eq 1 && $dhcpengine == kea ]]; then
+        dots "Setting up and starting DHCP Server (Kea)"
+    else
+        case $linuxReleaseName_lower in
+            *debian*)
+                if [[ $bldhcp -eq 1 ]]; then
+                    dots "Setting up and starting DHCP Server (incl. fix for Debian)"
+                    sed -i.fog "s/INTERFACESv4=\"\"/INTERFACESv4=\"$interface\"/g" /etc/default/isc-dhcp-server
+                else
+                    dots "Setting up and starting DHCP Server"
+                fi
+                ;;
+            *)
                 dots "Setting up and starting DHCP Server"
-            fi
-            ;;
-        *)
-            dots "Setting up and starting DHCP Server"
-            ;;
-    esac
+                ;;
+        esac
+    fi
     case $bldhcp in
         1)
             serverip=$(ip -4 -o addr show $interface | awk -F'([ /])+' '/global/ {print $4}')
@@ -2582,6 +2755,11 @@ configureDHCP() {
             network=$(mask2network $serverip $submask)
             [[ -z $startrange ]] && startrange=$(addToAddress $network 10)
             [[ -z $endrange ]] && endrange=$(subtract1fromAddress $(echo $(interface2broadcast $interface)))
+            [[ ! $(validip $routeraddress) -eq 0 ]] && routeraddress=$(echo $routeraddress | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
+            [[ ! $(validip $dnsaddress) -eq 0 ]] && dnsaddress=$(echo $dnsaddress | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
+            if [[ $dhcpengine == kea ]]; then
+                configureKeaDHCP || exit 1
+            else
             [[ -f $dhcpconfig ]] && dhcptouse=$dhcpconfig
             [[ -f $dhcpconfigother ]] && dhcptouse=$dhcpconfigother
             if [[ -z $dhcptouse || ! -f $dhcptouse ]]; then
@@ -2669,6 +2847,19 @@ configureDHCP() {
             echo "    }" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             diffconfig "${dhcptouse}"
+            # Non-fatal syntax check; ISC has historically started without one.
+            if command -v dhcpd >/dev/null 2>&1; then
+                dhcpd -t -cf "$dhcptouse" >>$error_log 2>&1 || echo " * Warning: dhcpd -t reported issues with $dhcptouse (see $error_log)" >>$error_log 2>&1
+            fi
+            fi
+            # When FOG owns DHCP, make sure the other engine is not also bound to
+            # port 67 (covers an admin switching engines on an existing box).
+            otherdhcp=""
+            [[ $dhcpengine == kea ]] && otherdhcp="$iscservice" || otherdhcp="$keaservice"
+            if [[ -n $otherdhcp && $systemctl == yes ]]; then
+                systemctl is-active --quiet $otherdhcp && systemctl stop $otherdhcp >>$error_log 2>&1
+                systemctl is-enabled --quiet $otherdhcp && systemctl disable $otherdhcp >>$error_log 2>&1
+            fi
             case $systemctl in
                 yes)
                     systemctl is-enabled --quiet $dhcpd && true || systemctl enable $dhcpd >>$error_log 2>&1

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -406,7 +406,7 @@ checkInternetConnection() {
     dots "Testing internet connection"
     DEBIAN_FRONTEND=noninteractive $packageinstaller curl >>$error_log 2>&1
 
-    http_sites=("neverssl.com" "httpbin.org")
+    http_sites=("httpbin.org" "neverssl.com")
     https_sites=("github.com" "fogproject.org")
     dns_ok=0
     http_ok=0

--- a/lib/redhat/config.sh
+++ b/lib/redhat/config.sh
@@ -84,4 +84,7 @@ fi
 [[ -z $tftpdirdst ]] && tftpdirdst="/tftpboot"
 [[ -z $ftpconfig ]] && ftpconfig="/etc/vsftpd/vsftpd.conf"
 [[ -z $dhcpd ]] && dhcpd="dhcpd"
+[[ -z $iscservice ]] && iscservice="dhcpd"
+[[ -z $keapackage ]] && keapackage="kea"
+[[ -z $keaservice ]] && keaservice="kea-dhcp4"
 [[ -z $snapindir ]] && snapindir="/opt/fog/snapins"

--- a/lib/ubuntu/config.sh
+++ b/lib/ubuntu/config.sh
@@ -65,3 +65,6 @@ fi
 [[ -z $snapindir ]] && snapindir="/opt/fog/snapins"
 [[ -z $dhcpd ]] && dhcpd="isc-dhcp-server"
 [[ -z $dhcpname ]] && dhcpname="isc-dhcp-server"
+[[ -z $iscservice ]] && iscservice="isc-dhcp-server"
+[[ -z $keapackage ]] && keapackage="kea-dhcp4-server"
+[[ -z $keaservice ]] && keaservice="kea-dhcp4-server"

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1877');
+        define('FOG_VERSION', '1.5.10.1879');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1881');
+        define('FOG_VERSION', '1.5.10.1882');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1870');
+        define('FOG_VERSION', '1.5.10.1877');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1879');
+        define('FOG_VERSION', '1.5.10.1880');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.1880');
+        define('FOG_VERSION', '1.5.10.1881');
         define('FOG_SCHEMA', 273);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -644,7 +644,7 @@ class LDAP extends FOGController
             $grpMemAttr . ($enableNestedGroup ? ":1.2.840.113556.1.4.1941:" : ""),
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**
@@ -675,7 +675,7 @@ class LDAP extends FOGController
             $grpMemAttr . ($enableNestedGroup ? ":1.2.840.113556.1.4.1941:" : ""),
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -408,8 +408,8 @@ class Registration extends FOGBase
                 ->addPriMAC($this->PriMAC)
                 ->addAddMAC($this->MACs);
             if (self::getSetting('FOG_QUICKREG_PROD_KEY_BIOS') > 0) {
-                $productKey = base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW));
-                if (!preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
+                $productKey = trim(base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
+                if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new Exception(_('Invalid product key supplied'));
                 }
                 self::$Host->set('productKey', $productKey);
@@ -470,8 +470,8 @@ class Registration extends FOGBase
                 ->addPriMAC($this->PriMAC)
                 ->addAddMAC($this->MACs);
             if (self::getSetting('FOG_QUICKREG_PROD_KEY_BIOS') > 0) {
-                $productKey = base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW));
-                if (!preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
+                $productKey = trim(base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
+                if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new Exception(_('Invalid product key supplied'));
                 }
                 self::$Host->set('productKey', $productKey);

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -140,8 +140,8 @@ class Registration extends FOGBase
                 return;
             }
             self::stripAndDecode($_REQUEST);
-            $productKey = filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW);
-            if (!preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
+            $productKey = trim(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW));
+            if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                 throw new Exception(_('Invalid product key supplied'));
             }
             $username = isset($_REQUEST['username']) ? $_REQUEST['username'] : '';

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -62,7 +62,7 @@ try {
             && isset($str[5])
         ) {
             $Task->set('bpm', (float)$str[0])
-                ->set('timeElapsed', max(0, (float)$str[1]))
+                ->set('timeElapsed', strip_tags($str[1]))
                 ->set('timeRemaining', strip_tags($str[2]))
                 ->set('dataCopied', strip_tags($str[3]))
                 ->set('dataTotal', strip_tags($str[4]))


### PR DESCRIPTION
Admin/Mobile LDAP group access is broken since commit 1c5e04ddb891b25716e59ea5d65abde39704d562.

RFC2037's posixGroup uses simple "memberUid: johndoe" attribute/value pairs, but the code is trying to filter groups using "cn: johndoe".  In otherwords, $usrNamAttr has been used instead of $grpMemAttr.

The resulting filter string is something like:
(&(|(name=fogadmins)(memberuid=fogadmins))(|(memberuid=cn=johndoe,ou=accounts,dc=example,dc=org)(memberuid=cn=johndoe)(cn=johndoe)))

Instead of the intended:
(&(|(name=fogadmins)(memberuid=fogadmins))(|(memberuid=cn=johndoe,ou=accounts,dc=example,dc=org)(memberuid=cn=johndoe)(memberuid=johndoe)))