### PR TITLE
fix(ldap): RFC2307 group login + plugin hardening (1.6)

### DIFF
--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -1113,7 +1113,7 @@ class LDAP extends FOGController
          */
         $pat = sprintf(
             '#%s#i',
-            $userDN
+            preg_quote($userDN, '#')
         );
         /**
          * Check groups for membership

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -1025,7 +1025,7 @@ class LDAP extends FOGController
             $grpMemAttr,
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**
@@ -1055,7 +1055,7 @@ class LDAP extends FOGController
             $grpMemAttr,
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -133,39 +133,54 @@ class LDAPPluginHook extends Hook
         $items = json_decode(
             Route::getData()
         );
-        foreach ($items->data as &$ldap) {
-            $access = self::getClass('LDAP', $ldap->id)->authLDAP($user, $pass);
-            if ($access) {
-                $displayName = self::getClass('LDAP', $ldap->id)
-                    ->getDisplayName($user, $pass);
-            }
-            $ldapAPI = self::getClass('LDAP', $ldap->id)->get('allowapi');
-            unset($ldap);
-            switch ($access) {
-                case 2:
-                    // This is an admin account, break the loop
-                    $tmpUser
-                        ->set('name', $user)
-                        ->set('password', $pass)
-                        ->set('display', $displayName)
-                        ->set('type', self::LDAP_ADMIN)
-                        ->set('api', $ldapAPI)
-                        ->save();
-                    break 2;
-                case 1:
-                    // This is an unprivileged user account.
-                    $tmpUser
-                        ->set('name', $user)
-                        ->set('password', $pass)
-                        ->set('display', $displayName)
-                        ->set('type', self::LDAP_MOBILE)
-                        ->set('api', $ldapAPI)
-                        ->save();
+        /**
+         * Authenticate against every configured LDAP server and keep the
+         * most privileged result (admin beats mobile beats none). A server
+         * where the user is absent must not downgrade a match found on
+         * another server, so we accumulate the best access level and act on
+         * it once after the loop rather than per-server.
+         */
+        $bestAccess = 0;
+        $displayName = '';
+        $ldapAPI = 0;
+        foreach ($items->data as $ldap) {
+            $LDAP = self::getClass('LDAP', $ldap->id);
+            $access = (int)$LDAP->authLDAP($user, $pass);
+            if ($access > $bestAccess) {
+                $bestAccess = $access;
+                $displayName = $LDAP->getDisplayName($user, $pass);
+                $ldapAPI = $LDAP->get('allowapi');
+                /**
+                 * Admin is the highest level; no need to keep looking.
+                 */
+                if ($bestAccess >= 2) {
                     break;
-                default:
-                    $tmpUser = new User(-1);
+                }
             }
-            unset($ldap);
+        }
+        switch ($bestAccess) {
+            case 2:
+                // This is an admin account.
+                $tmpUser
+                    ->set('name', $user)
+                    ->set('password', $pass)
+                    ->set('display', $displayName)
+                    ->set('type', self::LDAP_ADMIN)
+                    ->set('api', $ldapAPI)
+                    ->save();
+                break;
+            case 1:
+                // This is an unprivileged user account.
+                $tmpUser
+                    ->set('name', $user)
+                    ->set('password', $pass)
+                    ->set('display', $displayName)
+                    ->set('type', self::LDAP_MOBILE)
+                    ->set('api', $ldapAPI)
+                    ->save();
+                break;
+            default:
+                $tmpUser = new User(-1);
         }
         $arguments['user'] = $tmpUser;
     }

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
@@ -75,6 +75,7 @@ class LDAPManagement extends FOGPage
         $adminGroup = filter_input(INPUT_POST, 'adminGroup');
         $userGroup = filter_input(INPUT_POST, 'userGroup');
         $userNameAttr = filter_input(INPUT_POST, 'userNameAttr');
+        $groupNameAttr = filter_input(INPUT_POST, 'groupNameAttr');
         $grpMemberAttr = filter_input(INPUT_POST, 'grpMemberAttr');
         $searchScope = filter_input(INPUT_POST, 'searchScope');
         $bindDN = filter_input(INPUT_POST, 'bindDN');
@@ -822,7 +823,7 @@ class LDAPManagement extends FOGPage
     public function addPost()
     {
         self::checkAuthAndCSRF();
-        header('Content-type: appication/json');
+        header('Content-type: application/json');
         self::$HookManager->processEvent('LDAP_ADD_POST');
         $ldap = trim(
             filter_input(INPUT_POST, 'ldap')
@@ -875,6 +876,7 @@ class LDAPManagement extends FOGPage
         );
 
         $isLDAPs = (int)isset($_POST['isLDAPs']);
+        $isAPI = (int)isset($_POST['allowapi']);
 
         $serverFault = false;
         try {
@@ -919,6 +921,7 @@ class LDAPManagement extends FOGPage
                 ->set('useGroupMatch', $useGroupMatch)
                 ->set('grpSearchDN', $grpSearchDN)
                 ->set('displayNameOn', $displayNameOn)
+                ->set('allowapi', $isAPI)
                 ->set('displayNameAttr', $displayNameAttr);
             if (!$LDAP->save()) {
                 $serverFault = true;
@@ -1758,7 +1761,7 @@ class LDAPManagement extends FOGPage
                     $this->ldapGeneralPost();
             }
             if (!$this->obj->save()) {
-                $serverFault = false;
+                $serverFault = true;
                 throw new Exception(_('LDAP Server update failed!'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;


### PR DESCRIPTION
LDAP plugin fixes for the 1.6 line. Each commit is a single, self-contained change.

### Fixes
1. **RFC2307 posixGroup matching** — the group-membership filter's third alternative used the user-name attribute instead of the group-member attribute, so `memberUid: johndoe` style membership never matched (it resolved to `(cn=johndoe)`). Now resolves to `(memberUid=johndoe)`. This is the 1.6 port of #837 (which targets the older 1.5 plugin).
2. **Escape the user DN before regex use** — the fallback membership loop built a regex straight from the DN (`sprintf('#%s#i', $userDN)`); a DN with regex metacharacters could match too loosely or produce an invalid pattern, making `preg_grep()` return false and silently deny access. Now `preg_quote()`-escaped.
3. **LDAP management page bugs** — `editPost()` now reports a failed save as HTTP 500 (was 400); `addPost()` now persists the "Allow API" checkbox (the create form rendered it but never saved it); `add()` now defines `$groupNameAttr` (it was referenced but never assigned, so the field didn't repopulate on validation-error redisplay); fixed an `appication/json` Content-type typo.
4. **Multi-server access selection** — `checkAddUser()` looped every LDAP server and acted per-server, so a later server where the user was absent could overwrite a valid match from an earlier server with `new User(-1)` and deny login. It now accumulates the most privileged result (admin > mobile > none), short-circuits once admin is found, sources display-name/API from the granting server, and saves once.

All changes pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
