### PR TITLE
fix(ldap): rfc2307 group filter (#837) + DN regex escaping + multi-server access

### DIFF
--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -732,7 +732,7 @@ class LDAP extends FOGController
          */
         $pat = sprintf(
             '#%s#i',
-            $userDN
+            preg_quote($userDN, '#')
         );
         /**
          * Check groups for membership

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -644,7 +644,7 @@ class LDAP extends FOGController
             $grpMemAttr . ($enableNestedGroup ? ":1.2.840.113556.1.4.1941:" : ""),
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**
@@ -675,7 +675,7 @@ class LDAP extends FOGController
             $grpMemAttr . ($enableNestedGroup ? ":1.2.840.113556.1.4.1941:" : ""),
             $usrNamAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $usrNamAttr,
+            $grpMemAttr,
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -127,34 +127,49 @@ class LDAPPluginHook extends Hook
         /**
          * Create our new user (initially at least)
          */
+        /**
+         * Authenticate against every configured LDAP server and keep the
+         * most privileged result (admin beats mobile beats none). A server
+         * where the user is absent must not downgrade a match found on
+         * another server, so we accumulate the best access level and act on
+         * it once after the loop rather than per-server.
+         */
+        $bestAccess = 0;
         foreach ((array)self::getClass('LDAPManager')
-            ->find() as &$ldap
+            ->find() as $ldap
         ) {
-            $access = $ldap->authLDAP($user, $pass);
-            unset($ldap);
-            switch ($access) {
-                case 2:
-                    // This is an admin account, break the loop
-                    $tmpUser
-                        ->set('name', $user)
-                        ->set('password', $pass)
-                        ->set('type', 990)
-                        ->save();
-                    break 2;
-                case 1:
-                    // This is an unprivileged user account.
-                    $tmpUser
-                        ->set('name', $user)
-                        ->set('password', $pass)
-                        ->set('type', 991)
-                        ->save();
+            $access = (int)$ldap->authLDAP($user, $pass);
+            if ($access > $bestAccess) {
+                $bestAccess = $access;
+                /**
+                 * Admin is the highest level; no need to keep looking.
+                 */
+                if ($bestAccess >= 2) {
                     break;
-                default:
-                    $tmpUser = new User(-1);
+                }
             }
         }
+        switch ($bestAccess) {
+            case 2:
+                // This is an admin account.
+                $tmpUser
+                    ->set('name', $user)
+                    ->set('password', $pass)
+                    ->set('type', 990)
+                    ->save();
+                break;
+            case 1:
+                // This is an unprivileged user account.
+                $tmpUser
+                    ->set('name', $user)
+                    ->set('password', $pass)
+                    ->set('type', 991)
+                    ->save();
+                break;
+            default:
+                $tmpUser = new User(-1);
+        }
         $arguments['user'] = $tmpUser;
-        unset($ldaps);
     }
     /**
      * Sets our ldap types


### PR DESCRIPTION
Three LDAP plugin fixes for `dev-branch`. Each commit is a single, self-contained change.

### Fixes
1. **RFC2307 posixGroup group filter** (by @fussinator) — the last `(%s=%s)` attribute/value pair in the admin/mobile group filters used `usrNamAttr` instead of `grpMemAttr`, so `memberUid: johndoe` style membership never matched. This is @fussinator's fix from #837, carried over here with his authorship preserved (his PR was based on `stable`; this lands it on `dev-branch`, which is where it belongs).
2. **Escape the user DN before regex use** — the fallback membership loop built a regex straight from the DN (`sprintf('#%s#i', $userDN)`); a DN containing regex metacharacters could match too loosely or produce an invalid pattern, making `preg_grep()` return false and silently deny access. Now `preg_quote()`-escaped.
3. **Multi-server access selection** — `checkAddUser()` looped every LDAP server and acted per-server, so a later server where the user was absent could overwrite a valid match from an earlier server with `new User(-1)` and deny login. It now accumulates the most privileged result (admin > mobile > none), short-circuits once admin is found, and saves once.

Supersedes #837 (closed); the RFC2307 commit here is @fussinator's, the other two were found while reviewing the same code path.

All changes pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
