### PR TITLE
feat(plugins): non-destructive schema migrations with per-plugin versioning

### DIFF
--- a/docs/PLUGIN_SCHEMA_MIGRATIONS.md
+++ b/docs/PLUGIN_SCHEMA_MIGRATIONS.md
@@ -1,0 +1,196 @@
+# Plugin Schema Migrations
+
+Bundled plugins ship their own database tables. Historically a plugin's
+schema was only created when an admin clicked **Install**, and re-installing
+**dropped and recreated** the tables (losing data). There was no way to
+deliver a schema change — a new column, a new index — to a plugin that was
+already installed: a FOG upgrade left the old plugin tables untouched.
+
+This document describes the mechanism that replaces that. Plugins now declare
+their schema as an **ordered, append-only list of migration steps** (mirroring
+how FOG's core schema works in `commons/schema.php`). Steps are applied
+**incrementally and non-destructively**, and each plugin tracks how many steps
+it has applied so an upgrade only runs what is new.
+
+---
+
+## The contract
+
+A table-owning plugin's **top-level manager** implements one method:
+
+```php
+public function schema()
+{
+    return [
+        // 0
+        $this->createSql(),
+        // 1  (added in a later release)
+        "ALTER TABLE `mytable` ADD COLUMN `myCol` VARCHAR(40) NULL",
+    ];
+}
+```
+
+Rules:
+
+1. **The list is flat and append-only.** One list covers *every* table the
+   plugin owns. New schema changes are **always appended to the END**. Never
+   insert, reorder, or delete existing entries — the index of each step is its
+   identity.
+2. **Each step is a SQL string or a callable.** A callable runs arbitrary PHP
+   and returns `true` on success or an **error string** on failure (used when a
+   value must be resolved at run time — see *Seed data* below).
+3. **Steps must be idempotent / additive.** Use `CREATE TABLE IF NOT EXISTS`
+   (via `Schema::createTable($name, true, ...)`) and `ALTER TABLE ... ADD ...`.
+   Never `DROP`. The runner tolerates "already exists / does not exist" errors
+   (see *Idempotency*), so re-running a step is safe.
+
+Each table's `CREATE TABLE` lives in a `createSql()` method on the manager that
+owns that table, and the top-level `schema()` aggregates them. A single-table
+plugin's `schema()` is just `[$this->createSql()]`.
+
+`install()` becomes a thin, non-destructive wrapper:
+
+```php
+public function install()
+{
+    $res = Schema::applyUpdates($this->schema(), 0);
+    return $res['error'] === null;
+}
+```
+
+`uninstall()` is unchanged — it remains the **only** path that drops tables,
+and only fires from the explicit **Uninstall** button.
+
+---
+
+## How steps are applied
+
+`Schema::applyUpdates(array $steps, int $applied): array`
+(`lib/fog/schema.class.php`) is the shared runner. It runs steps from index
+`$applied` onward, returns `['applied' => int, 'error' => string|null]`, and is
+used by both the install path and the upgrade path so there is one code path.
+
+### Version tracking
+
+Each plugin row (`plugins` table) has a **`pSchema`** column — an integer count
+of how many of its `schema()` steps have been applied. `applyUpdates()` advances
+it. Comparison:
+
+```
+applied (plugins.pSchema)  <  count(manager->schema())   ⇒  upgrade pending
+```
+
+This check is **independent of `FOG_SCHEMA`** (the core schema version). A plugin
+self-reports whether it is behind by comparing its own stored count to the number
+of steps its *code* defines. `Plugin::needsSchemaUpdate()` is exactly that
+comparison.
+
+### Idempotency
+
+`applyUpdates()` tolerates the same MySQL error codes the core Schema Updater
+does, so additive steps are safe to re-run:
+
+| Code | Meaning |
+|------|---------|
+| 1050 | Table already exists |
+| 1054 | Unknown column |
+| 1060 | Duplicate column name |
+| 1061 | Duplicate key name |
+| 1062 | Duplicate entry |
+| 1091 | Can't DROP; doesn't exist |
+
+A callable step that runs its own queries should follow the same philosophy
+(e.g. tolerate `1062` when seeding a row with an explicit primary key).
+
+---
+
+## The user-facing flow (notify + one-click)
+
+There is **no silent auto-apply** — consistent with how FOG already gates schema
+changes behind an explicit action and a backup reminder.
+
+1. When an installed plugin's `schema()` defines more steps than its `pSchema`,
+   it is "behind."
+2. The **dashboard** shows a warning banner: *"N plugin(s) need a database
+   update."* (computed on dashboard load via
+   `PluginManager::getPluginsNeedingUpdate()`).
+3. The **Plugin Management** list shows an amber **"Update available"** button on
+   that plugin's row.
+4. The admin applies it, **individually** (click the row's button) or in **bulk**
+   (select rows → **Install/Update ▾ → Update selected**). Both hit the
+   `plugin/upgrade` action, which runs `Plugin::installdb()` for each *installed*
+   selected plugin. The table redraws and the flag clears.
+
+`Plugin::installdb()` applies pending steps from `pSchema` forward and saves the
+new count. It is non-destructive. (Plugins that have not yet adopted `schema()`
+fall back to their legacy `install()`.)
+
+---
+
+## Adding a schema change to an existing plugin
+
+1. Append the new step to the **end** of the top-level manager's `schema()`:
+
+   ```php
+   public function schema()
+   {
+       return [
+           $this->createSql(),                       // 0
+           "ALTER TABLE `mytable` ADD COLUMN ...",   // 1  ← new
+       ];
+   }
+   ```
+
+2. That's it. Installed copies of the plugin will report "update available" and
+   the admin applies it. No `FOG_SCHEMA` bump is required for detection.
+
+   > **Note:** the bundled migration that adds the `pSchema` column *does* ride
+   > along with a `FOG_SCHEMA` bump (it is a core table change). Subsequent
+   > *plugin* schema changes do not need one — detection is per-plugin.
+
+---
+
+## Special cases
+
+### Seed / default data
+
+If a step inserts default rows or settings, it must be safe to run on a system
+that already has them (an existing install upgrading from `pSchema = 0`):
+
+- **Rows with explicit primary keys** (e.g. accesscontrol's roles/rules): a plain
+  `INSERT` is fine — a re-run hits `1062` and is skipped. Existing rows are
+  preserved.
+- **Settings without a unique key** (e.g. capone, ldap — `globalSettings.settingKey`
+  is only indexed, not unique): insert **only if absent**, so an admin's
+  customized value is never overwritten. Use a callable step that checks
+  `SettingManager::exists($key, '', 'name')` before inserting.
+- **Run-time values** (e.g. accesscontrol's Administrator→fog-user row): resolve
+  the value inside a callable step and tolerate the duplicate-entry error.
+
+### Triggers (persistentgroups)
+
+A trigger has no data, so drop-and-recreate is non-destructive but not covered by
+the idempotency skip-list. Model it as a callable step that does
+`DROP TRIGGER IF EXISTS` then `CREATE TRIGGER`. A future trigger change ships as a
+**new appended step** that drops-and-recreates with the new definition.
+
+### Plugins that own no table
+
+`taskstateedit` / `tasktypeedit` edit existing core tables and own nothing. They
+have no `schema()` method, so they never report "update available" and
+`installdb()` falls back to their no-op `install()`. Nothing to do.
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `lib/fog/schema.class.php` | `Schema::applyUpdates()` — the shared idempotent runner |
+| `lib/fog/plugin.class.php` | `Plugin::installdb()`, `Plugin::needsSchemaUpdate()`; `pSchema` field map |
+| `lib/fog/pluginmanager.class.php` | `PluginManager::getPluginsNeedingUpdate()` |
+| `lib/pages/pluginmanagement.page.php` | `upgrade`/`upgradePost` action; list JSON enrichment |
+| `lib/pages/dashboardpage.page.php` | "needs update" dashboard banner |
+| `management/js/fog/plugin/fog.plugin.list.js` | "Update available" badge + bulk Update button |
+| `commons/schema.php` | core migration that adds the `plugins.pSchema` column |
+| `lib/plugins/location/class/locationmanager.class.php` | reference implementation |

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4216,3 +4216,11 @@ $this->schema[] = [
     // current (implicit) order until an admin reorders them.
     "UPDATE `snapinAssoc` SET `saSequence`=`saID` WHERE `saSequence`=0",
 ];
+// 295
+$this->schema[] = [
+    // Per-plugin applied schema-migration counter. Lets installed plugins
+    // receive additive (non-destructive) schema changes on upgrade, the same
+    // way core tables do via this list. Defaults to 0 (no steps applied).
+    "ALTER TABLE `plugins` "
+    . "ADD COLUMN `pSchema` INTEGER NOT NULL DEFAULT 0",
+];

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -42,6 +42,7 @@ class Plugin extends FOGController
         'runfile' => 'pRunfile',
         'location' => 'pLocation',
         'description' => 'pDescription',
+        'schema' => 'pSchema',
         'pAnon5' => 'pAnon5'
     ];
     /**
@@ -197,5 +198,55 @@ class Plugin extends FOGController
         }
 
         return new $classManager();
+    }
+    /**
+     * Installs / upgrades this plugin's database non-destructively.
+     *
+     * Plugins that adopt the schema() contract (an ordered, append-only
+     * list of migration steps) get their pending steps applied and the
+     * applied count tracked in `pSchema`, so a re-install or a FOG upgrade
+     * only adds what is missing and never drops existing data.
+     *
+     * Plugins not yet migrated to schema() fall back to the legacy
+     * (destructive) install() so existing behavior is preserved until they
+     * are converted.
+     *
+     * @return bool True on success, false if a step failed.
+     */
+    public function installdb()
+    {
+        $manager = $this->getManager();
+        if (!method_exists($manager, 'schema')) {
+            return method_exists($manager, 'install')
+                ? (bool)$manager->install()
+                : true;
+        }
+        $applied = (int)$this->get('schema');
+        $res = Schema::applyUpdates($manager->schema(), $applied);
+        if ($res['applied'] !== $applied) {
+            $this->set('schema', $res['applied'])->save();
+        }
+        return $res['error'] === null;
+    }
+    /**
+     * Whether this installed plugin has pending schema migrations.
+     *
+     * Self-contained and independent of FOG_SCHEMA: it simply compares the
+     * applied step count (pSchema) against the number of steps the plugin's
+     * code currently defines in schema(). True means installdb() has work to
+     * do. Only meaningful for converted (schema()-aware), installed plugins.
+     *
+     * @return bool
+     */
+    public function needsSchemaUpdate()
+    {
+        if ((int)$this->get('installed') < 1) {
+            return false;
+        }
+        $manager = $this->getManager();
+        if (!method_exists($manager, 'schema')) {
+            return false;
+        }
+        return (int)$this->get('schema') < count((array)$manager->schema());
     }
 }

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -21,4 +21,26 @@
  */
 class PluginManager extends FOGManagerController
 {
+    /**
+     * Returns the installed plugins that have pending schema migrations.
+     *
+     * Independent of FOG_SCHEMA: each plugin self-reports via
+     * Plugin::needsSchemaUpdate(). Used to drive the dashboard "needs
+     * update" notice and the plugin list badge.
+     *
+     * @return array Array of Plugin objects needing an upgrade.
+     */
+    public function getPluginsNeedingUpdate()
+    {
+        $needing = [];
+        Route::listem('plugin', ['installed' => 1]);
+        $plugins = json_decode(Route::getData());
+        foreach ((array)$plugins->data as $row) {
+            $plugin = self::getClass('Plugin', $row->id);
+            if ($plugin->needsSchemaUpdate()) {
+                $needing[] = $plugin;
+            }
+        }
+        return $needing;
+    }
 }

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -589,6 +589,64 @@ class Schema extends FOGController
         return $sql;
     }
     /**
+     * Applies an ordered, append-only list of schema update steps,
+     * starting after the already-applied count.
+     *
+     * Mirrors the core Schema Updater's idempotent runner: "already
+     * exists / does not exist" style errors are tolerated so additive
+     * steps (CREATE TABLE IF NOT EXISTS, ALTER TABLE ... ADD COLUMN,
+     * INSERT IGNORE, ...) are safe to re-run. This is what makes a
+     * re-run/upgrade non-destructive: nothing here drops data.
+     *
+     * Each step is either a SQL string or a callable. A callable should
+     * return true on success or an error string on failure.
+     *
+     * @param array $steps   Ordered steps (SQL string or callable).
+     * @param int   $applied Number of steps already applied.
+     *
+     * @return array ['applied' => int, 'error' => string|null]
+     */
+    public static function applyUpdates($steps, $applied = 0)
+    {
+        $steps = (array)$steps;
+        $applied = (int)$applied;
+        $total = count($steps);
+        if ($total <= $applied) {
+            return ['applied' => $applied, 'error' => null];
+        }
+        $skiperrs = [
+            1050, // Table already exists
+            1054, // Unknown column
+            1060, // Duplicate column name
+            1061, // Duplicate key name
+            1062, // Duplicate entry
+            1091, // Can't DROP; does not exist
+        ];
+        $items = array_slice($steps, $applied, null, true);
+        foreach ($items as $index => $step) {
+            if (!$step) {
+                $applied = $index + 1;
+                continue;
+            }
+            if (is_callable($step)) {
+                $result = $step();
+                if (is_string($result)) {
+                    return ['applied' => $applied, 'error' => $result];
+                }
+            } elseif (false !== self::$DB->query($step)->error) {
+                $err = self::$DB->errorCode;
+                if (!in_array($err, $skiperrs)) {
+                    return [
+                        'applied' => $applied,
+                        'error' => self::$DB->error
+                    ];
+                }
+            }
+            $applied = $index + 1;
+        }
+        return ['applied' => $applied, 'error' => null];
+    }
+    /**
      * The sql to drop the table passed.
      *
      * @param string $name The table name to drop.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,9 +59,9 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2396');
+        define('FOG_VERSION', '1.6.0-beta.2403');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 294);
+        define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');
     }

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -194,6 +194,26 @@ class DashboardPage extends FOGPage
             $title = $pendingMACs . ' ' . _('Pending macs');
             self::displayAlert($title, $macPend, 'warning', true, true);
         }
+        $pluginsNeedingUpdate = self::getClass('PluginManager')
+            ->getPluginsNeedingUpdate();
+        $pluginUpdateCount = count($pluginsNeedingUpdate);
+        if ($pluginUpdateCount > 0) {
+            $title = $pluginUpdateCount
+                . ' '
+                . (
+                    $pluginUpdateCount != 1 ?
+                    _('plugins need a database update') :
+                    _('plugin needs a database update')
+                );
+            $pluginPend = sprintf(
+                '%s <a href="?node=%s"><b>%s</b></a> %s',
+                _('Click'),
+                'plugin',
+                _('here'),
+                _('to apply the update.')
+            );
+            self::displayAlert($title, $pluginPend, 'warning', true, true);
+        }
         $SystemUptime = self::$FOGCore->systemUptime();
         $fields = [
             _('Web Server') => filter_input(

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -64,7 +64,13 @@ class PluginManagement extends FOGPage
         if (self::$ajax) {
             header('Content-type: application/json');
             Route::listem('plugin');
-            echo Route::getData();
+            $data = json_decode(Route::getData());
+            foreach ((array)$data->data as &$row) {
+                $plugin = self::getClass('Plugin', $row->id);
+                $row->needsupdate = $plugin->needsSchemaUpdate() ? 1 : 0;
+                unset($row);
+            }
+            echo json_encode($data);
             exit;
         }
         $this->title = _('List All Plugins');
@@ -83,6 +89,10 @@ class PluginManagement extends FOGPage
 
         $remove = ' method="post" action="'
             . '../management/index.php?node=plugin&sub=remove'
+            . '" ';
+
+        $update = ' method="post" action="'
+            . '../management/index.php?node=plugin&sub=upgrade'
             . '" ';
 
         // Activate/Deactivate Plugins
@@ -113,6 +123,11 @@ class PluginManagement extends FOGPage
                     'id' => 'remove',
                     'text' => _('Uninstall selected'),
                     'props' => $remove
+                ],
+                [
+                    'id' => 'update',
+                    'text' => _('Update selected'),
+                    'props' => $update
                 ]
             ],
             'left',
@@ -260,23 +275,14 @@ class PluginManagement extends FOGPage
                 Route::getData()
             );
             foreach ($Plugins->data as &$Plugin) {
-                $installPlugin = self::getClass(
-                    $Plugin->name
-                    . 'Manager'
-                );
-                if (!method_exists($installPlugin, 'install')) {
-                    $serverFault = true;
-                    throw new Exception(
-                        _('Unable to install, no method exists for ')
-                        . $Plugin->name
-                    );
-                }
-                if (!$installPlugin->install($Plugin->name)) {
+                $pluginObj = self::getClass('Plugin', $Plugin->id);
+                if (!$pluginObj->installdb()) {
                     throw new Exception(
                         _('Failed to install ')
                         . $Plugin->name
                     );
                 }
+                unset($Plugin);
             }
             if (!$PluginManager->update($ids, '', $install)) {
                 $serverFault = true;
@@ -305,6 +311,104 @@ class PluginManagement extends FOGPage
                 [
                     'error' => $e->getMessage(),
                     'title' => _('Plugin Install Fail')
+                ]
+            );
+        }
+        self::$HookManager->processEvent(
+            $hook,
+            [
+                'Plugin' => &$this->obj,
+                'hook' => &$hook,
+                'code' => &$code,
+                'msg' => $msg,
+                'serverFault' => &$serverFault
+            ]
+        );
+        http_response_code($code);
+        echo $msg;
+        exit;
+    }
+    /**
+     * Redirect to index.
+     *
+     * @return void
+     */
+    public function upgrade()
+    {
+    }
+    /**
+     * Apply pending schema migrations to already-installed plugins.
+     *
+     * Unlike install, this does not filter on install state: it runs
+     * installdb() (non-destructive) for each selected plugin so a plugin
+     * whose code ships newer schema() steps gets caught up without a
+     * drop/recreate.
+     *
+     * @return void
+     */
+    public function upgradePost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+        $plugins = filter_input_array(
+            INPUT_POST,
+            [
+                'plugins' => [
+                    'flags' => FILTER_REQUIRE_ARRAY
+                ]
+            ]
+        );
+        $plugins = $plugins['plugins'];
+        self::$HookManager->processEvent('PLUGIN_UPGRADE_POST');
+
+        $serverFault = false;
+        try {
+            // Only update plugins that are actually installed (the reverse of
+            // the install filter): updating a not-installed plugin is a no-op
+            // for the admin's intent.
+            Route::listem(
+                'plugin',
+                [
+                    'id' => $plugins,
+                    'installed' => 1
+                ]
+            );
+            $Plugins = json_decode(
+                Route::getData()
+            );
+            foreach ($Plugins->data as &$Plugin) {
+                $pluginObj = self::getClass('Plugin', $Plugin->id);
+                if (!$pluginObj->installdb()) {
+                    throw new Exception(
+                        _('Failed to update ')
+                        . $Plugin->name
+                    );
+                }
+                unset($Plugin);
+            }
+            $code = HTTPResponseCodes::HTTP_ACCEPTED;
+            $hook = 'PLUGIN_UPGRADE_SUCCESS';
+            $msg = json_encode(
+                [
+                    'msg' => (
+                        count($plugins ?: []) == 1 ?
+                        _('Plugin updated!') :
+                        _('Plugins updated!')
+                    ),
+                    'title' => _('Plugin Update Success')
+                ]
+            );
+        } catch (Exception $e) {
+            $code = (
+                $serverFault ?
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
+                HTTPResponseCodes::HTTP_BAD_REQUEST
+            );
+            $hook = 'PLUGIN_UPGRADE_FAIL';
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Plugin Update Fail')
                 ]
             );
         }

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
@@ -32,10 +32,9 @@ class AccessControlAssociationManager extends FOGManagerController
      *
      * @return bool
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -71,27 +70,50 @@ class AccessControlAssociationManager extends FOGManagerController
             'ruaID',
             'ruaID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        } else {
-            Route::ids(
-                'user',
-                ['name' => 'fog']
-            );
-            $fogUserID = json_decode(
-                Route::getData(),
-                true
-            );
-            $fogUserID = array_shift($fogUserID);
-            $sql = sprintf(
-                "INSERT INTO `%s` VALUES (1, '%s', 1, %d)",
-                $this->tablename,
-                'Administrator-fog',
-                intval($fogUserID[0])
-            );
-            self::$DB->query($sql);
+    }
+    /**
+     * Seeds the default Administrator-to-fog-user association. The row has
+     * an explicit primary key, so a re-run is idempotent (the duplicate
+     * entry is tolerated). The fog user id is resolved at run time, so this
+     * is a callable schema() step rather than a static SQL string.
+     *
+     * @return bool|string True on success, error string on failure.
+     */
+    public function seedAssoc()
+    {
+        Route::ids(
+            'user',
+            ['name' => 'fog']
+        );
+        $fogUserID = json_decode(
+            Route::getData(),
+            true
+        );
+        $fogUserID = array_shift($fogUserID);
+        $sql = sprintf(
+            "INSERT INTO `%s` VALUES (1, '%s', 1, %d)",
+            $this->tablename,
+            'Administrator-fog',
+            intval($fogUserID[0])
+        );
+        if (false !== self::$DB->query($sql)->error
+            && self::$DB->errorCode != 1062
+        ) {
+            return self::$DB->error;
         }
-        return self::getClass('AccessControlRuleManager')->install();
+        return true;
+    }
+    /**
+     * Installs the table + seed non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        if (false === self::$DB->query($this->createSql())) {
+            return false;
+        }
+        return $this->seedAssoc() === true;
     }
     /**
      * Uninstalls the plugin

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
@@ -32,15 +32,9 @@ class AccessControlManager extends FOGManagerController
      *
      * @return bool
      */
-    public function install()
+    public function createSql()
     {
-        /**
-         * Add the information into the database.
-         * This is commented out so we don't actually
-         * create anything.
-         */
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -80,19 +74,69 @@ class AccessControlManager extends FOGManagerController
             'rID',
             'rID'
         );
-
-        if (!self::$DB->query($sql)) {
-            return false;
-        } else {
-            $sql = sprintf(
-                "INSERT INTO `%s` VALUES"
-                . "(1, 'Administrator', 'FOG Administrator', 'fog', NOW()),"
-                . "(2, 'Technician', 'FOG Technician', 'fog', NOW())",
-                $this->tablename
-            );
-            self::$DB->query($sql);
-        }
-        return self::getClass('AccessControlAssociationManager')->install();
+    }
+    /**
+     * Seeds the default roles. Rows carry explicit primary keys, so a re-run
+     * is idempotent (duplicate entries are tolerated by the schema runner).
+     * Used as a step in schema().
+     *
+     * @return string
+     */
+    public function seedSql()
+    {
+        return sprintf(
+            "INSERT INTO `%s` VALUES"
+            . "(1, 'Administrator', 'FOG Administrator', 'fog', NOW()),"
+            . "(2, 'Technician', 'FOG Technician', 'fog', NOW())",
+            $this->tablename
+        );
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. It covers all
+     * four accesscontrol tables and their seed/index steps, in the original
+     * install order. Append new steps (e.g. "ALTER TABLE `roles` ADD COLUMN
+     * ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        $assoc = self::getClass('AccessControlAssociationManager');
+        $rule = self::getClass('AccessControlRuleManager');
+        $ruleAssoc = self::getClass('AccessControlRuleAssociationManager');
+        return [
+            // 0  roles
+            $this->createSql(),
+            // 1
+            $this->seedSql(),
+            // 2  roleUserAssoc
+            $assoc->createSql(),
+            // 3  (dynamic: resolves the fog user id at run time)
+            function () use ($assoc) {
+                return $assoc->seedAssoc();
+            },
+            // 4  rules
+            $rule->createSql(),
+            // 5
+            $rule->seedSql(),
+            // 6
+            $rule->indexSql(),
+            // 7  roleRuleAssoc
+            $ruleAssoc->createSql(),
+            // 8
+            $ruleAssoc->indexSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + seed any
+     * missing default rows). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the plugin

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
@@ -28,14 +28,16 @@ class AccessControlRuleAssociationManager extends FOGManagerController
      */
     public $tablename = 'roleRuleAssoc';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in
+     * AccessControlManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -70,11 +72,29 @@ class AccessControlRuleAssociationManager extends FOGManagerController
             'rraID',
             'rraID'
         );
-        if (self::$DB->query($sql)) {
-            $sql = "CREATE UNIQUE INDEX `indexmul` "
-                . "ON `roleRuleAssoc` (`rraRoleID`, `rraRuleID`)";
-            return self::$DB->query($sql);
+    }
+    /**
+     * The unique index step for this table (idempotent: a duplicate key
+     * name is tolerated by the schema runner). Used in schema().
+     *
+     * @return string
+     */
+    public function indexSql()
+    {
+        return "CREATE UNIQUE INDEX `indexmul` "
+            . "ON `roleRuleAssoc` (`rraRoleID`, `rraRuleID`)";
+    }
+    /**
+     * Installs the table non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        if (false === self::$DB->query($this->createSql())) {
+            return false;
         }
-        return false;
+        self::$DB->query($this->indexSql());
+        return true;
     }
 }

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
@@ -32,15 +32,9 @@ class AccessControlRuleManager extends FOGManagerController
      *
      * @return bool
      */
-    public function install()
+    public function createSql()
     {
-        /**
-         * Add the information into the database.
-         * This is commented out so we don't actually
-         * create anything.
-         */
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -89,10 +83,17 @@ class AccessControlRuleManager extends FOGManagerController
             'ruleID',
             'ruleID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        $sql = 'INSERT INTO '
+    }
+    /**
+     * Seeds this plugin's default rules. The rows carry explicit primary
+     * keys, so a re-run is idempotent: the schema runner tolerates the
+     * duplicate-entry error. Used as a step in AccessControlManager::schema().
+     *
+     * @return string
+     */
+    public function seedSql()
+    {
+        return 'INSERT INTO '
             . $this->tablename
             . ' VALUES '
             . '(2, "DELETE_MENU_DATA-user", "DELETE_MENU_DATA", "user", '
@@ -171,14 +172,31 @@ class AccessControlRuleManager extends FOGManagerController
             . '"logviewer", "menu", "fog", NOW(), "about"), '
             . '(39, "DELETE_MENULINK_DATA-config", "DELETE_MENULINK_DATA", '
             . '"config", "menu", "fog", NOW(), "about")';
-        if (self::$DB->query($sql)) {
-            $sql = "CREATE UNIQUE INDEX `indexmul` "
-                    . "ON `rules` (`ruleValue`, `ruleNode`)";
-            self::$DB->query($sql);
-            return self::getClass('AccessControlRuleAssociationManager')->install();
-        } else {
-            return true;
+    }
+    /**
+     * The unique index step for this table (idempotent: a duplicate key
+     * name is tolerated by the schema runner). Used in schema().
+     *
+     * @return string
+     */
+    public function indexSql()
+    {
+        return "CREATE UNIQUE INDEX `indexmul` "
+            . "ON `rules` (`ruleValue`, `ruleNode`)";
+    }
+    /**
+     * Installs the table + seed non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        if (false === self::$DB->query($this->createSql())) {
+            return false;
         }
+        self::$DB->query($this->seedSql());
+        self::$DB->query($this->indexSql());
+        return true;
     }
     /**
      * Uninstalls the plugin

--- a/packages/web/lib/plugins/capone/class/caponemanager.class.php
+++ b/packages/web/lib/plugins/capone/class/caponemanager.class.php
@@ -28,14 +28,15 @@ class CaponeManager extends FOGManagerController
      */
     public $tablename = 'capone';
     /**
-     * Installs the capone database
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -71,44 +72,85 @@ class CaponeManager extends FOGManagerController
             'cID',
             'cID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        $category = sprintf('Plugin: Capone');
-        $insert_fields = [
+    }
+    /**
+     * Seeds this plugin's global settings, but only the ones that are
+     * missing, so an admin's existing values are never overwritten on a
+     * re-run/upgrade. Used as a step in schema().
+     *
+     * @return bool
+     */
+    public function seedSettings()
+    {
+        $category = 'Plugin: Capone';
+        $fields = [
             'name',
             'description',
             'value',
             'category'
         ];
-        $insert_values = [];
-        $insert_values[] = [
-            'FOG_PLUGIN_CAPONE_DMI',
-            'This setting is used for the capone '
-            . 'module to set the DMI field used.',
-            '',
-            $category
+        $settings = [
+            [
+                'FOG_PLUGIN_CAPONE_DMI',
+                'This setting is used for the capone '
+                . 'module to set the DMI field used.',
+                '',
+                $category
+            ],
+            [
+                'FOG_PLUGIN_CAPONE_REGEX',
+                'This setting is used for the capone '
+                . 'module to set the reg ex used.',
+                '',
+                $category
+            ],
+            [
+                'FOG_PLUGIN_CAPONE_SHUTDOWN',
+                'This setting is used for the capone '
+                . 'module to set the shutdown after imaging.',
+                '',
+                $category
+            ]
         ];
-        $insert_values[] = [
-            'FOG_PLUGIN_CAPONE_REGEX',
-            'This setting is used for the capone '
-            . 'module to set the reg ex used.',
-            '',
-            $category
-        ];
-        $insert_values[] = [
-            'FOG_PLUGIN_CAPONE_SHUTDOWN',
-            'This setting is used for the capone '
-            . 'module to set the shutdown after imaging.',
-            '',
-            $category
-        ];
-        self::getClass('SettingManager')
-            ->insertBatch(
-                $insert_fields,
-                $insert_values
-            );
+        $SettingManager = self::getClass('SettingManager');
+        $toInsert = [];
+        foreach ($settings as $setting) {
+            if (!$SettingManager->exists($setting[0], '', 'name')) {
+                $toInsert[] = $setting;
+            }
+        }
+        if (count($toInsert)) {
+            $SettingManager->insertBatch($fields, $toInsert);
+        }
         return true;
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `capone` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            function () {
+                return $this->seedSettings();
+            },
+        ];
+    }
+    /**
+     * Installs the capone database non-destructively (create-if-absent +
+     * seed any missing settings). Does not drop existing data or values.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Removes the database items when plugin is removed.

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -32,14 +32,15 @@ class LDAPManager extends FOGManagerController
      */
     public $tablename = 'LDAPServers';
     /**
-     * Install the plugin, creates the table for us.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -151,19 +152,76 @@ class LDAPManager extends FOGManagerController
             'lsID',
             'lsID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
+    }
+    /**
+     * Seeds this plugin's global settings, but only the ones that are
+     * missing, so an admin's existing values are never overwritten on a
+     * re-run/upgrade. Used as a step in schema().
+     *
+     * @return bool
+     */
+    public function seedSettings()
+    {
+        $category = 'Plugin: LDAP';
+        $fields = [
+            'name',
+            'description',
+            'value',
+            'category'
+        ];
+        $settings = [
+            [
+                'FOG_PLUGIN_LDAP_USER_FILTER',
+                'Insert the filter type codes comma separated. Default: 990,991',
+                '990,991',
+                $category
+            ],
+            [
+                'FOG_PLUGIN_LDAP_PORTS',
+                'Allowed LDAP Ports as defined by user. Default: 389,636',
+                '389,636',
+                $category
+            ]
+        ];
+        $SettingManager = self::getClass('SettingManager');
+        $toInsert = [];
+        foreach ($settings as $setting) {
+            if (!$SettingManager->exists($setting[0], '', 'name')) {
+                $toInsert[] = $setting;
+            }
         }
-        $sql = "INSERT INTO `globalSettings` "
-            . "(`settingKey`,`settingDesc`,`settingValue`,`settingCategory`) "
-            . "VALUES "
-            . "('FOG_PLUGIN_LDAP_USER_FILTER',"
-            . "'Insert the filter type codes comma separated. Default: 990,991',"
-            . "'990,991','Plugin: LDAP'),"
-            . "('FOG_PLUGIN_LDAP_PORTS',"
-            . "'Allowed LDAP Ports as defined by user. Default: 389,636',"
-            . "'389,636','Plugin: LDAP')";
-        return self::$DB->query($sql);
+        if (count($toInsert)) {
+            $SettingManager->insertBatch($fields, $toInsert);
+        }
+        return true;
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `LDAPServers` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            function () {
+                return $this->seedSettings();
+            },
+        ];
+    }
+    /**
+     * Installs the plugin database non-destructively (create-if-absent +
+     * seed any missing settings). Does not drop existing data or values.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the plugin

--- a/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
@@ -30,14 +30,16 @@ class LocationAssociationManager extends FOGManagerController
      */
     public $tablename = 'locationAssoc';
     /**
-     * Install our table.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive: it only creates the table when absent and is safe to
+     * re-run. Used as a step in LocationManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -69,6 +71,14 @@ class LocationAssociationManager extends FOGManagerController
             'laID',
             'laID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * Install our table non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
 }

--- a/packages/web/lib/plugins/location/class/locationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationmanager.class.php
@@ -28,14 +28,16 @@ class LocationManager extends FOGManagerController
      */
     public $tablename = 'location';
     /**
-     * Install our database
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive: it only creates the table when absent and is safe to
+     * re-run. Used as the first step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -95,11 +97,36 @@ class LocationManager extends FOGManagerController
             'lID',
             'lID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        return self::getClass('LocationAssociationManager')
-            ->install();
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list.
+     *
+     * One flat list covering every table this plugin owns. New schema
+     * changes are appended to the END (e.g. "ALTER TABLE `location` ADD
+     * COLUMN ...") and are applied incrementally and non-destructively by
+     * Schema::applyUpdates(), tracked via the plugins.pSchema counter.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            self::getClass('LocationAssociationManager')->createSql(),
+        ];
+    }
+    /**
+     * Install our database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the database

--- a/packages/web/lib/plugins/ou/class/ouassociationmanager.class.php
+++ b/packages/web/lib/plugins/ou/class/ouassociationmanager.class.php
@@ -28,14 +28,15 @@ class OUAssociationManager extends FOGManagerController
      */
     public $tablename = 'ouAssoc';
     /**
-     * Install our table.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in OUManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -67,6 +68,14 @@ class OUAssociationManager extends FOGManagerController
             'oaID',
             'oaID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * Install our table non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
 }

--- a/packages/web/lib/plugins/ou/class/oumanager.class.php
+++ b/packages/web/lib/plugins/ou/class/oumanager.class.php
@@ -28,14 +28,15 @@ class OUManager extends FOGManagerController
      */
     public $tablename = 'ou';
     /**
-     * Install our database
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -79,11 +80,32 @@ class OUManager extends FOGManagerController
             'ouID',
             'ouID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        return self::getClass('OUAssociationManager')
-            ->install();
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list (all tables).
+     * Append new steps (e.g. "ALTER TABLE `ou` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            self::getClass('OUAssociationManager')->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the database

--- a/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
+++ b/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
@@ -24,14 +24,13 @@
 class PersistentGroupsManager extends FOGManagerController
 {
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TRIGGER statement for this plugin.
      *
-     * @return bool
+     * @return string
      */
-    public function install()
+    public function triggerSql()
     {
-        $this->uninstall();
-        $sql = "CREATE TRIGGER `persistentGroups` 
+        return "CREATE TRIGGER `persistentGroups`
             AFTER INSERT ON `groupMembers` 
             FOR EACH ROW
                 BEGIN
@@ -94,7 +93,39 @@ class PersistentGroupsManager extends FOGManagerController
         END IF;
 
         END;";
-        return self::$DB->query($sql);
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list.
+     *
+     * This plugin manages a trigger (no data), so each step drops-if-exists
+     * then creates. A future trigger change ships as a NEW appended step that
+     * drops-and-recreates with the new definition; pSchema tracks which step
+     * has been applied so it runs exactly once.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            function () {
+                self::$DB->query('DROP TRIGGER IF EXISTS `persistentGroups`');
+                if (false !== self::$DB->query($this->triggerSql())->error) {
+                    return self::$DB->error;
+                }
+                return true;
+            },
+        ];
+    }
+    /**
+     * Installs the trigger non-destructively (idempotent drop+create).
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the plugin.

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
@@ -30,13 +30,14 @@ class PushbulletManager extends FOGManagerController
      */
     public $tablename = 'pushbullet';
     /**
-     * Perform the database and plugin installation
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
         $fields = [
             'pID',
             'pToken',
@@ -65,7 +66,7 @@ class PushbulletManager extends FOGManagerController
             'pID',
             'pToken'
         ];
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             $fields,
@@ -78,6 +79,29 @@ class PushbulletManager extends FOGManagerController
             'pID',
             'pID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `pushbullet` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
 }

--- a/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
@@ -28,14 +28,16 @@ class SiteHostAssociationManager extends FOGManagerController
      */
     public $tablename = 'siteHostAssoc';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in
+     * SiteManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -68,11 +70,15 @@ class SiteHostAssociationManager extends FOGManagerController
             'shaID',
             'shaID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        //return true;
-        return self::getClass('SiteUserAssociationManager')->install();
+    }
+    /**
+     * Installs the database non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
     /**
      * Uninstalls plugin.

--- a/packages/web/lib/plugins/site/class/sitemanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitemanager.class.php
@@ -28,14 +28,15 @@ class SiteManager extends FOGManagerController
      */
     public $tablename = 'site';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -64,11 +65,36 @@ class SiteManager extends FOGManagerController
             'sID',
             'sID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        //return true;
-        return self::getClass('SiteHostAssociationManager')->install();
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list (all 4 tables).
+     * Append new steps (e.g. "ALTER TABLE `site` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            self::getClass('SiteHostAssociationManager')->createSql(),
+            // 2
+            self::getClass('SiteUserAssociationManager')->createSql(),
+            // 3
+            self::getClass('SiteUserRestrictionManager')->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls plugin.
@@ -77,7 +103,7 @@ class SiteManager extends FOGManagerController
      */
     public function uninstall()
     {
-        self::getClass('SiteHostAssociationManager')->install();
+        self::getClass('SiteHostAssociationManager')->uninstall();
         return parent::uninstall();
     }
 }

--- a/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
@@ -28,14 +28,16 @@ class SiteUserAssociationManager extends FOGManagerController
      */
     public $tablename = 'siteUserAssoc';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in
+     * SiteManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -68,11 +70,15 @@ class SiteUserAssociationManager extends FOGManagerController
             'suaID',
             'suaID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        //return true;
-        return self::getClass('SiteUserRestrictionManager')->install();
+    }
+    /**
+     * Installs the database non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
     /**
      * Uninstalls plugin.

--- a/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
@@ -28,14 +28,16 @@ class SiteUserRestrictionManager extends FOGManagerController
      */
     public $tablename = 'siteUserRestriction';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in
+     * SiteManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -64,9 +66,14 @@ class SiteUserRestrictionManager extends FOGManagerController
             'surID',
             'surID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        return true;
+    }
+    /**
+     * Installs the database non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
 }

--- a/packages/web/lib/plugins/slack/class/slackmanager.class.php
+++ b/packages/web/lib/plugins/slack/class/slackmanager.class.php
@@ -28,14 +28,15 @@ class SlackManager extends FOGManagerController
      */
     public $tablename = 'slack';
     /**
-     * Install our table.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -69,6 +70,29 @@ class SlackManager extends FOGManagerController
             'sID',
             'sID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `slack` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
 }

--- a/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
+++ b/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
@@ -30,14 +30,15 @@ class SubnetGroupManager extends FOGManagerController
      */
     public $tablename = 'subnetgroup';
     /**
-     * Installs the database for the plugin.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -76,6 +77,29 @@ class SubnetGroupManager extends FOGManagerController
             'sgID',
             'sgID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `subnetgroup` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
 }

--- a/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
@@ -30,14 +30,16 @@ class WindowsKeyAssociationManager extends FOGManagerController
      */
     public $tablename = 'windowsKeysAssoc';
     /**
-     * Install our table.
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in
+     * WindowsKeyManager::schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -71,6 +73,14 @@ class WindowsKeyAssociationManager extends FOGManagerController
             'wkaID',
             'wkaID'
         );
-        return self::$DB->query($sql);
+    }
+    /**
+     * Install our table non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
     }
 }

--- a/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
@@ -28,14 +28,15 @@ class WindowsKeyManager extends FOGManagerController
      */
     public $tablename = 'windowsKeys';
     /**
-     * Install our database
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
      *
-     * @return bool
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
      */
-    public function install()
+    public function createSql()
     {
-        $this->uninstall();
-        $sql = Schema::createTable(
+        return Schema::createTable(
             $this->tablename,
             true,
             [
@@ -79,11 +80,33 @@ class WindowsKeyManager extends FOGManagerController
             'wkID',
             'wkID'
         );
-        if (!self::$DB->query($sql)) {
-            return false;
-        }
-        return self::getClass('WindowsKeyAssociationManager')
-            ->install();
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list (all tables).
+     * Append new steps (e.g. "ALTER TABLE `windowsKeys` ADD COLUMN ...") to
+     * the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+            // 1
+            self::getClass('WindowsKeyAssociationManager')->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
     }
     /**
      * Uninstalls the database

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -8,13 +8,15 @@
         activateBtn = $('#activate'),
         installBtn = $('#install'),
         deactivateBtn = $('#deactivate'),
-        removeBtn = $('#remove');
+        removeBtn = $('#remove'),
+        updateBtn = $('#update');
 
     function disableButtons(disable) {
         activateBtn.prop('disabled', disable);
         installBtn.prop('disabled', disable);
         deactivateBtn.prop('disabled', disable);
         removeBtn.prop('disabled', disable);
+        updateBtn.prop('disabled', disable);
     }
     function onSelect(selected) {
         var disabled = selected.count() == 0;
@@ -62,8 +64,9 @@
                 render: function(data, type, row) {
                     var enabled = '<span class="label label-success"><i class="fa fa-check-circle"></i></span>';
                     var disabled = '<span class="label label-danger"><i class="fa fa-times-circle"></i></span>';
+                    var update = '<button type="button" class="btn btn-warning btn-xs plugin-update-btn" data-id="'+row.id+'" title="Apply pending database update"><i class="fa fa-exclamation-triangle"></i> Update available</button>';
                     if (data > 0) {
-                        return enabled;
+                        return row.needsupdate > 0 ? update : enabled;
                     } else {
                         return disabled;
                     }
@@ -141,6 +144,50 @@
             }
             table.draw(false);
             table.rows({selected: true}).deselect();
+        });
+    });
+    // Bulk update: apply pending schema migrations to all selected plugins.
+    updateBtn.on('click', function(e) {
+        e.preventDefault();
+        disableButtons(true);
+        var method = $(this).attr('method'),
+            action = $(this).attr('action'),
+            rows = table.rows({selected: true}),
+            toUpdate = $.getSelectedIds(table),
+            opts = {
+                plugins: toUpdate,
+                btnpressed: 1
+            };
+        $.apiCall(method, action, opts, function(err) {
+            disableButtons(false);
+            if (err) {
+                return;
+            }
+            table.draw(false);
+            table.rows({selected: true}).deselect();
+        });
+    });
+    // Per-row one-click upgrade: the "Update available" badge applies that
+    // plugin's pending schema migrations via the same (non-destructive)
+    // upgrade endpoint the bulk Update button uses.
+    $('#dataTable').on('click', '.plugin-update-btn', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var btn = $(this),
+            id = btn.data('id'),
+            method = updateBtn.attr('method'),
+            action = updateBtn.attr('action'),
+            opts = {
+                plugins: [id],
+                btnpressed: 1
+            };
+        btn.prop('disabled', true);
+        $.apiCall(method, action, opts, function(err) {
+            if (err) {
+                btn.prop('disabled', false);
+                return;
+            }
+            table.draw(false);
         });
     });
     removeBtn.on('click', function(e) {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2051,6 +2051,10 @@ msgstr "Host erstellen fehlgeschlagen"
 msgid "Failed to uninstall "
 msgstr "Verbindung nicht möglich"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Fehler beim Aktualisieren des Tasks"
+
 msgid "Failed to update Session"
 msgstr "Fehler beim Aktualisieren der Sitzung"
 
@@ -4779,6 +4783,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Drucker aktualisiert!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Plugin-Name"
 
@@ -4795,6 +4807,10 @@ msgid "Plugin uninstalled!"
 msgstr "Plugin-Name"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Plugins"
 
@@ -4808,6 +4824,10 @@ msgstr "Plugin-Name"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Plugin-Name"
 
 msgid "Port"
 msgstr "Port"
@@ -6594,9 +6614,6 @@ msgstr "Fehler beim Aktualisieren des Tasks"
 msgid "Unable to find master Storage Node"
 msgstr "Fehler beim Finden des Master Storage Nodes"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -6738,6 +6755,10 @@ msgstr "Erweiterte Anmeldung erforderlich"
 #, fuzzy
 msgid "Update not required"
 msgstr "Ein Name ist erforderlich!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "ausgewählte Images hinzufügen"
 
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
@@ -7555,6 +7576,12 @@ msgstr "per Host"
 msgid "please see the hosts service settings section."
 msgstr "nutzen Sie bitte die Host Service Settings."
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr "Installation zurück zu kehren, falls erforderlich."
 
@@ -7662,6 +7689,10 @@ msgstr "Das wird Ihr Backup in Ihrem "
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "auf alle Knoten in der Gruppe."
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Drucker aktualisiert!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7975,10 +8006,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Drucker aktualisiert!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "Zeilennummer nicht richtig eingestellt"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2051,6 +2051,10 @@ msgstr "Failed to create Host"
 msgid "Failed to uninstall "
 msgstr "Failed to connect"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Failed to update Task"
+
 msgid "Failed to update Session"
 msgstr "Failed to update Session"
 
@@ -4775,6 +4779,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Printer updated!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "Printer update failed!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Printer updated!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Plugin Name"
 
@@ -4791,6 +4803,10 @@ msgid "Plugin uninstalled!"
 msgstr "Plugin Name"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Printer updated!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Plugin"
 
@@ -4804,6 +4820,10 @@ msgstr "Plugin Name"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Plugin Name"
 
 msgid "Port"
 msgstr "Port"
@@ -6586,9 +6606,6 @@ msgstr "Failed to update task"
 msgid "Unable to find master Storage Node"
 msgstr "Failed to destroy Storage Node"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Unable to open file for reading"
 
@@ -6730,6 +6747,10 @@ msgstr "Advanced Login Required"
 #, fuzzy
 msgid "Update not required"
 msgstr "An image name is required!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "Remove selected printers"
 
 msgid "Upload Reports"
 msgstr "Upload Reports"
@@ -7543,6 +7564,12 @@ msgstr "snapin per host"
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -7649,6 +7676,10 @@ msgstr ""
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "Delete all hosts within group"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Printer updated!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7958,10 +7989,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Printer Name"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Printer updated!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "Row number not set properly"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2095,6 +2095,10 @@ msgid "Failed to uninstall "
 msgstr "No se ha podido destruir"
 
 #, fuzzy
+msgid "Failed to update "
+msgstr "No se pudo crear la tarea"
+
+#, fuzzy
 msgid "Failed to update Session"
 msgstr "No se pudo crear Sesión"
 
@@ -4897,6 +4901,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Impresora actualiza!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Impresora actualiza!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Nombre de la impresora"
 
@@ -4913,6 +4925,10 @@ msgid "Plugin uninstalled!"
 msgstr "Nombre de la impresora"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Impresora actualiza!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Nombre de la impresora"
 
@@ -4926,6 +4942,10 @@ msgstr "Nombre de la impresora"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Nombre de la impresora"
 
 msgid "Port"
 msgstr "Puerto"
@@ -6735,9 +6755,6 @@ msgstr "No se pudo crear la tarea"
 msgid "Unable to find master Storage Node"
 msgstr "No se ha podido destruir nodo de almacenamiento"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "No se puede abrir archivo para lectura"
 
@@ -6880,6 +6897,10 @@ msgstr "Avanzada Menú Inicio de sesión"
 #, fuzzy
 msgid "Update not required"
 msgstr "Se requiere un nombre de imagen!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "Impresora"
 
 #, fuzzy
 msgid "Upload Reports"
@@ -7699,6 +7720,12 @@ msgstr "snapin por host"
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -7802,6 +7829,10 @@ msgstr ""
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "Borrar todos los hosts dentro del grupo"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Impresora actualiza!"
 
 msgid "to clear the field on every host in this group."
 msgstr ""
@@ -8122,10 +8153,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Nombre de la impresora"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Impresora actualiza!"
 
 #, fuzzy
 #~ msgid "Rule Update Fail"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2051,6 +2051,10 @@ msgstr "Host erstellen fehlgeschlagen"
 msgid "Failed to uninstall "
 msgstr "Verbindung nicht möglich"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Fehler beim Aktualisieren des Tasks"
+
 msgid "Failed to update Session"
 msgstr "Fehler beim Aktualisieren der Sitzung"
 
@@ -4780,6 +4784,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Drucker aktualisiert!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Plugin-Name"
 
@@ -4796,6 +4808,10 @@ msgid "Plugin uninstalled!"
 msgstr "Plugin-Name"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Plugins"
 
@@ -4809,6 +4825,10 @@ msgstr "Plugin-Name"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Plugin-Name"
 
 msgid "Port"
 msgstr "Port"
@@ -6595,9 +6615,6 @@ msgstr "Fehler beim Aktualisieren des Tasks"
 msgid "Unable to find master Storage Node"
 msgstr "Fehler beim Finden des Master Storage Nodes"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -6739,6 +6756,10 @@ msgstr "Erweiterte Anmeldung erforderlich"
 #, fuzzy
 msgid "Update not required"
 msgstr "Ein Name ist erforderlich!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "ausgewählte Images hinzufügen"
 
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
@@ -7556,6 +7577,12 @@ msgstr "per Host"
 msgid "please see the hosts service settings section."
 msgstr "nutzen Sie bitte die Host Service Settings."
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr "Installation zurück zu kehren, falls erforderlich."
 
@@ -7663,6 +7690,10 @@ msgstr "Das wird Ihr Backup in Ihrem "
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "auf alle Knoten in der Gruppe."
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Drucker aktualisiert!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7976,10 +8007,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Drucker aktualisiert!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "Zeilennummer nicht richtig eingestellt"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2055,6 +2055,10 @@ msgstr "Impossible de créer Host"
 msgid "Failed to uninstall "
 msgstr "Échec de connexion"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Impossible de mettre à jour la tâche"
+
 msgid "Failed to update Session"
 msgstr "Impossible de mettre à jour Session"
 
@@ -4780,6 +4784,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Imprimante mis à jour!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Imprimante mis à jour!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Nom Plugin"
 
@@ -4796,6 +4808,10 @@ msgid "Plugin uninstalled!"
 msgstr "Nom Plugin"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Imprimante mis à jour!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Brancher"
 
@@ -4809,6 +4825,10 @@ msgstr "Nom Plugin"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Nom Plugin"
 
 msgid "Port"
 msgstr "Port"
@@ -6593,9 +6613,6 @@ msgstr "Impossible de mettre à jour la tâche"
 msgid "Unable to find master Storage Node"
 msgstr "Impossible de détruire le nœud de stockage"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
@@ -6737,6 +6754,10 @@ msgstr "Avancée Login requis"
 #, fuzzy
 msgid "Update not required"
 msgstr "Un nom de l'image est nécessaire!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "Imprimante"
 
 msgid "Upload Reports"
 msgstr "Télécharger Rapports"
@@ -7550,6 +7571,12 @@ msgstr "snapin par hôte"
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -7657,6 +7684,10 @@ msgstr ""
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "Supprimer tous les hôtes au sein du groupe"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Imprimante mis à jour!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7970,10 +8001,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Nom de l'imprimante"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Imprimante mis à jour!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "Numéro de ligne pas réglé correctement"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1971,6 +1971,10 @@ msgstr "Impossibile creare Host"
 msgid "Failed to uninstall "
 msgstr "Connessione fallita"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Impossibile aggiornare Task"
+
 msgid "Failed to update Session"
 msgstr "Impossibile aggiornare Session"
 
@@ -4567,6 +4571,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Aggiornamento stampante riuscito"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "Aggiornamento della stampante non riuscito"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Aggiornamento stampante riuscito"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Nome Plugin"
 
@@ -4582,6 +4594,10 @@ msgstr "Nome Plugin"
 msgid "Plugin uninstalled!"
 msgstr "Nome Plugin"
 
+#, fuzzy
+msgid "Plugin updated!"
+msgstr "aggiornato stampante!"
+
 msgid "Plugins"
 msgstr "Plugins"
 
@@ -4595,6 +4611,10 @@ msgstr "Nome Plugin"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Nome Plugin"
 
 msgid "Port"
 msgstr "Porta"
@@ -6277,9 +6297,6 @@ msgstr "Impossibile aggiornare compito"
 msgid "Unable to find master Storage Node"
 msgstr "Impossibile trovare il Nodo Archiviazione master"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Impossibile aprire il file per la lettura"
 
@@ -6418,6 +6435,10 @@ msgstr "Avanzata Login Richiesto"
 #, fuzzy
 msgid "Update not required"
 msgstr "È richiesto un nome!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "Aggiungi stampanti selezionate"
 
 msgid "Upload Reports"
 msgstr "Carica Report"
@@ -7175,6 +7196,12 @@ msgstr "per host"
 msgid "please see the hosts service settings section."
 msgstr "Si prega di consultare la sezione di impostazioni del servizio host"
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr "installazione precedente se necessario"
 
@@ -7272,6 +7299,10 @@ msgstr "Questo salverà il backup nella tua"
 
 msgid "to all nodes in the group"
 msgstr "a tutti i nodi del gruppo"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "aggiornato stampante!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7574,10 +7605,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Stampante aggiunta"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "aggiornato stampante!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "numero di riga non impostato correttamente"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1712,6 +1712,9 @@ msgstr ""
 msgid "Failed to uninstall "
 msgstr ""
 
+msgid "Failed to update "
+msgstr ""
+
 msgid "Failed to update Session"
 msgstr ""
 
@@ -4016,6 +4019,12 @@ msgstr ""
 msgid "Plugin Uninstall Success"
 msgstr ""
 
+msgid "Plugin Update Fail"
+msgstr ""
+
+msgid "Plugin Update Success"
+msgstr ""
+
 msgid "Plugin activated!"
 msgstr ""
 
@@ -4028,6 +4037,9 @@ msgstr ""
 msgid "Plugin uninstalled!"
 msgstr ""
 
+msgid "Plugin updated!"
+msgstr ""
+
 msgid "Plugins"
 msgstr ""
 
@@ -4038,6 +4050,9 @@ msgid "Plugins installed!"
 msgstr ""
 
 msgid "Plugins uninstalled!"
+msgstr ""
+
+msgid "Plugins updated!"
 msgstr ""
 
 msgid "Port"
@@ -5541,9 +5556,6 @@ msgstr ""
 msgid "Unable to find master Storage Node"
 msgstr ""
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr ""
 
@@ -5656,6 +5668,9 @@ msgid "Update Not Required"
 msgstr ""
 
 msgid "Update not required"
+msgstr ""
+
+msgid "Update selected"
 msgstr ""
 
 msgid "Upload Reports"
@@ -6357,6 +6372,12 @@ msgstr ""
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -6448,6 +6469,9 @@ msgid "this will save the backup in your home"
 msgstr ""
 
 msgid "to all nodes in the group"
+msgstr ""
+
+msgid "to apply the update."
 msgstr ""
 
 msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2054,6 +2054,10 @@ msgstr "Falha ao criar o Host"
 msgid "Failed to uninstall "
 msgstr "Falhou ao conectar"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "Falha ao atualizar Task"
+
 msgid "Failed to update Session"
 msgstr "Falha ao atualizar Session"
 
@@ -4779,6 +4783,14 @@ msgid "Plugin Uninstall Success"
 msgstr "Impressora atualizado!"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "Impressora atualizado!"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "Nome Plugin"
 
@@ -4795,6 +4807,10 @@ msgid "Plugin uninstalled!"
 msgstr "Nome Plugin"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "Impressora atualizado!"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "Plugar"
 
@@ -4808,6 +4824,10 @@ msgstr "Nome Plugin"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "Nome Plugin"
 
 msgid "Port"
 msgstr "Porta"
@@ -6589,9 +6609,6 @@ msgstr "Falha ao atualizar tarefa"
 msgid "Unable to find master Storage Node"
 msgstr "Falha ao destruir Storage Node"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "Não é possível abrir arquivo para leitura"
 
@@ -6733,6 +6750,10 @@ msgstr "Avançada Login obrigatório"
 #, fuzzy
 msgid "Update not required"
 msgstr "Um nome de imagem é necessário!"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "Impressora"
 
 msgid "Upload Reports"
 msgstr "carregar relatórios"
@@ -7546,6 +7567,12 @@ msgstr "snap-in por host"
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -7653,6 +7680,10 @@ msgstr ""
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "Excluir todos os hosts dentro do grupo"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "Impressora atualizado!"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7966,10 +7997,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "Nome da impressora"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "Impressora atualizado!"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "número da linha não definido adequadamente"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2052,6 +2052,10 @@ msgstr "无法创建主机"
 msgid "Failed to uninstall "
 msgstr "连接失败"
 
+#, fuzzy
+msgid "Failed to update "
+msgstr "无法更新任务"
+
 msgid "Failed to update Session"
 msgstr "无法更新会话"
 
@@ -4775,6 +4779,14 @@ msgid "Plugin Uninstall Success"
 msgstr "打印机更新！"
 
 #, fuzzy
+msgid "Plugin Update Fail"
+msgstr "打印机更新失败！"
+
+#, fuzzy
+msgid "Plugin Update Success"
+msgstr "打印机更新！"
+
+#, fuzzy
 msgid "Plugin activated!"
 msgstr "插件名称"
 
@@ -4791,6 +4803,10 @@ msgid "Plugin uninstalled!"
 msgstr "插件名称"
 
 #, fuzzy
+msgid "Plugin updated!"
+msgstr "打印机更新！"
+
+#, fuzzy
 msgid "Plugins"
 msgstr "插入"
 
@@ -4804,6 +4820,10 @@ msgstr "插件名称"
 
 msgid "Plugins uninstalled!"
 msgstr ""
+
+#, fuzzy
+msgid "Plugins updated!"
+msgstr "插件名称"
 
 msgid "Port"
 msgstr "港口"
@@ -6580,9 +6600,6 @@ msgstr "无法更新任务"
 msgid "Unable to find master Storage Node"
 msgstr "未能摧毁存储节点"
 
-msgid "Unable to install, no method exists for "
-msgstr ""
-
 msgid "Unable to open file for reading"
 msgstr "无法打开文件进行读取"
 
@@ -6724,6 +6741,10 @@ msgstr "高级需要登录"
 #, fuzzy
 msgid "Update not required"
 msgstr "图像名是必需的！"
+
+#, fuzzy
+msgid "Update selected"
+msgstr "打印机"
 
 msgid "Upload Reports"
 msgstr "上传报告"
@@ -7535,6 +7556,12 @@ msgstr "每个主机管理单元"
 msgid "please see the hosts service settings section."
 msgstr ""
 
+msgid "plugin needs a database update"
+msgstr ""
+
+msgid "plugins need a database update"
+msgstr ""
+
 msgid "previous install if needed"
 msgstr ""
 
@@ -7640,6 +7667,10 @@ msgstr ""
 #, fuzzy
 msgid "to all nodes in the group"
 msgstr "删除组内的所有主机"
+
+#, fuzzy
+msgid "to apply the update."
+msgstr "打印机更新！"
 
 #, fuzzy
 msgid "to clear the field on every host in this group."
@@ -7953,10 +7984,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Role added!"
 #~ msgstr "打印机名称"
-
-#, fuzzy
-#~ msgid "Role updated!"
-#~ msgstr "打印机更新！"
 
 #~ msgid "Row number not set properly"
 #~ msgstr "行数设置不正确"


### PR DESCRIPTION
## Summary

Closes #840.

Bundled plugins had no way to evolve their database schema after first install:

- A plugin's schema was created only when an admin clicked **Install**, and
  re-installing **dropped and recreated** the tables — losing data.
- A schema change shipped in a new release never reached an already-installed
  plugin; the core Schema Updater only touches core tables.

This PR introduces a non-destructive, per-plugin migration mechanism modelled on
how FOG's core schema already works, and converts every bundled plugin to it.

## How it works

- **`schema()` contract** — a plugin's top-level manager returns an ordered,
  **append-only** list of migration steps (SQL strings or callables). New changes
  are appended to the end; each table's `CREATE TABLE IF NOT EXISTS` lives in a
  `createSql()` helper.
- **`Schema::applyUpdates($steps, $applied)`** — shared idempotent runner; tolerates
  the same "already exists / not-exists" error codes the core updater does, so
  additive steps are safe to re-run. Nothing here drops data.
- **`plugins.pSchema`** — new integer counter of applied steps per plugin
  (added via a core `schema.php` migration; `FOG_SCHEMA` 294 → 295). Detection is
  `pSchema < count(schema())` — **independent of `FOG_SCHEMA`**, so a plugin
  self-reports when it is behind.
- **Notify + one-click apply** — installed plugins that are behind raise a
  **dashboard banner** and an **"Update available"** badge on the plugin list.
  Admins apply individually (row button) or in bulk (**Update selected**, the
  reverse of the install filter). No silent auto-apply — consistent with FOG's
  existing "ask before schema changes" UX.
- `install()` is now non-destructive; `uninstall()` remains the only path that
  drops tables.

## Plugins converted

location, subnetgroup, slack, pushbullet, ou, windowskey, site (4 tables),
capone & ldap (idempotent **settings seeds** that preserve admin-customized
values), persistentgroups (trigger via callable step), accesscontrol (4 tables +
explicit-PK seeds + dynamic fog-user row). `taskstateedit` / `tasktypeedit` own no
tables and correctly need no `schema()`.

Also fixes a **pre-existing bug**: `SiteManager::uninstall()` called the child
`->install()` instead of `->uninstall()`, so uninstalling site never dropped its
child tables.

## Docs

`docs/PLUGIN_SCHEMA_MIGRATIONS.md` — the contract, idempotency rules, version
tracking, the UX flow, how to add a future migration, and the seed/trigger/no-table
special cases.

## Testing notes

- Verified manually: detect → banner/badge → apply (individual + bulk) → counter
  advances, badge clears, **no data loss**.
- Expected one-time behavior: because `pSchema` defaults to 0, plugins installed
  *before* this change show "update available" once; applying is a harmless,
  idempotent no-op that reconciles the counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
