### PR TITLE
feat(plugins): ntfy notification plugin for working-1.6 (+ pushbullet event fix)

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '760.0-feature.2407');
+        define('FOG_VERSION', '760.0-feature.2408');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,8 +59,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2406');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '760.0-feature.2407');
+        define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '760.0-feature.2410');
+        define('FOG_VERSION', '760.0-feature.2411');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '760.0-feature.2409');
+        define('FOG_VERSION', '760.0-feature.2410');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '760.0-feature.2408');
+        define('FOG_VERSION', '760.0-feature.2409');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 295);
         define('FOG_BCACHE_VER', 152);

--- a/packages/web/lib/plugins/ntfy/class/ntfy.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfy.class.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The ntfy database and object definer
+ *
+ * PHP version 5
+ *
+ * @category Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * The ntfy database and object definer
+ *
+ * @category Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class Ntfy extends FOGController
+{
+    /**
+     * The ntfy table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'ntfy';
+    /**
+     * The database fields and commonized items.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'nID',
+        'serverURL' => 'nServerURL',
+        'topicEndpoint' => 'nTopicEndpoint',
+        'credentials' => 'nCredentials',
+    ];
+    /**
+     * The required fields
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'serverURL',
+        'topicEndpoint',
+    ];
+}

--- a/packages/web/lib/plugins/ntfy/class/ntfyexception.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfyexception.class.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Exception class for ntfy
+ *
+ * PHP Version 5
+ *
+ * @category NtfyException
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Exception class for ntfy
+ *
+ * @category NtfyException
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class NtfyException extends Exception
+{
+}

--- a/packages/web/lib/plugins/ntfy/class/ntfyextends.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfyextends.class.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * The base class of ntfy elements
+ *
+ * Extends the ntfy elements into the event class.
+ *
+ * PHP version 5
+ *
+ * @category NtfyExtends
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * The base class of ntfy elements
+ *
+ * Extends the ntfy elements into the event class.
+ *
+ * @category NtfyExtends
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+abstract class NtfyExtends extends Event
+{
+    /**
+     * The name
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * The description
+     *
+     * @var string
+     */
+    protected $description;
+    /**
+     * The event loop
+     *
+     * @var mixed
+     */
+    protected static $eventloop;
+    /**
+     * The elements to use
+     *
+     * @var mixed
+     */
+    protected static $elements;
+    /**
+     * The short description
+     *
+     * @var mixed
+     */
+    protected static $shortdesc;
+    /**
+     * The message
+     *
+     * @var mixed
+     */
+    protected static $message;
+    /**
+     * The item is active
+     *
+     * @var bool
+     */
+    public $active;
+    /**
+     * Initialize the class item
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$eventloop = function (&$Ntfy) {
+            self::getClass(
+                'NtfyHandler',
+                $Ntfy->serverURL,
+                $Ntfy->topicEndpoint,
+                $Ntfy->credentials
+            )->pushNote(
+                sprintf(
+                    '%s %s',
+                    self::$elements['HostName'],
+                    _(self::$shortdesc)
+                ),
+                _(self::$message)
+            );
+        };
+    }
+    /**
+     * Perform action
+     *
+     * @param string $event the event to enact
+     * @param mixed  $data  the data
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$elements = $data;
+        Route::listem('ntfy');
+        $Ntfys = json_decode(
+            Route::getData()
+        );
+        foreach ($Ntfys->data as &$Ntfy) {
+            self::$eventloop($Ntfy);
+            unset($Ntfy);
+        }
+    }
+}

--- a/packages/web/lib/plugins/ntfy/class/ntfyextends.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfyextends.class.php
@@ -78,17 +78,23 @@ abstract class NtfyExtends extends Event
     {
         parent::__construct();
         self::$eventloop = function (&$Ntfy) {
+            // Some events (e.g. login failure) carry no host, so HostName
+            // may be absent -- build the title without a leading space.
+            $hostName = self::$elements['HostName'] ?? '';
+            $title = trim(
+                sprintf(
+                    '%s %s',
+                    $hostName,
+                    _(self::$shortdesc)
+                )
+            );
             self::getClass(
                 'NtfyHandler',
                 $Ntfy->serverURL,
                 $Ntfy->topicEndpoint,
                 $Ntfy->credentials
             )->pushNote(
-                sprintf(
-                    '%s %s',
-                    self::$elements['HostName'],
-                    _(self::$shortdesc)
-                ),
+                $title,
                 _(self::$message)
             );
         };
@@ -108,8 +114,12 @@ abstract class NtfyExtends extends Event
         $Ntfys = json_decode(
             Route::getData()
         );
+        // Invoke the closure stored in the static property. Calling
+        // self::$eventloop($x) directly is parsed as a static method named
+        // by a local variable, not as invoking the closure.
+        $eventloop = self::$eventloop;
         foreach ($Ntfys->data as &$Ntfy) {
-            self::$eventloop($Ntfy);
+            $eventloop($Ntfy);
             unset($Ntfy);
         }
     }

--- a/packages/web/lib/plugins/ntfy/class/ntfyhandler.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfyhandler.class.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Ntfy handler
+ *
+ * PHP version 5
+ *
+ * @category NtfyHandler
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Ntfy handler
+ *
+ * Speaks ntfy's publish protocol: the message text is the POST body and the
+ * title is sent via the "Title" header. Optional credentials authenticate
+ * against protected topics -- "user:pass" uses HTTP basic auth, anything else
+ * is treated as an access token and sent as "Authorization: Bearer <token>".
+ *
+ * @category NtfyHandler
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class NtfyHandler extends Ntfy
+{
+    /**
+     * The full topic URL to publish to (server + endpoint).
+     *
+     * @var string
+     */
+    private $_topicURL;
+    /**
+     * The credentials used to authenticate (token or "user:pass").
+     *
+     * @var string
+     */
+    private $_credentials;
+    /**
+     * Ntfy constructor.
+     *
+     * @param string $serverURL     The ntfy server base URL.
+     * @param string $topicEndpoint The topic to publish to.
+     * @param string $credentials   Optional token or "user:pass".
+     *
+     * @throws NtfyException
+     */
+    public function __construct($serverURL, $topicEndpoint, $credentials = '')
+    {
+        $this->_topicURL = rtrim($serverURL, '/') . '/' . ltrim($topicEndpoint, '/');
+        $this->_credentials = (string)$credentials;
+        if (!function_exists('curl_init')) {
+            throw new NtfyException(
+                'cURL library is not loaded.'
+            );
+        }
+    }
+    /**
+     * Publish a notification to the topic.
+     *
+     * @param string $title The notification title.
+     * @param string $body  The notification message body.
+     *
+     * @return object Response.
+     * @throws NtfyException
+     */
+    public function pushNote($title, $body = '')
+    {
+        $headers = [];
+        if ($title !== '' && $title !== null) {
+            $headers[] = 'Title: ' . str_replace(
+                ["\r", "\n"],
+                ' ',
+                $title
+            );
+        }
+        $auth = false;
+        if ($this->_credentials !== '') {
+            if (strpos($this->_credentials, ':') !== false) {
+                // HTTP basic auth (user:pass) via CURLOPT_USERPWD.
+                $auth = $this->_credentials;
+            } else {
+                // ntfy access token.
+                $headers[] = 'Authorization: Bearer ' . $this->_credentials;
+            }
+        }
+        return $this->_curlRequest(
+            $this->_topicURL,
+            'POST',
+            (string)$body,
+            $auth,
+            $headers
+        );
+    }
+    /**
+     * Send a request to the ntfy server using cURL.
+     *
+     * @param string $url     URL to send the request to.
+     * @param string $method  HTTP method.
+     * @param string $body    Raw request body (the message text).
+     * @param mixed  $auth    "user:pass" for basic auth, or false.
+     * @param array  $headers Extra HTTP headers.
+     *
+     * @return object Response.
+     * @throws NtfyException
+     */
+    private function _curlRequest(
+        $url,
+        $method,
+        $body = '',
+        $auth = false,
+        array $headers = []
+    ) {
+        $data = self::$FOGURLRequests->process(
+            $url,
+            $method,
+            $body,
+            false,
+            $auth,
+            false,
+            false,
+            false,
+            $headers
+        );
+        return json_decode($data[0]);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/class/ntfymanager.class.php
+++ b/packages/web/lib/plugins/ntfy/class/ntfymanager.class.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Manager class for ntfy
+ *
+ * PHP version 5
+ *
+ * @category NtfyManager
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Manager class for ntfy
+ *
+ * @category NtfyManager
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class NtfyManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'ntfy';
+    /**
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
+     *
+     * Non-destructive and safe to re-run. Used as a step in schema().
+     *
+     * @return string
+     */
+    public function createSql()
+    {
+        $fields = [
+            'nID',
+            'nServerURL',
+            'nTopicEndpoint',
+            'nCredentials'
+        ];
+        $types = [
+            'INTEGER',
+            'VARCHAR(255)',
+            'VARCHAR(255)',
+            'VARCHAR(255)'
+        ];
+        $notnulls = [
+            false,
+            false,
+            false,
+            false
+        ];
+        $defaults = [
+            false,
+            false,
+            false,
+            false
+        ];
+        $keys = [
+            'nID'
+        ];
+        return Schema::createTable(
+            $this->tablename,
+            true,
+            $fields,
+            $types,
+            $notnulls,
+            $defaults,
+            $keys,
+            'InnoDB',
+            'utf8',
+            'nID',
+            'nID'
+        );
+    }
+    /**
+     * The plugin's ordered, append-only schema migration list. Append new
+     * steps (e.g. "ALTER TABLE `ntfy` ADD COLUMN ...") to the END.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0
+            $this->createSql(),
+        ];
+    }
+    /**
+     * Installs the database non-destructively (create-if-absent + apply any
+     * pending additive steps). Does not drop existing data.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
+    }
+}

--- a/packages/web/lib/plugins/ntfy/config/plugin.config.php
+++ b/packages/web/lib/plugins/ntfy/config/plugin.config.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin configuration file.
+ *
+ * PHP version 5
+ *
+ * @category Config
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Plugin configuration file.
+ *
+ * @category Config
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+$fog_plugin = [];
+$fog_plugin['name'] = 'ntfy';
+$fog_plugin['description'] = 'Adds ntfy notifications using either the '
+    . 'ntfy.sh default server or a self-hosted server.';
+$fog_plugin['menuicon'] = 'fa fa-comment fa-fw';
+$fog_plugin['menuicon_hover'] = null;
+$fog_plugin['entrypoint'] = 'html/run.php';

--- a/packages/web/lib/plugins/ntfy/events/imagecomplete_ntfy.event.php
+++ b/packages/web/lib/plugins/ntfy/events/imagecomplete_ntfy.event.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Pushes notification on image completion.
+ *
+ * PHP version 5
+ *
+ * @category ImageComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Pushes notification on image completion.
+ *
+ * @category ImageComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class ImageComplete_Ntfy extends NtfyExtends
+{
+    /**
+     * Name of this event.
+     *
+     * @var string
+     */
+    protected $name = 'ImageComplete_Ntfy';
+    /**
+     * Description of this event.
+     *
+     * @var string
+     */
+    protected $description = 'Triggers when a host finishes imaging';
+    /**
+     * Active flag.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$EventManager
+            ->register(
+                'HOST_IMAGE_COMPLETE',
+                $this
+            )
+            ->register(
+                'HOST_IMAGEUP_COMPLETE',
+                $this
+            );
+    }
+    /**
+     * Perform action when event met.
+     *
+     * @param string $event The event to perform from.
+     * @param mixed  $data  The data to send.
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$message = 'This host has finished imaging.';
+        self::$shortdesc = 'Imaging Complete';
+        parent::onEvent($event, $data);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/events/imagefail_ntfy.event.php
+++ b/packages/web/lib/plugins/ntfy/events/imagefail_ntfy.event.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Pushes notification on imaging failure.
+ *
+ * PHP version 5
+ *
+ * @category ImageFail_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Pushes notification on imaging failure.
+ *
+ * @category ImageFail_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class ImageFail_Ntfy extends NtfyExtends
+{
+    /**
+     * The name of the event.
+     *
+     * @var string
+     */
+    protected $name = 'ImageFail_Ntfy';
+    /**
+     * The description of the event.
+     *
+     * @var string
+     */
+    protected $description = 'Triggers when a host fails imaging';
+    /**
+     * Active flag.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * Initialize object
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$EventManager
+            ->register(
+                'HOST_IMAGE_FAIL',
+                $this
+            );
+    }
+    /**
+     * Perform action when event met.
+     *
+     * @param string $event The event to perform from.
+     * @param mixed  $data  The data to send.
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$message = 'This host has failed to image';
+        self::$shortdesc = 'Failed';
+        parent::onEvent($event, $data);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/events/loginfailure_ntfy.event.php
+++ b/packages/web/lib/plugins/ntfy/events/loginfailure_ntfy.event.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Pushes notification on login failure.
+ *
+ * PHP version 5
+ *
+ * @category LoginFailure_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Pushes notification on login failure.
+ *
+ * @category LoginFailure_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class LoginFailure_Ntfy extends NtfyExtends
+{
+    /**
+     * The name of the event.
+     *
+     * @var string
+     */
+    protected $name = 'LoginFailure_Ntfy';
+    /**
+     * The description of the event.
+     *
+     * @var string
+     */
+    protected $description = 'Triggers when a an invalid login occurs';
+    /**
+     * Active flag.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$EventManager
+            ->register(
+                'LoginFail',
+                $this
+            );
+    }
+    /**
+     * Perform action when event met.
+     *
+     * @param string $event The event to perform from.
+     * @param mixed  $data  The data to send.
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$message = 'If you see repeatedly, please check your security';
+        self::$shortdesc = sprintf(
+            '%s %s. %s: %s',
+            $data['Failure'],
+            _('failed to login'),
+            _('Remote address attempting to login'),
+            filter_input(INPUT_SERVER, 'REMOTE_ADDR')
+        );
+        parent::onEvent($event, $data);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/events/snapincomplete_ntfy.event.php
+++ b/packages/web/lib/plugins/ntfy/events/snapincomplete_ntfy.event.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Pushes notification on snapin completion.
+ *
+ * PHP version 5
+ *
+ * @category SnapinComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Pushes notification on snapin completion.
+ *
+ * @category SnapinComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SnapinComplete_Ntfy extends NtfyExtends
+{
+    /**
+     * The name of the event.
+     *
+     * @var string
+     */
+    protected $name = 'SnapinComplete_Ntfy';
+    /**
+     * The description of the event.
+     *
+     * @var string
+     */
+    protected $description = 'Triggers when a host completes snapin taskings';
+    /**
+     * The active flag.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$EventManager
+            ->register(
+                'HOST_SNAPIN_COMPLETE',
+                $this
+            );
+    }
+    /**
+     * Perform action when event met.
+     *
+     * @param string $event The event to perform from.
+     * @param mixed  $data  The data to send.
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$message = sprintf(
+            'Host %s has completed snapin tasking.',
+            $data['Host']->get('name')
+        );
+        self::$shortdesc = 'Snapin(s) Complete';
+        parent::onEvent($event, $data);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/events/snapintaskcomplete_ntfy.event.php
+++ b/packages/web/lib/plugins/ntfy/events/snapintaskcomplete_ntfy.event.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Pushes notification on snapin task completion.
+ *
+ * PHP version 5
+ *
+ * @category SnapinTaskComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Pushes notification on snapin task completion.
+ *
+ * @category SnapinTaskComplete_Ntfy
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SnapinTaskComplete_Ntfy extends NtfyExtends
+{
+    /**
+     * Name of the event.
+     *
+     * @var string
+     */
+    protected $name = 'SnapinTaskComplete_Ntfy';
+    /**
+     * Description of the event.
+     *
+     * @var string
+     */
+    protected $description = 'Triggers when a host completes snapin task';
+    /**
+     * Active flag.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * Initialize object
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        self::$EventManager
+            ->register(
+                'HOST_SNAPINTASK_COMPLETE',
+                $this
+            );
+    }
+    /**
+     * Perform action when event met.
+     *
+     * @param string $event The event to perform from.
+     * @param mixed  $data  The data to send.
+     *
+     * @return void
+     */
+    public function onEvent($event, $data)
+    {
+        self::$message = sprintf(
+            'The snapin has completed installation on %s with status code: %s',
+            $data['Host']->get('name'),
+            $data['SnapinTask']->get('return')
+        );
+        self::$shortdesc = sprintf(
+            '%s completed',
+            $data['Snapin']->get('name')
+        );
+        parent::onEvent($event, $data);
+    }
+}

--- a/packages/web/lib/plugins/ntfy/hooks/addntfyapi.hook.php
+++ b/packages/web/lib/plugins/ntfy/hooks/addntfyapi.hook.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Injects ntfy stuff into the api system.
+ *
+ * PHP version 5
+ *
+ * @category AddNtfyAPI
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Injects ntfy stuff into the api system.
+ *
+ * @category AddNtfyAPI
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddNtfyAPI extends Hook
+{
+    /**
+     * The name of the hook.
+     *
+     * @var string
+     */
+    public $name = 'AddNtfyAPI';
+    /**
+     * The description.
+     *
+     * @var string
+     */
+    public $description = 'Add ntfy stuff into the api system.';
+    /**
+     * For posterity.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * The node the hook works with.
+     *
+     * @var string
+     */
+    public $node = 'ntfy';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'API_VALID_CLASSES',
+            [$this, 'injectAPIElements']
+        );
+    }
+    /**
+     * This function injects ntfy elements for
+     * api access.
+     *
+     * @param mixed $arguments The arguments to modify.
+     *
+     * @return void
+     */
+    public function injectAPIElements($arguments)
+    {
+        $arguments['validClasses'][] = $this->node;
+    }
+}

--- a/packages/web/lib/plugins/ntfy/hooks/addntfyjs.hook.php
+++ b/packages/web/lib/plugins/ntfy/hooks/addntfyjs.hook.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Sets the javascript files up for this plugin.
+ *
+ * PHP version 5
+ *
+ * @category AddNtfyJS
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Sets the javascript files up for this plugin.
+ *
+ * @category AddNtfyJS
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddNtfyJS extends Hook
+{
+    /**
+     * The name of this hook.
+     *
+     * @var string
+     */
+    public $name = 'AddNtfyJS';
+    /**
+     * The description.
+     *
+     * @var string
+     */
+    public $description = 'Add ntfy JS files.';
+    /**
+     * For posterity.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * What plugin this works against.
+     *
+     * @var string
+     */
+    public $node = 'ntfy';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'PAGE_JS_FILES',
+            [$this, 'injectJSFiles']
+        );
+    }
+    /**
+     * The files we need to inject.
+     *
+     * @param mixed $arguments The arguments to modify.
+     *
+     * @return void
+     */
+    public function injectJSFiles($arguments)
+    {
+        global $node;
+        global $sub;
+        $subset = $sub;
+        if ($sub == 'membership') {
+            $subset = 'edit';
+        }
+        $node = str_replace(
+            '_',
+            '-',
+            $node
+        );
+        $subset = str_replace(
+            '_',
+            '-',
+            $subset
+        );
+        switch ($node) {
+            case 'ntfy':
+                if (empty($subset)) {
+                    $filepaths = "../lib/plugins/{$this->node}/js/fog.{$node}.js";
+                } else {
+                    $filepaths
+                        = "../lib/plugins/{$this->node}/js/fog.{$node}.{$subset}.js";
+                }
+                if ($subset && !file_exists($filepaths)) {
+                    $arguments['files'][]
+                        = "../lib/plugins/{$this->node}/js/fog.{$node}.list.js";
+                }
+                break;
+            default:
+                return;
+        }
+        $arguments['files'][] = $filepaths;
+    }
+}

--- a/packages/web/lib/plugins/ntfy/hooks/addntfymenuitem.hook.php
+++ b/packages/web/lib/plugins/ntfy/hooks/addntfymenuitem.hook.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Adds the ntfy menu item to the menu.
+ *
+ * PHP version 5
+ *
+ * @category AddNtfyMenuItem
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Adds the ntfy menu item to the menu.
+ *
+ * @category AddNtfyMenuItem
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddNtfyMenuItem extends Hook
+{
+    /**
+     * The name of this hook
+     *
+     * @var string
+     */
+    public $name = 'AddNtfyMenuItem';
+    /**
+     * The Description of this hook
+     *
+     * @var string
+     */
+    public $description = 'Add menu item for ntfy';
+    /**
+     * The active flag
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * The node that enacts upon
+     *
+     * @var string
+     */
+    public $node = 'ntfy';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'MAIN_MENU_DATA',
+            [$this, 'menuData']
+        )->register(
+            'SEARCH_PAGES',
+            [$this, 'addSearch']
+        )->register(
+            'PAGES_WITH_OBJECTS',
+            [$this, 'addPageWithObject']
+        );
+    }
+    /**
+     * Inserts the ntfy menu item
+     *
+     * @param array $arguments the arguments to alter
+     *
+     * @return void
+     */
+    public function menuData($arguments)
+    {
+        $arguments['hook_main'][$this->node]
+            = [_('ntfy Accounts'), 'fa fa-comment'];
+    }
+    /**
+     * Adds the ntfy page to objects elements.
+     *
+     * @param mixed $arguments The arguments to change.
+     *
+     * @return void
+     */
+    public function addPageWithObject($arguments)
+    {
+        $arguments['PagesWithObjects'][] = $this->node;
+    }
+    /**
+     * Inserts the search
+     *
+     * @param array $arguments the arguments to alter
+     *
+     * @return void
+     */
+    public function addSearch($arguments)
+    {
+        $arguments['searchPages'][] = $this->node;
+    }
+}

--- a/packages/web/lib/plugins/ntfy/js/fog.ntfy.add.js
+++ b/packages/web/lib/plugins/ntfy/js/fog.ntfy.add.js
@@ -1,0 +1,13 @@
+(function($) {
+    var createForm = $('#ntfy-create-form'),
+        createFormBtn = $('#send');
+    createForm.on('submit', function(e) {
+        e.preventDefault();
+    });
+    createFormBtn.on('click', function() {
+        createFormBtn.prop('disabled', true);
+        createForm.processForm(function(err) {
+            createFormBtn.prop('disabled', false);
+        });
+    });
+})(jQuery);

--- a/packages/web/lib/plugins/ntfy/js/fog.ntfy.list.js
+++ b/packages/web/lib/plugins/ntfy/js/fog.ntfy.list.js
@@ -1,0 +1,71 @@
+(function($) {
+    var deleteSelected = $('#deleteSelected'),
+        createnewBtn = $('#createnew'),
+        createnewModal = $('#createnewModal'),
+        createForm = $('#create-form'),
+        createnewSendBtn = $('#send');
+
+    function disableButtons(disable) {
+        deleteSelected.prop('disabled', disable);
+    }
+    function onSelect(selected) {
+        var disabled = selected.count() == 0;
+        disableButtons(disabled);
+    }
+
+    disableButtons(true);
+    var table = $('#dataTable').registerTable(onSelect, {
+        columns: [
+            {data: 'serverURL'},
+            {data: 'topicEndpoint'}
+        ],
+        rowId: 'id',
+        columnDefs: [
+            {
+                responsivePriority: -1,
+                targets: 0,
+            },
+        ],
+        processing: true,
+        serverSide: true,
+        ajax: {
+            url: '../management/index.php?node='+Common.node+'&sub=list',
+            type: 'POST'
+        }
+    });
+
+    if (Common.search && Common.search.length > 0) {
+        table.search(Common.search).draw();
+    }
+
+    createnewModal.registerModal(Common.createModalShow, Common.createModalHide);
+    createnewBtn.on('click', function(e) {
+        e.preventDefault();
+        createnewModal.modal('show');
+    });
+    createnewSendBtn.on('click', function(e) {
+        e.preventDefault();
+        createForm.processForm(function(err) {
+            if (err) {
+                return;
+            }
+            table.draw(false);
+            table.rows({selected: true}).deselect();
+            createnewModal.modal('hide');
+        });
+    });
+
+    deleteSelected.on('click', function() {
+        disableButtons(true);
+        $.deleteSelected(table, function(err) {
+            // if we couldn't delete the items, enable the buttons
+            // as the rows still exist and are selected.
+            disableButtons(false);
+            if (err) {
+                return;
+            }
+            table.draw(false);
+            table.rows({selected: true}).deselect();
+        });
+    });
+})(jQuery);

--- a/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
+++ b/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
@@ -87,7 +87,7 @@ class NtfyManagement extends FOGPage
             ) => self::makeInput(
                 'form-control ntfytopic-input',
                 'topicEndpoint',
-                _('Topic Endpoint'),
+                _('Topic name you choose, e.g. fog-alerts'),
                 'text',
                 'topicEndpoint',
                 $topicEndpoint,
@@ -97,7 +97,8 @@ class NtfyManagement extends FOGPage
                 $labelClass,
                 'credentials',
                 _('Credentials')
-            ) => self::makeInput(
+            ) => '<div class="input-group">'
+            . self::makeInput(
                 'form-control ntfycredentials-input',
                 'credentials',
                 _('Token or user:pass (optional)'),
@@ -105,7 +106,8 @@ class NtfyManagement extends FOGPage
                 'credentials',
                 '',
                 false
-            ),
+            )
+            . '</div>',
         ];
     }
     /**

--- a/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
+++ b/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Page presenter for ntfy plugin
+ *
+ * PHP version 5
+ *
+ * @category NtfyManagement
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Page presenter for ntfy plugin
+ *
+ * @category NtfyManagement
+ * @package  FOGProject
+ * @author   Tony Lam <tonylam5349@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class NtfyManagement extends FOGPage
+{
+    /**
+     * The node name
+     *
+     * @var string
+     */
+    public $node = 'ntfy';
+    /**
+     * The initializer for the page.
+     *
+     * @param string $name the name of the page
+     *
+     * @return void
+     */
+    public function __construct($name = '')
+    {
+        $this->name = 'ntfy Management';
+        parent::__construct($this->name);
+        $this->headerData = [
+            _('Server URL'),
+            _('Topic Endpoint'),
+        ];
+        $this->attributes = [
+            [],
+            []
+        ];
+    }
+    /**
+     * Builds the add/link form fields.
+     *
+     * @return array
+     */
+    private function _addFields()
+    {
+        $serverURL = filter_input(
+            INPUT_POST,
+            'serverURL',
+            FILTER_DEFAULT,
+            ['options' => ['default' => 'https://ntfy.sh']]
+        );
+        $topicEndpoint = filter_input(INPUT_POST, 'topicEndpoint');
+
+        $labelClass = 'col-sm-3 control-label';
+
+        return [
+            self::makeLabel(
+                $labelClass,
+                'serverURL',
+                _('Server URL')
+            ) => self::makeInput(
+                'form-control ntfyserver-input',
+                'serverURL',
+                _('Server URL'),
+                'text',
+                'serverURL',
+                $serverURL,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'topicEndpoint',
+                _('Topic Endpoint')
+            ) => self::makeInput(
+                'form-control ntfytopic-input',
+                'topicEndpoint',
+                _('Topic Endpoint'),
+                'text',
+                'topicEndpoint',
+                $topicEndpoint,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'credentials',
+                _('Credentials')
+            ) => self::makeInput(
+                'form-control ntfycredentials-input',
+                'credentials',
+                _('Token or user:pass (optional)'),
+                'password',
+                'credentials',
+                '',
+                false
+            ),
+        ];
+    }
+    /**
+     * Presents for creating a new link
+     *
+     * @return void
+     */
+    public function add()
+    {
+        $this->title = _('Link ntfy Topic');
+
+        $fields = $this->_addFields();
+
+        $buttons = self::makeButton(
+            'send',
+            _('Create'),
+            'btn btn-primary pull-right'
+        );
+
+        self::$HookManager->processEvent(
+            'NTFY_ADD_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'Ntfy' => self::getClass('Ntfy')
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            'form-horizontal',
+            'ntfy-create-form',
+            $this->formAction,
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="box box-solid" id="ntfy-create">';
+        echo '<div class="box-body">';
+        echo '<div class="box box-primary">';
+        echo '<div class="box-header with-borader">';
+        echo '<h4 class="box-title">';
+        echo _('Link ntfy Topic');
+        echo '</h4>';
+        echo '</div>';
+        echo '<div class="box-body">';
+        echo $rendered;
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+        echo '<div class="box-footer with-border">';
+        echo $buttons;
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+    }
+    /**
+     * Presents the modal form for creating a new link
+     *
+     * @return void
+     */
+    public function addModal()
+    {
+        $fields = $this->_addFields();
+
+        self::$HookManager->processEvent(
+            'NTFY_ADD_FIELDS',
+            [
+                'fields' => &$fields,
+                'Ntfy' => self::getClass('Ntfy')
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            'form-horizontal',
+            'create-form',
+            '../management/index.php?node=ntfy&sub=add',
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo $rendered;
+        echo '</form>';
+    }
+    /**
+     * Actually insert the new object
+     *
+     * @return void
+     */
+    public function addPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+        self::$HookManager->processEvent('NTFY_ADD_POST');
+
+        $serverURL = trim(
+            filter_input(INPUT_POST, 'serverURL')
+        );
+        $topicEndpoint = trim(
+            filter_input(INPUT_POST, 'topicEndpoint')
+        );
+        $credentials = (string)filter_input(INPUT_POST, 'credentials');
+
+        $serverFault = false;
+        try {
+            if (!$serverURL || !$topicEndpoint) {
+                throw new Exception(
+                    _('A server URL and topic endpoint are required')
+                );
+            }
+            $existing = self::getClass('NtfyManager')
+                ->distinct(
+                    'id',
+                    [
+                        'serverURL' => $serverURL,
+                        'topicEndpoint' => $topicEndpoint
+                    ]
+                );
+            if ($existing > 0) {
+                throw new Exception(_('Topic already linked'));
+            }
+            $Ntfy = self::getClass('Ntfy')
+                ->set('serverURL', $serverURL)
+                ->set('topicEndpoint', $topicEndpoint)
+                ->set('credentials', $credentials);
+            if (!$Ntfy->save()) {
+                $serverFault = true;
+                throw new Exception(_('Add ntfy topic failed!'));
+            }
+            self::getClass(
+                'NtfyHandler',
+                $serverURL,
+                $topicEndpoint,
+                $credentials
+            )->pushNote(
+                'FOG',
+                _('Topic linked')
+            );
+            $code = HTTPResponseCodes::HTTP_CREATED;
+            $hook = 'NTFY_ADD_SUCCESS';
+            $msg = json_encode(
+                [
+                    'msg' => _('Topic successfully added!'),
+                    'title' => _('Link ntfy Topic Success')
+                ]
+            );
+        } catch (Exception $e) {
+            $code = (
+                $serverFault ?
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
+                HTTPResponseCodes::HTTP_BAD_REQUEST
+            );
+            $hook = 'NTFY_ADD_FAIL';
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Link ntfy Topic Fail')
+                ]
+            );
+        }
+        self::$HookManager->processEvent(
+            $hook,
+            [
+                'Ntfy' => &$Ntfy,
+                'hook' => &$hook,
+                'code' => &$code,
+                'msg' => &$msg,
+                'serverFault' => &$serverFault
+            ]
+        );
+        http_response_code($code);
+        unset($Ntfy);
+        echo $msg;
+        exit;
+    }
+}

--- a/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
+++ b/packages/web/lib/plugins/ntfy/pages/ntfymanagement.page.php
@@ -222,14 +222,8 @@ class NtfyManagement extends FOGPage
                 );
             }
             $existing = self::getClass('NtfyManager')
-                ->distinct(
-                    'id',
-                    [
-                        'serverURL' => $serverURL,
-                        'topicEndpoint' => $topicEndpoint
-                    ]
-                );
-            if ($existing > 0) {
+                ->exists($topicEndpoint, 0, 'topicEndpoint');
+            if ($existing) {
                 throw new Exception(_('Topic already linked'));
             }
             $Ntfy = self::getClass('Ntfy')

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletextends.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletextends.class.php
@@ -78,16 +78,22 @@ abstract class PushbulletExtends extends Event
     {
         parent::__construct();
         self::$eventloop = function (&$Pushbullet) {
+            // Some events (e.g. login failure) carry no host, so HostName
+            // may be absent -- build the title without a leading space.
+            $hostName = self::$elements['HostName'] ?? '';
+            $title = trim(
+                sprintf(
+                    '%s %s',
+                    $hostName,
+                    _(self::$shortdesc)
+                )
+            );
             self::getClass(
                 'PushbulletHandler',
                 $Pushbullet->token
             )->pushNote(
                 '',
-                sprintf(
-                    '%s %s',
-                    self::$elements['HostName'],
-                    _(self::$shortdesc)
-                ),
+                $title,
                 _(self::$message)
             );
         };
@@ -107,8 +113,12 @@ abstract class PushbulletExtends extends Event
         $Pushbullets = json_decode(
             Route::getData()
         );
+        // Invoke the closure stored in the static property. Calling
+        // self::$eventloop($x) directly is parsed as a static method named
+        // by a local variable, not as invoking the closure.
+        $eventloop = self::$eventloop;
         foreach ($Pushbullets->data as &$Pushbullet) {
-            self::$eventloop($Pushbullet);
+            $eventloop($Pushbullet);
             unset($Pushbullet);
         }
     }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6588,6 +6588,9 @@ msgstr "Konto ist bereits verknüpft"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "Account erfolgreich hinzugefügt"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -208,6 +208,9 @@ msgstr "Ein Drucker mit diesem Namen ist bereits vorhanden!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
@@ -510,6 +513,10 @@ msgstr "Gruppe hinzufügen fehlgeschlagen!"
 #, fuzzy
 msgid "Add module failed!"
 msgstr "Benutzer hinzufügen fehlgeschlagen!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
+msgstr "Snapin hinzufügen fehlgeschlagen"
 
 #, fuzzy
 msgid "Add ou failed!"
@@ -1408,6 +1415,9 @@ msgstr "Erstellt von"
 
 msgid "Created by FOG Reg on"
 msgstr "Erstellt von FOG Reg am"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "Cron"
@@ -3661,6 +3671,16 @@ msgstr "Verknüpfen des Slack Accounts fehlgeschlagen"
 msgid "Link Slack Account Success"
 msgstr "Slack Account erfolgreich verknüpft"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Slack Account erfolgreich verknüpft"
+
 #, fuzzy
 msgid "List"
 msgstr "Zeige"
@@ -5335,6 +5355,10 @@ msgstr "Allgemeine Informationen"
 msgid "Server Shell"
 msgstr "Server-Shell"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Server-Shell"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6547,9 +6571,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Regel Zuordnung"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "zu viele MACs"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Konto ist bereits verknüpft"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "Account erfolgreich hinzugefügt"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7549,6 +7590,10 @@ msgstr "Knoten enthalten dieses Image"
 #, fuzzy
 msgid "not found on this node"
 msgstr "auf diesem Knoten nicht gefunden"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -213,6 +213,9 @@ msgstr "An image already exists with this name!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "An image already exists with this name!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "An image already exists with this name!"
@@ -513,6 +516,10 @@ msgstr "Add snapin failed!"
 
 #, fuzzy
 msgid "Add module failed!"
+msgstr "Add snapin failed!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
 msgstr "Add snapin failed!"
 
 #, fuzzy
@@ -1409,6 +1416,9 @@ msgstr "Created By"
 
 msgid "Created by FOG Reg on"
 msgstr "Created by FOG Reg on"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "Cron"
@@ -3657,6 +3667,16 @@ msgstr "Link Slack Account"
 msgid "Link Slack Account Success"
 msgstr "Link Slack Account"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Link Slack Account"
+
 #, fuzzy
 msgid "List"
 msgstr "Host List"
@@ -5331,6 +5351,10 @@ msgstr "General Information"
 msgid "Server Shell"
 msgstr "Server Shell"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Server Shell"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6539,9 +6563,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Image Association"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "Host Primary MAC"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Account already linked"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "successfully updated"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7537,6 +7578,10 @@ msgstr "Could not find any nodes containing this image"
 #, fuzzy
 msgid "not found on this node"
 msgstr "Image not found on node"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6580,6 +6580,9 @@ msgstr "Account already linked"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "successfully updated"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6729,6 +6729,9 @@ msgstr ""
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "actualizado exitosamente"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -211,6 +211,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Una imagen ya existe con este nombre!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
@@ -520,6 +523,10 @@ msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
 msgid "Add module failed!"
+msgstr "Añadir fallidos SNAPin!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
 msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
@@ -1423,6 +1430,9 @@ msgid "Created Time"
 msgstr "Creado"
 
 msgid "Created by FOG Reg on"
+msgstr ""
+
+msgid "Credentials"
 msgstr ""
 
 msgid "Cron"
@@ -3748,6 +3758,16 @@ msgstr ""
 msgid "Link Slack Account Success"
 msgstr ""
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "actualización de servicio no pudo"
+
 #, fuzzy
 msgid "List"
 msgstr "Línea"
@@ -5462,6 +5482,10 @@ msgstr "Información general"
 msgid "Server Shell"
 msgstr ""
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Servidor web"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6690,8 +6714,24 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Asociación para la imagen"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 msgid "Too many MACs"
 msgstr ""
+
+msgid "Topic Endpoint"
+msgstr ""
+
+msgid "Topic already linked"
+msgstr ""
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "actualizado exitosamente"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7691,6 +7731,9 @@ msgstr "No se pudo encontrar ningún nodos que contienen esta imagen"
 #, fuzzy
 msgid "not found on this node"
 msgstr "No se encontró Clase FOGPage para este nodo"
+
+msgid "ntfy Accounts"
+msgstr ""
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -208,6 +208,9 @@ msgstr "Ein Drucker mit diesem Namen ist bereits vorhanden!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
@@ -510,6 +513,10 @@ msgstr "Gruppe hinzufügen fehlgeschlagen!"
 #, fuzzy
 msgid "Add module failed!"
 msgstr "Benutzer hinzufügen fehlgeschlagen!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
+msgstr "Snapin hinzufügen fehlgeschlagen"
 
 #, fuzzy
 msgid "Add ou failed!"
@@ -1408,6 +1415,9 @@ msgstr "Erstellt von"
 
 msgid "Created by FOG Reg on"
 msgstr "Erstellt von FOG Reg am"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "Cron"
@@ -3662,6 +3672,16 @@ msgstr "Verknüpfen des Slack Accounts fehlgeschlagen"
 msgid "Link Slack Account Success"
 msgstr "Slack Account erfolgreich verknüpft"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Slack Account erfolgreich verknüpft"
+
 #, fuzzy
 msgid "List"
 msgstr "Zeige"
@@ -5336,6 +5356,10 @@ msgstr "Allgemeine Informationen"
 msgid "Server Shell"
 msgstr "Server-Shell"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Server-Shell"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6548,9 +6572,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Regel Zuordnung"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "zu viele MACs"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Konto ist bereits verknüpft"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "Account erfolgreich hinzugefügt"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7550,6 +7591,10 @@ msgstr "Knoten enthalten dieses Image"
 #, fuzzy
 msgid "not found on this node"
 msgstr "auf diesem Knoten nicht gefunden"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6589,6 +6589,9 @@ msgstr "Konto ist bereits verknüpft"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "Account erfolgreich hinzugefügt"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6587,6 +6587,9 @@ msgstr "Compte déjà lié"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "mise à jour réussie"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -214,6 +214,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Une image existe déjà avec ce nom!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
@@ -514,6 +517,10 @@ msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
 msgid "Add module failed!"
+msgstr "Ajouter SnapIn a échoué!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
 msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
@@ -1413,6 +1420,9 @@ msgstr "Créé par"
 
 msgid "Created by FOG Reg on"
 msgstr "Créé par FOG Reg sur"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "Cron"
@@ -3661,6 +3671,16 @@ msgstr "Lien compte Slack"
 msgid "Link Slack Account Success"
 msgstr "Lien compte Slack"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Lien compte Slack"
+
 #, fuzzy
 msgid "List"
 msgstr "Ligne"
@@ -5338,6 +5358,10 @@ msgstr "Informations générales"
 msgid "Server Shell"
 msgstr "serveur Shell"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "serveur Shell"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6546,9 +6570,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Association Image"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "Hôte MAC primaire"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Compte déjà lié"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "mise à jour réussie"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7544,6 +7585,10 @@ msgstr "Impossible de trouver des noeuds contenant cette image"
 #, fuzzy
 msgid "not found on this node"
 msgstr "Image not found sur le noeud"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Comptes Slack"
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6275,6 +6275,9 @@ msgstr "Account già collegato"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "Account aggiunto con successo!"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -204,6 +204,9 @@ msgstr "Nome stampante già esistente on questo nome!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Esiste già un ruolo con questo nome!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Un host già esiste con questo nome!"
@@ -490,6 +493,10 @@ msgstr "Aggiunta gruppo non riuscito!"
 #, fuzzy
 msgid "Add module failed!"
 msgstr "Aggiunta utente fallita!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
+msgstr "Aggiungi snapin non riuscito!"
 
 #, fuzzy
 msgid "Add ou failed!"
@@ -1345,6 +1352,9 @@ msgstr "Creato da"
 
 msgid "Created by FOG Reg on"
 msgstr "Creato da FOG Reg su"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "cron"
@@ -3495,6 +3505,16 @@ msgstr "Connessione Account Slack fallita"
 msgid "Link Slack Account Success"
 msgstr "Connessione Account Slack completata"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Connessione Account Slack completata"
+
 msgid "List"
 msgstr "Elenca"
 
@@ -5093,6 +5113,10 @@ msgstr "Informazione generale"
 msgid "Server Shell"
 msgstr "Server Shell"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Server Shell"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6235,8 +6259,25 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Regole di associazione"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 msgid "Too many MACs"
 msgstr "Troppi MAC"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Account già collegato"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "Account aggiunto con successo!"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7171,6 +7212,10 @@ msgstr "nodi che contengono questa immagine"
 
 msgid "not found on this node"
 msgstr "Non trovato su questo nodo"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Slack Accounts"
 
 msgid "object"
 msgstr "oggetto"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5538,6 +5538,9 @@ msgstr ""
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 msgid "Topic successfully added!"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -166,6 +166,9 @@ msgstr ""
 msgid "A rule already exists with that type-value pair!"
 msgstr ""
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 msgid "A site already exists with this name!"
 msgstr ""
 
@@ -411,6 +414,9 @@ msgid "Add menu failed!"
 msgstr ""
 
 msgid "Add module failed!"
+msgstr ""
+
+msgid "Add ntfy topic failed!"
 msgstr ""
 
 msgid "Add ou failed!"
@@ -1152,6 +1158,9 @@ msgid "Created Time"
 msgstr ""
 
 msgid "Created by FOG Reg on"
+msgstr ""
+
+msgid "Credentials"
 msgstr ""
 
 msgid "Cron"
@@ -3056,6 +3065,15 @@ msgstr ""
 msgid "Link Slack Account Success"
 msgstr ""
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+msgid "Link ntfy Topic Success"
+msgstr ""
+
 msgid "List"
 msgstr ""
 
@@ -4488,6 +4506,9 @@ msgstr ""
 msgid "Server Shell"
 msgstr ""
 
+msgid "Server URL"
+msgstr ""
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -5502,7 +5523,22 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 msgid "Too many MACs"
+msgstr ""
+
+msgid "Topic Endpoint"
+msgstr ""
+
+msgid "Topic already linked"
+msgstr ""
+
+msgid "Topic linked"
+msgstr ""
+
+msgid "Topic successfully added!"
 msgstr ""
 
 msgid "Total Clients"
@@ -6346,6 +6382,9 @@ msgid "nodes containing this image"
 msgstr ""
 
 msgid "not found on this node"
+msgstr ""
+
+msgid "ntfy Accounts"
 msgstr ""
 
 msgid "object"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6583,6 +6583,9 @@ msgstr "Conta já ligados"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "atualizado com sucesso"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -213,6 +213,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "A rule already exists with that type-value pair!"
 msgstr "Uma imagem já existe com este nome!"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
@@ -513,6 +516,10 @@ msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
 msgid "Add module failed!"
+msgstr "Adicionar snap-in falhou!"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
 msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
@@ -1412,6 +1419,9 @@ msgstr "Criado por"
 
 msgid "Created by FOG Reg on"
 msgstr "Criado por FOG Reg em"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "cron"
@@ -3660,6 +3670,16 @@ msgstr "Link Conta Slack"
 msgid "Link Slack Account Success"
 msgstr "Link Conta Slack"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "Link Conta Slack"
+
 #, fuzzy
 msgid "List"
 msgstr "Linha"
@@ -5335,6 +5355,10 @@ msgstr "Informação geral"
 msgid "Server Shell"
 msgstr "Shell servidor"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "Shell servidor"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6542,9 +6566,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "Associação imagem"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "Hospedeiro primário MAC"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "Conta já ligados"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "atualizado com sucesso"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7540,6 +7581,10 @@ msgstr "Não foi possível encontrar todos os nós que contêm esta imagem"
 #, fuzzy
 msgid "not found on this node"
 msgstr "Imagem não encontrada no nó"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "Contas Slack"
 
 #, fuzzy
 msgid "object"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6574,6 +6574,9 @@ msgstr "帐户已链接"
 msgid "Topic linked"
 msgstr ""
 
+msgid "Topic name you choose, e.g. fog-alerts"
+msgstr ""
+
 #, fuzzy
 msgid "Topic successfully added!"
 msgstr "成功更新"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -213,6 +213,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "A rule already exists with that type-value pair!"
 msgstr "图像已经存在具有此名称！"
 
+msgid "A server URL and topic endpoint are required"
+msgstr ""
+
 #, fuzzy
 msgid "A site already exists with this name!"
 msgstr "图像已经存在具有此名称！"
@@ -513,6 +516,10 @@ msgstr "添加管理单元失败！"
 
 #, fuzzy
 msgid "Add module failed!"
+msgstr "添加管理单元失败！"
+
+#, fuzzy
+msgid "Add ntfy topic failed!"
 msgstr "添加管理单元失败！"
 
 #, fuzzy
@@ -1410,6 +1417,9 @@ msgstr "由...制作"
 
 msgid "Created by FOG Reg on"
 msgstr "创建者FOG上注册"
+
+msgid "Credentials"
+msgstr ""
 
 msgid "Cron"
 msgstr "克龙"
@@ -3658,6 +3668,16 @@ msgstr "链接松弛账户"
 msgid "Link Slack Account Success"
 msgstr "链接松弛账户"
 
+msgid "Link ntfy Topic"
+msgstr ""
+
+msgid "Link ntfy Topic Fail"
+msgstr ""
+
+#, fuzzy
+msgid "Link ntfy Topic Success"
+msgstr "链接松弛账户"
+
 #, fuzzy
 msgid "List"
 msgstr "线"
@@ -5331,6 +5351,10 @@ msgstr "一般信息"
 msgid "Server Shell"
 msgstr "服务器外壳"
 
+#, fuzzy
+msgid "Server URL"
+msgstr "服务器外壳"
+
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
@@ -6533,9 +6557,26 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr "图像协会"
 
+msgid "Token or user:pass (optional)"
+msgstr ""
+
 #, fuzzy
 msgid "Too many MACs"
 msgstr "主机主MAC"
+
+msgid "Topic Endpoint"
+msgstr ""
+
+#, fuzzy
+msgid "Topic already linked"
+msgstr "帐户已链接"
+
+msgid "Topic linked"
+msgstr ""
+
+#, fuzzy
+msgid "Topic successfully added!"
+msgstr "成功更新"
 
 #, fuzzy
 msgid "Total Clients"
@@ -7529,6 +7570,10 @@ msgstr "找不到包含该图像的任何节点"
 #, fuzzy
 msgid "not found on this node"
 msgstr "图片没有节点发现"
+
+#, fuzzy
+msgid "ntfy Accounts"
+msgstr "斯莱克账户"
 
 #, fuzzy
 msgid "object"


### PR DESCRIPTION
## Summary
Adds an **ntfy** notification plugin to `working-1.6` and fixes a `working-1.6`-only event regression in the existing **pushbullet** plugin. This is the `working-1.6` home for #760 (which targeted `dev-branch`, forked from the older pushbullet plugin).

Original author credit (Tony Lam / @TonyKaito) is preserved in the new file headers.

## ntfy plugin
Sends FOG event notifications (image complete/fail, snapin complete, snapin-task complete, login failure) to an ntfy server — ntfy.sh or self-hosted — plus a per-topic management page with optional auth for protected topics.

Brought up to current `working-1.6` conventions and fixed from the original PR:
- **Schema migrations**: `createSql()` + append-only `schema()` + non-destructive `install()` via `Schema::applyUpdates()` — no drop-and-recreate on re-install; participates in the dashboard "update available" flow (see `docs/PLUGIN_SCHEMA_MIGRATIONS.md`).
- **Correct ntfy protocol**: message as the POST body, title via the `Title` header (the fork still spoke pushbullet's JSON). Optional `credentials` authenticate protected topics: `user:pass` → HTTP basic, otherwise → `Authorization: Bearer <token>`.
- Added the missing **API** and **JS** hooks (the JS hook is why `fog.ntfy.*.js` loads); menu hook converted to the `hook_main` pattern; JS split into `fog.ntfy.add.js` / `fog.ntfy.list.js`.
- Page rebuilt on `makeInput/makeLabel/makeButton/formFields/makeFormTag` with `checkAuthAndCSRF()` + `HTTPResponseCodes`; output escaped via the helpers. Renamed to `ntfymanagement.page.php` / class `NtfyManagement` so the page loader (`*.page.php`, class == filename) registers it.
- Fixed: `NtfyException` typo, removed pushbullet-only recipient parsing and the undefined `_apiKey` path, bareword array keys, and slack leftovers.

### Bugs found and fixed during live testing
- **Password reveal** — wrapped the credentials field in `.input-group` so the show/hide eye toggle works.
- **False "Topic already linked"** — core `FOGManagerController::distinct()` reuses a single `:countVal` placeholder for every condition, so a multi-field check returned a bogus non-zero count on an empty table. Switched dedup to `exists()` on the topic endpoint.
- **HTTP 500 on a fired event** — `self::$eventloop($x)` is parsed by PHP as a static method named by a local variable, not as invoking the closure. Assign the closure to a local first. Also guard a missing `HostName` for host-less events (login failure).

## pushbullet fix (same `working-1.6` regression)
pushbullet has the identical `self::$eventloop($x)` bug — it would 500 on any fired event under PHP 8; it just hadn't been exercised. Applied the same closure-invocation fix and `HostName` guard.

## dev-branch status
**Not affected by the eventloop bug.** dev-branch invokes via `array_map(self::$eventloop, ...->find())`, which passes the closure as a value (correct). The bug was introduced by the `working-1.6` `foreach { self::$eventloop($x) }` refactor. slack uses a direct per-event call and has no eventloop closure.

## Verification
- `php -l` clean across all files; full app bootstraps with the plugin (all classes autoload); `schema()` emits valid non-destructive SQL.
- ntfy protocol confirmed against ntfy.sh (title + message land correctly).
- End-to-end in a live install: install → table create, add-topic round-trip, dedup, and a real **login-failure event delivering a clean notification** to the topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
