### PR TITLE
fix(db): unique SQL placeholders in distinct() multi-condition queries (#843)

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1124,7 +1124,11 @@ abstract class FOGManagerController extends FOGBase
             $compare = '=';
         }
         $whereArray = [];
-        $countVals = $countKeys = [];
+        $countVals = [];
+        // Monotonic index so every bound value gets a unique placeholder.
+        // Reusing one shared :countVal collided across conditions and built
+        // a malformed query for multi-condition lookups.
+        $phIndex = 0;
         if (count($findWhere ?: []) > 0) {
             array_walk(
                 $findWhere,
@@ -1135,28 +1139,31 @@ abstract class FOGManagerController extends FOGBase
                     &$whereArray,
                     $compare,
                     &$countVals,
-                    &$countKeys
+                    &$phIndex
                 ) {
                     $field = trim($field);
                     if (is_array($value) && count($value ?: []) > 0) {
-                        foreach ((array) $value as $index => &$val) {
-                            $countKeys[] = sprintf(':countVal%d', $index);
-                            $countVals[sprintf('countVal%d', $index)] = $val;
+                        $inKeys = [];
+                        foreach ((array) $value as &$val) {
+                            $ph = sprintf('countVal%d', $phIndex++);
+                            $inKeys[] = ':' . $ph;
+                            $countVals[$ph] = $val;
                             unset($val);
                         }
                         $whereArray[] = sprintf(
                             '`%s`.`%s` IN (%s)',
                             $this->databaseTable,
                             $this->databaseFields[$field],
-                            implode(',', $countKeys)
+                            implode(',', $inKeys)
                         );
                     } else {
                         if (is_array($value)) {
                             $value = '';
                         }
-                        $countVals['countVal'] = $value;
+                        $ph = sprintf('countVal%d', $phIndex++);
+                        $countVals[$ph] = $value;
                         $whereArray[] = sprintf(
-                            '`%s`.`%s`%s:countVal',
+                            '`%s`.`%s`%s:%s',
                             $this->databaseTable,
                             $this->databaseFields[$field],
                             (
@@ -1166,7 +1173,8 @@ abstract class FOGManagerController extends FOGBase
                                 ) ?
                                 ' LIKE' :
                                 $compare
-                            )
+                            ),
+                            $ph
                         );
                     }
                     unset($value, $field);


### PR DESCRIPTION
Fixes #843.

`FOGManagerController::distinct()` reused a single `:countVal` placeholder for every scalar condition (overwriting the bound value and producing `col1=:countVal AND col2=:countVal`), and array `IN` conditions shared a by-reference key list that was never reset and restarted element indexes at `0`. Any multi-condition `distinct()` returned a wrong count — most visibly a **non-zero match against an empty table**, which made the new ntfy plugin reject every create as "Topic already linked."

### Fix
Use a monotonic counter so every bound value (scalar or `IN` element) gets a unique placeholder, and scope each `IN` field's key list locally.

### Verification
On a live install, across matching / non-matching / empty cases:

| Case | Before | After |
|---|---|---|
| two scalar conds, non-matching (empty result) | `1` ❌ | `0` ✅ |
| two scalar conds, matching | — | `1` ✅ |
| scalar + array `IN`, matching | — | `1` ✅ |
| two array `IN`s, matching | — | `1` ✅ |

`php -l` clean.

> Adjacent (left for a follow-up, noted in #843): the same method references an undefined `$isEnabled` in its no-condition branch, emitting a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
