### PR TITLE
fix(db): drop dead $isEnabled from distinct() (#843)

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1187,33 +1187,18 @@ abstract class FOGManagerController extends FOGBase
             $this->databaseFields[$field],
             $this->databaseTable,
             (
-                (isset($whereArray) && count($whereArray)) ?
+                count($whereArray) ?
                 sprintf(
-                    ' WHERE %s%s',
+                    ' WHERE %s',
                     implode(
                         sprintf(
                             ' %s ',
                             $whereOperator
                         ),
-                        (array) $whereArray
-                    ),
-                    (
-                        (isset($isEnabled) && $isEnabled) ?
-                        sprintf(
-                            ' AND %s',
-                            $isEnabled
-                        ) :
-                        ''
+                        $whereArray
                     )
                 ) :
-                (
-                    $isEnabled ?
-                    sprintf(
-                        ' WHERE %s',
-                        $isEnabled
-                    ) :
-                    ''
-                )
+                ''
             )
         );
 


### PR DESCRIPTION
Follow-up to #844 (the adjacent item noted in #843).

`distinct()` referenced an undefined `$isEnabled` while assembling the WHERE clause. It is never assigned in the method (always falsy) and the no-condition branch used it unguarded, emitting an "Undefined variable" warning on every conditionless call. Removed the dead branches — the WHERE is now just the joined conditions, or empty.

Verified on a live install: the conditionless path runs with no warning and `distinct()` still returns correct counts for conditionless and multi-condition cases. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)