### PR TITLE
fix(db): distinct() unique placeholders + drop dead $isEnabled (#843)

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1361,7 +1361,11 @@ abstract class FOGManagerController extends FOGBase
             $compare = '=';
         }
         $whereArray = array();
-        $countVals = $countKeys = array();
+        $countVals = array();
+        // Monotonic index so every bound value gets a unique placeholder.
+        // Reusing one shared :countVal collided across conditions and built
+        // a malformed query for multi-condition lookups.
+        $phIndex = 0;
         if (count($findWhere) > 0) {
             array_walk(
                 $findWhere,
@@ -1372,28 +1376,31 @@ abstract class FOGManagerController extends FOGBase
                     &$whereArray,
                     $compare,
                     &$countVals,
-                    &$countKeys
+                    &$phIndex
                 ) {
                     $field = trim($field);
                     if (is_array($value) && count($value) > 0) {
-                        foreach ((array) $value as $index => &$val) {
-                            $countKeys[] = sprintf(':countVal%d', $index);
-                            $countVals[sprintf('countVal%d', $index)] = $val;
+                        $inKeys = array();
+                        foreach ((array) $value as &$val) {
+                            $ph = sprintf('countVal%d', $phIndex++);
+                            $inKeys[] = ':' . $ph;
+                            $countVals[$ph] = $val;
                             unset($val);
                         }
                         $whereArray[] = sprintf(
                             '`%s`.`%s` IN (%s)',
                             $this->databaseTable,
                             $this->databaseFields[$field],
-                            implode(',', $countKeys)
+                            implode(',', $inKeys)
                         );
                     } else {
                         if (is_array($value)) {
                             $value = '';
                         }
-                        $countVals['countVal'] = $value;
+                        $ph = sprintf('countVal%d', $phIndex++);
+                        $countVals[$ph] = $value;
                         $whereArray[] = sprintf(
-                            '`%s`.`%s`%s:countVal',
+                            '`%s`.`%s`%s:%s',
                             $this->databaseTable,
                             $this->databaseFields[$field],
                             (
@@ -1403,7 +1410,8 @@ abstract class FOGManagerController extends FOGBase
                                 ) ?
                                 ' LIKE' :
                                 $compare
-                            )
+                            ),
+                            $ph
                         );
                     }
                     unset($value, $field);
@@ -1416,33 +1424,18 @@ abstract class FOGManagerController extends FOGBase
             $this->databaseFields[$field],
             $this->databaseTable,
             (
-                (isset($whereArray) && count($whereArray)) ?
+                count($whereArray) ?
                 sprintf(
-                    ' WHERE %s%s',
+                    ' WHERE %s',
                     implode(
                         sprintf(
                             ' %s ',
                             $whereOperator
                         ),
-                        (array) $whereArray
-                    ),
-                    (
-                        (isset($isEnabled) && $isEnabled) ?
-                        sprintf(
-                            ' AND %s',
-                            $isEnabled
-                        ) :
-                        ''
+                        $whereArray
                     )
                 ) :
-                (
-                    $isEnabled ?
-                    sprintf(
-                        ' WHERE %s',
-                        $isEnabled
-                    ) :
-                    ''
-                )
+                ''
             )
         );
 


### PR DESCRIPTION
Ports the working-1.6 `distinct()` fixes (#844, #845) to `dev-branch` — both bugs are present identically here (verified; `dev-branch`'s `distinct()` was byte-identical to pre-fix working-1.6).

1. **Placeholder collision** — scalar conditions all bound to `:countVal` (overwriting the value, producing `col1=:countVal AND col2=:countVal`); array `IN` conditions shared a by-ref key list that was never reset and restarted indexes at `0`. Any multi-condition `distinct()` returned a wrong count. Fixed with a monotonic per-value placeholder and locally-scoped `IN` key lists.
2. **Dead `$isEnabled`** — referenced but never assigned in `distinct()`, unguarded in the no-condition branch (warning on every conditionless call). Removed.

### Verification
Tested against the live 1.5 codebase (file was identical to dev-branch), then restored:
- `distinct('id')` (conditionless) → correct row count, **no `isEnabled` warning**
- `distinct('id', ['name'=>..., 'description'=>...])` non-matching → `0` (previously wrong)

`php -l` clean.

Refs #843. (working-1.6 equivalents: #844, #845.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)