### PR TITLE
docs(plugins): plugin authoring guide + helloworld skeleton

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,425 @@
+# Building a FOG Plugin — Start to Finish
+
+This guide walks you from an empty directory to a working, installable FOG
+plugin on the **working‑1.6** framework. It uses a complete, runnable example
+plugin — **`helloworld`** — that ships alongside this document at
+[`packages/web/lib/plugins/helloworld/`](../packages/web/lib/plugins/helloworld/).
+Copy that directory, rename it, and you have a head start.
+
+> **Scope:** this targets the working‑1.6 plugin framework (the `formFields` /
+> `makeInput` page helpers, the `addPost`/`editPost` JSON pattern, and the
+> non‑destructive `schema()` migration contract). The 1.5.x line renders pages
+> differently (raw HTML strings, `*page.class.php` file names) and lacks the
+> `schema()` migration mechanism; this guide does not cover it.
+
+---
+
+## 1. What a plugin is
+
+A FOG plugin is just a directory under `packages/web/lib/plugins/<name>/`
+containing PHP classes that FOG auto‑discovers. There is no build step and no
+registration list to edit — drop the directory in, activate the plugin in the
+UI (**Plugin Management**), and it works.
+
+A typical plugin provides:
+
+- a **model** (one entity / table row),
+- a **manager** (the table + its migrations),
+- a **page** (the UI and its form POST handlers),
+- **hooks** (menu entry, JS injection, API exposure, …),
+- **JS** files (one per sub‑page).
+
+The running example, `helloworld`, manages a trivial entity with a `name` and a
+`description`, end to end.
+
+---
+
+## 2. Mental model (how the pieces connect)
+
+- **Boot chain.** Every entry point loads `commons/base.inc.php` →
+  `commons/init.php` → `LoadGlobals`, which sets the shared singletons
+  (`FOGBase::$DB`, `$HookManager`, `$EventManager`, `$currentUser`).
+- **Autoloader.** `Initiator` scans `BASEPATH` recursively, adds every
+  directory containing a `*.{class,page,hook,event,report}.php` file to the PHP
+  `include_path`, then registers PHP's **default** `spl_autoload`. That default
+  autoloader **lowercases the class name** to find the file. So:
+
+  > **The filename must be `strtolower(ClassName)` + the suffix.**
+  > `class HelloWorldManagement` ⇒ `helloworldmanagement.page.php`.
+  > `class AddHelloWorldJS` ⇒ `addhelloworldjs.hook.php`.
+
+  (Class names in code are PascalCase; the files on disk are all‑lowercase.)
+- **Routing.** The whole UI is driven by `?node=<x>&sub=<y>&id=<n>`. `node` maps
+  to a page class (`helloworld` → `HelloWorldManagement`, matched by its
+  `public $node = 'helloworld'`), and `sub` maps to a method on it
+  (`sub=add` → `add()`, `sub=addPost` → `addPost()`, `sub=list` → the inherited
+  DataTables list).
+- **ORM.** Models declare `$databaseTable` and `$databaseFields`
+  (friendly‑name → column). You then use `get()/set()/save()/load()/destroy()`,
+  or `new HelloWorld(42)` to auto‑load by id.
+- **Hooks/events.** Cross‑cutting integration is done by registering callbacks
+  against named events: `self::$HookManager->register('EVENT', [$this, 'fn'])`
+  and firing with `processEvent('EVENT', ['data' => &$data])`.
+
+---
+
+## 3. Directory layout
+
+```
+packages/web/lib/plugins/helloworld/
+├── config/
+│   └── plugin.config.php          # discovery metadata ($fog_plugin[...])
+├── class/
+│   ├── helloworld.class.php        # HelloWorld         (model, FOGController)
+│   └── helloworldmanager.class.php # HelloWorldManager  (manager + schema())
+├── pages/
+│   └── helloworldmanagement.page.php  # HelloWorldManagement (FOGPage)
+├── hooks/
+│   ├── addhelloworldmenuitem.hook.php # menu entry + search/objects
+│   ├── addhelloworldjs.hook.php       # JS injection
+│   └── addhelloworldapi.hook.php      # REST API exposure
+└── js/
+    ├── fog.helloworld.list.js
+    ├── fog.helloworld.add.js
+    └── fog.helloworld.edit.js
+```
+
+The directory name **is** the plugin's machine name and routing `node`. Keep it
+lowercase and use it consistently (`$fog_plugin['name']`, each hook's
+`public $node`, the page's `public $node`).
+
+---
+
+## 4. Step by step
+
+### 4.1 `config/plugin.config.php`
+
+Discovery metadata. `Plugin::getPlugins()` `include`s this file and reads the
+`$fog_plugin` array.
+
+```php
+$fog_plugin = [];
+$fog_plugin['name']        = 'helloworld';           // == directory name
+$fog_plugin['description'] = 'Skeleton example plugin …';
+$fog_plugin['menuicon']    = 'fa fa-cube fa-fw';     // "fa …" => icon; else <img src>
+$fog_plugin['menuicon_hover'] = null;
+$fog_plugin['entrypoint']  = 'html/run.php';         // legacy/conventional; not shipped
+```
+
+> The `entrypoint` is vestigial — no plugin actually ships `html/run.php`;
+> routing happens through the `node` → page‑class mapping. Declare it anyway for
+> consistency with every other plugin.
+
+### 4.2 Model — `class/helloworld.class.php`
+
+```php
+class HelloWorld extends FOGController
+{
+    protected $databaseTable = 'helloWorld';
+    protected $databaseFields = [
+        'id'          => 'hwID',
+        'name'        => 'hwName',
+        'description' => 'hwDesc',
+    ];
+    protected $databaseFieldsRequired = ['name'];
+}
+```
+
+That's the entire ORM contract. `$databaseFields` maps friendly names (used in
+code and in the API) to real column names. `$databaseFieldsRequired` is enforced
+on `save()`.
+
+### 4.3 Manager + migrations — `class/helloworldmanager.class.php`
+
+The manager owns table creation and **schema evolution**. This is the most
+important part to get right, so it gets its own section (§5). The shape:
+
+```php
+class HelloWorldManager extends FOGManagerController
+{
+    public $tablename = 'helloWorld';
+
+    public function createSql() { return Schema::createTable(/* … */); }
+
+    public function schema()
+    {
+        return [
+            $this->createSql(),     // step 0 — create the table
+            // append future steps here, never reorder/remove
+        ];
+    }
+
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
+    }
+}
+```
+
+### 4.4 Page — `pages/helloworldmanagement.page.php`
+
+The page extends `FOGPage`, declares `public $node = 'helloworld'`, and sets the
+list columns in its constructor:
+
+```php
+public function __construct($name = '')
+{
+    $this->name = 'Hello World Management';
+    parent::__construct($this->name);
+    $this->headerData = [_('Name'), _('Description')];
+    $this->attributes = [[], []];
+}
+```
+
+You do **not** write a list/`index()` method — `FOGPage` provides it. The list
+page renders a DataTable whose JSON comes from `?node=helloworld&sub=list`; the
+columns are produced by the router from your model fields, so the column keys
+available to the JS are `mainlink` (the linked name), `id`, and every field by
+its **friendly name** (here `description`).
+
+Forms are built with helpers and rendered with `formFields()`:
+
+| Helper | Purpose |
+|---|---|
+| `self::makeFormTag(...)` | opening `<form>` |
+| `self::makeLabel($class, $for, $text)` | a `<label>` |
+| `self::makeInput($class, $name, $placeholder, $type, $id, $value, $required)` | an `<input>` |
+| `self::makeTextarea(...)` | a `<textarea>` |
+| `self::makeButton($id, $text, $class)` | a `<button>` |
+| `self::selectForm($name, $items, $selected, ...)` | a `<select>` |
+| `self::formFields($fields)` | renders a `[label => field]` array |
+| `self::tabFields($tabData, $obj)` | the tabbed edit layout |
+| `self::makeTabUpdateURL($tab, $id)` | the POST URL for a tab |
+
+**The POST pattern.** `addPost()` and `editPost()` return JSON and follow the
+same skeleton every time:
+
+```php
+public function addPost()
+{
+    self::checkAuthAndCSRF();                 // ALWAYS first
+    header('Content-type: application/json');
+    $name = trim(filter_input(INPUT_POST, 'name'));   // never raw $_POST
+
+    $serverFault = false;
+    try {
+        // validate, then build + save the model …
+        if (!$obj->save()) { $serverFault = true; throw new Exception(_('…')); }
+        $code = HTTPResponseCodes::HTTP_CREATED;
+        $msg  = json_encode(['msg' => _('…'), 'title' => _('…')]);
+    } catch (Exception $e) {
+        $code = $serverFault
+            ? HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR   // 500 = our fault
+            : HTTPResponseCodes::HTTP_BAD_REQUEST;            // 400 = bad input
+        $msg  = json_encode(['error' => $e->getMessage(), 'title' => _('…')]);
+    }
+    http_response_code($code);
+    echo $msg;
+    exit;
+}
+```
+
+> Set `$serverFault = true` **only** when the failure is server‑side (a failed
+> `save()`), so genuine failures return `500` and validation errors return
+> `400`. Getting this backwards is a real bug we've fixed before.
+
+The **edit** page uses tabs. `edit()` builds `$tabData` and calls
+`tabFields()`; each tab has a `generator` closure that renders its body
+(`helloworldGeneral()`), and `editPost()` dispatches on the global `$tab` to the
+matching `*GeneralPost()` that mutates `$this->obj` before the shared `save()`.
+
+### 4.5 Hooks — `hooks/*.hook.php`
+
+Each hook is a small class extending `Hook`, with `public $node`, that registers
+callbacks **in its constructor, guarded by the install check**:
+
+```php
+public function __construct()
+{
+    parent::__construct();
+    if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+        return;                       // do nothing unless this plugin is installed
+    }
+    self::$HookManager->register('MAIN_MENU_DATA', [$this, 'menuData']);
+}
+```
+
+The example ships three hooks:
+
+- **Menu** (`AddHelloWorldMenuItem`) — `MAIN_MENU_DATA` adds the sidebar entry;
+  `SEARCH_PAGES` makes it searchable; `PAGES_WITH_OBJECTS` enables the
+  edit/delete object flow. (`SUB_MENULINK_DATA` would add extra sub‑links such
+  as Export/Import — omitted here.)
+- **JS** (`AddHelloWorldJS`) — `PAGE_JS_FILES` injects `fog.<node>.<sub>.js` for
+  the current sub‑page.
+- **API** (`AddHelloWorldAPI`) — `API_VALID_CLASSES` exposes the node over REST
+  so `/fog/helloworld` reuses the same ORM as the UI.
+
+### 4.6 JavaScript — `js/fog.helloworld.*.js`
+
+One file per sub‑page (`list`, `add`, `edit`), each an IIFE. The **list** file
+registers the server‑side DataTable and the create modal; its `columns[].data`
+keys must match the list endpoint (`mainlink`, then your field names) and their
+order must match `$headerData`. The **add**/**edit** files wire the form buttons
+to `processForm()` (which POSTs and shows notifications) and, on edit, the delete
+confirm modal to `$.apiCall(... &sub=delete ...)`.
+
+Shared helpers you'll use: `Common.node`, `Common.id`, `Common.search`,
+`$.apiCall()`, `$.deleteSelected()`, `<form>.processForm()`,
+`$('#dataTable').registerTable()`.
+
+---
+
+## 5. Database & migrations (the important part)
+
+FOG has **no automatic per‑column migration**. `Schema::createTable()` emits
+`CREATE TABLE IF NOT EXISTS`, which does nothing on a table that already
+exists — so simply adding a column to `createSql()` will **not** reach existing
+installs. Use the **`schema()` contract** instead.
+
+**`schema()` returns an ordered, append‑only list of steps.** Each step is a SQL
+string (or a closure returning SQL). On install/upgrade the framework
+(`Plugin::installdb()`) calls:
+
+```php
+Schema::applyUpdates($manager->schema(), $applied);
+```
+
+where `$applied` is the count stored in the plugin's `pSchema` column. Only
+steps from index `$applied` onward run, and the new count is saved back. So:
+
+> **To add a column later, append a new step. Never reorder or delete existing
+> steps** — the applied count is positional.
+
+```php
+public function schema()
+{
+    return [
+        // 0 — create the table
+        $this->createSql(),
+        // 1 — added later; runs once on upgrade, skipped thereafter
+        "ALTER TABLE `helloWorld` ADD COLUMN `hwColor` VARCHAR(255) NULL",
+    ];
+}
+```
+
+`applyUpdates()` is defensive: it ignores "already exists / duplicate column /
+duplicate key / unknown column / duplicate entry" errors, so re‑running is
+safe. A closure step may return a string to signal a hard error and stop.
+
+Seed data (e.g. default `globalSettings` rows) is just another step — return the
+`INSERT` SQL, or a closure for anything that needs runtime values (see
+`accesscontrolmanager`'s `schema()` for the closure pattern).
+
+> **Legacy note.** Older plugins implement a destructive `install()` that calls
+> `uninstall()` (drop) then recreates. New plugins should implement `schema()`
+> (the framework prefers it and falls back to `install()` only when `schema()`
+> is absent). The example provides both; its `install()` just applies the schema
+> from `0`.
+
+---
+
+## 6. Lifecycle
+
+1. **Discovery.** `Plugin::getPlugins()` scans the plugins directory, `include`s
+   each `config/plugin.config.php`, and upserts a row in the `plugins` table.
+2. **Activation.** An admin enables the plugin in **Plugin Management**. Its
+   `node` is added to `FOGBase::$pluginsinstalled`, which is what every hook
+   constructor checks before registering.
+3. **Install / upgrade.** `Plugin::installdb()` runs `schema()` via
+   `applyUpdates()` and tracks `pSchema`. This is idempotent and
+   non‑destructive — safe to run on every upgrade.
+4. **Uninstall.** Inherited `uninstall()` drops the table; override it if you
+   need to clean up settings, associations, or users you created.
+
+---
+
+## 7. Settings
+
+Global configuration lives in the `globalSettings` table.
+
+- Read: `FOGBase::getSetting('FOG_PLUGIN_HELLOWORLD_FOO')`
+- Write: `FOGBase::setSetting('FOG_PLUGIN_HELLOWORLD_FOO', $value)`
+- Naming: `ALL_CAPS_WITH_UNDERSCORES`, prefixed `FOG_PLUGIN_<NAME>_…`.
+- Create defaults as a `schema()` seed step (an `INSERT` into `globalSettings`).
+
+---
+
+## 8. Security & output conventions
+
+- **Output:** wrap every user‑controlled value with `Initiator::e($value)` when
+  echoing into HTML. All output also passes through the global
+  `sanitizeOutput` buffer.
+- **Input:** use `filter_input(INPUT_POST, 'key')` (or the already‑sanitized
+  superglobals) — never raw `$_POST`/`$_GET`.
+- **CSRF/auth:** call `self::checkAuthAndCSRF()` at the top of every state‑
+  changing POST handler.
+- **Instantiation:** prefer `self::getClass('HelloWorld')` /
+  `self::getClass('HelloWorldManager')` over `new`.
+- **Translation:** wrap UI strings in `_('…')`.
+
+---
+
+## 9. Common hook events
+
+| Event | Purpose |
+|---|---|
+| `MAIN_MENU_DATA` | add the top‑level sidebar entry (`hook_main[node] = [label, icon]`) |
+| `SUB_MENULINK_DATA` | add sub‑links (Export/Import/…) under the node |
+| `SEARCH_PAGES` | make the node searchable |
+| `PAGES_WITH_OBJECTS` | enable the object (edit/delete) flow for the node |
+| `PAGE_JS_FILES` | inject JS files for the current page |
+| `API_VALID_CLASSES` | expose the node over the REST API |
+| `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
+| `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
+
+Fire your own events with `&`‑by‑reference args so listeners can mutate them
+(see the example's `HELLOWORLD_*` events).
+
+---
+
+## 10. Gotchas (learned the hard way)
+
+- **`CREATE TABLE IF NOT EXISTS` never alters a live table.** Add columns via a
+  new `schema()` step, not by editing `createSql()`.
+- **Filename = `strtolower(ClassName)` + suffix.** A mismatch means the class
+  silently won't autoload.
+- **`menuicon`** beginning with `fa` is rendered as a font‑awesome icon;
+  anything else is treated as an `<img>` `src`.
+- **`$serverFault`** must be `true` only for server‑side failures, so HTTP
+  status codes are honest (`500` vs `400`).
+- **Hook constructors must early‑return** when the node isn't in
+  `$pluginsinstalled`, or your hooks run for a plugin that isn't enabled.
+- **List columns** in the JS must match `$headerData` order and the keys the
+  router emits (`mainlink`, `id`, friendly field names).
+
+---
+
+## 11. Install & test your plugin
+
+1. Copy `helloworld/` to `packages/web/lib/plugins/<yourname>/` and rename the
+   directory, the classes, the files (lowercased), every `$node`, and the
+   `$fog_plugin['name']`.
+2. Deploy to the web root (e.g. `copybacktrunk.sh "" "" "1.6"`).
+3. In the UI: **Plugin System → Plugin Management → install/activate** your
+   plugin.
+4. Confirm: the sidebar entry appears, **Create New** saves a row (check the
+   table exists and `pSchema` advanced), **list** shows it, **edit** updates it,
+   **delete** removes it.
+5. Quick static checks while developing:
+   `php -l <file>` on each PHP file and `node --check <file>` on each JS file.
+
+---
+
+## 12. Reference plugins
+
+- **`helloworld`** — this guide's minimal, complete CRUD example.
+- **`subnetgroup`** — a clean real CRUD plugin (model→class relationship,
+  Export/Import, `schema()`).
+- **`accesscontrol`** — a multi‑table plugin showing a richer `schema()` with
+  seed and closure steps.
+- **`ldap`** — authentication/integration plugin (custom hooks beyond CRUD).
+
+When in doubt, copy the closest existing plugin and adapt it — the conventions
+above are followed consistently across all of them.

--- a/packages/web/lib/plugins/helloworld/class/helloworld.class.php
+++ b/packages/web/lib/plugins/helloworld/class/helloworld.class.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Hello World example plugin (single-entity model).
+ *
+ * A model extends FOGController and describes one row/entity. The ORM is
+ * driven entirely by $databaseTable and $databaseFields; access values with
+ * get('name') / set('name', ...) / save() / load() / destroy(), and
+ * instantiate with an id (new HelloWorld(42)) to auto-load.
+ *
+ * NOTE: the autoloader uses PHP's default spl_autoload, which lowercases the
+ * class name to find the file. So class HelloWorld must live in the file
+ * helloworld.class.php.
+ *
+ * PHP version 5
+ *
+ * @category HelloWorld
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Hello World example plugin (model).
+ *
+ * @category HelloWorld
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class HelloWorld extends FOGController
+{
+    /**
+     * The database table this model maps to.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'helloWorld';
+    /**
+     * friendly name => real column name.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'hwID',
+        'name' => 'hwName',
+        'description' => 'hwDesc',
+    ];
+    /**
+     * Fields that must be set before save() will succeed.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'name',
+    ];
+}

--- a/packages/web/lib/plugins/helloworld/class/helloworldmanager.class.php
+++ b/packages/web/lib/plugins/helloworld/class/helloworldmanager.class.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Hello World example plugin (collection manager + schema).
+ *
+ * A manager extends FOGManagerController and owns table-level concerns:
+ * querying collections and creating/migrating the table.
+ *
+ * Database migrations use the NON-DESTRUCTIVE schema() contract: an ordered,
+ * APPEND-ONLY list of steps. On install/upgrade the framework
+ * (Plugin::installdb()) calls Schema::applyUpdates(schema(), $applied) and
+ * records how many steps have run in the plugin's `pSchema` column, so only
+ * pending steps are applied and existing data is never dropped.
+ *
+ * PHP version 5
+ *
+ * @category HelloWorldManager
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Hello World example plugin (manager).
+ *
+ * @category HelloWorldManager
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class HelloWorldManager extends FOGManagerController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    public $tablename = 'helloWorld';
+    /**
+     * The CREATE TABLE (IF NOT EXISTS) statement for this table.
+     *
+     * Non-destructive and safe to re-run; used as step 0 of schema().
+     *
+     * @return string
+     */
+    public function createSql()
+    {
+        return Schema::createTable(
+            $this->tablename,
+            true,
+            [
+                'hwID',
+                'hwName',
+                'hwDesc',
+            ],
+            [
+                'INTEGER',
+                'VARCHAR(255)',
+                'LONGTEXT',
+            ],
+            [
+                false,
+                false,
+                false,
+            ],
+            [
+                false,
+                false,
+                false,
+            ],
+            [
+                'hwID',
+            ],
+            'InnoDB',
+            'utf8',
+            'hwID',
+            'hwID'
+        );
+    }
+    /**
+     * The ordered, APPEND-ONLY schema migration list.
+     *
+     * Each step is a SQL string (or a closure returning a SQL string). To
+     * evolve the schema, append a new step to the END of this array and never
+     * reorder or remove existing entries -- the applied count in `pSchema`
+     * tracks position, so reordering would re-run or skip the wrong step.
+     *
+     * @return array
+     */
+    public function schema()
+    {
+        return [
+            // 0 - create the table.
+            $this->createSql(),
+            //
+            // Example of adding a column LATER (append, do not edit step 0):
+            //
+            // 1 - add an optional colour column.
+            // "ALTER TABLE `helloWorld` ADD COLUMN `hwColor` VARCHAR(255) NULL",
+            //
+        ];
+    }
+    /**
+     * Installs/upgrades the database non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        $res = Schema::applyUpdates($this->schema(), 0);
+        return $res['error'] === null;
+    }
+}

--- a/packages/web/lib/plugins/helloworld/config/plugin.config.php
+++ b/packages/web/lib/plugins/helloworld/config/plugin.config.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Hello World example plugin configuration.
+ *
+ * This file is read by Plugin::getPlugins() during discovery. The
+ * $fog_plugin array tells FOG the plugin's machine name (must match the
+ * directory name), its description, the menu icon, and a (legacy) entry
+ * point. The machine name is also the routing "node" used in
+ * ?node=<name>&sub=<method>.
+ *
+ * PHP version 5
+ *
+ * @category HelloWorld
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+$fog_plugin = [];
+// Machine name. MUST equal this plugin's directory name (lowercase).
+$fog_plugin['name'] = 'helloworld';
+$fog_plugin['description'] = 'Skeleton example plugin demonstrating the FOG '
+    . 'plugin structure (config, model, manager, page, hooks, JS).';
+// A font-awesome class ("fa ...") is rendered as an icon; anything else is
+// treated as an <img> src.
+$fog_plugin['menuicon'] = 'fa fa-cube fa-fw';
+$fog_plugin['menuicon_hover'] = null;
+// Legacy/conventional entry point. No plugin actually ships this file today
+// (routing is handled by the node -> page-class mapping), but every plugin
+// declares it for consistency.
+$fog_plugin['entrypoint'] = 'html/run.php';

--- a/packages/web/lib/plugins/helloworld/hooks/addhelloworldapi.hook.php
+++ b/packages/web/lib/plugins/helloworld/hooks/addhelloworldapi.hook.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Exposes Hello World through the REST API.
+ *
+ * Registering the node in API_VALID_CLASSES lets /fog/helloworld endpoints
+ * resolve to this plugin's model/manager (list/get/create/update/delete),
+ * reusing the same ORM the UI uses.
+ *
+ * PHP version 5
+ *
+ * @category AddHelloWorldAPI
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Injects Hello World into the API system.
+ *
+ * @category AddHelloWorldAPI
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddHelloWorldAPI extends Hook
+{
+    /**
+     * The name of this hook.
+     *
+     * @var string
+     */
+    public $name = 'AddHelloWorldAPI';
+    /**
+     * The description.
+     *
+     * @var string
+     */
+    public $description = 'Add Hello World into the API system.';
+    /**
+     * For posterity.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * The node the hook works with.
+     *
+     * @var string
+     */
+    public $node = 'helloworld';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'API_VALID_CLASSES',
+            [$this, 'injectAPIElements']
+        );
+    }
+    /**
+     * Marks this node as a valid API class.
+     *
+     * @param mixed $arguments The arguments to modify.
+     *
+     * @return void
+     */
+    public function injectAPIElements($arguments)
+    {
+        $arguments['validClasses'][] = $this->node;
+    }
+}

--- a/packages/web/lib/plugins/helloworld/hooks/addhelloworldjs.hook.php
+++ b/packages/web/lib/plugins/helloworld/hooks/addhelloworldjs.hook.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Injects the Hello World JavaScript for the relevant sub-page.
+ *
+ * The PAGE_JS_FILES event lets a plugin add JS files to the page. The
+ * convention is one file per sub-page: fog.<node>.<sub>.js (e.g.
+ * fog.helloworld.list.js for sub=list, fog.helloworld.edit.js for sub=edit).
+ *
+ * PHP version 5
+ *
+ * @category AddHelloWorldJS
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Injects the Hello World JS files.
+ *
+ * @category AddHelloWorldJS
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddHelloWorldJS extends Hook
+{
+    /**
+     * The name of this hook.
+     *
+     * @var string
+     */
+    public $name = 'AddHelloWorldJS';
+    /**
+     * The description.
+     *
+     * @var string
+     */
+    public $description = 'Add Hello World JS files.';
+    /**
+     * For posterity.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * What plugin this works against.
+     *
+     * @var string
+     */
+    public $node = 'helloworld';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'PAGE_JS_FILES',
+            [$this, 'injectJSFiles']
+        );
+    }
+    /**
+     * Adds the per-sub-page JS file for this node.
+     *
+     * @param mixed $arguments The arguments to modify.
+     *
+     * @return void
+     */
+    public function injectJSFiles($arguments)
+    {
+        global $node;
+        global $sub;
+        if ($node !== $this->node) {
+            return;
+        }
+        $subset = str_replace('_', '-', (string)$sub);
+        if (empty($subset)) {
+            $filepath = "../lib/plugins/{$this->node}/js/fog.{$this->node}.js";
+        } else {
+            $filepath = "../lib/plugins/{$this->node}/js/"
+                . "fog.{$this->node}.{$subset}.js";
+        }
+        $arguments['files'][] = $filepath;
+    }
+}

--- a/packages/web/lib/plugins/helloworld/hooks/addhelloworldmenuitem.hook.php
+++ b/packages/web/lib/plugins/helloworld/hooks/addhelloworldmenuitem.hook.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Adds the Hello World menu item and wires the page into search/objects.
+ *
+ * Hooks register callbacks against named events in their constructor, but
+ * ONLY after confirming the plugin is installed (the $pluginsinstalled
+ * guard). Class AddHelloWorldMenuItem must live in the file
+ * addhelloworldmenuitem.hook.php (lowercased class name + .hook.php).
+ *
+ * PHP version 5
+ *
+ * @category AddHelloWorldMenuItem
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Adds the Hello World menu item.
+ *
+ * @category AddHelloWorldMenuItem
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class AddHelloWorldMenuItem extends Hook
+{
+    /**
+     * The name of this hook.
+     *
+     * @var string
+     */
+    public $name = 'AddHelloWorldMenuItem';
+    /**
+     * The description of this hook.
+     *
+     * @var string
+     */
+    public $description = 'Add menu item for Hello World.';
+    /**
+     * For posterity.
+     *
+     * @var bool
+     */
+    public $active = true;
+    /**
+     * The node this hook enacts with.
+     *
+     * @var string
+     */
+    public $node = 'helloworld';
+    /**
+     * Initialize object.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        self::$HookManager->register(
+            'MAIN_MENU_DATA',
+            [$this, 'menuData']
+        )->register(
+            'SEARCH_PAGES',
+            [$this, 'addSearch']
+        )->register(
+            'PAGES_WITH_OBJECTS',
+            [$this, 'addPageWithObject']
+        );
+    }
+    /**
+     * Adds the top-level menu entry.
+     *
+     * @param mixed $arguments The arguments to change.
+     *
+     * @return void
+     */
+    public function menuData($arguments)
+    {
+        $arguments['hook_main'][$this->node]
+            = [_('Hello World'), 'fa fa-cube'];
+    }
+    /**
+     * Registers the page as searchable.
+     *
+     * @param mixed $arguments The arguments to change.
+     *
+     * @return void
+     */
+    public function addSearch($arguments)
+    {
+        $arguments['searchPages'][] = $this->node;
+    }
+    /**
+     * Registers the page as using internalized objects (enables edit/delete).
+     *
+     * @param mixed $arguments The arguments to change.
+     *
+     * @return void
+     */
+    public function addPageWithObject($arguments)
+    {
+        $arguments['PagesWithObjects'][] = $this->node;
+    }
+}

--- a/packages/web/lib/plugins/helloworld/js/fog.helloworld.add.js
+++ b/packages/web/lib/plugins/helloworld/js/fog.helloworld.add.js
@@ -1,0 +1,20 @@
+/**
+ * Hello World standalone create page (sub=add).
+ *
+ * Submits the create form through processForm(), which POSTs to addPost and
+ * surfaces success/error via the standard notification helpers.
+ */
+(function($) {
+    var createForm = $('#helloworld-create-form'),
+        createFormBtn = $('#send');
+
+    createForm.on('submit', function(e) {
+        e.preventDefault();
+    });
+    createFormBtn.on('click', function() {
+        createFormBtn.prop('disabled', true);
+        createForm.processForm(function(err) {
+            createFormBtn.prop('disabled', false);
+        });
+    });
+})(jQuery);

--- a/packages/web/lib/plugins/helloworld/js/fog.helloworld.edit.js
+++ b/packages/web/lib/plugins/helloworld/js/fog.helloworld.edit.js
@@ -1,0 +1,59 @@
+/**
+ * Hello World edit page (sub=edit).
+ *
+ * Handles the General tab: update (processForm -> editPost) and delete
+ * (confirm modal -> $.apiCall to sub=delete), then redirect back to the list.
+ */
+$(function() {
+    var originalName = $('#name').val(),
+        updateName = function(newName) {
+            var e = $('#pageTitle'),
+                text = e.text();
+            text = text.replace(': ' + originalName, ': ' + newName);
+            document.title = text;
+            e.text(text);
+        };
+
+    var generalForm = $('#helloworld-general-form'),
+        generalFormBtn = $('#general-send'),
+        generalDeleteBtn = $('#general-delete'),
+        generalDeleteModal = $('#deleteModal'),
+        generalDeleteModalConfirm = $('#confirmDeleteModal');
+
+    generalForm.on('submit', function(e) {
+        e.preventDefault();
+    });
+    generalFormBtn.on('click', function() {
+        generalFormBtn.prop('disabled', true);
+        generalDeleteBtn.prop('disabled', true);
+        generalForm.processForm(function(err) {
+            generalFormBtn.prop('disabled', false);
+            generalDeleteBtn.prop('disabled', false);
+            if (err) {
+                return;
+            }
+            updateName($('#name').val());
+            originalName = $('#name').val();
+        });
+    });
+    generalDeleteBtn.on('click', function() {
+        generalDeleteModal.modal('show');
+    });
+    generalDeleteModalConfirm.on('click', function() {
+        var method = 'post',
+            action = '../management/index.php?node='
+                + Common.node
+                + '&sub=delete&id='
+                + Common.id;
+        $.apiCall(method, action, null, function(err) {
+            if (err) {
+                return;
+            }
+            setTimeout(function() {
+                window.location = '../management/index.php?node='
+                    + Common.node
+                    + '&sub=list';
+            }, 2000);
+        });
+    });
+});

--- a/packages/web/lib/plugins/helloworld/js/fog.helloworld.list.js
+++ b/packages/web/lib/plugins/helloworld/js/fog.helloworld.list.js
@@ -1,0 +1,82 @@
+/**
+ * Hello World list page (sub=list).
+ *
+ * Wires the DataTable (server-side, hits ?node=helloworld&sub=list), the
+ * "create new" modal (submits to addPost via processForm), and bulk delete.
+ * The `columns[].data` keys match the column data emitted by the list
+ * endpoint: 'mainlink' (the linked name) and any model field by its friendly
+ * name (here 'description'). Column order matches $headerData on the page.
+ */
+(function($) {
+    var deleteSelected = $('#deleteSelected'),
+        createnewBtn = $('#createnew'),
+        createnewModal = $('#createnewModal'),
+        createForm = $('#create-form'),
+        createnewSendBtn = $('#send');
+
+    function disableButtons(disable) {
+        deleteSelected.prop('disabled', disable);
+    }
+    function onSelect(selected) {
+        disableButtons(selected.count() == 0);
+    }
+
+    disableButtons(true);
+    var table = $('#dataTable').registerTable(onSelect, {
+        order: [
+            [0, 'asc']
+        ],
+        columns: [
+            {data: 'mainlink'},
+            {data: 'description'}
+        ],
+        rowId: 'id',
+        columnDefs: [
+            {
+                responsivePriority: -1,
+                targets: 0
+            }
+        ],
+        processing: true,
+        serverSide: true,
+        ajax: {
+            url: '../management/index.php?node='
+            + Common.node
+            + '&sub=list',
+            type: 'post'
+        }
+    });
+
+    if (Common.search && Common.search.length > 0) {
+        table.search(Common.search).draw();
+    }
+
+    createnewModal.registerModal(Common.createModalShow, Common.createModalHide);
+    createnewBtn.on('click', function(e) {
+        e.preventDefault();
+        createnewModal.modal('show');
+    });
+    createnewSendBtn.on('click', function(e) {
+        e.preventDefault();
+        createForm.processForm(function(err) {
+            if (err) {
+                return;
+            }
+            table.draw(false);
+            table.rows({selected: true}).deselect();
+            createnewModal.modal('hide');
+        });
+    });
+
+    deleteSelected.on('click', function() {
+        disableButtons(true);
+        $.deleteSelected(table, function(err) {
+            disableButtons(false);
+            if (err) {
+                return;
+            }
+            table.draw(false);
+            table.rows({selected: true}).deselect();
+        });
+    });
+})(jQuery);

--- a/packages/web/lib/plugins/helloworld/pages/helloworldmanagement.page.php
+++ b/packages/web/lib/plugins/helloworld/pages/helloworldmanagement.page.php
@@ -1,0 +1,490 @@
+<?php
+/**
+ * Hello World example plugin (management page).
+ *
+ * A page extends FOGPage and renders the UI plus handles its POSTs. The
+ * routing is ?node=helloworld&sub=<method>, e.g. sub=add -> add(),
+ * sub=addPost -> addPost(), sub=edit -> edit(), sub=list -> the inherited
+ * DataTables JSON list (driven by $headerData/$attributes + the JS list file).
+ *
+ * Conventions used here:
+ *  - self::makeLabel / makeInput / makeTextarea / makeButton / makeFormTag /
+ *    formFields build form markup.
+ *  - addPost()/editPost() return JSON and ALWAYS run self::checkAuthAndCSRF().
+ *  - user output goes through Initiator::e(); reads use filter_input().
+ *
+ * PHP version 5
+ *
+ * @category HelloWorldManagement
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Hello World example plugin (management page).
+ *
+ * @category HelloWorldManagement
+ * @package  FOGProject
+ * @author   FOG Project <info@fogproject.org>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class HelloWorldManagement extends FOGPage
+{
+    /**
+     * The node this page operates on (matches the plugin machine name).
+     *
+     * @var string
+     */
+    public $node = 'helloworld';
+    /**
+     * Initialize the page and define the list table columns.
+     *
+     * $headerData are the column headers; the matching column data keys live
+     * in js/fog.helloworld.list.js (here: 'mainlink' and 'description').
+     *
+     * @param string $name The page name.
+     *
+     * @return void
+     */
+    public function __construct($name = '')
+    {
+        $this->name = 'Hello World Management';
+        parent::__construct($this->name);
+        $this->headerData = [
+            _('Name'),
+            _('Description'),
+        ];
+        $this->attributes = [
+            [],
+            [],
+        ];
+    }
+    /**
+     * The standalone "create" page (sub=add).
+     *
+     * @return void
+     */
+    public function add()
+    {
+        $this->title = _('Create New Hello World');
+
+        $name = filter_input(INPUT_POST, 'name');
+        $description = filter_input(INPUT_POST, 'description');
+
+        $labelClass = 'col-sm-3 control-label';
+
+        $fields = [
+            self::makeLabel(
+                $labelClass,
+                'name',
+                _('Name')
+            ) => self::makeInput(
+                'form-control helloworldname-input',
+                'name',
+                _('Name'),
+                'text',
+                'name',
+                $name,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'description',
+                _('Description')
+            ) => self::makeTextarea(
+                'form-control helloworlddescription-input',
+                'description',
+                _('Description'),
+                'description',
+                $description
+            ),
+        ];
+
+        $buttons = self::makeButton(
+            'send',
+            _('Create'),
+            'btn btn-primary pull-right'
+        );
+
+        self::$HookManager->processEvent(
+            'HELLOWORLD_ADD_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'HelloWorld' => self::getClass('HelloWorld'),
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            'form-horizontal',
+            'helloworld-create-form',
+            $this->formAction,
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="box box-solid" id="helloworld-create">';
+        echo '<div class="box-body">';
+        echo '<div class="box box-primary">';
+        echo '<div class="box-header with-border">';
+        echo '<h4 class="box-title">';
+        echo _('Create New Hello World');
+        echo '</h4>';
+        echo '</div>';
+        echo '<div class="box-body">';
+        echo $rendered;
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+        echo '<div class="box-footer with-border">';
+        echo $buttons;
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+    }
+    /**
+     * The "create" form rendered inside the list page modal.
+     *
+     * @return void
+     */
+    public function addModal()
+    {
+        $name = filter_input(INPUT_POST, 'name');
+        $description = filter_input(INPUT_POST, 'description');
+
+        $labelClass = 'col-sm-3 control-label';
+
+        $fields = [
+            self::makeLabel(
+                $labelClass,
+                'name',
+                _('Name')
+            ) => self::makeInput(
+                'form-control helloworldname-input',
+                'name',
+                _('Name'),
+                'text',
+                'name',
+                $name,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'description',
+                _('Description')
+            ) => self::makeTextarea(
+                'form-control helloworlddescription-input',
+                'description',
+                _('Description'),
+                'description',
+                $description
+            ),
+        ];
+
+        self::$HookManager->processEvent(
+            'HELLOWORLD_ADD_FIELDS',
+            [
+                'fields' => &$fields,
+                'HelloWorld' => self::getClass('HelloWorld'),
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            'form-horizontal',
+            'create-form',
+            '../management/index.php?node=helloworld&sub=add',
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo $rendered;
+        echo '</form>';
+    }
+    /**
+     * Persist a new entry. Returns JSON.
+     *
+     * @return void
+     */
+    public function addPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+        self::$HookManager->processEvent('HELLOWORLD_ADD_POST');
+        $name = trim(
+            filter_input(INPUT_POST, 'name')
+        );
+        $description = trim(
+            filter_input(INPUT_POST, 'description')
+        );
+
+        $serverFault = false;
+        try {
+            if (empty($name)) {
+                throw new Exception(_('Please enter a name'));
+            }
+            $exists = self::getClass('HelloWorldManager')
+                ->exists($name);
+            if ($exists) {
+                throw new Exception(
+                    _('An entry already exists with this name!')
+                );
+            }
+            $HelloWorld = self::getClass('HelloWorld')
+                ->set('name', $name)
+                ->set('description', $description);
+            if (!$HelloWorld->save()) {
+                $serverFault = true;
+                throw new Exception(_('Add Hello World failed!'));
+            }
+            $code = HTTPResponseCodes::HTTP_CREATED;
+            $hook = 'HELLOWORLD_ADD_SUCCESS';
+            $msg = json_encode(
+                [
+                    'msg' => _('Hello World added!'),
+                    'title' => _('Hello World Create Success'),
+                ]
+            );
+        } catch (Exception $e) {
+            $code = (
+                $serverFault ?
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
+                HTTPResponseCodes::HTTP_BAD_REQUEST
+            );
+            $hook = 'HELLOWORLD_ADD_FAIL';
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Hello World Create Fail'),
+                ]
+            );
+        }
+        self::$HookManager->processEvent(
+            $hook,
+            [
+                'HelloWorld' => &$HelloWorld,
+                'hook' => &$hook,
+                'code' => &$code,
+                'msg' => &$msg,
+                'serverFault' => &$serverFault,
+            ]
+        );
+        http_response_code($code);
+        unset($HelloWorld);
+        echo $msg;
+        exit;
+    }
+    /**
+     * The "General" tab body shown on the edit page.
+     *
+     * @return void
+     */
+    public function helloworldGeneral()
+    {
+        $name = (
+            filter_input(INPUT_POST, 'name') ?:
+            $this->obj->get('name')
+        );
+        $description = (
+            filter_input(INPUT_POST, 'description') ?:
+            $this->obj->get('description')
+        );
+
+        $labelClass = 'col-sm-3 control-label';
+
+        $fields = [
+            self::makeLabel(
+                $labelClass,
+                'name',
+                _('Name')
+            ) => self::makeInput(
+                'form-control helloworldname-input',
+                'name',
+                _('Name'),
+                'text',
+                'name',
+                $name,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'description',
+                _('Description')
+            ) => self::makeTextarea(
+                'form-control helloworlddescription-input',
+                'description',
+                _('Description'),
+                'description',
+                $description
+            ),
+        ];
+
+        $buttons = self::makeButton(
+            'general-send',
+            _('Update'),
+            'btn btn-primary pull-right'
+        );
+        $buttons .= self::makeButton(
+            'general-delete',
+            _('Delete'),
+            'btn btn-danger pull-left'
+        );
+
+        self::$HookManager->processEvent(
+            'HELLOWORLD_GENERAL_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'HelloWorld' => $this->obj,
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            'form-horizontal',
+            'helloworld-general-form',
+            self::makeTabUpdateURL(
+                'helloworld-general',
+                $this->obj->get('id')
+            ),
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="box box-solid">';
+        echo '<div class="box-body">';
+        echo $rendered;
+        echo '</div>';
+        echo '<div class="box-footer with-border">';
+        echo $buttons;
+        echo $this->deleteModal();
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+    }
+    /**
+     * Apply the General tab edits to $this->obj (saved by editPost()).
+     *
+     * @return void
+     */
+    public function helloworldGeneralPost()
+    {
+        self::checkAuthAndCSRF();
+        $name = trim(
+            filter_input(INPUT_POST, 'name')
+        );
+        $description = trim(
+            filter_input(INPUT_POST, 'description')
+        );
+
+        if (empty($name)) {
+            throw new Exception(_('Please enter a name'));
+        }
+        $exists = self::getClass('HelloWorldManager')
+            ->exists($name);
+        if ($name != $this->obj->get('name')
+            && $exists
+        ) {
+            throw new Exception(
+                _('An entry already exists with this name!')
+            );
+        }
+        $this->obj
+            ->set('name', $name)
+            ->set('description', $description);
+    }
+    /**
+     * The edit page (sub=edit) -- renders tabs.
+     *
+     * @return void
+     */
+    public function edit()
+    {
+        $this->title = sprintf(
+            '%s: %s %s: %s',
+            _('Edit'),
+            $this->obj->get('name'),
+            _('ID'),
+            $this->obj->get('id')
+        );
+
+        $tabData = [];
+
+        // General
+        $tabData[] = [
+            'name' => _('General'),
+            'id' => 'helloworld-general',
+            'generator' => function () {
+                $this->helloworldGeneral();
+            },
+        ];
+
+        echo self::tabFields($tabData, $this->obj);
+    }
+    /**
+     * Persist edits. Returns JSON.
+     *
+     * @return void
+     */
+    public function editPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+        self::$HookManager->processEvent(
+            'HELLOWORLD_EDIT_POST',
+            ['HelloWorld' => &$this->obj]
+        );
+        $serverFault = false;
+        try {
+            global $tab;
+            switch ($tab) {
+                case 'helloworld-general':
+                    $this->helloworldGeneralPost();
+            }
+            if (!$this->obj->save()) {
+                $serverFault = true;
+                throw new Exception(_('Hello World update failed!'));
+            }
+            $code = HTTPResponseCodes::HTTP_ACCEPTED;
+            $hook = 'HELLOWORLD_EDIT_SUCCESS';
+            $msg = json_encode(
+                [
+                    'msg' => _('Hello World updated!'),
+                    'title' => _('Hello World Update Success'),
+                ]
+            );
+        } catch (Exception $e) {
+            $code = (
+                $serverFault ?
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
+                HTTPResponseCodes::HTTP_BAD_REQUEST
+            );
+            $hook = 'HELLOWORLD_EDIT_FAIL';
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Hello World Update Fail'),
+                ]
+            );
+        }
+        self::$HookManager->processEvent(
+            $hook,
+            [
+                'HelloWorld' => &$this->obj,
+                'hook' => &$hook,
+                'code' => &$code,
+                'msg' => &$msg,
+                'serverFault' => &$serverFault,
+            ]
+        );
+        http_response_code($code);
+        echo $msg;
+        exit;
+    }
+}


### PR DESCRIPTION
Implements #847.

Adds a start-to-finish **plugin authoring guide** plus a **copy-paste skeleton plugin** for the working-1.6 framework, so plugin development can be handed off instead of living only in the maintainer's head.

### What's here
- **`docs/plugin-development.md`** — the guide: mental model + boot/routing/ORM, directory layout, the autoloader filename rule, step-by-step build of each layer, the **`schema()`/`applyUpdates`/`pSchema` migration contract** (the correct, non-destructive way to add columns — vs. the `CREATE TABLE IF NOT EXISTS` trap), the `FOGPage` builder helpers, the `addPost`/`editPost` JSON pattern, hook-event reference, security/output conventions, gotchas, and an install/test checklist.
- **`packages/web/lib/plugins/helloworld/`** — a minimal but complete CRUD skeleton (config, model, manager+`schema()`, page, menu/JS/API hooks, list/add/edit JS) that someone can clone and rename.

### Self-verification done
- `php -l` passes on all 6 PHP files; `node --check` passes on all 3 JS files.
- Every class maps to its lowercased filename per the autoloader (`HelloWorldManagement` → `helloworldmanagement.page.php`, etc.).
- Structure mirrors the known-working `subnetgroup` plugin (same JS file set, hook pattern, page methods, ORM shape).

### Not yet done (one manual step)
A live install/activate smoke test (deploy → Plugin Management → activate → create/edit/delete a row, confirm the table + `pSchema`). I didn't run it since it writes to a live FOG install/DB. It's written up as the test checklist in §11 of the guide. Happy to walk through it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
