### PR TITLE
Fix login language session persistence

### DIFF
--- a/packages/web/lib/pages/processlogin.class.php
+++ b/packages/web/lib/pages/processlogin.class.php
@@ -132,10 +132,6 @@ class ProcessLogin extends FOGPage
         $this->_username = $uname;
         $this->_password = $upass;
         $type = self::$FOGUser->get('type');
-        if (isset($_SESSION['FOG_LANG']) && $_SESSION['FOG_LANG'] != $ulang) {
-            $_SESSION['FOG_LANG'] = $ulang;
-            Initiator::language($ulang);
-        }
         self::$HookManager
             ->processEvent(
                 'USER_TYPE_HOOK',
@@ -143,6 +139,10 @@ class ProcessLogin extends FOGPage
             );
         if (!isset($_POST['login'])) {
             return;
+        }
+        if (isset($_SESSION['FOG_LANG']) && $_SESSION['FOG_LANG'] != $ulang) {
+            $_SESSION['FOG_LANG'] = $ulang;
+            Initiator::language($ulang);
         }
         if (!$this->_username) {
             self::setMessage(self::$foglang['InvalidLogin']);
@@ -193,6 +193,11 @@ class ProcessLogin extends FOGPage
             BASEPATH . 'fog_login_accepted.log'
         );
         chmod(BASEPATH . 'fog_login_accepted.log', 0200);
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $_SESSION['FOG_LANG'] = $ulang;
+        Initiator::language($ulang);
         $this->_setRedirMode();
     }
     /**


### PR DESCRIPTION
## Summary

This fixes an issue where the language selected on the login form is not preserved after logging in.

`processMainLogin()` runs on normal page loads as well as login POST requests. Because the selected language fallback used `FOG_DEFAULT_LOCALE` when no POST value was present, refreshing the page could overwrite `$_SESSION['FOG_LANG']` with the default locale.

This change only updates the selected language during login POST handling and reapplies the selected language before redirecting after a successful login.

## Testing

- Set `FOG_DEFAULT_LOCALE` to `en`
- Logged in with Chinese, French, and Italian selected from the login page
- Confirmed the dashboard rendered in the selected language after login
- Refreshed the dashboard
- Confirmed the selected language remained active after refresh