### PR TITLE
Fix Chinese language label

### DIFF
--- a/packages/web/commons/text.php
+++ b/packages/web/commons/text.php
@@ -385,7 +385,7 @@ $foglang['NotExtended'] = _('Class is not extended from FOGPage');
 $foglang['DoNotList'] = _('Do not list on menu');
 // Language menu options.
 $foglang['LanguagePhrase'] = _('Language');
-$foglangt['Language']['zh'] = '中国的';
+$foglangt['Language']['zh'] = '中文';
 $foglangt['Language']['en'] = 'English';
 $foglangt['Language']['es'] = 'Español';
 $foglangt['Language']['fr'] = 'Français';


### PR DESCRIPTION
## Summary

This updates the Chinese language label in the login language selector from `中国的` to `中文`.
`中国的` reads more like "of China" or "Chinese" as an adjective, while `中文` is the more natural label for the Chinese language.

## Testing

- Confirmed the language selector displays `中文` for Chinese