### PR TITLE
Plugin page: surface "Update available" on the always-visible name column

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         define('FOG_VERSION', '1.6.0-beta.2603');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 307);
-        define('FOG_BCACHE_VER', 202);
+        define('FOG_BCACHE_VER', 203);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // FOG_BASE_DIR is intentionally hardcoded here. Deriving it from a setting would
         // create a circular dependency (getSetting() needs the cache dir before DB is up).

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -52,6 +52,21 @@
         },
         columnDefs: [
             {
+                // Surface the "Update available" action on the plugin name,
+                // which is the always-visible column (responsivePriority -1).
+                // The Installed column that would otherwise carry it is a
+                // low-priority column and gets collapsed behind the responsive
+                // expander, hiding which plugin actually needs the update.
+                render: function(data, type, row) {
+                    // Keep sorting/searching keyed on the plain name only.
+                    if (type !== 'display') {
+                        return data;
+                    }
+                    if (row.needsupdate > 0) {
+                        return data + ' <button type="button" class="btn btn-warning btn-sm plugin-update-btn" data-id="'+row.id+'" title="Apply pending database update"><i class="fa fa-exclamation-triangle"></i> Update available</button>';
+                    }
+                    return data;
+                },
                 responsivePriority: -1,
                 targets: 0
             },
@@ -72,12 +87,13 @@
                 targets: 3
             },
             {
+                // Installed status only; the "Update available" action now
+                // rides on the always-visible name column above.
                 render: function(data, type, row) {
                     var enabled = '<span class="badge bg-success"><i class="fa fa-check-circle"></i></span>';
                     var disabled = '<span class="badge bg-danger"><i class="fa fa-times-circle"></i></span>';
-                    var update = '<button type="button" class="btn btn-warning btn-sm plugin-update-btn" data-id="'+row.id+'" title="Apply pending database update"><i class="fa fa-exclamation-triangle"></i> Update available</button>';
                     if (data > 0) {
-                        return row.needsupdate > 0 ? update : enabled;
+                        return enabled;
                     } else {
                         return disabled;
                     }


### PR DESCRIPTION
## Problem

The plugin list (`PluginManagement`) is a responsive DataTables table. Only the **Plugin Name** column is `responsivePriority: -1` (always visible); the per-plugin **Update available** button lived in the **Installed** column, which is a default-priority column that collapses behind the responsive expander (▶).

Result: an admin who sees the dashboard's "plugin update available" indicator and clicks through lands on a list where nothing shows *which* plugin needs the update — they'd have to expand every row to find the one carrying the button.

## Change

- Move the `.plugin-update-btn` "Update available" button onto the always-visible **Plugin Name** column, so it's immediately visible and still one-click actionable (the existing delegated click handler is unchanged).
- Revert the **Installed** column to a plain installed-status badge (no longer redundantly carrying the button).
- Guard the name-column render with `type !== 'display'` so the button markup never pollutes sort/search keys.
- Bump `FOG_BCACHE_VER` 202 → 203 so browsers pick up the changed JS (this is the shared CSS+JS cache-buster).

Only `fog.plugin.list.js` and the `FOG_BCACHE_VER` constant change. No PHP/data-flow changes — `needsupdate` was already provided per-row by the server.

## Test plan

1. Deploy this branch.
2. Have a converted (schema()-aware) plugin with a pending migration (`pSchema` < defined schema steps).
3. Open **Plugin Management** — the plugin with the pending update shows a yellow "⚠ Update available" button inline next to its name in the collapsed list, without expanding.
4. Click it → the plugin's pending schema migration applies (same non-destructive `upgrade` endpoint as before) and the table redraws.

> ⚠️ Holding merge for now — coordinate with the other in-flight `working-1.6` work before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)