### PR TITLE
Translate report menu labels

### DIFF
--- a/packages/web/lib/pages/reportmanagementpage.class.php
+++ b/packages/web/lib/pages/reportmanagementpage.class.php
@@ -140,7 +140,7 @@ class ReportManagementPage extends FOGPage
                 $item[] = ucfirst(trim($rep));
                 unset($rep);
             }
-            $item = implode(' ', $item);
+            $item = _(implode(' ', $item));
             $this->menu = self::fastmerge(
                 (array)$this->menu,
                 array(

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6863,3 +6863,21 @@ msgstr ""
 
 msgid "you set the bandwidth field on that node to 1000"
 msgstr ""
+
+msgid "History Report"
+msgstr ""
+
+msgid "Hosts And Users"
+msgstr ""
+
+msgid "Inventory Report"
+msgstr ""
+
+msgid "Pending Mac List"
+msgstr ""
+
+msgid "Product Keys"
+msgstr ""
+
+msgid "User Tracking"
+msgstr ""


### PR DESCRIPTION
## Summary

This updates report submenu labels to pass through gettext before rendering.

Report submenu labels are generated dynamically from report filenames, for example `equipment_loan.report.php` becomes `Equipment Loan`. These labels were rendered directly, so gettext entries in `messages.po` were not applied.

This also adds the dynamically generated report labels to `messages.pot`.

## Testing

- Confirmed report submenu labels translate when matching gettext entries exist
- Opened Report Management
- Confirmed report submenu labels are translated when matching gettext entries exist