### PR TITLE
Multicast deploy of per-LV LVM images: emit LV files in sidecar order

### DIFF
--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -437,6 +437,62 @@ class MulticastTask extends FOGService
         return $this->_MultiSess;
     }
     /**
+     * Returns the LV image filenames a dNpM.lvm sidecar names, in sidecar
+     * line order. udpcast synchronizes by file order alone, so this must
+     * skip exactly the lines the FOS client skips (swap LVs and volumes
+     * with no image file); any divergence misassigns every later stream.
+     * Returns false for a sidecar this server cannot parse (a newer
+     * LVMFORMAT) — the client refuses those before opening a receiver.
+     *
+     * @param string $sidecar full path to the dNpM.lvm sidecar
+     *
+     * @return array|false
+     */
+    private function _getLVMImageList($sidecar)
+    {
+        $lines = @file(
+            $sidecar,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        if (!$lines) {
+            return false;
+        }
+        switch (trim(array_shift($lines))) {
+            case 'LVMFORMAT 1':
+                $fstypefield = 4;
+                $imagefield = 5;
+                break;
+            case 'LVMFORMAT 2':
+                $fstypefield = 5;
+                $imagefield = 6;
+                break;
+            default:
+                return false;
+        }
+        $lvimages = [];
+        foreach ($lines as $line) {
+            $fields = preg_split('/\s+/', trim($line));
+            if ($fields[0] !== 'LV') {
+                continue;
+            }
+            if (isset($fields[$fstypefield])
+                && $fields[$fstypefield] == 'swap'
+            ) {
+                continue;
+            }
+            $image = (
+                isset($fields[$imagefield]) ?
+                $fields[$imagefield] :
+                ''
+            );
+            if ($image == '' || $image == '-') {
+                continue;
+            }
+            $lvimages[] = $image;
+        }
+        return $lvimages;
+    }
+    /**
      * Sets/Gets the command needed to start the tasking
      *
      * @return string
@@ -512,6 +568,8 @@ class MulticastTask extends FOGService
             ' --nopointopoint',
         ];
         $buildcmd = array_values(array_filter($buildcmd));
+        $lvfiles = [];
+        $lvmscan = false;
         switch ($this->getImageType()) {
             case 1:
                 switch ($this->getOSID()) {
@@ -536,6 +594,7 @@ class MulticastTask extends FOGService
                                 $filelist[] = 'rec.img.*';
                             }
                         } else {
+                            $lvmscan = true;
                             $filename = 'd1p%d.%s';
                             $iterator = new DirectoryIterator(
                                 $this->getImagePath()
@@ -560,6 +619,7 @@ class MulticastTask extends FOGService
                         unset($files, $sys, $rec);
                         break;
                     default:
+                        $lvmscan = true;
                         $filename = 'd1p%d.%s';
                         $iterator = new DirectoryIterator(
                             $this->getImagePath()
@@ -583,6 +643,7 @@ class MulticastTask extends FOGService
                 }
                 break;
             case 2:
+                $lvmscan = true;
                 $filename = 'd1p%d.%s';
                 $iterator = new DirectoryIterator(
                     $this->getImagePath()
@@ -605,6 +666,7 @@ class MulticastTask extends FOGService
                 unset($iterator);
                 break;
             case 3:
+                $lvmscan = true;
                 $filename = 'd%dp%d.%s';
                 $iterator = new DirectoryIterator(
                     $this->getImagePath()
@@ -639,6 +701,47 @@ class MulticastTask extends FOGService
                 }
                 unset($iterator);
         }
+        if ($lvmscan) {
+            /*
+             * Per-LV LVM images (dNpM.lvm sidecars) have no dNpM.img for
+             * that partition; a placeholder of that name keeps the sort
+             * and single-partition filter behaving as if it existed, and
+             * the send loop below expands it into the sidecar's LV image
+             * files in line order — the order the FOS client restores in.
+             */
+            $iterator = new DirectoryIterator(
+                $this->getImagePath()
+            );
+            foreach ($iterator as $fileInfo) {
+                if ($fileInfo->isDot()) {
+                    continue;
+                }
+                if (!preg_match(
+                    '/^(d\d+p\d+)\.lvm$/',
+                    $fileInfo->getFilename(),
+                    $match
+                )
+                ) {
+                    continue;
+                }
+                if ($this->getImageType() != 3
+                    && strpos($match[1], 'd1p') !== 0
+                ) {
+                    continue;
+                }
+                $lvimages = $this->_getLVMImageList(
+                    $this->getImagePath() . DS . $fileInfo->getFilename()
+                );
+                if ($lvimages === false) {
+                    continue;
+                }
+                $placeholder = $match[1] . '.img';
+                $filelist = array_diff((array)$filelist, [$placeholder]);
+                $filelist[] = $placeholder;
+                $lvfiles[$placeholder] = $lvimages;
+            }
+            unset($iterator);
+        }
         @natcasesort($filelist);
         $partid = self::getPartitions();
         if ($partid < 1) {
@@ -648,8 +751,18 @@ class MulticastTask extends FOGService
                 preg_grep("/^d[0-9]p$partid\.img$/", (array)$filelist)
             );
         }
+        $sendfiles = [];
+        foreach ($filelist as $file) {
+            if (!isset($lvfiles[$file])) {
+                $sendfiles[] = $file;
+                continue;
+            }
+            foreach ($lvfiles[$file] as $lvfile) {
+                $sendfiles[] = $lvfile;
+            }
+        }
         ob_start();
-        foreach ($filelist as $i => $file) {
+        foreach ($sendfiles as $i => $file) {
             printf(
                 '%s --file %s%s%s;',
                 sprintf(
@@ -668,7 +781,7 @@ class MulticastTask extends FOGService
                 $file
             );
         }
-        unset($filelist, $buildcmd);
+        unset($filelist, $sendfiles, $lvfiles, $buildcmd);
         return ob_get_clean();
     }
     /**

--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -41,6 +41,17 @@ if (isset($_REQUEST['client'])) {
         FOG_CLIENT_VERSION :
         '0.0.0'
     );
+} elseif (isset($_REQUEST['caps'])) {
+    /*
+     * Space-separated feature tokens probed by FOS before it relies on
+     * server-side behavior a version string can't identify. An older
+     * server answers this query with FOG_VERSION (no tokens), which
+     * probing clients treat as "capability absent".
+     *
+     * mclvm: multicast tasks emit per-LV LVM image files in sidecar
+     * order (fos docs/adr/0007).
+     */
+    $ver = 'mclvm';
 } elseif (isset($_REQUEST['url'])) {
     FOGCore::checkAuthAndCSRF();
     $url = $_REQUEST['url'];
@@ -79,7 +90,7 @@ if (isset($_REQUEST['client'])) {
     // restrict query params to known ones
     if (!empty($parts['query'])) {
         parse_str($parts['query'], $q);
-        $allowedKeys = ['client', 'clientver'];
+        $allowedKeys = ['client', 'clientver', 'caps'];
         foreach (array_keys($q) as $k) {
             if (!in_array($k, $allowedKeys, true)) {
                 http_response_code(403);


### PR DESCRIPTION
## What

Server half of multicast LVM deploy, per [fos ADR-0007](https://github.com/FOGProject/fos/blob/master/docs/adr/0007-multicast-lvm-sidecar-order-contract.md) (client half: FOGProject/fos#123).

udpcast synchronizes by nothing but file order — the server chains one `udp-sender --file …;` per image file, the client opens one receiver per file it expects, and the Nth receiver gets the Nth file. Per-LV LVM images (fos ADR-0004/0006) add a variable number of files per partition, so both sides must derive the same sequence or partclone restores one LV's filesystem onto another. Both sides now derive it from the same `dNpM.lvm` sidecar.

## Changes

**`multicasttask.class.php`** — the `dNpM`-enumerating branches of `getCMD()` (image types 1–3) also scan for `dNpM.lvm` sidecars. Each sidecar contributes a `dNpM.img` *placeholder* to the file list, so `natcasesort()` and the single-partition filter behave exactly as if the flat file existed; the send loop then expands the placeholder into the sidecar's LV image files in line order. The new `_getLVMImageList()` parser skips exactly the lines the FOS client skips: non-`LV` tags, swap LVs, `-`/empty image fields, and whole sidecars with an unknown `LVMFORMAT` header (the client refuses those before opening a receiver). If a stale flat `dNpM.img` coexists with a sidecar, the sidecar wins — matching client dispatch. Today the enumeration's greedy `sscanf` (`d1p3.root.img` → ext `root.img`) silently drops every LV file; that was harmless only because the client refused multicast LVM outright.

**`getversion.php`** — new `caps` branch returning space-separated feature tokens (`mclvm`). New FOS probes `getversion.php?caps=1` before a multicast LVM deploy and refuses cleanly when the token is absent — the dangerous skew is new FOS against an old server, where the first LV receiver would join the *next flat partition's* session and write the wrong filesystem into the LV. An old server answers the probe with `FOG_VERSION` (no token) → clean refusal, disk untouched. `caps` also joins the url-proxy allowlist so node-to-node forwarding keeps working.

No changes to `mc_checkin.php` (the `##@GO` contract old clients poll for) or the multicast manager (completion is task-state and process-exit driven, not per-file).

## Verification

Desk-checked by loading the real class with stubbed framework dependencies and running `getCMD()` over fixture image directories, old file vs this branch:

- **Flat images are byte-identical** across image types 1–4, the osid 1/2 single-file and 5/6/7 sys/rec legacy paths, and single-partition tasks — flat multicast is provably unchanged.
- LVM fixtures produce `d1p1.img d1p2.root.img d1p2.home.img d1p3.img` (LV files at their partition's slot, sidecar line order, swap skipped), for both LVMFORMAT 1 and 2, single- and multi-disk (type 3), with disk-2 sidecars correctly ignored for types 1/2.
- Single-partition tasks on an LVM partition send exactly that partition's LV files; `--max-wait` lands only on the first file either way.
- `LVMFORMAT 3` (future) sidecars are skipped entirely — the client refuses those itself.

End-to-end proof still needs a real rig (server + ≥2 receivers on a shared segment); the capability probe ensures every skew pairing fails as a refusal, not corruption. Same community-validation bar as ADR-0004/0006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)