### PR TITLE
installer: honor -X on DHCP config failure; report unwritten Kea config (Refs #730)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3293,6 +3293,11 @@ EOFAPL
 )
     # Tier 1: base classes must validate or we refuse to start a broken server.
     _writeKeaConfig "$target" "$baseclasses"
+    if [[ ! -s $target ]]; then
+        echo "Failed"
+        echo "Kea base configuration could not be written to $target (verify $(dirname "$target") is a writable directory); see $error_log"
+        return 1
+    fi
     if command -v kea-dhcp4 >/dev/null 2>&1; then
         if ! kea-dhcp4 -t "$target" >>$error_log 2>&1; then
             echo "Failed"
@@ -3344,14 +3349,22 @@ configureDHCP() {
             [[ ! $(validip $routeraddress) -eq 0 ]] && routeraddress=$(echo $routeraddress | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
             [[ ! $(validip $dnsaddress) -eq 0 ]] && dnsaddress=$(echo $dnsaddress | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
             if [[ $dhcpengine == kea ]]; then
-                configureKeaDHCP || exit 1
+                if ! configureKeaDHCP; then
+                    # Honor -X/--exitFail: a Kea config failure must not abort
+                    # the whole installer, or later steps (TFTP/PXE) never run.
+                    [[ -z $exitFail ]] && exit 1
+                    return
+                fi
             else
             [[ -f $dhcpconfig ]] && dhcptouse=$dhcpconfig
             [[ -f $dhcpconfigother ]] && dhcptouse=$dhcpconfigother
             if [[ -z $dhcptouse || ! -f $dhcptouse ]]; then
                 echo "Failed"
                 echo "Could not find dhcp config file"
-                exit 1
+                # Honor -X/--exitFail: same as the Kea branch, don't abort the
+                # whole installer or later steps (TFTP/PXE) never run.
+                [[ -z $exitFail ]] && exit 1
+                return
             fi
             mv -fv "${dhcptouse}" "${dhcptouse}.${timestamp}" >>$error_log 2>&1
             echo "# DHCP Server Configuration file\n#see /usr/share/doc/dhcp*/dhcpd.conf.sample" > $dhcptouse


### PR DESCRIPTION
## Problem

A forum report (FOG 1.6.0-beta.2644) showed the Kea DHCP installer path aborting the entire install — TFTP/PXE never got set up — **even with `-X`/`--exitFail`**.

Root cause: `configureDHCP` aborted with a raw `exit 1` when the Kea or ISC dhcp config step failed, bypassing `errorStat()` and the `-X` contract. Because `configureTFTPandPXE` runs immediately after `configureDHCP`, a DHCP failure took TFTP/PXE down with it.

Separately, when the Kea config file was absent/unwritable at validation time, `kea-dhcp4 -t` reports "Unable to open file" (a raw `fopen()` failure *before* JSON parsing) — which the installer misattributed to "failed validation."

## Changes (`lib/common/functions.sh`)

- **Kea and ISC branches now honor `$exitFail`**: `exit 1` only without `-X`; otherwise print the failure and `return` so later steps (TFTP/PXE) still run. Behavior without `-X` is unchanged.
- **`configureKeaDHCP` guards for an unwritten/empty target** (`[[ -s $target ]]`) and reports "could not be written to … verify … is a writable directory" instead of misreporting an absent/unreadable file as "failed validation (kea-dhcp4 -t)."

## Scope / risk

Single file, 15 insertions / 2 deletions. No behavior change absent `-X`. Does not touch the ISC config-writing logic beyond the same `-X` safety fix.

## Not covered here

The *underlying* trigger for the reporter's "Unable to open file" (bad `/etc/kea` state vs AppArmor/SELinux confinement of the `kea-dhcp4` binary) needs environment info to pin down; the write guard now makes a genuine write failure self-reporting, but MAC confinement would be a policy/docs matter, not an installer-code cure.

Refs #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)