### PR TITLE
Make LDAP work with native RBAC, and stop it granting implicit admin

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4598,3 +4598,33 @@ $this->schema[] = [
     . "else is ignored. Default is 0, which is disabled and lets FOG pick a "
     . "port per session.' WHERE `settingKey` = 'FOG_MULTICAST_PORT_OVERRIDE'",
 ];
+// Guarded for the same reason as step 312: working-1.6 and dev-branch number
+// the same migration differently, so an install may already carry the column.
+$columnuAuthSource = array_filter(
+    (array)DatabaseManager::getColumns(
+        'users',
+        'uAuthSource'
+    )
+);
+// 314
+$this->schema[] = count($columnuAuthSource ?: []) ? [] : [
+    // Records which external provider vouched for an account ('' = local).
+    //
+    // Authorization::getPermissions() treats "no role rows at all" as an
+    // implicit administrator so that upgrades cannot lock anyone out. The
+    // LDAP plugin has always created its users with no role rows, so after
+    // native RBAC landed every LDAP-authenticated user silently became a
+    // full administrator -- the plugin still wrote uType 990/991, and
+    // nothing reads uType for authorization any more.
+    //
+    // The provenance has to live in core, not in the plugin, because the
+    // rule it protects lives in core. It is deliberately NOT keyed on the
+    // plugin's uType sentinels: uType is a shared generic field that is
+    // admin-editable at runtime (FOG_PLUGIN_LDAP_USER_FILTER) and writable
+    // over the API and CSV import, and a second auth plugin would have to
+    // invent its own magic numbers and hope they never collide. Storing the
+    // provider name makes the deny-by-default a standing property of the
+    // resolver rather than a check that runs once at login.
+    "ALTER TABLE `users` "
+    . "ADD COLUMN `uAuthSource` VARCHAR(32) NOT NULL DEFAULT ''",
+];

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -305,8 +305,26 @@ class Authorization extends FOGBase
             ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         if (!is_array($rows) || count($rows) < 1) {
-            // Zero role assignments, direct or group-sourced = implicit
-            // administrator.
+            // Zero role assignments, direct or group-sourced.
+            //
+            // For a LOCAL account this stays "implicit administrator", which
+            // is what keeps an upgrade from locking every existing user out
+            // before any role has been assigned.
+            //
+            // For an EXTERNALLY authenticated account it must not. An auth
+            // plugin creates its users on the fly at login, so a role-less
+            // externally sourced user is the normal case rather than the
+            // upgrade edge case the fallback was written for -- which made
+            // every LDAP-authenticated user a full administrator once RBAC
+            // landed. Deny instead: an external identity gets exactly the
+            // roles its provider mapped to it, and nothing by default.
+            //
+            // This is checked here, in the resolver, rather than at account
+            // creation, so it holds for every account with a provider stamp
+            // no matter how or when that account came to exist.
+            if ('' !== self::_authSource($userID)) {
+                return self::$_permCache[$userID] = [];
+            }
             return self::$_permCache[$userID] = null;
         }
         $perms = [];
@@ -319,6 +337,43 @@ class Authorization extends FOGBase
         return self::$_permCache[$userID] = array_values(
             array_unique($perms)
         );
+    }
+    /**
+     * The external provider that authenticates a user, '' when local.
+     *
+     * Read straight from the table rather than through the User model so a
+     * permission lookup cannot recurse back into a controller that may
+     * itself consult permissions. Only ever called on the zero-role path,
+     * so this costs nothing for the common case.
+     *
+     * @param int $userID the user id
+     *
+     * @return string
+     */
+    private static function _authSource($userID)
+    {
+        // The whole row, not the single column: this runs on every request
+        // that reaches the zero-role branch, including during the window
+        // between deploying this code and running the schema update, when
+        // `uAuthSource` does not exist yet. Naming the column in the SELECT
+        // would make that query fail and deny every user until the update
+        // ran -- and the update itself is reached through an authenticated
+        // page. Selecting the row degrades to "no such column, therefore
+        // local", which is exactly the pre-upgrade behaviour.
+        $row = self::$DB
+            ->query(
+                'SELECT * FROM `users` WHERE `uId` = :userid',
+                [],
+                ['userid' => (int)$userID]
+            )
+            ->fetch()
+            ->get();
+        // No row at all is a different matter: the id does not name a real
+        // user, so there is no provenance to trust and nothing to grant.
+        if (!is_array($row) || count($row) < 1) {
+            return 'unknown';
+        }
+        return trim((string)($row['uAuthSource'] ?? ''));
     }
     /**
      * Does the user hold the given permission?

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -163,6 +163,11 @@ class Authorization extends FOGBase
         'inventory' => 'host',
         'ipxe' => 'ipxe',
         'keysequence' => 'ipxe',
+        // Plugin-added classes otherwise fall through to the fail-open
+        // branch below and are readable by any authenticated user. This one
+        // carries a directory service account credential, so it is mapped
+        // explicitly ahead of the general fix for that fallback.
+        'ldap' => 'ldap',
         'macaddressassociation' => 'host',
         'module' => 'module',
         'moduleassociation' => 'module',

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,9 +59,9 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2726');
-        define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 313);
+        define('FOG_VERSION', 'ldap.0-feature.2727');
+        define('FOG_CHANNEL', 'Feature');
+        define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // FOG_BASE_DIR is intentionally hardcoded here. Deriving it from a setting would

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2730');
+        define('FOG_VERSION', 'ldap.0-feature.2731');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2727');
+        define('FOG_VERSION', 'ldap.0-feature.2728');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2729');
+        define('FOG_VERSION', 'ldap.0-feature.2730');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2732');
+        define('FOG_VERSION', 'ldap.0-feature.2733');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2728');
+        define('FOG_VERSION', 'ldap.0-feature.2729');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', 'ldap.0-feature.2731');
+        define('FOG_VERSION', 'ldap.0-feature.2732');
         define('FOG_CHANNEL', 'Feature');
         define('FOG_SCHEMA', 314);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -107,12 +107,23 @@ class User extends FOGController
             $username
         );
         $tmpUser = new User();
+        // An external provider (LDAP today, any auth plugin tomorrow) sets
+        // this to true to state that it has already proven the identity
+        // against its own directory. Without it a plugin had no way to say
+        // "this person is who they claim" and its only option was to write
+        // the directory password into uPass so the compare below would pass
+        // -- which is why FOG has been storing bcrypt hashes of live AD
+        // passwords. It is honoured ONLY for accounts carrying an
+        // authsource stamp, so it can never be used to bypass the password
+        // of a local account.
+        $authenticated = false;
         self::$HookManager->processEvent(
             'USER_LOGGING_IN',
             [
                 'username' => $username,
                 'password' => $password,
-                'user' => &$tmpUser
+                'user' => &$tmpUser,
+                'authenticated' => &$authenticated
             ]
         );
         $typeIsValid = true;
@@ -122,7 +133,19 @@ class User extends FOGController
                 ->set('name', $username)
                 ->load('name');
         }
-        if ($tmpUser->isValid()
+        $isExternal = ('' !== trim((string)$tmpUser->get('authsource')));
+        // An externally sourced account has no usable local password, so a
+        // local credential must never authenticate it. This is the check
+        // that makes a leftover shadow row harmless: with the auth plugin
+        // uninstalled or its server unreachable nothing vouches for the
+        // account, and the row stops being a login. It also replaces the
+        // LDAP plugin's own isLdapType() guard, which never fired because
+        // USER_TYPE_HOOK rewrote the type it tested one block earlier.
+        if ($isExternal && true !== $authenticated) {
+            return false;
+        }
+        if (!$isExternal
+            && $tmpUser->isValid()
             && preg_match('#^[a-f0-9]{32}$#i', $tmpUser->get('password'))
             && md5($password) === $tmpUser->get('password')
         ) {
@@ -130,7 +153,9 @@ class User extends FOGController
                 ->set('password', $password)
                 ->save();
         }
-        $passValid = (bool)password_verify(
+        // $isExternal implies $authenticated by the guard above, which
+        // returned for every other external case.
+        $passValid = $isExternal ? true : (bool)password_verify(
             $password,
             $tmpUser->get('password')
         );

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -41,7 +41,10 @@ class User extends FOGController
         'type' => 'uType',
         'display' => 'uDisplay',
         'api' => 'uAllowAPI',
-        'token' => 'uAPIToken'
+        'token' => 'uAPIToken',
+        // '' = local account. Non-empty names the external provider that
+        // authenticates this user (e.g. 'ldap'); see schema step 314.
+        'authsource' => 'uAuthSource'
     ];
     /**
      * The required fields

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -244,6 +244,85 @@ class LDAPManager extends FOGManagerController
         return (string)(array_shift($ids) ?: '');
     }
     /**
+     * Brings shadow rows created before role mapping into the new model.
+     *
+     * Rows this plugin created previously carry uType 990/991, no
+     * provenance stamp and no role, which under native RBAC resolves to
+     * implicit administrator. Two things have to happen to them, and
+     * neither can wait for the user to log in again: the stamp is what
+     * stops core accepting a local password against the row, and the role
+     * is what stops the zero-role fallback granting everything.
+     *
+     * 990 is deliberately mapped to the admin role even though it also
+     * covers users of a server with group matching disabled -- the old code
+     * stored both as 990. Mapping them all to the admin role preserves the
+     * access these accounts have today rather than cutting anyone off mid
+     * upgrade, and the first login afterwards re-syncs each of them to the
+     * tier they actually belong to, because role sync is authoritative over
+     * the mapped roles. An account that never logs in again holds a visible,
+     * revocable role instead of silent implicit administrator, which is the
+     * improvement either way.
+     *
+     * @return mixed true, or an error string to halt the update
+     */
+    public function backfillIdentities()
+    {
+        // uAuthSource arrives in core schema step 314. A plugin update can
+        // be run before the core update has happened, and PDODB does not
+        // throw on query errors, so stamping a column that is not there yet
+        // would fail silently and leave these rows unprotected.
+        $column = array_filter(
+            (array)DatabaseManager::getColumns('users', 'uAuthSource')
+        );
+        if (count($column) < 1) {
+            return _(
+                'The FOG schema update must be run before this plugin can '
+                . 'be updated: users.uAuthSource does not exist yet.'
+            );
+        }
+        $roleByType = [
+            LDAPPluginHook::LDAP_ADMIN => self::getSetting(
+                'FOG_PLUGIN_LDAP_ADMIN_ROLE'
+            ),
+            LDAPPluginHook::LDAP_MOBILE => self::getSetting(
+                'FOG_PLUGIN_LDAP_USER_ROLE'
+            )
+        ];
+        foreach ($roleByType as $uType => $roleId) {
+            $roleId = trim((string)$roleId);
+            if ('' === $roleId) {
+                // No mapping configured: stamp only. The row ends up with a
+                // provenance and no role, which denies rather than grants.
+                continue;
+            }
+            // INSERT IGNORE leans on the unique (ruaRoleID, ruaUserID) key
+            // so re-running the update cannot duplicate a grant.
+            self::$DB->query(
+                'INSERT IGNORE INTO `roleUserAssoc` '
+                . '(`ruaRoleID`, `ruaUserID`) '
+                . 'SELECT :roleid, `uId` FROM `users` '
+                . 'WHERE `uType` = :utype',
+                [],
+                ['roleid' => $roleId, 'utype' => $uType]
+            );
+        }
+        // Stamped last, so a failure part way through leaves rows without
+        // provenance rather than with provenance and no role -- the former
+        // is the pre-existing state, the latter would lock the account out.
+        self::$DB->query(
+            'UPDATE `users` SET `uAuthSource` = :source '
+            . 'WHERE `uType` IN (:admintype, :mobiletype) '
+            . "AND `uAuthSource` = ''",
+            [],
+            [
+                'source' => LDAPPluginHook::AUTH_SOURCE,
+                'admintype' => LDAPPluginHook::LDAP_ADMIN,
+                'mobiletype' => LDAPPluginHook::LDAP_MOBILE
+            ]
+        );
+        return true;
+    }
+    /**
      * The plugin's ordered, append-only schema migration list. Append new
      * steps (e.g. "ALTER TABLE `LDAPServers` ADD COLUMN ...") to the END.
      *
@@ -266,6 +345,10 @@ class LDAPManager extends FOGManagerController
             // re-run on an existing install; a new step does.
             function () {
                 return $this->seedSettings();
+            },
+            // 3
+            function () {
+                return $this->backfillIdentities();
             },
         ];
     }

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -181,6 +181,36 @@ class LDAPManager extends FOGManagerController
                 'Allowed LDAP Ports as defined by user. Default: 389,636',
                 '389,636',
                 $category
+            ],
+            [
+                'FOG_PLUGIN_LDAP_ADMIN_ROLE',
+                'Role granted to a user found in an LDAP server\'s admin '
+                . 'group. Blank grants nothing.',
+                self::_defaultRoleId('Administrator'),
+                $category
+            ],
+            [
+                'FOG_PLUGIN_LDAP_USER_ROLE',
+                'Role granted to a user found in an LDAP server\'s user '
+                . 'group. Blank grants nothing.',
+                self::_defaultRoleId('Technician'),
+                $category
+            ],
+            [
+                // Group matching is per-server and off by default, and with
+                // it off the directory cannot tell an admin from anyone who
+                // can bind -- so this is the role EVERY bindable account
+                // gets on such a server. It used to be hardcoded to full
+                // administrator, which made every account in the directory
+                // a FOG superuser on a stock config. Defaulting it to the
+                // technician tier keeps that from being the shipped
+                // behaviour while leaving the choice with the admin.
+                'FOG_PLUGIN_LDAP_NOMATCH_ROLE',
+                'Role granted to every account that can bind to an LDAP '
+                . 'server which has group matching disabled. Blank grants '
+                . 'nothing.',
+                self::_defaultRoleId('Technician'),
+                $category
             ]
         ];
         $SettingManager = self::getClass('SettingManager');
@@ -196,6 +226,24 @@ class LDAPManager extends FOGManagerController
         return true;
     }
     /**
+     * The id of a seeded role, looked up by name.
+     *
+     * Matched by name rather than by the ids the core schema seeds (1 and
+     * 2), following the precedent core itself sets when it back-grants the
+     * technician permission set: a role can be renamed or renumbered, and a
+     * blank default is a safe answer here because a blank role setting
+     * grants nothing.
+     *
+     * @param string $name the role name to resolve
+     *
+     * @return string
+     */
+    private static function _defaultRoleId($name)
+    {
+        $ids = Route::getIds('role', ['name' => $name], 'id');
+        return (string)(array_shift($ids) ?: '');
+    }
+    /**
      * The plugin's ordered, append-only schema migration list. Append new
      * steps (e.g. "ALTER TABLE `LDAPServers` ADD COLUMN ...") to the END.
      *
@@ -207,6 +255,15 @@ class LDAPManager extends FOGManagerController
             // 0
             $this->createSql(),
             // 1
+            function () {
+                return $this->seedSettings();
+            },
+            // 2
+            // seedSettings() again, deliberately. It only inserts settings
+            // that are missing, so re-running it is how an already-installed
+            // plugin picks up the role mapping keys added above without
+            // disturbing values an admin has already chosen. Step 1 does not
+            // re-run on an existing install; a new step does.
             function () {
                 return $this->seedSettings();
             },

--- a/packages/web/lib/plugins/ldap/hooks/addldapapi.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/addldapapi.hook.php
@@ -53,39 +53,20 @@ class AddLDAPAPI extends Hook
     public function __construct()
     {
         parent::__construct();
+        // API_MASSDATA_MAPPING/adjustMassData is no longer registered. It
+        // hid every LDAP user from User Management, which made sense while
+        // an LDAP user was an unmanageable shadow row, but they now hold
+        // real roles an admin needs to be able to see and change. Hiding
+        // them also meant the accounts with the most access on an install
+        // were the only ones absent from the user list.
+        //
+        // It carried a latent bug too: it appended " WHERE ..." to ttlstr
+        // unconditionally, so stacking it with another plugin that filters
+        // the same list (the site plugin) produced two WHERE clauses in one
+        // statement.
         $this->registerInstalled([
             ['API_VALID_CLASSES', 'injectAPIElements'],
-            ['API_MASSDATA_MAPPING', 'adjustMassData'],
         ]);
-    }
-    /**
-     * Remove the users with ldap types from the list.
-     *
-     * @param mixed $arguments The arguments to modify.
-     *
-     * @return void
-     */
-    public function adjustMassData($arguments)
-    {
-        if ($arguments['classname'] != 'user') {
-            return;
-        }
-        $where = "`users`.`uType` NOT IN ('"
-            . implode("','", LDAPPluginHook::LDAP_TYPES)
-            . "')";
-
-        $arguments['ttlstr'] .= " WHERE $where";
-
-        $arguments['data'] = FOGManagerController::complex(
-            $arguments['pass_vars'],
-            $arguments['table'],
-            $arguments['tableID'],
-            $arguments['columns'],
-            $arguments['sqlstr'],
-            $arguments['fltrstr'],
-            $arguments['ttlstr'],
-            $where
-        );
     }
     /**
      * This function injects site elements for

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -29,6 +29,21 @@ class LDAPPluginHook extends Hook
     const LDAP_ADMIN = '990';
     const LDAP_MOBILE = '991';
     /**
+     * Stamped on users.uAuthSource so core knows this account is
+     * externally authenticated and must not fall back to implicit
+     * administrator or to a local password compare.
+     */
+    const AUTH_SOURCE = 'ldap';
+    /**
+     * Access tiers, ordered: a higher tier wins when several LDAP servers
+     * answer for the same user. TIER_NOMATCH sits below a verified user
+     * match because it means "we could not check", not "we checked".
+     */
+    const TIER_NONE = 0;
+    const TIER_NOMATCH = 1;
+    const TIER_USER = 2;
+    const TIER_ADMIN = 3;
+    /**
      * The user types to filter
      *
      * @var array
@@ -82,21 +97,27 @@ class LDAPPluginHook extends Hook
         if (count(self::$_userTypes) < 1) {
             self::$_userTypes = self::LDAP_TYPES;
         }
+        // USER_TYPES_FILTER, USER_TYPE_VALID and USER_LOGGING_OUT are no
+        // longer registered. All three defended the pre-RBAC two-tier model
+        // and under roles they combined into "an LDAP user can never hold a
+        // role":
+        //  - USER_TYPES_FILTER made Role::loadUsers() and
+        //    UserGroup::loadUsers() array_diff LDAP users out of their
+        //    membership lists, so the next save of any role deleted their
+        //    roleUserAssoc rows -- including rows nobody had touched.
+        //  - USER_LOGGING_OUT destroyed the user row outright, taking its
+        //    roles with it, and only fired on an explicit logout anyway.
+        //  - USER_TYPE_VALID (isLdapType) was dead: USER_TYPE_HOOK rewrites
+        //    990/991 to 0/1 one block earlier, so it only ever saw the
+        //    rewritten value. Core's authsource check replaces it.
+        // This plugin is the only registrant of all three, so the core
+        // firings simply go inert.
         self::$HookManager->register(
             'USER_LOGGING_IN',
             [$this, 'checkAddUser']
         )->register(
             'USER_TYPE_HOOK',
             [$this, 'setLdapType']
-        )->register(
-            'USER_TYPES_FILTER',
-            [$this, 'setTypeFilter']
-        )->register(
-            'USER_TYPE_VALID',
-            [$this, 'isLdapType']
-        )->register(
-            'USER_LOGGING_OUT',
-            [$this, 'removeLdapShadow']
         );
     }
     /**
@@ -135,54 +156,147 @@ class LDAPPluginHook extends Hook
         );
         /**
          * Authenticate against every configured LDAP server and keep the
-         * most privileged result (admin beats mobile beats none). A server
-         * where the user is absent must not downgrade a match found on
-         * another server, so we accumulate the best access level and act on
-         * it once after the loop rather than per-server.
+         * most privileged result (admin beats user beats unverified beats
+         * none). A server where the user is absent must not downgrade a
+         * match found on another server, so we accumulate the best tier and
+         * act on it once after the loop rather than per-server.
+         *
+         * A server with group matching disabled is its own tier rather than
+         * an admin match: authLDAP() returns 2 there, but it means "this
+         * account can bind and we have no way to check what it is", not
+         * "this account is an administrator". Ranking it below a verified
+         * user-group match keeps an unverifiable server from outranking a
+         * server that actually answered the question.
          */
-        $bestAccess = 0;
+        $bestTier = self::TIER_NONE;
         $displayName = '';
         $ldapAPI = 0;
         foreach ($items->data as $ldap) {
             $LDAP = self::getClass('LDAP', $ldap->id);
             $access = (int)$LDAP->authLDAP($user, $pass);
-            if ($access > $bestAccess) {
-                $bestAccess = $access;
+            if ($access < 1) {
+                continue;
+            }
+            if (!$LDAP->get('useGroupMatch')) {
+                $tier = self::TIER_NOMATCH;
+            } elseif ($access >= 2) {
+                $tier = self::TIER_ADMIN;
+            } else {
+                $tier = self::TIER_USER;
+            }
+            if ($tier > $bestTier) {
+                $bestTier = $tier;
                 $displayName = $LDAP->getDisplayName($user, $pass);
                 $ldapAPI = $LDAP->get('allowapi');
                 /**
-                 * Admin is the highest level; no need to keep looking.
+                 * Admin is the highest tier; no need to keep looking.
                  */
-                if ($bestAccess >= 2) {
+                if ($bestTier >= self::TIER_ADMIN) {
                     break;
                 }
             }
         }
-        switch ($bestAccess) {
-            case 2:
-                // This is an admin account.
-                $tmpUser
-                    ->set('name', $user)
-                    ->set('password', $pass)
-                    ->set('display', $displayName)
-                    ->set('type', self::LDAP_ADMIN)
-                    ->set('api', $ldapAPI)
-                    ->save();
+        if (self::TIER_NONE === $bestTier) {
+            $arguments['user'] = new User(-1);
+            return;
+        }
+        // Rows this plugin created before it stopped storing directory
+        // passwords still hold a bcrypt hash of the user's real password.
+        // Overwrite uPass once, on the first login after the upgrade, and
+        // leave it alone thereafter -- hashing a fresh token on every login
+        // would burn a bcrypt round per sign-in for no benefit.
+        $needsPassword = (
+            !$tmpUser->isValid()
+            || self::AUTH_SOURCE !== $tmpUser->get('authsource')
+        );
+        // uType is kept as the marker identifying a row this plugin owns --
+        // uninstall() and FOG_PLUGIN_LDAP_USER_FILTER both key on it -- but
+        // it no longer decides anything. Authorization comes from the role
+        // assigned below; provenance comes from authsource.
+        $tmpUser
+            ->set('name', $user)
+            ->set('display', $displayName)
+            ->set('type', (
+                self::TIER_ADMIN === $bestTier ?
+                self::LDAP_ADMIN :
+                self::LDAP_MOBILE
+            ))
+            ->set('api', $ldapAPI)
+            ->set('authsource', self::AUTH_SOURCE);
+        if ($needsPassword) {
+            // Never the directory password. The account is authenticated by
+            // the vouch below, so uPass only has to be something no typed
+            // password can ever match.
+            $tmpUser->set('password', self::getToken(64));
+        }
+        $this->_syncRoles($tmpUser, self::_roleForTier($bestTier));
+        $tmpUser->save();
+        $arguments['user'] = $tmpUser;
+        // Tell core we have already proven this identity, so it skips the
+        // local password compare instead of us having to make one succeed.
+        $arguments['authenticated'] = true;
+    }
+    /**
+     * The configured role id for an access tier, '' when unset.
+     *
+     * @param int $tier one of the TIER_* constants
+     *
+     * @return string
+     */
+    private static function _roleForTier($tier)
+    {
+        switch ($tier) {
+            case self::TIER_ADMIN:
+                $key = 'FOG_PLUGIN_LDAP_ADMIN_ROLE';
                 break;
-            case 1:
-                // This is an unprivileged user account.
-                $tmpUser
-                    ->set('name', $user)
-                    ->set('password', $pass)
-                    ->set('display', $displayName)
-                    ->set('type', self::LDAP_MOBILE)
-                    ->set('api', $ldapAPI)
-                    ->save();
+            case self::TIER_USER:
+                $key = 'FOG_PLUGIN_LDAP_USER_ROLE';
+                break;
+            case self::TIER_NOMATCH:
+                $key = 'FOG_PLUGIN_LDAP_NOMATCH_ROLE';
                 break;
             default:
-                $tmpUser = new User(-1);
+                return '';
         }
-        $arguments['user'] = $tmpUser;
+        return trim((string)self::getSetting($key));
+    }
+    /**
+     * Makes the directory authoritative over the mapped roles only.
+     *
+     * The three mapped roles are recomputed from the directory on every
+     * login, so revoking someone's LDAP group membership downgrades them
+     * the next time they sign in. Any other role an admin attached by hand
+     * is left alone -- without that carve-out the sync would silently
+     * revoke deliberate grants, and an admin would have no way to give an
+     * LDAP user anything extra.
+     *
+     * Reading get('roles') here is also what arms the sync: assocSetter()
+     * no-ops on an association that was never loaded or set, so the read
+     * below is load-bearing, not just informational.
+     *
+     * @param User   $userObj the user being authenticated
+     * @param string $roleId  the role this login earns, '' for none
+     *
+     * @return void
+     */
+    private function _syncRoles($userObj, $roleId)
+    {
+        $managed = array_map(
+            'strval',
+            array_filter(
+                [
+                    self::getSetting('FOG_PLUGIN_LDAP_ADMIN_ROLE'),
+                    self::getSetting('FOG_PLUGIN_LDAP_USER_ROLE'),
+                    self::getSetting('FOG_PLUGIN_LDAP_NOMATCH_ROLE')
+                ]
+            )
+        );
+        $current = array_map('strval', (array)$userObj->get('roles'));
+        $roles = array_values(array_diff($current, $managed));
+        if ('' !== (string)$roleId) {
+            $roles[] = (string)$roleId;
+        }
+        $userObj->set('roles', array_values(array_unique($roles)));
     }
     /**
      * Sets our ldap types
@@ -197,46 +311,6 @@ class LDAPPluginHook extends Hook
             $arguments['type'] = 0;
         } elseif ($arguments['type'] == self::LDAP_MOBILE) {
             $arguments['type'] = 1;
-        }
-    }
-    /**
-     * Sets our user type to filter from user list
-     *
-     * @param mixed $arguments the item to adjust
-     *
-     * @return void
-     */
-    public function setTypeFilter($arguments)
-    {
-        $arguments['types'] = self::$_userTypes;
-    }
-    /**
-     * Tests if the user is containing the ldap types.
-     *
-     * @param mixed $arguments the item to adjust
-     *
-     * @return void
-     */
-    public function isLdapType($arguments)
-    {
-        $types = self::$_userTypes;
-        if (in_array($arguments['type'], $types)) {
-            $arguments['typeIsValid'] = false;
-        }
-    }
-    /**
-     * Cleans up logged out users
-     *
-     * @return void
-     */
-    public function removeLdapShadow()
-    {
-        if (!self::$FOGUser instanceof User) {
-            return;
-        }
-        $types = self::$_userTypes;
-        if (in_array(self::$FOGUser->get('type'), $types)) {
-            self::$FOGUser->destroy();
         }
     }
 }

--- a/packages/web/lib/plugins/ldap/js/fog.ldap.export.js
+++ b/packages/web/lib/plugins/ldap/js/fog.ldap.export.js
@@ -14,7 +14,6 @@
         {data: 'userGroup', visible: false},
         {data: 'searchScope', visible: false},
         {data: 'bindDN', visible: false},
-        {data: 'bindPwd', visible: false},
         {data: 'grpSearchDN', visible: false},
         {data: 'useGroupMatch', visible: false},
         {data: 'displayNameOn', visible: false},

--- a/packages/web/lib/plugins/ldap/js/fog.ldap.report.file.js
+++ b/packages/web/lib/plugins/ldap/js/fog.ldap.report.file.js
@@ -20,7 +20,6 @@
         {data: 'userGroup', visible: false},
         {data: 'searchScope', visible: false},
         {data: 'bindDN', visible: false},
-        {data: 'bindPwd', visible: false},
         {data: 'grpSearchDN', visible: false},
         {data: 'useGroupMatch', visible: false},
         {data: 'displayNameOn', visible: false},

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
@@ -606,10 +606,12 @@ class LDAPManagement extends FOGPage
             filter_input(INPUT_POST, 'bindDN') ?:
             $this->obj->get('bindDN')
         );
-        $bindPwd = (
-            filter_input(INPUT_POST, 'bindPwd') ?:
-            $this->obj->get('bindPwd')
-        );
+        // Deliberately NOT seeded from the stored value. type="password"
+        // hides it on screen but the value attribute is still in the page
+        // source, so rendering it handed the directory service account
+        // credential to anyone who could open the edit page. Blank means
+        // "unchanged" on save; see ldapGeneralPost().
+        $bindPwd = (string)filter_input(INPUT_POST, 'bindPwd');
         $template = filter_input(INPUT_POST, 'template');
         $searchScopes = [
             _('Base Only'),
@@ -896,7 +898,7 @@ class LDAPManagement extends FOGPage
             . self::makeInput(
                 'form-control ldapbindpwd-input',
                 'bindPwd',
-                '',
+                _('Leave blank to keep the current password'),
                 'password',
                 'bindPwd',
                 $bindPwd
@@ -1083,12 +1085,18 @@ class LDAPManagement extends FOGPage
             ->set('userGroup', $userGroup)
             ->set('searchScope', $searchScope)
             ->set('bindDN', $bindDN)
-            ->set('bindPwd', $bindPwd)
             ->set('useGroupMatch', $useGroupMatch)
             ->set('grpSearchDN', $grpSearchDN)
             ->set('displayNameOn', $displayNameOn)
             ->set('allowapi', $isAPI)
             ->set('displayNameAttr', $displayNameAttr);
+        // The edit form no longer renders the stored password back into the
+        // field, so an empty submission means "leave it as it is" rather
+        // than "clear it". Without this an admin editing any other setting
+        // on the page would silently wipe the bind credential.
+        if ('' !== $bindPwd) {
+            $this->obj->set('bindPwd', $bindPwd);
+        }
     }
     /**
      * Presents the user with fields to edit

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
@@ -1143,6 +1143,33 @@ class LDAPManagement extends FOGPage
             $filters
         );
 
+        // Role mapping. Read individually rather than through the batched
+        // $find above: that form returns values positionally, so a setting
+        // an admin has blanked out would shift every later value by one.
+        $adminRole = (
+            filter_input(INPUT_POST, 'adminrole') ?:
+            self::getSetting('FOG_PLUGIN_LDAP_ADMIN_ROLE')
+        );
+        $userRole = (
+            filter_input(INPUT_POST, 'userrole') ?:
+            self::getSetting('FOG_PLUGIN_LDAP_USER_ROLE')
+        );
+        $nomatchRole = (
+            filter_input(INPUT_POST, 'nomatchrole') ?:
+            self::getSetting('FOG_PLUGIN_LDAP_NOMATCH_ROLE')
+        );
+
+        // Route::names() would emit a JSON content-type header into what is
+        // an HTML fragment, so build the id => name map from ids(). Both
+        // calls order by name, so the two lists line up.
+        $roleIds = Route::getIds('role', [], 'id');
+        $roleNames = Route::getIds('role', [], 'name');
+        $roles = (
+            count($roleIds) === count($roleNames) ?
+            array_combine($roleIds, $roleNames) :
+            []
+        );
+
         $labelClass = 'col-sm-3 col-form-label';
 
         $fields = [
@@ -1171,7 +1198,50 @@ class LDAPManagement extends FOGPage
                 'port',
                 $port,
                 true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'adminrole',
+                _('Role for LDAP admin group')
+            ) => self::selectForm(
+                'adminrole',
+                $roles,
+                $adminRole,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'userrole',
+                _('Role for LDAP user group')
+            ) => self::selectForm(
+                'userrole',
+                $roles,
+                $userRole,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'nomatchrole',
+                _('Role when group matching is off')
+            ) => self::selectForm(
+                'nomatchrole',
+                $roles,
+                $nomatchRole,
+                true
             )
+            // Spelled out rather than left implicit: on a server with group
+            // matching off this role is granted to everyone who can bind,
+            // which is the whole directory. An admin choosing it should see
+            // that, not have to infer it.
+            . '<small class="form-text text-muted">'
+            . _(
+                'Applies to LDAP servers that have group matching '
+                . 'disabled. On those servers FOG cannot tell an '
+                . 'administrator from any other account, so every user who '
+                . 'can authenticate against the directory receives this '
+                . 'role.'
+            )
+            . '</small>'
         ];
 
         $buttons = self::makeButton(
@@ -1235,6 +1305,11 @@ class LDAPManagement extends FOGPage
         $port = trim(
             filter_input(INPUT_POST, 'port')
         );
+        $roleFields = [
+            'adminrole' => 'FOG_PLUGIN_LDAP_ADMIN_ROLE',
+            'userrole' => 'FOG_PLUGIN_LDAP_USER_ROLE',
+            'nomatchrole' => 'FOG_PLUGIN_LDAP_NOMATCH_ROLE'
+        ];
 
         $serverFault = false;
         try {
@@ -1269,6 +1344,26 @@ class LDAPManagement extends FOGPage
             if (!self::setSetting('FOG_PLUGIN_LDAP_PORTS', implode(',', $ports))) {
                 $serverFault = true;
                 throw new Exception(_('Unable to set ldap ports.'));
+            }
+            // Blank is a legitimate choice meaning "grant nothing", so only
+            // a non-blank value is checked -- and it is checked against the
+            // roles that actually exist, because a setting naming a deleted
+            // role would otherwise fail silently at login.
+            $validRoles = array_map(
+                'strval',
+                (array)Route::getIds('role', [], 'id')
+            );
+            foreach ($roleFields as $field => $settingKey) {
+                $roleId = trim((string)filter_input(INPUT_POST, $field));
+                if ('' !== $roleId && !in_array($roleId, $validRoles, true)) {
+                    throw new Exception(
+                        _('A selected role no longer exists')
+                    );
+                }
+                if (!self::setSetting($settingKey, $roleId)) {
+                    $serverFault = true;
+                    throw new Exception(_('Unable to set LDAP role mapping.'));
+                }
             }
             $hook = 'LDAP_GLOBAL_EDIT_SUCCESS';
             $code = HTTPResponseCodes::HTTP_ACCEPTED;

--- a/packages/web/lib/plugins/ldap/reports/ldap_report.report.php
+++ b/packages/web/lib/plugins/ldap/reports/ldap_report.report.php
@@ -45,14 +45,14 @@ class LDAP_Report extends ReportManagement
             _('User Group'),
             _('Search Scope'),
             _('Bind DN'),
-            _('Bind Password'),
+            // Bind Password removed: the export handed out the directory
+            // service account credential in cleartext.
             _('Group Search DN'),
             _('Use Group Match'),
             _('Display Name Enabled'),
             _('Display Name Attribute')
         ];
         $this->attributes = [
-            [],
             [],
             [],
             [],

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -120,6 +120,13 @@ class Route extends FOGBase
             'password',
             'token',
         ],
+        // The directory service account's password. Unlike a host's ADPass
+        // there is no consumer that legitimately reads this back out over
+        // the API -- only the web tier binds with it -- so it has no reason
+        // to appear in a listing.
+        'ldap' => [
+            'bindPwd',
+        ],
     ];
     /**
      * Stores the valid classes.

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -600,6 +600,21 @@ class Route extends FOGBase
                 HTTPResponseCodes::HTTP_UNAUTHORIZED
             );
         }
+        // passwordValidate() proves the credential; it says nothing about
+        // whether this account may use the API. The token branch above
+        // tests uAllowAPI, so without the same test here turning "Allow
+        // API" off left basic auth as an unaffected way in.
+        //
+        // Reloading also gives the acting user a fully populated object,
+        // matching what the token branch binds -- passwordValidate() only
+        // fills in id, name and type on the object it was called against.
+        $apiUser = self::getClass('User', (int)self::$FOGUser->get('id'));
+        if (!$apiUser->isValid() || !$apiUser->get('api')) {
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_UNAUTHORIZED
+            );
+        }
+        self::$FOGUser = $apiUser;
     }
     /**
      * Sends the response code through break head as needed.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6644,6 +6644,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -226,6 +226,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A role with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -694,6 +697,12 @@ msgstr "Jährlich"
 #, fuzzy
 msgid "Applications"
 msgstr "Anwendungen"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5421,6 +5430,12 @@ msgstr "Site Zugehörigkeit"
 msgid "Role added!"
 msgstr "Drucker hinzugefügt"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "Drucker-Update fehlgeschlagen!"
@@ -5428,6 +5443,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Drucker aktualisiert!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -7000,6 +7018,10 @@ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Fehler beim Aktualisieren des Tasks"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3776,6 +3776,9 @@ msgstr "Neueste Version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Level muss eine integer sein."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -231,6 +231,9 @@ msgstr "An image already exists with this name!"
 msgid "A role with this name already exists!"
 msgstr "A hostname with that name already exists."
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -696,6 +699,12 @@ msgstr "Annually"
 #, fuzzy
 msgid "Applications"
 msgstr "Actions"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5417,6 +5426,12 @@ msgstr "Image Association"
 msgid "Role added!"
 msgstr "Printer Name"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "Printer update failed!"
@@ -5424,6 +5439,9 @@ msgstr "Printer update failed!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Printer updated!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -6992,6 +7010,10 @@ msgstr "Unable to open file for reading"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Failed to update task"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Unable to open file for reading"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6639,6 +6639,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "This setting defines "
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "Task type is not valid"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3772,6 +3772,9 @@ msgstr "Latest Version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Event must be a string"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -229,6 +229,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "A role with this name already exists!"
 msgstr "Sesión con ese nombre ya existe"
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -707,6 +710,12 @@ msgstr "Anualmente"
 #, fuzzy
 msgid "Applications"
 msgstr "Comportamiento"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5547,6 +5556,12 @@ msgstr "Asociación para la imagen"
 msgid "Role added!"
 msgstr "Nombre de la impresora"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "actualización de la impresora ha fallado!"
@@ -5554,6 +5569,9 @@ msgstr "actualización de la impresora ha fallado!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Impresora actualiza!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -7141,6 +7159,10 @@ msgstr "No se puede abrir archivo para lectura"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "No se pudo crear la tarea"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "No se puede abrir archivo para lectura"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6805,6 +6805,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr ""
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "tipo de tarea no es válida"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3864,6 +3864,9 @@ msgstr "Versión del sistema"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Evento debe ser una cadena"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -226,6 +226,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A role with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -694,6 +697,12 @@ msgstr "Jährlich"
 #, fuzzy
 msgid "Applications"
 msgstr "Anwendungen"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5422,6 +5431,12 @@ msgstr "Site Zugehörigkeit"
 msgid "Role added!"
 msgstr "Drucker hinzugefügt"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "Drucker-Update fehlgeschlagen!"
@@ -5429,6 +5444,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Drucker aktualisiert!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -7001,6 +7019,10 @@ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Fehler beim Aktualisieren des Tasks"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3777,6 +3777,9 @@ msgstr "Neueste Version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Level muss eine integer sein."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6645,6 +6645,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -232,6 +232,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "A role with this name already exists!"
 msgstr "Un nom d'hôte avec ce nom existe déjà."
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -697,6 +700,12 @@ msgstr "Annuellement"
 #, fuzzy
 msgid "Applications"
 msgstr "actes"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5424,6 +5433,12 @@ msgstr "Association Image"
 msgid "Role added!"
 msgstr "Nom de l'imprimante"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "mise à jour de l'imprimante a échoué!"
@@ -5431,6 +5446,9 @@ msgstr "mise à jour de l'imprimante a échoué!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Imprimante mis à jour!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -6999,6 +7017,10 @@ msgstr "Impossible d'ouvrir le fichier pour la lecture"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Impossible de mettre à jour la tâche"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6646,6 +6646,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Ce paramètre définit "
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "Type de tâche n'est pas valide"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3776,6 +3776,9 @@ msgstr "Dernière version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Événement doit être une chaîne"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3619,6 +3619,9 @@ msgstr "Ultima versione"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "Livello deve essere una stringa"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6349,6 +6349,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "L'impostazione \"nodo master\" definisce quale"
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "Tipo di attività non è valido"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -222,6 +222,9 @@ msgstr "Esiste già un ruolo con questo nome!"
 msgid "A role with this name already exists!"
 msgstr "Un nome host con questo nome esiste già"
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -666,6 +669,12 @@ msgstr "Annualmente"
 
 msgid "Applications"
 msgstr "Applicazioni"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 msgid "Approve"
 msgstr "Approva"
@@ -5193,6 +5202,12 @@ msgstr "Associazione Sito"
 msgid "Role added!"
 msgstr "Stampante aggiunta"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "Aggiornamento della stampante non è riuscito!"
@@ -5200,6 +5215,9 @@ msgstr "Aggiornamento della stampante non è riuscito!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "aggiornato stampante!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -6690,6 +6708,10 @@ msgstr "Impossibile aprire il file per la lettura"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Impossibile aggiornare compito"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Impossibile aprire il file per la lettura"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -213,6 +213,10 @@ msgstr "この名前のロールは既に存在します！"
 msgid "A role with this name already exists!"
 msgstr "その名前のホストは既に存在します"
 
+#, fuzzy
+msgid "A selected role no longer exists"
+msgstr "選択したプリンターを追加"
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -653,6 +657,12 @@ msgstr "毎年"
 
 msgid "Applications"
 msgstr "アプリケーション"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 msgid "Approve"
 msgstr "承認"
@@ -5146,11 +5156,20 @@ msgstr "ルールの関連付け"
 msgid "Role added!"
 msgstr "ロールを追加しました！"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 msgid "Role update failed!"
 msgstr "ロールの更新に失敗しました！"
 
 msgid "Role updated!"
 msgstr "ロールを更新しました！"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 #, fuzzy
 msgid "Roles"
@@ -6623,6 +6642,10 @@ msgid "Unable to remove protected items"
 msgstr ""
 
 #, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "更新できません"
+
+#, fuzzy
 msgid "Unable to set action field"
 msgstr "更新できません"
 
@@ -8027,9 +8050,6 @@ msgstr ""
 #, php-format
 #~ msgid "Add new rule"
 #~ msgstr "新しいルールを追加"
-
-#~ msgid "Add selected printers"
-#~ msgstr "選択したプリンターを追加"
 
 #~ msgid "Add selected rules"
 #~ msgstr "選択したルールを追加"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6291,6 +6291,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "「マスターノード」設定は、どのノードを"
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 msgid "The current user is invalid."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3580,6 +3580,10 @@ msgstr "最新バージョン"
 msgid "Leave a field blank to keep each host's current value."
 msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
 
+#, fuzzy
+msgid "Leave blank to keep the current password"
+msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
+
 msgid "Level must be an integer"
 msgstr "レベルは整数である必要があります"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3167,6 +3167,9 @@ msgstr ""
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5596,6 +5596,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr ""
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 msgid "The current user is invalid."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -184,6 +184,9 @@ msgstr ""
 msgid "A role with this name already exists!"
 msgstr ""
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -571,6 +574,12 @@ msgid "Annually"
 msgstr ""
 
 msgid "Applications"
+msgstr ""
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
 msgstr ""
 
 msgid "Approve"
@@ -4575,10 +4584,19 @@ msgstr ""
 msgid "Role added!"
 msgstr ""
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 msgid "Role update failed!"
 msgstr ""
 
 msgid "Role updated!"
+msgstr ""
+
+msgid "Role when group matching is off"
 msgstr ""
 
 msgid "Roles"
@@ -5894,6 +5912,9 @@ msgid "Unable to open file for reading"
 msgstr ""
 
 msgid "Unable to remove protected items"
+msgstr ""
+
+msgid "Unable to set LDAP role mapping."
 msgstr ""
 
 msgid "Unable to set action field"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -231,6 +231,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "A role with this name already exists!"
 msgstr "Um nome de host com esse nome já existe."
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -696,6 +699,12 @@ msgstr "Anualmente"
 #, fuzzy
 msgid "Applications"
 msgstr "Ações"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5421,6 +5430,12 @@ msgstr "Associação imagem"
 msgid "Role added!"
 msgstr "Nome da impressora"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "atualização da impressora falhou!"
@@ -5428,6 +5443,9 @@ msgstr "atualização da impressora falhou!"
 #, fuzzy
 msgid "Role updated!"
 msgstr "Impressora atualizado!"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -6995,6 +7013,10 @@ msgstr "Não é possível abrir arquivo para leitura"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "Falha ao atualizar tarefa"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "Não é possível abrir arquivo para leitura"
 
 #, fuzzy
 msgid "Unable to set action field"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3775,6 +3775,9 @@ msgstr "Última versão"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Evento deve ser uma string"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6643,6 +6643,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Esta configuração define "
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "tipo de tarefa não é válido"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6639,6 +6639,11 @@ msgstr ""
 msgid "The 'Is Master Node' setting defines which"
 msgstr "此设置定义"
 
+msgid ""
+"The FOG schema update must be run before this plugin can be updated: "
+"users.uAuthSource does not exist yet."
+msgstr ""
+
 #, fuzzy
 msgid "The current user is invalid."
 msgstr "任务类型无效"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3773,6 +3773,9 @@ msgstr "最新版本"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave blank to keep the current password"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "事件必须是字符串"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -231,6 +231,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "A role with this name already exists!"
 msgstr "使用此名称的主机名已经存在。"
 
+msgid "A selected role no longer exists"
+msgstr ""
+
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
@@ -696,6 +699,12 @@ msgstr "每年"
 #, fuzzy
 msgid "Applications"
 msgstr "操作"
+
+msgid ""
+"Applies to LDAP servers that have group matching disabled. On those servers "
+"FOG cannot tell an administrator from any other account, so every user who "
+"can authenticate against the directory receives this role."
+msgstr ""
 
 #, fuzzy
 msgid "Approve"
@@ -5417,6 +5426,12 @@ msgstr "图像协会"
 msgid "Role added!"
 msgstr "打印机名称"
 
+msgid "Role for LDAP admin group"
+msgstr ""
+
+msgid "Role for LDAP user group"
+msgstr ""
+
 #, fuzzy
 msgid "Role update failed!"
 msgstr "打印机更新失败！"
@@ -5424,6 +5439,9 @@ msgstr "打印机更新失败！"
 #, fuzzy
 msgid "Role updated!"
 msgstr "打印机更新！"
+
+msgid "Role when group matching is off"
+msgstr ""
 
 msgid "Roles"
 msgstr ""
@@ -6986,6 +7004,10 @@ msgstr "无法打开文件进行读取"
 #, fuzzy
 msgid "Unable to remove protected items"
 msgstr "无法更新任务"
+
+#, fuzzy
+msgid "Unable to set LDAP role mapping."
+msgstr "无法打开文件进行读取"
 
 #, fuzzy
 msgid "Unable to set action field"


### PR DESCRIPTION
## What this is

The LDAP plugin was never updated when native RBAC landed. `Authorization::getPermissions()` treats "no role rows at all" as an implicit administrator — a deliberate choice so upgrades cannot lock anyone out — and the LDAP plugin has *always* created its users with no role rows. That was harmless before RBAC, because `uType` carried the privilege tier. Afterwards, nothing reads `uType` for authorization, so **every LDAP-authenticated user silently became a full administrator in both the UI and the API**.

With `lsUseGroupMatch` off (the shipped default) `LDAP::authLDAP()` returns access level 2 for anyone who can bind, so on a stock configuration that was every account in the directory.

## What changed

| # | Commit | |
|---|---|---|
| 1 | `2ac798ca1` | `users.uAuthSource` + resolver denies role-less external identities |
| 2 | `96bfdd6fd` | `authenticated` flag on `USER_LOGGING_IN`; stop storing directory passwords |
| 3 | `282d3ce1c` | Three admin-chosen role mappings + settings UI |
| 4 | `a73267ede` | Login assigns the mapped role; three hook registrations retired |
| 5 | `ef2b314c7` | Backfill existing shadow rows; stop hiding LDAP users |
| 6 | `88b20dbea` | Stop handing out the LDAP bind password |
| 7 | `caea14f19` | Enforce Allow API on the basic-auth branch |

Provenance lives in core (`uAuthSource`) rather than keying on the plugin's `uType` 990/991 sentinels, because `uType` is a shared generic field: admin-editable at runtime via `FOG_PLUGIN_LDAP_USER_FILTER`, writable over the API and CSV import, and a second auth plugin would have to invent its own magic numbers and hope they never collide.

The no-group-match outcome is a **configurable role** rather than a hardcoded constant, defaulting to Technician. Anyone who wants the old behaviour sets one dropdown instead of patching a constant.

## Deploy order

1. **Core schema update first** (adds `uAuthSource`, `FOG_SCHEMA` 313 → 314).
2. **Then the LDAP plugin update** (seeds settings, backfills shadow rows).

Reversed, the plugin update refuses with an explanatory error rather than silently no-opping — `uAuthSource` would not exist and PDODB does not throw on query errors.

## Local accounts

No behaviour change. `authenticated` stays false, `uAuthSource` is `''`, and the `password_verify()` path is untouched. The implicit-administrator fallback still applies to local users; changing that is separate, still-open work.

## Verification

```sql
SELECT uName, uType, uAuthSource FROM users WHERE uAuthSource = 'ldap';
SELECT ruaRoleID, ruaUserID FROM roleUserAssoc
 WHERE ruaUserID IN (SELECT uId FROM users WHERE uAuthSource = 'ldap');
```

- LDAP admin-group user: holds the mapped Administrator role, `uPass` is not a hash of their directory password.
- LDAP user-group user: holds Technician, no Users/Roles/Settings menu, `GET /fog/user` returns 403.
- Log out and back in: role is re-asserted, the row is **not** destroyed.
- LDAP users now appear in User Management (they were hidden before).
- View Source on the LDAP edit page contains no password.

## Status

Lint-verified against a real PHP 7.4 container (not just `php -l` on 8.x — PHP-8-only syntax lints clean on 8 and dies at runtime as a blank 500). **Not runtime-verified**; that is what this merge is for.

## Not included

Core authorization work that this investigation surfaced but which is separate: moving the admin/grant guards into the ORM chokepoints (`effectiveAdminExists()` still has zero callers), closing the plugin API fail-open, and flipping the local implicit-admin default to deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s