### PR TITLE
RBAC hardening: standing lockout guards, no API fail-open, deny-by-default

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -256,6 +256,19 @@ The example ships three hooks:
 - **API** (`AddHelloWorldAPI`) — `API_VALID_CLASSES` exposes the node over REST
   so `/fog/helloworld` reuses the same ORM as the UI.
 
+> **Name API classes after your permission node.** Access to a REST class is
+> resolved to `<node>.<action>` by matching the class name against the nodes
+> registered through `PERMISSION_REGISTRY_DATA`. A class is claimed by a node
+> when it either *is* the node (`site`) or *starts with* the node and ends in
+> `association` (`sitehostassociation`) — the same shape core uses for
+> `groupassociation` → `group`. Longest match wins.
+>
+> A class no node claims is restricted to administrators and logs a line
+> naming it. That is deliberate: an unmapped class used to be readable and
+> writable by **any** authenticated user regardless of role. If your endpoint
+> is admin-only when you did not intend it to be, check the log and rename the
+> class (or register the node) rather than working around it.
+
 ### 4.6 JavaScript — `js/fog.helloworld.*.js`
 
 One file per sub‑page (`list`, `add`, `edit`), each an IIFE. The **list** file
@@ -370,7 +383,7 @@ Global configuration lives in the `globalSettings` table.
 | `SEARCH_PAGES` | make the node searchable |
 | `PAGES_WITH_OBJECTS` | enable the object (edit/delete) flow for the node |
 | `PAGE_JS_FILES` | inject JS files for the current page |
-| `API_VALID_CLASSES` | expose the node over the REST API |
+| `API_VALID_CLASSES` | expose the node over the REST API (name classes after your permission node — see §4.5) |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
 

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4393,8 +4393,8 @@ $this->schema[] = [
     // Permissions granted to roles. rpName holds '<node>.<action>'
     // (e.g. 'host.edit'), a node wildcard ('host.*'), or the global
     // wildcard '*'. A user's permissions are the union across all
-    // assigned roles; users with no role at all remain implicit
-    // administrators (see the Authorization class).
+    // assigned roles; access is deny-by-default, so a user with no role
+    // holds nothing (see the Authorization class).
     "CREATE TABLE IF NOT EXISTS `rolePermissions` ("
     . "`rpID` INT NOT NULL AUTO_INCREMENT,"
     . "`rpRoleID` INT NOT NULL,"

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4649,3 +4649,74 @@ $this->schema[] = [
     . "10.0.0.0/8,192.168.5.20. Leave empty to allow any source, which is the "
     . "default and matches the behaviour of earlier versions.','','Security')",
 ];
+// 316
+$this->schema[] = [
+    // Materialise the implicit-administrator fallback into real roles, so
+    // that fallback can be removed.
+    //
+    // Authorization::getPermissions() has treated "no role rows at all" as
+    // full access since RBAC landed, to keep an upgrade from locking
+    // everyone out before any role was assigned. That makes an accidental
+    // role deletion a silent promotion, and it is the reason a role-less
+    // account created by an auth plugin was an administrator. Removing it
+    // requires that every account which relies on it today first holds a
+    // role that says the same thing explicitly.
+    //
+    // uType is the only record of what these accounts were: 0 was an
+    // administrator, 1 the mobile tier whose UI was deleted in 2017.
+    "INSERT IGNORE INTO `roles` "
+    . "(`rName`,`rDesc`,`rCreatedBy`,`rCreatedTime`) "
+    . "VALUES ('Legacy Restricted','Pre-1.6 restricted (mobile) tier: "
+    . "deploy and monitor only','fog',NOW())",
+    // Deliberately not the seeded Technician role: Technician carries
+    // host.* and group.*, which is strictly broader than the old mobile
+    // tier could ever do. This grants what that tier actually had -- see
+    // and task hosts and images, watch tasks, read reports -- and nothing
+    // that edits or deletes.
+    "INSERT IGNORE INTO `rolePermissions` (`rpRoleID`,`rpName`) "
+    . "SELECT `r`.`rID`, `p`.`n` FROM `roles` `r` JOIN ("
+    . "SELECT 'host.view' AS `n` "
+    . "UNION ALL SELECT 'host.task' "
+    . "UNION ALL SELECT 'image.view' "
+    . "UNION ALL SELECT 'image.task' "
+    . "UNION ALL SELECT 'task.view' "
+    . "UNION ALL SELECT 'task.task' "
+    . "UNION ALL SELECT 'report.view'"
+    . ") `p` WHERE `r`.`rName` = 'Legacy Restricted'",
+    // Only accounts that hold no role at all, directly or through a group,
+    // are touched: those are exactly the ones relying on the fallback.
+    // Anyone already carrying a role has been deliberately scoped and must
+    // not be promoted.
+    //
+    // Externally sourced accounts are excluded. Their provenance stamp
+    // already denies them by default and their provider assigns their role
+    // at login; backfilling them from uType would hand every LDAP account
+    // the administrator role that the previous release removed.
+    //
+    // The role-less tests go through derived tables rather than a plain
+    // subquery on roleUserAssoc because MySQL refuses to read the insert
+    // target directly (ER_UPDATE_TABLE_USED); a derived table materialises
+    // first and is allowed.
+    "INSERT IGNORE INTO `roleUserAssoc` (`ruaRoleID`,`ruaUserID`) "
+    . "SELECT `r`.`rID`, `u`.`uId` FROM `users` `u` "
+    . "JOIN `roles` `r` ON `r`.`rName` = 'Administrator' "
+    . "WHERE `u`.`uType` = 0 AND `u`.`uAuthSource` = '' "
+    . "AND `u`.`uId` NOT IN ("
+    . "SELECT `d`.`uid` FROM (SELECT DISTINCT `ruaUserID` AS `uid` "
+    . "FROM `roleUserAssoc`) `d`) "
+    . "AND `u`.`uId` NOT IN ("
+    . "SELECT `g`.`uid` FROM (SELECT DISTINCT `gm`.`ugmUserID` AS `uid` "
+    . "FROM `userGroupMembers` `gm` JOIN `roleUserGroupAssoc` `rg` "
+    . "ON `rg`.`rugGroupID` = `gm`.`ugmGroupID`) `g`)",
+    "INSERT IGNORE INTO `roleUserAssoc` (`ruaRoleID`,`ruaUserID`) "
+    . "SELECT `r`.`rID`, `u`.`uId` FROM `users` `u` "
+    . "JOIN `roles` `r` ON `r`.`rName` = 'Legacy Restricted' "
+    . "WHERE `u`.`uType` = 1 AND `u`.`uAuthSource` = '' "
+    . "AND `u`.`uId` NOT IN ("
+    . "SELECT `d`.`uid` FROM (SELECT DISTINCT `ruaUserID` AS `uid` "
+    . "FROM `roleUserAssoc`) `d`) "
+    . "AND `u`.`uId` NOT IN ("
+    . "SELECT `g`.`uid` FROM (SELECT DISTINCT `gm`.`ugmUserID` AS `uid` "
+    . "FROM `userGroupMembers` `gm` JOIN `roleUserGroupAssoc` `rg` "
+    . "ON `rg`.`rugGroupID` = `gm`.`ugmGroupID`) `g`)",
+];

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -898,6 +898,186 @@ class Authorization extends FOGBase
         return false;
     }
     /**
+     * Builds the adminExistsGiven() change map for deleting rows of an
+     * RBAC-relevant class, then refuses the delete if it would leave the
+     * install with no effective administrator.
+     *
+     * The guards used to live only in the three management pages, so every
+     * path that was not those pages -- the REST API, assocSetter()'s
+     * cascade, a plugin calling the ORM -- walked straight past them. Both
+     * delete paths in this codebase issue raw SQL (Route::deletemass() and
+     * FOGController::destroy() each build their own DELETE), so the guard
+     * has to sit on the operations rather than on a model method, which is
+     * what makes it a standing property rather than a UI courtesy.
+     *
+     * Unrecognised classes are not RBAC-relevant and pass through
+     * untouched.
+     *
+     * @param string $classname the model class being deleted from
+     * @param array  $ids       the ids of the rows being removed
+     *
+     * @throws Exception when no administrator would remain
+     * @return void
+     */
+    public static function assertAdminRemainsAfterDelete($classname, $ids)
+    {
+        $ids = array_values(
+            array_filter(array_map('intval', (array)$ids))
+        );
+        if (count($ids) < 1) {
+            return;
+        }
+        $changes = [];
+        switch (strtolower((string)$classname)) {
+            case 'user':
+                $changes = ['excludeUsers' => $ids];
+                break;
+            case 'role':
+                $changes = ['removeRoles' => $ids];
+                break;
+            case 'usergroup':
+                $changes = ['removeGroups' => $ids];
+                break;
+            case 'rolepermission':
+                $changes = [
+                    'rolePermissions' => self::_remaining(
+                        'rolepermission',
+                        $ids,
+                        'roleID',
+                        'name'
+                    )
+                ];
+                break;
+            case 'roleuserassociation':
+                $changes = [
+                    'userRoles' => self::_remaining(
+                        'roleuserassociation',
+                        $ids,
+                        'userID',
+                        'roleID'
+                    )
+                ];
+                break;
+            case 'roleusergroupassociation':
+                $changes = [
+                    'groupRoles' => self::_remaining(
+                        'roleusergroupassociation',
+                        $ids,
+                        'usergroupID',
+                        'roleID'
+                    )
+                ];
+                break;
+            case 'usergroupmember':
+                $changes = [
+                    'userGroups' => self::_remaining(
+                        'usergroupmember',
+                        $ids,
+                        'userID',
+                        'usergroupID'
+                    )
+                ];
+                break;
+            default:
+                return;
+        }
+        if (self::adminExistsGiven($changes)) {
+            return;
+        }
+        throw new Exception(
+            _('This would leave no account able to administer FOG.')
+        );
+    }
+    /**
+     * The state an association/permission table would be left in.
+     *
+     * adminExistsGiven() takes proposed FULL lists, not deltas, so for the
+     * rows being deleted we look up every owner they touch and return what
+     * that owner would still hold afterwards. Owners not named here are
+     * left alone by the simulation, which is why only the affected ones
+     * need computing.
+     *
+     * @param string $class   the association class
+     * @param array  $ids     the row ids being deleted
+     * @param string $ownerBy the field naming the owning entity
+     * @param string $valueBy the field holding the value being taken away
+     *
+     * @return array ownerID => [remaining values]
+     */
+    private static function _remaining($class, $ids, $ownerBy, $valueBy)
+    {
+        $owners = array_unique(
+            array_map(
+                'intval',
+                (array)Route::getIds($class, ['id' => $ids], $ownerBy)
+            )
+        );
+        $remaining = [];
+        foreach ($owners as $owner) {
+            $allIds = array_map(
+                'intval',
+                (array)Route::getIds($class, [$ownerBy => $owner], 'id')
+            );
+            $keptIds = array_values(array_diff($allIds, $ids));
+            $remaining[$owner] = (count($keptIds) < 1)
+                ? []
+                : array_values(
+                    (array)Route::getIds($class, ['id' => $keptIds], $valueBy)
+                );
+        }
+        return $remaining;
+    }
+    /**
+     * Refuses a permission grant that would be an escalation.
+     *
+     * A role permission row is a free-text string, so any caller able to
+     * create one could invent '*' and promote itself -- the role management
+     * page validated names against the registry, but the REST API reached
+     * the same table without passing through it.
+     *
+     * Two rules: the name has to be one the registry actually knows, and
+     * handing out the global wildcard requires already holding it. The
+     * second is what stops a role.create holder writing itself an
+     * administrator role.
+     *
+     * @param string $permName the permission string being granted
+     *
+     * @throws Exception when the grant is invalid or an escalation
+     * @return void
+     */
+    public static function assertCanGrant($permName)
+    {
+        $permName = trim((string)$permName);
+        if ('' === $permName) {
+            throw new Exception(_('A permission name is required.'));
+        }
+        if ('*' === $permName) {
+            if (!self::can('*')) {
+                throw new Exception(
+                    _('Only an administrator may grant full access.')
+                );
+            }
+            return;
+        }
+        $valid = ['*'];
+        foreach ((array)self::registry() as $node => $actions) {
+            $valid[] = $node;
+            $valid[] = $node . '.*';
+            foreach ((array)$actions as $action) {
+                $valid[] = $node . '.' . $action;
+            }
+        }
+        if (!in_array($permName, $valid, true)) {
+            throw new Exception(
+                sprintf(
+                    '%s: %s',
+                    _('Unknown permission'),
+                    $permName
+                )
+            );
+        }
+    }
+    /**
      * Reset the per-request caches (used after role/permission writes so
      * subsequent checks in the same request see the new state).
      *

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -17,10 +17,11 @@
  * a node wildcard ('host.*'), or the global wildcard '*'. A user's
  * permissions are the union across all roles assigned to them.
  *
- * Upgrade stance: a user with NO role at all is an implicit administrator
- * (full access). Deny only ever applies once a user has at least one role.
- * getPermissions() therefore distinguishes null (no roles = implicit
- * admin) from an empty array (roles granting nothing = deny).
+ * Access is deny-by-default: a user holds exactly what their roles grant,
+ * and an account with no role can do nothing. Earlier 1.6 betas treated
+ * "no role" as an implicit administrator so that adopting RBAC could not
+ * lock an install out; schema step 316 converted those accounts to
+ * explicit roles and the fallback was removed.
  *
  * @category Authorization
  * @package  FOGProject
@@ -206,7 +207,7 @@ class Authorization extends FOGBase
     ];
     /**
      * Per-user permission cache for this request.
-     * userID => array of permission strings, or null = implicit admin.
+     * userID => array of permission strings.
      *
      * @var array
      */
@@ -263,8 +264,7 @@ class Authorization extends FOGBase
      *
      * @param int $userID the user id (defaults to the current user)
      *
-     * @return array|null permission strings; null = user has no role at
-     *                    all and is an implicit administrator.
+     * @return array permission strings; empty = no access.
      */
     public static function getPermissions($userID = null)
     {
@@ -285,12 +285,12 @@ class Authorization extends FOGBase
             return self::$_permCache[$userID];
         }
         // Effective permissions are the union of roles assigned directly to
-        // the user and roles assigned to any group the user belongs to. A
-        // LEFT JOIN keeps a row for a role that grants zero permissions
-        // (rpName NULL) so having-a-role is distinguishable from having no
-        // role at all; the group arm's inner JOIN yields a row only once a
-        // role actually reaches the user through a group (a role-less group
-        // confers nothing and leaves the user unmanaged).
+        // the user and roles assigned to any group the user belongs to. The
+        // LEFT JOIN on rolePermissions keeps a row for a role that grants
+        // nothing (rpName NULL) rather than dropping the assignment; the
+        // group arm's inner JOIN yields a row only once a role actually
+        // reaches the user through a group, so a role-less group confers
+        // nothing. Either way an empty result means no access.
         $sql = 'SELECT `rpName` '
             . 'FROM `roleUserAssoc` '
             . 'LEFT JOIN `rolePermissions` ON `rpRoleID` = `ruaRoleID` '
@@ -310,27 +310,19 @@ class Authorization extends FOGBase
             ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         if (!is_array($rows) || count($rows) < 1) {
-            // Zero role assignments, direct or group-sourced.
+            // Zero role assignments, direct or group-sourced, grants
+            // nothing. This used to mean "implicit administrator" so that
+            // adopting RBAC could not lock an install out before any role
+            // was assigned; schema step 316 turned every account that
+            // relied on that into an explicit role, so the fallback has
+            // done its job and is gone.
             //
-            // For a LOCAL account this stays "implicit administrator", which
-            // is what keeps an upgrade from locking every existing user out
-            // before any role has been assigned.
-            //
-            // For an EXTERNALLY authenticated account it must not. An auth
-            // plugin creates its users on the fly at login, so a role-less
-            // externally sourced user is the normal case rather than the
-            // upgrade edge case the fallback was written for -- which made
-            // every LDAP-authenticated user a full administrator once RBAC
-            // landed. Deny instead: an external identity gets exactly the
-            // roles its provider mapped to it, and nothing by default.
-            //
-            // This is checked here, in the resolver, rather than at account
-            // creation, so it holds for every account with a provider stamp
-            // no matter how or when that account came to exist.
-            if ('' !== self::_authSource($userID)) {
-                return self::$_permCache[$userID] = [];
-            }
-            return self::$_permCache[$userID] = null;
+            // Deny is what makes the rest of the system trustworthy: while
+            // the fallback existed, removing a user's last role promoted
+            // them instead of restricting them, and every guard against
+            // that had to be remembered by each caller rather than being a
+            // property of the resolver.
+            return self::$_permCache[$userID] = [];
         }
         $perms = [];
         foreach ($rows as $row) {
@@ -342,43 +334,6 @@ class Authorization extends FOGBase
         return self::$_permCache[$userID] = array_values(
             array_unique($perms)
         );
-    }
-    /**
-     * The external provider that authenticates a user, '' when local.
-     *
-     * Read straight from the table rather than through the User model so a
-     * permission lookup cannot recurse back into a controller that may
-     * itself consult permissions. Only ever called on the zero-role path,
-     * so this costs nothing for the common case.
-     *
-     * @param int $userID the user id
-     *
-     * @return string
-     */
-    private static function _authSource($userID)
-    {
-        // The whole row, not the single column: this runs on every request
-        // that reaches the zero-role branch, including during the window
-        // between deploying this code and running the schema update, when
-        // `uAuthSource` does not exist yet. Naming the column in the SELECT
-        // would make that query fail and deny every user until the update
-        // ran -- and the update itself is reached through an authenticated
-        // page. Selecting the row degrades to "no such column, therefore
-        // local", which is exactly the pre-upgrade behaviour.
-        $row = self::$DB
-            ->query(
-                'SELECT * FROM `users` WHERE `uId` = :userid',
-                [],
-                ['userid' => (int)$userID]
-            )
-            ->fetch()
-            ->get();
-        // No row at all is a different matter: the id does not name a real
-        // user, so there is no provenance to trust and nothing to grant.
-        if (!is_array($row) || count($row) < 1) {
-            return 'unknown';
-        }
-        return trim((string)($row['uAuthSource'] ?? ''));
     }
     /**
      * Does the user hold the given permission?
@@ -395,9 +350,6 @@ class Authorization extends FOGBase
             return true;
         }
         $perms = self::getPermissions($userID);
-        if (null === $perms) {
-            return true;
-        }
         if (in_array('*', $perms, true)
             || in_array($perm, $perms, true)
         ) {
@@ -629,9 +581,8 @@ class Authorization extends FOGBase
         );
     }
     /**
-     * Is the user unrestricted by object scope? Implicit administrators
-     * (no role) and holders of the global '*' see every object; object
-     * boundaries never apply to them.
+     * Is the user unrestricted by object scope? Holders of the global '*'
+     * see every object; object boundaries never apply to them.
      *
      * @param int|null $userID the user id (defaults to current user)
      *
@@ -639,15 +590,11 @@ class Authorization extends FOGBase
      */
     private static function _isUnrestricted($userID = null)
     {
-        $perms = self::getPermissions($userID);
-        if (null === $perms) {
-            return true;
-        }
-        return in_array('*', $perms, true);
+        return in_array('*', self::getPermissions($userID), true);
     }
     /**
      * Public view of _isUnrestricted for scope-enforcing plugins (Site) that
-     * must let implicit admins / global '*' holders bypass list filtering.
+     * must let global '*' holders bypass list filtering.
      *
      * @param int|null $userID the user id (defaults to current user)
      *
@@ -667,7 +614,7 @@ class Authorization extends FOGBase
      * listener registered the boundary does not exist and every object is
      * in scope, so this is inert on a stock install.
      *
-     * Unrestricted users (implicit admin / global '*') and requests with
+     * Unrestricted users (global '*' holders) and requests with
      * no concrete single-object id (id < 1 — list, create, mass op) always
      * pass; scope is only meaningful for one existing object.
      *
@@ -774,9 +721,9 @@ class Authorization extends FOGBase
     }
     /**
      * Is there at least one effective administrator besides the excluded
-     * users? An effective administrator is a user with no role at all
-     * (implicit admin) or one holding the global '*' permission through
-     * any role. Used by the lockout guards in role/user management.
+     * users? An effective administrator is a user holding the global '*'
+     * permission through any role, directly or via a group. Used by the
+     * lockout guards in role/user management and by the delete guard.
      *
      * @param array $excludeUserIDs user ids to pretend do not exist
      *
@@ -804,8 +751,8 @@ class Authorization extends FOGBase
      *                         permission list of specific roles
      *                         (memberships unchanged).
      * - 'removeRoles'      => [roleID, ...] roles about to be deleted —
-     *                         their assocs vanish, so members may fall
-     *                         back to implicit admin.
+     *                         their assocs vanish, so members lose whatever
+     *                         those roles granted them.
      * - 'groupUsers'       => [groupID => [userID, ...]] proposed FULL
      *                         membership of specific groups.
      * - 'userGroups'       => [userID => [groupID, ...]] proposed FULL
@@ -815,9 +762,8 @@ class Authorization extends FOGBase
      * - 'removeGroups'     => [groupID, ...] groups about to be deleted —
      *                         their memberships and role assignments vanish.
      *
-     * A user is an effective administrator when they hold '*' — or no role
-     * at all — counting roles reached both directly and through any group
-     * they belong to.
+     * A user is an effective administrator when they hold '*', counting
+     * roles reached both directly and through any group they belong to.
      *
      * @param array $changes the proposed changes (see above)
      *
@@ -940,14 +886,11 @@ class Authorization extends FOGBase
                 );
             }
         }
-        $rolled = [];
-        foreach ($membership as $uids2) {
-            $rolled = array_merge($rolled, $uids2);
-        }
-        if (count(array_diff($users, $rolled))) {
-            // A role-less user remains: implicit administrator.
-            return true;
-        }
+        // A role-less user used to count as an implicit administrator here.
+        // With the fallback gone they have no access at all, so treating
+        // them as proof that someone can still administer FOG would make
+        // this guard answer "yes" precisely when an install has locked
+        // itself out. Only a real holder of '*' counts now.
         foreach ($starRoles as $rid) {
             if (count(array_intersect($membership[$rid] ?? [], $users))) {
                 return true;

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -544,13 +544,71 @@ class Authorization extends FOGBase
             return null;
         }
         $class = strtolower(trim((string)$class));
-        if (!isset(self::API_CLASS_ENTITIES[$class])) {
-            // Unknown model class (plugin-added): allow.
-            return null;
+        $entity = self::API_CLASS_ENTITIES[$class] ?? self::_pluginEntity($class);
+        if ('' === $entity) {
+            // A class nothing claims. Previously this returned null, which
+            // meant allow, so every plugin-added REST class was reachable
+            // by any authenticated user regardless of role -- a role
+            // granting nothing could still create and delete Site and
+            // Location objects.
+            //
+            // Deny by requiring a permission no role can be granted: the
+            // registry has no 'unmapped' node, so assertCanGrant() will not
+            // issue it and only a holder of '*' satisfies it. That keeps a
+            // third-party plugin working for administrators instead of
+            // breaking it outright, while restricted roles lose the free
+            // pass. The log line names the class so the fix is obvious.
+            error_log(
+                sprintf(
+                    '%s: %s. %s',
+                    _('API class is not mapped to a permission node'),
+                    $class,
+                    _('Only administrators may use it until the plugin '
+                        . 'registers a matching permission node.')
+                )
+            );
+            return 'unmapped.' . $class;
         }
-        return self::API_CLASS_ENTITIES[$class]
+        return $entity
             . '.'
             . self::API_ROUTE_ACTIONS[$routeName];
+    }
+    /**
+     * The permission node owning a plugin-added API class, '' if none.
+     *
+     * Plugins already declare their node in PERMISSION_REGISTRY_DATA and
+     * name their API classes after it -- either the node itself ('site') or
+     * the node followed by an association suffix ('sitehostassociation'),
+     * exactly as core does for 'groupassociation' => 'group'. Deriving the
+     * mapping from what plugins already register means no plugin has to be
+     * edited and no second registration can drift out of step with the
+     * first.
+     *
+     * Longest match wins, so a node cannot shadow a more specific one, and
+     * the association suffix is required rather than accepting any prefix
+     * -- without it a node like 'site' would claim any class merely
+     * starting with those letters.
+     *
+     * @param string $class the lowercased API class name
+     *
+     * @return string
+     */
+    private static function _pluginEntity($class)
+    {
+        $best = '';
+        foreach (array_keys((array)self::registry()) as $node) {
+            $node = strtolower((string)$node);
+            if ('' === $node || strlen($node) <= strlen($best)) {
+                continue;
+            }
+            if ($class === $node
+                || (0 === strpos($class, $node)
+                    && 'association' === substr($class, -11))
+            ) {
+                $best = $node;
+            }
+        }
+        return $best;
     }
     /**
      * Enforce a permission for an API request. Returns silently when

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -793,6 +793,20 @@ abstract class FOGController extends FOGBase
                     )
                 );
             }
+            // Lockout guard for the other delete path. Route::deletemass()
+            // covers the API and assocSetter()'s cascade; this covers a
+            // model destroyed directly. Both build their own DELETE, so
+            // neither can rely on the other. Only the by-id form is
+            // guarded: destroying by some other key is a bulk operation
+            // that goes through deletemass() in practice, and resolving
+            // arbitrary keys to ids here would cost a query on every
+            // destroy() in the system.
+            if ('id' === $key) {
+                Authorization::assertAdminRemainsAfterDelete(
+                    strtolower(get_class($this)),
+                    [$val]
+                );
+            }
             $column = $this->databaseFields[$key];
             $eColumn = sprintf(
                 '`%s`.`%s`',

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -223,6 +223,13 @@ class Role extends FOGController
         if (count($add ?: [])) {
             $insert_values = [];
             foreach ($add as $permission) {
+                // Rows are written with insertBatch rather than through
+                // RolePermission::save(), so the guard there does not see
+                // them -- this is the path PUT /fog/role/<id> takes. Only
+                // newly added strings are checked: a role may legitimately
+                // still hold a permission whose plugin has since been
+                // uninstalled, and re-saving it should not fail.
+                Authorization::assertCanGrant($permission);
                 $insert_values[] = [
                     $this->get('id'),
                     $permission

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -14,8 +14,9 @@
  * Role — native role-based access control.
  *
  * A role is a named set of permissions (see RolePermission) assigned to
- * users (see RoleUserAssociation). Users with no role at all are treated
- * as implicit administrators — see Authorization::getPermissions().
+ * users (see RoleUserAssociation) or to whole user groups (see
+ * RoleUserGroupAssociation). Access is deny-by-default: a user with no
+ * role can do nothing — see Authorization::getPermissions().
  *
  * The roles/roleUserAssoc tables are shared with (and adopted from) the
  * retired accesscontrol plugin, so plugin-era roles and user assignments
@@ -253,8 +254,9 @@ class Role extends FOGController
     {
         // Funnel cleanup through the cascade authority (the role case in
         // Route::deletemass removes the rolePermissions and roleUserAssoc
-        // rows). Members of a deleted role fall back to implicit-admin
-        // access, consistent with the no-role upgrade stance.
+        // rows). Members lose whatever this role granted them; the
+        // last-administrator guard in Route::deletemass is what keeps that
+        // from locking the install out.
         Route::deletemass('role', ['id' => $this->get('id')]);
         return parent::destroy($key);
     }

--- a/packages/web/lib/fog/rolepermission.class.php
+++ b/packages/web/lib/fog/rolepermission.class.php
@@ -60,4 +60,22 @@ class RolePermission extends FOGController
     {
         return new Role($this->get('roleID'));
     }
+    /**
+     * Stores the permission, refusing an invalid or escalating grant.
+     *
+     * The permission string is free text as far as the table is concerned,
+     * so anything able to write this row could invent '*' and promote
+     * itself. The role management page validated names against the
+     * registry before writing; the REST API reached the same table without
+     * doing so, which made role.create a self-grant path to full access.
+     * Validating here means every writer is covered rather than the one
+     * that remembered to ask.
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        Authorization::assertCanGrant($this->get('name'));
+        return parent::save();
+    }
 }

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2737');
+        define('FOG_VERSION', '1.6.0-beta.2738');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 315);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2738');
+        define('FOG_VERSION', '1.6.0-beta.2739');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 315);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2740');
+        define('FOG_VERSION', '1.6.0-beta.2741');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,9 +59,9 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2739');
+        define('FOG_VERSION', '1.6.0-beta.2740');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 315);
+        define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // FOG_BASE_DIR is intentionally hardcoded here. Deriving it from a setting would

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -106,6 +106,13 @@ class Route extends FOGBase
      *
      * @var array
      */
+    /**
+     * Recursion depth of deletemass(), so the lockout guard runs once per
+     * operation rather than once per cascaded table.
+     *
+     * @var int
+     */
+    private static $_deleteDepth = 0;
     public static $sensitiveFields = [
         'host' => [
             'ADPass',
@@ -3428,6 +3435,18 @@ class Route extends FOGBase
 
             self::ids($classname, $whereItems);
             $itemIDs = json_decode(Route::getData(), true);
+            // Lockout guard. Only at the outermost call: the cascade below
+            // re-enters deletemass() for each dependent table, and those
+            // intermediate states are part of one operation that has
+            // already been judged as a whole -- checking them individually
+            // would refuse deletes that are actually fine.
+            if (self::$_deleteDepth < 1) {
+                Authorization::assertAdminRemainsAfterDelete(
+                    $classname,
+                    $itemIDs
+                );
+            }
+            self::$_deleteDepth++;
             switch ($classname) {
                 case 'host':
                     $snapinjobIDs = ['jobID' => Route::getIds('snapinjob', ['hostID' => $itemIDs])];
@@ -3581,6 +3600,9 @@ class Route extends FOGBase
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
             );
+        } finally {
+            // max() because the guard above can throw before the increment.
+            self::$_deleteDepth = max(0, self::$_deleteDepth - 1);
         }
     }
     /**

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -8267,8 +8267,8 @@ msgid "there will be a database backup stored on your"
 msgstr "existiert ein Backup, gespeichert auf dem"
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -302,6 +302,9 @@ msgstr "Eine gültige Datenbankverbindung konnte nicht hergestellt werden"
 msgid "API"
 msgstr "API?"
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr "API?"
 
@@ -4698,6 +4701,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -211,6 +211,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "Ein Gruppenname ist erforderlich!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "muss angegeben werden"
 
@@ -4700,6 +4704,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Sie dürfen nur"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "Admingruppe"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6891,6 +6899,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
@@ -7096,6 +7107,10 @@ msgstr "Unbekannt"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -306,6 +306,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -4695,6 +4698,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Error, Is an image associated with this host"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -8254,8 +8254,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -216,6 +216,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "An image name is required!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "No image specified"
 
@@ -4697,6 +4701,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "You are only allowed to assign"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "Modify Group"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6883,6 +6891,9 @@ msgstr " | This is not the primary group"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -7088,6 +7099,10 @@ msgstr "Unknown"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Unknown upload error occurred.  Return code: "
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Unknown upload error occurred.  Return code: "
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -214,6 +214,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "Se requiere un nombre de imagen!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "No hay imagen especificada"
 
@@ -4813,6 +4817,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Sólo se le permite asignar"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "modificar Grupo"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -7034,6 +7042,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -7238,6 +7249,10 @@ msgstr "Desconocido"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Se produjo un error de carga desconocida. Código de retorno: "
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Se produjo un error de carga desconocida. Código de retorno: "
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8405,8 +8405,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -305,6 +305,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -4811,6 +4814,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Error, es una imagen asociada con este anfitrión"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -211,6 +211,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "Ein Gruppenname ist erforderlich!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "muss angegeben werden"
 
@@ -4701,6 +4705,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Sie dürfen nur"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "Admingruppe"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6892,6 +6900,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
@@ -7097,6 +7108,10 @@ msgstr "Unbekannt"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -302,6 +302,9 @@ msgstr "Eine gültige Datenbankverbindung konnte nicht hergestellt werden"
 msgid "API"
 msgstr "API?"
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr "API?"
 
@@ -4699,6 +4702,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8268,8 +8268,8 @@ msgid "there will be a database backup stored on your"
 msgstr "existiert ein Backup, gespeichert auf dem"
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -307,6 +307,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -4700,6 +4703,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Erreur, est une image associée à cet hôte"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -217,6 +217,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "Un nom de l'image est nécessaire!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "Aucune image spécifiée"
 
@@ -4702,6 +4706,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Vous êtes seulement autorisé à attribuer"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "Modifier Groupe"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6890,6 +6898,9 @@ msgstr " | Cela ne veut pas le groupe principal"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -7095,6 +7106,10 @@ msgstr "Inconnu"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -8262,8 +8262,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -293,6 +293,9 @@ msgstr "Non è possibile effettuare una connessione di database valida"
 msgid "API"
 msgstr "API?"
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr "API?"
 
@@ -4502,6 +4505,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Uno o più MAC sono associati a questo host"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 msgid "Only allowed to have"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -7886,8 +7886,8 @@ msgid "there will be a database backup stored on your"
 msgstr "Ci sarà un backup del database memorizzato sul tuo"
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -208,6 +208,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "È richiesto un nome di gruppo!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "deve essere specificato"
 
@@ -4503,6 +4507,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Permesso solo di avere"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "Gruppo amministrativo"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6586,6 +6594,9 @@ msgstr "Questo non è il gruppo primario"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr "Queste immagini devono essere attivate con le relative"
 
@@ -6784,6 +6795,10 @@ msgstr "Sconosciuto"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Si è verificato errore di caricamento sconosciuto"
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Si è verificato errore di caricamento sconosciuto"
 
 msgid "Unknown upload error occurred"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -200,6 +200,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr "\"name\" プロパティを使用する場合は、名前を定義する必要があります"
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "プリンター名は必須です！"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "指定する必要があります"
 
@@ -4464,6 +4468,9 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "使用できるのは次のみです"
 
+msgid "Only an administrator may grant full access."
+msgstr ""
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6522,6 +6529,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr "これらのイメージは関連付けられた"
 
@@ -6718,6 +6728,10 @@ msgid "Unknown"
 msgstr "不明"
 
 msgid "Unknown DB error"
+msgstr "不明なデータベースエラー"
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "不明なデータベースエラー"
 
 msgid "Unknown upload error occurred"
@@ -7961,9 +7975,6 @@ msgstr ""
 
 #~ msgid "A password is required!"
 #~ msgstr "パスワードは必須です！"
-
-#~ msgid "A printer name is required!"
-#~ msgstr "プリンター名は必須です！"
 
 #~ msgid "A rule already exists with this name"
 #~ msgstr "この名前のルールは既に存在します"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -282,6 +282,9 @@ msgstr "有効なデータベース接続を確立できませんでした"
 msgid "API"
 msgstr "API？"
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr "API？"
 
@@ -4463,6 +4466,11 @@ msgid "One or more macs are associated with a host"
 msgstr "1 つ以上の MAC アドレスがホストに関連付けられています"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 msgid "Only allowed to have"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -7812,8 +7812,8 @@ msgid "there will be a database backup stored on your"
 msgstr "データベースのバックアップが保存されます"
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6975,8 +6975,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -172,6 +172,9 @@ msgstr ""
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A permission name is required."
+msgstr ""
+
 msgid "A port must be specified"
 msgstr ""
 
@@ -3957,6 +3960,9 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr ""
 
+msgid "Only an administrator may grant full access."
+msgstr ""
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -5805,6 +5811,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -5977,6 +5986,9 @@ msgid "Unknown"
 msgstr ""
 
 msgid "Unknown DB error"
+msgstr ""
+
+msgid "Unknown permission"
 msgstr ""
 
 msgid "Unknown upload error occurred"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -244,6 +244,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -3955,6 +3958,11 @@ msgid "One or more macs are associated with a host"
 msgstr ""
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 msgid "Only allowed to have"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -306,6 +306,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -4699,6 +4702,11 @@ msgid "One or more macs are associated with a host"
 msgstr "Erro, é uma imagem associada com este anfitrião"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -8258,8 +8258,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -216,6 +216,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "Um nome de imagem é necessário!"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "Nenhuma imagem especificada"
 
@@ -4701,6 +4705,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "Você só está autorizado a transferir"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "modificar Grupo"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6886,6 +6894,9 @@ msgstr " | Este não é o grupo primário"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -7091,6 +7102,10 @@ msgstr "Desconhecido"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -306,6 +306,9 @@ msgstr ""
 msgid "API"
 msgstr ""
 
+msgid "API class is not mapped to a permission node"
+msgstr ""
+
 msgid "API?"
 msgstr ""
 
@@ -4695,6 +4698,11 @@ msgid "One or more macs are associated with a host"
 msgstr "错误，与此主机关联的图像"
 
 msgid "Online"
+msgstr ""
+
+msgid ""
+"Only administrators may use it until the plugin registers a matching "
+"permission node."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -216,6 +216,10 @@ msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
 #, fuzzy
+msgid "A permission name is required."
+msgstr "图像名是必需的！"
+
+#, fuzzy
 msgid "A port must be specified"
 msgstr "没有指定的图像"
 
@@ -4697,6 +4701,10 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr "您只能分配"
 
+#, fuzzy
+msgid "Only an administrator may grant full access."
+msgstr "修改组"
+
 msgid ""
 "Only snapins shared by every host in the group can be ordered here. Saving "
 "sets this order on each host (shared snapins run first, in this order; any "
@@ -6877,6 +6885,9 @@ msgstr "|这不是主要组"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG."
+msgstr ""
+
 msgid "Those images should be activated with the associated"
 msgstr ""
 
@@ -7082,6 +7093,10 @@ msgstr "未知"
 
 #, fuzzy
 msgid "Unknown DB error"
+msgstr "发生未知上传错误。返回代码："
+
+#, fuzzy
+msgid "Unknown permission"
 msgstr "发生未知上传错误。返回代码："
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -8245,8 +8245,8 @@ msgid "there will be a database backup stored on your"
 msgstr ""
 
 msgid ""
-"this account has no role and therefore has full administrator access. Assign "
-"it a role to limit its permissions."
+"this account has no role, so it has no access to any management page. Ask an "
+"administrator to assign it a role."
 msgstr ""
 
 msgid "this backup will enable you to return to the"

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -203,20 +203,23 @@ if (in_array(strtolower($pageLength), ['search', 'list'])) {
                 <?= FOGPage::makeInput('scrollMode', 'scrollMode', '', 'hidden', 'scrollMode', self::getSetting('FOG_TABLE_SCROLL_MODE')); ?>
                 <?= FOGPage::makeInput('showpass', 'showpass', '', 'hidden', 'showpass', self::getSetting('FOG_ENABLE_SHOW_PASSWORDS')); ?>
                 <?php
-        // No-role warning: a user with zero role assignments is an
-        // implicit administrator by design (upgrade stance). Warn
-        // them once roles are actually in use on this system.
+        // No-role warning: with deny-by-default a user holding zero roles
+        // can reach nothing but the exempt nodes (dashboard, logout), and
+        // every menu entry disappears -- which looks like a broken install
+        // rather than a permission state. Say so explicitly. The old
+        // "are roles in use anywhere?" guard is gone: it existed only to
+        // avoid nagging installs where no-role meant implicit admin, and
+        // no-role is now equally broken whether or not anyone else has a
+        // role.
         $showNoRoleBanner = self::$FOGUser
             && self::$FOGUser->isValid()
-            && null === Authorization::getPermissions()
-            && self::getClass('RoleUserAssociationManager')
-                ->distinct('userID') > 0;
+            && !count(Authorization::getPermissions());
 if ($showNoRoleBanner):
     ?>
                 <div class="container-fluid pt-3" id="no-role-banner">
                     <div class="alert alert-warning alert-dismissible fade show mb-0" role="alert">
                         <strong><?= _('No role assigned'); ?>:</strong>
-                        <?= _('this account has no role and therefore has full administrator access. Assign it a role to limit its permissions.'); ?>
+                        <?= _('this account has no role, so it has no access to any management page. Ask an administrator to assign it a role.'); ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<?= _('Close'); ?>"></button>
                     </div>
                 </div>


### PR DESCRIPTION
Follow-on to #871 (LDAP/RBAC). Three stories, each a separately revertable commit.

## `ef514f9bd` — Make the lockout and grant guards standing properties

- `Authorization::assertAdminRemainsAfterDelete()` — the delete path (`Route::deletemass`, `FOGController::destroy`) could remove the last user or role holding `*`. The guard now runs there rather than being remembered by each caller. Recursion-guarded via `Route::$_deleteDepth` so cascade deletes don't re-check.
- `Authorization::assertCanGrant()` — `rolePermissions.rpName` is free text, so anything able to write the row could invent `*` and self-promote. The role page validated; the REST API did not. Now enforced in `RolePermission::save()` **and** in `Role::_syncPermissions()`, which writes via `insertBatch` and bypasses the model.
- Basic-auth API requests now reload the user, reject unless `uAllowAPI`, and bind the identity so permission checks see a real user.
- `ldap.bindPwd` added to `Route::$sensitiveFields`.

## `515bc0869` — Stop plugin API classes failing open

`_apiPermission()` returned `null` (= no check) for any class missing from `API_CLASS_ENTITIES`, so every plugin-added API class was readable/writable by any authenticated user. Now unmapped classes resolve through `_pluginEntity()` (longest-match against registry nodes, requiring an exact match or an `*association` suffix) and otherwise return an unsatisfiable `unmapped.<class>` permission plus an `error_log` line. **Zero plugin edits required** — the mapping is derived from the class name and the permission registry the plugin already declares. Naming contract documented in `docs/plugin-development.md`.

## `4ddb79669` + `b6f40115b` — Materialise the fallback, then remove it

Schema step 316 converts every account that relied on the implicit-administrator fallback into an explicit role (`uType 0` → Administrator, `uType 1` → a new "Legacy Restricted" role: view/task on host, image, task + report.view). Only role-less, local (`uAuthSource = ''`) users are touched.

Then the fallback comes out. `getPermissions()` always returns an array; zero role rows means no access. `can()`, `_isUnrestricted()` and `adminExistsGiven()` lose their `null` special-cases; `_authSource()` is gone.

Recovery, since a mistake here is no longer self-healing: the guards above refuse any change leaving no holder of `*`, and `schema`/`login` remain in `EXEMPT_NODES` so the schema updater stays reachable by an account that can reach nothing else.

## Testing notes

`FOG_SCHEMA` is 316. Step 316's SQL was verified against a real MariaDB 11 instance (derived tables are used to avoid `ER_UPDATE_TABLE_USED` on the insert target). All changed PHP files lint clean under `php:7.4-cli`.

Worth exercising after deploy: log in as a user whose only role is Legacy Restricted; try to delete the last `*`-holding role (should refuse); hit a plugin API class as a non-admin (should 403); confirm the settings-page banner reads correctly for a role-less account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s