### PR TITLE
Explain the schema updater login prompt to a signed-in non-admin

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2741');
+        define('FOG_VERSION', '1.6.0-beta.2742');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -63,6 +63,33 @@ class SchemaUpdaterPage extends FOGPage
         // page.class.php already loads fog.login.js for any invalid user, so
         // the form is wired up, and it reloads ?node=schema on success.
         if (self::hasFogUsers() && !self::isSchemaAdmin()) {
+            // A non-admin who is already signed in gets bounced here by the
+            // same stale-schema redirect, and a bare "Sign in to start your
+            // session" under their own name in the sidebar reads as a broken
+            // page rather than a permission answer. Say what happened before
+            // showing the form -- the form still has to be here, because
+            // signing in as an administrator is the only way forward and
+            // there is no other reachable page to do it on.
+            if (self::$FOGUser && self::$FOGUser->isValid()) {
+                printf(
+                    '<div class="container-fluid pt-3">'
+                    . '<div class="alert alert-warning" role="alert">'
+                    . '<strong>%s</strong> %s</div></div>',
+                    Initiator::e(
+                        sprintf(
+                            _('Signed in as %s.'),
+                            self::$FOGUser->get('name')
+                        )
+                    ),
+                    Initiator::e(
+                        _(
+                            'Applying a database schema update requires an '
+                            . 'administrator account. Sign in as an '
+                            . 'administrator to continue.'
+                        )
+                    )
+                );
+            }
             ProcessLogin::mainLoginForm();
             return;
         }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -711,6 +711,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "freigeben"
@@ -5792,6 +5797,10 @@ msgid "Sign In"
 msgstr "Unterschrift"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -713,6 +713,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "Host approved"
@@ -5788,6 +5793,10 @@ msgid "Sign In"
 msgstr "Signed"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -724,6 +724,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "Creado"
@@ -5923,6 +5928,10 @@ msgid "Sign In"
 msgstr "Línea"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -711,6 +711,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "freigeben"
@@ -5793,6 +5798,10 @@ msgid "Sign In"
 msgstr "Unterschrift"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -714,6 +714,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "hôte approuvé"
@@ -5795,6 +5800,10 @@ msgid "Sign In"
 msgstr "Signé"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -683,6 +683,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 msgid "Approve"
 msgstr "Approva"
 
@@ -5551,6 +5556,10 @@ msgid "Sign In"
 msgstr "firmato"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -671,6 +671,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 msgid "Approve"
 msgstr "承認"
 
@@ -5508,6 +5513,10 @@ msgid "Sign In"
 msgstr "署名済み"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 msgid "Site"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -588,6 +588,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 msgid "Approve"
 msgstr ""
 
@@ -4888,6 +4893,10 @@ msgid "Sign In"
 msgstr ""
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 msgid "Site"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -713,6 +713,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "hospedar aprovado"
@@ -5792,6 +5797,10 @@ msgid "Sign In"
 msgstr "Assinado"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -713,6 +713,11 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
+msgid ""
+"Applying a database schema update requires an administrator account. Sign in "
+"as an administrator to continue."
+msgstr ""
+
 #, fuzzy
 msgid "Approve"
 msgstr "主机批准"
@@ -5788,6 +5793,10 @@ msgid "Sign In"
 msgstr "签"
 
 msgid "Sign in to start your session"
+msgstr ""
+
+#, php-format
+msgid "Signed in as %s."
 msgstr ""
 
 #, fuzzy


### PR DESCRIPTION
Follow-up to #872, found during live testing with an LDAP non-admin (`einstein`).

While the schema is stale, `DatabaseManager::establish()` redirects every request to `?node=schema` — so a signed-in **non**-administrator lands there too. The page then rendered a bare "Sign in to start your session" underneath their own username in the sidebar, which reads as a broken page rather than a permission answer.

Now it states the situation first ("Signed in as einstein. Applying a database schema update requires an administrator account…") and still shows the form, because signing in as an administrator is the only way forward and there is no other reachable page to do it on while the schema is stale.

Lints clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s