### PR TITLE
Let logout complete while the schema is stale

### DIFF
--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -121,7 +121,21 @@ class DatabaseManager extends FOGCore
          */
         $isLoginPost = (self::$reqmethod === 'POST'
             && filter_input(INPUT_GET, 'sub') === 'login');
-        if (!in_array($filename, $okayFiles) && !$isLoginPost) {
+        /**
+         * Logout must complete for the same reason, from the other side. The
+         * session is destroyed in management/index.php, which never runs
+         * because establish() redirects during boot -- so the Logout link on
+         * a stale-schema install did nothing, and whoever was signed in could
+         * not get back to the login form to sign in as someone who can apply
+         * the update. The idle-timeout redirect in User::isLoggedIn() lands on
+         * the same node and looped for the same reason.
+         *
+         * Nothing is granted by letting this through: logout() only clears
+         * cookies and session state, touches no table, and the redirect that
+         * follows it comes straight back here unauthenticated.
+         */
+        $isLogout = (filter_input(INPUT_GET, 'node') === 'logout');
+        if (!in_array($filename, $okayFiles) && !$isLoginPost && !$isLogout) {
             /**
              * If we are not already redirected to schema updater,
              * perform our redirect.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2742');
+        define('FOG_VERSION', '1.6.0-beta.2743');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);


### PR DESCRIPTION
Found alongside #873, same root cause from the other side.

`DatabaseManager::establish()` runs during boot and redirects every request to `?node=schema`. The session is destroyed in `management/index.php`, which therefore never executes — so on a stale-schema install the **Logout link did nothing**. Whoever was signed in could not get back to the login form to sign in as someone able to apply the update. `User::isLoggedIn()`'s idle-timeout redirect targets the same node and looped for the same reason.

Carved out alongside the existing login-POST exception, and for the same reason: the two routes that change *who you are* have to work, or an established install is stranded with a credential it can't use and no way to swap it.

Nothing is granted by allowing it — `User::logout()` only clears cookies and session state, writes to no table, and the redirect that follows comes straight back through this gate unauthenticated.

Lints clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s