### PR TITLE
Schema updater: send a signed-in non-admin through logout, not a dead login form

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2743');
+        define('FOG_VERSION', '1.6.0-beta.2744');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -64,17 +64,27 @@ class SchemaUpdaterPage extends FOGPage
         // the form is wired up, and it reloads ?node=schema on success.
         if (self::hasFogUsers() && !self::isSchemaAdmin()) {
             // A non-admin who is already signed in gets bounced here by the
-            // same stale-schema redirect, and a bare "Sign in to start your
-            // session" under their own name in the sidebar reads as a broken
-            // page rather than a permission answer. Say what happened before
-            // showing the form -- the form still has to be here, because
-            // signing in as an administrator is the only way forward and
-            // there is no other reachable page to do it on.
+            // same stale-schema redirect. They are shown the way out rather
+            // than a login form, because the form does not work for them:
+            // page.class.php only enqueues fog.login.js when the user is
+            // INVALID, so for a signed-in user nothing intercepts the submit,
+            // the browser posts natively, and loginPost() answers with
+            // Content-type: application/json -- a raw JSON blob on screen
+            // instead of a reloaded page.
+            //
+            // Sending them through logout is also the honest sequence: it
+            // ends the session that cannot do this, and the login form they
+            // land on afterwards is the wired one. Logout survives the
+            // stale-schema redirect for exactly this reason (see the
+            // carve-out in DatabaseManager::establish()).
             if (self::$FOGUser && self::$FOGUser->isValid()) {
                 printf(
                     '<div class="container-fluid pt-3">'
                     . '<div class="alert alert-warning" role="alert">'
-                    . '<strong>%s</strong> %s</div></div>',
+                    . '<p><strong>%s</strong> %s</p>'
+                    . '<a href="../management/index.php?node=logout" '
+                    . 'class="btn btn-primary">%s</a>'
+                    . '</div></div>',
                     Initiator::e(
                         sprintf(
                             _('Signed in as %s.'),
@@ -84,11 +94,12 @@ class SchemaUpdaterPage extends FOGPage
                     Initiator::e(
                         _(
                             'Applying a database schema update requires an '
-                            . 'administrator account. Sign in as an '
-                            . 'administrator to continue.'
+                            . 'administrator account.'
                         )
-                    )
+                    ),
+                    Initiator::e(_('Log out and sign in as an administrator'))
                 );
+                return;
             }
             ProcessLogin::mainLoginForm();
             return;

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -711,9 +711,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3936,6 +3934,9 @@ msgstr "Standorte"
 
 msgid "Log Viewer"
 msgstr "Log-Viewer"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "Anmeldung"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -713,9 +713,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3932,6 +3930,9 @@ msgstr "Locations"
 
 msgid "Log Viewer"
 msgstr "Log Viewer"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "Login"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -724,9 +724,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -4027,6 +4025,9 @@ msgstr "Acción"
 #, fuzzy
 msgid "Log Viewer"
 msgstr "FOG Visor de registro"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 #, fuzzy
 msgid "Login"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -711,9 +711,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3937,6 +3935,9 @@ msgstr "Standorte"
 
 msgid "Log Viewer"
 msgstr "Log-Viewer"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "Anmeldung"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -714,9 +714,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3936,6 +3934,9 @@ msgstr "Emplacements"
 
 msgid "Log Viewer"
 msgstr "Log Viewer"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "S'identifier"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -683,9 +683,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 msgid "Approve"
@@ -3763,6 +3761,9 @@ msgstr "sedi"
 
 msgid "Log Viewer"
 msgstr "Log Viewer"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "Accesso"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -671,9 +671,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 msgid "Approve"
@@ -3724,6 +3722,9 @@ msgstr "ロケーション"
 
 msgid "Log Viewer"
 msgstr "ログビューアー"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "ログイン"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -588,9 +588,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 msgid "Approve"
@@ -3300,6 +3298,9 @@ msgid "Locations"
 msgstr ""
 
 msgid "Log Viewer"
+msgstr ""
+
+msgid "Log out and sign in as an administrator"
 msgstr ""
 
 msgid "Login"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -713,9 +713,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3935,6 +3933,9 @@ msgstr "localizações"
 
 msgid "Log Viewer"
 msgstr "Visualizador de log"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "Entrar"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -713,9 +713,7 @@ msgid ""
 "can authenticate against the directory receives this role."
 msgstr ""
 
-msgid ""
-"Applying a database schema update requires an administrator account. Sign in "
-"as an administrator to continue."
+msgid "Applying a database schema update requires an administrator account."
 msgstr ""
 
 #, fuzzy
@@ -3933,6 +3931,9 @@ msgstr "位置"
 
 msgid "Log Viewer"
 msgstr "日志查看器"
+
+msgid "Log out and sign in as an administrator"
+msgstr ""
 
 msgid "Login"
 msgstr "登录"


### PR DESCRIPTION
Follow-up to #873. The login form that #873 left in place does not work for a user who is **already** signed in — and shouldn't, since it would mean two sign-ins on one browser session.

Mechanically: `page.class.php` only enqueues `fog.login.js` when the user is **invalid**. For a signed-in user nothing intercepts the submit, so the browser posts natively and `loginPost()` answers with `Content-type: application/json` — a raw JSON blob on screen instead of a reloaded page.

Offer the logout link instead. That's also the honest sequence: it ends the session that can't do this, and the login form landed on afterwards is the wired one. Logout survives the stale-schema redirect thanks to #874.

The unauthenticated case is unchanged and still renders the form directly.

Lints clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s