### PR TITLE
Schema updater: use alert-link so the logout control reads in dark mode

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2744');
+        define('FOG_VERSION', '1.6.0-beta.2745');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -79,11 +79,18 @@ class SchemaUpdaterPage extends FOGPage
             // carve-out in DatabaseManager::establish()).
             if (self::$FOGUser && self::$FOGUser->isValid()) {
                 printf(
+                    // alert-link, not btn-primary: a .btn inside a .alert
+                    // renders its label unreadably dark on the fill under the
+                    // dark theme. .alert-link is Bootstrap's own mechanism for
+                    // a link in this exact placement -- it takes its color
+                    // from --bs-alert-link-color, which the alert variant
+                    // defines per theme -- so it is legible in both without
+                    // this page having to know anything about the palette.
                     '<div class="container-fluid pt-3">'
                     . '<div class="alert alert-warning" role="alert">'
-                    . '<p><strong>%s</strong> %s</p>'
+                    . '<p class="mb-1"><strong>%s</strong> %s</p>'
                     . '<a href="../management/index.php?node=logout" '
-                    . 'class="btn btn-primary">%s</a>'
+                    . 'class="alert-link">%s</a>'
                     . '</div></div>',
                     Initiator::e(
                         sprintf(


### PR DESCRIPTION
Follow-up to #875. The `btn btn-primary` inside the `alert alert-warning` rendered its label unreadably dark on the blue fill under the dark theme (fine in light mode).

Switched to `.alert-link`, which is Bootstrap's own mechanism for a link in that exact placement — it takes its color from `--bs-alert-link-color`, which each alert variant defines per theme. Legible in both, and this page doesn't have to know anything about the palette.

Deliberately did **not** chase the underlying cascade: nothing in `fog-default-ui.scss` targets `.alert` colors and both vendored bundles set `.btn-primary{--bs-btn-color:#fff}`, so if `.btn-primary` labels are dark elsewhere in dark mode that's a separate theme bug worth its own fix rather than a reason to hand-patch one button.

Lints clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s