### PR TITLE
Fix the lockout guard: '*' permission collided with the query builder's wildcard

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -815,10 +815,29 @@ class Authorization extends FOGBase
         foreach ((array)$rows as $row) {
             $groupRoles[(int)$row['rugGroupID']][] = (int)$row['rugRoleID'];
         }
-        $starRoles = array_map(
-            'intval',
-            (array)Route::getIds('rolepermission', ['name' => '*'], 'roleID')
-        );
+        // Raw SQL, NOT Route::getIds(). The query builder treats '*' and '+'
+        // in a scalar filter value as user-facing wildcards: _buildSql()
+        // rewrites them to '%' and switches the comparison to LIKE, so
+        // ['name' => '*'] compiled to `rpName LIKE '%'` and matched EVERY
+        // permission row. This guard therefore saw every role that grants
+        // anything at all as a holder of the global '*', and answered "an
+        // administrator remains" for practically any deletion -- verified by
+        // deleting the only '*' role on a live install and locking it out.
+        // The RBAC permission string collides with the builder's own
+        // wildcard syntax, so the lookup has to bypass the builder.
+        $rows = self::$DB
+            ->query(
+                'SELECT DISTINCT `rpRoleID` FROM `rolePermissions` '
+                . 'WHERE `rpName` = :perm',
+                [],
+                ['perm' => '*']
+            )
+            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        $starRoles = [];
+        foreach ((array)$rows as $row) {
+            $starRoles[] = (int)$row['rpRoleID'];
+        }
         // Apply direct role<->user deltas.
         foreach ((array)($changes['roleUsers'] ?? []) as $rid => $uids) {
             $membership[(int)$rid] = array_map('intval', (array)$uids);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2745');
+        define('FOG_VERSION', '1.6.0-beta.2746');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);


### PR DESCRIPTION
**The lockout guard added in #872 never worked.** Found by live-testing it on a real install, which locked the install out.

`adminExistsGiven()` looked up who holds the global `*` permission via:

```php
Route::getIds('rolepermission', ['name' => '*'], 'roleID')
```

`Route::_buildSql()` (route.class.php:3708) treats `*` and `+` in a scalar filter value as user-facing wildcards — it rewrites them to `%` and switches the comparison to `LIKE`. So that compiled to `WHERE rpName LIKE '%'`, matching **every** permission row.

Verified against a live database:

| query | roleIDs returned |
|---|---|
| `WHERE rpName LIKE '%'` (what the guard saw) | 1, 2, 3, 4 |
| `WHERE rpName = '*'` (the truth) | 1 |

The guard therefore treated every role that grants anything at all as a `*` holder, and answered "an administrator remains" for practically any deletion. Deleting the only `*`-holding role was allowed by **both** call sites — `RoleManagement::_guardRoleRemoval()` and `Authorization::assertAdminRemainsAfterDelete()` — and locked the install out completely (`/role/list` → 403 for every user). Restored from a dump taken beforehand.

Fix: read the table directly with a bound parameter, the way `getPermissions()` already does. The RBAC permission string collides with the builder's own wildcard syntax, so this lookup can't go through the builder at all. It's the only such site — grepped.

**Enforcement was never affected.** `getPermissions()` has always used raw SQL, so restricted users were restricted correctly throughout; only the "is anyone still an admin?" question was answered wrongly.

Lints clean under `php:7.4-cli`.

**Follow-up worth its own issue:** any `Route::getIds()` filter whose *value* can legitimately contain `*` or `+` is silently a `LIKE`. That's a bug class, not just this one site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s