### PR TITLE
Confine the '*'/'+' wildcard rewrite to request-supplied filters

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -720,6 +720,43 @@ class Authorization extends FOGBase
         );
     }
     /**
+     * The ids of every role granting exactly this permission string.
+     *
+     * Reads the table directly rather than going through Route::getIds().
+     * Permission strings are the one kind of value that collides with the
+     * query builder's caller-facing wildcard syntax: '*' and '+' are what
+     * the RBAC grammar uses for "everything" and what the builder used to
+     * rewrite into a SQL '%'. Route::expandSearchWildcards() now confines
+     * that rewrite to request-supplied filters, but a permission lookup
+     * should not depend on that distinction holding -- it is the query
+     * whose wrong answer unlocks the install, so it owns its own SQL.
+     *
+     * Matches the exact string only. 'host.*' and '*' are DIFFERENT
+     * permissions here; wildcard semantics are applied when a permission is
+     * CHECKED (see can()), not when roles holding one are listed.
+     *
+     * @param string $permission the permission string, e.g. '*'
+     *
+     * @return array role ids
+     */
+    public static function rolesHolding($permission)
+    {
+        $rows = self::$DB
+            ->query(
+                'SELECT DISTINCT `rpRoleID` FROM `rolePermissions` '
+                . 'WHERE `rpName` = :perm',
+                [],
+                ['perm' => (string)$permission]
+            )
+            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        $roleIDs = [];
+        foreach ((array)$rows as $row) {
+            $roleIDs[] = (int)$row['rpRoleID'];
+        }
+        return $roleIDs;
+    }
+    /**
      * Is there at least one effective administrator besides the excluded
      * users? An effective administrator is a user holding the global '*'
      * permission through any role, directly or via a group. Used by the
@@ -815,29 +852,7 @@ class Authorization extends FOGBase
         foreach ((array)$rows as $row) {
             $groupRoles[(int)$row['rugGroupID']][] = (int)$row['rugRoleID'];
         }
-        // Raw SQL, NOT Route::getIds(). The query builder treats '*' and '+'
-        // in a scalar filter value as user-facing wildcards: _buildSql()
-        // rewrites them to '%' and switches the comparison to LIKE, so
-        // ['name' => '*'] compiled to `rpName LIKE '%'` and matched EVERY
-        // permission row. This guard therefore saw every role that grants
-        // anything at all as a holder of the global '*', and answered "an
-        // administrator remains" for practically any deletion -- verified by
-        // deleting the only '*' role on a live install and locking it out.
-        // The RBAC permission string collides with the builder's own
-        // wildcard syntax, so the lookup has to bypass the builder.
-        $rows = self::$DB
-            ->query(
-                'SELECT DISTINCT `rpRoleID` FROM `rolePermissions` '
-                . 'WHERE `rpName` = :perm',
-                [],
-                ['perm' => '*']
-            )
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
-            ->get();
-        $starRoles = [];
-        foreach ((array)$rows as $row) {
-            $starRoles[] = (int)$row['rpRoleID'];
-        }
+        $starRoles = self::rolesHolding('*');
         // Apply direct role<->user deltas.
         foreach ((array)($changes['roleUsers'] ?? []) as $rid => $uids) {
             $membership[(int)$rid] = array_map('intval', (array)$uids);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2746');
+        define('FOG_VERSION', '1.6.0-beta.2747');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -358,6 +358,11 @@ class Route extends FOGBase
     /**
      * Just ensures the where items are consistent for later use
      *
+     * A STRING argument is request-supplied (the `[*:whereItems]` URL
+     * segment), so its values get the caller-facing wildcard convenience --
+     * see expandSearchWildcards(). An ARRAY argument came from PHP code and
+     * is left exactly as passed, so a value is matched literally.
+     *
      * @param string|array $whereItems The test item.
      * @return array $whereItems The normalized structure
      */
@@ -372,6 +377,46 @@ class Route extends FOGBase
                     $whereItems[$key] = explode(',', $val);
                 }
             }
+            $whereItems = self::expandSearchWildcards($whereItems);
+        }
+        return $whereItems;
+    }
+    /**
+     * Turn the caller-facing wildcards '*' and '+' into the SQL '%'.
+     *
+     * This USED to live in _buildSql(), where it ran against every filter
+     * value including ones built in PHP -- so any internal lookup whose
+     * value could legitimately contain '*' or '+' silently became a LIKE
+     * against a wildcard. Authorization::adminExistsGiven() looked up the
+     * holders of the RBAC global permission with ['name' => '*'], which
+     * compiled to `rpName LIKE '%'` and matched every permission row; the
+     * lockout guard consequently believed an administrator always remained
+     * and let an install delete its last one.
+     *
+     * The convenience is real, but it belongs to values that came from the
+     * request -- a URL where-string or the JSON search body -- not to
+     * values assembled by code. Applying it at those two entry points
+     * instead of in the builder keeps the feature and removes the trap.
+     *
+     * _buildSql() still switches to LIKE when a value contains '%', so a
+     * caller that genuinely wants a pattern (the capone plugin looks up
+     * 'FOG_PLUGIN_CAPONE_%') passes one and is unaffected.
+     *
+     * @param array $whereItems the parsed filters
+     *
+     * @return array
+     */
+    public static function expandSearchWildcards($whereItems)
+    {
+        foreach ((array)$whereItems as $key => $val) {
+            if (is_array($val)) {
+                // Array values compile to IN (...) and were never wildcarded.
+                continue;
+            }
+            if (!is_string($val)) {
+                continue;
+            }
+            $whereItems[$key] = str_replace(['+', '*'], '%', $val);
         }
         return $whereItems;
     }
@@ -2584,7 +2629,10 @@ class Route extends FOGBase
                 unset($key);
             }
 
-            return $find;
+            // Request-supplied, so the caller-facing '*'/'+' wildcards apply
+            // here (they used to be expanded down in _buildSql, which also
+            // caught internally-built filters -- see expandSearchWildcards).
+            return self::expandSearchWildcards($find);
         } catch (Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
@@ -3705,12 +3753,16 @@ class Route extends FOGBase
                             $where .= ' IN (' . implode(',', $placeholders) . ')';
                         }
                     } else {
-                        $field = str_replace(
-                            ['+', '*'],
-                            '%',
-                            $field
-                        );
-                        $oper = false !== strpos($field, '%') ? 'LIKE' : '=';
+                        // No wildcard rewriting here. '*'/'+' are expanded at
+                        // the request-facing entry points only (see
+                        // expandSearchWildcards); a value assembled in PHP is
+                        // matched literally, so a permission string like '*'
+                        // or a path containing '+' cannot turn itself into a
+                        // LIKE that matches far more than the caller meant. A
+                        // caller wanting a pattern passes '%' explicitly.
+                        $oper = false !== strpos((string)$field, '%')
+                            ? 'LIKE'
+                            : '=';
                         if ($retWhere) {
                             $db = DatabaseManager::getLink();
                             $where .= ' ' . $oper . ' ' . $db->quote($field);


### PR DESCRIPTION
Fixes the **bug class** behind #877, plus the `Authorization::rolesHolding()` helper.

## The class

`Route::_buildSql()` rewrote `*` and `+` to `%` in every **scalar** filter value, then switched the comparison to `LIKE`. That's a caller-facing search convenience — but it ran against filters assembled in PHP too, so any internal lookup whose value could legitimately contain those characters silently became a pattern match.

I swept every entry point (`getIds`/`getCount`/`deletemass`/`ids`/`count`): **159 scalar-value filters**. Almost all are ids and flags and are safe, but these are values that can contain a `+`:

- `storagenode[path]`
- `plugin[name]`
- `role[name]` (LDAP plugin)

Array values take the `IN (...)` branch and were never affected.

## The fix

The convenience belongs to values that came from the **request**, so it moves to the two entry points that receive them:

- `handleWhereItems()` — only in the `is_string()` branch (the `[*:whereItems]` URL segment)
- `getsearchbody()` — the JSON search body

An array passed by PHP code is now left exactly as given. `_buildSql()` still selects `LIKE` when a value contains `%`, so a caller that genuinely wants a pattern passes one — the capone plugin looks up `'FOG_PLUGIN_CAPONE_%'` and is unaffected. `Route::search()` doesn't use this path at all (it resolves ids via `unisearch` first).

**Behaviour change worth knowing:** a programmatic filter that passed `*` or `+` and relied on the accidental `LIKE` now matches literally. Any such call was matching more rows than its author asked for.

## rolesHolding()

`Authorization::rolesHolding($perm)` reads `rolePermissions` directly with a bound parameter. `adminExistsGiven()` now calls it instead of carrying its own inline SQL. Permission strings are the one value type that collides with the builder's wildcard grammar, and this is the query whose wrong answer unlocks the install — so it owns its SQL rather than depending on the request/programmatic distinction holding forever.

Both files lint clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s