### PR TITLE
Fix 500 in the site REST filter for restricted users

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2747');
+        define('FOG_VERSION', '1.6.0-beta.2748');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/plugins/site/hooks/filtersitemassdata.hook.php
+++ b/packages/web/lib/plugins/site/hooks/filtersitemassdata.hook.php
@@ -95,11 +95,20 @@ class FilterSiteMassData extends Hook
         if (Authorization::isUnrestricted()) {
             return;
         }
-        $data = &$arguments['data'];
-        if (empty($data['data']) || !is_array($data['data'])) {
+        // Snapshot the envelope by value rather than working through a live
+        // reference to Route::$data. Site::filterInScope() below issues its
+        // own Route::getIds(), and getIds() finishes with `self::$data = ''`
+        // -- so the payload this hook is filtering was being blanked out from
+        // under it mid-method. Reading $data['data'] afterwards then hit
+        // "Cannot access offset of type string on string" and 500'd the
+        // request. Any restricted user listing a scoped class over REST hit
+        // this; it stayed hidden because that needs an API user who holds a
+        // non-'*' role, which nothing exercised until now.
+        $payload = $arguments['data'];
+        if (empty($payload['data']) || !is_array($payload['data'])) {
             return;
         }
-        $rows = $data['data'];
+        $rows = $payload['data'];
         $ids = [];
         foreach ($rows as $row) {
             $ids[] = (int)(
@@ -119,10 +128,16 @@ class FilterSiteMassData extends Hook
             }
         }
         if (count($kept) === count($rows)) {
+            // Nothing filtered, but Route::$data may still have been clobbered
+            // by the lookups above, so restore the snapshot before returning
+            // instead of leaving the caller with an empty payload.
+            $arguments['data'] = $payload;
             return;
         }
-        $data['data'] = array_values($kept);
-        $data['recordsFiltered'] = count($kept);
-        $data['recordsTotal'] = count($kept);
+        $payload['data'] = array_values($kept);
+        $payload['recordsFiltered'] = count($kept);
+        $payload['recordsTotal'] = count($kept);
+        // Single write-back through the reference the HookManager handed us.
+        $arguments['data'] = $payload;
     }
 }


### PR DESCRIPTION
Found while verifying the #872 API fail-open fix with a restricted API user.

`FilterSiteMassData::filterMassData()` held a live reference to `Route::$data`, then called `Site::filterInScope()` — which issues its own `Route::getIds()`. `getIds()` finishes with `self::$data = ''`, so **the payload being filtered was blanked out from under the hook mid-method**. The next read of `$data['data']` hit `Cannot access offset of type string on string` and 500'd.

```
PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string
  in .../lib/plugins/site/hooks/filtersitemassdata.hook.php:124
```

Every restricted user listing a scoped class (`host`, `user`, `group`, `usergroup`) over REST hit this. It stayed hidden because reproducing it needs an API user holding a **non-`*`** role — nothing exercised that until the RBAC work produced one. `GET /fog/host/list` as a Legacy Restricted API user 500s on the current build.

Fix: snapshot the envelope by value, mutate the copy, write back once through the reference at the end. The early "nothing was filtered" return now also restores the snapshot instead of leaving the caller holding whatever the inner lookups left behind.

The sibling hook (`ListSiteHosts`, the web AJAX path) re-lists and assigns `Route::getData()` as its last act, so it never reads through a stale reference — unaffected.

Lints clean under `php:7.4-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s