### PR TITLE
Make RBAC the authority for who may deploy a schema

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -353,6 +353,19 @@ abstract class FOGBase
      */
     public static $mySchema = 0;
     /**
+     * Schema step that backfilled roles onto every pre-RBAC local account.
+     *
+     * A database below this version predates RBAC: role assignments either do
+     * not exist yet or are incomplete, so permission checks there report "no
+     * access" for accounts that are in fact administrators. isSchemaAdmin()
+     * uses it to bound the legacy uType fallback to exactly that window. A
+     * fixed step number, not FOG_SCHEMA -- it must not follow future bumps,
+     * or the fallback would revive on every subsequent upgrade.
+     *
+     * @var int
+     */
+    const RBAC_ROLE_BACKFILL_SCHEMA = 316;
+    /**
      * Allows pages to include the main gui or not.
      *
      * @var bool
@@ -3663,6 +3676,32 @@ abstract class FOGBase
     public static function isSchemaAdmin()
     {
         if (!self::$FOGUser || !self::$FOGUser->isValid()) {
+            return false;
+        }
+        // RBAC is the authority. A schema deploy rewrites the whole database,
+        // so the global '*' holder -- and only the global '*' holder -- gets
+        // to drive one. No scoped role, however broad, qualifies.
+        if (Authorization::isUnrestricted()) {
+            return true;
+        }
+        // Legacy fallback, deliberately confined to the pre-RBAC upgrade
+        // window and nothing else.
+        //
+        // Schema step 316 is what gives every pre-existing local account an
+        // explicit role (uType 0 -> Administrator, uType 1 -> Legacy
+        // Restricted). Until it has run, roleUserAssoc either does not exist
+        // at all or holds no row for this user, so getPermissions() correctly
+        // resolves to nothing and the check above cannot succeed. Without
+        // this branch an administrator upgrading from any pre-RBAC release
+        // would find the schema updater -- the one page able to create the
+        // role tables in the first place -- permanently unreachable.
+        //
+        // Keyed on the installed schema version rather than probing for the
+        // tables so that it retires itself: the moment the deploy it enables
+        // finishes, mySchema is 316 and this branch is dead for good. uType
+        // is a migration input here, not a standing second opinion on who is
+        // an administrator.
+        if (self::$mySchema >= self::RBAC_ROLE_BACKFILL_SCHEMA) {
             return false;
         }
         // Resolve the type through USER_TYPE_HOOK, the same way ProcessLogin

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2748');
+        define('FOG_VERSION', '1.6.0-beta.2749');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);


### PR DESCRIPTION
`FOGBase::isSchemaAdmin()` gated schema deploys on `uType === 0`. Since RBAC landed that is a second — and sometimes contradicting — opinion on who is an administrator: the real answer is whether the account holds a role granting `*`, and a `uType 0` account stripped of every role could still rewrite the entire database.

It now asks `Authorization::isUnrestricted()`.

## The upgrade window

`uType` survives only as a *migration input*, bounded to databases below schema step 316 — the step that backfills roles onto pre-RBAC local accounts (`uType 0` → Administrator, `uType 1` → Legacy Restricted). Below that version `roleUserAssoc` is absent or incomplete, so permission checks legitimately resolve to nothing, and an administrator upgrading from any pre-RBAC release would find the schema updater — the one page able to create the role tables in the first place — permanently unreachable.

Keying the bound on the stored schema version rather than probing for the tables makes the fallback **self-retiring**: the moment the deploy it enables completes, `mySchema` is 316 and the branch is dead for good. It is not a standing second authority.

The bound is a fixed constant (`RBAC_ROLE_BACKFILL_SCHEMA = 316`), deliberately *not* `FOG_SCHEMA` — it must not follow future bumps, or the fallback would revive on every later upgrade.

## Safety on a pre-RBAC database

`getPermissions()` runs raw SQL against `roleUserAssoc`/`rolePermissions`. On a schema where those tables do not exist, `PDODB::query()` catches the `PDOException` and returns `$this` (`$throwOnQueryError` is `false` and nothing sets it), so the chain resolves to `null`, `getPermissions()` returns `[]`, and the fallback branch is reached rather than a 500.

## Verification

- `php -l` under a real `php:7.4-cli` container.
- Live install (schema 316, fallback inactive): the LDAP-sourced admin holds the Administrator role carrying `*` and still qualifies; the Technician-role user does not.

Follow-up, deliberately not in this PR: retiring `uType` entirely — re-keying the LDAP plugin's `uninstall()` and `FOG_PLUGIN_LDAP_USER_FILTER` to `uAuthSource`, converting `User::passwordValidate()`'s `$adminTest`, and removing the now-inert `USER_TYPES_FILTER` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s