### PR TITLE
Retire uType as an authority; add LDAPGroupMap (story 1 of #882)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -3345,11 +3345,14 @@ abstract class FOGBase
                 $user = self::$FOGUser->get('name');
             }
             $pass = filter_input(INPUT_POST, 'fogguipass');
+            // Re-authentication proves a human with valid credentials is
+            // present; it is not a second authorization step. Whether this
+            // deletion is allowed was already decided by the node's delete
+            // permission before we got here.
             $validate = self::getClass('User')
                 ->passwordValidate(
                     $user,
-                    $pass,
-                    true
+                    $pass
                 );
             if (!$validate) {
                 header('Content-type: application/json');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2750');
+        define('FOG_VERSION', '1.6.0-beta.2751');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2749');
+        define('FOG_VERSION', '1.6.0-beta.2750');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -85,17 +85,25 @@ class User extends FOGController
     /**
      * Validates the users password and user
      *
-     * @param string $username  the username to test
-     * @param string $password  the password to test
-     * @param string $adminTest the admin test
-     * @param bool   $remember  Are we remembering user?
+     * The $adminTest parameter is gone. It made the credential typed into
+     * the re-authentication prompt (FOG_REAUTH_ON_DELETE) have to belong to
+     * a uType 0 account -- pre-RBAC shorthand for "not a mobile user", back
+     * when FOG had exactly two tiers and the mobile one could not perform a
+     * destructive action anyway. Under roles the tiering is the role's job:
+     * the acting user has already had to pass the node's delete permission
+     * before checkauth() is reached, so re-testing an account type here
+     * decided nothing and would, if translated literally to "must hold '*'",
+     * have newly blocked every scoped role from deleting anything.
+     *
+     * @param string $username the username to test
+     * @param string $password the password to test
+     * @param bool   $remember Are we remembering user?
      *
      * @return bool
      */
     public function passwordValidate(
         $username,
         $password,
-        $adminTest = false,
         $remember = false
     ) {
         /**
@@ -188,11 +196,6 @@ class User extends FOGController
             ->set('password', '', true)
             ->set('type', $type);
         unset($tmpUser);
-        if ($adminTest === true) {
-            if ($this->get('type') > 0) {
-                $passValid = false;
-            }
-        }
         if ($remember && $passValid) {
             // Remember-me is per-user, carried by the foguserauth* cookies
             // and UserAuth token below. It must NOT touch the shared
@@ -253,7 +256,7 @@ class User extends FOGController
             self::PATTERN,
             $username
         );
-        if ($this->passwordValidate($username, $password, false, $remember)) {
+        if ($this->passwordValidate($username, $password, $remember)) {
             if (!$test) {
                 return new self(0);
             }

--- a/packages/web/lib/plugins/ldap/class/ldapgroupmap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapgroupmap.class.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * LDAP Authentication plugin
+ *
+ * PHP version 5
+ *
+ * @category LDAPGroupMap
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Maps one directory group to one FOG role or user group.
+ *
+ * Replaces the two fixed buckets a server used to have (lsAdminGroup and
+ * lsUserGroup, each pointing at one globally configured role). Those could
+ * only ever express "admin" and "not admin", which was the right shape when
+ * FOG itself had two tiers and is a dead end under roles: an organisation
+ * with Helpdesk, Imaging Techs and per-site admins cannot say so.
+ *
+ * Rows are scoped to a server on purpose -- a group name only means
+ * something relative to the directory it came from.
+ *
+ * Refs https://github.com/FOGProject/fogproject/issues/882
+ *
+ * @category LDAPGroupMap
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class LDAPGroupMap extends FOGController
+{
+    /**
+     * Target kinds. A role is the shortcut for the common case; a user
+     * group is the better answer, because the group holds the roles and
+     * core RBAC stays the single place policy is expressed.
+     */
+    const TARGET_ROLE = 'role';
+    const TARGET_USERGROUP = 'usergroup';
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'LDAPGroupMap';
+    /**
+     * The table fields.
+     *
+     * 'name' is the directory group name rather than a label of its own:
+     * it is what identifies the row to a human, and it keeps the generic
+     * list/render helpers that expect a 'name' working without inventing a
+     * second field nobody would fill in.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'lgmID',
+        'serverID' => 'lgmServerID',
+        'name' => 'lgmGroup',
+        'targetType' => 'lgmTargetType',
+        'targetID' => 'lgmTargetID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'serverID',
+        'name',
+        'targetType',
+        'targetID'
+    ];
+    /**
+     * The additional fields.
+     *
+     * @var array
+     */
+    protected $additionalFields = [
+        'ldapserver'
+    ];
+    /**
+     * Database -> Class field relationships
+     *
+     * Only the server is related here. The target cannot be, because which
+     * class it points at depends on targetType, and the relationship map
+     * is static.
+     *
+     * @var array
+     */
+    protected $databaseFieldClassRelationships = [
+        'LDAP' => [
+            'id',
+            'serverID',
+            'ldapserver'
+        ]
+    ];
+}

--- a/packages/web/lib/plugins/ldap/class/ldapgroupmapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapgroupmapmanager.class.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * LDAP Authentication plugin
+ *
+ * PHP version 5
+ *
+ * @category LDAPGroupMapManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Manager for the directory-group to role/user-group mappings.
+ *
+ * Refs https://github.com/FOGProject/fogproject/issues/882
+ *
+ * @category LDAPGroupMapManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class LDAPGroupMapManager extends FOGManagerController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    public $tablename = 'LDAPGroupMap';
+    /**
+     * Returns the CREATE TABLE (IF NOT EXISTS) statement for this table.
+     *
+     * Non-destructive and safe to re-run. Used as a step in
+     * LDAPManager::schema().
+     *
+     * The unique index across all four meaningful columns is what makes
+     * the migration below idempotent: re-running it can only INSERT IGNORE
+     * over rows that already exist. It also stops the same group being
+     * mapped to the same target twice, which would be invisible in the UI
+     * and would double nothing but confusion.
+     *
+     * lgmGroup is VARCHAR(255) rather than LONGTEXT (which is what
+     * lsAdminGroup/lsUserGroup used) because it has to be indexable, and
+     * one row now holds one group instead of a comma-separated list.
+     *
+     * @return string
+     */
+    public function createSql()
+    {
+        return Schema::createTable(
+            $this->tablename,
+            true,
+            [
+                'lgmID',
+                'lgmServerID',
+                'lgmGroup',
+                'lgmTargetType',
+                'lgmTargetID'
+            ],
+            [
+                'INTEGER',
+                'INTEGER',
+                'VARCHAR(255)',
+                "ENUM('role', 'usergroup')",
+                'INTEGER'
+            ],
+            [
+                false,
+                false,
+                false,
+                false,
+                false
+            ],
+            [
+                false,
+                false,
+                false,
+                "'role'",
+                false
+            ],
+            [
+                [
+                    'lgmServerID',
+                    'lgmGroup',
+                    'lgmTargetType',
+                    'lgmTargetID'
+                ]
+            ],
+            'InnoDB',
+            'utf8',
+            'lgmID',
+            'lgmID'
+        );
+    }
+    /**
+     * Installs the database non-destructively.
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return self::$DB->query($this->createSql());
+    }
+    /**
+     * Uninstalls plugin.
+     *
+     * @return void
+     */
+    public function uninstall()
+    {
+        return parent::uninstall();
+    }
+}

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -317,6 +317,88 @@ class LDAPManager extends FOGManagerController
         return true;
     }
     /**
+     * Turns each server's two group buckets into LDAPGroupMap rows.
+     *
+     * lsAdminGroup and lsUserGroup are already comma-separated lists of
+     * group names; what they lacked was any way to point different names
+     * at different roles. Every name in the admin list becomes a mapping
+     * to whatever FOG_PLUGIN_LDAP_ADMIN_ROLE names, and every name in the
+     * user list a mapping to FOG_PLUGIN_LDAP_USER_ROLE -- so this reshapes
+     * the data without changing anyone's access.
+     *
+     * Servers with group matching off are migrated too. Their group lists
+     * are inert while it stays off (nothing queries groups), but they are
+     * the admin's configuration and dropping them would lose work the
+     * moment they enabled matching.
+     *
+     * Idempotent: INSERT IGNORE against the unique index means re-running
+     * cannot duplicate a mapping, and an admin who has since deleted a
+     * mapping does not get it resurrected -- because the source columns
+     * are read as they are, and a second run inserts the same rows the
+     * first one did.
+     *
+     * Deliberately raw SQL rather than Route::getIds(): a directory group
+     * name can legitimately contain '+' (multi-valued RDNs) or '*', and
+     * Route's query builder rewrites both into a SQL wildcard, turning an
+     * exact lookup into a LIKE that matches far too much.
+     *
+     * Refs https://github.com/FOGProject/fogproject/issues/882
+     *
+     * @return bool
+     */
+    public function migrateGroupMappings()
+    {
+        $roleByColumn = [
+            'lsAdminGroup' => trim(
+                (string)self::getSetting('FOG_PLUGIN_LDAP_ADMIN_ROLE')
+            ),
+            'lsUserGroup' => trim(
+                (string)self::getSetting('FOG_PLUGIN_LDAP_USER_ROLE')
+            )
+        ];
+        $servers = self::$DB
+            ->query(
+                'SELECT `lsID`, `lsAdminGroup`, `lsUserGroup` '
+                . 'FROM `LDAPServers`'
+            )
+            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        foreach ((array)$servers as $server) {
+            foreach ($roleByColumn as $column => $roleId) {
+                if ('' === $roleId) {
+                    // No role configured for this bucket, so there is
+                    // nothing for the group names to map to. Leaving the
+                    // source column alone means the admin can set the
+                    // mapping up by hand later without having lost it.
+                    continue;
+                }
+                $groups = array_filter(
+                    array_map(
+                        'trim',
+                        explode(',', (string)($server[$column] ?? ''))
+                    ),
+                    'strlen'
+                );
+                foreach ($groups as $group) {
+                    self::$DB->query(
+                        'INSERT IGNORE INTO `LDAPGroupMap` '
+                        . '(`lgmServerID`, `lgmGroup`, `lgmTargetType`, '
+                        . '`lgmTargetID`) '
+                        . 'VALUES (:server, :group, :type, :target)',
+                        [],
+                        [
+                            'server' => (int)$server['lsID'],
+                            'group' => $group,
+                            'type' => LDAPGroupMap::TARGET_ROLE,
+                            'target' => (int)$roleId
+                        ]
+                    );
+                }
+            }
+        }
+        return true;
+    }
+    /**
      * The plugin's ordered, append-only schema migration list. Append new
      * steps (e.g. "ALTER TABLE `LDAPServers` ADD COLUMN ...") to the END.
      *
@@ -353,6 +435,14 @@ class LDAPManager extends FOGManagerController
             // effect.
             "DELETE FROM `globalSettings` "
             . "WHERE `settingKey` = 'FOG_PLUGIN_LDAP_USER_FILTER'",
+            // 5
+            function () {
+                return self::getClass('LDAPGroupMapManager')->install();
+            },
+            // 6
+            function () {
+                return $this->migrateGroupMappings();
+            },
         ];
     }
     /**
@@ -394,6 +484,7 @@ class LDAPManager extends FOGManagerController
                 ['id' => $userIDs]
             );
         }
+        self::getClass('LDAPGroupMapManager')->uninstall();
         return parent::uninstall();
     }
 }

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -171,12 +171,6 @@ class LDAPManager extends FOGManagerController
         ];
         $settings = [
             [
-                'FOG_PLUGIN_LDAP_USER_FILTER',
-                'Insert the filter type codes comma separated. Default: 990,991',
-                '990,991',
-                $category
-            ],
-            [
                 'FOG_PLUGIN_LDAP_PORTS',
                 'Allowed LDAP Ports as defined by user. Default: 389,636',
                 '389,636',
@@ -350,6 +344,15 @@ class LDAPManager extends FOGManagerController
             function () {
                 return $this->backfillIdentities();
             },
+            // 4
+            // FOG_PLUGIN_LDAP_USER_FILTER answered "which user rows does
+            // this plugin own?" with a list of uType sentinels. uAuthSource
+            // answers it directly, so the setting is gone from the UI and
+            // from seedSettings(); drop the stored row too rather than
+            // leave an orphan an admin can still find and edit to no
+            // effect.
+            "DELETE FROM `globalSettings` "
+            . "WHERE `settingKey` = 'FOG_PLUGIN_LDAP_USER_FILTER'",
         ];
     }
     /**
@@ -370,7 +373,13 @@ class LDAPManager extends FOGManagerController
      */
     public function uninstall()
     {
-        $find = ['type' => LDAPPluginHook::LDAP_TYPES];
+        // Which rows this plugin owns is the provenance stamp, not the old
+        // uType sentinels. Keying on uType meant uninstalling could only
+        // find rows written by this plugin's own past versions, and would
+        // happily delete a local account that had somehow been given a 990
+        // -- uType is a shared column anyone can write, including over the
+        // API and CSV import.
+        $find = ['authsource' => LDAPPluginHook::AUTH_SOURCE];
         $userIDs = Route::getIds(
             'user',
             $find

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -25,7 +25,11 @@
  */
 class LDAPPluginHook extends Hook
 {
-    const LDAP_TYPES = ['990', '991'];
+    /**
+     * Legacy uType sentinels. No longer written -- retained only to read
+     * rows created before provenance moved to uAuthSource: setLdapType()
+     * and LDAPManager::backfillIdentities().
+     */
     const LDAP_ADMIN = '990';
     const LDAP_MOBILE = '991';
     /**
@@ -43,12 +47,6 @@ class LDAPPluginHook extends Hook
     const TIER_NOMATCH = 1;
     const TIER_USER = 2;
     const TIER_ADMIN = 3;
-    /**
-     * The user types to filter
-     *
-     * @var array
-     */
-    private static $_userTypes = [];
     /**
      * The name of this hook.
      *
@@ -84,19 +82,15 @@ class LDAPPluginHook extends Hook
         if (!in_array($this->node, self::$pluginsinstalled)) {
             return;
         }
-        $userFilterTypes = self::getSetting('FOG_PLUGIN_LDAP_USER_FILTER');
-        $types = explode(',', $userFilterTypes);
-        foreach ($types as &$type) {
-            $type = trim($type);
-            if (!$type) {
-                continue;
-            }
-            self::$_userTypes[] = $type;
-            unset($type);
-        }
-        if (count(self::$_userTypes) < 1) {
-            self::$_userTypes = self::LDAP_TYPES;
-        }
+        // FOG_PLUGIN_LDAP_USER_FILTER is gone. It existed to answer "which
+        // existing user rows does this plugin own?" by listing the uType
+        // sentinels it wrote (990,991), which made the answer an
+        // admin-editable, API-writable list of magic numbers on a column
+        // shared with every other consumer of uType. uAuthSource answers
+        // the same question directly and cannot be confused with another
+        // provider's rows, so the setting has no job left -- see
+        // checkAddUser() and LDAPManager::uninstall().
+        //
         // USER_TYPES_FILTER, USER_TYPE_VALID and USER_LOGGING_OUT are no
         // longer registered. All three defended the pre-RBAC two-tier model
         // and under roles they combined into "an LDAP user can never hold a
@@ -132,20 +126,28 @@ class LDAPPluginHook extends Hook
     {
         $user = trim($arguments['username']);
         $pass = trim($arguments['password']);
-        $ldapTypes = self::$_userTypes;
         /**
-         * Check the user and validate the type is not
-         * our ldap inserted items. If not return as the
-         * user is already allowed.
+         * An existing row that this plugin does not own is left alone --
+         * a local account named the same as a directory account must not
+         * be hijacked into an LDAP login, and neither must a row belonging
+         * to some other auth provider.
+         *
+         * Ownership is the provenance stamp, not the uType sentinels this
+         * used to read. Rows created before the stamp existed are stamped
+         * by LDAPManager::backfillIdentities(), which runs from this
+         * plugin's own migration list -- so the two always ship together
+         * and a legacy row is never left unrecognised.
+         *
+         * A row that does not exist yet falls through, which is what
+         * creates the account on a directory user's first login.
          */
         $tmpUser = $arguments['user']
             ->set('name', $user)
             ->load('name');
-        if ($tmpUser->isValid()) {
-            $ldapType = $tmpUser->get('type');
-            if (!in_array($ldapType, $ldapTypes)) {
-                return;
-            }
+        if ($tmpUser->isValid()
+            && self::AUTH_SOURCE !== trim((string)$tmpUser->get('authsource'))
+        ) {
+            return;
         }
         /**
          * Create our new user (initially at least)
@@ -209,18 +211,15 @@ class LDAPPluginHook extends Hook
             !$tmpUser->isValid()
             || self::AUTH_SOURCE !== $tmpUser->get('authsource')
         );
-        // uType is kept as the marker identifying a row this plugin owns --
-        // uninstall() and FOG_PLUGIN_LDAP_USER_FILTER both key on it -- but
-        // it no longer decides anything. Authorization comes from the role
-        // assigned below; provenance comes from authsource.
+        // uType is no longer written. It carried two meanings at once --
+        // "this plugin owns the row" and "this account is an admin" -- and
+        // both have moved: provenance is authsource, authorization is the
+        // role assigned below. Writing a sentinel nothing reads would only
+        // invite something to start reading it again. Rows created before
+        // this change keep their 990/991; nothing consults it.
         $tmpUser
             ->set('name', $user)
             ->set('display', $displayName)
-            ->set('type', (
-                self::TIER_ADMIN === $bestTier ?
-                self::LDAP_ADMIN :
-                self::LDAP_MOBILE
-            ))
             ->set('api', $ldapAPI)
             ->set('authsource', self::AUTH_SOURCE);
         if ($needsPassword) {
@@ -299,7 +298,17 @@ class LDAPPluginHook extends Hook
         $userObj->set('roles', array_values(array_unique($roles)));
     }
     /**
-     * Sets our ldap types
+     * Maps this plugin's legacy uType sentinels back onto core's 0/1.
+     *
+     * Retained for exactly one caller: FOGBase::isSchemaAdmin()'s fallback
+     * for a database still below the schema step that backfills roles. On
+     * such an install a directory administrator's row predates both the
+     * role tables and the authsource stamp, and 990 is the only evidence
+     * of what the account was -- without this mapping that admin could not
+     * reach the schema updater to create the tables in the first place.
+     *
+     * Nothing writes 990/991 any more, and that fallback retires itself
+     * once the backfill runs, so this goes inert on its own.
      *
      * @param mixed $arguments the item to adjust
      *

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
@@ -1125,35 +1125,15 @@ class LDAPManagement extends FOGPage
     public function globalsettings()
     {
         $this->title = _('Editing Global LDAP Settings');
-        $find = [
-            'name' => [
-                'FOG_PLUGIN_LDAP_PORTS',
-                'FOG_PLUGIN_LDAP_USER_FILTER'
-            ]
-        ];
-        $settings = Route::getIds(
-            'setting',
-            $find,
-            'value'
-        );
-        list(
-            $ports,
-            $filters
-        ) = $settings;
-
         $port = (
             filter_input(INPUT_POST, 'port') ?:
-            $ports
+            self::getSetting('FOG_PLUGIN_LDAP_PORTS')
         );
 
-        $filter = (
-            filter_input(INPUT_POST, 'filter') ?:
-            $filters
-        );
-
-        // Role mapping. Read individually rather than through the batched
-        // $find above: that form returns values positionally, so a setting
-        // an admin has blanked out would shift every later value by one.
+        // Role mapping. Read one setting at a time rather than batching them
+        // into a single Route::getIds('setting', ...) call: that form returns
+        // values positionally, so a setting an admin has blanked out would
+        // shift every later value by one.
         $adminRole = (
             filter_input(INPUT_POST, 'adminrole') ?:
             self::getSetting('FOG_PLUGIN_LDAP_ADMIN_ROLE')
@@ -1181,19 +1161,6 @@ class LDAPManagement extends FOGPage
         $labelClass = 'col-sm-3 col-form-label';
 
         $fields = [
-            self::makeLabel(
-                $labelClass,
-                'filter',
-                _('LDAP User Filter')
-            ) => self::makeInput(
-                'form-control ldapuserfilter-input',
-                'filter',
-                '990,991',
-                'text',
-                'filter',
-                $filter,
-                true
-            ),
             self::makeLabel(
                 $labelClass,
                 'port',
@@ -1307,9 +1274,6 @@ class LDAPManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         header('Content-type: application/json');
-        $filter = trim(
-            filter_input(INPUT_POST, 'filter')
-        );
         $port = trim(
             filter_input(INPUT_POST, 'port')
         );
@@ -1321,18 +1285,6 @@ class LDAPManagement extends FOGPage
 
         $serverFault = false;
         try {
-            if (!$filter) {
-                throw new Exception(_('A filter must be specified'));
-            }
-            $filter = preg_replace('#\s+#', '', $filter);
-            $filters = explode(',', $filter);
-            foreach ($filters as &$filter) {
-                $filter = intval($filter);
-                if (!is_int($filter) || $filter < 2) {
-                    throw new Exception(_('All filters must be numeric and greater than 1'));
-                }
-                unset($filter);
-            }
             if (!$port) {
                 throw new Exception(_('A port must be specified'));
             }
@@ -1344,10 +1296,6 @@ class LDAPManagement extends FOGPage
                     throw new Exception(_('All ports must be numeric, greater than 0, and less than 65536'));
                 }
                 unset($port);
-            }
-            if (!self::setSetting('FOG_PLUGIN_LDAP_USER_FILTER', implode(',', $filters))) {
-                $serverFault = true;
-                throw new Exception(_('Unable to set user filter.'));
             }
             if (!self::setSetting('FOG_PLUGIN_LDAP_PORTS', implode(',', $ports))) {
                 $serverFault = true;

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -172,10 +172,6 @@ msgid "A filename is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "muss angegeben werden"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
 
@@ -625,10 +621,6 @@ msgstr "Rollentyp"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "Bandbreite sollte numerisch und größer als 0 sein."
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3750,10 +3742,6 @@ msgstr "LDAP-Server aktualisiert"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "LDAP-Server"
 
 msgid "Language"
@@ -7072,10 +7060,6 @@ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 msgid "Unable to set ldap ports."
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Datei kann zum Lesen nicht geöffnet werden"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8407,6 +8391,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "muss angegeben werden"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
@@ -8517,6 +8505,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "Bandbreite sollte numerisch und größer als 0 sein."
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8712,6 +8704,10 @@ msgstr ""
 #~ msgstr "Ungültiger Typ"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "LDAP-Server"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
@@ -8835,6 +8831,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Grundlegende Informationen nicht gefunden"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -177,10 +177,6 @@ msgid "A filename is required!"
 msgstr "An image name is required!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "No image specified"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "An image already exists with this name!"
 
@@ -629,10 +625,6 @@ msgstr "Module Type"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "Bandwidth should be numeric and greater than 0"
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3746,10 +3738,6 @@ msgstr "LDAP Server Name"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "LDAP Server"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "LDAP Server"
 
 msgid "Language"
@@ -7064,10 +7052,6 @@ msgstr "Unable to open file for reading"
 msgid "Unable to set ldap ports."
 msgstr "Unable to open file for reading"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Unable to open file for reading"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8394,6 +8378,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "No image specified"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "An image already exists with this name!"
 
@@ -8504,6 +8492,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Add snapin failed!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "Bandwidth should be numeric and greater than 0"
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8695,6 +8687,10 @@ msgstr ""
 #~ msgstr "Invalid type"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "LDAP Server"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Latest Version"
 
@@ -8818,6 +8814,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Unable to find basic information"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Unable to open file for reading"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -175,10 +175,6 @@ msgid "A filename is required!"
 msgstr "Se requiere un nombre de imagen!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "No hay imagen especificada"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
@@ -640,9 +636,6 @@ msgid "All Types"
 msgstr "Tipo de módulo"
 
 msgid "All files synced for this item"
-msgstr ""
-
-msgid "All filters must be numeric and greater than 1"
 msgstr ""
 
 msgid "All hosts must have the same image assigned"
@@ -3837,10 +3830,6 @@ msgstr "Impresora actualiza!"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "servidor TFTP"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "servidor TFTP"
 
 msgid "Language"
@@ -7213,10 +7202,6 @@ msgstr "No se puede abrir archivo para lectura"
 msgid "Unable to set ldap ports."
 msgstr "No se puede abrir archivo para lectura"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "No se puede abrir archivo para lectura"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8544,6 +8529,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "No hay imagen especificada"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Una imagen ya existe con este nombre!"
 
@@ -8856,6 +8845,10 @@ msgstr ""
 #~ msgstr "tipo no válido"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "servidor TFTP"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Versión del sistema"
 
@@ -8970,6 +8963,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "No se puede encontrar información básica"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "No se puede abrir archivo para lectura"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -172,10 +172,6 @@ msgid "A filename is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "muss angegeben werden"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
 
@@ -625,10 +621,6 @@ msgstr "Rollentyp"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "Bandbreite sollte numerisch und größer als 0 sein."
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3751,10 +3743,6 @@ msgstr "LDAP-Server aktualisiert"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "LDAP-Server"
 
 msgid "Language"
@@ -7073,10 +7061,6 @@ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 msgid "Unable to set ldap ports."
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Datei kann zum Lesen nicht geöffnet werden"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8408,6 +8392,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "muss angegeben werden"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
@@ -8518,6 +8506,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "Bandbreite sollte numerisch und größer als 0 sein."
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8713,6 +8705,10 @@ msgstr ""
 #~ msgstr "Ungültiger Typ"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "LDAP-Server"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
@@ -8836,6 +8832,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Grundlegende Informationen nicht gefunden"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -178,10 +178,6 @@ msgid "A filename is required!"
 msgstr "Un nom de l'image est nécessaire!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "Aucune image spécifiée"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
@@ -630,10 +626,6 @@ msgstr "Type de module"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "La bande passante doit être numérique et supérieur à 0"
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3750,10 +3742,6 @@ msgstr "Serveur LDAP Nom"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "Serveur LDAP"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "Serveur LDAP"
 
 msgid "Language"
@@ -7071,10 +7059,6 @@ msgstr "Impossible d'ouvrir le fichier pour la lecture"
 msgid "Unable to set ldap ports."
 msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Impossible d'ouvrir le fichier pour la lecture"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8402,6 +8386,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "Aucune image spécifiée"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Une image existe déjà avec ce nom!"
 
@@ -8512,6 +8500,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Ajouter SnapIn a échoué!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "La bande passante doit être numérique et supérieur à 0"
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8707,6 +8699,10 @@ msgstr ""
 #~ msgstr "Type non valide"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "Serveur LDAP"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Dernière version"
 
@@ -8830,6 +8826,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Impossible de trouver des informations de base"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -172,10 +172,6 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "È richiesto un nome di gruppo!"
 
-#, fuzzy
-msgid "A filter must be specified"
-msgstr "deve essere specificato"
-
 msgid "A group already exists with this name!"
 msgstr "Esiste già un gruppo con questo nome!"
 
@@ -602,10 +598,6 @@ msgstr "Tipo regola"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "Larghezza di banda deve essere numerico e maggiore di 0"
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3596,10 +3588,6 @@ msgstr "LDAP Server modificato!"
 
 msgid "LDAP Servers"
 msgstr "LDAP Servers"
-
-#, fuzzy
-msgid "LDAP User Filter"
-msgstr "Server LDAP"
 
 msgid "Language"
 msgstr "Lingua"
@@ -6762,10 +6750,6 @@ msgstr "Impossibile aprire il file per la lettura"
 msgid "Unable to set ldap ports."
 msgstr "Impossibile aprire il file per la lettura"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Impossibile aprire il file per la lettura"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8018,6 +8002,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "deve essere specificato"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Un host già esiste con questo nome!"
 
@@ -8125,6 +8113,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Aggiunta utente fallita!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "Larghezza di banda deve essere numerico e maggiore di 0"
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8315,6 +8307,10 @@ msgstr ""
 #~ msgid "Invalid Type"
 #~ msgstr "Tipo non valido"
 
+#, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "Server LDAP"
+
 #~ msgid "Latest SVN Version"
 #~ msgstr "Ultima versione di SVN"
 
@@ -8429,6 +8425,10 @@ msgstr ""
 
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Impossibile trovare informazioni di base!"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Impossibile aprire il file per la lettura"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -165,10 +165,6 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "名前は必須です！"
 
-#, fuzzy
-msgid "A filter must be specified"
-msgstr "指定する必要があります"
-
 msgid "A group already exists with this name!"
 msgstr "この名前のグループは既に存在します！"
 
@@ -589,10 +585,6 @@ msgstr "ルールタイプ"
 #, fuzzy
 msgid "All files synced for this item"
 msgstr "この項目のすべてのファイルが同期されました。"
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "帯域幅は 0 より大きい数値で指定してください"
 
 #, fuzzy
 msgid "All hosts must have the same image assigned"
@@ -3556,10 +3548,6 @@ msgstr "LDAP サーバーを更新しました！"
 
 msgid "LDAP Servers"
 msgstr "LDAP サーバー"
-
-#, fuzzy
-msgid "LDAP User Filter"
-msgstr "ユーザーフィルター"
 
 msgid "Language"
 msgstr "言語"
@@ -6694,10 +6682,6 @@ msgstr "更新できません"
 msgid "Unable to set ldap ports."
 msgstr "更新できません"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "サーバー情報を取得できません！"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -7973,6 +7957,10 @@ msgstr ""
 #~ msgid "A broadcast address is required"
 #~ msgstr "ブロードキャストアドレスは必須です"
 
+#, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "指定する必要があります"
+
 #~ msgid "A group is required for a location"
 #~ msgstr "ロケーションにはグループが必要です"
 
@@ -8121,6 +8109,10 @@ msgstr ""
 
 #~ msgid "All Pending MACs approved"
 #~ msgstr "保留中のすべての MAC アドレスを承認しました"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "帯域幅は 0 より大きい数値で指定してください"
 
 #~ msgid "All snapins"
 #~ msgstr "すべてのスナップイン"
@@ -8936,6 +8928,10 @@ msgstr ""
 
 #~ msgid "LDAP General"
 #~ msgstr "LDAP 全般"
+
+#, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "ユーザーフィルター"
 
 #~ msgid "Last Updated Time"
 #~ msgstr "最終更新時刻"
@@ -9838,6 +9834,10 @@ msgstr ""
 
 #~ msgid "Unable to find basic information!"
 #~ msgstr "基本情報が見つかりません！"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "サーバー情報を取得できません！"
 
 #~ msgid "Update General?"
 #~ msgstr "全般設定を更新しますか？"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -142,9 +142,6 @@ msgstr ""
 msgid "A filename is required!"
 msgstr ""
 
-msgid "A filter must be specified"
-msgstr ""
-
 msgid "A group already exists with this name!"
 msgstr ""
 
@@ -514,9 +511,6 @@ msgid "All Types"
 msgstr ""
 
 msgid "All files synced for this item"
-msgstr ""
-
-msgid "All filters must be numeric and greater than 1"
 msgstr ""
 
 msgid "All hosts must have the same image assigned"
@@ -3144,9 +3138,6 @@ msgid "LDAP Server updated!"
 msgstr ""
 
 msgid "LDAP Servers"
-msgstr ""
-
-msgid "LDAP User Filter"
 msgstr ""
 
 msgid "Language"
@@ -5959,9 +5950,6 @@ msgid "Unable to set dmi field"
 msgstr ""
 
 msgid "Unable to set ldap ports."
-msgstr ""
-
-msgid "Unable to set user filter."
 msgstr ""
 
 msgid "Unable to uninstall, no method exists for "

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -177,10 +177,6 @@ msgid "A filename is required!"
 msgstr "Um nome de imagem é necessário!"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "Nenhuma imagem especificada"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
@@ -629,10 +625,6 @@ msgstr "Tipo de módulo"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "A largura de banda deve ser numérico e maior do que 0"
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3749,10 +3741,6 @@ msgstr "Nome do servidor LDAP"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "Servidor LDAP"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "Servidor LDAP"
 
 msgid "Language"
@@ -7067,10 +7055,6 @@ msgstr "Não é possível abrir arquivo para leitura"
 msgid "Unable to set ldap ports."
 msgstr "Não é possível abrir arquivo para leitura"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "Não é possível abrir arquivo para leitura"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8398,6 +8382,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "Nenhuma imagem especificada"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "Uma imagem já existe com este nome!"
 
@@ -8508,6 +8496,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "Adicionar snap-in falhou!"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "A largura de banda deve ser numérico e maior do que 0"
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8703,6 +8695,10 @@ msgstr ""
 #~ msgstr "tipo inválido"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "Servidor LDAP"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Última versão"
 
@@ -8826,6 +8822,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Incapaz de encontrar informações básicas"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "Não é possível abrir arquivo para leitura"
 
 #, fuzzy
 #~ msgid "Update Master Node"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -177,10 +177,6 @@ msgid "A filename is required!"
 msgstr "图像名是必需的！"
 
 #, fuzzy
-msgid "A filter must be specified"
-msgstr "没有指定的图像"
-
-#, fuzzy
 msgid "A group already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
@@ -629,10 +625,6 @@ msgstr "模块类型"
 
 msgid "All files synced for this item"
 msgstr ""
-
-#, fuzzy
-msgid "All filters must be numeric and greater than 1"
-msgstr "带宽应该是数字和大于0"
 
 msgid "All hosts must have the same image assigned"
 msgstr ""
@@ -3747,10 +3739,6 @@ msgstr "LDAP服务器名称"
 
 #, fuzzy
 msgid "LDAP Servers"
-msgstr "LDAP服务器"
-
-#, fuzzy
-msgid "LDAP User Filter"
 msgstr "LDAP服务器"
 
 msgid "Language"
@@ -7058,10 +7046,6 @@ msgstr "无法打开文件进行读取"
 msgid "Unable to set ldap ports."
 msgstr "无法打开文件进行读取"
 
-#, fuzzy
-msgid "Unable to set user filter."
-msgstr "无法打开文件进行读取"
-
 msgid "Unable to uninstall, no method exists for "
 msgstr ""
 
@@ -8385,6 +8369,10 @@ msgid "{node}"
 msgstr ""
 
 #, fuzzy
+#~ msgid "A filter must be specified"
+#~ msgstr "没有指定的图像"
+
+#, fuzzy
 #~ msgid "A hostext already exists with this name!"
 #~ msgstr "图像已经存在具有此名称！"
 
@@ -8495,6 +8483,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add rule failed!"
 #~ msgstr "添加管理单元失败！"
+
+#, fuzzy
+#~ msgid "All filters must be numeric and greater than 1"
+#~ msgstr "带宽应该是数字和大于0"
 
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
@@ -8690,6 +8682,10 @@ msgstr ""
 #~ msgstr "无效类型"
 
 #, fuzzy
+#~ msgid "LDAP User Filter"
+#~ msgstr "LDAP服务器"
+
+#, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "最新版本"
 
@@ -8813,6 +8809,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Unable to find basic information!"
 #~ msgstr "无法找到基本信息"
+
+#, fuzzy
+#~ msgid "Unable to set user filter."
+#~ msgstr "无法打开文件进行读取"
 
 #, fuzzy
 #~ msgid "Update Master Node"


### PR DESCRIPTION
Two commits, reviewable separately.

---

## 1. Retire `uType` as an authority

`uType` carried two unrelated meanings on one shared, admin-editable, API-writable column: *"the LDAP plugin owns this row"* and *"this account is an administrator"*. Roles own the second (#872, #880) and `uAuthSource` owns the first (#871), so nothing needs to read `uType` to make a decision any more.

- **`checkAddUser()`** decides whether an existing row is this plugin's by its **authsource stamp** instead of the `990`/`991` sentinels. A local account sharing a directory account's name is still left alone, and so is a row belonging to another provider — but that can no longer be spoofed by writing `990` into a column anyone can set over the API or CSV import.
- **`uninstall()`** likewise, so it deletes what this plugin actually created rather than whatever currently carries a magic number.
- **Logins stop writing `990`/`991`.** Writing a sentinel nothing reads only invites something to start reading it again.
- **`FOG_PLUGIN_LDAP_USER_FILTER` removed.** Its only job was configuring which sentinels counted as "ours". Gone from the form and `seedSettings()`; a migration step drops the stored row rather than leaving an orphan an admin can still edit to no effect.

`setLdapType()` / `USER_TYPE_HOOK` **stay.** They now serve exactly one caller — `isSchemaAdmin()`'s fallback for a database below the role backfill — where `990` is the only surviving evidence that a directory account was an administrator, and without it that admin could not reach the schema updater to create the role tables. That fallback retires itself, so this does too.

### ⚠️ Access change, called out deliberately

`User::passwordValidate()`'s `$adminTest` parameter is **removed**, so `FOG_REAUTH_ON_DELETE` no longer requires the typed credential to belong to a `uType 0` account.

It was pre-RBAC shorthand for "not a mobile user", from when FOG had two tiers and the lower one could not perform a destructive action anyway. The acting user must already hold the node's **delete** permission before `checkauth()` runs, so it decided nothing — and translating it literally to "must hold `*`" would have **newly blocked every scoped role from deleting anything**. Every account that could satisfy the prompt before still can.

Pre-existing and *not* changed here: `checkauth()` accepts an arbitrary `fogguiuser`, so the prompt can be satisfied with someone else's credentials. That may well be intended (a supervisor approving a junior's delete). Worth a decision separately.

### Deliberately not done

- **Dropping the `users.uType` column.** The pre-backfill fallback still reads it, and it is exposed as `type` on the REST user endpoints — a separate breaking change, best made once the pre-RBAC upgrade path is behind us.
- **Removing the inert `USER_TYPES_FILTER` firings.** They are plugin integration points; LDAP simply stopped registering for them.

---

## 2. `LDAPGroupMap` — story 1 of #882

Shape only. Nothing reads the new table yet, so no login behaves differently.

An LDAP server could express exactly two things: an admin-group list and a user-group list, each pointing at one globally configured role. `LDAPGroupMap` holds **one directory group per row**, scoped to its server, targeting either a role or a user group.

The unique index across all four meaningful columns is load-bearing: it makes the migration idempotent and stops the same group being mapped to the same target twice.

**Migration reshapes without regrading anyone** — every name already in `lsAdminGroup` becomes a mapping to whatever `FOG_PLUGIN_LDAP_ADMIN_ROLE` names, every name in `lsUserGroup` to `FOG_PLUGIN_LDAP_USER_ROLE`. Both source columns stay: they are still what the plugin reads until story 2, and a half-migrated install must keep working.

Raw SQL rather than `Route::getIds()`, deliberately — a directory group name can legitimately contain `+` (multi-valued RDNs) or `*`, and Route's query builder rewrites both into a SQL wildcard. That is the same builder bug that defeated the RBAC lockout guard in #877.

---

## Verification

`php -l` on every touched file under a real `php:7.4-cli` container, and the generated `CREATE TABLE` rendered through the real `Schema::createTable()` to confirm it is valid SQL and the composite index is well inside InnoDB's limit.

Live pass needed on redeploy: LDAP login still works, a local account sharing a directory name still authenticates locally, a delete with `FOG_REAUTH_ON_DELETE` on, and the plugin update creating + populating `LDAPGroupMap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s