### PR TITLE
Fix API basic auth under FastCGI; map LDAP groups to roles and user groups (#882 stories 2-4)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2304,6 +2304,11 @@ EOF
                     echo "    fastcgi_index index.php;" >> "$phploc"
                     echo "    include fastcgi.conf;" >> "$phploc"
                     echo "    fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;" >> "$phploc"
+                    # The API supports HTTP basic auth, but nginx forwards
+                    # only the fastcgi_params whitelist and Authorization is
+                    # not on it, so PHP_AUTH_USER/PHP_AUTH_PW were never
+                    # populated and basic auth could not succeed.
+                    echo "    fastcgi_param HTTP_AUTHORIZATION \$http_authorization;" >> "$phploc"
                     echo "    fastcgi_buffers 16 16k;" >> "$phploc"
                     echo "    fastcgi_buffer_size 32k;" >> "$phploc"
                     echo "}" >> "$phploc"
@@ -2467,6 +2472,14 @@ EOF
                         echo "        SetHandler \"proxy:fcgi://127.0.0.1:9000/\"" >> "$etcconf"
                     fi
                     echo "    </FilesMatch>" >> "$etcconf"
+                    # The API supports HTTP basic auth, but proxy_fcgi drops
+                    # the Authorization header, so PHP_AUTH_USER/PHP_AUTH_PW
+                    # were never populated and basic auth could not succeed.
+                    # SetEnvIf is used in preference to CGIPassAuth because
+                    # CGIPassAuth needs httpd >= 2.4.13 and an unknown
+                    # directive stops Apache from starting at all; SetEnvIf
+                    # works on every 2.4 and is a no-op under mod_php.
+                    echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                     echo "    KeepAlive Off" >> "$etcconf"
                     echo "    ServerName $ipaddress" >> "$etcconf"
                     echo "    ServerAlias $hostname" >> "$etcconf"
@@ -2488,6 +2501,8 @@ EOF
                             echo "        SetHandler \"proxy:fcgi://127.0.0.1:9000/\"" >> "$etcconf"
                         fi
                         echo "    </FilesMatch>" >> "$etcconf"
+                        # Keeps API basic auth working; see the :80 vhost.
+                        echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                         echo "    ServerName $ipaddress" >> "$etcconf"
                         echo "    ServerAlias $hostname" >> "$etcconf"
                         echo "    DocumentRoot $docroot" >> "$etcconf"
@@ -2558,6 +2573,8 @@ EOF
                             echo "        SetHandler \"proxy:fcgi://127.0.0.1:9000/\"" >> "$etcconf"
                         fi
                         echo "    </FilesMatch>" >> "$etcconf"
+                        # Keeps API basic auth working; see the :80 vhost.
+                        echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                         echo "    ServerName $ipaddress" >> "$etcconf"
                         echo "    ServerAlias $hostname" >> "$etcconf"
                         echo "    DocumentRoot $docroot" >> "$etcconf"

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2752');
+        define('FOG_VERSION', '1.6.0-beta.2753');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.2751');
+        define('FOG_VERSION', '1.6.0-beta.2752');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 316);
         define('FOG_BCACHE_VER', 240);

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -548,12 +548,53 @@ class LDAP extends FOGController
         return $entries[0][$displayNameAttr][0];
     }
     /**
-     * Checks if the user/pass are valid
+     * Removes the server and the group mappings scoped to it.
      *
-     * @param string $user the username to validate
-     * @param string $pass the password to validate
+     * Mappings are per-server by design, so a mapping whose server is gone
+     * can never be read again. Deleting them keeps the table from
+     * accumulating rows nothing can reach, and stops a later server that
+     * happens to reuse this auto-increment id from inheriting them.
      *
-     * @return bool|int
+     * Refs https://github.com/FOGProject/fogproject/issues/882
+     *
+     * @param string $key the key to destroy on
+     *
+     * @return bool
+     */
+    public function destroy($key = 'id')
+    {
+        $id = (int)$this->get('id');
+        if ($id > 0) {
+            try {
+                self::$DB->query(
+                    'DELETE FROM `LDAPGroupMap` WHERE `lgmServerID` = :server',
+                    [],
+                    ['server' => $id]
+                );
+            } catch (Exception $e) {
+                error_log(
+                    sprintf(
+                        '%s %s() %s: %s',
+                        _('Plugin'),
+                        __METHOD__,
+                        _('Could not remove the group mappings'),
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+        return parent::destroy($key);
+    }
+    /**
+     * Authenticates the user against this server.
+     *
+     * @param string $user the username to authenticate
+     * @param string $pass the password to authenticate with
+     *
+     * @return array|bool the matched mapped group names, or false when the
+     *                    server grants this user nothing. An empty array
+     *                    means the credential bound but group matching is
+     *                    off, so there was nothing to match against.
      */
     public function authLDAP($user, $pass)
     {
@@ -930,68 +971,142 @@ class LDAP extends FOGController
          */
         $userDN = $entries[0]['dn'];
         /**
-         * If use group match is used, get access level,
-         * otherwise group scanning isn't used. Assume all
-         * are admins.
+         * The bind above already proved the identity. What is left is
+         * "which of this server's mapped groups is this user in?", which
+         * only means anything when group matching is switched on.
+         *
+         * With group matching off we cannot enumerate groups at all, so
+         * the empty array below is not "matched nothing" -- it is "there
+         * was nothing to match against". The caller separates the two by
+         * reading useGroupMatch, and gives that case the single configured
+         * fallback role (FOG_PLUGIN_LDAP_NOMATCH_ROLE).
          */
-        if ($useGroupMatch) {
-            $accessLevel = $this->_getAccessLevel($grpNamAttr, $grpMemAttr, $userDN, $user);
-        } else {
-            $accessLevel = 2;
+        if (!$useGroupMatch) {
+            @$this->unbind();
+            return [];
         }
+        $matched = $this->_getMatchedGroups(
+            $grpNamAttr,
+            $grpMemAttr,
+            $userDN,
+            $user
+        );
         /**
          * Close our connection
          */
         @$this->unbind();
-
         /**
-         * If access level is not changed
-         *
-         * @return bool
+         * Group matching is on and the user is in none of the mapped
+         * groups, so this server grants nothing. Denying here preserves
+         * the old accessLevel == 0 behaviour: a bind alone has never been
+         * enough when the server is configured to check groups.
          */
-        if ($accessLevel == 0) {
+        if (empty($matched)) {
             error_log(
                 sprintf(
                     '%s %s() %s. %s!',
                     _('Plugin'),
                     __METHOD__,
-                    _('Access level is still 0 or false'),
+                    _('User matched none of the mapped groups'),
                     _('No access is allowed')
                 )
             );
             return false;
         }
         /**
-         * Return the access level
+         * Return the group names that matched
          *
-         * @return int
+         * @return array
          */
-        return $accessLevel;
+        return $matched;
     }
     /**
-     * Get's the access level
+     * The directory group names mapped to something on this server.
+     *
+     * Read with raw bound SQL rather than Route::getIds() on purpose:
+     * _buildSql() rewrites '*' and '+' in a scalar filter value into a SQL
+     * LIKE wildcard, and both are legal in an LDAP group name -- '+'
+     * separates the components of a multi-valued RDN. A group called
+     * "Techs+Chicago" would otherwise silently match rows it must not.
+     *
+     * @return array the distinct group names, empty when none are mapped
+     */
+    private function _mappedGroupNames()
+    {
+        try {
+            $rows = self::$DB
+                ->query(
+                    'SELECT DISTINCT `lgmGroup` FROM `LDAPGroupMap` '
+                    . 'WHERE `lgmServerID` = :server',
+                    [],
+                    ['server' => (int)$this->get('id')]
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+        } catch (Exception $e) {
+            error_log(
+                sprintf(
+                    '%s %s() %s: %s',
+                    _('Plugin'),
+                    __METHOD__,
+                    _('Could not read the group mappings'),
+                    $e->getMessage()
+                )
+            );
+            return [];
+        }
+        /**
+         * PDODB reports a failed query as false rather than throwing
+         * (throwOnQueryError is off), and (array)false is [false], not [].
+         * Normalise before iterating or a missing table becomes a bogus
+         * row instead of no rows.
+         */
+        if (!is_array($rows)) {
+            return [];
+        }
+        $names = [];
+        foreach ((array)$rows as $row) {
+            $name = trim((string)($row['lgmGroup'] ?? ''));
+            if ('' !== $name) {
+                $names[] = $name;
+            }
+        }
+        return array_values(array_unique($names));
+    }
+    /**
+     * Which of this server's mapped groups the user belongs to.
+     *
+     * This replaces _getAccessLevel(), which answered the narrower
+     * question "is this user an admin, a plain user, or neither?" by
+     * running the same membership query twice -- once against the admin
+     * group list, once against the user group list -- and collapsing the
+     * answer to 2, 1 or 0. That shape could only ever express two tiers.
+     *
+     * Returning the matched names instead costs nothing: the old code
+     * already OR'd a comma-separated list of names into one filter, so
+     * asking for the group name attribute back turns two scalar queries
+     * into one that says which names matched. Everything above this is
+     * then free to treat membership as additive, the way RBAC does.
+     *
+     * Refs https://github.com/FOGProject/fogproject/issues/882
      *
      * @param string $grpNamAttr the group name item
      * @param string $grpMemAttr the group finder item
      * @param string $userDN     the user dn information
      * @param string $user       the actual username
      *
-     * @return int
+     * @return array the mapped group names the user is a member of
      */
-    private function _getAccessLevel($grpNamAttr, $grpMemAttr, $userDN, $user)
+    private function _getMatchedGroups($grpNamAttr, $grpMemAttr, $userDN, $user)
     {
+        $mapped = $this->_mappedGroupNames();
         /**
-         * Preset our access level value
+         * Nothing is mapped, so nothing can match. Bail before querying
+         * the directory rather than building a filter with an empty OR.
          */
-        $accessLevel = false;
-        /**
-         * Get our admin group
-         */
-        $adminGroup = $this->get('adminGroup');
-        /**
-         * Get our user group
-         */
-        $userGroup = $this->get('userGroup');
+        if (empty($mapped)) {
+            return [];
+        }
         /**
          * The user name attribute in use (e.g. uid=)
          */
@@ -1008,18 +1123,21 @@ class LDAP extends FOGController
         /**
          * Group filter layout should be consistent across
          * the board.
+         *
+         * Group names are escaped here where the two-bucket version did
+         * not escape them. They now come from an admin-editable table
+         * rather than a settings string, and an unescaped '*' or ')' in a
+         * name would otherwise alter the filter's meaning.
          */
         $grpNamAttr_forimplode = ')(' . $grpNamAttr . '=';
-        $grpMemAttr_forimplode = ')(' . $grpMemAttr . '=';
-        /**
-         * Setup our new filter
-         */
-        $adminGroups = explode(',', $adminGroup);
-        $adminGroups = array_map('trim', $adminGroups);
+        $escaped = [];
+        foreach ($mapped as $name) {
+            $escaped[] = $this->escape($name, null, LDAP_ESCAPE_FILTER);
+        }
         $filter = sprintf(
             '(&(|(%s=%s))(|(%s=%s)(%s=%s=%s)(%s=%s)))',
             $grpNamAttr,
-            implode($grpNamAttr_forimplode, (array)$adminGroups),
+            implode($grpNamAttr_forimplode, $escaped),
             $grpMemAttr,
             $this->escape($userDN, null, LDAP_ESCAPE_FILTER),
             $grpMemAttr,
@@ -1029,50 +1147,30 @@ class LDAP extends FOGController
             $this->escape($user, null, LDAP_ESCAPE_FILTER)
         );
         /**
-         * The attribute to get.
+         * Ask for the name back -- that is what turns "did anything match"
+         * into "which ones matched".
          */
-        $attr = [$grpMemAttr];
+        $attr = [$grpNamAttr, $grpMemAttr];
         /**
          * Read in the attributes
          */
         $result = $this->_result($grpSearchDN, $filter, $attr);
         if (false !== $result) {
-            return 2;
+            $matched = $this->_namesFromEntries(
+                $this->get_entries($result),
+                $grpNamAttr,
+                $mapped
+            );
+            if (!empty($matched)) {
+                return $matched;
+            }
         }
         /**
-         * If no record is returned then user is not in the
-         * admin group. Change the filter and check the mobile
-         * group for membership.
-         */
-        $userGroups = explode(',', $userGroup);
-        $userGroups = array_map('trim', $userGroups);
-        $filter = sprintf(
-            '(&(|(%s=%s))(|(%s=%s)(%s=%s=%s)(%s=%s)))',
-            $grpNamAttr,
-            implode($grpNamAttr_forimplode, (array)$userGroups),
-            $grpMemAttr,
-            $this->escape($userDN, null, LDAP_ESCAPE_FILTER),
-            $grpMemAttr,
-            $usrNamAttr,
-            $this->escape($user, null, LDAP_ESCAPE_FILTER),
-            $grpMemAttr,
-            $this->escape($user, null, LDAP_ESCAPE_FILTER)
-        );
-        /**
-         * The attribute to get.
-         */
-        $attr = [$grpMemAttr];
-        /**
-         * Execute the ldap query
-         */
-        $result = $this->_result($grpSearchDN, $filter, $attr);
-        /**
-         * If no record is returned then lets try the looping method
-         */
-        if (false !== $result) {
-            return 1;
-        }
-        /**
+         * The filter returned nothing usable, so fall back to the looping
+         * method. This path is kept because some directories do not answer
+         * the compound filter above -- it is the same fallback the
+         * two-bucket version had, generalised from two names to N.
+         *
          * Setup the generalized filter
          */
         $filter = sprintf(
@@ -1082,7 +1180,7 @@ class LDAP extends FOGController
         /**
          * The attribute to get.
          */
-        $attr = [$grpMemAttr];
+        $attr = [$grpNamAttr, $grpMemAttr];
         /**
          * Read in the attributes
          */
@@ -1102,7 +1200,7 @@ class LDAP extends FOGController
                 )
             );
             @$this->unbind();
-            return false;
+            return [];
         }
         /**
          * Get the entries found
@@ -1118,6 +1216,7 @@ class LDAP extends FOGController
         /**
          * Check groups for membership
          */
+        $matched = [];
         foreach ((array)$entries as $entry) {
             /**
              * If this cycle doesn't have the dn, skip it
@@ -1126,82 +1225,72 @@ class LDAP extends FOGController
                 continue;
             }
             /**
-             * Get the dn entry we need to test against
+             * Which mapped names this group's dn corresponds to. The
+             * substring test is what the two-bucket version used, kept so
+             * directories that name a group only in its DN still match.
              */
             $dn = $entry['dn'];
-            /**
-             * Get the users related to this dn
-             */
-            $users = $entry[$grpMemAttr];
-            /**
-             * Tests the presence of our admin group
-             */
-            $admin = false;
-            if ($adminGroup) {
-                $admin = strpos($dn, $adminGroup);
+            $hits = [];
+            foreach ($mapped as $name) {
+                if (false !== stripos($dn, $name)) {
+                    $hits[] = $name;
+                }
             }
-            /**
-             * Tests the presence of our mobile group
-             */
-            $user = false;
-            if ($userGroup) {
-                $user = strpos($dn, $userGroup);
-            }
-            /**
-             * If we can't find our relative dn
-             * set go back to top of loop.
-             */
-            if (false === $admin
-                && false === $user
-            ) {
+            if (empty($hits)) {
                 continue;
             }
             /**
-             * If the dn is in the admin scope
+             * Test if the user dn exists in this group. Unlike the tiered
+             * version there is no early break: every group the user is in
+             * contributes, because the targets are additive.
              */
-            if (false !== $admin) {
-                /**
-                 * Test if the user dn exists in this group
-                 */
-                $adm = preg_grep($pat, $users);
-                /**
-                 * Ensure we only return "filled" items
-                 */
-                $adm = array_filter($adm);
-                /**
-                 * If so, no need to move on, set access level and break loop
-                 */
-                if (count($adm) > 0) {
-                    $accessLevel = 2;
-                    break;
-                }
+            $users = $entry[$grpMemAttr] ?? [];
+            $found = array_filter(preg_grep($pat, (array)$users));
+            if (count($found) > 0) {
+                $matched = array_merge($matched, $hits);
             }
-            /**
-             * If the dn is in the mobile scope
-             */
-            if (false !== $user) {
+        }
+        return array_values(array_unique($matched));
+    }
+    /**
+     * Pulls the mapped group names out of a set of directory entries.
+     *
+     * The directory decides the spelling it returns, so a name is matched
+     * case-insensitively and then reported using the spelling stored in
+     * the mapping table -- that is the one the lookup in
+     * LDAPPluginHook has to match against.
+     *
+     * @param array  $entries    entries as returned by get_entries()
+     * @param string $grpNamAttr the group name attribute
+     * @param array  $mapped     the mapped group names to match against
+     *
+     * @return array
+     */
+    private function _namesFromEntries($entries, $grpNamAttr, array $mapped)
+    {
+        $lookup = [];
+        foreach ($mapped as $name) {
+            $lookup[strtolower($name)] = $name;
+        }
+        $matched = [];
+        foreach ((array)$entries as $entry) {
+            if (!isset($entry[$grpNamAttr])) {
+                continue;
+            }
+            foreach ((array)$entry[$grpNamAttr] as $key => $value) {
                 /**
-                 * Test if the user dn exists in this group
+                 * get_entries() puts an item count alongside the values.
                  */
-                $usr = preg_grep($pat, $users);
-                /**
-                 * Ensure we only return "filled" items
-                 */
-                $usr = array_filter($usr);
-                /**
-                 * If so, set our access level. We remain in loop
-                 * so if another group has this same user as admin
-                 * it can get it's proper permissions.
-                 */
-                if (count($usr) > 0) {
-                    $accessLevel = 1;
+                if ('count' === $key) {
+                    continue;
+                }
+                $key = strtolower(trim((string)$value));
+                if (isset($lookup[$key])) {
+                    $matched[] = $lookup[$key];
                 }
             }
         }
-        /**
-         * Return the access level
-         */
-        return $accessLevel;
+        return array_values(array_unique($matched));
     }
     /**
      * Get the results

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -39,14 +39,22 @@ class LDAPPluginHook extends Hook
      */
     const AUTH_SOURCE = 'ldap';
     /**
-     * Access tiers, ordered: a higher tier wins when several LDAP servers
-     * answer for the same user. TIER_NOMATCH sits below a verified user
-     * match because it means "we could not check", not "we checked".
+     * The ordered access tiers (TIER_NONE/NOMATCH/USER/ADMIN) are gone.
+     *
+     * They existed because authLDAP() returned a scalar access level, so
+     * two servers answering for the same user had to be reconciled by
+     * ranking them. Now that real group membership is available the
+     * question does not arise: RBAC permissions are additive, so every
+     * group the user matched on every server contributes its target and
+     * nothing has to outrank anything.
+     *
+     * The one case that still needs a single configured answer -- a server
+     * with group matching switched off, which cannot enumerate groups --
+     * is handled inline in checkAddUser() by
+     * FOG_PLUGIN_LDAP_NOMATCH_ROLE.
+     *
+     * Refs https://github.com/FOGProject/fogproject/issues/882
      */
-    const TIER_NONE = 0;
-    const TIER_NOMATCH = 1;
-    const TIER_USER = 2;
-    const TIER_ADMIN = 3;
     /**
      * The name of this hook.
      *
@@ -157,48 +165,61 @@ class LDAPPluginHook extends Hook
             Route::getData()
         );
         /**
-         * Authenticate against every configured LDAP server and keep the
-         * most privileged result (admin beats user beats unverified beats
-         * none). A server where the user is absent must not downgrade a
-         * match found on another server, so we accumulate the best tier and
-         * act on it once after the loop rather than per-server.
+         * Authenticate against every configured LDAP server and union what
+         * each one grants. Every server is asked, because a user can be
+         * present in more than one directory and each contributes its own
+         * group matches -- there is no "best" answer to stop early on.
          *
-         * A server with group matching disabled is its own tier rather than
-         * an admin match: authLDAP() returns 2 there, but it means "this
-         * account can bind and we have no way to check what it is", not
-         * "this account is an administrator". Ranking it below a verified
-         * user-group match keeps an unverifiable server from outranking a
-         * server that actually answered the question.
+         * A server where the user is absent contributes nothing and must
+         * not take anything away from a server where they are present,
+         * which is why the accumulators only ever grow.
+         *
+         * A server with group matching switched off cannot enumerate
+         * groups, so it can only say "this account binds". That earns the
+         * single configured fallback role and nothing more -- it means "we
+         * could not check what this account is", not "this account is an
+         * administrator".
          */
-        $bestTier = self::TIER_NONE;
+        $authenticated = false;
+        $roleIds = [];
+        $groupIds = [];
         $displayName = '';
         $ldapAPI = 0;
         foreach ($items->data as $ldap) {
             $LDAP = self::getClass('LDAP', $ldap->id);
-            $access = (int)$LDAP->authLDAP($user, $pass);
-            if ($access < 1) {
+            $matched = $LDAP->authLDAP($user, $pass);
+            if (false === $matched) {
                 continue;
             }
-            if (!$LDAP->get('useGroupMatch')) {
-                $tier = self::TIER_NOMATCH;
-            } elseif ($access >= 2) {
-                $tier = self::TIER_ADMIN;
-            } else {
-                $tier = self::TIER_USER;
-            }
-            if ($tier > $bestTier) {
-                $bestTier = $tier;
+            /**
+             * Display name and API access come from the first server that
+             * accepted the credential. With the tier ladder gone there is
+             * no "most privileged" server to prefer, and OR-ing allowapi
+             * across servers would let a server that grants nothing else
+             * still hand out API access.
+             */
+            if (!$authenticated) {
                 $displayName = $LDAP->getDisplayName($user, $pass);
                 $ldapAPI = $LDAP->get('allowapi');
-                /**
-                 * Admin is the highest tier; no need to keep looking.
-                 */
-                if ($bestTier >= self::TIER_ADMIN) {
-                    break;
-                }
             }
+            $authenticated = true;
+            if (!$LDAP->get('useGroupMatch')) {
+                $nomatch = trim(
+                    (string)self::getSetting('FOG_PLUGIN_LDAP_NOMATCH_ROLE')
+                );
+                if ('' !== $nomatch) {
+                    $roleIds[] = $nomatch;
+                }
+                continue;
+            }
+            $targets = self::_targetsForGroups(
+                (int)$LDAP->get('id'),
+                (array)$matched
+            );
+            $roleIds = array_merge($roleIds, $targets['roles']);
+            $groupIds = array_merge($groupIds, $targets['usergroups']);
         }
-        if (self::TIER_NONE === $bestTier) {
+        if (!$authenticated) {
             $arguments['user'] = new User(-1);
             return;
         }
@@ -228,7 +249,7 @@ class LDAPPluginHook extends Hook
             // password can ever match.
             $tmpUser->set('password', self::getToken(64));
         }
-        $this->_syncRoles($tmpUser, self::_roleForTier($bestTier));
+        $this->_syncTargets($tmpUser, $roleIds, $groupIds);
         $tmpUser->save();
         $arguments['user'] = $tmpUser;
         // Tell core we have already proven this identity, so it skips the
@@ -236,66 +257,200 @@ class LDAPPluginHook extends Hook
         $arguments['authenticated'] = true;
     }
     /**
-     * The configured role id for an access tier, '' when unset.
+     * The roles and user groups a set of matched groups grants.
      *
-     * @param int $tier one of the TIER_* constants
+     * Raw bound SQL rather than Route::getIds() on purpose: _buildSql()
+     * turns '*' and '+' in a scalar filter value into a SQL LIKE wildcard,
+     * and both are legal in an LDAP group name ('+' separates the parts of
+     * a multi-valued RDN), so a group named "Techs+Chicago" would match
+     * mappings it must not.
      *
-     * @return string
+     * @param int   $serverId the LDAP server the names came from
+     * @param array $groups   the matched directory group names
+     *
+     * @return array ['roles' => [...], 'usergroups' => [...]]
      */
-    private static function _roleForTier($tier)
+    private static function _targetsForGroups($serverId, array $groups)
     {
-        switch ($tier) {
-            case self::TIER_ADMIN:
-                $key = 'FOG_PLUGIN_LDAP_ADMIN_ROLE';
-                break;
-            case self::TIER_USER:
-                $key = 'FOG_PLUGIN_LDAP_USER_ROLE';
-                break;
-            case self::TIER_NOMATCH:
-                $key = 'FOG_PLUGIN_LDAP_NOMATCH_ROLE';
-                break;
-            default:
-                return '';
+        $out = [
+            'roles' => [],
+            'usergroups' => []
+        ];
+        $groups = array_values(
+            array_filter(
+                array_map('trim', $groups),
+                'strlen'
+            )
+        );
+        if (empty($groups)) {
+            return $out;
         }
-        return trim((string)self::getSetting($key));
+        $names = [];
+        $binds = ['server' => (int)$serverId];
+        foreach ($groups as $index => $group) {
+            $key = 'g' . $index;
+            $names[] = ':' . $key;
+            $binds[$key] = $group;
+        }
+        try {
+            $rows = self::$DB
+                ->query(
+                    'SELECT `lgmTargetType`, `lgmTargetID` '
+                    . 'FROM `LDAPGroupMap` '
+                    . 'WHERE `lgmServerID` = :server '
+                    . 'AND `lgmGroup` IN (' . implode(',', $names) . ')',
+                    [],
+                    $binds
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+        } catch (Exception $e) {
+            error_log(
+                sprintf(
+                    '%s %s() %s: %s',
+                    _('Plugin'),
+                    __METHOD__,
+                    _('Could not read the group mappings'),
+                    $e->getMessage()
+                )
+            );
+            return $out;
+        }
+        /**
+         * PDODB reports a failed query as false rather than throwing
+         * (throwOnQueryError is off), and (array)false is [false], not [].
+         */
+        if (!is_array($rows)) {
+            return $out;
+        }
+        foreach ($rows as $row) {
+            $id = trim((string)($row['lgmTargetID'] ?? ''));
+            if ('' === $id || '0' === $id) {
+                continue;
+            }
+            $type = (string)($row['lgmTargetType'] ?? '');
+            if (LDAPGroupMap::TARGET_USERGROUP === $type) {
+                $out['usergroups'][] = $id;
+            } else {
+                $out['roles'][] = $id;
+            }
+        }
+        $out['roles'] = array_values(array_unique($out['roles']));
+        $out['usergroups'] = array_values(array_unique($out['usergroups']));
+        return $out;
     }
     /**
-     * Makes the directory authoritative over the mapped roles only.
+     * Every role and user group this plugin considers its own to manage.
      *
-     * The three mapped roles are recomputed from the directory on every
-     * login, so revoking someone's LDAP group membership downgrades them
-     * the next time they sign in. Any other role an admin attached by hand
-     * is left alone -- without that carve-out the sync would silently
-     * revoke deliberate grants, and an admin would have no way to give an
-     * LDAP user anything extra.
+     * This is the carve-out that keeps the sync from stamping on manual
+     * grants: anything that appears as a mapping target is recomputed from
+     * the directory on each login, and anything else an admin attached by
+     * hand is left alone.
      *
-     * Reading get('roles') here is also what arms the sync: assocSetter()
-     * no-ops on an association that was never loaded or set, so the read
-     * below is load-bearing, not just informational.
+     * Deriving the set from the map rather than from a settings list is
+     * what makes it self-maintaining -- stop mapping a role and it stops
+     * being managed, exactly as clearing the old setting did.
      *
-     * @param User   $userObj the user being authenticated
-     * @param string $roleId  the role this login earns, '' for none
+     * The user-group half matters more than the role half: the Site plugin
+     * scopes on user groups, so a sync without this carve-out would
+     * silently move people between sites every time they signed in.
+     *
+     * @return array ['roles' => [...], 'usergroups' => [...]]
+     */
+    private static function _managedTargets()
+    {
+        $managed = [
+            'roles' => [],
+            'usergroups' => []
+        ];
+        try {
+            $rows = self::$DB
+                ->query(
+                    'SELECT DISTINCT `lgmTargetType`, `lgmTargetID` '
+                    . 'FROM `LDAPGroupMap`'
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+        } catch (Exception $e) {
+            error_log(
+                sprintf(
+                    '%s %s() %s: %s',
+                    _('Plugin'),
+                    __METHOD__,
+                    _('Could not read the group mappings'),
+                    $e->getMessage()
+                )
+            );
+            $rows = [];
+        }
+        /**
+         * PDODB reports a failed query as false rather than throwing
+         * (throwOnQueryError is off), and (array)false is [false], not [].
+         */
+        if (!is_array($rows)) {
+            $rows = [];
+        }
+        foreach ($rows as $row) {
+            $id = trim((string)($row['lgmTargetID'] ?? ''));
+            if ('' === $id) {
+                continue;
+            }
+            $type = (string)($row['lgmTargetType'] ?? '');
+            if (LDAPGroupMap::TARGET_USERGROUP === $type) {
+                $managed['usergroups'][] = $id;
+            } else {
+                $managed['roles'][] = $id;
+            }
+        }
+        /**
+         * The no-match role is granted by this plugin but never appears in
+         * the map, so it has to be named explicitly or turning group
+         * matching back on would leave it attached forever.
+         */
+        $nomatch = trim(
+            (string)self::getSetting('FOG_PLUGIN_LDAP_NOMATCH_ROLE')
+        );
+        if ('' !== $nomatch) {
+            $managed['roles'][] = $nomatch;
+        }
+        $managed['roles'] = array_values(array_unique($managed['roles']));
+        $managed['usergroups'] = array_values(
+            array_unique($managed['usergroups'])
+        );
+        return $managed;
+    }
+    /**
+     * Makes the directory authoritative over the mapped targets only.
+     *
+     * Every mapped role and user group is recomputed from the directory on
+     * each login, so removing someone from an LDAP group downgrades them
+     * the next time they sign in. Anything outside the managed set is left
+     * alone -- without that carve-out the sync would silently revoke
+     * deliberate grants, and an admin would have no way to give an LDAP
+     * user anything extra.
+     *
+     * Reading get('roles') and get('usergroups') here is also what arms the
+     * sync: assocSetter() no-ops on an association that was never loaded or
+     * set, so both reads are load-bearing, not just informational.
+     *
+     * @param User  $userObj  the user being authenticated
+     * @param array $roleIds  the role ids this login earns
+     * @param array $groupIds the user group ids this login earns
      *
      * @return void
      */
-    private function _syncRoles($userObj, $roleId)
+    private function _syncTargets($userObj, array $roleIds, array $groupIds)
     {
-        $managed = array_map(
-            'strval',
-            array_filter(
-                [
-                    self::getSetting('FOG_PLUGIN_LDAP_ADMIN_ROLE'),
-                    self::getSetting('FOG_PLUGIN_LDAP_USER_ROLE'),
-                    self::getSetting('FOG_PLUGIN_LDAP_NOMATCH_ROLE')
-                ]
-            )
-        );
+        $managed = self::_managedTargets();
         $current = array_map('strval', (array)$userObj->get('roles'));
-        $roles = array_values(array_diff($current, $managed));
-        if ('' !== (string)$roleId) {
-            $roles[] = (string)$roleId;
-        }
+        $roles = array_diff($current, $managed['roles']);
+        $roles = array_merge($roles, array_map('strval', $roleIds));
         $userObj->set('roles', array_values(array_unique($roles)));
+
+        $current = array_map('strval', (array)$userObj->get('usergroups'));
+        $groups = array_diff($current, $managed['usergroups']);
+        $groups = array_merge($groups, array_map('strval', $groupIds));
+        $userObj->set('usergroups', array_values(array_unique($groups)));
     }
     /**
      * Maps this plugin's legacy uType sentinels back onto core's 0/1.

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagement.page.php
@@ -1115,6 +1115,15 @@ class LDAPManagement extends FOGPage
                 $this->ldapGeneral();
             }
         ];
+
+        // Group Mappings
+        $tabData[] = [
+            'name' => _('Group Mappings'),
+            'id' => 'ldap-groupmap',
+            'generator' => function () {
+                $this->ldapGroupMap();
+            }
+        ];
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -1354,6 +1363,311 @@ class LDAPManagement extends FOGPage
         );
     }
     /**
+     * The selectable mapping targets, keyed "type:id".
+     *
+     * Roles and user groups share one control rather than getting a type
+     * selector plus a dependent id selector. Two dependent controls need
+     * javascript to stay consistent and can be posted in an impossible
+     * combination; one list cannot.
+     *
+     * @return array
+     */
+    private static function _mapTargetChoices()
+    {
+        $choices = [];
+        $ids = (array)Route::getIds('role', [], 'id');
+        $names = (array)Route::getIds('role', [], 'name');
+        if (count($ids) === count($names)) {
+            foreach (array_combine($ids, $names) as $id => $name) {
+                $key = LDAPGroupMap::TARGET_ROLE . ':' . $id;
+                $choices[$key] = sprintf('%s - %s', _('Role'), $name);
+            }
+        }
+        $ids = (array)Route::getIds('usergroup', [], 'id');
+        $names = (array)Route::getIds('usergroup', [], 'name');
+        if (count($ids) === count($names)) {
+            foreach (array_combine($ids, $names) as $id => $name) {
+                $key = LDAPGroupMap::TARGET_USERGROUP . ':' . $id;
+                $choices[$key] = sprintf('%s - %s', _('User Group'), $name);
+            }
+        }
+        return $choices;
+    }
+    /**
+     * The mappings already defined for the server being edited.
+     *
+     * Raw bound SQL rather than Route::getIds() for the same reason the
+     * rest of this feature uses it: _buildSql() turns '*' and '+' in a
+     * scalar filter value into a SQL wildcard. The server id here could
+     * not trip that, but keeping one access pattern means nobody has to
+     * remember which of the two is in play when they add a filter later.
+     *
+     * @return array
+     */
+    private function _currentMappings()
+    {
+        try {
+            $rows = self::$DB
+                ->query(
+                    'SELECT `lgmID`, `lgmGroup`, `lgmTargetType`, '
+                    . '`lgmTargetID` FROM `LDAPGroupMap` '
+                    . 'WHERE `lgmServerID` = :server '
+                    . 'ORDER BY `lgmGroup`',
+                    [],
+                    ['server' => (int)$this->obj->get('id')]
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+        } catch (Exception $e) {
+            return [];
+        }
+        /**
+         * PDODB reports a failed query as false rather than throwing
+         * (throwOnQueryError is off), and (array)false is [false], not [].
+         * Normalise or a missing table renders as one blank mapping row.
+         */
+        return is_array($rows) ? $rows : [];
+    }
+    /**
+     * The directory group to role/user group mappings for this server.
+     *
+     * Authoring lives here, on the server, because a group name only means
+     * something relative to the directory it came from -- the same "Admins"
+     * in two directories is two different groups.
+     *
+     * Refs https://github.com/FOGProject/fogproject/issues/882
+     *
+     * @return void
+     */
+    public function ldapGroupMap()
+    {
+        $choices = self::_mapTargetChoices();
+        $mappings = $this->_currentMappings();
+
+        echo self::makeFormTag(
+            '',
+            'ldap-groupmap-form',
+            self::makeTabUpdateURL(
+                'ldap-groupmap',
+                $this->obj->get('id')
+            ),
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="card">';
+        echo '<div class="card-body">';
+        echo '<p>';
+        echo _(
+            'A user signing in through this server receives every role and '
+            . 'user group mapped to a directory group they belong to. '
+            . 'Mapping to a user group is preferred: the group holds the '
+            . 'roles, so policy stays in one place.'
+        );
+        echo '</p>';
+        /**
+         * Group matching is what makes these mappings readable at all, so
+         * say so here rather than leaving an admin to wonder why a mapping
+         * they just added does nothing.
+         */
+        if (!$this->obj->get('useGroupMatch')) {
+            echo '<div class="alert alert-warning">';
+            echo Initiator::e(
+                _(
+                    'Group Matching is off for this server, so directory '
+                    . 'groups cannot be read and these mappings are not '
+                    . 'used. Users who can bind receive the fallback role '
+                    . 'from the global LDAP settings instead.'
+                )
+            );
+            echo '</div>';
+        }
+        if (empty($choices)) {
+            echo '<div class="alert alert-warning">';
+            echo Initiator::e(
+                _('There are no roles or user groups to map to yet.')
+            );
+            echo '</div>';
+        }
+        echo '<table class="table table-striped">';
+        echo '<thead><tr>';
+        echo '<th>' . _('Directory Group') . '</th>';
+        echo '<th>' . _('Grants') . '</th>';
+        echo '<th>' . _('Remove') . '</th>';
+        echo '</tr></thead><tbody>';
+        if (empty($mappings)) {
+            printf(
+                '<tr><td colspan="3">%s</td></tr>',
+                Initiator::e(_('No mappings defined.'))
+            );
+        }
+        foreach ($mappings as $map) {
+            $key = $map['lgmTargetType'] . ':' . $map['lgmTargetID'];
+            /**
+             * A target that no longer exists is shown rather than hidden,
+             * because a mapping that silently grants nothing is exactly
+             * what an admin comes to this page to find.
+             */
+            $label = (
+                $choices[$key] ??
+                sprintf(
+                    '%s (%s)',
+                    $key,
+                    _('no longer exists')
+                )
+            );
+            printf(
+                '<tr><td>%s</td><td>%s</td>'
+                . '<td><input type="checkbox" name="mapRemove[]" '
+                . 'value="%s"/></td></tr>',
+                Initiator::e($map['lgmGroup']),
+                Initiator::e($label),
+                Initiator::e($map['lgmID'])
+            );
+        }
+        echo '</tbody></table>';
+
+        $labelClass = 'col-sm-3 col-form-label';
+        $fields = [
+            self::makeLabel(
+                $labelClass,
+                'mapGroup',
+                _('Add Directory Group')
+            ) => self::makeInput(
+                'form-control ldapmapgroup-input',
+                'mapGroup',
+                _('Domain Admins'),
+                'text',
+                'mapGroup'
+            ),
+            self::makeLabel(
+                $labelClass,
+                'mapTarget',
+                _('Grants')
+            ) => self::selectForm(
+                'mapTarget',
+                $choices,
+                '',
+                true
+            )
+        ];
+        $buttons = self::makeButton(
+            'groupmap-send',
+            _('Update'),
+            'btn btn-primary float-end'
+        );
+        self::$HookManager->processEvent(
+            'LDAP_GROUPMAP_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'LDAP' => self::getClass('LDAP')
+            ]
+        );
+        echo self::formFields($fields);
+        unset($fields);
+        echo '</div>';
+        echo '<div class="card-footer">';
+        echo $buttons;
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+    }
+    /**
+     * Applies removals and the optional addition from the mapping tab.
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    public function ldapGroupMapPost()
+    {
+        self::checkAuthAndCSRF();
+        $remove = filter_input_array(
+            INPUT_POST,
+            [
+                'mapRemove' => [
+                    'filter' => FILTER_VALIDATE_INT,
+                    'flags' => FILTER_REQUIRE_ARRAY
+                ]
+            ]
+        );
+        $remove = array_filter((array)($remove['mapRemove'] ?? []));
+        foreach ($remove as $id) {
+            $map = self::getClass('LDAPGroupMap', (int)$id);
+            /**
+             * Only rows belonging to the server being edited, so a crafted
+             * post cannot delete another server's mappings.
+             */
+            if (!$map->isValid()
+                || (int)$map->get('serverID') !== (int)$this->obj->get('id')
+            ) {
+                continue;
+            }
+            $map->destroy();
+        }
+        $group = trim((string)filter_input(INPUT_POST, 'mapGroup'));
+        $target = trim((string)filter_input(INPUT_POST, 'mapTarget'));
+        /**
+         * Nothing to add is not an error -- this same post is how removals
+         * are submitted.
+         */
+        if ('' === $group && '' === $target) {
+            return;
+        }
+        if ('' === $group || '' === $target) {
+            throw new Exception(
+                _('Both a directory group and a target are required.')
+            );
+        }
+        $choices = self::_mapTargetChoices();
+        /**
+         * Validated against the rendered list rather than parsed, so a
+         * posted target must be one that actually exists. A mapping naming
+         * a deleted role would otherwise fail silently at login.
+         */
+        if (!isset($choices[$target])) {
+            throw new Exception(_('The selected target no longer exists.'));
+        }
+        list($type, $targetId) = explode(':', $target, 2);
+        /**
+         * Raw bound SQL, not a manager count(): the group name is typed by
+         * the admin and _buildSql() turns '*' or '+' in a scalar filter
+         * value into a SQL wildcard, which would report a duplicate that
+         * is not one. The unique index is the real guard; this only exists
+         * to turn its error into a readable message.
+         */
+        $exists = self::$DB
+            ->query(
+                'SELECT `lgmID` FROM `LDAPGroupMap` '
+                . 'WHERE `lgmServerID` = :server AND `lgmGroup` = :group '
+                . 'AND `lgmTargetType` = :type AND `lgmTargetID` = :target',
+                [],
+                [
+                    'server' => (int)$this->obj->get('id'),
+                    'group' => $group,
+                    'type' => $type,
+                    'target' => (int)$targetId
+                ]
+            )
+            ->fetch('', 'fetch_all')
+            ->get();
+        /**
+         * is_array, not !empty: PDODB reports a failed query as false, and
+         * (array)false is [false] -- which would report every new mapping
+         * as a duplicate.
+         */
+        if (is_array($exists) && !empty($exists)) {
+            throw new Exception(_('That mapping already exists.'));
+        }
+        self::getClass('LDAPGroupMap')
+            ->set('serverID', $this->obj->get('id'))
+            ->set('name', $group)
+            ->set('targetType', $type)
+            ->set('targetID', $targetId)
+            ->save();
+    }
+    /**
      * Updates the current item
      *
      * @return void
@@ -1371,6 +1685,10 @@ class LDAPManagement extends FOGPage
                 switch ($tab) {
                     case 'ldap-general':
                         $this->ldapGeneralPost();
+                        break;
+                    case 'ldap-groupmap':
+                        $this->ldapGroupMapPost();
+                        break;
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -624,6 +624,76 @@ class Route extends FOGBase
         }
     }
     /**
+     * Reads a $_SERVER value, preferring filter_input.
+     *
+     * filter_input(INPUT_SERVER) reads the SAPI's original request table,
+     * not the live $_SERVER array. Keys PHP synthesises after startup --
+     * PHP_AUTH_USER/PHP_AUTH_PW among them -- can therefore come back null
+     * under FPM even though $_SERVER holds them. Falling back to $_SERVER
+     * is the only way to see them reliably; the value is treated as
+     * untrusted either way (see _basicAuthCredentials).
+     *
+     * @param string $key The $_SERVER key to read.
+     *
+     * @return string
+     */
+    private static function _serverVar($key)
+    {
+        $val = filter_input(INPUT_SERVER, $key);
+        if ($val === null || $val === false) {
+            $val = $_SERVER[$key] ?? '';
+        }
+        return (string)$val;
+    }
+    /**
+     * Resolves HTTP basic auth credentials for the current request.
+     *
+     * PHP only populates PHP_AUTH_USER/PHP_AUTH_PW when the Authorization
+     * header actually reaches it. Under FastCGI it does not arrive on its
+     * own: nginx passes only the fastcgi_params whitelist, and Apache's
+     * proxy_fcgi strips it unless CGIPassAuth/SetEnvIf puts it back. FOG's
+     * installer now emits that config, but every install that predates the
+     * fix still has webserver config without it, and those must keep
+     * working without a reinstall -- so decode the header ourselves when
+     * PHP_AUTH_USER is absent.
+     *
+     * REDIRECT_HTTP_AUTHORIZATION is checked too: the Apache vhost rewrites
+     * /fog/* into /fog/api/index.php, and Apache prefixes REDIRECT_ onto
+     * environment variables that survive an internal redirect.
+     *
+     * This only recovers a credential the client already sent. It is not a
+     * second way in: the caller still has to clear passwordValidate() and
+     * the uAllowAPI test below.
+     *
+     * @return array The username and password, empty strings if absent.
+     */
+    private static function _basicAuthCredentials()
+    {
+        $user = self::_serverVar('PHP_AUTH_USER');
+        if ($user !== '') {
+            return [$user, self::_serverVar('PHP_AUTH_PW')];
+        }
+        $keys = [
+            'HTTP_AUTHORIZATION',
+            'REDIRECT_HTTP_AUTHORIZATION'
+        ];
+        foreach ($keys as $key) {
+            $header = trim(self::_serverVar($key));
+            if (stripos($header, 'basic ') !== 0) {
+                continue;
+            }
+            // strict base64 decode: a malformed header is not a credential.
+            $decoded = base64_decode(substr($header, 6), true);
+            if ($decoded === false || strpos($decoded, ':') === false) {
+                continue;
+            }
+            // Split on the first colon only -- colons are legal in a
+            // password, but not in a username.
+            return explode(':', $decoded, 2);
+        }
+        return ['', ''];
+    }
+    /**
      * Test authentication.
      *
      * @return void
@@ -643,9 +713,10 @@ class Route extends FOGBase
             self::$FOGUser = $pwtoken;
             return;
         }
+        list($authUser, $authPass) = self::_basicAuthCredentials();
         $auth = self::$FOGUser->passwordValidate(
-            filter_input(INPUT_SERVER, 'PHP_AUTH_USER'),
-            filter_input(INPUT_SERVER, 'PHP_AUTH_PW')
+            $authUser,
+            $authPass
         );
         if (!$auth) {
             self::sendResponse(
@@ -2272,7 +2343,7 @@ class Route extends FOGBase
                 ($task->debug ?? false),
                 $deploySnapins,
                 $class instanceof Group,
-                filter_input(INPUT_SERVER, 'PHP_AUTH_USER') ?? 'API',
+                (self::_basicAuthCredentials()[0] ?: 'API'),
                 $task->passreset ?? '',
                 $task->sessionjoin ?? '',
                 $task->wol ?? 1,

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -287,6 +287,12 @@ msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
 msgid "A user group with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "Dieser Benutzername ist bereits vorhanden!"
@@ -326,9 +332,6 @@ msgstr "Zugangs-Token"
 
 msgid "Access Token"
 msgstr "Zugangs-Token"
-
-msgid "Access level is still 0 or false"
-msgstr "Zugriffsstufe ist immer noch 0 oder falsch"
 
 #, fuzzy
 msgid "Access token"
@@ -399,6 +402,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Hinzufügen"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Speichergruppe hinzufügen"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -844,6 +851,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast hinzugefügt!"
@@ -1272,12 +1282,19 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 msgid "Could not read tmp file."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "Konnte nicht registriert werden."
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1637,6 +1654,10 @@ msgstr "Das Verzeichnis existiert bereits"
 
 msgid "Directory Cleaner"
 msgstr "Verzeichnis-Bereiniger"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Verzeichnis"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2374,6 +2395,9 @@ msgstr "Standort aktualisiert"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "Grafisch"
@@ -2479,8 +2503,18 @@ msgid "Group Management"
 msgstr "Gruppenverwaltung"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "Host Standort"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "Host Standort"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Gruppemmitglieder Attribut"
@@ -4440,6 +4474,10 @@ msgstr "Keine Verbindung zur Datenbank hergestellt"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Nicht synchronisieren"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "Keine Master-Knoten sind aktiviert, um dieses Image zu löschen"
 
@@ -5398,6 +5436,10 @@ msgstr "Wert des Schlüssels zurückgeben"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Rollenname"
 
 #, fuzzy
 msgid "Role Association"
@@ -6648,6 +6690,10 @@ msgid "Text"
 msgstr "Text"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Dieser Host ist bereits vorhanden."
 
@@ -6694,6 +6740,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
 
@@ -6737,6 +6786,10 @@ msgstr "Es gibt keine Images auf diesem Server."
 #, fuzzy
 msgid "There are no members to sync to"
 msgstr "Es gibt keine Hosts in dieser Gruppe"
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
+msgstr "Es gibt keine Gruppen auf diesem Server."
 
 msgid "There are no snapins associated with this host"
 msgstr "Mit diesem Host sind keine Snapins verknüpft"
@@ -7421,6 +7474,9 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8095,6 +8151,10 @@ msgstr "nicht verfügbar"
 msgid "never"
 msgstr ""
 
+#, fuzzy
+msgid "no longer exists"
+msgstr "läuft nicht mehr"
+
 msgid "no response from server"
 msgstr ""
 
@@ -8425,6 +8485,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Access Controls"
 #~ msgstr "Zugriffskontrollen"
+
+#~ msgid "Access level is still 0 or false"
+#~ msgstr "Zugriffsstufe ist immer noch 0 oder falsch"
 
 #, fuzzy
 #~ msgid "Accesscontrol Create Fail"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,12 @@ msgstr "An image already exists with this name!"
 msgid "A user group with this name already exists!"
 msgstr "A hostname with that name already exists."
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "An image already exists with this name!"
@@ -330,9 +336,6 @@ msgstr "Access Token"
 
 msgid "Access Token"
 msgstr "Access Token"
-
-msgid "Access level is still 0 or false"
-msgstr ""
 
 #, fuzzy
 msgid "Access token"
@@ -403,6 +406,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Add"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Add Storage Group"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -846,6 +853,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast Name"
@@ -1273,12 +1283,19 @@ msgstr "Could not read tmp file."
 msgid "Could not read snapin file"
 msgstr "Could not read tmp file."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Could not read tmp file."
+
 msgid "Could not read tmp file."
 msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "Could not create printer"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1638,6 +1655,10 @@ msgstr "Directory Already Exists"
 
 msgid "Directory Cleaner"
 msgstr "Directory Cleaner"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Directory"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2374,6 +2395,9 @@ msgstr "Location Updated"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "Graphical"
@@ -2479,8 +2503,18 @@ msgid "Group Management"
 msgstr "Group Management"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "Host Location"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "Host Location"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr ""
@@ -4436,6 +4470,10 @@ msgstr "No connection to the database"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Installed Plugins"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "No master nodes are enabled to delete this image"
 
@@ -5394,6 +5432,10 @@ msgstr "Returning value of key"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Module Name"
 
 #, fuzzy
 msgid "Role Association"
@@ -6643,6 +6685,10 @@ msgid "Text"
 msgstr "Text"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Printer already exists"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Printer already exists"
 
@@ -6688,6 +6734,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6729,6 +6778,10 @@ msgstr "There are no images on this server."
 
 #, fuzzy
 msgid "There are no members to sync to"
+msgstr "There are no groups on this server."
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
 msgstr "There are no groups on this server."
 
 msgid "There are no snapins associated with this host"
@@ -7413,6 +7466,9 @@ msgstr "User update failed"
 msgid "User group updated!"
 msgstr "User updated"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Record not found, Error: %s"
@@ -8082,6 +8138,10 @@ msgstr "n/a"
 
 msgid "never"
 msgstr ""
+
+#, fuzzy
+msgid "no longer exists"
+msgstr " no longer exists"
 
 msgid "no response from server"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -291,6 +291,12 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "A user group with this name already exists!"
 msgstr "Sesión con ese nombre ya existe"
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
@@ -330,9 +336,6 @@ msgid "Access Denied"
 msgstr "impresora iPrint"
 
 msgid "Access Token"
-msgstr ""
-
-msgid "Access level is still 0 or false"
 msgstr ""
 
 #, fuzzy
@@ -408,6 +411,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Añadir"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Grupo de almacenamiento"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -858,6 +865,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nombre de host"
@@ -1288,12 +1298,19 @@ msgstr "No se pudo leer el archivo tmp."
 msgid "Could not read snapin file"
 msgstr "No se pudo leer el archivo tmp."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "No se pudo leer el archivo tmp."
+
 msgid "Could not read tmp file."
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "No se pudo crear la impresora"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1666,6 +1683,10 @@ msgstr "nombre de usuario ya existe"
 #, fuzzy
 msgid "Directory Cleaner"
 msgstr "directorios Cleaned"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Directorio"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2422,6 +2443,9 @@ msgstr "información de LDAP actualizado!"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 msgid "Graph Color"
 msgstr ""
 
@@ -2529,8 +2553,18 @@ msgid "Group Management"
 msgstr "Gestión de usuarios"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "Lista de host"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "Lista de host"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr ""
@@ -4550,6 +4584,10 @@ msgstr "Haga clic en el botón para exportar la base de datos."
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Instalador inteligente (recomendado)"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr ""
 
@@ -5525,6 +5563,10 @@ msgstr "Volviendo valor de clave"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Nombre del módulo"
 
 #, fuzzy
 msgid "Role Association"
@@ -6811,6 +6853,10 @@ msgid "Text"
 msgstr "Siguiente"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Impresora ya existe"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Impresora ya existe"
 
@@ -6857,6 +6903,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Error, es una imagen asociada con este anfitrión"
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6899,6 +6948,10 @@ msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 msgid "There are no members to sync to"
+msgstr "No hay grupos en este servidor."
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
 msgstr "No hay grupos en este servidor."
 
 #, fuzzy
@@ -7566,6 +7619,9 @@ msgstr "actualización Valoración falló"
 #, fuzzy
 msgid "User group updated!"
 msgstr "el usuario actualiza"
+
+msgid "User matched none of the mapped groups"
+msgstr ""
 
 #, fuzzy
 msgid "User not found"
@@ -8236,6 +8292,9 @@ msgid "n/a"
 msgstr ""
 
 msgid "never"
+msgstr ""
+
+msgid "no longer exists"
 msgstr ""
 
 msgid "no response from server"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -287,6 +287,12 @@ msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
 msgid "A user group with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "Dieser Benutzername ist bereits vorhanden!"
@@ -326,9 +332,6 @@ msgstr "Zugangs-Token"
 
 msgid "Access Token"
 msgstr "Zugangs-Token"
-
-msgid "Access level is still 0 or false"
-msgstr "Zugriffsstufe ist immer noch 0 oder falsch"
 
 #, fuzzy
 msgid "Access token"
@@ -399,6 +402,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Hinzufügen"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Speichergruppe hinzufügen"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -844,6 +851,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast hinzugefügt!"
@@ -1272,12 +1282,19 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 msgid "Could not read tmp file."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "Konnte nicht registriert werden."
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1637,6 +1654,10 @@ msgstr "Das Verzeichnis existiert bereits"
 
 msgid "Directory Cleaner"
 msgstr "Verzeichnis-Bereiniger"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Verzeichnis"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2374,6 +2395,9 @@ msgstr "Standort aktualisiert"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "Grafisch"
@@ -2479,8 +2503,18 @@ msgid "Group Management"
 msgstr "Gruppenverwaltung"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "Host Standort"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "Host Standort"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Gruppemmitglieder Attribut"
@@ -4441,6 +4475,10 @@ msgstr "Keine Verbindung zur Datenbank hergestellt"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Nicht synchronisieren"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "Keine Master-Knoten sind aktiviert, um dieses Image zu löschen"
 
@@ -5399,6 +5437,10 @@ msgstr "Wert des Schlüssels zurückgeben"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Rollenname"
 
 #, fuzzy
 msgid "Role Association"
@@ -6649,6 +6691,10 @@ msgid "Text"
 msgstr "Text"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Dieser Host ist bereits vorhanden."
 
@@ -6695,6 +6741,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
 
@@ -6738,6 +6787,10 @@ msgstr "Es gibt keine Images auf diesem Server."
 #, fuzzy
 msgid "There are no members to sync to"
 msgstr "Es gibt keine Hosts in dieser Gruppe"
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
+msgstr "Es gibt keine Gruppen auf diesem Server."
 
 msgid "There are no snapins associated with this host"
 msgstr "Mit diesem Host sind keine Snapins verknüpft"
@@ -7422,6 +7475,9 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8096,6 +8152,10 @@ msgstr "nicht verfügbar"
 msgid "never"
 msgstr ""
 
+#, fuzzy
+msgid "no longer exists"
+msgstr "läuft nicht mehr"
+
 msgid "no response from server"
 msgstr ""
 
@@ -8426,6 +8486,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Access Controls"
 #~ msgstr "Zugriffskontrollen"
+
+#~ msgid "Access level is still 0 or false"
+#~ msgstr "Zugriffsstufe ist immer noch 0 oder falsch"
 
 #, fuzzy
 #~ msgid "Accesscontrol Create Fail"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -293,6 +293,12 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "A user group with this name already exists!"
 msgstr "Un nom d'hôte avec ce nom existe déjà."
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
@@ -331,9 +337,6 @@ msgstr "Jeton d'accès"
 
 msgid "Access Token"
 msgstr "Jeton d'accès"
-
-msgid "Access level is still 0 or false"
-msgstr ""
 
 #, fuzzy
 msgid "Access token"
@@ -404,6 +407,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Ajouter"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Ajouter un groupe de stockage"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -847,6 +854,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nom de diffusion"
@@ -1277,12 +1287,19 @@ msgstr "Impossible de lire le fichier tmp."
 msgid "Could not read snapin file"
 msgstr "Impossible de lire le fichier tmp."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Impossible de lire le fichier tmp."
+
 msgid "Could not read tmp file."
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "Impossible de créer l'imprimante"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1642,6 +1659,10 @@ msgstr "Répertoire existe déjà"
 
 msgid "Directory Cleaner"
 msgstr "Directory Cleaner"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Annuaire"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2378,6 +2399,9 @@ msgstr "Emplacement Mise à jour"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "Graphique"
@@ -2483,8 +2507,18 @@ msgid "Group Management"
 msgstr "Gestion du Groupe"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "hôte Lieu"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "hôte Lieu"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr ""
@@ -4440,6 +4474,10 @@ msgstr "Pas de connexion à la base de données"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Plugins installés"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "Aucun nœuds maîtres sont activés pour supprimer cette image"
 
@@ -5401,6 +5439,10 @@ msgstr "De retour valeur de clé"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Nom du module"
 
 #, fuzzy
 msgid "Role Association"
@@ -6650,6 +6692,10 @@ msgid "Text"
 msgstr "Texte"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Imprimante existe déjà"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Imprimante existe déjà"
 
@@ -6695,6 +6741,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6738,6 +6787,10 @@ msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
 msgid "There are no members to sync to"
+msgstr "Il n'y a pas de groupes sur ce serveur."
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
 msgstr "Il n'y a pas de groupes sur ce serveur."
 
 msgid "There are no snapins associated with this host"
@@ -7420,6 +7473,9 @@ msgstr "mise à jour de l'utilisateur a échoué"
 msgid "User group updated!"
 msgstr "mis à jour l'utilisateur"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Enregistrement non trouvé, Erreur: %s"
@@ -8089,6 +8145,10 @@ msgstr "n / a"
 
 msgid "never"
 msgstr ""
+
+#, fuzzy
+msgid "no longer exists"
+msgstr " n'existe plus"
 
 msgid "no response from server"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -279,6 +279,12 @@ msgstr "Esiste già un gruppo con questo nome!"
 msgid "A user group with this name already exists!"
 msgstr "Un nome host con questo nome esiste già"
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 msgid "A username already exists with this name!"
 msgstr "Esiste già un nome utente con questo nome!"
 
@@ -317,9 +323,6 @@ msgstr "Token di accesso"
 
 msgid "Access Token"
 msgstr "Token di accesso"
-
-msgid "Access level is still 0 or false"
-msgstr "Il livello di accesso è ancora 0 o falso"
 
 #, fuzzy
 msgid "Access token"
@@ -389,6 +392,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Aggiungere"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Aggiungere gruppo di archiviazione"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -813,6 +820,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast aggiunto!"
@@ -1214,11 +1224,18 @@ msgstr "Impossibile leggere il file tmp."
 msgid "Could not read snapin file"
 msgstr "Impossibile leggere il file snapin"
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Impossibile leggere il file tmp."
+
 msgid "Could not read tmp file."
 msgstr "Impossibile leggere il file tmp."
 
 msgid "Could not register"
 msgstr "Non posso registrare"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1570,6 +1587,10 @@ msgstr "Directory esiste già"
 
 msgid "Directory Cleaner"
 msgstr "directory Cleaner"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "elenco"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2285,6 +2306,9 @@ msgstr "Posizione aggiornata!"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "grafico"
@@ -2388,8 +2412,18 @@ msgid "Group Management"
 msgstr "Direzione del Gruppo"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "Host Luoghi"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "Host Luoghi"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Attributo membro del gruppo"
@@ -4254,6 +4288,10 @@ msgstr "Nessun collegamento stabilito al database"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Non sincronizzo"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "Non nodi master sono abilitati per eliminare questa immagine"
 
@@ -5171,6 +5209,10 @@ msgstr "Tornando valore della chiave"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Nome regola"
 
 #, fuzzy
 msgid "Role Association"
@@ -6354,6 +6396,10 @@ msgid "Text"
 msgstr "Testo"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Questo host esiste già"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Questo host esiste già"
 
@@ -6398,6 +6444,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Il MAC primario associato è"
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 "Le impostazioni tendono ad essere le impostazioni globali che influenzano "
@@ -6440,6 +6489,10 @@ msgstr "Non ci sono immagini su questo server"
 #, fuzzy
 msgid "There are no members to sync to"
 msgstr "Non ci sono host a cui affidare compiti in questo gruppo"
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
+msgstr "Non ci sono gruppi su questo server"
 
 msgid "There are no snapins associated with this host"
 msgstr "Non ci sono snapins associati con questo host"
@@ -7100,6 +7153,9 @@ msgstr "Aggiornamento utente non riuscita"
 msgid "User group updated!"
 msgstr "Utente aggiornato"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Record non trovato"
@@ -7726,6 +7782,10 @@ msgstr "n/d"
 msgid "never"
 msgstr ""
 
+#, fuzzy
+msgid "no longer exists"
+msgstr "non è più in esecuzione"
+
 msgid "no response from server"
 msgstr ""
 
@@ -8034,6 +8094,9 @@ msgstr ""
 
 #~ msgid "Access Controls"
 #~ msgstr "Controllo accessi"
+
+#~ msgid "Access level is still 0 or false"
+#~ msgstr "Il livello di accesso è ancora 0 o falso"
 
 #, fuzzy
 #~ msgid "Accesscontrol Create Fail"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -268,6 +268,12 @@ msgstr "この名前のグループは既に存在します！"
 msgid "A user group with this name already exists!"
 msgstr "その名前のホストは既に存在します"
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 msgid "A username already exists with this name!"
 msgstr "このユーザー名は既に存在します！"
 
@@ -305,9 +311,6 @@ msgstr "アクセス拒否"
 
 msgid "Access Token"
 msgstr "アクセストークン"
-
-msgid "Access level is still 0 or false"
-msgstr "アクセスレベルが 0 または false のままです"
 
 #, fuzzy
 msgid "Access token"
@@ -378,6 +381,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "追加"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "ディレクトリを追加"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -800,6 +807,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "新しいブロードキャストアドレス"
@@ -1200,11 +1210,18 @@ msgstr "一時ファイルを読み取れませんでした。"
 msgid "Could not read snapin file"
 msgstr "スナップインファイルを読み取れませんでした"
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "一時ファイルを読み取れませんでした。"
+
 msgid "Could not read tmp file."
 msgstr "一時ファイルを読み取れませんでした。"
 
 msgid "Could not register"
 msgstr "登録できませんでした"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1556,6 +1573,10 @@ msgstr "ディレクトリは既に存在します"
 
 msgid "Directory Cleaner"
 msgstr "ディレクトリクリーナー"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "ディレクトリ"
 
 msgid "Disable on all hosts"
 msgstr ""
@@ -2261,6 +2282,9 @@ msgstr "ロケーションを更新しました！"
 msgid "Got in line at"
 msgstr "キューに登録されました:"
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "メインカラー"
@@ -2363,8 +2387,18 @@ msgid "Group Management"
 msgstr "グループ管理"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "グループ管理"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "グループ管理"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "グループメンバー属性"
@@ -4216,6 +4250,10 @@ msgstr "データベースへのリンクが確立されていません"
 msgid "No mac addresses to be removed"
 msgstr "削除するグループが選択されていません"
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "同期していません"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "このイメージを削除できる有効なマスターノードがありません"
 
@@ -5131,6 +5169,10 @@ msgstr "キーの値を返しています"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "ロール"
 
 #, fuzzy
 msgid "Role Association"
@@ -6296,6 +6338,10 @@ msgid "Text"
 msgstr "テキスト"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "このホストは既に存在します"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "このホストは既に存在します"
 
@@ -6339,6 +6385,10 @@ msgstr "これは既に別のイメージで使用されています"
 msgid "The primary mac associated is"
 msgstr "関連付けられたプライマリ MAC アドレス:"
 
+#, fuzzy
+msgid "The selected target no longer exists."
+msgstr "選択したプリンターを追加"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "これらの設定は通常グローバル設定であり、すべてのホストに影響します。"
 
@@ -6378,6 +6428,10 @@ msgstr "このサーバーにはイメージがありません"
 #, fuzzy
 msgid "There are no members to sync to"
 msgstr "同期対象のメンバーがありません"
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
+msgstr "このサーバーにはグループがありません"
 
 msgid "There are no snapins associated with this host"
 msgstr "このホストには関連付けられたスナップインがありません"
@@ -7034,6 +7088,9 @@ msgstr "ユーザーの更新に失敗しました！"
 msgid "User group updated!"
 msgstr "ユーザーを更新しました！"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "レコードが見つかりません"
@@ -7649,6 +7706,10 @@ msgstr "N/A"
 msgid "never"
 msgstr ""
 
+#, fuzzy
+msgid "no longer exists"
+msgstr "選択したプリンターを追加"
+
 msgid "no response from server"
 msgstr ""
 
@@ -8030,11 +8091,11 @@ msgstr ""
 #~ msgid "Access Controls"
 #~ msgstr "アクセス制御"
 
+#~ msgid "Access level is still 0 or false"
+#~ msgstr "アクセスレベルが 0 または false のままです"
+
 #~ msgid "Account removed from FOG GUI at"
 #~ msgstr "FOG GUI から削除されたアカウント:"
-
-#~ msgid "Add Directory"
-#~ msgstr "ディレクトリを追加"
 
 #~ msgid "Add Event"
 #~ msgstr "イベントを追加"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -232,6 +232,12 @@ msgstr ""
 msgid "A user group with this name already exists!"
 msgstr ""
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 msgid "A username already exists with this name!"
 msgstr ""
 
@@ -267,9 +273,6 @@ msgid "Access Denied"
 msgstr ""
 
 msgid "Access Token"
-msgstr ""
-
-msgid "Access level is still 0 or false"
 msgstr ""
 
 msgid "Access token"
@@ -333,6 +336,9 @@ msgid "Active at 5 minutes or more"
 msgstr ""
 
 msgid "Add"
+msgstr ""
+
+msgid "Add Directory Group"
 msgstr ""
 
 msgid "Add Hello World failed!"
@@ -702,6 +708,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 msgid "Broadcast Address"
 msgstr ""
 
@@ -1063,10 +1072,16 @@ msgstr ""
 msgid "Could not read snapin file"
 msgstr ""
 
+msgid "Could not read the group mappings"
+msgstr ""
+
 msgid "Could not read tmp file."
 msgstr ""
 
 msgid "Could not register"
+msgstr ""
+
+msgid "Could not remove the group mappings"
 msgstr ""
 
 msgid "Could not send data from file"
@@ -1367,6 +1382,9 @@ msgid "Directory Already Exists"
 msgstr ""
 
 msgid "Directory Cleaner"
+msgstr ""
+
+msgid "Directory Group"
 msgstr ""
 
 msgid "Disable on all hosts"
@@ -2004,6 +2022,9 @@ msgstr ""
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 msgid "Graph Color"
 msgstr ""
 
@@ -2088,7 +2109,16 @@ msgstr ""
 msgid "Group Management"
 msgstr ""
 
+msgid "Group Mappings"
+msgstr ""
+
 msgid "Group Matching"
+msgstr ""
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
 msgstr ""
 
 msgid "Group Member Attribute"
@@ -3740,6 +3770,9 @@ msgstr ""
 msgid "No mac addresses to be removed"
 msgstr ""
 
+msgid "No mappings defined."
+msgstr ""
+
 msgid "No master nodes are enabled to delete this image"
 msgstr ""
 
@@ -4563,6 +4596,9 @@ msgid "Returning value of key"
 msgstr ""
 
 msgid "Reverse"
+msgstr ""
+
+msgid "Role"
 msgstr ""
 
 msgid "Role Association"
@@ -5602,6 +5638,9 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
+msgid "That mapping already exists."
+msgstr ""
+
 msgid "That session has already started"
 msgstr ""
 
@@ -5643,6 +5682,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -5677,6 +5719,9 @@ msgid "There are no images available!"
 msgstr ""
 
 msgid "There are no members to sync to"
+msgstr ""
+
+msgid "There are no roles or user groups to map to yet."
 msgstr ""
 
 msgid "There are no snapins associated with this host"
@@ -6248,6 +6293,9 @@ msgid "User group update failed!"
 msgstr ""
 
 msgid "User group updated!"
+msgstr ""
+
+msgid "User matched none of the mapped groups"
 msgstr ""
 
 msgid "User not found"
@@ -6823,6 +6871,9 @@ msgid "n/a"
 msgstr ""
 
 msgid "never"
+msgstr ""
+
+msgid "no longer exists"
 msgstr ""
 
 msgid "no response from server"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,12 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "A user group with this name already exists!"
 msgstr "Um nome de host com esse nome já existe."
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
@@ -330,9 +336,6 @@ msgstr "token de acesso"
 
 msgid "Access Token"
 msgstr "token de acesso"
-
-msgid "Access level is still 0 or false"
-msgstr ""
 
 #, fuzzy
 msgid "Access token"
@@ -403,6 +406,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "Adicionar"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "Adicionar grupo de armazenamento"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -846,6 +853,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nome transmissão"
@@ -1276,12 +1286,19 @@ msgstr "Não foi possível ler o arquivo tmp."
 msgid "Could not read snapin file"
 msgstr "Não foi possível ler o arquivo tmp."
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "Não foi possível ler o arquivo tmp."
+
 msgid "Could not read tmp file."
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not register"
 msgstr "Não foi possível criar impressora"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1641,6 +1658,10 @@ msgstr "Diretório já existe"
 
 msgid "Directory Cleaner"
 msgstr "Cleaner diretório"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "Diretório"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2377,6 +2398,9 @@ msgstr "Localização Atualizado"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "Gráfico"
@@ -2482,8 +2506,18 @@ msgid "Group Management"
 msgstr "grupo de Gestão"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "anfitrião Localização"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "anfitrião Localização"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr ""
@@ -4439,6 +4473,10 @@ msgstr "Sem conexão com o banco de dados"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "Plugins instalados"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "Nenhum nós mestre são habilitadas para apagar esta imagem"
 
@@ -5398,6 +5436,10 @@ msgstr "Retornando valor da chave"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "Nome do módulo"
 
 #, fuzzy
 msgid "Role Association"
@@ -6647,6 +6689,10 @@ msgid "Text"
 msgstr "Texto"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "Impressora já existe"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "Impressora já existe"
 
@@ -6693,6 +6739,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6734,6 +6783,10 @@ msgstr "Não há imagens neste servidor."
 
 #, fuzzy
 msgid "There are no members to sync to"
+msgstr "Não existem grupos neste servidor."
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
 msgstr "Não existem grupos neste servidor."
 
 msgid "There are no snapins associated with this host"
@@ -7416,6 +7469,9 @@ msgstr "atualização do utilizador falhou"
 msgid "User group updated!"
 msgstr "usuário atualizada"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "Registro não encontrado, erro: %s"
@@ -8085,6 +8141,10 @@ msgstr "n / D"
 
 msgid "never"
 msgstr ""
+
+#, fuzzy
+msgid "no longer exists"
+msgstr " não existe mais"
 
 msgid "no response from server"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,12 @@ msgstr "图像已经存在具有此名称！"
 msgid "A user group with this name already exists!"
 msgstr "使用此名称的主机名已经存在。"
 
+msgid ""
+"A user signing in through this server receives every role and user group "
+"mapped to a directory group they belong to. Mapping to a user group is "
+"preferred: the group holds the roles, so policy stays in one place."
+msgstr ""
+
 #, fuzzy
 msgid "A username already exists with this name!"
 msgstr "图像已经存在具有此名称！"
@@ -330,9 +336,6 @@ msgstr "访问令牌"
 
 msgid "Access Token"
 msgstr "访问令牌"
-
-msgid "Access level is still 0 or false"
-msgstr ""
 
 #, fuzzy
 msgid "Access token"
@@ -403,6 +406,10 @@ msgstr ""
 
 msgid "Add"
 msgstr "加"
+
+#, fuzzy
+msgid "Add Directory Group"
+msgstr "添加存储组"
 
 #, fuzzy
 msgid "Add Hello World failed!"
@@ -846,6 +853,9 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
+msgid "Both a directory group and a target are required."
+msgstr ""
+
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "广播名称"
@@ -1274,12 +1284,19 @@ msgstr "无法读取tmp文件。"
 msgid "Could not read snapin file"
 msgstr "无法读取tmp文件。"
 
+#, fuzzy
+msgid "Could not read the group mappings"
+msgstr "无法读取tmp文件。"
+
 msgid "Could not read tmp file."
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not register"
 msgstr "无法创建打印机"
+
+msgid "Could not remove the group mappings"
+msgstr ""
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1639,6 +1656,10 @@ msgstr "目录已经存在"
 
 msgid "Directory Cleaner"
 msgstr "目录清洁"
+
+#, fuzzy
+msgid "Directory Group"
+msgstr "目录"
 
 #, fuzzy
 msgid "Disable on all hosts"
@@ -2375,6 +2396,9 @@ msgstr "更新位置"
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grants"
+msgstr ""
+
 #, fuzzy
 msgid "Graph Color"
 msgstr "图形"
@@ -2480,8 +2504,18 @@ msgid "Group Management"
 msgstr "集团管理"
 
 #, fuzzy
+msgid "Group Mappings"
+msgstr "主机位置"
+
+#, fuzzy
 msgid "Group Matching"
 msgstr "主机位置"
+
+msgid ""
+"Group Matching is off for this server, so directory groups cannot be read "
+"and these mappings are not used. Users who can bind receive the fallback "
+"role from the global LDAP settings instead."
+msgstr ""
 
 msgid "Group Member Attribute"
 msgstr ""
@@ -4437,6 +4471,10 @@ msgstr "没有连接到数据库"
 msgid "No mac addresses to be removed"
 msgstr ""
 
+#, fuzzy
+msgid "No mappings defined."
+msgstr "已安装的插件"
+
 msgid "No master nodes are enabled to delete this image"
 msgstr "无主节点启用删除这张图片"
 
@@ -5394,6 +5432,10 @@ msgstr "返回键的值"
 
 msgid "Reverse"
 msgstr ""
+
+#, fuzzy
+msgid "Role"
+msgstr "模块名称"
 
 #, fuzzy
 msgid "Role Association"
@@ -6643,6 +6685,10 @@ msgid "Text"
 msgstr "文本"
 
 #, fuzzy
+msgid "That mapping already exists."
+msgstr "打印机已经存在"
+
+#, fuzzy
 msgid "That session has already started"
 msgstr "打印机已经存在"
 
@@ -6688,6 +6734,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected target no longer exists."
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6729,6 +6778,10 @@ msgstr "有此服务器上没有图像。"
 
 #, fuzzy
 msgid "There are no members to sync to"
+msgstr "有此服务器上没有组。"
+
+#, fuzzy
+msgid "There are no roles or user groups to map to yet."
 msgstr "有此服务器上没有组。"
 
 msgid "There are no snapins associated with this host"
@@ -7407,6 +7460,9 @@ msgstr "用户更新失败"
 msgid "User group updated!"
 msgstr "用户更新"
 
+msgid "User matched none of the mapped groups"
+msgstr ""
+
 #, fuzzy
 msgid "User not found"
 msgstr "未发现记录，错误： %s"
@@ -8074,6 +8130,10 @@ msgstr "N / A"
 
 msgid "never"
 msgstr ""
+
+#, fuzzy
+msgid "no longer exists"
+msgstr "不复存在"
 
 msgid "no response from server"
 msgstr ""


### PR DESCRIPTION
Two independent changes.

## 1. API HTTP basic auth never worked under FastCGI

The API advertises basic auth as an alternative to token auth, but it could not succeed on a stock install: the `Authorization` header does not reach PHP.

- **nginx** forwards only the `fastcgi_params` whitelist, and `Authorization` is not on it. FOG's generated `php.loc` never added it.
- **Apache + php-fpm** — `proxy_fcgi` strips it unless `CGIPassAuth` or `SetEnvIf` puts it back. FOG's generated vhost did neither, in any of its three `<VirtualHost>` blocks.
- **Apache + mod_php** was the only configuration where this ever worked.

Without the header PHP never synthesises `PHP_AUTH_USER`/`PHP_AUTH_PW`, so `_testAuth()` called `passwordValidate(null, null)` and every basic-auth request 401'd, including a correct one.

Fixed on both sides:

- The **installer** now emits the forwarding config. `SetEnvIf` rather than `CGIPassAuth`, because `CGIPassAuth` needs httpd >= 2.4.13 and an unknown directive stops Apache from starting (RHEL 7 ships 2.4.6).
- **`Route`** resolves the credential itself when `PHP_AUTH_USER` is absent, decoding `HTTP_AUTHORIZATION` and `REDIRECT_HTTP_AUTHORIZATION` (where it lands after the vhost's `/fog/*` rewrite). This is what fixes existing installs, which will not get the new webserver config without a reinstall.

Reading `$_SERVER` directly as a fallback is deliberate: `filter_input(INPUT_SERVER)` reads the SAPI's startup table, so keys PHP synthesises later can come back null under FPM even when `$_SERVER` has them.

**This widens nothing.** It only recovers a credential the client already sent. `_testToken()` still runs first, so the system API token is required before any username is looked at, and the caller must still clear `passwordValidate()` and the `uAllowAPI` test.

Note: FOG has no login rate limiting anywhere, on this path or any other. Worth a separate issue.

## 2. LDAP group mappings become real — #882 stories 2, 3, 4

Story 1 (in #881) added `LDAPGroupMap` and migrated the two fixed buckets into it, but nothing read the table and nothing could author it.

**Story 2** — `LDAP::_getAccessLevel()` answered "admin, plain user, or neither?" by running the same membership query twice, once per bucket, collapsing it to 2/1/0. Replaced by `_getMatchedGroups()`, which ORs every mapped group name into one filter and asks for the group name attribute back, so the answer is *which* names matched. Same number of round trips, not one per group.

`authLDAP()` returns the matched names instead of a scalar. `false` still means "this server grants nothing" — including group matching on with no group matched, which denied access before and still does. An empty array is the group-matching-off case.

Group names are now escaped into the LDAP filter; they come from an admin-editable table rather than a settings string.

**Story 3** — the tier ladder is deleted. It existed only to reconcile two servers returning scalars; with real membership, RBAC's additive rule applies and every matched group contributes its target. The managed set for the sync carve-out is derived from the map itself, so it stays correct as mappings change, and now covers **user groups** as well as roles — the Site plugin scopes on user groups, so syncing them without the carve-out would move people between sites on login.

**Story 4** — a Group Mappings tab on the LDAP server edit page. Authoring lives on the server because a group name only means something relative to its directory. Roles and user groups share one target list: two dependent controls can be posted in an impossible combination, one list cannot. Targets that no longer exist are shown rather than hidden.

Every `LDAPGroupMap` read uses raw bound SQL, not `Route::getIds()` — `_buildSql()` turns `*` and `+` in a scalar filter value into a SQL wildcard, and both are legal in an LDAP group name (`+` separates the parts of a multi-valued RDN).

Deleting an LDAP server now deletes its mappings.

Story 5 (read-side tabs on the Role and User Group pages) is not included.

## Testing

The story 1 migration was verified live. Stories 2-4 are linted against PHP 7.4 but **not yet exercised against a real directory** — that needs a deploy with the installer run, since the webserver config changes are outside the web root.

Refs #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s