### PR TITLE
Fix HTTP 500 on PHP 7.4 from the `mixed` hint on Initiator::e()

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -33,7 +33,15 @@ class Initiator
         }
     }
 
-    public static function e(mixed $value): string
+    /**
+     * No native `mixed` type hint here on purpose. `mixed` is a real type only
+     * from PHP 8.0; on 7.4 the parser reads it as a *class* name, so every call
+     * throws an uncaught TypeError ("must be an instance of mixed") and the
+     * request dies with a zero-byte 500 before any output. _verCheck() below
+     * still admits 7.4, so that is a supported target. The (string) cast makes
+     * the hint redundant anyway. Refs forums.fogproject.org topic 18204.
+     */
+    public static function e($value): string
     {
         return htmlspecialchars((string)($value ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }


### PR DESCRIPTION
## The bug

`Initiator::e()` on `stable` is declared `e(mixed $value)`. `mixed` became a real type in **PHP 8.0**; on **7.4** the parser reads it as a *class* type-hint, so every call site throws an uncaught `TypeError`:

```
Fatal error: Uncaught TypeError: Argument 1 passed to Initiator::e()
must be an instance of mixed, string given ... commons/init.php:36
```

There is no exception or shutdown handler in `packages/web`, so the request dies with a **zero-byte 500** — a blank white page in Firefox, "HTTP ERROR 500" elsewhere. No error surfaces to the user.

This is a **total outage**, not a schema-page problem. `FOGPage::__construct` calls `Initiator::e()`, so every page dies. It only *looks* schema-specific because `DatabaseManager::establish()` redirects an out-of-date install to `?node=schema` during `LoadGlobals` — before the fatal — so the schema page is the first one you land on after upgrading.

PHP 7.4 is a supported target: `_verCheck()` admits `>= 7.4`, `base.inc.php` polyfills `str_contains()`, and the installer installs the distro-default PHP with no version floor. **Ubuntu 20.04 ships 7.4.3**, which is what the reporter is running.

## Why stable still has it

Already fixed on `dev-branch` (10d4bce68) and `working-1.6` (9160be22c) on 2026-07-25 — but `stable` never received the cherry-pick. The two lines are diverged, so every **1.5.10.1903** install on PHP 7.4 is still dead. This ports the fix.

## The fix

Drop the hint. It was redundant — the `(string)($value ?? '')` cast already coerces.

## Verification

- Reproduced the fatal on `origin/stable` under real `php:7.4-cli`.
- Post-fix output is **byte-identical** on **7.4.33** and **8.3.32** for strings, `null`, ints, and quote-heavy input.
- `php -l` across every `.php` under `packages/`, `src/`, `bin/`, `lib/` on 7.4: **clean**.
- Swept the tree for the rest of the bug class — no other native `mixed` hints, and no unpolyfilled PHP 8.0+ functions (`str_contains`, `str_starts_with`, `get_debug_type`, `array_is_list`, …). `init.php:36` was the only PHP-8-only construct on `stable`.
- `php-cs-fixer --dry-run`: 0 of 433 files changed, so the pre-commit hook adds no collateral.

Refs https://forums.fogproject.org/topic/18204/

🤖 Generated with [Claude Code](https://claude.com/claude-code)