### PR TITLE
PHP 7.4: polyfill str_starts_with(), and fix str_contains() empty-needle divergence

### DIFF
--- a/packages/web/commons/base.inc.php
+++ b/packages/web/commons/base.inc.php
@@ -18,6 +18,19 @@ if (!function_exists('str_contains')) {
     }
 }
 
+// str_starts_with() is PHP 8.0+, but _verCheck() admits 7.4 and the installer
+// takes the distro-default PHP with no version floor (Ubuntu 20.04 = 7.4.3).
+// SnapinClient::json() calls it, and an undefined-function fatal there is a
+// zero-byte 500 the FOG Client reads as a transport failure -- snapins just
+// silently never deploy. Same bug class as the `mixed` hint in init.php.
+// Refs forums.fogproject.org topic 18204.
+if (!function_exists('str_starts_with')) {
+    function str_starts_with($haystack, $needle)
+    {
+        return strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 // Set security-related headers.
 header('X-Frame-Options: sameorigin');
 header('X-XSS-Protection: 1; mode=block');

--- a/packages/web/commons/base.inc.php
+++ b/packages/web/commons/base.inc.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
  * @link     https://fogproject.org
  */
 
+// The empty needle must short-circuit to true, matching PHP 8's str_contains()
+// -- "" is contained in every string. It cannot be left to strpos(), which on
+// 7.4 rejects an empty needle with a warning and returns false; that is what
+// made this polyfill disagree with the native function it stands in for.
 if (!function_exists('str_contains')) {
     function str_contains($haystack, $needle)
     {
-        return $needle !== '' && strpos($haystack, $needle) !== false;
+        return $needle === '' || strpos($haystack, $needle) !== false;
     }
 }
 


### PR DESCRIPTION
Found while sweeping `working-1.6` for the rest of the PHP 7.4 bug class after the `Initiator::e(mixed …)` fix (#899 ports that one to `stable`).

## The bug

`SnapinClient::json()` (`packages/web/lib/client/snapinclient.class.php:172`) calls `str_starts_with()` to normalise a storage node's `location_url`. That function is **PHP 8.0+**, and `base.inc.php` only polyfilled `str_contains()` — so on 7.4 it is:

```
Fatal error: Uncaught Error: Call to undefined function str_starts_with()
```

7.4 is a supported target: `_verCheck()` admits `>= 7.4`, and the installer takes the distro-default PHP with no version floor (Ubuntu 20.04 ships 7.4.3).

## Why nobody has reported it

There is no exception or shutdown handler in `packages/web`, so the fatal becomes a **zero-byte 500** — and a non-2xx status is invisible to the FOG Client, which reads it as a transport failure. On a 7.4 box, snapins simply never deploy, with nothing in the UI explaining why. Only hosts that actually have a snapin task reach the loop, so the rest of FOG looks perfectly healthy.

## The fix

Polyfill it, rather than rewriting the call site to `strncmp()` — matches the `str_contains()` pattern already in that file.

## Verification

- Identical results under the 7.4.33 polyfill and native 8.3.32 for `('://x','://')`, `('http://x','://')`, `('abc','')`, `('','x')`, `('abc','abc')`, `('ab','abc')` — including the empty-needle case, where `strncmp()` correctly gives PHP 8's `true`.
- Whole tree lints clean on 7.4.
- Re-swept `working-1.6` and `dev-branch`: no native `mixed` hints remain, and this was the only unpolyfilled PHP 8.0+ function. `dev-branch` does not have this call site.

Refs https://forums.fogproject.org/topic/18204/

🤖 Generated with [Claude Code](https://claude.com/claude-code)