### PR TITLE
Make the str_contains() polyfill agree with the function it replaces

### DIFF
--- a/packages/web/commons/base.inc.php
+++ b/packages/web/commons/base.inc.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
  * @link     https://fogproject.org
  */
 
+// The empty needle must short-circuit to true, matching PHP 8's str_contains()
+// -- "" is contained in every string. It cannot be left to strpos(), which on
+// 7.4 rejects an empty needle with a warning and returns false; that is what
+// made this polyfill disagree with the native function it stands in for.
 if (!function_exists('str_contains')) {
     function str_contains($haystack, $needle)
     {
-        return $needle !== '' && strpos($haystack, $needle) !== false;
+        return $needle === '' || strpos($haystack, $needle) !== false;
     }
 }
 


### PR DESCRIPTION
## The divergence

`base.inc.php` polyfills `str_contains()` for PHP 7.4 as:

```php
return $needle !== '' && strpos($haystack, $needle) !== false;
```

That guard makes `str_contains($h, '')` return **`false`**. PHP 8's native `str_contains()` returns **`true`** — `""` is contained in every string. So a 7.4 install and a PHP 8 install answer the same call differently, which is worse than either answer on its own.

## Why the guard can't just be dropped

On 7.4, `strpos()` rejects an empty needle with `Warning: strpos(): Empty needle` and returns `false` — so `strpos($h, '') !== false` is *still* wrong, and now noisy as well. The empty needle has to short-circuit to `true` before `strpos()` is reached.

## Scope

There are **no `str_contains()` call sites on this branch** — the polyfill is dormant here. Fixed anyway so it's correct for the first caller, and so the two branches don't disagree. Ported from `working-1.6` (#900), which does have two call sites (`fogssh.class.php:135,137`, both with literal non-empty needles, so no reachable behaviour change there either).

## Verification

Identical results to native 8.3.32 under 7.4.33 with `error_reporting=E_ALL`, no warning emitted:

| case | polyfill (7.4) | native (8.3) |
|---|---|---|
| `('abc','b')` | true | true |
| `('abc','z')` | false | false |
| `('abc','')` | **true** | **true** |
| `('','')` | **true** | **true** |
| `('','x')` | false | false |
| `('abc','abc')` | true | true |
| `('a/b','/')` | true | true |

Tree lints clean on 7.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)