### PR TITLE
Stop the installer reporting failures on a successful upgrade

### DIFF
--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -49,14 +49,24 @@ if [[ $systemctl == yes ]]; then
             initdpath="/usr/lib/systemd/system"
             ;;
     esac
+    # Alias mysql/mysqld onto whichever DB unit the distro actually ships, so the
+    # $dbservice lookup in functions.sh finds a name whatever the packaging.
+    #
+    # The /etc/systemd/system sources previously read `$initdpath/mariadb` with no
+    # .service suffix, which produced a *dangling* link. That is not cosmetic:
+    # /etc/systemd/system takes precedence over $initdpath, so a broken link there
+    # shadows the distro's working alias and systemd reports the unit as "bad" --
+    # which is what the `grep -v bad` guard in functions.sh is working around.
+    # linkIfAbsent() replaces such a link when it finds one, healing installs that
+    # already ran an affected version. Refs forums topic 18204.
     if [[ -e $initdpath/mariadb.service ]]; then
-        ln -s $initdpath/{mariadb,mysql}.service >>$error_log 2>&1
-        ln -s $initdpath/{mariadb,mysqld}.service >>$error_log 2>&1
-        ln -s $initdpath/mariadb /etc/systemd/system/mysql.service >>$error_log 2>&1
-        ln -s $initdpath/mariadb /etc/systemd/system/mysqld.service >>$error_log 2>&1
+        linkIfAbsent $initdpath/mariadb.service $initdpath/mysql.service
+        linkIfAbsent $initdpath/mariadb.service $initdpath/mysqld.service
+        linkIfAbsent $initdpath/mariadb.service /etc/systemd/system/mysql.service
+        linkIfAbsent $initdpath/mariadb.service /etc/systemd/system/mysqld.service
     elif [[ -e $initdpath/mysqld.service ]]; then
-        ln -s $initdpath/mysql{d,}.service >>$error_log 2>&1
-        ln -s $initdpath/mysqld.service /etc/systemd/system/mysql.service >>$error_log 2>&1
+        linkIfAbsent $initdpath/mysqld.service $initdpath/mysql.service
+        linkIfAbsent $initdpath/mysqld.service /etc/systemd/system/mysql.service
     fi
 else
     initdpath="/etc/init.d"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -21,6 +21,29 @@ dots() {
     printf " * %s%*.*s" "$1" 0 $((60-${#1})) "$pad"
     return 0
 }
+# Create a symlink only when nothing already owns the destination.
+#
+# Bare `ln -s` logged "failed to create symbolic link ...: File exists" on every
+# re-install, because the link survives from the previous run. Harmless, but it
+# made a successful upgrade read as a failed one and sent at least one reporter
+# chasing the installer instead of the real fault (forums topic 18204).
+#
+# `ln -sf` is deliberately not used: some distros own these paths themselves
+# (Fedora ships /usr/lib/systemd/system/mysql.service), and clobbering a
+# packaged file is worse than skipping a link we did not need to make.
+linkIfAbsent() {
+    local target="$1" link="$2"
+    # A dangling link here is one we created ourselves on an older version, back
+    # when the systemd unit sources below were missing their .service suffix. It
+    # is useless to systemd -- and worse, one in /etc/systemd/system shadows the
+    # working unit in /usr/lib -- so replace it. A real file, or a link that
+    # resolves, is left strictly alone.
+    if [[ -L $link && ! -e $link ]]; then
+        rm -f "$link" >>$error_log 2>&1
+    fi
+    [[ -e $link || -L $link ]] && return 0
+    ln -s "$target" "$link" >>$error_log 2>&1
+}
 backupReports() {
     dots "Backing up user reports"
     [[ ! -d ../rpttmp/ ]] && mkdir ../rpttmp/ >>$error_log
@@ -2080,7 +2103,9 @@ EOF
             fi
             diffconfig "${etcconf}"
             errorStat $?
-            ln -s $webdirdest $webdirdest/ >>$error_log 2>&1
+            # Self-referential link so /fog/fog/... resolves. $webdirdest carries
+            # a trailing slash, hence the basename.
+            linkIfAbsent $webdirdest ${webdirdest%/}/$(basename $webdirdest)
             case $osid in
                 1)
                     phpfpmconf='/etc/php-fpm.d/www.conf';
@@ -2102,7 +2127,13 @@ EOF
                 sed -i 's/pm\.start_servers = .*/pm.start_servers = 5/g' $phpfpmconf >>$error_log 2>&1
             fi
             if [[ $osid -eq 2 ]]; then
-                a2enmod php >>$error_log 2>&1
+                # No `a2enmod php` here. Debian/Ubuntu name that module
+                # php<version> (php7.4, php8.3), never plain php, so the call
+                # only ever printed "ERROR: Module php does not exist!" -- the
+                # line that made a working install look broken in forums topic
+                # 18204. Enabling mod_php would be wrong anyway: FOG serves PHP
+                # through FPM via proxy_fcgi below, and mod_php forces
+                # mpm_prefork, which conflicts.
                 a2enmod proxy_fcgi setenvif >>$error_log 2>&1
                 a2enmod rewrite >>$error_log 2>&1
                 a2enmod ssl >>$error_log 2>&1


### PR DESCRIPTION
Three installer complaints from forums topic 18204, reported together and all *looking* cosmetic — one of them isn't.

**None of these caused the HTTP 500 in that thread** (that was the `mixed` hint on `Initiator::e()`, already fixed). They're the red herring that sent the reporter into the installer instead of the web tier.

## 1. `ERROR: Module php does not exist!` — noise

`a2enmod php`. Debian/Ubuntu name that module `php<version>` (`php7.4`, `php8.3`), never plain `php`, so this line has only ever failed — on every Debian-family install FOG has ever done. Verified on a real `ubuntu:20.04` container:

```
--- available apache modules matching php ---
php7.4.conf
php7.4.load
--- a2enmod php ---
ERROR: Module php does not exist!   exit=1
```

**Removed rather than corrected to `a2enmod php$php_ver`.** FOG serves PHP through FPM via `proxy_fcgi` on the very next line; mod_php would force `mpm_prefork` and conflict with that.

## 2. Dangling systemd unit links — the real defect

The `/etc/systemd/system` aliases were sourced from `$initdpath/mariadb` — **no `.service` suffix**. Line 55 got it right, line 61 got it right, 57 and 58 didn't. On any box where those paths weren't already taken, the installer created a **broken** link:

```
etc/mysql.service   -> .../lib/mariadb   *** DANGLING ***
etc/mysqld.service  -> .../lib/mariadb   *** DANGLING ***
```

That's not cosmetic: `/etc/systemd/system` takes **precedence** over `$initdpath`, so a broken link there shadows the distro's working alias, and systemd reports the unit as `bad`. Corroboration that this has bitten before — the `$dbservice` lookup in `functions.sh` already filters through **`grep -v bad`**, working around the symptom.

## 3. `File exists` on every re-run — noise

Bare `ln -s` isn't repeatable, so an upgrade logged a wall of failures for links that were already correct. This is the bulk of what the reporter pasted, and it's why a working install read as a broken one. The repo's own committed `bin/error_logs/*.log` show the identical lines.

## The fix

2 and 3 are fixed together by `linkIfAbsent()`: link only when nothing owns the destination, and replace a link that *dangles* — which heals boxes that already ran an affected version.

**`ln -sf` is deliberately not used.** Some distros own these paths (Fedora ships `/usr/lib/systemd/system/mysql.service` itself), and clobbering a packaged file is worse than skipping a link we didn't need to make.

## Verification

Both files pass `bash -n`; no call sites left unconverted. Helper exercised against the real scenarios:

| scenario | result |
|---|---|
| clean box | link created, `.service` suffix correct |
| re-run / upgrade | no-op, **zero** log output |
| box left dangling by the old code | **healed** |
| distro-owned regular file | left untouched |
| working distro symlink to another unit | left untouched |

`$webdirdest` link name and target are byte-identical to the old `ln -s $webdirdest $webdirdest/` across all three webroot shapes.

Companion PR for `working-1.6`: #903. The helper and the `config.sh` block are byte-identical across both branches; only the call sites differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
