### PR TITLE
Resolve the DB unit to one name instead of three

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1408,8 +1408,27 @@ configureMySql() {
     # ---------------------------------------------------------
     stopInitScript
     dots "Setting up and starting MySQL"
-    dbservice=$(systemctl list-units | grep -o -e "mariadb\.service" -e "mysqld\.service" -e "mysql\.service" | tr -d '@')
-    [[ -z $dbservice ]] && dbservice=$(systemctl list-unit-files | grep -v bad | grep -o -e "mariadb\.service" -e "mysqld\.service" -e "mysql\.service" | tr -d '@')
+    # Resolve exactly one unit name.
+    #
+    # `grep -o` prints one line per match, and `systemctl list-unit-files` lists
+    # the mysql/mysqld alias symlinks alongside the real unit -- so the fallback
+    # yielded a three-line $dbservice (it does on a stock Fedora box). Unquoted,
+    # that word-split into `systemctl enable|stop|start` as three arguments, two
+    # of them alias names rather than the real unit. The fallback is the
+    # fresh-install path: the primary lookup only sees units already running, and
+    # RedHat-family packages do not auto-start the DB.
+    dbunits=$(systemctl list-units | grep -o -e "mariadb\.service" -e "mysqld\.service" -e "mysql\.service" | tr -d '@')
+    [[ -z $dbunits ]] && dbunits=$(systemctl list-unit-files | grep -v bad | grep -o -e "mariadb\.service" -e "mysqld\.service" -e "mysql\.service" | tr -d '@')
+    # Preference is explicit because grep cannot express it -- `-e` order does not
+    # rank matches, it just reports whichever appeared first in the input. Real
+    # unit first, aliases after.
+    dbservice=""
+    for dbcandidate in mariadb.service mysqld.service mysql.service; do
+        if grep -qFx "$dbcandidate" <<<"$dbunits"; then
+            dbservice=$dbcandidate
+            break
+        fi
+    done
     for mysqlconf in $(grep -rl '.*skip-networking' /etc | grep -v init.d); do
         sed -i '/.*skip-networking/ s/^#*/#/' -i $mysqlconf >>$error_log 2>&1
     done
@@ -1422,9 +1441,9 @@ configureMySql() {
             chown -R mysql:mysql /var/lib/mysql >>$error_log 2>&1
             mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql >>$error_log 2>&1
         fi
-        systemctl is-enabled --quiet $dbservice || systemctl enable $dbservice >>$error_log 2>&1
-        systemctl is-active --quiet $dbservice && systemctl stop $dbservice >>$error_log 2>&1
-        systemctl start $dbservice >>$error_log 2>&1
+        systemctl is-enabled --quiet "$dbservice" || systemctl enable "$dbservice" >>$error_log 2>&1
+        systemctl is-active --quiet "$dbservice" && systemctl stop "$dbservice" >>$error_log 2>&1
+        systemctl start "$dbservice" >>$error_log 2>&1
     else
         case $osid in
             1)


### PR DESCRIPTION
`configureMySql()` built `$dbservice` with `grep -o` and three `-e` patterns. `grep -o` prints **one line per match**, and `systemctl list-unit-files` lists the `mysql`/`mysqld` alias symlinks alongside the real unit — so the fallback lookup returned a three-line value. Verified on a stock Fedora box:

```
raw candidates: mariadb.service mysql.service mysqld.service
dbservice     : $'mariadb.service\nmysql.service\nmysqld.service'
word-split    : 3 args -> mariadb.service mysql.service mysqld.service
```

Unquoted, that fed `systemctl enable|stop|start` **three** arguments — two of them alias names rather than the real unit — where one was intended.

## This is the fresh-install path, not an edge case

The primary lookup uses `systemctl list-units`, which only sees units **already running**. RedHat-family packages don't auto-start the DB after install — so on a new Fedora/RHEL install the primary comes back empty, the fallback fires, and this is exactly where it lands.

## Two changes

1. **Resolve to a single name, preference stated explicitly.** `grep` cannot express preference — `-e` order does not rank matches, it reports whichever appeared first in the *input*. So the real unit was never actually preferred over its aliases; it just usually sorted that way by luck.
2. **Quote `$dbservice` at the three `systemctl` call sites**, so a multi-valued result can never silently become multiple arguments again.

On `working-1.6` the alpine `rc-service -l | grep mariadb` lookup was also bounded with `head -1` — same unbounded shape. This branch has no alpine lookup, so there's no counterpart here; the resolution block is otherwise byte-identical across the two branches.

## Verification

| check | result |
|---|---|
| fallback path on this box | **1 arg** (was 3) |
| primary path on this box | unchanged, `mariadb.service` |
| input `mysql.service` | → `mysql.service` |
| input `mysqld.service` + `mysql.service` | → `mysqld.service` |
| input all three | → `mariadb.service` |
| input empty | → empty (unchanged from before) |
| `bash -n` | passes |

**Not verified:** whether `systemctl enable` on the alias names errors or merely no-ops on a fresh RedHat box — that needs an actual install run to observe. The multi-argument expansion itself is demonstrated above.

Companion PR for `working-1.6`: #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)