### PR TITLE
Add isPopulated() so association guards stop trusting isLoaded()

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -1084,7 +1084,25 @@ abstract class FOGBase
         return -1;
     }
     /**
-     * Check if isLoaded.
+     * Internal recursion guard for the get()/set()/loadItem() lazy-load
+     * chain -- NOT a "does this key hold data" predicate.
+     *
+     * This is a test-and-set: every call marks $key loaded, even one that
+     * returns false. That side effect is required so a loadX() method's
+     * own set() call doesn't see "not loaded" again, re-trigger loadItem(),
+     * and recurse forever. It means a bare `if ($this->isLoaded($key))`
+     * used as a standalone precondition -- anywhere the false branch isn't
+     * immediately followed, in the same call, by an actual load -- will
+     * silently poison the flag for the rest of the request: later code
+     * that calls get($key) expecting a real lazy-loaded value instead
+     * sees the (now-true) flag, skips the real load, and falls back to
+     * get()'s "never set" default.
+     *
+     * Use isPopulated($key) instead for "do I actually have data for this
+     * key" checks -- it has no such side effect. This exact confusion
+     * (Host::save()'s snapins guard + assocSetter()'s own isLoaded() gate)
+     * caused phantom saSnapinID=0 rows to be inserted on every FOG client
+     * check-in.
      *
      * @param string|int $key the key to see if loaded
      *
@@ -1097,6 +1115,23 @@ abstract class FOGBase
         $this->isLoaded[$key] = true;
 
         return $result ? $result : false;
+    }
+    /**
+     * Whether $key currently holds resolved data -- a pure,
+     * side-effect-free predicate. Unlike isLoaded() (a recursion guard for
+     * the internal lazy-load chain; see its docblock), this is safe to use
+     * as a standalone precondition anywhere the caller means "do I have
+     * real data for this key," e.g. "only sync this association if the
+     * caller actually touched it."
+     *
+     * @param string|int $key the key to check
+     *
+     * @return bool
+     */
+    protected function isPopulated($key)
+    {
+        $key = $this->key($key);
+        return array_key_exists($key, $this->data);
     }
     /**
      * Reset request variables.

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -1124,6 +1124,13 @@ abstract class FOGBase
      * real data for this key," e.g. "only sync this association if the
      * caller actually touched it."
      *
+     * Deliberately isset(), not array_key_exists(): get()'s own fallback
+     * to '' is gated the same way (`isset($this->data[$key]) ? ... : ''`),
+     * so this only reports true when get() is actually about to return
+     * real data instead of that fallback -- the two must agree, or a key
+     * explicitly set to null would read as "populated" here while get()
+     * still silently handed back ''.
+     *
      * @param string|int $key the key to check
      *
      * @return bool
@@ -1131,7 +1138,7 @@ abstract class FOGBase
     protected function isPopulated($key)
     {
         $key = $this->key($key);
-        return array_key_exists($key, $this->data);
+        return isset($this->data[$key]);
     }
     /**
      * Reset request variables.

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1263,13 +1263,23 @@ abstract class FOGController extends FOGBase
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't loaded yet.
-        if (!$this->isLoaded($plural)) {
+        // Don't work on item that isn't populated yet. isPopulated(), not
+        // isLoaded(): isLoaded() marks a key loaded on every call, even
+        // one that answers false, so a bare isLoaded() gate anywhere else
+        // in the request (present or future) could poison this check and
+        // make it proceed on stale/empty data. isPopulated() only reports
+        // true once real data is actually here.
+        if (!$this->isPopulated($plural)) {
             return $this;
         }
 
-        // Get the current items.
+        // Get the current items. Guard against a non-array fallback (e.g.
+        // an empty string) so a bad value can't cast to [''] below and be
+        // diffed in as a phantom "new" association.
         $items = $this->get($plural);
+        if (!$items) {
+            $items = [];
+        }
 
         // Fetch current associations from the database.
         $cur = Route::getIds(

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -282,19 +282,20 @@ class Host extends FOGController
         // the "< 1" guard on setSnapinOrder()'s save path; without this a 0
         // would be inserted and later surface as a phantom run-order entry.
         //
-        // Deliberately unconditional: FOGBase::isLoaded() marks a key loaded
-        // on every call, even when it answers false and nothing follows up
-        // by loading it. Gating this on isLoaded('snapins') let a plain
-        // check-in (nothing else touches 'snapins' first) poison that flag,
-        // so the assocSetter('Snapin', 'snapin') call below trusted it and
-        // skipped the real DB load, falling back to get()'s empty-string
-        // default -- which then got cast to ['' ] and inserted as saSnapinID=0.
-        // get() already lazy-loads correctly when not yet loaded, so just
-        // call it directly.
-        $this->set(
-            'snapins',
-            self::positiveIntIds($this->get('snapins'))
-        );
+        // Gated on isPopulated(), not isLoaded(): isLoaded() marks a key
+        // loaded on every call, even when it answers false, which let this
+        // exact check poison assocSetter('Snapin', 'snapin') below into
+        // trusting stale state, skipping the real DB load, and falling back
+        // to get()'s empty-string default -- which then got cast to ['']
+        // and inserted as saSnapinID=0. isPopulated() is a pure predicate
+        // with no such side effect, so this only runs (and assocSetter only
+        // proceeds) when 'snapins' actually holds real data.
+        if ($this->isPopulated('snapins')) {
+            $this->set(
+                'snapins',
+                self::positiveIntIds($this->get('snapins'))
+            );
+        }
         $this
             ->assocSetter('Group', 'group')
             ->assocSetter('Module', 'module')
@@ -303,7 +304,7 @@ class Host extends FOGController
         // assocSetter inserts new snapin associations with sequence 0; give
         // any unsequenced rows a run-order value after the existing ones so
         // newly added snapins land at the end rather than jumping to front.
-        if ($this->isLoaded('snapins')) {
+        if ($this->isPopulated('snapins')) {
             $this->_appendSnapinSequence();
         }
         // Safety net: never leave the host with MAC rows but no primary MAC.

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -281,12 +281,20 @@ class Host extends FOGController
         // write) before assocSetter persists it as a snapinAssoc row. Mirrors
         // the "< 1" guard on setSnapinOrder()'s save path; without this a 0
         // would be inserted and later surface as a phantom run-order entry.
-        if ($this->isLoaded('snapins')) {
-            $this->set(
-                'snapins',
-                self::positiveIntIds($this->get('snapins'))
-            );
-        }
+        //
+        // Deliberately unconditional: FOGBase::isLoaded() marks a key loaded
+        // on every call, even when it answers false and nothing follows up
+        // by loading it. Gating this on isLoaded('snapins') let a plain
+        // check-in (nothing else touches 'snapins' first) poison that flag,
+        // so the assocSetter('Snapin', 'snapin') call below trusted it and
+        // skipped the real DB load, falling back to get()'s empty-string
+        // default -- which then got cast to ['' ] and inserted as saSnapinID=0.
+        // get() already lazy-loads correctly when not yet loaded, so just
+        // call it directly.
+        $this->set(
+            'snapins',
+            self::positiveIntIds($this->get('snapins'))
+        );
         $this
             ->assocSetter('Group', 'group')
             ->assocSetter('Module', 'module')

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -129,7 +129,10 @@ class Image extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isLoaded('hosts')) {
+        // isPopulated(), not isLoaded(): isLoaded() marks a key loaded on
+        // every call even when it answers false, so it can't be trusted as
+        // a standalone "did the caller actually set hosts" precondition.
+        if ($this->isPopulated('hosts')) {
             $ids = Route::getIds(
                 'host',
                 ['imageID' => $this->get('id')]

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -248,9 +248,16 @@ class Role extends FOGController
      */
     private function _syncPermissions()
     {
-        if (!$this->isLoaded('permissions')) {
-            return $this;
-        }
+        // Deliberately unconditional: FOGBase::isLoaded() marks a key loaded
+        // on every call, even when it answers false and nothing follows up
+        // by loading it. Gating this on isLoaded('permissions') would let a
+        // save that never touches permissions (e.g. a plain rename) poison
+        // that flag, so any later get('permissions') on this same object
+        // (e.g. the API response after save()) would skip the real DB load
+        // and see an empty list instead of the role's actual permissions.
+        // get() already lazy-loads correctly when not yet loaded; when
+        // nothing changed, $permissions and $cur end up identical below and
+        // this is a no-op past the two SELECTs.
         $permissions = array_values(
             array_unique(
                 array_filter(

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -248,16 +248,16 @@ class Role extends FOGController
      */
     private function _syncPermissions()
     {
-        // Deliberately unconditional: FOGBase::isLoaded() marks a key loaded
-        // on every call, even when it answers false and nothing follows up
-        // by loading it. Gating this on isLoaded('permissions') would let a
-        // save that never touches permissions (e.g. a plain rename) poison
-        // that flag, so any later get('permissions') on this same object
+        // Gated on isPopulated(), not isLoaded(): isLoaded() marks a key
+        // loaded on every call, even when it answers false, so a save that
+        // never touches permissions (e.g. a plain rename) would poison
+        // that flag, and a later get('permissions') on this same object
         // (e.g. the API response after save()) would skip the real DB load
         // and see an empty list instead of the role's actual permissions.
-        // get() already lazy-loads correctly when not yet loaded; when
-        // nothing changed, $permissions and $cur end up identical below and
-        // this is a no-op past the two SELECTs.
+        // isPopulated() is a pure predicate with no such side effect.
+        if (!$this->isPopulated('permissions')) {
+            return $this;
+        }
         $permissions = array_values(
             array_unique(
                 array_filter(


### PR DESCRIPTION
## Summary
- `FOGBase::isLoaded($key)` is a test-and-set recursion guard for the internal `get()`/`set()`/`loadItem()` lazy-load chain — every call marks the key loaded, even one that answers `false`. That's required internally (a `loadX()` method's own `set()` call must not see "not loaded" again and recurse forever), but it means a bare `if ($this->isLoaded($key))` used as a standalone precondition elsewhere silently poisons the flag for the rest of the request.
- That's exactly how this went wrong: `Host::save()`'s snapins guard (added in 8e31b5cf0 to strip stale/blank snapin ids) checked `isLoaded('snapins')` on a plain FOG client check-in where nothing else touches `'snapins'` first. The check answered `false` (correctly — guard skipped) but poisoned the flag anyway. `assocSetter('Snapin', 'snapin')`, called right after, then trusted the poisoned flag and proceeded on `get('snapins')`'s empty-string fallback.
- **Severity correction (h/t review comment from a parallel investigation):** this isn't just a phantom-row-insertion bug. `assocSetter()`'s removal half runs *before* its insert half and had no guard of its own: `(array)''` casts to `['']`, and `array_diff($cur, [''])` subtracts nothing, so `$rem` came out as the host's **entire real snapin list**. On the first check-in a host received after picking up a build containing 8e31b5cf0 (2026-06-24 onward), every one of its real `snapinAssoc` rows was deleted, and only then did a single phantom `saSnapinID = 0` row get inserted. Subsequent check-ins just churned that 0 row (delete + reinsert), which is what steady-state production logging showed. **A `DELETE FROM snapinAssoc WHERE saSnapinID = 0` cleanup does not restore the lost real assignments** — any host that checked in during that window needs its snapins manually reassigned. Worth flagging in release notes since the failure was silent (no error, no log line, Snapins tab just came back empty).
- Rather than patch each guard individually (an earlier version of this PR did exactly that), this fixes the general mechanism: added `FOGBase::isPopulated($key)` — `isset($this->data[$key])`, matching `get()`'s own fallback condition exactly, so it only reports true when `get()` is actually about to return real data — and switched every standalone gate to it:
  - `assocSetter()`'s own "don't work on an unloaded item" check — the single shared implementation behind **all 24 call sites across every association type** (groups, modules, printers, snapins, role users/usergroups, storage groups, powermanagement, and the OU/WindowsKey/Location/Site/LDAP plugins). This is the high-leverage fix: no bare `isLoaded()` check anywhere else, present or future, can fool `assocSetter()` again, and the delete-everything failure mode above is now impossible for any of the 24 relations, not just snapins.
  - `Host::save()`'s snapins guard.
  - `Role::_syncPermissions()` — identical shape: a role save that never touches permissions (e.g. a plain rename) would poison the flag, so a later `get('permissions')` on that object (e.g. building the API response after `save()`) would see an empty list instead of the role's real permissions.
  - `Image::save()`'s hosts-reassignment guard — also fixes a latent second-save `TypeError` (`count()` on a non-countable `''`) that a parallel review flagged for the pre-isPopulated() version of this guard.
- `isLoaded()` itself, and the internal `get()`/`set()`/`add()`/`remove()` call sites that pair it with an immediate load, are unchanged — recursion-safety isn't touched.
- Also added a defensive fallback in `assocSetter()`: guard `$items` against a falsy (e.g. empty-string) `get()` result before the `(array)` cast, so a bad value can't turn into `['']` and get diffed in as a phantom association or a mass-delete — belt and suspenders alongside the isPopulated() fix, and now provably unreachable via the poisoning path since the isPopulated() gate returns early first.

## Test plan
- [ ] Deploy to a test FOG server and let a host check in repeatedly; confirm no new `snapinAssoc` rows with `saSnapinID = 0` appear, and confirm existing real snapin assignments survive repeated check-ins.
- [ ] Edit a role's name without touching permissions, then re-fetch it via the API; confirm `permissions` still reflects the real list.
- [ ] Edit a role's permissions and confirm they still save correctly (isPopulated() gate doesn't regress the working case).
- [ ] **Remediation on affected installs is two steps, not one:** (1) `DELETE FROM snapinAssoc WHERE saSnapinID = 0` to clear the phantom rows; (2) any host that checked in between 2026-06-24 and this fix landing needs its real snapin assignments manually recreated — they were deleted, not just polluted.

A companion PR applies the equivalent fix to `dev-branch` (which has its own independent set of bare `isLoaded()` gates — different call sites, same underlying bug shape — but never received 8e31b5cf0 and was never vulnerable to the specific snapin data-loss bug this PR was originally opened for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
