### PR TITLE
fix(web): make the task pane action buttons honour their float classes

### DIFF
--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -168,10 +168,13 @@ class TaskManagement extends FOGPage
             ['tabData' => &$tabData]
         );
         echo self::tabFields($tabData, false);
+        // Create is this modal's commit action, so it is the primary and sits
+        // right; the dismiss sits left. Matches the multicast session modal on
+        // imagemanagement, which is the reference for this pane shape.
         $modalApprovalBtns = self::makeButton(
             'tasking-send',
             _('Create'),
-            'btn btn-outline-secondary float-end'
+            'btn btn-primary float-end'
         );
         $modalApprovalBtns .= self::makeButton(
             'tasking-close',
@@ -258,10 +261,11 @@ class TaskManagement extends FOGPage
             []
         ];
         echo '<!-- Active Tasks -->';
-        $this->render(12, 'active-tasks-table');
-        echo '<div class="btn-group">';
-        echo $this->_paneButtons('active', 'active');
-        echo '</div>';
+        $this->render(
+            12,
+            'active-tasks-table',
+            $this->_paneButtons('active', 'active')
+        );
     }
     /**
      * Renders the active multicast tasks pane.
@@ -283,10 +287,11 @@ class TaskManagement extends FOGPage
             []
         ];
         echo '<!-- Active Multi-cast Tasks -->';
-        $this->render(12, 'active-multicast-table');
-        echo '<div class="btn-group">';
-        echo $this->_paneButtons('activemulticast', 'multicast');
-        echo '</div>';
+        $this->render(
+            12,
+            'active-multicast-table',
+            $this->_paneButtons('activemulticast', 'multicast')
+        );
     }
     /**
      * Renders the active snapin tasks pane.
@@ -308,10 +313,11 @@ class TaskManagement extends FOGPage
             []
         ];
         echo '<!-- Active Snapin Tasks -->';
-        $this->render(12, 'active-snapintasks-table');
-        echo '<div class="btn-group">';
-        echo $this->_paneButtons('activesnapins', 'snapins');
-        echo '</div>';
+        $this->render(
+            12,
+            'active-snapintasks-table',
+            $this->_paneButtons('activesnapins', 'snapins')
+        );
     }
     /**
      * Renders the scheduled tasks pane.
@@ -335,10 +341,11 @@ class TaskManagement extends FOGPage
             []
         ];
         echo '<!-- Scheduled Tasks -->';
-        $this->render(12, 'scheduled-task-table');
-        echo '<div class="btn-group">';
-        echo $this->_paneButtons('activescheduled', 'scheduled');
-        echo '</div>';
+        $this->render(
+            12,
+            'scheduled-task-table',
+            $this->_paneButtons('activescheduled', 'scheduled')
+        );
     }
     /**
      * Renders the queued path deletions pane.
@@ -366,10 +373,11 @@ class TaskManagement extends FOGPage
             []
         ];
         echo '<!-- Scheduled Deletions -->';
-        $this->render(12, 'scheduled-deletion-table');
-        echo '<div class="btn-group">';
-        echo $this->_paneButtons('activescheduleddels', 'deletions');
-        echo '</div>';
+        $this->render(
+            12,
+            'scheduled-deletion-table',
+            $this->_paneButtons('activescheduleddels', 'deletions')
+        );
     }
     /**
      * Renders the recent (completed/cancelled) tasks pane.


### PR DESCRIPTION
## Summary

The five task panes (active, multicast, snapins, scheduled, deletions) echoed `_paneButtons()` inside a bare `<div class="btn-group">`. `btn-group` is a flex container, so `float-start`/`float-end` on its children are inert — Cancel Selected / Pause Reload / Resume Reload rendered as one joined, left-aligned pill regardless of the classes they carried.

The classes were already correct per the button convention in `CLAUDE.md`. Only the container was wrong.

Pass the buttons through `render()`'s `$buttons` argument instead, which wraps them in `.btn-actionbox` the way every other list page does. Floats now apply:

- **Cancel Selected** (`btn-danger`) and **Pause Reload** (`btn-warning`) — left
- **Resume Reload** (`btn-success`) — right

That matches the multicast sessions pane on `imagemanagement.page.php:1331`, which is the reference for this shape.

Emitted position is unchanged: `FOGPage::process()` returns `ob_get_clean() . $actionbox`, appending the actionbox after the table — exactly where the old `echo` was.

Also promotes the create-tasking modal's **Create** button from `btn-outline-secondary` to `btn-primary`. It is the modal's commit action, so per the convention it is the primary and sits right; the multicast session modal already does this.

## Notes

- The JS binds these by class within the pane (`$pane.find('.cancel-selected')`, `.pause-refresh`, `.resume-refresh` — `fog.task.list.js:426-428`), so the wrapper change does not affect the bindings.
- No JS or CSS changed, so no `FOG_BCACHE_VER` bump is needed.
- The `btn-group` at `taskmanagement.page.php:416` (the Recent tab's state filter) is a genuine `role="group"` radio set and is deliberately left alone.

## Out of scope, flagged not fixed

`fog-default-ui.scss:338` forces every modal-footer button to the modal type's colour with `!important`, and its "plain cancel" carve-out at `:362` still targets Bootstrap 3's `.pull-left`, which no longer exists after the BS5 migration. So the task modal's buttons will still both render green until that is addressed. Fixing it changes the left button on every modal in the app, so it does not belong in this PR.

## Test plan

- [ ] Task Management → each of the five panes: Cancel Selected and Pause Reload sit left, Resume Reload sits right
- [ ] Cancel Selected still POSTs to the right per-pane endpoint; Pause/Resume Reload still toggle the auto-refresh
- [ ] Recent tab's state filter is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)