### PR TITLE
fix(web): filter association ids in assocSetter, not at one caller

### DIFF
--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1273,13 +1273,22 @@ abstract class FOGController extends FOGBase
             return $this;
         }
 
-        // Get the current items. Guard against a non-array fallback (e.g.
-        // an empty string) so a bad value can't cast to [''] below and be
-        // diffed in as a phantom "new" association.
-        $items = $this->get($plural);
-        if (!$items) {
-            $items = [];
-        }
+        // Get the current items, normalized to positive integer ids.
+        //
+        // Every relation routed through here diffs on a "{$alterItem}ID"
+        // column, so a non-positive or non-numeric entry can only ever be
+        // junk. Two shapes of junk reach this point: a wholly falsy get()
+        // fallback (an empty string casts to [''], which subtracts nothing
+        // from $cur and then inserts as id 0), and a 0 sitting inside an
+        // otherwise valid list.
+        //
+        // Filtering here rather than at the caller is the point. The filter
+        // used to live in Host::save() alone (8e31b5cf0), which left the
+        // other 23 assocSetter() call sites unguarded -- and patching a
+        // shared hole at one caller is what produced the snapin wipe this
+        // supersedes (PR #906). A standing property of the writer cannot be
+        // bypassed by a caller that does not know it needs to opt in.
+        $items = self::positiveIntIds($this->get($plural));
 
         // Fetch current associations from the database.
         $cur = Route::getIds(

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -277,25 +277,12 @@ class Host extends FOGController
             $objNeeded = false;
             unset($DBPowerManagementIDs, $RemovePowerManagementIDs);
         }
-        // Drop any stale/blank snapin id (e.g. a 0 slipping in from a non-UI
-        // write) before assocSetter persists it as a snapinAssoc row. Mirrors
-        // the "< 1" guard on setSnapinOrder()'s save path; without this a 0
-        // would be inserted and later surface as a phantom run-order entry.
-        //
-        // Gated on isPopulated(), not isLoaded(): isLoaded() marks a key
-        // loaded on every call, even when it answers false, which let this
-        // exact check poison assocSetter('Snapin', 'snapin') below into
-        // trusting stale state, skipping the real DB load, and falling back
-        // to get()'s empty-string default -- which then got cast to ['']
-        // and inserted as saSnapinID=0. isPopulated() is a pure predicate
-        // with no such side effect, so this only runs (and assocSetter only
-        // proceeds) when 'snapins' actually holds real data.
-        if ($this->isPopulated('snapins')) {
-            $this->set(
-                'snapins',
-                self::positiveIntIds($this->get('snapins'))
-            );
-        }
+        // The stale/blank snapin id filter that used to sit here (8e31b5cf0)
+        // now lives in assocSetter(), where it guards every relation instead
+        // of this one. Filtering at a single caller was the original mistake:
+        // it left the other assocSetter() call sites able to persist an id-0
+        // row, and the isLoaded() gate it needed in order to run at all is
+        // what poisoned assocSetter into wiping the host's snapins (PR #906).
         $this
             ->assocSetter('Group', 'group')
             ->assocSetter('Module', 'module')


### PR DESCRIPTION
Follow-up to #906. Small, and deliberately narrow.

## The point

`8e31b5cf0` added a positive-id filter to `Host::save()` to stop a blank/0 snapin id being persisted as a `snapinAssoc` row. But the hole it patched isn't in `Host::save()` — it's in `assocSetter()`, whose insert loop (`fogcontroller.class.php:1311-1322`) writes `$diff` verbatim for **all 24** of its call sites: hosts, groups, modules, printers, users, usergroups, roles, snapins, storage groups, powermanagement, plus the ldap/location/ou/site/windowskey plugins.

Filtering at one caller left the other 23 relations exposed — and the `isLoaded()` gate that filter needed in order to run at all is what poisoned `assocSetter` into deleting the host's snapins and inserting `saSnapinID=0`. #906 fixed the gate. This fixes the layering that made the gate necessary.

So: move the filter into `assocSetter`, where it's a standing property of the writer rather than something each caller has to know to opt into. Every relation routed through here diffs on a `{$alterItem}ID` column, so a non-positive or non-numeric entry can only ever be junk.

## Relationship to 8d0769ee3's guard

This subsumes `if (!$items) { $items = []; }`. That covers a wholly falsy `get()` fallback, but not a `0` sitting inside an otherwise valid list — `set('groups', [0, 3])` still inserted a `groupID=0` row.

**No current caller does that.** I checked: no page, hook or router sets a plural directly; they all reach the plurals through `addRemItem()`, which `array_filter()`s `0` and `''` out before they get to `add()`/`remove()`. So this is not fixing a live bug.

It's fixing the *shape*. "No caller does this today" is a point-in-time census, not a property of the writer, and a filter that only holds while every caller stays well-behaved is the same pre-flight-check-guarding-a-continuous-risk pattern that produced this whole regression.

## Also

`Host::save()`'s block then has nothing left to do and is removed.

One behaviour note worth stating: the in-memory `'snapins'` value is no longer rewritten to the filtered list as a side effect of saving, so it now reflects what the caller actually passed. Nothing reads it expecting otherwise — `_appendSnapinSequence()` reads the association rows back from the database, and the REST path re-instantiates before serializing.

## Verification

`positiveIntIds()` returns ints while `Route::getIds()` returns strings, so I checked the boundary explicitly:

```
array_diff(["3","7"], [3,7]) => []      // no spurious deletes
array_diff([3,7], ["3","7"]) => []      // no spurious inserts
```

Normalization of each junk shape:

```
""          => []
null        => []
[0,3]       => [3]
["","3"]    => [3]
["3","0"]   => [3]
```

## Test plan

- [ ] Host → Snapins tab: add snapins, save, confirm they persist and are sequenced after existing ones
- [ ] Host → Snapins tab: remove all, save, confirm the rows go
- [ ] Host → General tab: change only the hostname, save, confirm snapin/group/printer/module associations survive
- [ ] Groups, Printers, Modules tabs: add and remove still persist
- [ ] Role → Users / User Groups tabs: add and remove still persist
- [ ] `SELECT * FROM snapinAssoc WHERE saSnapinID = 0` stays empty through all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)