### PR TITLE
Add isPopulated() so association guards stop trusting isLoaded()

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -960,7 +960,25 @@ abstract class FOGBase
         return -1;
     }
     /**
-     * Check if isLoaded.
+     * Internal recursion guard for the get()/set()/loadItem() lazy-load
+     * chain -- NOT a "does this key hold data" predicate.
+     *
+     * This is a test-and-set: every call marks $key loaded, even one that
+     * returns false. That side effect is required so a loadX() method's
+     * own set() call doesn't see "not loaded" again, re-trigger loadItem(),
+     * and recurse forever. It means a bare `if ($this->isLoaded($key))`
+     * used as a standalone precondition -- anywhere the false branch isn't
+     * immediately followed, in the same call, by an actual load -- will
+     * silently poison the flag for the rest of the request: later code
+     * that calls get($key) expecting a real lazy-loaded value instead
+     * sees the (now-true) flag, skips the real load, and falls back to
+     * get()'s "never set" default.
+     *
+     * Use isPopulated($key) instead for "do I actually have data for this
+     * key" checks -- it has no such side effect. This exact confusion, on
+     * the working-1.6 branch, caused phantom saSnapinID=0 rows (and, worse,
+     * mass-deletion of real associations) to be inserted on every FOG
+     * client check-in.
      *
      * @param string|int $key the key to see if loaded
      *
@@ -973,6 +991,30 @@ abstract class FOGBase
         $this->isLoaded[$key] = true;
 
         return $result ? $result : false;
+    }
+    /**
+     * Whether $key currently holds resolved data -- a pure,
+     * side-effect-free predicate. Unlike isLoaded() (a recursion guard for
+     * the internal lazy-load chain; see its docblock), this is safe to use
+     * as a standalone precondition anywhere the caller means "do I have
+     * real data for this key," e.g. "only sync this association if the
+     * caller actually touched it."
+     *
+     * Deliberately isset(), not array_key_exists(): get()'s own fallback
+     * to '' is gated the same way (`isset($this->data[$key]) ? ... : ''`),
+     * so this only reports true when get() is actually about to return
+     * real data instead of that fallback -- the two must agree, or a key
+     * explicitly set to null would read as "populated" here while get()
+     * still silently handed back ''.
+     *
+     * @param string|int $key the key to check
+     *
+     * @return bool
+     */
+    protected function isPopulated($key)
+    {
+        $key = $this->key($key);
+        return isset($this->data[$key]);
     }
     /**
      * Reset request variables.

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1146,8 +1146,13 @@ abstract class FOGController extends FOGBase
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't loaded yet.
-        if (!$this->isLoaded($plural)) {
+        // Don't work on item that isn't populated yet. isPopulated(), not
+        // isLoaded(): isLoaded() marks a key loaded on every call, even
+        // one that answers false, so a bare isLoaded() gate anywhere else
+        // in the request (present or future) could poison this check and
+        // make it proceed on stale/empty data. isPopulated() only reports
+        // true once real data is actually here.
+        if (!$this->isPopulated($plural)) {
             return $this;
         }
 

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -303,7 +303,10 @@ class Host extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isLoaded('mac')) {
+        // isPopulated(), not isLoaded(): isLoaded() marks a key loaded on
+        // every call even when it answers false, so it can't be trusted as
+        // a standalone "did the caller actually set this" precondition.
+        if ($this->isPopulated('mac')) {
             if (!$this->get('mac')->isValid()) {
                 throw new Exception(self::$foglang['InvalidMAC']);
             }
@@ -381,7 +384,8 @@ class Host extends FOGController
                 $HostWithMAC
             );
         }
-        if ($this->isLoaded('additionalMACs')) {
+        // isPopulated(), not isLoaded() -- see the save() entry comment.
+        if ($this->isPopulated('additionalMACs')) {
             self::_retValidMacs(
                 $this->get('additionalMACs'),
                 $addMacs
@@ -483,7 +487,8 @@ class Host extends FOGController
                 $RemoveAddMAC
             );
         }
-        if ($this->isLoaded('pendingMACs')) {
+        // isPopulated(), not isLoaded() -- see the save() entry comment.
+        if ($this->isPopulated('pendingMACs')) {
             self::_retValidMacs($this->get('pendingMACs'), $pendMacs);
             $RealPendMACs = array_filter($pendMacs);
             unset($pendMacs);
@@ -581,7 +586,8 @@ class Host extends FOGController
                 $RemovePendMAC
             );
         }
-        if ($this->isLoaded('powermanagementtasks')) {
+        // isPopulated(), not isLoaded() -- see the save() entry comment.
+        if ($this->isPopulated('powermanagementtasks')) {
             $DBPowerManagementIDs = self::getSubObjectIDs(
                 'PowerManagement',
                 array('hostID'=>$this->get('id'))

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -137,7 +137,10 @@ class Image extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isLoaded('hosts')) {
+        // isPopulated(), not isLoaded(): isLoaded() marks a key loaded on
+        // every call even when it answers false, so it can't be trusted as
+        // a standalone "did the caller actually set hosts" precondition.
+        if ($this->isPopulated('hosts')) {
             if (count($this->get('hosts')) > 0) {
                 $DBIDs = self::getSubObjectIDs(
                     'Host',

--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -254,13 +254,23 @@ class Site extends FOGController
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't loaded yet.
-        if (!$this->isLoaded($plural)) {
+        // Don't work on item that isn't populated yet. isPopulated(), not
+        // isLoaded(): isLoaded() marks a key loaded on every call, even
+        // one that answers false, so a bare isLoaded() gate anywhere else
+        // in the request (present or future) could poison this check and
+        // make it proceed on stale/empty data. isPopulated() only reports
+        // true once real data is actually here.
+        if (!$this->isPopulated($plural)) {
             return $this;
         }
 
-        // Get the current items.
+        // Get the current items. Guard against a non-array fallback (e.g.
+        // an empty string) so a bad value can't cast to [''] below and be
+        // diffed in as a phantom association.
         $items = $this->get($plural);
+        if (!$items) {
+            $items = [];
+        }
         Route::ids(
             $classCall,
             [$objstr => $this->get('id')],


### PR DESCRIPTION
## Summary
Companion to #906 (working-1.6). `FOGBase::isLoaded($key)` is a test-and-set recursion guard for the internal `get()`/`set()`/`loadItem()` lazy-load chain — every call marks the key loaded, even one that answers `false`. That's required internally, but it means a bare `if ($this->isLoaded($key))` used as a standalone precondition elsewhere silently poisons the flag for the rest of the request: later code calling `get($key)` expecting a real lazy-loaded value instead sees the (now-true) flag, skips the real load, and falls back to `get()`'s `''` default — which, cast to an array, becomes `['']` and gets diffed in as a phantom association, or worse, makes `assocSetter()`'s unguarded removal half treat the object's *entire real association list* as stale and delete it.

`dev-branch` never received the working-1.6 commit that introduced the specific snapins guard behind #906 (and persists host↔snapin associations through an entirely different, older mechanism, so it was never vulnerable to that specific bug). But it carries its own independent set of bare `isLoaded()` gates with the identical shape:
- `assocSetter()`'s own "don't work on an unloaded item" check (`fogcontroller.class.php:1150`) — the shared implementation behind every core association type on this branch.
- The Site plugin's own duplicated copy of `assocSetter()` (`site.class.php:258`) — this branch hasn't consolidated it into the shared method the way working-1.6 has.
- `Host::save()`'s `mac`, `additionalMACs`, `pendingMACs`, and `powermanagementtasks` guards.
- `Image::save()`'s hosts-reassignment guard.

None of these were confirmed live-exploited on this branch (unlike the working-1.6 case, nothing else in the request currently poisons any of these specific flags before their own guard checks them), but they're all the identical footgun shape, and the shared `assocSetter()` gate in particular is a single choke point worth closing defensively rather than waiting for some future change to trip it the way 8e31b5cf0 did on working-1.6.

Fix, ported directly from #906: added `FOGBase::isPopulated($key)` — `isset($this->data[$key])`, matching `get()`'s own fallback condition exactly — and switched every standalone gate listed above to it. `isLoaded()` itself is unchanged, as are the internal `get()`/`set()`/`add()`/`remove()` call sites that pair it with an immediate load, and the already-correct `MACAddressAssociation::getHost()`/`Inventory::getHost()` pattern (check paired with an immediate load in the same block — not a bug, left alone).

Also added the same defensive fallback to the Site plugin's `assocSetter` copy that the shared one already had on this branch: guard `$items` against a falsy `get()` result before the `(array)` cast.

## Test plan
- [ ] Save a host without touching MACs/power-management tasks; confirm no unintended MAC/power-management changes.
- [ ] Save an image without touching its host list; confirm no unintended host reassignment, and no `count()` `TypeError` on a repeated save of the same instance.
- [ ] Save a Site-plugin-managed host/user/group association without touching that specific relation; confirm no unintended deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)