### PR TITLE
fix(web): stop isLoaded() gates poisoning association writes (1.5 port)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -966,7 +966,23 @@ abstract class FOGBase
         return -1;
     }
     /**
-     * Check if isLoaded.
+     * Internal recursion guard for the get()/set()/loadItem() lazy-load
+     * chain -- NOT a "does this key hold data" predicate.
+     *
+     * This is a test-and-set: every call marks $key loaded, even one that
+     * returns false. That side effect is required so a loadX() method's own
+     * set() call doesn't see "not loaded" again, re-trigger loadItem(), and
+     * recurse forever. It means a bare `if ($this->isLoaded($key))` used as
+     * a standalone precondition -- anywhere the false branch isn't
+     * immediately followed, in the same call, by an actual load -- silently
+     * poisons the flag for the rest of the request: later code calling
+     * get($key) and expecting a real lazy-loaded value instead sees the
+     * (now-true) flag, skips the load, and falls back to get()'s default.
+     *
+     * Use isPopulated($key) for "do I actually have data for this key"
+     * checks. On 1.6 this exact confusion made assocSetter() delete every
+     * snapin association for a host and insert a phantom snapinID=0 row on
+     * each client check-in (FOGProject/fogproject#906).
      *
      * @param string|int $key the key to see if loaded
      *
@@ -979,6 +995,52 @@ abstract class FOGBase
         $this->isLoaded[$key] = true;
 
         return $result ? $result : false;
+    }
+    /**
+     * Whether $key currently holds resolved data -- a pure, side-effect-free
+     * predicate. Unlike isLoaded() (a recursion guard for the internal
+     * lazy-load chain; see its docblock), this is safe to use as a
+     * standalone precondition anywhere the caller means "do I have real data
+     * for this key", e.g. "only sync this association if the caller actually
+     * touched it".
+     *
+     * Deliberately isset(), not array_key_exists(): get()'s own fallback to
+     * '' is gated the same way, so the two must agree or a key explicitly
+     * set to null would read as populated here while get() still handed back
+     * the '' fallback.
+     *
+     * @param string|int $key the key to check
+     *
+     * @return bool
+     */
+    protected function isPopulated($key)
+    {
+        $key = $this->key($key);
+
+        return isset($this->data[$key]);
+    }
+    /**
+     * Reduce a value to the positive integer ids it contains.
+     *
+     * Association writers diff on integer id columns, so a non-positive or
+     * non-numeric entry can only ever be junk -- and a falsy scalar casts to
+     * array('') which subtracts nothing from the current set and then
+     * inserts as id 0.
+     *
+     * @param mixed $ids the collection (or scalar) to reduce
+     *
+     * @return array
+     */
+    public static function positiveIntIds($ids)
+    {
+        return array_values(
+            array_filter(
+                array_map('intval', (array)$ids),
+                function ($id) {
+                    return $id > 0;
+                }
+            )
+        );
     }
     /**
      * Reset request variables.

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1146,16 +1146,21 @@ abstract class FOGController extends FOGBase
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't loaded yet.
-        if (!$this->isLoaded($plural)) {
+        // Don't work on item that isn't populated yet. isPopulated(), not
+        // isLoaded(): isLoaded() marks a key loaded on every call, even one
+        // that answers false, so a bare isLoaded() gate anywhere else in the
+        // request could poison this check into proceeding on empty data --
+        // which diffs to "remove everything". isPopulated() has no such side
+        // effect. See FOGProject/fogproject#906.
+        if (!$this->isPopulated($plural)) {
             return $this;
         }
 
-        // Get the current items.
-        $items = $this->get($plural);
-        if (!$items) {
-            $items = array();
-        }
+        // Get the current items, normalized to positive integer ids. Every
+        // relation routed through here diffs on a "{$alterItem}ID" column, so
+        // a non-positive or non-numeric entry can only be junk -- whether a
+        // falsy get() fallback or a 0 sitting inside an otherwise valid list.
+        $items = self::positiveIntIds($this->get($plural));
         Route::ids(
             $classCall,
             [$objstr => $this->get('id')],

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -310,7 +310,7 @@ class Host extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isLoaded('mac')) {
+        if ($this->isPopulated('mac')) {
             if (!$this->get('mac')->isValid()) {
                 throw new Exception(self::$foglang['InvalidMAC']);
             }
@@ -388,7 +388,7 @@ class Host extends FOGController
                 $HostWithMAC
             );
         }
-        if ($this->isLoaded('additionalMACs')) {
+        if ($this->isPopulated('additionalMACs')) {
             self::_retValidMacs(
                 $this->get('additionalMACs'),
                 $addMacs
@@ -490,7 +490,7 @@ class Host extends FOGController
                 $RemoveAddMAC
             );
         }
-        if ($this->isLoaded('pendingMACs')) {
+        if ($this->isPopulated('pendingMACs')) {
             self::_retValidMacs($this->get('pendingMACs'), $pendMacs);
             $RealPendMACs = array_filter($pendMacs);
             unset($pendMacs);
@@ -588,7 +588,7 @@ class Host extends FOGController
                 $RemovePendMAC
             );
         }
-        if ($this->isLoaded('powermanagementtasks')) {
+        if ($this->isPopulated('powermanagementtasks')) {
             $DBPowerManagementIDs = self::getSubObjectIDs(
                 'PowerManagement',
                 array('hostID'=>$this->get('id'))

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -137,7 +137,11 @@ class Image extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isLoaded('hosts')) {
+        // isPopulated(), not isLoaded(): the latter is a test-and-set, so on
+        // a second save() of one instance the gate answered true while
+        // get('hosts') short-circuited to '', making the count() calls below
+        // a PHP 8 TypeError. See FOGProject/fogproject#906.
+        if ($this->isPopulated('hosts')) {
             if (count($this->get('hosts')) > 0) {
                 $DBIDs = self::getSubObjectIDs(
                     'Host',

--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -254,13 +254,19 @@ class Site extends FOGController
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't loaded yet.
-        if (!$this->isLoaded($plural)) {
+        // Don't work on item that isn't populated yet. isPopulated(), not
+        // isLoaded(): isLoaded() marks a key loaded on every call, even one
+        // that answers false, so a bare isLoaded() gate anywhere else in the
+        // request could poison this check into proceeding on empty data.
+        // See FOGProject/fogproject#906.
+        if (!$this->isPopulated($plural)) {
             return $this;
         }
 
-        // Get the current items.
-        $items = $this->get($plural);
+        // Get the current items, normalized to positive integer ids -- this
+        // copy had no guard at all, so a falsy get() fallback reached
+        // array_diff() as a string and fatalled under PHP 8.
+        $items = self::positiveIntIds($this->get($plural));
         Route::ids(
             $classCall,
             [$objstr => $this->get('id')],


### PR DESCRIPTION
Port of #906 and #910 from `working-1.6`.

## Background

`FOGBase::isLoaded()` is a **test-and-set**: it returns whether a key was already marked, then unconditionally marks it. That is required for its real job — the re-entrancy guard in the `get()`/`set()`/`loadItem()` lazy-load chain, where marking before the load is what stops a `loadX()` method's own `set()` from recursing forever.

It cannot answer *"does this key hold data"*, because asking changes the answer for everyone who asks later. A bare `isLoaded()` gate used as a standalone precondition poisons the flag for the rest of the request, and a writer downstream then reads an unloaded key, gets `get()`'s `''` fallback, and diffs it to *"remove everything"*.

On 1.6 that deleted every `snapinAssoc` row for a host and inserted a phantom `snapinID=0`, on every client check-in. Reproduced live through the REST API, the UI General tab and the client-authorize path.

## 1.5 does not have that bug — verified, not assumed

`Host::save()`'s four bare gates here use `'mac'`, `'additionalMACs'`, `'pendingMACs'` and `'powermanagementtasks'`. None collide with an `assocSetter()` plural, so `assocSetter`'s own gate is still the *first* call for its key and correctly bails.

Confirmed empirically against both 1.5.10 lab servers, on PHP 8.0 and PHP 8.5 — assign snapins, save touching only `description`, then only `pub_key`:

```
=== 10.253.25.2 (PHP 8.0) host 3 ===        === 10.254.25.2 (PHP 8.5) host 1 ===
AFTER assigning [1,2]:        [1,2]         AFTER assigning [1]:           [1]
AFTER description-only save(): [1,2]         AFTER description-only save(): [1]
AFTER pub_key-only save():     [1,2]         AFTER pub_key-only save():     [1]
```

So this is a **latent** port, not a live fix. The shape is here, and each gate still poisons its own key, so a second `save()` of one instance misreads it.

## Changes

- **`fogcontroller.class.php` `assocSetter()`** and **the site plugin's private copy** now gate on `isPopulated()`. The site copy had *no* falsy guard at all, so a `''` fallback reached `array_diff()` as a string and fatalled under PHP 8.
- **`$items` normalized through `positiveIntIds()`**, so neither a falsy fallback (which casts to `array('')` and inserts as id 0) nor a `0` inside an otherwise valid list can become an association row. Filtering in the shared writer rather than per-caller is the point: on 1.6 the same filter lived in `Host::save()` alone, which left the other call sites unguarded and required the `isLoaded()` gate that caused the wipe.
- **`image.class.php`** hosts gate — on a second `save()` it answered true while `get('hosts')` short-circuited to `''`, making the `count()` calls a PHP 8 `TypeError` rather than merely a wrong answer.
- **`Host::save()`'s four gates.** Behaviour is unchanged: `set()`/`get()` populate the key and mark it loaded together, so both predicates agree on every reachable path. The key is simply no longer poisoned for a later reader.
- **`FOGBase`** gains `isPopulated()` (pure `isset()`, deliberately matching `get()`'s own fallback check so the two can't disagree on a null) and `positiveIntIds()`, plus a docblock on `isLoaded()` stating the test-and-set contract.

## Deliberately unchanged

`inventory.class.php:95` and `macaddressassociation.class.php:69` — `if (!$this->isLoaded('host')) { $this->set('host', ...); }`. Both are correct memoization that *depends* on the test-and-set side effect. Left alone.

## Verification

- Syntax checked under a real `php:7.4-cli` container, not just the host PHP.
- `positiveIntIds()` returns ints while the current-set lookups return strings; `array_diff()` matches across that boundary, so no spurious inserts or deletes.

## Test plan

- [ ] Host → Snapins / Groups / Printers / Service tabs: add and remove still persist
- [ ] Host → General tab: change only the hostname, save, confirm all associations survive
- [ ] Host MACs: primary, additional and pending MAC edits still save
- [ ] Image → Hosts tab: assign and unassign still work; unrelated image save leaves them alone
- [ ] Site plugin: host/user/group/usergroup site assignments still save
- [ ] `SELECT * FROM snapinAssoc WHERE saSnapinID = 0` stays empty throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)