### PR TITLE
fix(web): sequence group-pushed snapins at the source

### DIFF
--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -250,6 +250,22 @@ class Group extends FOGController
                     $insert_fields,
                     $insert_values
                 );
+            // insertBatch cannot carry the sequence: it upserts on the
+            // (saHostID, saSnapinID) unique key, so a snapin the host already
+            // had would have its deliberate run-order overwritten. The rows
+            // therefore land at sequence 0, which sorts them ahead of every
+            // deliberately ordered snapin (Host::loadSnapins orders by
+            // sequence ASC, and createSnapinTasking numbers the tasks in that
+            // order). Number them per host afterwards instead.
+            //
+            // Host::save() used to sweep these up incidentally -- its
+            // appendSnapinSequence() gate was always true, because
+            // assocSetter() had already consumed the isLoaded() flag it
+            // tested. Fixing that gate (#906/#910) correctly stopped the
+            // sweep, so the sequence is assigned here at the source.
+            foreach ($hosts as $hostID) {
+                Host::appendSnapinSequence($hostID);
+            }
         }
 
         return $this;

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -292,7 +292,7 @@ class Host extends FOGController
         // any unsequenced rows a run-order value after the existing ones so
         // newly added snapins land at the end rather than jumping to front.
         if ($this->isPopulated('snapins')) {
-            $this->_appendSnapinSequence();
+            self::appendSnapinSequence($this->get('id'));
         }
         // Safety net: never leave the host with MAC rows but no primary MAC.
         // The primac join requires hmPrimary='1', so a host with no primary
@@ -1557,7 +1557,7 @@ class Host extends FOGController
             }
         }
         // Staged in-memory here; the snapinAssoc rows (and their run-order
-        // sequence) are persisted in save() via assocSetter()/_appendSnapinSequence().
+        // sequence) are persisted in save() via assocSetter()/appendSnapinSequence().
         return $this->addRemItem(
             'snapins',
             (array)$addArray,
@@ -1583,13 +1583,28 @@ class Host extends FOGController
      * Assigns a run-order sequence to any snapin associations that do
      * not have one yet, placing newly added snapins after existing ones.
      *
-     * @return object
+     * Static and host-id-parameterized rather than an instance method so a
+     * caller that already knows the host id does not have to construct (and
+     * fully load) a Host just to sequence its rows. Group::addSnapin() is
+     * that caller: it writes snapinAssoc rows for every member host with a
+     * direct insertBatch, which cannot carry the sequence itself -- the
+     * batch upserts on the (saHostID, saSnapinID) unique key, so including
+     * sequence would overwrite the deliberate ordering of any snapin the
+     * host already had.
+     *
+     * @param int $hostID the host whose unsequenced rows to number
+     *
+     * @return void
      */
-    private function _appendSnapinSequence()
+    public static function appendSnapinSequence($hostID)
     {
+        $hostID = (int)$hostID;
+        if ($hostID < 1) {
+            return;
+        }
         Route::listem(
             'snapinassociation',
-            ['hostID' => $this->get('id')],
+            ['hostID' => $hostID],
             false,
             'AND',
             'sequence'
@@ -1610,14 +1625,13 @@ class Host extends FOGController
             self::getClass('SnapinAssociationManager')
                 ->update(
                     [
-                        'hostID' => $this->get('id'),
+                        'hostID' => $hostID,
                         'snapinID' => $snapinID
                     ],
                     '',
                     ['sequence' => ++$maxSequence]
                 );
         }
-        return $this;
     }
     /**
      * Sets the run order of the host's snapins from an ordered list of

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -452,8 +452,12 @@ class StorageGroup extends FOGController
     public function save()
     {
         parent::save();
+        // No assocSetter('StorageGroup', 'storagenode') here: it derived the
+        // plural 'storagenodes', which is not in $additionalFields and has no
+        // loader, so the key could never hold data and the call was dead.
+        // Node membership is managed by addNode()/removeNode(), which write
+        // StorageNodeManager directly and never touch that key.
         return $this
-            ->assocSetter('StorageGroup', 'storagenode', true)
             ->assocSetter('Image', 'image')
             ->assocSetter('SnapinGroup', 'snapin')
             ->load();


### PR DESCRIPTION
Follow-up to #906 / #910. Two things, both surfaced while auditing those.

## 1. Group-pushed snapins land at sequence 0

`Group::addSnapin()` writes `snapinAssoc` rows for every member host with a direct `insertBatch` of `['hostID', 'snapinID']` — **no sequence**, so the rows default to `0`. `Host::loadSnapins()` orders by `sequence` ASC and `createSnapinTasking()` numbers the snapin tasks in that order, so a group-pushed snapin sorted permanently **ahead** of every snapin the host's own run order had placed deliberately. Several group-pushed snapins also tied at 0.

**Why nothing had to fix this before:** `Host::save()` swept it up by accident. Its `_appendSnapinSequence()` gate was `if ($this->isLoaded('snapins'))`, which was *always* true — `assocSetter()` had already consumed the test-and-set flag eleven lines earlier — so the sweep ran on every host save regardless of whether snapins were touched. Correcting that gate to `isPopulated()` in #906/#910 correctly stopped the sweep and unmasked this.

I've assigned the sequence at the source rather than restoring an incidental repair that was never that method's job.

**The sequence can't go into the batch itself.** `insertBatch()` builds `ON DUPLICATE KEY UPDATE \`field\`=VALUES(\`field\`)` for *every* field passed, and `snapinAssoc` carries a UNIQUE on `(saHostID, saSnapinID)` (schema.php:1504). Including `sequence` would therefore overwrite the deliberate run-order of any snapin the host already had, every time a group re-pushed it. The rows are numbered per host after the insert instead.

To do that without constructing (and fully loading) a `Host` per member host, `_appendSnapinSequence()` becomes:

```php
public static function appendSnapinSequence($hostID)
```

Behaviour is unchanged for its existing caller in `Host::save()`. It now returns `void` rather than `$this`, since it was never used in a chain.

## 2. Dead `assocSetter()` call in `StorageGroup::save()`

`assocSetter('StorageGroup', 'storagenode', true)` derives the plural `storagenodes`, which is **not** in `StorageGroup::$additionalFields` (`allnodes`, `enablednodes`, `usedtasks`, `images`, `snapins`) and has no loader — so the key could never hold data.

Node membership is actually managed by `addNode()`/`removeNode()` (`:349`, `:369`), which write `StorageNodeManager->update(['storagegroupID' => …])` directly and never touch that key.

Under the old `isLoaded()` gate this could fire on a second `save()` of one instance with an empty `$items`. The `isPopulated()` gate already made it unreachable; removing the line makes that explicit.

## Scope

**1.6 only.** dev-branch has no snapin sequencing at all — no `sequence` column, no `setSnapinOrder`, no `appendSnapinSequence` — so there is nothing to port.

No JS/CSS changed, so no `FOG_BCACHE_VER` bump. No new setting, so no `FOG_SCHEMA` bump.

## Verification

- `php -l` clean, and syntax verified under a real `php:7.4-cli` container.
- `$hosts` is guaranteed a populated array at the new loop: it is only reachable when `$insert_values` is non-empty, which requires the `array_walk` above it to have run.

## Test plan

- [ ] Host with snapins in a deliberate run order → push a snapin to it from a Group → the pushed snapin is sequenced **last**, existing order untouched
- [ ] Push the *same* snapin again from the group → its sequence is not reset
- [ ] Push a snapin to a group whose hosts have no snapins → sequences start at 1, no ties
- [ ] Deploy the resulting tasking and confirm `snapinTasks.sequence` numbers 1..N in the expected order
- [ ] Storage group: add/remove nodes still works; images and snapin groups still associate

🤖 Generated with [Claude Code](https://claude.com/claude-code)