### PR TITLE
fix(web): two silent no-ops in the bulk-join API and group printer level

### DIFF
--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -1051,7 +1051,7 @@ class GroupManagement extends FOGPage
         if (isset($_POST['confirmlevelup'])) {
             $level = filter_input(INPUT_POST, 'level');
             self::getClass('HostManager')->update(
-                ['id' => $this->get('hosts')],
+                ['id' => $this->obj->get('hosts')],
                 '',
                 ['printerLevel' => $level]
             );

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -4444,7 +4444,7 @@ class Route extends FOGBase
                                     $c->addPrinter($vars->printers);
                                 }
                                 if (isset($vars->modules)) {
-                                    $c->addModules($vars->modules);
+                                    $c->addModule($vars->modules);
                                 }
                                 if (isset($vars->groups)) {
                                     $c->addGroup($vars->groups);


### PR DESCRIPTION
Two long-standing bugs, unrelated to each other. Both surfaced while auditing the `assocSetter()` call sites for #906 / #910; neither is caused by those changes.

## 1. `Route::editmass()` calls a method that doesn't exist

`route.class.php` — the `host` arm:

```php
if (isset($vars->modules)) {
    $c->addModules($vars->modules);   // <-- no such method
}
```

`Host` has `addModule()` (`host.class.php:1672`), and the `group` arm eleven lines below already calls it by the correct name. `addModules` is the **only** plural-typo variant of any `add*()` call in the file.

`Host` has no `__call()`, so this isn't a silently-skipped write — a bulk-join `PUT` carrying a `modules` body throws an uncaught `Error`. The modules never apply, and neither does the `groups` handling that comes after it in the same arm.

## 2. Group "set printer level" filters on the wrong object

`groupmanagement.page.php` — `groupPrinterPost()`:

```php
self::getClass('HostManager')->update(
    ['id' => $this->get('hosts')],   // <-- the page, not the group
    '',
    ['printerLevel' => $level]
);
```

On a page class `$this` is the *page*, so this reads `FOGPage::get()` — an unrelated `$data` bag (`fogpage.class.php:957`) — instead of `$this->obj->get('hosts')` off the group.

The key is undefined there, so it yields `null`. `FOGManagerController::perform_update()` then `trim()`s that to `''` and emits `WHERE \`hosts\`.\`hostID\`=''`, which MySQL casts to `0` on an INT column. No host has id 0, so **the update silently matched nothing** and the chosen printer level was never applied to any host in the group. The UI reported success.

(Worth stating plainly since a null filter *could* have gone the other way: this is a no-op, not a mass update of every host.)

Every other host-id filter in this file — 15 of them, including the structurally identical one at `:737` — already uses `$this->obj->get('hosts')`. This was the only one that didn't.

## Sweep

Checked the rest of `lib/pages/` for the same shape (`$this->get()` on a plural association key where `$this->obj->get()` was meant): **no other instances**.

## Scope

**1.6 only.** dev-branch has no `addModules` call and no `confirmlevelup` branch at all — the group printer-level feature doesn't exist there.

No JS/CSS changed → no `FOG_BCACHE_VER` bump. No new setting → no `FOG_SCHEMA` bump.

## Test plan

- [ ] `PUT` to the bulk-join endpoint with a `modules` body across several host ids → modules apply to every host, no 500
- [ ] Same request with `modules` **and** `groups` → both apply (the `groups` handling was unreachable before)
- [ ] Group → Printers tab → set a printer level → confirm `hosts.hostPrinterLevel` actually changes for every member host
- [ ] Group → Printers tab → "make default" still works (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)