### PR TITLE
Add isDirty() to stop assocSetter() re-diffing untouched associations

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -120,6 +120,14 @@ abstract class FOGBase
      */
     protected $isLoaded = array();
     /**
+     * Tracks which keys a caller has actually written (via set()/add()/
+     * remove()), as opposed to keys merely lazy-loaded for reading. See
+     * isDirty()'s docblock.
+     *
+     * @var array
+     */
+    protected $dirty = array();
+    /**
      * The length of a given string item.
      *
      * @var int
@@ -1018,6 +1026,38 @@ abstract class FOGBase
         $key = $this->key($key);
 
         return isset($this->data[$key]);
+    }
+    /**
+     * Whether a caller has actually written $key this request -- via
+     * set(), add(), or remove() -- as opposed to it merely being
+     * lazy-loaded for reading. A pure, side-effect-free predicate.
+     *
+     * Stricter than isPopulated(): a key can be populated (get() will
+     * return real data) without being dirty (nothing asked to change it).
+     * Use this instead of isPopulated() wherever the guard means "only do
+     * this if the caller actually intended a change" -- e.g. assocSetter(),
+     * which otherwise re-runs its DB diff on every save() for any
+     * association a request happened to read for display, even when
+     * nothing about it changed.
+     *
+     * set()/add()/remove() mark their key dirty as the last thing they do.
+     * loadItem() clears the mark for its own key immediately after
+     * dispatching to a loadX() method, since anything set() does purely to
+     * cache a lazy load is not a caller-driven change. Because a genuine
+     * write always marks dirty *after* any nested loadItem() call it
+     * triggers first (both check isLoaded() and lazy-load before
+     * mutating), a real change can never be erased by a load that
+     * happens to run first in the same call.
+     *
+     * @param string|int $key the key to check
+     *
+     * @return bool
+     */
+    protected function isDirty($key)
+    {
+        $key = $this->key($key);
+
+        return isset($this->dirty[$key]);
     }
     /**
      * Reduce a value to the positive integer ids it contains.

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -261,6 +261,7 @@ abstract class FOGController extends FOGBase
             );
             self::info($msg);
             $this->data[$key] = $value;
+            $this->dirty[$key] = true;
         } catch (Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
@@ -311,6 +312,7 @@ abstract class FOGController extends FOGBase
                 $this->data[$key] = array($this->data[$key]);
             }
             $this->data[$key][] = $value;
+            $this->dirty[$key] = true;
         } catch (Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
@@ -365,6 +367,7 @@ abstract class FOGController extends FOGBase
                 unset($this->data[$key][$ind]);
             }
             $this->data[$key] = array_values(array_filter($this->data[$key]));
+            $this->dirty[$key] = true;
         } catch (Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
@@ -871,6 +874,12 @@ abstract class FOGController extends FOGBase
         $methodCall = sprintf('load%s', ucfirst($key));
         if (method_exists($this, $methodCall)) {
             $this->{$methodCall}();
+            // A loadX() method caches what it fetched via set(), which
+            // marks $key dirty as an unavoidable side effect. That's a
+            // cache-fill, not a caller-driven change, so retract the mark
+            // immediately -- isDirty() should only ever report true for a
+            // key a caller actually meant to write.
+            unset($this->dirty[$key]);
         }
         unset($methodCall);
 
@@ -1146,13 +1155,15 @@ abstract class FOGController extends FOGBase
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't populated yet. isPopulated(), not
-        // isLoaded(): isLoaded() marks a key loaded on every call, even one
-        // that answers false, so a bare isLoaded() gate anywhere else in the
-        // request could poison this check into proceeding on empty data --
-        // which diffs to "remove everything". isPopulated() has no such side
-        // effect. See FOGProject/fogproject#906.
-        if (!$this->isPopulated($plural)) {
+        // Don't work on an association the caller didn't actually touch.
+        // isDirty(), not isPopulated(): isPopulated() is also true when a
+        // key was merely lazy-loaded for reading (e.g. reported in a
+        // status response), which would otherwise make this run a full
+        // DB diff -- for a no-op result -- on every save() that happens
+        // to read this association first. isDirty() only reports true
+        // for a real caller-driven write, so an untouched association
+        // costs nothing here, not even the Route::ids() lookup below.
+        if (!$this->isDirty($plural)) {
             return $this;
         }
 

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -310,7 +310,12 @@ class Host extends FOGController
     public function save()
     {
         parent::save();
-        if ($this->isPopulated('mac')) {
+        // isDirty(), not isPopulated(): isPopulated() is also true when
+        // 'mac' was merely lazy-loaded for reading, which would make an
+        // unrelated host save re-run this whole MAC-sync block for a
+        // no-op result. isDirty() only reports true when the caller
+        // actually set the primary MAC.
+        if ($this->isDirty('mac')) {
             if (!$this->get('mac')->isValid()) {
                 throw new Exception(self::$foglang['InvalidMAC']);
             }
@@ -388,7 +393,8 @@ class Host extends FOGController
                 $HostWithMAC
             );
         }
-        if ($this->isPopulated('additionalMACs')) {
+        // isDirty(), not isPopulated() -- see the save() entry comment.
+        if ($this->isDirty('additionalMACs')) {
             self::_retValidMacs(
                 $this->get('additionalMACs'),
                 $addMacs
@@ -490,7 +496,8 @@ class Host extends FOGController
                 $RemoveAddMAC
             );
         }
-        if ($this->isPopulated('pendingMACs')) {
+        // isDirty(), not isPopulated() -- see the save() entry comment.
+        if ($this->isDirty('pendingMACs')) {
             self::_retValidMacs($this->get('pendingMACs'), $pendMacs);
             $RealPendMACs = array_filter($pendMacs);
             unset($pendMacs);
@@ -588,7 +595,8 @@ class Host extends FOGController
                 $RemovePendMAC
             );
         }
-        if ($this->isPopulated('powermanagementtasks')) {
+        // isDirty(), not isPopulated() -- see the save() entry comment.
+        if ($this->isDirty('powermanagementtasks')) {
             $DBPowerManagementIDs = self::getSubObjectIDs(
                 'PowerManagement',
                 array('hostID'=>$this->get('id'))

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -137,11 +137,12 @@ class Image extends FOGController
     public function save()
     {
         parent::save();
-        // isPopulated(), not isLoaded(): the latter is a test-and-set, so on
-        // a second save() of one instance the gate answered true while
-        // get('hosts') short-circuited to '', making the count() calls below
-        // a PHP 8 TypeError. See FOGProject/fogproject#906.
-        if ($this->isPopulated('hosts')) {
+        // isDirty(), not isPopulated(): isPopulated() is also true when
+        // 'hosts' was merely lazy-loaded for reading, which would make an
+        // unrelated image save (e.g. renaming it) re-run this whole
+        // reassignment block for a no-op result. isDirty() only reports
+        // true when the caller actually set the host list.
+        if ($this->isDirty('hosts')) {
             if (count($this->get('hosts')) > 0) {
                 $DBIDs = self::getSubObjectIDs(
                     'Host',

--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -254,12 +254,13 @@ class Site extends FOGController
         $objstr = "{$obj}ID";
         $assocstr = "{$alterItem}ID";
 
-        // Don't work on item that isn't populated yet. isPopulated(), not
-        // isLoaded(): isLoaded() marks a key loaded on every call, even one
-        // that answers false, so a bare isLoaded() gate anywhere else in the
-        // request could poison this check into proceeding on empty data.
-        // See FOGProject/fogproject#906.
-        if (!$this->isPopulated($plural)) {
+        // Don't work on an association the caller didn't actually touch.
+        // isDirty(), not isPopulated(): isPopulated() is also true when a
+        // key was merely lazy-loaded for reading, which would otherwise
+        // make this run a full DB diff -- for a no-op result -- on every
+        // save() that happens to read this association first. isDirty()
+        // only reports true for a real caller-driven write.
+        if (!$this->isDirty($plural)) {
             return $this;
         }
 


### PR DESCRIPTION
Companion to #916 (working-1.6). Port of the same isDirty() design to dev-branch's independent set of guards (see #912 for context on why dev-branch needed its own port of the isPopulated() fix in the first place).

## The point

isPopulated() (#912) correctly answers "does this key hold data" — but that's true whether the data arrived via a genuine caller-driven write or merely because something lazy-loaded it for display this request. Either way, `assocSetter()` (and its duplicated copy in the Site plugin, and the `Host`/`Image` guards that mirror it) proceed to run a DB diff against it — harmlessly (an untouched association diffs to nothing), but not for free. At scale, a routine check-in that reads an association for a status response, followed by an unrelated save later in the same request, currently issues an avoidable query per association type.

## The mechanism

`FOGBase::isDirty($key)`: true only when `set()`/`add()`/`remove()` wrote `$key` as a real caller-driven change, not when `loadItem()` cached a lazy load.

Every `load{X}()` method on this branch (~35, audited directly) calls `$this->set()` exactly once, on exactly its own key — never a second key, never `add()`/`remove()`. So a `loadX()`'s cache-fill `set()` call is distinguishable from a real write purely by *when* it happens: always inside `loadItem()`'s dispatch, never outside it.

- `set()`/`add()`/`remove()` mark `$this->dirty[$key] = true` as the last thing they do.
- `loadItem($key)` immediately `unset($this->dirty[$key])` right after dispatching to a `loadX()` method.

Safe by construction: each `loadItem($key)` call is its own stack frame keyed to its own `$key` (a `loadX()` reading a different key recurses into a separate frame clearing a different key, no cross-interference), and a genuine write always marks dirty strictly after any nested `loadItem()` it triggers first (`set()`/`add()`/`remove()` all lazy-load before mutating) — so a real change can never be erased by a load that runs first in the same call. Recursion safety (`isLoaded()` and the internal `get()`/`set()`/`add()`/`remove()`/`loadItem()` call sites that use it) is untouched.

## Changes

Switched every current `isPopulated()` guard to `isDirty()`: `assocSetter()`'s own gate, its duplicated copy in `site.class.php`, `Host::save()`'s `mac`/`additionalMACs`/`pendingMACs`/`powermanagementtasks` guards, and `Image::save()`'s hosts guard. `isPopulated()` itself is left in place but has no remaining callers after this change.

## Test plan

- [ ] Host save with no association/MAC/power-management changes: confirm the relevant guard blocks don't run and no diff query fires.
- [ ] Host save that changes one association or MAC list: still persists correctly.
- [ ] A request that reads an association for display but never writes it, followed by an unrelated save in the same request: association untouched, no diff query fires.
- [ ] Image save with hosts untouched: no host reassignment.
- [ ] Site plugin association saves: still persist correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)