### PR TITLE
ci: add push-triggered stub delegating to fog-workflows version check

### DIFF
--- a/.github/workflows/check-fog-version.yml
+++ b/.github/workflows/check-fog-version.yml
@@ -1,0 +1,30 @@
+name: Check FOG version
+
+# Push-triggered trigger stub. All the actual version-drift-detection logic
+# lives in FOGProject/fog-workflows as a reusable workflow (workflow_call) -
+# this file exists only because GitHub Actions has no native cross-repo push
+# trigger, so something has to live here to react to pushes/merges. See
+# fog-docs' Development section for the full picture.
+#
+# `stable` is intentionally not watched - its version is owned entirely by
+# fog-workflows' stable-releases.yml release flow.
+
+on:
+  push:
+    branches:
+      - working-1.6
+      - dev-branch
+      - 'rc-*'
+      - 'feature-*'
+  workflow_dispatch: {}
+
+concurrency:
+  group: fog-version-check-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    uses: FOGProject/fog-workflows/.github/workflows/check-fog-version.yml@main
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Supersedes #921. Instead of a full workflow living in this repo that opens a review PR on version drift, the version-drift-detection logic now lives in [`FOGProject/fog-workflows`](https://github.com/FOGProject/fog-workflows/blob/main/.github/workflows/check-fog-version.yml) as a reusable (`workflow_call`) workflow — the same repo that already owns this project's release automation via `stable-releases.yml`, just for the same reason `FOG_VERSION`/`FOG_CHANNEL` need a backstop in the first place: the client-side `.githooks/pre-commit` hook never runs on a PR merged through GitHub's web UI, so the version silently goes stale.

This file is the thin trigger stub that has to exist here because GitHub Actions has no native cross-repo `push` trigger — it just delegates to the reusable workflow via `uses:` and should rarely need to change.

Two behavior changes from #921:
- **`stable` is excluded.** Its version is owned entirely by `stable-releases.yml`'s release flow in fog-workflows.
- **Direct commit, not a review PR.** Detected drift is committed straight to the branch that drifted, the same way the local hook already commits without review — this is a mechanical correction, not something that needs a human in the loop.

Needs the equivalent stub added to `dev-branch` too (separate PR) and to the existing `feature-*` branches, since GitHub resolves a push-triggered workflow from the copy of the file on the branch that received the push.

## Test plan
- [ ] Merge, then confirm a push to `working-1.6` triggers this stub, which triggers the reusable workflow in fog-workflows, which correctly computes the expected `1.6.0-beta.*` version.
- [ ] Confirm drift (this branch is currently a few merges ahead of its stored version, per #921's description) gets fixed via a direct commit, not a PR.
- [ ] Confirm no run fires for `stable`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013fKXqgACVAVHNpYm9ZXRwN)_