### PR TITLE
ci: add push-triggered stub delegating to fog-workflows version check (dev-branch)

### DIFF
--- a/.github/workflows/check-fog-version.yml
+++ b/.github/workflows/check-fog-version.yml
@@ -1,0 +1,30 @@
+name: Check FOG version
+
+# Push-triggered trigger stub. All the actual version-drift-detection logic
+# lives in FOGProject/fog-workflows as a reusable workflow (workflow_call) -
+# this file exists only because GitHub Actions has no native cross-repo push
+# trigger, so something has to live here to react to pushes/merges. See
+# fog-docs' Development section for the full picture.
+#
+# `stable` is intentionally not watched - its version is owned entirely by
+# fog-workflows' stable-releases.yml release flow.
+
+on:
+  push:
+    branches:
+      - working-1.6
+      - dev-branch
+      - 'rc-*'
+      - 'feature-*'
+  workflow_dispatch: {}
+
+concurrency:
+  group: fog-version-check-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    uses: FOGProject/fog-workflows/.github/workflows/check-fog-version.yml@main
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Same stub as #922, targeting `dev-branch`. See #922 for the full rationale — this is the same file, just opened against a different base since GitHub resolves a push-triggered workflow from the copy of the file that exists on the branch receiving the push (so it has to land on both branches, not just one).

Supersedes #921 for this branch. All the actual version-drift-detection logic lives in [`FOGProject/fog-workflows`](https://github.com/FOGProject/fog-workflows/blob/main/.github/workflows/check-fog-version.yml); this file only delegates to it via `uses:`.

## Test plan
- [ ] Merge, then confirm a push to `dev-branch` triggers this stub → the fog-workflows reusable workflow, which correctly computes the expected version.
- [ ] Confirm any drift is fixed via a direct commit, not a PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_013fKXqgACVAVHNpYm9ZXRwN)_