### PR TITLE
ci: add push-triggered stub delegating to fog-workflows version check (feature-ldap-rbac)

### DIFF
--- a/.github/workflows/check-fog-version.yml
+++ b/.github/workflows/check-fog-version.yml
@@ -1,0 +1,30 @@
+name: Check FOG version
+
+# Push-triggered trigger stub. All the actual version-drift-detection logic
+# lives in FOGProject/fog-workflows as a reusable workflow (workflow_call) -
+# this file exists only because GitHub Actions has no native cross-repo push
+# trigger, so something has to live here to react to pushes/merges. See
+# fog-docs' Development section for the full picture.
+#
+# `stable` is intentionally not watched - its version is owned entirely by
+# fog-workflows' stable-releases.yml release flow.
+
+on:
+  push:
+    branches:
+      - working-1.6
+      - dev-branch
+      - 'rc-*'
+      - 'feature-*'
+  workflow_dispatch: {}
+
+concurrency:
+  group: fog-version-check-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    uses: FOGProject/fog-workflows/.github/workflows/check-fog-version.yml@main
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Same stub as #922/#923, targeting this branch. Existing `feature-*`/`rc-*` branches don't automatically inherit the stub added to `dev-branch` (#923) since they predate it, so it needs to land here too for pushes on this branch to be watched — see #922 for the full rationale.

## Test plan
- [ ] Merge, then confirm a push to this branch triggers the fog-workflows reusable workflow and correctly computes/fixes drift if any exists.


---
_Generated by [Claude Code](https://claude.ai/code/session_013fKXqgACVAVHNpYm9ZXRwN)_