### PR TITLE
docs: link Version Sync Automation doc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This gives us a Production, Staging, and Dev branches to follow standard devops 
 | Staging          | dev-branch                                                                                                            | Patch
 | Dev              | working-*, {feature-name}                                                                                             | Major, Minor
 
-See also: [Version Sync Automation](https://docs.fogproject.org/development/version-sync-automation/) for how `FOG_VERSION`/`FOG_CHANNEL` are kept in sync with git state on each branch.
+See also: [Version Sync Automation](https://docs.fogproject.org/en/latest/version-sync-automation) for how `FOG_VERSION`/`FOG_CHANNEL` are kept in sync with git state on each branch.
 
 ### Version Format
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This gives us a Production, Staging, and Dev branches to follow standard devops 
 | Staging          | dev-branch                                                                                                            | Patch
 | Dev              | working-*, {feature-name}                                                                                             | Major, Minor
 
+See also: [Version Sync Automation](https://docs.fogproject.org/development/version-sync-automation/) for how `FOG_VERSION`/`FOG_CHANNEL` are kept in sync with git state on each branch.
 
 ### Version Format
 


### PR DESCRIPTION
Adds a See also link from the Versioning and branches section to the new fog-docs page explaining how FOG_VERSION/FOG_CHANNEL are kept in sync (docs.fogproject.org/development/version-sync-automation/, see FOGProject/fog-docs#72). Same change as #929 on dev-branch.