### PR TITLE
refactor(githooks): make fog-version.sh a pure compute, add apply script

### DIFF
--- a/.githooks/lib/apply-fog-version.sh
+++ b/.githooks/lib/apply-fog-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+#
+# Writes FOG_VERSION/FOG_CHANNEL into packages/web/lib/fog/system.class.php.
+#
+# Pairs with fog-version.sh, which computes what these values should be -
+# this script only knows how to write them, not what they should be, so the
+# formula never has to be duplicated alongside the write step.
+#
+# Usage: apply-fog-version.sh <version> <channel>
+
+set -e
+
+version="$1"
+channel="$2"
+
+project_dir=$(git rev-parse --show-toplevel)
+system_file="$project_dir/packages/web/lib/fog/system.class.php"
+
+sed -i "s/define('FOG_VERSION',.*);/define('FOG_VERSION', '$version');/g" "$system_file"
+sed -i "s/define('FOG_CHANNEL',.*);/define('FOG_CHANNEL', '$channel');/g" "$system_file"

--- a/.githooks/lib/fog-version.sh
+++ b/.githooks/lib/fog-version.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env sh
 #
-# Recomputes FOG_VERSION/FOG_CHANNEL for the given (or current) branch and
-# rewrites packages/web/lib/fog/system.class.php in place.
+# Computes what FOG_VERSION/FOG_CHANNEL should be for the given (or
+# current) branch and prints them, one per line (version, then channel).
 #
-# Deliberately does NOT `git add`, `git commit`, or assume it's running
-# mid-commit - it only touches the working tree. That's what lets it be
-# shared between .githooks/pre-commit (which stages the result itself,
-# mid-commit) and a CI job (which has no commit in progress and stages/
-# commits/pushes on its own afterward).
+# Deliberately does NOT touch packages/web/lib/fog/system.class.php or any
+# other file - purely a function of git state, so it's safe to run ad hoc
+# (locally or in CI) without leaving a dirty working tree behind. Pair with
+# apply-fog-version.sh to actually write the result somewhere.
 #
 # Usage: fog-version.sh [branch-name]
 #   branch-name defaults to the currently checked out branch.
@@ -102,5 +101,5 @@ if [ "$drifted" = true ]; then
     compute_version "$((gitcount + 1))"
 fi
 
-sed -i "s/define('FOG_VERSION',.*);/define('FOG_VERSION', '$trunkversion');/g" "$system_file"
-sed -i "s/define('FOG_CHANNEL',.*);/define('FOG_CHANNEL', '$channel');/g" "$system_file"
+printf '%s\n' "$trunkversion"
+printf '%s\n' "$channel"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -61,11 +61,14 @@ psrfix
 # Define the path to the system file
 system_file="$project_dir/packages/web/lib/fog/system.class.php"
 
-# Recompute FOG_VERSION/FOG_CHANNEL for the current branch. The logic is
+# Recompute FOG_VERSION/FOG_CHANNEL for the current branch. The formula is
 # shared with fog-workflows' CI check (see .githooks/lib/fog-version.sh) so
 # a local commit and CI's periodic sweep never compute two different
 # answers for the same branch state.
-sh "$project_dir/.githooks/lib/fog-version.sh"
+fog_version=$(sh "$project_dir/.githooks/lib/fog-version.sh")
+sh "$project_dir/.githooks/lib/apply-fog-version.sh" \
+    "$(printf '%s\n' "$fog_version" | sed -n '1p')" \
+    "$(printf '%s\n' "$fog_version" | sed -n '2p')"
 
 # Add the modified system file to the staging area
 git add "$system_file"


### PR DESCRIPTION
Same change as #931 on dev-branch, ported to working-1.6. Part of the same set - see #931 for the full rationale and the note about merging alongside the fog-workflows CI change and the feature-* branch ports.