### PR TITLE
feat(githooks): skip apply-fog-version.sh entirely when nothing drifted

### DIFF
--- a/.githooks/lib/fog-version.sh
+++ b/.githooks/lib/fog-version.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 #
 # Computes what FOG_VERSION/FOG_CHANNEL should be for the given (or
-# current) branch and prints them, one per line (version, then channel).
+# current) branch and prints three lines: version, channel, and whether
+# that differs from what's currently committed (true/false) - so a caller
+# can skip writing/committing entirely when nothing needs to change,
+# instead of always writing and checking `git diff` afterward.
 #
 # Deliberately does NOT touch packages/web/lib/fog/system.class.php or any
 # other file - purely a function of git state, so it's safe to run ad hoc
@@ -103,3 +106,4 @@ fi
 
 printf '%s\n' "$trunkversion"
 printf '%s\n' "$channel"
+printf '%s\n' "$drifted"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -66,10 +66,12 @@ system_file="$project_dir/packages/web/lib/fog/system.class.php"
 # a local commit and CI's periodic sweep never compute two different
 # answers for the same branch state.
 fog_version=$(sh "$project_dir/.githooks/lib/fog-version.sh")
-sh "$project_dir/.githooks/lib/apply-fog-version.sh" \
-    "$(printf '%s\n' "$fog_version" | sed -n '1p')" \
-    "$(printf '%s\n' "$fog_version" | sed -n '2p')"
+if [ "$(printf '%s\n' "$fog_version" | sed -n '3p')" = "true" ]; then
+    sh "$project_dir/.githooks/lib/apply-fog-version.sh" \
+        "$(printf '%s\n' "$fog_version" | sed -n '1p')" \
+        "$(printf '%s\n' "$fog_version" | sed -n '2p')"
 
-# Add the modified system file to the staging area
-git add "$system_file"
+    # Add the modified system file to the staging area
+    git add "$system_file"
+fi
 


### PR DESCRIPTION
fog-version.sh now prints a third line (true/false) - whether its computed value differs from what's committed. .githooks/pre-commit uses it to skip apply-fog-version.sh and git add entirely when nothing needs to change, instead of always writing and relying on git diff afterward.

Matching change needed on fog-workflows' check-fog-version.yml, which now reads this same third line to gate its apply/commit step - see FOGProject/fog-workflows#5. Also needs porting to working-1.6 and all three feature-* branches, same as the previous set (#931-935), since CI runs each branch's own copy of the script.