### PR TITLE
docs: add current-version badges for stable/dev-branch/working-1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ This gives us a Production, Staging, and Dev branches to follow standard devops 
 
 See also: [Version Sync Automation](https://docs.fogproject.org/en/latest/version-sync-automation) for how `FOG_VERSION`/`FOG_CHANNEL` are kept in sync with git state on each branch.
 
+Current version on each of the main branches (updated automatically - see the doc above):
+
+| Branch | Version |
+|---|---|
+| [`stable`](https://github.com/FOGProject/fogproject/tree/stable) | [![stable version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/stable.json)](https://github.com/FOGProject/fogproject/tree/stable) |
+| [`dev-branch`](https://github.com/FOGProject/fogproject/tree/dev-branch) | [![dev-branch version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/dev-branch.json)](https://github.com/FOGProject/fogproject/tree/dev-branch) |
+| [`working-1.6`](https://github.com/FOGProject/fogproject/tree/working-1.6) | [![working-1.6 version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/working-1.6.json)](https://github.com/FOGProject/fogproject/tree/working-1.6) |
+
 ### Version Format
 
 Our versions are formatted in a x.x.x.x format like so:


### PR DESCRIPTION
Adds a small table under the versioning section with a live version badge per core branch, linked to that branch. Reads badges/*.json from fog-workflows (see FOGProject/fog-workflows#7 for how those get written).

Verified: all three badge JSONs already exist on fog-workflows' main with correct current values (dev-branch/working-1.6 from a live workflow_dispatch test, stable seeded manually with the current release tag since stable-releases.yml only writes its badge on an actual release), and the shields.io endpoint badge renders successfully (200 OK) for each.