### PR TITLE
Keep FOS kernels signed for Secure Boot, and make enrolment a short visit

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -108,11 +108,15 @@ usage() {
     echo -e "\t-X    --exitFail\t\tDo not exit if item fails"
     echo -e "\t-T    --no-tftpbuild\t\tDo not rebuild the tftpd config file"
     echo -e "\t-F    --no-vhost\t\tDo not overwrite vhost file"
+    echo -e "\t      --secure-boot-key\t\tPrivate key used to re-sign the FOS"
+    echo -e "\t                       \t\t\tkernels for UEFI Secure Boot"
+    echo -e "\t      --secure-boot-cert\tCertificate matching --secure-boot-key"
+    echo -e "\t                        \t\t\t(both are required together)"
     exit 0
 }
 
 shortopts="h?odEUHSCKYyXxTPFf:c:W:D:B:s:e:b:N:"
-longopts="help,uninstall,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,bootfile:,no-exportbuild,exitFail,no-tftpbuild"
+longopts="help,uninstall,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,bootfile:,no-exportbuild,exitFail,no-tftpbuild,secure-boot-key:,secure-boot-cert:"
 
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
@@ -270,6 +274,26 @@ while :; do
             novhost="y"
             shift
             ;;
+        --secure-boot-key)
+            if [[ -f $2 ]]; then
+                ssecureBootKey="$2"
+            else
+                echo "$1 requires a readable private key file after"
+                usage
+                exit 3
+            fi
+            shift 2
+            ;;
+        --secure-boot-cert)
+            if [[ -f $2 ]]; then
+                ssecureBootCert="$2"
+            else
+                echo "$1 requires a readable certificate file after"
+                usage
+                exit 3
+            fi
+            shift 2
+            ;;
         --)
             shift 
             break 
@@ -400,6 +424,26 @@ esac
 [[ -n $sbackupPath ]] && backupPath=$sbackupPath
 [[ -n $sexitFail ]] && exitFail=$sexitFail
 [[ -n $snoTftpBuild ]] && noTftpBuild=$snoTftpBuild
+[[ -n $ssecureBootKey ]] && secureBootKey=$ssecureBootKey
+[[ -n $ssecureBootCert ]] && secureBootCert=$ssecureBootCert
+
+# Secure Boot signing is opt-in and only meaningful as a pair. Refuse half a
+# pair rather than silently leaving kernels unsigned on a server whose admin
+# believes they are signed -- that failure only shows up at a client, as a
+# Security Policy Violation with nothing on the server to explain it.
+if [[ -n $secureBootKey || -n $secureBootCert ]]; then
+    if [[ -z $secureBootKey || -z $secureBootCert ]]; then
+        echo " * --secure-boot-key and --secure-boot-cert must be set together"
+        exit 9
+    fi
+    for sbfile in "$secureBootKey" "$secureBootCert"; do
+        if [[ ! -r $sbfile ]]; then
+            echo " * Cannot read Secure Boot signing file: $sbfile"
+            exit 9
+        fi
+    done
+    unset sbfile
+fi
 
 [[ -f $fogpriorconfig ]] && grep -l webroot $fogpriorconfig >>$error_log 2>&1
 case $? in

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3274,6 +3274,18 @@ _installSecureBootSigner() {
         echo "Failed"
         return 0
     }
+    # Point the helper at this install's config. It takes no arguments on
+    # purpose -- that is what stops a compromised web server naming its own key
+    # -- so the path has to be baked in here rather than passed at call time.
+    # Quoted: $fogprogramdir may contain a space, and `CONF=/a/fog custom/x`
+    # assigns only "/a/fog" and then tries to RUN "custom/x". bash -n does not
+    # catch that -- it is valid syntax, just not what anyone meant.
+    sed -i "s|^CONF=.*|CONF=\"${conf}\"|" "$helper" >>$error_log 2>&1
+    if ! grep -qxF "CONF=\"${conf}\"" "$helper"; then
+        echo "Failed"
+        echo " * Could not set the config path in $helper."
+        return 0
+    fi
     # Root-owned, root-readable only: the web user learns nothing about where
     # the key lives, and cannot rewrite these paths to point somewhere else.
     # SECUREBOOT_CERT is the normalised PEM -- sbsign cannot read DER.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3194,6 +3194,39 @@ _publishSecureBootKit() {
     chown -R "${apacheuser}":"${apacheuser}" "$kitdir" >>$error_log 2>&1
     echo "Done"
 }
+# Normalise --secure-boot-cert to PEM and echo the path.
+#
+# sbsign and sbverify read certificates with PEM_read_bio_X509 and reject DER
+# outright:
+#
+#   $ sbsign --key MOK.priv --cert MOK.der --output out.efi in.efi
+#   Can't load certificate from file 'MOK.der'
+#   error:0480006C:PEM routines:get_name:no start line ... Expecting: CERTIFICATE
+#
+# mokutil and MokManager want the opposite -- DER. So an admin following any
+# Secure Boot guide ends up holding one of each, with nothing telling them which
+# tool takes which, and handing the wrong one to --secure-boot-cert fails at
+# signing time with an OpenSSL error that says nothing about the format.
+#
+# Convert once here rather than pushing the distinction onto the user: the flag
+# accepts either, _resignKernels and the signing helper get PEM, and
+# _publishSecureBootKit still converts to DER for enrolment.
+_secureBootCertPem() {
+    local pem="${fogprogramdir}/.fog-secureboot.pem"
+    [[ -z $secureBootCert ]] && return 1
+    mkdir -p "$fogprogramdir" >>$error_log 2>&1
+    if openssl x509 -in "$secureBootCert" -inform pem -noout >/dev/null 2>&1; then
+        cp -f "$secureBootCert" "$pem" >>$error_log 2>&1 || return 1
+    elif ! openssl x509 -in "$secureBootCert" -inform der -outform pem \
+            -out "$pem" >>$error_log 2>&1; then
+        return 1
+    fi
+    # World-readable on purpose: a certificate is public, and it is the private
+    # key next to it that the 0600 config protects.
+    chown root:root "$pem" >>$error_log 2>&1
+    chmod 0644 "$pem" >>$error_log 2>&1
+    echo "$pem"
+}
 # Re-sign the FOS kernels for UEFI Secure Boot.
 #
 # The kernels above are downloaded unsigned on every install AND every upgrade,
@@ -3214,11 +3247,16 @@ _publishSecureBootKit() {
 # Removes the helper, its config and the sudoers rule again when signing is
 # turned off, so disabling the feature actually disables the privilege.
 _installSecureBootSigner() {
-    local bindir="/opt/fog/bin"
+    # $fogprogramdir, not a "/opt/fog" literal: GH-850 made the base path
+    # installer-driven, and hardcoding it here would scatter the helper, its
+    # config and the staging directory back into /opt/fog on a server installed
+    # anywhere else.
+    local bindir="${fogprogramdir}/bin"
     local helper="${bindir}/fog-sign-kernel"
-    local conf="/opt/fog/.fog-secureboot"
-    local stagedir="/opt/fog/secureboot-staging"
+    local conf="${fogprogramdir}/.fog-secureboot"
+    local stagedir="${fogprogramdir}/secureboot-staging"
     local sudoersfile="/etc/sudoers.d/fog-secureboot"
+    local certpem
 
     if [[ -z $secureBootKey || -z $secureBootCert ]]; then
         rm -f "$helper" "$conf" "$sudoersfile" >>$error_log 2>&1
@@ -3226,6 +3264,11 @@ _installSecureBootSigner() {
     fi
 
     dots "Installing Secure Boot signing helper"
+    certpem=$(_secureBootCertPem) || {
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate (PEM or DER)."
+        return 0
+    }
     mkdir -p "$bindir" >>$error_log 2>&1
     install -o root -g root -m 0755 ../packages/secureboot/fog-sign-kernel "$helper" >>$error_log 2>&1 || {
         echo "Failed"
@@ -3233,9 +3276,10 @@ _installSecureBootSigner() {
     }
     # Root-owned, root-readable only: the web user learns nothing about where
     # the key lives, and cannot rewrite these paths to point somewhere else.
+    # SECUREBOOT_CERT is the normalised PEM -- sbsign cannot read DER.
     {
         echo "SECUREBOOT_KEY=${secureBootKey}"
-        echo "SECUREBOOT_CERT=${secureBootCert}"
+        echo "SECUREBOOT_CERT=${certpem}"
         echo "SECUREBOOT_STAGING=${stagedir}"
     } > "$conf"
     chown root:root "$conf" >>$error_log 2>&1
@@ -3271,21 +3315,29 @@ _resignKernels() {
         return 0
     fi
     dots "Signing FOS kernels for Secure Boot"
-    local kernel kpath failed=0
+    local kernel kpath failed=0 certpem
+    # sbsign/sbverify take PEM only; the admin may well have handed us the DER
+    # copy that mokutil wanted. See _secureBootCertPem().
+    certpem=$(_secureBootCertPem) || {
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate (PEM or DER)."
+        echo "   Secure Boot clients will not boot until this is fixed."
+        return 0
+    }
     for kernel in bzImage bzImage32 arm_Image; do
         kpath="${webdirdest}/service/ipxe/${kernel}"
         [[ -f $kpath ]] || continue
         # Already carrying our signature means nothing was re-downloaded since
         # the last run, so there is nothing to do. Skipping here is what keeps a
         # second invocation from stacking a second signature on the same image.
-        sbverify --cert "$secureBootCert" "$kpath" >/dev/null 2>&1 && continue
+        sbverify --cert "$certpem" "$kpath" >/dev/null 2>&1 && continue
         # Otherwise this is a freshly downloaded, unsigned kernel. Snapshot it,
         # because sbsign will not cleanly re-sign an already-signed image and the
         # next run needs an unsigned original to work from. The snapshot has to
         # be refreshed every time rather than kept forever, or an upgrade would
         # re-sign the *previous* version over the new one.
         cp -af "$kpath" "${kpath}.unsigned" >>$error_log 2>&1
-        if sbsign --key "$secureBootKey" --cert "$secureBootCert" \
+        if sbsign --key "$secureBootKey" --cert "$certpem" \
                 --output "$kpath" "${kpath}.unsigned" >>$error_log 2>&1; then
             chown "${username}" "$kpath" >>$error_log 2>&1
         else

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2328,6 +2328,7 @@ writeUpdateFile() {
         mysqldbname installlang storageLocation fogupdateloaded docroot webroot
         caCreated httpproto startrange endrange packages noTftpBuild tftpAdvOpts
         sslpath backupPath php_ver sslprivkey sendreports
+        secureBootKey secureBootCert
     )
     # Keys written by older installers that must be stripped on upgrade.
     local -a deprecatedKeys=( storageftpuser storageftppass bootfilename notpxedefaultfile php_verAdds )
@@ -3153,6 +3154,151 @@ downloadfiles() {
     cp -vf ${copypath}FOGService.msi ${copypath}SmartInstaller.exe ${webdirdest}/client/ >>$error_log 2>&1
     errorStat $?
     cd $cwd
+    _resignKernels
+    _installSecureBootSigner
+    _publishSecureBootKit
+}
+# Publish the MOK enrolment kit under the web root.
+#
+# Only the *certificate* is published -- it is public by design, and is the
+# thing you are meant to distribute. The private key stays where the admin put
+# it and is never copied anywhere near the web root; that separation is the one
+# thing in this feature that must not be got wrong.
+_publishSecureBootKit() {
+    local kitdir="${webdirdest}/service/secureboot"
+
+    if [[ -z $secureBootCert ]]; then
+        rm -rf "$kitdir" >>$error_log 2>&1
+        return 0
+    fi
+
+    dots "Publishing Secure Boot enrolment kit"
+    mkdir -p "$kitdir" >>$error_log 2>&1
+    # A DER copy of the certificate is what mokutil wants. Accept a PEM cert
+    # too, since openssl is happy to produce either and admins mix them up.
+    if openssl x509 -in "$secureBootCert" -inform der -noout >/dev/null 2>&1; then
+        cp -f "$secureBootCert" "${kitdir}/MOK.der" >>$error_log 2>&1
+    elif openssl x509 -in "$secureBootCert" -outform der -out "${kitdir}/MOK.der" >>$error_log 2>&1; then
+        :
+    else
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate."
+        return 0
+    fi
+    cp -f ../packages/secureboot/fog-enroll-mok.sh "${kitdir}/" >>$error_log 2>&1
+    cp -f ../packages/secureboot/fog-enroll-mok.desktop "${kitdir}/" >>$error_log 2>&1
+    # Keep the directory from being browsable, matching service/ipxe.
+    echo '<?php header("HTTP/1.1 404 Not Found");' > "${kitdir}/index.php"
+    chmod 0644 "${kitdir}"/MOK.der "${kitdir}"/*.desktop "${kitdir}"/index.php >>$error_log 2>&1
+    chmod 0755 "${kitdir}/fog-enroll-mok.sh" >>$error_log 2>&1
+    chown -R "${apacheuser}":"${apacheuser}" "$kitdir" >>$error_log 2>&1
+    echo "Done"
+}
+# Re-sign the FOS kernels for UEFI Secure Boot.
+#
+# The kernels above are downloaded unsigned on every install AND every upgrade,
+# so without this a working Secure Boot setup silently stops booting the moment
+# someone updates FOG. That is the single most common way the setup breaks.
+#
+# No-op unless both secureBootKey and secureBootCert are configured. Missing
+# sbsign is a warning rather than a failure: the rest of the install is fine and
+# aborting it would be a worse outcome than an unsigned kernel the admin is told
+# about.
+# Install the root-only signing helper the web UI calls through sudo.
+#
+# The Kernel Update page runs as the web user, which must never be able to read
+# the signing key -- a web compromise would otherwise walk off with it. So the
+# key stays root-only and the web user gets a single, argument-less command it
+# may run as root.
+#
+# Removes the helper, its config and the sudoers rule again when signing is
+# turned off, so disabling the feature actually disables the privilege.
+_installSecureBootSigner() {
+    local bindir="/opt/fog/bin"
+    local helper="${bindir}/fog-sign-kernel"
+    local conf="/opt/fog/.fog-secureboot"
+    local stagedir="/opt/fog/secureboot-staging"
+    local sudoersfile="/etc/sudoers.d/fog-secureboot"
+
+    if [[ -z $secureBootKey || -z $secureBootCert ]]; then
+        rm -f "$helper" "$conf" "$sudoersfile" >>$error_log 2>&1
+        return 0
+    fi
+
+    dots "Installing Secure Boot signing helper"
+    mkdir -p "$bindir" >>$error_log 2>&1
+    install -o root -g root -m 0755 ../packages/secureboot/fog-sign-kernel "$helper" >>$error_log 2>&1 || {
+        echo "Failed"
+        return 0
+    }
+    # Root-owned, root-readable only: the web user learns nothing about where
+    # the key lives, and cannot rewrite these paths to point somewhere else.
+    {
+        echo "SECUREBOOT_KEY=${secureBootKey}"
+        echo "SECUREBOOT_CERT=${secureBootCert}"
+        echo "SECUREBOOT_STAGING=${stagedir}"
+    } > "$conf"
+    chown root:root "$conf" >>$error_log 2>&1
+    chmod 0600 "$conf" >>$error_log 2>&1
+
+    # The web user owns only the staging directory -- it has to write the
+    # downloaded kernel there and read the signed result back.
+    mkdir -p "$stagedir" >>$error_log 2>&1
+    chown "${apacheuser}":"${apacheuser}" "$stagedir" >>$error_log 2>&1
+    chmod 0750 "$stagedir" >>$error_log 2>&1
+
+    # Validate before installing: a malformed sudoers drop-in breaks sudo for
+    # the whole machine, which is a far worse outcome than no signing.
+    echo "${apacheuser} ALL=(root) NOPASSWD: ${helper}" > "${sudoersfile}.tmp"
+    chmod 0440 "${sudoersfile}.tmp" >>$error_log 2>&1
+    if visudo -cqf "${sudoersfile}.tmp" >>$error_log 2>&1; then
+        mv -f "${sudoersfile}.tmp" "$sudoersfile" >>$error_log 2>&1
+        chown root:root "$sudoersfile" >>$error_log 2>&1
+        echo "Done"
+    else
+        rm -f "${sudoersfile}.tmp" >>$error_log 2>&1
+        echo "Failed"
+        echo " * Refusing to install an invalid sudoers rule; the web Kernel"
+        echo "   Update page will download unsigned kernels. See $error_log."
+    fi
+}
+_resignKernels() {
+    [[ -z $secureBootKey || -z $secureBootCert ]] && return 0
+    if ! command -v sbsign >/dev/null 2>&1 || ! command -v sbverify >/dev/null 2>&1; then
+        echo " * WARNING: Secure Boot signing configured but sbsign/sbverify are not installed."
+        echo "   Install sbsigntool (Debian/Ubuntu) or sbsigntools (RHEL/Fedora)"
+        echo "   and re-run the installer, or Secure Boot clients will not boot."
+        return 0
+    fi
+    dots "Signing FOS kernels for Secure Boot"
+    local kernel kpath failed=0
+    for kernel in bzImage bzImage32 arm_Image; do
+        kpath="${webdirdest}/service/ipxe/${kernel}"
+        [[ -f $kpath ]] || continue
+        # Already carrying our signature means nothing was re-downloaded since
+        # the last run, so there is nothing to do. Skipping here is what keeps a
+        # second invocation from stacking a second signature on the same image.
+        sbverify --cert "$secureBootCert" "$kpath" >/dev/null 2>&1 && continue
+        # Otherwise this is a freshly downloaded, unsigned kernel. Snapshot it,
+        # because sbsign will not cleanly re-sign an already-signed image and the
+        # next run needs an unsigned original to work from. The snapshot has to
+        # be refreshed every time rather than kept forever, or an upgrade would
+        # re-sign the *previous* version over the new one.
+        cp -af "$kpath" "${kpath}.unsigned" >>$error_log 2>&1
+        if sbsign --key "$secureBootKey" --cert "$secureBootCert" \
+                --output "$kpath" "${kpath}.unsigned" >>$error_log 2>&1; then
+            chown "${username}" "$kpath" >>$error_log 2>&1
+        else
+            failed=1
+        fi
+    done
+    if [[ $failed -ne 0 ]]; then
+        echo "Failed"
+        echo " * At least one kernel could not be signed. See $error_log."
+        echo "   Secure Boot clients will not boot until this is fixed."
+        return 0
+    fi
+    echo "Done"
 }
 # The architecture -> boot-file mapping below intentionally mirrors the ISC
 # "class" blocks in the ISC branch of configureDHCP(). Keep the two in sync.
@@ -3201,6 +3347,31 @@ _keaBaseClasses() {
             "boot-file-name": "snponly.efi"
         }
 EOFCLS
+}
+# A Secure Boot class, emitted commented out.
+#
+# Left commented for two reasons. DHCP option 93 carries the client
+# architecture and nothing else, so there is no way to tell from a request
+# whether Secure Boot is on -- a site has to opt specific machines in. And this
+# must not simply replace the arch 7/8/9 classes: upstream ships exactly one
+# signed x86-64 iPXE binary, an all-drivers build that takes the NIC over from
+# the firmware and hangs on some hardware. FOG defaults to snponly.efi to avoid
+# exactly that, and there is no signed snponly equivalent (ipxe/ipxe#1776), so
+# pointing every UEFI client here would break machines that work today.
+#
+# The binaries are staged at $tftpdir/secureboot by downloadipxesecureboot()
+# on every install, so the path below always exists.
+_keaSecureBootClassCommented() {
+    cat <<'EOFSBC'
+#        Secure Boot clients. Uncomment, add a leading comma to the entry
+#        above, and narrow the test to the machines whose firmware has your
+#        MOK enrolled -- by subnet, MAC or a client class of your own.
+#        {
+#            "name": "FOG-UEFI-64-SecureBoot",
+#            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
+#            "boot-file-name": "secureboot/ipxe-shimx64.efi"
+#        }
+EOFSBC
 }
 _keaAppleClass() {
     cat <<'EOFAPL'
@@ -3317,9 +3488,11 @@ writeKeaSample() {
                 { \"name\": \"routers\", \"data\": \"$routeraddress\" }"
     [[ $(validip $dnsaddress) -eq 0 ]] && optdata="${optdata},
                 { \"name\": \"domain-name-servers\", \"data\": \"$dnsaddress\" }"
-    # Full reference: base classes + Apple BSDP. The admin can trim as needed.
+    # Full reference: base classes + Apple BSDP, plus a commented-out Secure
+    # Boot class. The admin can trim as needed.
     _writeKeaConfig "$target" "$(_keaBaseClasses),
-$(_keaAppleClass)"
+$(_keaAppleClass)
+$(_keaSecureBootClassCommented)"
     if [[ -s $target ]]; then
         echo
         echo " * A sample Kea DHCP config for a dedicated/external DHCP server was"
@@ -3461,6 +3634,17 @@ configureDHCP() {
             echo "        }" >> "$dhcptouse"
             echo "    }" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
+            # Secure Boot clients, commented out on purpose -- see the note on
+            # _keaSecureBootClassCommented(). Option 93 cannot tell us whether
+            # Secure Boot is on, and the only signed iPXE build is an
+            # all-drivers one that hangs on some NICs, so this has to be opted
+            # into per machine rather than applied to every UEFI client.
+            echo "# Secure Boot clients. Uncomment and narrow the match to the machines" >> "$dhcptouse"
+            echo "# whose firmware has your MOK enrolled." >> "$dhcptouse"
+            echo "#class \"FOG-UEFI-64-SecureBoot\" {" >> "$dhcptouse"
+            echo "#    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
+            echo "#    filename \"secureboot/ipxe-shimx64.efi\";" >> "$dhcptouse"
+            echo "#}" >> "$dhcptouse"
             diffconfig "${dhcptouse}"
             # Non-fatal syntax check; ISC has historically started without one.
             if command -v dhcpd >/dev/null 2>&1; then

--- a/packages/secureboot/fog-enroll-mok.desktop
+++ b/packages/secureboot/fog-enroll-mok.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Enrol FOG Secure Boot key
+Comment=Trust the FOG imaging server's signing key on this machine
+Exec=bash -c 'cd "$(dirname "%k")" && ./fog-enroll-mok.sh'
+Icon=security-high
+Terminal=true
+Categories=System;Security;

--- a/packages/secureboot/fog-enroll-mok.sh
+++ b/packages/secureboot/fog-enroll-mok.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# fog-enroll-mok.sh - enrol FOG's Secure Boot certificate on this machine.
+#
+# Run this from a stock Ubuntu or Debian live USB. Those boot fine with Secure
+# Boot switched on, using the distribution's own signed shim/GRUB/kernel, so
+# there is no need to go into firmware setup and turn Secure Boot off just to
+# get the key enrolled.
+#
+# Copy this script and MOK.der onto the USB stick together and double-click
+# fog-enroll-mok.desktop, or run this script directly. It expects MOK.der to be
+# sitting next to it.
+#
+set -u
+
+scriptdir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+cert="${scriptdir}/MOK.der"
+
+pause() {
+    echo
+    read -rsn1 -p "Press any key to close this window..."
+    echo
+}
+
+fail() {
+    echo
+    echo "  ERROR: $*" >&2
+    pause
+    exit 1
+}
+
+echo "==============================================="
+echo " FOG - enrol the Secure Boot signing key"
+echo "==============================================="
+echo
+
+[[ -r $cert ]] || fail "MOK.der not found next to this script (looked in ${scriptdir})."
+
+command -v mokutil >/dev/null 2>&1 || fail "mokutil is not installed on this live session."
+command -v openssl >/dev/null 2>&1 || fail "openssl is not installed on this live session."
+
+# Re-exec through sudo rather than making the tech remember to. Ubuntu live
+# sessions allow this without a password.
+if [[ $EUID -ne 0 ]]; then
+    exec sudo -- "$0" "$@"
+fi
+
+sbstate=$(mokutil --sb-state 2>/dev/null)
+echo " Secure Boot state: ${sbstate:-unknown}"
+
+# The fingerprint is the SHA-256 of the DER bytes, which is exactly what the
+# FOG web page displays. Checking it is the whole security of this step: it is
+# what stops someone from talking you into trusting a key that is not yours.
+fingerprint=$(openssl x509 -in "$cert" -inform der -noout -fingerprint -sha256 2>/dev/null \
+    | sed 's/^.*=//')
+subject=$(openssl x509 -in "$cert" -inform der -noout -subject 2>/dev/null | sed 's/^subject=*//')
+
+[[ -n $fingerprint ]] || fail "Could not read $cert -- is it really a DER certificate?"
+
+echo " Certificate:       ${subject}"
+echo " SHA-256:           ${fingerprint}"
+echo
+echo " Compare that SHA-256 against the one shown on your FOG server's"
+echo " Secure Boot page BEFORE continuing. If they differ, stop."
+echo
+read -rp " Does the fingerprint match? [y/N] " answer
+case "$answer" in
+    [Yy]*) ;;
+    *) echo; echo " Aborted -- nothing was changed."; pause; exit 1 ;;
+esac
+
+if mokutil --test-key "$cert" 2>/dev/null | grep -qi "already enrolled"; then
+    echo
+    echo " This key is already enrolled on this machine. Nothing to do."
+    pause
+    exit 0
+fi
+
+echo
+echo " You will now be asked for a one-time password, twice."
+echo
+echo " It is only used to confirm, after the reboot, that the person at the"
+echo " keyboard is the person who ran this. It is not stored and does not need"
+echo " to be strong -- pick something you can retype in a minute."
+echo
+
+if ! mokutil --import "$cert"; then
+    fail "mokutil --import failed."
+fi
+
+cat <<'EOFNEXT'
+
+ Done. Now reboot this machine.
+
+ Instead of booting normally it will stop on a blue MOK Manager screen.
+ Work through it in this order:
+
+   1. Enroll MOK
+   2. View key 0        <- check the name shown is your FOG server's
+   3. Continue
+   4. Yes
+   5. Enter the password you just chose
+   6. Reboot
+
+ If MOK Manager does NOT appear, the machine did not boot through a shim and
+ nothing has been enrolled.
+EOFNEXT
+pause
+exit 0

--- a/packages/secureboot/fog-sign-kernel
+++ b/packages/secureboot/fog-sign-kernel
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# fog-sign-kernel - sign a staged FOS kernel for UEFI Secure Boot.
+#
+# Invoked by the web UI's Kernel Update page through a narrow sudoers rule, so
+# that the signing key can stay root-only. The web server downloads a kernel
+# into the staging directory, calls this, then ships the signed result to the
+# TFTP server -- which may be a remote storage node, which is why the signing
+# has to happen here rather than in place under service/ipxe.
+#
+# SECURITY: this script deliberately takes NO arguments. Every path it touches
+# comes from a root-owned config file, so a compromised web server cannot point
+# it at a key it should not use or a file outside the staging area. Note the
+# limit of that guarantee: the caller does control the *contents* of the staged
+# file, so anyone who can invoke this can have a kernel of their choosing
+# signed. What they cannot do is read the key and sign things elsewhere or
+# later. Closing the remaining gap would mean verifying the staged image
+# against a known-good hash before signing.
+#
+set -u
+
+CONF=/opt/fog/.fog-secureboot
+
+if [[ ! -r $CONF ]]; then
+    echo "fog-sign-kernel: $CONF is missing or unreadable" >&2
+    exit 1
+fi
+
+# Read one key from the config. Deliberately NOT "source" -- the config is
+# root-owned data, and parsing it as shell would turn any future write access
+# to it into root code execution.
+readconf() {
+    sed -n "s/^$1=//p" "$CONF" | head -1
+}
+
+signKey=$(readconf SECUREBOOT_KEY)
+signCert=$(readconf SECUREBOOT_CERT)
+stageDir=$(readconf SECUREBOOT_STAGING)
+
+if [[ -z $signKey || -z $signCert || -z $stageDir ]]; then
+    echo "fog-sign-kernel: $CONF is incomplete" >&2
+    exit 1
+fi
+
+staged="${stageDir}/kernel"
+
+if [[ ! -f $staged ]]; then
+    echo "fog-sign-kernel: nothing staged at $staged" >&2
+    exit 1
+fi
+
+# Resolve and re-check: the staged path must still be a regular file directly
+# inside the configured staging directory once symlinks are taken out, so a
+# symlink planted by the web user cannot redirect the write.
+resolved=$(readlink -f "$staged" 2>/dev/null)
+if [[ -z $resolved || $(dirname "$resolved") != "$(readlink -f "$stageDir")" ]]; then
+    echo "fog-sign-kernel: staged file is not inside $stageDir" >&2
+    exit 1
+fi
+if [[ -L $staged ]]; then
+    echo "fog-sign-kernel: staged file must not be a symlink" >&2
+    exit 1
+fi
+
+for f in "$signKey" "$signCert"; do
+    if [[ ! -r $f ]]; then
+        echo "fog-sign-kernel: cannot read $f" >&2
+        exit 1
+    fi
+done
+
+if ! command -v sbsign >/dev/null 2>&1; then
+    echo "fog-sign-kernel: sbsign not installed" >&2
+    exit 1
+fi
+
+if ! sbsign --key "$signKey" --cert "$signCert" \
+        --output "${resolved}.signed" "$resolved"; then
+    rm -f "${resolved}.signed"
+    echo "fog-sign-kernel: sbsign failed" >&2
+    exit 1
+fi
+
+# Hand the signed image back with the staging directory's ownership so the web
+# user can still read it for upload, but never the key that produced it.
+chown --reference="$resolved" "${resolved}.signed" 2>/dev/null
+mv -f "${resolved}.signed" "$resolved"
+exit 0

--- a/packages/secureboot/fog-sign-kernel
+++ b/packages/secureboot/fog-sign-kernel
@@ -19,7 +19,15 @@
 #
 set -u
 
-CONF=/opt/fog/.fog-secureboot
+# GH-850: the FOG base path is installer-driven, so the installer rewrites this
+# line to match $fogprogramdir when it installs the helper. The default below is
+# correct for a stock install and keeps this script runnable straight from the
+# repository.
+#
+# Substituted rather than passed as an argument, because taking no arguments at
+# all is this script's whole security property -- see above. An environment
+# variable would be no better: it puts the path back under the caller's control.
+CONF="/opt/fog/.fog-secureboot"
 
 if [[ ! -r $CONF ]]; then
     echo "fog-sign-kernel: $CONF is missing or unreadable" >&2

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2745,8 +2745,14 @@ abstract class FOGPage extends FOGBase
      */
     protected static function secureBootStagingDir()
     {
-        $helper = '/opt/fog/bin/fog-sign-kernel';
-        $stagedir = '/opt/fog/secureboot-staging';
+        // GH-850: the base path is installer-driven, so these must be derived
+        // from FOG_BASE_DIR rather than written as /opt/fog literals. The
+        // installer places both under $fogprogramdir; hardcoding the default
+        // meant that on a server installed anywhere else this returned '' and
+        // signing silently never happened -- leaving Secure Boot clients with
+        // an unsigned kernel and nothing on the server to say why.
+        $helper = FOG_BASE_DIR . DS . 'bin' . DS . 'fog-sign-kernel';
+        $stagedir = FOG_BASE_DIR . DS . 'secureboot-staging';
         if (!is_executable($helper) || !is_dir($stagedir)) {
             return '';
         }
@@ -2774,7 +2780,15 @@ abstract class FOGPage extends FOGBase
         }
         $output = array();
         $retVal = 1;
-        exec('sudo -n /opt/fog/bin/fog-sign-kernel 2>&1', $output, $retVal);
+        // escapeshellarg because this is no longer a literal: FOG_BASE_DIR is
+        // written by the installer from $fogprogramdir, which an admin may set
+        // to a path containing a space. exec() hands the string to a shell, so
+        // an unquoted path would split into two arguments and the sudoers rule
+        // -- which matches the exact command -- would refuse it.
+        $helper = escapeshellarg(
+            FOG_BASE_DIR . DS . 'bin' . DS . 'fog-sign-kernel'
+        );
+        exec("sudo -n {$helper} 2>&1", $output, $retVal);
         if ($retVal !== 0) {
             throw new Exception(
                 sprintf(

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2669,6 +2669,9 @@ abstract class FOGPage extends FOGBase
                         $_SESSION['tmp-kernel-file'],
                         $_SESSION['dl-kernel-file']
                     );
+                    // Sign before upload, not after: the TFTP target may be a
+                    // remote storage node, and the key never leaves this host.
+                    self::secureBootSign($tmpfile);
                     $orig = sprintf(
                         '/%s/%s',
                         trim(self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'), '/'),
@@ -2728,6 +2731,59 @@ abstract class FOGPage extends FOGBase
             echo $e->getMessage();
         }
         self::$FOGFTP->close();
+    }
+    /**
+     * Returns the Secure Boot staging directory, or an empty string when
+     * kernel signing is not configured on this server.
+     *
+     * Signing runs as root through a sudo helper so the web server never needs
+     * read access to the private key. That helper only ever touches this one
+     * directory, which is why a kernel destined to be signed has to be
+     * downloaded here rather than into the system temp directory.
+     *
+     * @return string
+     */
+    protected static function secureBootStagingDir()
+    {
+        $helper = '/opt/fog/bin/fog-sign-kernel';
+        $stagedir = '/opt/fog/secureboot-staging';
+        if (!is_executable($helper) || !is_dir($stagedir)) {
+            return '';
+        }
+        return $stagedir;
+    }
+    /**
+     * Signs a staged kernel for Secure Boot via the root helper.
+     *
+     * Does nothing when signing is not configured. When it is, a failure is
+     * fatal: shipping an unsigned kernel to the TFTP server would stop every
+     * Secure Boot client from booting, and it would do so silently, long after
+     * whoever ran the update had walked away.
+     *
+     * @param string $tmpfile the staged kernel
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    protected static function secureBootSign($tmpfile)
+    {
+        $stagedir = self::secureBootStagingDir();
+        if (!$stagedir || dirname($tmpfile) !== $stagedir) {
+            return;
+        }
+        $output = array();
+        $retVal = 1;
+        exec('sudo -n /opt/fog/bin/fog-sign-kernel 2>&1', $output, $retVal);
+        if ($retVal !== 0) {
+            throw new Exception(
+                sprintf(
+                    '%s: %s',
+                    _('Error: Failed to sign the kernel for Secure Boot'),
+                    implode(' ', $output)
+                )
+            );
+        }
     }
     /**
      * Fetches the inits

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -43,6 +43,7 @@ class FOGConfigurationPage extends FOGPage
             'license' => self::$foglang['License'],
             'kernelUpdate' => self::$foglang['KernelUpdate'],
             'initrdUpdate' => self::$foglang['InitrdUpdate'],
+            'secureBoot' => _('Secure Boot'),
             'pxemenu' => self::$foglang['PXEBootMenu'],
             'customizepxe' => self::$foglang['PXEConfiguration'],
             'newMenu' => self::$foglang['NewMenu'],
@@ -330,6 +331,93 @@ class FOGConfigurationPage extends FOGPage
         echo '</div>';
     }
     /**
+     * Show the Secure Boot enrolment page.
+     *
+     * Displays the certificate fingerprint and links to the enrolment kit, so
+     * a technician has something to check the key against before trusting it
+     * on a machine. Nothing here is secret: the kit contains the public
+     * certificate only.
+     *
+     * @return void
+     */
+    public function secureBoot()
+    {
+        $kitdir = BASEPATH . 'service/secureboot';
+        $certfile = $kitdir . '/MOK.der';
+        $kiturl = rtrim(self::getSetting('FOG_WEB_ROOT'), '/') . '/service/secureboot';
+        echo '<div class="col-xs-9">';
+        echo '<div class="panel panel-info">';
+        echo '<div class="panel-heading text-center">';
+        echo '<h4 class="title">';
+        echo _('Secure Boot');
+        echo '</h4>';
+        echo '</div>';
+        echo '<div class="panel-body">';
+        if (!file_exists($certfile)) {
+            printf(
+                '%s. %s <code>--secure-boot-key</code> %s <code>--secure-boot-cert</code> %s.',
+                _('Secure Boot kernel signing is not configured on this server'),
+                _('Re-run the installer with'),
+                _('and'),
+                _('to enable it')
+            );
+            echo '</div></div></div>';
+            return;
+        }
+        // The SHA-256 of the DER bytes IS the certificate fingerprint, so no
+        // openssl round trip is needed to show the value a technician will
+        // compare against.
+        $fingerprint = strtoupper(
+            implode(':', str_split(hash_file('sha256', $certfile), 2))
+        );
+        printf(
+            '%s. %s.',
+            _('FOS kernels on this server are signed for UEFI Secure Boot'),
+            _(
+                'Each client needs this certificate enrolled once, by someone '
+                . 'physically at the machine'
+            )
+        );
+        echo '</div>';
+        echo '<div class="panel-body">';
+        echo '<p><strong>' . _('Certificate SHA-256') . '</strong></p>';
+        echo '<pre>' . Initiator::e($fingerprint) . '</pre>';
+        echo '<p>';
+        echo _(
+            'Check this value matches what the enrolment script prints before '
+            . 'confirming. That comparison is what stops the wrong key being '
+            . 'trusted.'
+        );
+        echo '</p>';
+        echo '<p><strong>' . _('Enrolment kit') . '</strong></p>';
+        echo '<p>';
+        printf(
+            '%s. %s.',
+            _(
+                'Copy all three files onto a USB stick, boot the client from a '
+                . 'stock Ubuntu or Debian live image with Secure Boot left ON, '
+                . 'and run the launcher'
+            ),
+            _('No firmware changes are needed')
+        );
+        echo '</p>';
+        echo '<ul>';
+        foreach (array('MOK.der', 'fog-enroll-mok.sh', 'fog-enroll-mok.desktop') as $file) {
+            if (!file_exists($kitdir . '/' . $file)) {
+                continue;
+            }
+            printf(
+                '<li><a href="%1$s/%2$s">%2$s</a></li>',
+                Initiator::e($kiturl),
+                Initiator::e($file)
+            );
+        }
+        echo '</ul>';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+    }
+    /**
      * Download the form.
      *
      * @return void
@@ -350,16 +438,25 @@ class FOGConfigurationPage extends FOGPage
                     $dstName
                 )
             );
-            $_SESSION['tmp-kernel-file'] = sprintf(
-                '%s%s%s%s',
-                DS,
-                trim(
-                    sys_get_temp_dir(),
-                    DS
-                ),
-                DS,
-                basename($_SESSION['dest-kernel-file'])
-            );
+            // With Secure Boot signing configured the download has to land in
+            // the staging directory the root signing helper works on, under
+            // the fixed name it expects. Everywhere else, the system temp
+            // directory as before.
+            $stagedir = self::secureBootStagingDir();
+            if ($stagedir) {
+                $_SESSION['tmp-kernel-file'] = $stagedir . DS . 'kernel';
+            } else {
+                $_SESSION['tmp-kernel-file'] = sprintf(
+                    '%s%s%s%s',
+                    DS,
+                    trim(
+                        sys_get_temp_dir(),
+                        DS
+                    ),
+                    DS,
+                    basename($_SESSION['dest-kernel-file'])
+                );
+            }
             $file = filter_input(INPUT_GET, 'file');
             $_SESSION['dl-kernel-file'] = base64_decode(
                 $file

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -914,6 +914,9 @@ msgstr "Upload"
 msgid "Captured"
 msgstr "Erstellt"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Change password"
 msgstr "Passwort ändern"
@@ -967,6 +970,11 @@ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 #, fuzzy
@@ -1097,6 +1105,11 @@ msgstr "Bestätige Task"
 
 msgid "Conflicting path/file"
 msgstr "widersprüchliche(r) Pfad/Datei"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1549,6 +1562,11 @@ msgstr "Dauer"
 msgid "ESC is defaulted"
 msgstr "ESC ist standardmäßig eingestellt"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -1597,6 +1615,9 @@ msgstr "Endzeit"
 
 msgid "Engineer"
 msgstr "Ingenieur"
+
+msgid "Enrolment kit"
+msgstr ""
 
 #, fuzzy
 msgid "Enter a group name to search for"
@@ -1666,6 +1687,10 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Error: Failed to open temp file"
 msgstr "Fehler: Öffnen der Temp-Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Errors"
 msgstr "Fehler"
@@ -1933,6 +1958,9 @@ msgstr "FOG kann nicht mit der Datenbank verbinden."
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG-Server im Standard-Ordner."
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "FTP-Verbindung fehlgeschlagen"
@@ -4228,6 +4256,9 @@ msgstr "Keine Datei wurde hochgeladen"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "Kein nutzerfreundlicher Name vergeben"
 
@@ -4975,6 +5006,9 @@ msgstr "Schnell"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "Neustarten"
 
@@ -5407,6 +5441,13 @@ msgstr "Die Suche lieferte kein passendes Ergebnis"
 #, fuzzy
 msgid "Second parameter must be in array(class,function)"
 msgstr "Zweiter Parameter muss innerhalb des Arrays (Klasse, Funktion) sein"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
 
 msgid "Select Image"
 msgstr "Wählen Sie ein Image"
@@ -7210,6 +7251,10 @@ msgstr "vor"
 msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
 
+#, fuzzy
+msgid "and"
+msgstr "Ende"
+
 msgid "and Mac OS X"
 msgstr "und Mac OS X"
 
@@ -7926,6 +7971,9 @@ msgstr ""
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "In dieser Gruppe wurde kein Speicherknoten gefunden"
+
+msgid "to enable it"
+msgstr ""
 
 #, fuzzy
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -911,6 +911,9 @@ msgstr "Create"
 msgid "Captured"
 msgstr "Created"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Change password"
 msgstr "Management Password"
@@ -964,6 +967,11 @@ msgstr "Check that database is running"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 #, fuzzy
@@ -1092,6 +1100,11 @@ msgid "Confirm tasking"
 msgstr "Invalid task"
 
 msgid "Conflicting path/file"
+msgstr ""
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
 msgstr ""
 
 #, fuzzy
@@ -1545,6 +1558,11 @@ msgstr "Duration"
 msgid "ESC is defaulted"
 msgstr "Enabled as default"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Edit"
 
@@ -1593,6 +1611,9 @@ msgstr "End Time"
 
 msgid "Engineer"
 msgstr "Engineer"
+
+msgid "Enrolment kit"
+msgstr ""
 
 #, fuzzy
 msgid "Enter a group name to search for"
@@ -1662,6 +1683,10 @@ msgstr "Error: Failed to download kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Error: Failed to open temp file"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Error: Failed to download kernel"
 
 msgid "Errors"
 msgstr "Errors"
@@ -1928,6 +1953,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 msgid "FTP Connection has failed"
@@ -4219,6 +4247,9 @@ msgstr "No file was uploaded"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr ""
 
@@ -4962,6 +4993,9 @@ msgstr "Click"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "Reboot"
 
@@ -5393,6 +5427,13 @@ msgstr ""
 #, fuzzy
 msgid "Second parameter must be in array(class,function)"
 msgstr "Second parameter must be in the form array(Hook class,Function to run)"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "There are no images on this server."
 
 msgid "Select Image"
 msgstr "Select Image"
@@ -7198,6 +7239,10 @@ msgstr " ago"
 msgid "all current storage nodes"
 msgstr "Invalid storage node"
 
+#, fuzzy
+msgid "and"
+msgstr "End"
+
 msgid "and Mac OS X"
 msgstr ""
 
@@ -7909,6 +7954,9 @@ msgstr ""
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "Could not find a Storage Node, is there one enabled within this group?"
+
+msgid "to enable it"
+msgstr ""
 
 #, fuzzy
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -905,6 +905,9 @@ msgstr "Capturar"
 msgid "Captured"
 msgstr "Última captura"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr ""
 
@@ -954,6 +957,11 @@ msgstr "Campo obligatorio está vacio"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 #, fuzzy
@@ -1082,6 +1090,11 @@ msgstr ""
 #, fuzzy
 msgid "Conflicting path/file"
 msgstr "Archivo"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr ""
@@ -1509,6 +1522,11 @@ msgstr ""
 msgid "ESC is defaulted"
 msgstr ""
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -1563,6 +1581,9 @@ msgid "End Time"
 msgstr "Fecha ya existe"
 
 msgid "Engineer"
+msgstr ""
+
+msgid "Enrolment kit"
 msgstr ""
 
 #, fuzzy
@@ -1635,6 +1656,9 @@ msgid "Error: Failed to download kernel"
 msgstr ""
 
 msgid "Error: Failed to open temp file"
+msgstr ""
+
+msgid "Error: Failed to sign the kernel for Secure Boot"
 msgstr ""
 
 msgid "Errors"
@@ -1912,6 +1936,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 msgid "FTP Connection has failed"
@@ -4242,6 +4269,9 @@ msgstr "Archivo no fue subido"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 #, fuzzy
 msgid "No friendly name defined"
 msgstr "Alias"
@@ -4973,6 +5003,9 @@ msgstr ""
 msgid "RX"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr ""
 
@@ -5364,6 +5397,13 @@ msgstr ""
 
 msgid "Second parameter must be in array(class,function)"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "No hay imágenes en este servidor"
 
 #, fuzzy
 msgid "Select Image"
@@ -7135,6 +7175,9 @@ msgstr ""
 msgid "all current storage nodes"
 msgstr "todos los Nodos de Almacenamiento"
 
+msgid "and"
+msgstr ""
+
 msgid "and Mac OS X"
 msgstr ""
 
@@ -7836,6 +7879,9 @@ msgid "to be booted if no keys are pressed when the menu is"
 msgstr ""
 
 msgid "to clear the field on every host in this group."
+msgstr ""
+
+msgid "to enable it"
 msgstr ""
 
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -795,6 +795,9 @@ msgstr "Capture"
 msgid "Captured"
 msgstr "Capturée"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr "Changer le mot de passe"
 
@@ -843,6 +846,11 @@ msgstr "Vérifiez que la base de données est en cours d'exécution"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -958,6 +966,11 @@ msgstr "Confirmer l'affectation des tâches"
 
 msgid "Conflicting path/file"
 msgstr "Conflit de chemin / fichier"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "Copie de l'existant"
@@ -1348,6 +1361,11 @@ msgstr "Durée"
 msgid "ESC is defaulted"
 msgstr "ESC est par défaut"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Modifier"
 
@@ -1396,6 +1414,9 @@ msgstr "Heure de fin"
 
 msgid "Engineer"
 msgstr "Ingénieur"
+
+msgid "Enrolment kit"
+msgstr ""
 
 msgid "Enter a group name to search for"
 msgstr "Entrez un nom de groupe à rechercher"
@@ -1457,6 +1478,10 @@ msgstr "Erreur : Impossible de télécharger le noyau"
 
 msgid "Error: Failed to open temp file"
 msgstr "Erreur : Impossible d'ouvrir le fichier temporaire"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Erreur : Impossible de télécharger le noyau"
 
 msgid "Errors"
 msgstr "Erreurs"
@@ -1697,6 +1722,9 @@ msgstr "Le FOG ne parvient pas à communiquer avec la base de données"
 
 msgid "FOG server defaulting under the folder"
 msgstr "serveur FOG se trouvant par défaut dans le dossier"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "Connexion FTP a échoué"
@@ -3745,6 +3773,9 @@ msgstr "Aucun fichier n'a été téléchargé"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "Aucun nom usuel défini"
 
@@ -4421,6 +4452,9 @@ msgstr "Rapide"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "Redémarrage"
 
@@ -4783,6 +4817,13 @@ msgstr "Les résultats de la recherche sont faux"
 #, fuzzy
 msgid "Second parameter must be in array(class,function)"
 msgstr "Deuxième paramètre doit être sous la forme array (class, function)"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Il n'y a pas d'images sur ce serveur"
 
 msgid "Select Image"
 msgstr "Sélectionner l'image"
@@ -6367,6 +6408,10 @@ msgstr "depuis"
 msgid "all current storage nodes"
 msgstr "tous les nœuds de stockage actuels"
 
+#, fuzzy
+msgid "and"
+msgstr "Fin"
+
 msgid "and Mac OS X"
 msgstr "and MacOS X"
 
@@ -7004,6 +7049,9 @@ msgstr "pour être démarré si aucune touche n'est pressée lorsque le menu est
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "Impossible de trouver un nœud de stockage dans ce groupe"
+
+msgid "to enable it"
+msgstr ""
 
 #, fuzzy
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -813,6 +813,9 @@ msgstr "Catturare"
 msgid "Captured"
 msgstr "Catturato"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr "Cambia password"
 
@@ -868,6 +871,11 @@ msgstr "Controllare che database è in esecuzione"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -983,6 +991,11 @@ msgstr "Conferma il task"
 
 msgid "Conflicting path/file"
 msgstr "Percorso / file in conflitto"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "Copia da esistenti"
@@ -1376,6 +1389,11 @@ msgstr "Durata"
 msgid "ESC is defaulted"
 msgstr "ESC è predefinito"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Modifica"
 
@@ -1424,6 +1442,9 @@ msgstr "Fine del tempo"
 
 msgid "Engineer"
 msgstr "Ingegnere"
+
+msgid "Enrolment kit"
+msgstr ""
 
 #, fuzzy
 msgid "Enter a group name to search for"
@@ -1493,6 +1514,10 @@ msgstr "Errore: Impossibile scaricare il kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Errore: Impossibile aprire il file temporaneo"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Errore: Impossibile scaricare il kernel"
 
 msgid "Errors"
 msgstr "Errori"
@@ -1740,6 +1765,9 @@ msgstr "FOG non è in grado di comunicare con il database"
 
 msgid "FOG server defaulting under the folder"
 msgstr "server FOG per default nella cartella"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "Connessione FTP non è riuscita"
@@ -3803,6 +3831,9 @@ msgstr "Nessun file è stato caricato"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "Nessun nome amichevole definito"
 
@@ -4482,6 +4513,9 @@ msgstr "Veloce"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "Riavvio"
 
@@ -4866,6 +4900,13 @@ msgstr "Risultati di ricerca che restituiscono false"
 #, fuzzy
 msgid "Second parameter must be in array(class,function)"
 msgstr "Il secondo parametro deve essere un array (classe, funzione)"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Non ci sono immagini su questo server"
 
 msgid "Select Image"
 msgstr "Seleziona Immagine"
@@ -6482,6 +6523,10 @@ msgstr "fa"
 msgid "all current storage nodes"
 msgstr "tutti i nodi di archiviazione attivi"
 
+#, fuzzy
+msgid "and"
+msgstr "Fine"
+
 msgid "and Mac OS X"
 msgstr "e Mac OS X"
 
@@ -7122,6 +7167,9 @@ msgstr "per essere avviato se non è premuto nessun tasto quando il menu è"
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "Impossibile trovare un nodo di archiviazione in questo gruppo"
+
+msgid "to enable it"
+msgstr ""
 
 #, fuzzy
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -779,6 +779,9 @@ msgstr "キャプチャ"
 msgid "Captured"
 msgstr "キャプチャ済み"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr "パスワードを変更"
 
@@ -826,6 +829,11 @@ msgstr "データベースが稼働していることを確認してください
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -941,6 +949,11 @@ msgstr "タスクを確認"
 
 msgid "Conflicting path/file"
 msgstr "競合するパス/ファイル"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "既存の項目からコピー"
@@ -1327,6 +1340,11 @@ msgstr "期間"
 msgid "ESC is defaulted"
 msgstr "ESC が既定です"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "編集"
 
@@ -1374,6 +1392,9 @@ msgstr "終了時刻"
 
 msgid "Engineer"
 msgstr "担当者"
+
+msgid "Enrolment kit"
+msgstr ""
 
 msgid "Enter a group name to search for"
 msgstr "検索するグループ名を入力してください"
@@ -1434,6 +1455,10 @@ msgstr "エラー: カーネルのダウンロードに失敗しました"
 
 msgid "Error: Failed to open temp file"
 msgstr "エラー: 一時ファイルを開けませんでした"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "エラー: カーネルのダウンロードに失敗しました"
 
 msgid "Errors"
 msgstr "エラー"
@@ -1674,6 +1699,9 @@ msgstr "FOG はデータベースと通信できません"
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG サーバーは次のフォルダーを既定で使用します"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "FTP 接続に失敗しました"
@@ -3689,6 +3717,9 @@ msgstr "ファイルはアップロードされませんでした"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "表示名が定義されていません"
 
@@ -4352,6 +4383,9 @@ msgstr "クイック"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "再起動"
 
@@ -4715,6 +4749,13 @@ msgstr "検索結果が false を返しました"
 
 msgid "Second parameter must be in array(class,function)"
 msgstr "2 番目のパラメーターは array(class,function) 形式である必要があります"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "このサーバーにはイメージがありません"
 
 msgid "Select Image"
 msgstr "イメージを選択"
@@ -6272,6 +6313,10 @@ msgstr "前"
 msgid "all current storage nodes"
 msgstr "現在のすべてのストレージノード"
 
+#, fuzzy
+msgid "and"
+msgstr "終了"
+
 msgid "and Mac OS X"
 msgstr "および Mac OS X"
 
@@ -6895,6 +6940,9 @@ msgstr "メニュー表示中にキーが押されなかった場合に起動す
 
 msgid "to clear the field on every host in this group."
 msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
+
+msgid "to enable it"
+msgstr ""
 
 msgid "to get the requested Initrd"
 msgstr "要求された Initrd を取得するため"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -765,6 +765,9 @@ msgstr ""
 msgid "Captured"
 msgstr ""
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr ""
 
@@ -812,6 +815,11 @@ msgstr ""
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -926,6 +934,11 @@ msgid "Confirm tasking"
 msgstr ""
 
 msgid "Conflicting path/file"
+msgstr ""
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
 msgstr ""
 
 msgid "Copy from existing"
@@ -1313,6 +1326,11 @@ msgstr ""
 msgid "ESC is defaulted"
 msgstr ""
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr ""
 
@@ -1359,6 +1377,9 @@ msgid "End Time"
 msgstr ""
 
 msgid "Engineer"
+msgstr ""
+
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Enter a group name to search for"
@@ -1419,6 +1440,9 @@ msgid "Error: Failed to download kernel"
 msgstr ""
 
 msgid "Error: Failed to open temp file"
+msgstr ""
+
+msgid "Error: Failed to sign the kernel for Secure Boot"
 msgstr ""
 
 msgid "Errors"
@@ -1659,6 +1683,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 msgid "FTP Connection has failed"
@@ -3668,6 +3695,9 @@ msgstr ""
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr ""
 
@@ -4326,6 +4356,9 @@ msgstr ""
 msgid "RX"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr ""
 
@@ -4686,6 +4719,12 @@ msgid "Search results returned false"
 msgstr ""
 
 msgid "Second parameter must be in array(class,function)"
+msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+msgid "Secure Boot kernel signing is not configured on this server"
 msgstr ""
 
 msgid "Select Image"
@@ -6231,6 +6270,9 @@ msgstr ""
 msgid "all current storage nodes"
 msgstr ""
 
+msgid "and"
+msgstr ""
+
 msgid "and Mac OS X"
 msgstr ""
 
@@ -6851,6 +6893,9 @@ msgid "to be booted if no keys are pressed when the menu is"
 msgstr ""
 
 msgid "to clear the field on every host in this group."
+msgstr ""
+
+msgid "to enable it"
 msgstr ""
 
 msgid "to get the requested Initrd"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -790,6 +790,9 @@ msgstr "Captura"
 msgid "Captured"
 msgstr "Capturado"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr "Alterar senha"
 
@@ -838,6 +841,11 @@ msgstr "Verifique se o banco de dados está em execução"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -953,6 +961,11 @@ msgstr "Confirmar agendamento"
 
 msgid "Conflicting path/file"
 msgstr "Conflito de caminho/arquivo"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "Copiar de existente"
@@ -1339,6 +1352,11 @@ msgstr "Duração"
 msgid "ESC is defaulted"
 msgstr "ESC é o padrão"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -1386,6 +1404,9 @@ msgstr "Hora Final"
 
 msgid "Engineer"
 msgstr "Engenheiro"
+
+msgid "Enrolment kit"
+msgstr ""
 
 msgid "Enter a group name to search for"
 msgstr "Digite um nome de grupo para pesquisar"
@@ -1446,6 +1467,10 @@ msgstr "Erro: Falha ao baixar kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Erro: Falha ao abrir o arquivo temporário"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Erro: Falha ao baixar kernel"
 
 msgid "Errors"
 msgstr "Erros"
@@ -1686,6 +1711,9 @@ msgstr "FOG não consegue se comunicar com o banco de dados"
 
 msgid "FOG server defaulting under the folder"
 msgstr "Servidor FOG padronizando sob a pasta"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "Conexão FTP falhou"
@@ -3716,6 +3744,9 @@ msgstr "Nenhum arquivo foi enviado"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "Nenhum nome amigável definido"
 
@@ -4382,6 +4413,9 @@ msgstr "Rápido"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "Reiniciar"
 
@@ -4745,6 +4779,13 @@ msgstr "Resultados da pesquisa retornaram falso"
 
 msgid "Second parameter must be in array(class,function)"
 msgstr "Segundo parâmetro deve estar em array(classe,função)"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Não há imagens neste servidor"
 
 msgid "Select Image"
 msgstr "Selecionar Imagem"
@@ -6304,6 +6345,10 @@ msgstr "atrás"
 msgid "all current storage nodes"
 msgstr "todos os nós de armazenamento atuais"
 
+#, fuzzy
+msgid "and"
+msgstr "Fim"
+
 msgid "and Mac OS X"
 msgstr "e Mac OS X"
 
@@ -6930,6 +6975,9 @@ msgstr ""
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "Não foi possível encontrar um Nó de Armazenamento neste grupo"
+
+msgid "to enable it"
+msgstr ""
 
 msgid "to get the requested Initrd"
 msgstr "para obter o Initrd solicitado"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -788,6 +788,9 @@ msgstr "抓取"
 msgid "Captured"
 msgstr "已抓取"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Change password"
 msgstr "更改密码"
 
@@ -835,6 +838,11 @@ msgstr "检查数据库运行状态"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checkin Time"
@@ -950,6 +958,11 @@ msgstr "确认任务"
 
 msgid "Conflicting path/file"
 msgstr "确认环境变量/文件"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "从现有复制"
@@ -1336,6 +1349,11 @@ msgstr "期限"
 msgid "ESC is defaulted"
 msgstr "默认为ESC"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "编辑"
 
@@ -1383,6 +1401,9 @@ msgstr "结束时间"
 
 msgid "Engineer"
 msgstr "工程师"
+
+msgid "Enrolment kit"
+msgstr ""
 
 msgid "Enter a group name to search for"
 msgstr "输入组名搜索"
@@ -1443,6 +1464,10 @@ msgstr "错误：无法下载内核"
 
 msgid "Error: Failed to open temp file"
 msgstr "错误：无法打开临时文件"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "错误：无法下载内核"
 
 msgid "Errors"
 msgstr "错误"
@@ -1683,6 +1708,9 @@ msgstr "FOG无法与数据库通信"
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG服务器默认在此文件夹"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 msgid "FTP Connection has failed"
 msgstr "FTP连接失败"
@@ -3707,6 +3735,9 @@ msgstr "没有文件被上传"
 msgid "No files matched multicast image pattern"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No friendly name defined"
 msgstr "未定义友好名称"
 
@@ -4368,6 +4399,9 @@ msgstr "快速"
 msgid "RX"
 msgstr "RX"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Reboot"
 msgstr "重启"
 
@@ -4729,6 +4763,13 @@ msgstr "搜索结果返回为假"
 
 msgid "Second parameter must be in array(class,function)"
 msgstr "第二个参数的形式必须是数组（类，函数）"
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "此服务器上没有镜像"
 
 msgid "Select Image"
 msgstr "选择镜像"
@@ -6283,6 +6324,10 @@ msgstr "前"
 msgid "all current storage nodes"
 msgstr "所有目前的存储节点"
 
+#, fuzzy
+msgid "and"
+msgstr "结束"
+
 msgid "and Mac OS X"
 msgstr "和MAC OS X"
 
@@ -6905,6 +6950,9 @@ msgstr "将会启动，如果菜单显示时没有按下按键"
 #, fuzzy
 msgid "to clear the field on every host in this group."
 msgstr "该组内找不到存储节点"
+
+msgid "to enable it"
+msgstr ""
 
 msgid "to get the requested Initrd"
 msgstr "获取所请求的Initrd"


### PR DESCRIPTION
Follows the guide merged for #957 / #960. Companion changes on the same branch name in [FOGProject/fos](https://github.com/FOGProject/fos) (build-time signing) and [FOGProject/fog-docs](https://github.com/FOGProject/fog-docs) (the rewritten guide).

## The problem

A site running UEFI Secure Boot signs the FOS kernels with its own key and enrols that key per machine. Both halves were manual, and the signing half quietly came undone:

- `lib/common/functions.sh` copies freshly downloaded, **unsigned** kernels over `service/ipxe` on every install *and* every upgrade.
- The web **Kernel Update** page does the same over FTP.

Clients stopped booting the next time anyone updated FOG, with nothing on the server to explain it. The guide names this as the single most common way the setup breaks.

## What changed

**Signing survives upgrades.** `--secure-boot-key` / `--secure-boot-cert` are stored in `.fogsettings`, so both paths re-sign from then on. `_resignKernels()` skips images that already carry the configured signature — that is what stops a second run stacking a second signature — and refreshes its `.unsigned` snapshot each time, so an upgrade cannot re-sign the *previous* version over the new one.

**The web path signs without ever seeing the key.** The Kernel Update page runs as the web user, which must never be able to read the signing key. It signs through `/opt/fog/bin/fog-sign-kernel`, root-owned and reachable via a sudoers rule scoped to that one command. The helper **takes no arguments** — every path comes from a root-only config — so the caller cannot redirect it at a different key or file. The sudoers drop-in is validated with `visudo` before install, because a malformed one breaks `sudo` for the whole machine. Signing happens before the FTP upload, since the TFTP target may be a remote storage node.

> [!IMPORTANT]
> This protects the **key**, not the act of signing. Anyone who can already run code as the web server can have a kernel of their choosing signed. What they cannot do is walk off with the key and sign things elsewhere or later. The helper and the guide both say so plainly rather than implying more. Closing the remaining gap would mean verifying the staged image against a known-good hash before signing.

A signing failure **refuses the update** rather than installing a kernel clients cannot boot.

**Enrolment gets a kit.** The public certificate, a script and a `.desktop` launcher, published under `service/secureboot` and linked from a new **FOG Configuration → Secure Boot** page that displays the certificate fingerprint. The script prints the same fingerprint and makes the technician confirm it before trusting anything — that comparison is the whole security of the step, and the old guide only suggested eyeballing the CN in MokManager. It runs from a stock Ubuntu or Debian live USB, which already boots with Secure Boot **on**, so the visit no longer starts by turning Secure Boot off. Only the certificate is published; the private key never goes near the web root.

**`--secure-boot-stage`** optionally stages the signed chain: iPXE's Microsoft-signed shim, plus upstream's signed `snponly.efi` pulled from `ipxeboot.tar.gz`. Opt-in and never fatal — it fetches pinned third-party binaries, and an upstream hiccup must not fail an install.

The shim is installed as **`snponly-shimx64.efi`**, because the shim picks its second stage by stripping `-shim` from its own filename. That is upstream's own mechanism: `ipxeboot.tar.gz` ships `ipxe-shim.efi` and `snponly-shim.efi` as two symlinks to a single `shimx64.efi` for exactly this reason. Renaming does not disturb the signature, which covers file contents.

The shim comes from the `ipxe/shim` release rather than the tarball's bundled copy. Reading both PE certificate tables: the standalone build has two `WIN_CERTIFICATE` entries (Microsoft UEFI CA **2011 and 2023**), the bundled one has a single 2011 entry — no use on hardware shipping only the 2023 certificate.

> [!NOTE]
> Staging `snponly` rather than the all-drivers `ipxe.efi` means Secure Boot clients get **the same driver model FOG already serves everyone else** — it binds only the firmware's UEFI network protocol instead of replacing the NIC driver. These machines stop being a special case.

**The Secure Boot DHCP class is emitted commented out** in both the Kea sample and the ISC config. Option 93 carries the client architecture and nothing else, so there is no way to tell from a request whether Secure Boot is on — a site has to opt specific machines in once their firmware has the MOK enrolled.

## Verified

- `bash -n` on `installfog.sh` and `functions.sh`; `php -l` on both PHP files.
- `_resignKernels()` exercised in a sandbox with stubbed `sbsign`/`sbverify` across all three flows: fresh install signs once, a re-run with no new download skips, and an upgrade signs the **new** kernel rather than re-signing the stale `.unsigned`. An earlier revision double-signed on re-run; that is what the `sbverify` skip fixes.
- `fog-sign-kernel` guards tested: missing config, nothing staged, a symlink pointing outside the staging directory (refused, target untouched), and caller-supplied arguments (ignored).
- The staging sequence run against the real 12 MB `ipxeboot.tar.gz`: the `tar` path extracts, and both staged binaries carry the signatures described above.
- The generated Kea sample parses as valid JSON once `#` comments are stripped.
- The certificate fingerprint PHP computes matches `openssl x509 -fingerprint -sha256` exactly — the technician compares these two, so they have to agree.

## Not verified

No end-to-end run against a real FOG server or a Secure Boot client. The install → upgrade → Kernel Update cycle and the live USB enrolment both want testing on real hardware — see #960, which is already open for exactly that.

## Two corrections since this was opened

**A signed `snponly.efi` exists** (dc90e67). An earlier revision of this PR staged the all-drivers `ipxe.efi`, extracted from the release's `-sb.usb` disk image by parsing the MBR for the first partition's LBA start and loop-mounting at that offset. That was based on the belief that upstream published no signed `snponly` equivalent — the reason [ipxe/ipxe#1776](https://github.com/ipxe/ipxe/issues/1776) was filed, and why it is closed as not planned. The signed binaries ship in `ipxeboot.tar.gz` under `<arch>-sb/`, for arm64 as well as x86_64. The loop-mount machinery is deleted; a tarball needs none of it.

**Rebased onto `dev-branch`.** The branch was originally cut from `stable`, which predates 182701d (iPXE moved to the `fog-ipxe` repo) and 3c0b4ce (`autoexec.ipxe` hard-linked at the TFTP root). Both collided: the staging function no longer sources `src/ipxe/src/ipxescript`, which no longer exists, and its redundant root hard-link is gone — it now hard-links from `$tftpdirdst/autoexec/autoexec.ipxe`, matching the convention 3c0b4ce set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw