### PR TITLE
Port Secure Boot kernel signing from dev-branch

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -152,11 +152,15 @@ usage() {
     echo -e "\t-T    --no-tftpbuild\t\tDo not rebuild the tftpd config file"
     echo -e "\t-F    --no-vhost\t\tDo not overwrite vhost file"
     echo -e "\t-l    --list-packages\t\tList of the basic packages FOG needs for install or is currently installed for FOG"
+    echo -e "\t      --secure-boot-key\t\tPrivate key used to re-sign the FOS"
+    echo -e "\t                       \t\t\tkernels for UEFI Secure Boot"
+    echo -e "\t      --secure-boot-cert\tCertificate matching --secure-boot-key"
+    echo -e "\t                        \t\t\t(both are required together)"
     exit 0
 }
 
 shortopts="h?odEUHSCKYyXTFf:c:W:D:B:s:e:N:l"
-longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:"
+longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:"
 
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
@@ -398,6 +402,26 @@ while :; do
             listPackages=1
             shift
             ;;
+        --secure-boot-key)
+            if [[ -f $2 ]]; then
+                ssecureBootKey="$2"
+            else
+                echo "$1 requires a readable private key file after"
+                usage
+                exit 3
+            fi
+            shift 2
+            ;;
+        --secure-boot-cert)
+            if [[ -f $2 ]]; then
+                ssecureBootCert="$2"
+            else
+                echo "$1 requires a readable certificate file after"
+                usage
+                exit 3
+            fi
+            shift 2
+            ;;
         --)
             shift
             break
@@ -584,6 +608,26 @@ esac
 [[ -n $sbackupPath ]] && backupPath=$sbackupPath
 [[ -n $sexitFail ]] && exitFail=$sexitFail
 [[ -n $snoTftpBuild ]] && noTftpBuild=$snoTftpBuild
+[[ -n $ssecureBootKey ]] && secureBootKey=$ssecureBootKey
+[[ -n $ssecureBootCert ]] && secureBootCert=$ssecureBootCert
+
+# Secure Boot signing is opt-in and only meaningful as a pair. Refuse half a
+# pair rather than silently leaving kernels unsigned on a server whose admin
+# believes they are signed -- that failure only shows up at a client, as a
+# Security Policy Violation with nothing on the server to explain it.
+if [[ -n $secureBootKey || -n $secureBootCert ]]; then
+    if [[ -z $secureBootKey || -z $secureBootCert ]]; then
+        echo " * --secure-boot-key and --secure-boot-cert must be set together"
+        exit 9
+    fi
+    for sbfile in "$secureBootKey" "$secureBootCert"; do
+        if [[ ! -r $sbfile ]]; then
+            echo " * Cannot read Secure Boot signing file: $sbfile"
+            exit 9
+        fi
+    done
+    unset sbfile
+fi
 
 [[ -f $fogpriorconfig ]] && grep -l webroot $fogpriorconfig >>$error_log 2>&1
 case $? in

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2619,6 +2619,10 @@ writeUpdateFile() {
         # --fogprogramdir after sourcing this file, because .fogsettings itself
         # lives at $fogprogramdir/.fogsettings and so cannot be what locates it.
         fogprogramdir
+        # Persisted so every later upgrade re-signs the kernels without the
+        # admin passing the flags again -- an upgrade that silently replaced
+        # signed kernels with unsigned ones is the main way this setup breaks.
+        secureBootKey secureBootCert
     )
     # Keys written by older installers that must be stripped on upgrade.
     local -a deprecatedKeys=( storageftpuser storageftppass bootfilename notpxedefaultfile php_verAdds )
@@ -3977,6 +3981,215 @@ downloadfiles() {
     cp -vf ${copypath}FOGService.msi ${copypath}SmartInstaller.exe ${webdirdest}/client/ >>$error_log 2>&1
     errorStat $?
     cd $cwd
+    _resignKernels
+    _installSecureBootSigner
+    _publishSecureBootKit
+}
+# Publish the MOK enrolment kit under the web root.
+#
+# Only the *certificate* is published -- it is public by design, and is the
+# thing you are meant to distribute. The private key stays where the admin put
+# it and is never copied anywhere near the web root; that separation is the one
+# thing in this feature that must not be got wrong.
+_publishSecureBootKit() {
+    local kitdir="${webdirdest}/service/secureboot"
+
+    if [[ -z $secureBootCert ]]; then
+        rm -rf "$kitdir" >>$error_log 2>&1
+        return 0
+    fi
+
+    dots "Publishing Secure Boot enrolment kit"
+    mkdir -p "$kitdir" >>$error_log 2>&1
+    # A DER copy of the certificate is what mokutil wants. Accept a PEM cert
+    # too, since openssl is happy to produce either and admins mix them up.
+    if openssl x509 -in "$secureBootCert" -inform der -noout >/dev/null 2>&1; then
+        cp -f "$secureBootCert" "${kitdir}/MOK.der" >>$error_log 2>&1
+    elif openssl x509 -in "$secureBootCert" -outform der -out "${kitdir}/MOK.der" >>$error_log 2>&1; then
+        :
+    else
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate."
+        return 0
+    fi
+    cp -f ../packages/secureboot/fog-enroll-mok.sh "${kitdir}/" >>$error_log 2>&1
+    cp -f ../packages/secureboot/fog-enroll-mok.desktop "${kitdir}/" >>$error_log 2>&1
+    # Keep the directory from being browsable, matching service/ipxe.
+    echo '<?php header("HTTP/1.1 404 Not Found");' > "${kitdir}/index.php"
+    chmod 0644 "${kitdir}"/MOK.der "${kitdir}"/*.desktop "${kitdir}"/index.php >>$error_log 2>&1
+    chmod 0755 "${kitdir}/fog-enroll-mok.sh" >>$error_log 2>&1
+    chown -R "${apacheuser}":"${apacheuser}" "$kitdir" >>$error_log 2>&1
+    echo "Done"
+}
+# Normalise --secure-boot-cert to PEM and echo the path.
+#
+# sbsign and sbverify read certificates with PEM_read_bio_X509 and reject DER
+# outright:
+#
+#   $ sbsign --key MOK.priv --cert MOK.der --output out.efi in.efi
+#   Can't load certificate from file 'MOK.der'
+#   error:0480006C:PEM routines:get_name:no start line ... Expecting: CERTIFICATE
+#
+# mokutil and MokManager want the opposite -- DER. So an admin following any
+# Secure Boot guide ends up holding one of each, with nothing telling them which
+# tool takes which, and handing the wrong one to --secure-boot-cert fails at
+# signing time with an OpenSSL error that says nothing about the format.
+#
+# Convert once here rather than pushing the distinction onto the user: the flag
+# accepts either, _resignKernels and the signing helper get PEM, and
+# _publishSecureBootKit still converts to DER for enrolment.
+_secureBootCertPem() {
+    local pem="${fogprogramdir}/.fog-secureboot.pem"
+    [[ -z $secureBootCert ]] && return 1
+    mkdir -p "$fogprogramdir" >>$error_log 2>&1
+    if openssl x509 -in "$secureBootCert" -inform pem -noout >/dev/null 2>&1; then
+        cp -f "$secureBootCert" "$pem" >>$error_log 2>&1 || return 1
+    elif ! openssl x509 -in "$secureBootCert" -inform der -outform pem \
+            -out "$pem" >>$error_log 2>&1; then
+        return 1
+    fi
+    # World-readable on purpose: a certificate is public, and it is the private
+    # key next to it that the 0600 config protects.
+    chown root:root "$pem" >>$error_log 2>&1
+    chmod 0644 "$pem" >>$error_log 2>&1
+    echo "$pem"
+}
+# Re-sign the FOS kernels for UEFI Secure Boot.
+#
+# The kernels above are downloaded unsigned on every install AND every upgrade,
+# so without this a working Secure Boot setup silently stops booting the moment
+# someone updates FOG. That is the single most common way the setup breaks.
+#
+# No-op unless both secureBootKey and secureBootCert are configured. Missing
+# sbsign is a warning rather than a failure: the rest of the install is fine and
+# aborting it would be a worse outcome than an unsigned kernel the admin is told
+# about.
+# Install the root-only signing helper the web UI calls through sudo.
+#
+# The Kernel Update page runs as the web user, which must never be able to read
+# the signing key -- a web compromise would otherwise walk off with it. So the
+# key stays root-only and the web user gets a single, argument-less command it
+# may run as root.
+#
+# Removes the helper, its config and the sudoers rule again when signing is
+# turned off, so disabling the feature actually disables the privilege.
+_installSecureBootSigner() {
+    # $fogprogramdir, not a "/opt/fog" literal: GH-850 made the base path
+    # installer-driven, and hardcoding it here would scatter the helper, its
+    # config and the staging directory back into /opt/fog on a server installed
+    # anywhere else.
+    local bindir="${fogprogramdir}/bin"
+    local helper="${bindir}/fog-sign-kernel"
+    local conf="${fogprogramdir}/.fog-secureboot"
+    local stagedir="${fogprogramdir}/secureboot-staging"
+    local sudoersfile="/etc/sudoers.d/fog-secureboot"
+    local certpem
+
+    if [[ -z $secureBootKey || -z $secureBootCert ]]; then
+        rm -f "$helper" "$conf" "$sudoersfile" >>$error_log 2>&1
+        return 0
+    fi
+
+    dots "Installing Secure Boot signing helper"
+    certpem=$(_secureBootCertPem) || {
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate (PEM or DER)."
+        return 0
+    }
+    mkdir -p "$bindir" >>$error_log 2>&1
+    install -o root -g root -m 0755 ../packages/secureboot/fog-sign-kernel "$helper" >>$error_log 2>&1 || {
+        echo "Failed"
+        return 0
+    }
+    # Point the helper at this install's config. It takes no arguments on
+    # purpose -- that is what stops a compromised web server naming its own key
+    # -- so the path has to be baked in here rather than passed at call time.
+    # Quoted: $fogprogramdir may contain a space, and `CONF=/a/fog custom/x`
+    # assigns only "/a/fog" and then tries to RUN "custom/x". bash -n does not
+    # catch that -- it is valid syntax, just not what anyone meant.
+    sed -i "s|^CONF=.*|CONF=\"${conf}\"|" "$helper" >>$error_log 2>&1
+    if ! grep -qxF "CONF=\"${conf}\"" "$helper"; then
+        echo "Failed"
+        echo " * Could not set the config path in $helper."
+        return 0
+    fi
+    # Root-owned, root-readable only: the web user learns nothing about where
+    # the key lives, and cannot rewrite these paths to point somewhere else.
+    # SECUREBOOT_CERT is the normalised PEM -- sbsign cannot read DER.
+    {
+        echo "SECUREBOOT_KEY=${secureBootKey}"
+        echo "SECUREBOOT_CERT=${certpem}"
+        echo "SECUREBOOT_STAGING=${stagedir}"
+    } > "$conf"
+    chown root:root "$conf" >>$error_log 2>&1
+    chmod 0600 "$conf" >>$error_log 2>&1
+
+    # The web user owns only the staging directory -- it has to write the
+    # downloaded kernel there and read the signed result back.
+    mkdir -p "$stagedir" >>$error_log 2>&1
+    chown "${apacheuser}":"${apacheuser}" "$stagedir" >>$error_log 2>&1
+    chmod 0750 "$stagedir" >>$error_log 2>&1
+
+    # Validate before installing: a malformed sudoers drop-in breaks sudo for
+    # the whole machine, which is a far worse outcome than no signing.
+    echo "${apacheuser} ALL=(root) NOPASSWD: ${helper}" > "${sudoersfile}.tmp"
+    chmod 0440 "${sudoersfile}.tmp" >>$error_log 2>&1
+    if visudo -cqf "${sudoersfile}.tmp" >>$error_log 2>&1; then
+        mv -f "${sudoersfile}.tmp" "$sudoersfile" >>$error_log 2>&1
+        chown root:root "$sudoersfile" >>$error_log 2>&1
+        echo "Done"
+    else
+        rm -f "${sudoersfile}.tmp" >>$error_log 2>&1
+        echo "Failed"
+        echo " * Refusing to install an invalid sudoers rule; the web Kernel"
+        echo "   Update page will download unsigned kernels. See $error_log."
+    fi
+}
+_resignKernels() {
+    [[ -z $secureBootKey || -z $secureBootCert ]] && return 0
+    if ! command -v sbsign >/dev/null 2>&1 || ! command -v sbverify >/dev/null 2>&1; then
+        echo " * WARNING: Secure Boot signing configured but sbsign/sbverify are not installed."
+        echo "   Install sbsigntool (Debian/Ubuntu) or sbsigntools (RHEL/Fedora)"
+        echo "   and re-run the installer, or Secure Boot clients will not boot."
+        return 0
+    fi
+    dots "Signing FOS kernels for Secure Boot"
+    local kernel kpath failed=0 certpem
+    # sbsign/sbverify take PEM only; the admin may well have handed us the DER
+    # copy that mokutil wanted. See _secureBootCertPem().
+    certpem=$(_secureBootCertPem) || {
+        echo "Failed"
+        echo " * Could not read $secureBootCert as a certificate (PEM or DER)."
+        echo "   Secure Boot clients will not boot until this is fixed."
+        return 0
+    }
+    for kernel in bzImage bzImage32 arm_Image; do
+        kpath="${webdirdest}/service/ipxe/${kernel}"
+        [[ -f $kpath ]] || continue
+        # Already carrying our signature means nothing was re-downloaded since
+        # the last run, so there is nothing to do. Skipping here is what keeps a
+        # second invocation from stacking a second signature on the same image.
+        sbverify --cert "$certpem" "$kpath" >/dev/null 2>&1 && continue
+        # Otherwise this is a freshly downloaded, unsigned kernel. Snapshot it,
+        # because sbsign will not cleanly re-sign an already-signed image and the
+        # next run needs an unsigned original to work from. The snapshot has to
+        # be refreshed every time rather than kept forever, or an upgrade would
+        # re-sign the *previous* version over the new one.
+        cp -af "$kpath" "${kpath}.unsigned" >>$error_log 2>&1
+        if sbsign --key "$secureBootKey" --cert "$certpem" \
+                --output "$kpath" "${kpath}.unsigned" >>$error_log 2>&1; then
+            chown "${username}" "$kpath" >>$error_log 2>&1
+        else
+            failed=1
+        fi
+    done
+    if [[ $failed -ne 0 ]]; then
+        echo "Failed"
+        echo " * At least one kernel could not be signed. See $error_log."
+        echo "   Secure Boot clients will not boot until this is fixed."
+        return 0
+    fi
+    echo "Done"
 }
 # The architecture -> boot-file mapping below intentionally mirrors the ISC
 # "class" blocks in the ISC branch of configureDHCP(). Keep the two in sync.
@@ -4025,6 +4238,31 @@ _keaBaseClasses() {
             "boot-file-name": "snponly.efi"
         }
 EOFCLS
+}
+# A Secure Boot class, emitted commented out.
+#
+# Left commented for two reasons. DHCP option 93 carries the client
+# architecture and nothing else, so there is no way to tell from a request
+# whether Secure Boot is on -- a site has to opt specific machines in. And this
+# must not simply replace the arch 7/8/9 classes: upstream ships exactly one
+# signed x86-64 iPXE binary, an all-drivers build that takes the NIC over from
+# the firmware and hangs on some hardware. FOG defaults to snponly.efi to avoid
+# exactly that, and there is no signed snponly equivalent (ipxe/ipxe#1776), so
+# pointing every UEFI client here would break machines that work today.
+#
+# The binaries are staged at $tftpdir/secureboot by downloadipxesecureboot()
+# on every install, so the path below always exists.
+_keaSecureBootClassCommented() {
+    cat <<'EOFSBC'
+#        Secure Boot clients. Uncomment, add a leading comma to the entry
+#        above, and narrow the test to the machines whose firmware has your
+#        MOK enrolled -- by subnet, MAC or a client class of your own.
+#        {
+#            "name": "FOG-UEFI-64-SecureBoot",
+#            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
+#            "boot-file-name": "secureboot/ipxe-shimx64.efi"
+#        }
+EOFSBC
 }
 _keaAppleClass() {
     cat <<'EOFAPL'
@@ -4141,9 +4379,11 @@ writeKeaSample() {
                 { \"name\": \"routers\", \"data\": \"$routeraddress\" }"
     [[ $(validip $dnsaddress) -eq 0 ]] && optdata="${optdata},
                 { \"name\": \"domain-name-servers\", \"data\": \"$dnsaddress\" }"
-    # Full reference: base classes + Apple BSDP. The admin can trim as needed.
+    # Full reference: base classes + Apple BSDP, plus a commented-out Secure
+    # Boot class. The admin can trim as needed.
     _writeKeaConfig "$target" "$(_keaBaseClasses),
-$(_keaAppleClass)"
+$(_keaAppleClass)
+$(_keaSecureBootClassCommented)"
     if [[ -s $target ]]; then
         echo
         echo " * A sample Kea DHCP config for a dedicated/external DHCP server was"
@@ -4287,6 +4527,17 @@ configureDHCP() {
             echo "        }" >> "$dhcptouse"
             echo "    }" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
+            # Secure Boot clients, commented out on purpose -- see the note on
+            # _keaSecureBootClassCommented(). Option 93 cannot tell us whether
+            # Secure Boot is on, and the only signed iPXE build is an
+            # all-drivers one that hangs on some NICs, so this has to be opted
+            # into per machine rather than applied to every UEFI client.
+            echo "# Secure Boot clients. Uncomment and narrow the match to the machines" >> "$dhcptouse"
+            echo "# whose firmware has your MOK enrolled." >> "$dhcptouse"
+            echo "#class \"FOG-UEFI-64-SecureBoot\" {" >> "$dhcptouse"
+            echo "#    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
+            echo "#    filename \"secureboot/ipxe-shimx64.efi\";" >> "$dhcptouse"
+            echo "#}" >> "$dhcptouse"
             diffconfig "${dhcptouse}"
             # Non-fatal syntax check; ISC has historically started without one.
             if command -v dhcpd >/dev/null 2>&1; then

--- a/packages/secureboot/fog-enroll-mok.desktop
+++ b/packages/secureboot/fog-enroll-mok.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Enrol FOG Secure Boot key
+Comment=Trust the FOG imaging server's signing key on this machine
+Exec=bash -c 'cd "$(dirname "%k")" && ./fog-enroll-mok.sh'
+Icon=security-high
+Terminal=true
+Categories=System;Security;

--- a/packages/secureboot/fog-enroll-mok.sh
+++ b/packages/secureboot/fog-enroll-mok.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# fog-enroll-mok.sh - enrol FOG's Secure Boot certificate on this machine.
+#
+# Run this from a stock Ubuntu or Debian live USB. Those boot fine with Secure
+# Boot switched on, using the distribution's own signed shim/GRUB/kernel, so
+# there is no need to go into firmware setup and turn Secure Boot off just to
+# get the key enrolled.
+#
+# Copy this script and MOK.der onto the USB stick together and double-click
+# fog-enroll-mok.desktop, or run this script directly. It expects MOK.der to be
+# sitting next to it.
+#
+set -u
+
+scriptdir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+cert="${scriptdir}/MOK.der"
+
+pause() {
+    echo
+    read -rsn1 -p "Press any key to close this window..."
+    echo
+}
+
+fail() {
+    echo
+    echo "  ERROR: $*" >&2
+    pause
+    exit 1
+}
+
+echo "==============================================="
+echo " FOG - enrol the Secure Boot signing key"
+echo "==============================================="
+echo
+
+[[ -r $cert ]] || fail "MOK.der not found next to this script (looked in ${scriptdir})."
+
+command -v mokutil >/dev/null 2>&1 || fail "mokutil is not installed on this live session."
+command -v openssl >/dev/null 2>&1 || fail "openssl is not installed on this live session."
+
+# Re-exec through sudo rather than making the tech remember to. Ubuntu live
+# sessions allow this without a password.
+if [[ $EUID -ne 0 ]]; then
+    exec sudo -- "$0" "$@"
+fi
+
+sbstate=$(mokutil --sb-state 2>/dev/null)
+echo " Secure Boot state: ${sbstate:-unknown}"
+
+# The fingerprint is the SHA-256 of the DER bytes, which is exactly what the
+# FOG web page displays. Checking it is the whole security of this step: it is
+# what stops someone from talking you into trusting a key that is not yours.
+fingerprint=$(openssl x509 -in "$cert" -inform der -noout -fingerprint -sha256 2>/dev/null \
+    | sed 's/^.*=//')
+subject=$(openssl x509 -in "$cert" -inform der -noout -subject 2>/dev/null | sed 's/^subject=*//')
+
+[[ -n $fingerprint ]] || fail "Could not read $cert -- is it really a DER certificate?"
+
+echo " Certificate:       ${subject}"
+echo " SHA-256:           ${fingerprint}"
+echo
+echo " Compare that SHA-256 against the one shown on your FOG server's"
+echo " Secure Boot page BEFORE continuing. If they differ, stop."
+echo
+read -rp " Does the fingerprint match? [y/N] " answer
+case "$answer" in
+    [Yy]*) ;;
+    *) echo; echo " Aborted -- nothing was changed."; pause; exit 1 ;;
+esac
+
+if mokutil --test-key "$cert" 2>/dev/null | grep -qi "already enrolled"; then
+    echo
+    echo " This key is already enrolled on this machine. Nothing to do."
+    pause
+    exit 0
+fi
+
+echo
+echo " You will now be asked for a one-time password, twice."
+echo
+echo " It is only used to confirm, after the reboot, that the person at the"
+echo " keyboard is the person who ran this. It is not stored and does not need"
+echo " to be strong -- pick something you can retype in a minute."
+echo
+
+if ! mokutil --import "$cert"; then
+    fail "mokutil --import failed."
+fi
+
+cat <<'EOFNEXT'
+
+ Done. Now reboot this machine.
+
+ Instead of booting normally it will stop on a blue MOK Manager screen.
+ Work through it in this order:
+
+   1. Enroll MOK
+   2. View key 0        <- check the name shown is your FOG server's
+   3. Continue
+   4. Yes
+   5. Enter the password you just chose
+   6. Reboot
+
+ If MOK Manager does NOT appear, the machine did not boot through a shim and
+ nothing has been enrolled.
+EOFNEXT
+pause
+exit 0

--- a/packages/secureboot/fog-sign-kernel
+++ b/packages/secureboot/fog-sign-kernel
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# fog-sign-kernel - sign a staged FOS kernel for UEFI Secure Boot.
+#
+# Invoked by the web UI's Kernel Update page through a narrow sudoers rule, so
+# that the signing key can stay root-only. The web server downloads a kernel
+# into the staging directory, calls this, then ships the signed result to the
+# TFTP server -- which may be a remote storage node, which is why the signing
+# has to happen here rather than in place under service/ipxe.
+#
+# SECURITY: this script deliberately takes NO arguments. Every path it touches
+# comes from a root-owned config file, so a compromised web server cannot point
+# it at a key it should not use or a file outside the staging area. Note the
+# limit of that guarantee: the caller does control the *contents* of the staged
+# file, so anyone who can invoke this can have a kernel of their choosing
+# signed. What they cannot do is read the key and sign things elsewhere or
+# later. Closing the remaining gap would mean verifying the staged image
+# against a known-good hash before signing.
+#
+set -u
+
+# GH-850: the FOG base path is installer-driven, so the installer rewrites this
+# line to match $fogprogramdir when it installs the helper. The default below is
+# correct for a stock install and keeps this script runnable straight from the
+# repository.
+#
+# Substituted rather than passed as an argument, because taking no arguments at
+# all is this script's whole security property -- see above. An environment
+# variable would be no better: it puts the path back under the caller's control.
+CONF="/opt/fog/.fog-secureboot"
+
+if [[ ! -r $CONF ]]; then
+    echo "fog-sign-kernel: $CONF is missing or unreadable" >&2
+    exit 1
+fi
+
+# Read one key from the config. Deliberately NOT "source" -- the config is
+# root-owned data, and parsing it as shell would turn any future write access
+# to it into root code execution.
+readconf() {
+    sed -n "s/^$1=//p" "$CONF" | head -1
+}
+
+signKey=$(readconf SECUREBOOT_KEY)
+signCert=$(readconf SECUREBOOT_CERT)
+stageDir=$(readconf SECUREBOOT_STAGING)
+
+if [[ -z $signKey || -z $signCert || -z $stageDir ]]; then
+    echo "fog-sign-kernel: $CONF is incomplete" >&2
+    exit 1
+fi
+
+staged="${stageDir}/kernel"
+
+if [[ ! -f $staged ]]; then
+    echo "fog-sign-kernel: nothing staged at $staged" >&2
+    exit 1
+fi
+
+# Resolve and re-check: the staged path must still be a regular file directly
+# inside the configured staging directory once symlinks are taken out, so a
+# symlink planted by the web user cannot redirect the write.
+resolved=$(readlink -f "$staged" 2>/dev/null)
+if [[ -z $resolved || $(dirname "$resolved") != "$(readlink -f "$stageDir")" ]]; then
+    echo "fog-sign-kernel: staged file is not inside $stageDir" >&2
+    exit 1
+fi
+if [[ -L $staged ]]; then
+    echo "fog-sign-kernel: staged file must not be a symlink" >&2
+    exit 1
+fi
+
+for f in "$signKey" "$signCert"; do
+    if [[ ! -r $f ]]; then
+        echo "fog-sign-kernel: cannot read $f" >&2
+        exit 1
+    fi
+done
+
+if ! command -v sbsign >/dev/null 2>&1; then
+    echo "fog-sign-kernel: sbsign not installed" >&2
+    exit 1
+fi
+
+if ! sbsign --key "$signKey" --cert "$signCert" \
+        --output "${resolved}.signed" "$resolved"; then
+    rm -f "${resolved}.signed"
+    echo "fog-sign-kernel: sbsign failed" >&2
+    exit 1
+fi
+
+# Hand the signed image back with the staging directory's ownership so the web
+# user can still read it for upload, but never the key that produced it.
+chown --reference="$resolved" "${resolved}.signed" 2>/dev/null
+mv -f "${resolved}.signed" "$resolved"
+exit 0

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2100,6 +2100,9 @@ abstract class FOGPage extends FOGBase
                         $_SESSION['tmp-kernel-file'],
                         $_SESSION['dl-kernel-file']
                     );
+                    // Sign before upload, not after: the TFTP target may be a
+                    // remote storage node, and the key never leaves this host.
+                    self::secureBootSign($tmpfile);
                     $orig = sprintf(
                         '/%s/%s',
                         trim(self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'), '/'),
@@ -2184,6 +2187,73 @@ abstract class FOGPage extends FOGBase
                     'title' => _('Kernel Update Fail')
                 ]
             ));
+        }
+    }
+    /**
+     * Returns the Secure Boot staging directory, or an empty string when
+     * kernel signing is not configured on this server.
+     *
+     * Signing runs as root through a sudo helper so the web server never needs
+     * read access to the private key. That helper only ever touches this one
+     * directory, which is why a kernel destined to be signed has to be
+     * downloaded here rather than into the system temp directory.
+     *
+     * @return string
+     */
+    protected static function secureBootStagingDir()
+    {
+        // GH-850: the base path is installer-driven, so these must be derived
+        // from FOG_BASE_DIR rather than written as /opt/fog literals. The
+        // installer places both under $fogprogramdir; hardcoding the default
+        // meant that on a server installed anywhere else this returned '' and
+        // signing silently never happened -- leaving Secure Boot clients with
+        // an unsigned kernel and nothing on the server to say why.
+        $helper = FOG_BASE_DIR . DS . 'bin' . DS . 'fog-sign-kernel';
+        $stagedir = FOG_BASE_DIR . DS . 'secureboot-staging';
+        if (!is_executable($helper) || !is_dir($stagedir)) {
+            return '';
+        }
+        return $stagedir;
+    }
+    /**
+     * Signs a staged kernel for Secure Boot via the root helper.
+     *
+     * Does nothing when signing is not configured. When it is, a failure is
+     * fatal: shipping an unsigned kernel to the TFTP server would stop every
+     * Secure Boot client from booting, and it would do so silently, long after
+     * whoever ran the update had walked away.
+     *
+     * @param string $tmpfile the staged kernel
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    protected static function secureBootSign($tmpfile)
+    {
+        $stagedir = self::secureBootStagingDir();
+        if (!$stagedir || dirname($tmpfile) !== $stagedir) {
+            return;
+        }
+        $output = array();
+        $retVal = 1;
+        // escapeshellarg because this is no longer a literal: FOG_BASE_DIR is
+        // written by the installer from $fogprogramdir, which an admin may set
+        // to a path containing a space. exec() hands the string to a shell, so
+        // an unquoted path would split into two arguments and the sudoers rule
+        // -- which matches the exact command -- would refuse it.
+        $helper = escapeshellarg(
+            FOG_BASE_DIR . DS . 'bin' . DS . 'fog-sign-kernel'
+        );
+        exec("sudo -n {$helper} 2>&1", $output, $retVal);
+        if ($retVal !== 0) {
+            throw new Exception(
+                sprintf(
+                    '%s: %s',
+                    _('Error: Failed to sign the kernel for Secure Boot'),
+                    implode(' ', $output)
+                )
+            );
         }
     }
     /**

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -85,6 +85,9 @@ class SubMenuData extends Hook
                     'license' => self::$foglang['License'],
                     'kernel' => self::$foglang['KernelUpdate'],
                     'initrd' => self::$foglang['InitRdUpdate'],
+                    // Sits beside the two things it acts on: Secure Boot
+                    // signing is a property of the kernel this server serves.
+                    'secureBoot' => _('Secure Boot'),
                     'pxemenu' => self::$foglang['PXEBootMenu'],
                     'customizepxe' => self::$foglang['PXEConfiguration'],
                     'newMenu' => self::$foglang['NewMenu'],

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -296,6 +296,83 @@ class FOGConfigurationPage extends FOGPage
         $this->_downloadPost('initrd');
     }
     /**
+     * Show the Secure Boot enrolment page.
+     *
+     * Displays the certificate fingerprint and links to the enrolment kit, so
+     * a technician has something to check the key against before trusting it
+     * on a machine. Nothing here is secret: the kit contains the public
+     * certificate only, which is the thing you are meant to distribute.
+     *
+     * @return void
+     */
+    public function secureBoot()
+    {
+        $kitdir = BASEPATH . 'service/secureboot';
+        $certfile = $kitdir . DS . 'MOK.der';
+        $kiturl = rtrim(self::getSetting('FOG_WEB_ROOT'), '/')
+            . '/service/secureboot';
+        if (!file_exists($certfile)) {
+            echo $this->_box(
+                _('Secure Boot'),
+                '<p>' . sprintf(
+                    '%s. %s <code>--secure-boot-key</code> %s '
+                    . '<code>--secure-boot-cert</code> %s.',
+                    _('Secure Boot kernel signing is not configured on this server'),
+                    _('Re-run the installer with'),
+                    _('and'),
+                    _('to enable it')
+                ) . '</p>',
+                ['color' => 'info']
+            );
+            return;
+        }
+        // The SHA-256 of the DER bytes IS the certificate fingerprint, so no
+        // openssl round trip is needed to show the value a technician will
+        // compare against.
+        $fingerprint = strtoupper(
+            implode(':', str_split(hash_file('sha256', $certfile), 2))
+        );
+        $body = '<p>' . sprintf(
+            '%s. %s.',
+            _('FOS kernels on this server are signed for UEFI Secure Boot'),
+            _(
+                'Each client needs this certificate enrolled once, by someone '
+                . 'physically at the machine'
+            )
+        ) . '</p>';
+        $body .= '<p><strong>' . _('Certificate SHA-256') . '</strong></p>';
+        $body .= '<pre>' . Initiator::e($fingerprint) . '</pre>';
+        $body .= '<p>' . _(
+            'Check this value matches what the enrolment script prints before '
+            . 'confirming. That comparison is what stops the wrong key being '
+            . 'trusted.'
+        ) . '</p>';
+        $body .= '<p><strong>' . _('Enrolment kit') . '</strong></p>';
+        $body .= '<p>' . sprintf(
+            '%s. %s.',
+            _(
+                'Copy all three files onto a USB stick, boot the client from a '
+                . 'stock Ubuntu or Debian live image with Secure Boot left ON, '
+                . 'and run the launcher'
+            ),
+            _('No firmware changes are needed')
+        ) . '</p>';
+        $body .= '<ul>';
+        $kitfiles = ['MOK.der', 'fog-enroll-mok.sh', 'fog-enroll-mok.desktop'];
+        foreach ($kitfiles as $file) {
+            if (!file_exists($kitdir . DS . $file)) {
+                continue;
+            }
+            $body .= sprintf(
+                '<li><a href="%1$s/%2$s">%2$s</a></li>',
+                Initiator::e($kiturl),
+                Initiator::e($file)
+            );
+        }
+        $body .= '</ul>';
+        echo $this->_box(_('Secure Boot'), $body, ['color' => 'info']);
+    }
+    /**
      * Render the kernel/initrd download view.
      *
      * kernel() and initrd() were byte-for-byte identical except for the words
@@ -431,13 +508,29 @@ class FOGConfigurationPage extends FOGPage
         self::checkAuthAndCSRF();
         $dstName = filter_input(INPUT_POST, 'dstName');
         $file = trim(base64_decode(filter_input(INPUT_POST, 'file')));
-        $tmpFile = sprintf(
-            '%s%s%s%s',
-            DS,
-            str_replace(["\\", '/'], '', sys_get_temp_dir()),
-            DS,
-            basename(trim($dstName))
-        );
+        // With Secure Boot signing configured, a KERNEL download has to land in
+        // the staging directory the root signing helper works on, under the
+        // fixed name it expects -- the helper takes no arguments, so the path
+        // is how it is told what to sign.
+        //
+        // Kernels only. dev-branch had separate kernelPost()/initrdPost() so
+        // this distinction was implicit there; here the two share one method,
+        // and routing an initrd into the staging directory would hand the
+        // signer a file that must never be signed. Nothing verifies the
+        // initramfs under Secure Boot -- on any distribution -- so there is
+        // nothing to gain and a wrong-file signature to lose.
+        $stagedir = ($type === 'kernel') ? self::secureBootStagingDir() : '';
+        if ($stagedir) {
+            $tmpFile = $stagedir . DS . 'kernel';
+        } else {
+            $tmpFile = sprintf(
+                '%s%s%s%s',
+                DS,
+                str_replace(["\\", '/'], '', sys_get_temp_dir()),
+                DS,
+                basename(trim($dstName))
+            );
+        }
         if (file_exists($tmpFile)) {
             unlink($tmpFile);
         }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1106,6 +1106,9 @@ msgstr "Seriennummer"
 msgid "Case Version"
 msgstr "Neueste Version"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Neuen Standort erstellen"
@@ -1144,6 +1147,11 @@ msgstr "Gehäuse-Version"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1266,6 +1274,11 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1834,6 +1847,11 @@ msgstr "ausgeworfen"
 msgid "Duration"
 msgstr "Dauer"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -1893,6 +1911,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingenieur"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
@@ -1929,6 +1950,10 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Error: Failed to open temp file"
 msgstr "Fehler: Öffnen der Temp-Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Errors"
 msgstr "Fehler"
@@ -2078,6 +2103,9 @@ msgstr "FOG kann nicht mit der Datenbank verbinden."
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG-Server im Standard-Ordner."
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 #, fuzzy
 msgid "FTP Connection Failed"
@@ -4624,6 +4652,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5495,6 +5526,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Datum und Zeit"
@@ -5857,6 +5891,13 @@ msgstr "Service-Status"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "See all results"
@@ -7963,6 +8004,10 @@ msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
 
 #, fuzzy
+msgid "and"
+msgstr "Ende"
+
+#, fuzzy
 msgid "and below"
 msgstr "Nur Teilstruktur"
 
@@ -8606,6 +8651,9 @@ msgstr "Drucker aktualisiert!"
 msgid "to clear the field on every host in this group."
 msgstr "Dies ist nicht die primäre Gruppe"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "um den angeforderten Kernel herunterzuladen."
@@ -9179,10 +9227,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1108,6 +1108,9 @@ msgstr "System Serial"
 msgid "Case Version"
 msgstr "Latest Version"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Create New %s"
@@ -1146,6 +1149,11 @@ msgstr "Chassis Version"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1267,6 +1275,11 @@ msgstr "Error: Failed to download kernel"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Error: Failed to download kernel"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1835,6 +1848,11 @@ msgstr "Dropped"
 msgid "Duration"
 msgstr "Duration"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Edit"
 
@@ -1893,6 +1911,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Engineer"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "Equipment Loan"
 
@@ -1929,6 +1950,10 @@ msgstr "Error: Failed to download kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Error: Failed to open temp file"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Error: Failed to download kernel"
 
 msgid "Errors"
 msgstr "Errors"
@@ -2077,6 +2102,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 #, fuzzy
@@ -4621,6 +4649,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5493,6 +5524,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Host Update Failed"
@@ -5855,6 +5889,13 @@ msgstr "Service Status"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "There are no images on this server."
 
 #, fuzzy
 msgid "See all results"
@@ -7955,6 +7996,10 @@ msgstr " ago"
 msgid "all current storage nodes"
 msgstr "Invalid storage node"
 
+#, fuzzy
+msgid "and"
+msgstr "End"
+
 msgid "and below"
 msgstr ""
 
@@ -8595,6 +8640,9 @@ msgstr "Printer updated!"
 msgid "to clear the field on every host in this group."
 msgstr " | This is not the primary group"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "No key being requested"
@@ -9153,10 +9201,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Printer already exists"
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "There are no images on this server."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1120,6 +1120,9 @@ msgstr "sistema de serie"
 msgid "Case Version"
 msgstr "Versión del sistema"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Crear nuevo grupo"
@@ -1157,6 +1160,11 @@ msgstr "Versión chasis"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1283,6 +1291,11 @@ msgstr "Error: No se pudo descargar kernel"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Error: No se pudo descargar kernel"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1864,6 +1877,11 @@ msgstr "Caído"
 msgid "Duration"
 msgstr "Configuración"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -1925,6 +1943,9 @@ msgstr ""
 msgid "Engineer"
 msgstr ""
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr ""
 
@@ -1963,6 +1984,10 @@ msgstr "Error: No se pudo descargar kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Error: No se pudo abrir el archivo temporal"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Error: No se pudo descargar kernel"
 
 msgid "Errors"
 msgstr "errores"
@@ -2114,6 +2139,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 #, fuzzy
@@ -4734,6 +4762,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5619,6 +5650,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Tiempo de actividad del sistema"
@@ -5988,6 +6022,13 @@ msgstr "Estado del servicio"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 msgid "See all results"
@@ -8109,6 +8150,10 @@ msgstr " hace"
 msgid "all current storage nodes"
 msgstr "nodo de almacenamiento no válido"
 
+#, fuzzy
+msgid "and"
+msgstr "habilitado"
+
 msgid "and below"
 msgstr ""
 
@@ -8747,6 +8792,9 @@ msgstr "Impresora actualiza!"
 msgid "to clear the field on every host in this group."
 msgstr ""
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "se requiere ninguna clave"
@@ -9298,10 +9346,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impresora ya existe"
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1106,6 +1106,9 @@ msgstr "Seriennummer"
 msgid "Case Version"
 msgstr "Neueste Version"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Neuen Standort erstellen"
@@ -1144,6 +1147,11 @@ msgstr "Gehäuse-Version"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1266,6 +1274,11 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1834,6 +1847,11 @@ msgstr "ausgeworfen"
 msgid "Duration"
 msgstr "Dauer"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -1893,6 +1911,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingenieur"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
@@ -1929,6 +1950,10 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Error: Failed to open temp file"
 msgstr "Fehler: Öffnen der Temp-Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 msgid "Errors"
 msgstr "Fehler"
@@ -2078,6 +2103,9 @@ msgstr "FOG kann nicht mit der Datenbank verbinden."
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG-Server im Standard-Ordner."
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 #, fuzzy
 msgid "FTP Connection Failed"
@@ -4625,6 +4653,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5496,6 +5527,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Datum und Zeit"
@@ -5858,6 +5892,13 @@ msgstr "Service-Status"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "See all results"
@@ -7964,6 +8005,10 @@ msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
 
 #, fuzzy
+msgid "and"
+msgstr "Ende"
+
+#, fuzzy
 msgid "and below"
 msgstr "Nur Teilstruktur"
 
@@ -8607,6 +8652,9 @@ msgstr "Drucker aktualisiert!"
 msgid "to clear the field on every host in this group."
 msgstr "Dies ist nicht die primäre Gruppe"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "um den angeforderten Kernel herunterzuladen."
@@ -9180,10 +9228,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1110,6 +1110,9 @@ msgstr "Serial System"
 msgid "Case Version"
 msgstr "Dernière version"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Créer un nouveau %s"
@@ -1148,6 +1151,11 @@ msgstr "Châssis Version"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1270,6 +1278,11 @@ msgstr "Erreur: Impossible de télécharger le noyau"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Erreur: Impossible de télécharger le noyau"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1839,6 +1852,11 @@ msgstr "Chuté"
 msgid "Duration"
 msgstr "Durée"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "modifier"
 
@@ -1897,6 +1915,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingénieur"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "prêt d'équipement"
 
@@ -1933,6 +1954,10 @@ msgstr "Erreur: Impossible de télécharger le noyau"
 
 msgid "Error: Failed to open temp file"
 msgstr "Erreur: Impossible d'ouvrir le fichier temporaire"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Erreur: Impossible de télécharger le noyau"
 
 msgid "Errors"
 msgstr "les erreurs"
@@ -2081,6 +2106,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 #, fuzzy
@@ -4626,6 +4654,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5501,6 +5532,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Mise à jour de l'hôte a échoué"
@@ -5863,6 +5897,13 @@ msgstr "État du service"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
 msgid "See all results"
@@ -7963,6 +8004,10 @@ msgstr " depuis"
 msgid "all current storage nodes"
 msgstr "nœud de stockage non valide"
 
+#, fuzzy
+msgid "and"
+msgstr "Fin"
+
 msgid "and below"
 msgstr ""
 
@@ -8604,6 +8649,9 @@ msgstr "Imprimante mis à jour!"
 msgid "to clear the field on every host in this group."
 msgstr " | Cela ne veut pas le groupe principal"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "Aucune clé demandée"
@@ -9166,10 +9214,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Imprimante existe déjà"
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1064,6 +1064,9 @@ msgstr "Sistema seriale"
 msgid "Case Version"
 msgstr "Ultima versione"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Crea nuova posizione"
@@ -1102,6 +1105,11 @@ msgstr "Telaio Version"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1215,6 +1223,11 @@ msgstr "Errore: Impossibile scaricare il kernel"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Errore: Impossibile scaricare il kernel"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "Copia da esistenti"
@@ -1768,6 +1781,11 @@ msgstr "Dropped"
 msgid "Duration"
 msgstr "Durata"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Modifica"
 
@@ -1827,6 +1845,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingegnere"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "attrezzature di prestito"
 
@@ -1863,6 +1884,10 @@ msgstr "Errore: Impossibile scaricare il kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Errore: Impossibile aprire il file temporaneo"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Errore: Impossibile scaricare il kernel"
 
 msgid "Errors"
 msgstr "Errori"
@@ -2004,6 +2029,9 @@ msgstr "FOG non è in grado di comunicare con il database"
 
 msgid "FOG server defaulting under the folder"
 msgstr "server FOG per default nella cartella"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 #, fuzzy
 msgid "FTP Connection Failed"
@@ -4444,6 +4472,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5280,6 +5311,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Data e Ora"
@@ -5625,6 +5659,13 @@ msgstr "Stato servizio"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Non ci sono immagini su questo server"
 
 #, fuzzy
 msgid "See all results"
@@ -7630,6 +7671,10 @@ msgid "all current storage nodes"
 msgstr "tutti i nodi di archiviazione attivi"
 
 #, fuzzy
+msgid "and"
+msgstr "Fine"
+
+#, fuzzy
 msgid "and below"
 msgstr "Sottoalbero e inferiore"
 
@@ -8227,6 +8272,9 @@ msgstr "aggiornato stampante!"
 msgid "to clear the field on every host in this group."
 msgstr "Questo non è il gruppo primario"
 
+msgid "to enable it"
+msgstr ""
+
 msgid "to get the requested Kernel"
 msgstr "pr ottenere il Kernel richiesto"
 
@@ -8777,9 +8825,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Questo host esiste già"
-
-#~ msgid "There are no images on this server"
-#~ msgstr "Non ci sono immagini su questo server"
 
 #~ msgid "There are no locations on this server"
 #~ msgstr "Non ci sono posizioni su questo server"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1049,6 +1049,9 @@ msgstr "シャーシシリアル"
 msgid "Case Version"
 msgstr "シャーシバージョン"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "新しいロケーションを作成"
@@ -1087,6 +1090,11 @@ msgstr "シャーシバージョン"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1200,6 +1208,11 @@ msgstr "エラー: initrd のダウンロードに失敗しました"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "エラー: カーネルのダウンロードに失敗しました"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 msgid "Copy from existing"
 msgstr "既存の項目からコピー"
@@ -1752,6 +1765,11 @@ msgstr "切断済み"
 msgid "Duration"
 msgstr "期間"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "編集"
 
@@ -1812,6 +1830,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "担当者"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "機器貸出"
 
@@ -1847,6 +1868,10 @@ msgstr "エラー: カーネルのダウンロードに失敗しました"
 
 msgid "Error: Failed to open temp file"
 msgstr "エラー: 一時ファイルを開けませんでした"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "エラー: カーネルのダウンロードに失敗しました"
 
 msgid "Errors"
 msgstr "エラー"
@@ -1985,6 +2010,9 @@ msgstr "FOG はデータベースと通信できません"
 
 msgid "FOG server defaulting under the folder"
 msgstr "FOG サーバーは次のフォルダーを既定で使用します"
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
+msgstr ""
 
 #, fuzzy
 msgid "FTP Connection Failed"
@@ -4404,6 +4432,9 @@ msgstr ""
 "\"snapinfiles[]\" マルチパートフィールドを使用して、1 つ以上のファイルをアッ"
 "プロードする必要があります"
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 #, fuzzy
 msgid "No groups are being created or selected"
 msgstr "削除するグループが選択されていません"
@@ -5241,6 +5272,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr "Hello 送信間隔"
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "日時"
@@ -5583,6 +5617,12 @@ msgstr "設定"
 #, fuzzy
 msgid "Second paramater must be in [class,function]"
 msgstr "2 番目のパラメーターは array(class,function) 形式である必要があります"
+
+msgid "Secure Boot"
+msgstr ""
+
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr ""
 
 #, fuzzy
 msgid "See all results"
@@ -7558,6 +7598,10 @@ msgid "all current storage nodes"
 msgstr "現在のすべてのストレージノード"
 
 #, fuzzy
+msgid "and"
+msgstr "終了"
+
+#, fuzzy
 msgid "and below"
 msgstr "サブツリー以下"
 
@@ -8153,6 +8197,9 @@ msgstr "更新に失敗しました"
 
 msgid "to clear the field on every host in this group."
 msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
+
+msgid "to enable it"
+msgstr ""
 
 msgid "to get the requested Kernel"
 msgstr "要求されたカーネルを取得するため"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -922,6 +922,9 @@ msgstr ""
 msgid "Case Version"
 msgstr ""
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 msgid "Certificate Verification"
 msgstr ""
 
@@ -956,6 +959,11 @@ msgstr ""
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1061,6 +1069,11 @@ msgid "Confirm you would like to download a new initrd"
 msgstr ""
 
 msgid "Confirm you would like to download a new kernel"
+msgstr ""
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
 msgstr ""
 
 msgid "Copy from existing"
@@ -1534,6 +1547,11 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr ""
 
@@ -1588,6 +1606,9 @@ msgstr ""
 msgid "Engineer"
 msgstr ""
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr ""
 
@@ -1622,6 +1643,9 @@ msgid "Error: Failed to download kernel"
 msgstr ""
 
 msgid "Error: Failed to open temp file"
+msgstr ""
+
+msgid "Error: Failed to sign the kernel for Secure Boot"
 msgstr ""
 
 msgid "Errors"
@@ -1751,6 +1775,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 msgid "FTP Connection Failed"
@@ -3897,6 +3924,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4645,6 +4675,9 @@ msgstr ""
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 msgid "Real Time"
 msgstr ""
 
@@ -4951,6 +4984,12 @@ msgid "Search settings"
 msgstr ""
 
 msgid "Second paramater must be in [class,function]"
+msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+msgid "Secure Boot kernel signing is not configured on this server"
 msgstr ""
 
 msgid "See all results"
@@ -6719,6 +6758,9 @@ msgstr ""
 msgid "all current storage nodes"
 msgstr ""
 
+msgid "and"
+msgstr ""
+
 msgid "and below"
 msgstr ""
 
@@ -7271,6 +7313,9 @@ msgid "to apply the update."
 msgstr ""
 
 msgid "to clear the field on every host in this group."
+msgstr ""
+
+msgid "to enable it"
 msgstr ""
 
 msgid "to get the requested Kernel"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1108,6 +1108,9 @@ msgstr "Serial sistema"
 msgid "Case Version"
 msgstr "Última versão"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Criar novo %s"
@@ -1146,6 +1149,11 @@ msgstr "chassis Versão"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1268,6 +1276,11 @@ msgstr "Erro: falha ao baixar do kernel"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "Erro: falha ao baixar do kernel"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1838,6 +1851,11 @@ msgstr "Desistiu"
 msgid "Duration"
 msgstr "Duração"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -1896,6 +1914,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "Engenheiro"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "equipamento Loan"
 
@@ -1932,6 +1953,10 @@ msgstr "Erro: falha ao baixar do kernel"
 
 msgid "Error: Failed to open temp file"
 msgstr "Erro: Falha ao abrir o arquivo temporário"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "Erro: falha ao baixar do kernel"
 
 msgid "Errors"
 msgstr "erros"
@@ -2080,6 +2105,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 #, fuzzy
@@ -4625,6 +4653,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5498,6 +5529,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "Anfitrião Update Failed"
@@ -5860,6 +5894,13 @@ msgstr "status do serviço"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Não há imagens neste servidor."
 
 #, fuzzy
 msgid "See all results"
@@ -7959,6 +8000,10 @@ msgstr " atrás"
 msgid "all current storage nodes"
 msgstr "nó de armazenamento inválido"
 
+#, fuzzy
+msgid "and"
+msgstr "Fim"
+
 msgid "and below"
 msgstr ""
 
@@ -8600,6 +8645,9 @@ msgstr "Impressora atualizado!"
 msgid "to clear the field on every host in this group."
 msgstr " | Este não é o grupo primário"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "Nenhuma chave que está sendo solicitado"
@@ -9162,10 +9210,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impressora já existe"
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "Não há imagens neste servidor."
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1108,6 +1108,9 @@ msgstr "系统序列"
 msgid "Case Version"
 msgstr "最新版本"
 
+msgid "Certificate SHA-256"
+msgstr ""
+
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "新建%s"
@@ -1146,6 +1149,11 @@ msgstr "机箱版本"
 
 msgid ""
 "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid ""
+"Check this value matches what the enrolment script prints before confirming. "
+"That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1268,6 +1276,11 @@ msgstr "错误：无法下载内核"
 #, fuzzy
 msgid "Confirm you would like to download a new kernel"
 msgstr "错误：无法下载内核"
+
+msgid ""
+"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
+"or Debian live image with Secure Boot left ON, and run the launcher"
+msgstr ""
 
 #, fuzzy
 msgid "Copy from existing"
@@ -1836,6 +1849,11 @@ msgstr "下降"
 msgid "Duration"
 msgstr "为期"
 
+msgid ""
+"Each client needs this certificate enrolled once, by someone physically at "
+"the machine"
+msgstr ""
+
 msgid "Edit"
 msgstr "编辑"
 
@@ -1894,6 +1912,9 @@ msgstr ""
 msgid "Engineer"
 msgstr "工程师"
 
+msgid "Enrolment kit"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr "器材信贷"
 
@@ -1930,6 +1951,10 @@ msgstr "错误：无法下载内核"
 
 msgid "Error: Failed to open temp file"
 msgstr "错误：无法打开临时文件"
+
+#, fuzzy
+msgid "Error: Failed to sign the kernel for Secure Boot"
+msgstr "错误：无法下载内核"
 
 msgid "Errors"
 msgstr "错误"
@@ -2078,6 +2103,9 @@ msgid "FOG is unable to communicate with the database"
 msgstr ""
 
 msgid "FOG server defaulting under the folder"
+msgstr ""
+
+msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
 #, fuzzy
@@ -4621,6 +4649,9 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "No firmware changes are needed"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5492,6 +5523,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer with"
+msgstr ""
+
 #, fuzzy
 msgid "Real Time"
 msgstr "主机更新失败"
@@ -5854,6 +5888,13 @@ msgstr "服务状态"
 
 msgid "Second paramater must be in [class,function]"
 msgstr ""
+
+msgid "Secure Boot"
+msgstr ""
+
+#, fuzzy
+msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "有此服务器上没有图像。"
 
 #, fuzzy
 msgid "See all results"
@@ -7948,6 +7989,10 @@ msgstr "前"
 msgid "all current storage nodes"
 msgstr "无效的存储节点"
 
+#, fuzzy
+msgid "and"
+msgstr "结束"
+
 msgid "and below"
 msgstr ""
 
@@ -8585,6 +8630,9 @@ msgstr "打印机更新！"
 msgid "to clear the field on every host in this group."
 msgstr "|这不是主要组"
 
+msgid "to enable it"
+msgstr ""
+
 #, fuzzy
 msgid "to get the requested Kernel"
 msgstr "没有要求的关键"
@@ -9147,10 +9195,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "打印机已经存在"
-
-#, fuzzy
-#~ msgid "There are no images on this server"
-#~ msgstr "有此服务器上没有图像。"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"


### PR DESCRIPTION
#961 landed on `dev-branch` only, which had it backwards — 1.6 is the branch this matters on. The staging half (`downloadipxesecureboot`, the SELinux context) was already here; this brings the signing half across.

- `--secure-boot-key` / `--secure-boot-cert`, either PEM or DER
- re-signing on install **and** upgrade, and on web Kernel Update
- the root-only signing helper and its sudoers rule
- the MOK enrolment kit and its **FOG Configuration → Secure Boot** page

## Not a clean cherry-pick

Four places where 1.6 has diverged. Three are mechanical; one is a real bug the patch would have introduced.

**1. `installfog.sh` option strings.** Both branches had grown options the other lacks — `purge-*`, `external-ca`, `list-packages`, `fogprogramdir` here; `bootfile`, `-P`, `-x` there. Merged rather than taken from either side, so 1.6 keeps everything and gains the two new flags.

**2. `.fogsettings` persisted keys.** Same shape — 1.6's list carries the external-CA and `fogprogramdir` keys. Appended, not replaced.

**3. The config page moved.** It is `fogconfigurationpage.page.php` here, and the sub-menu lives in `submenudata.hook.php` rather than in the page class. `secureBoot()` was rewritten against 1.6's `_box()` helper rather than carrying dev-branch's hand-echoed markup — that markup is Bootstrap 3 (`panel`, `panel-heading`, `col-xs-9`) and would have rendered wrong on 1.6's Bootstrap 5 + AdminLTE 4 stack.

**4. The one that matters.** dev-branch has separate `kernelPost()` and `initrdPost()`, so *"stage kernels into the signing directory"* was implicit in which method the change went into. 1.6 DRY'd both into `_downloadPost($type)`.

Applying that hunk as written would have routed **initrds into the signing staging directory too**, handing the signer a file that must never be signed. Nothing verifies the initramfs under Secure Boot — on any distribution — so there is nothing to gain and a wrong-file signature to lose. Gated on `$type === 'kernel'`.

## Carried with it

Both fixes from the dev-branch rework:

- Paths derived from `FOG_BASE_DIR` rather than `/opt/fog` literals (GH-850). Without this, `secureBootStagingDir()` returns `''` on a relocated install and Kernel Update silently ships an **unsigned** kernel.
- `--secure-boot-cert` accepts DER as well as PEM — `sbsign` reads PEM only, `mokutil` wants DER, and every Secure Boot guide leaves an admin holding one of each.

## Verified

Every touched PHP file lints, every shell file parses, the ported `_secureBootCertPem()` converts a DER certificate under a non-default `$fogprogramdir`, and `secureBootSign()`'s only call site is `kernelfetch()`.

Not exercised against a live 1.6 install — the signing path needs a server with a key configured. The logic is identical to what merged in #961; the risk here is in the four divergences above, which is where the review attention is worth spending.

Refs #960, #961, GH-850