### PR TITLE
Label FOG's directories and ship a policy module instead of a blanket boolean

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -804,6 +804,10 @@ while [[ -z $blGo ]]; do
                 esac
             fi
             configureUsers
+            # GH-964: before either branch configures a web tier. Storage nodes
+            # get this too -- configureMinHttpd still runs as httpd_t and still
+            # has to reach the master over HTTP.
+            installSELinuxModule
             case $installtype in
                 [Ss])
                     checkDatabaseConnection

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -889,6 +889,15 @@ installFOGServices() {
     chown ${username}:${apacheuser} $fogprogramdir/cache >>$error_log 2>&1
     chmod 1777 $fogprogramdir/cache >>$error_log 2>&1
     errorStat $?
+    # GH-964: /opt/fog inherits usr_t, and httpd_t may READ usr_t but not write
+    # it. The lab's audit log carried 74,406 httpd_t->usr_t:file denials and
+    # every one of them was a write. Reads being allowed is what hides it:
+    # nothing fails until something tries to write, so the install looks clean
+    # and the settings-cache flush silently never happens.
+    #
+    # Labelled where the directory is created rather than in a sweep at the end,
+    # so a relocated $fogprogramdir (GH-850) is labelled wherever it landed.
+    setSELinuxContext "$fogprogramdir/cache" httpd_sys_rw_content_t
 }
 configureUDPCast() {
     dots "Setting up UDPCast"
@@ -1595,6 +1604,71 @@ confirmPackageInstallation() {
         eval $packageQuery >>$error_log 2>&1
         errorStat $?
     done
+}
+installSELinuxModule() {
+    # GH-964: FOG's web tier needs outbound HTTP, FTP and SSH. httpd_t gets
+    # none of them by default, and the boolean everyone reaches for --
+    # httpd_can_network_connect -- grants name_connect on the `port_type`
+    # ATTRIBUTE, i.e. every port type in the policy. Three ports wanted,
+    # several hundred granted, permanently, to the daemon serving the web UI.
+    #
+    # ssh_port_t has no narrow boolean at any width, so there is no
+    # combination of setsebool calls that covers FOG without the blanket one.
+    # A three-rule policy module does, and FOG owns it. See packages/selinux.
+    #
+    # Built from source rather than shipped as a .pp, because a compiled
+    # module is tied to the policy version of the machine that built it and
+    # refuses to load on an older one. Compiling against the target's own
+    # policy is what makes one source file work across Fedora, RHEL, Rocky
+    # and Alma.
+    #
+    # checkmodule and semodule_package come from checkpolicy and
+    # policycoreutils, so this needs nothing beyond what a host already has
+    # to have for semanage to exist. fog.te is deliberately written without
+    # refpolicy macros so that selinux-policy-devel -- which is not installed
+    # by default on any distro FOG supports -- is not required.
+    local src="../packages/selinux/fog.te"
+    local workdir
+    command -v selinuxenabled >>$error_log 2>&1 || return 0
+    selinuxenabled || return 0
+    [[ -f $src ]] || return 0
+    dots "Installing FOG SELinux policy module"
+    if ! command -v semodule >>$error_log 2>&1 \
+        || ! command -v checkmodule >>$error_log 2>&1 \
+        || ! command -v semodule_package >>$error_log 2>&1; then
+        echo "Skipped (no policy tooling)"
+        echo " * FOG's web tier needs outbound HTTP/FTP/SSH, which SELinux"
+        echo " *   denies by default. Under enforcing this presents as storage"
+        echo " *   node operations failing with nothing in FOG's own logs."
+        echo " * Install checkpolicy and policycoreutils, then re-run the"
+        echo " *   installer."
+        return 0
+    fi
+    # Deliberately rebuilt and reinstalled every run rather than skipped when
+    # `semodule -l` already lists fog. Skipping would mean a later version of
+    # fog.te never reaches a server that has the old one -- the same
+    # silently-not-upgraded failure the kernel re-signing exists to prevent.
+    # semodule -i is idempotent and this costs a couple of seconds on an
+    # operation nobody runs in a loop.
+    workdir=$(mktemp -d) || { echo "Failed"; return 0; }
+    # checkmodule writes its outputs beside its input, so build in the temp
+    # directory rather than dropping fog.mod/fog.pp into the source tree.
+    cp -f "$src" "$workdir/fog.te" >>$error_log 2>&1
+    if ! (cd "$workdir" && checkmodule -M -m -o fog.mod fog.te \
+        && semodule_package -o fog.pp -m fog.mod) >>$error_log 2>&1 \
+        || ! semodule -i "$workdir/fog.pp" >>$error_log 2>&1; then
+        rm -rf "$workdir"
+        # Not fatal, for the same reason downloadipxesecureboot is not: an
+        # otherwise good install should not abort over a policy module, and
+        # on a permissive host none of this matters anyway.
+        echo "Failed"
+        echo " * Could not build or load the FOG SELinux module. See $error_log."
+        echo " * Under SELinux enforcing, storage node operations over HTTP,"
+        echo " *   FTP and SSH will be denied until this is resolved."
+        return 0
+    fi
+    rm -rf "$workdir"
+    errorStat 0
 }
 setSELinuxContext() {
     # setSELinuxContext <directory> <type-to-register> <acceptable-type>...
@@ -2373,6 +2447,11 @@ configureSnapins() {
         chown -R $username:$apacheuser $snapindir
     fi
     errorStat $?
+    # GH-964: same usr_t problem as the cache directory, and here the write is
+    # the whole point -- uploading a snapin through the web UI is a write into
+    # this directory by httpd_t. Read-only labels would let the list render and
+    # fail only on upload.
+    setSELinuxContext "$snapindir" httpd_sys_rw_content_t
 }
 configureUsers() {
     userexists=0
@@ -2585,6 +2664,19 @@ configureStorage() {
     chmod -R 775 $storageLocation $storageLocationCapture >>$error_log 2>&1
     chown -R $(id -u $username):$(id -g $username) $storageLocation $storageLocationCapture >>$error_log 2>&1
     errorStat $?
+    # GH-964: on the lab this directory was unlabeled_t, which is worse than
+    # merely wrong -- httpd_t gets getattr/open/search on it and nothing else,
+    # so the web UI could not list an image directory, and unlabeled_t masks
+    # whatever the real denial would have been.
+    #
+    # httpd_sys_rw_content_t rather than a read-only type: the web tier renames
+    # and removes files here (image uploads, replication bookkeeping).
+    #
+    # NFS is deliberately NOT a consideration. nfsd_t reads any label with
+    # nfs_export_all_ro/_rw, which are on by default, and the lab's audit log
+    # confirms it -- zero nfsd_t denials across months of imaging. So this is
+    # about the web tier only; the capture/deploy data path never needed it.
+    setSELinuxContext "$storageLocation" httpd_sys_rw_content_t
 }
 clearScreen() {
     clear

--- a/packages/selinux/fog.te
+++ b/packages/selinux/fog.te
@@ -1,0 +1,102 @@
+module fog 1.0.0;
+
+########################################################################
+#
+# FOG's SELinux policy module.
+#
+# WHY THIS EXISTS
+# ---------------
+# FOG's web tier makes three kinds of outbound connection: HTTP to itself
+# and to storage nodes, FTP to storage nodes for image replication, and
+# SSH (via php-pecl-ssh2) for node management. Under SELinux, httpd_t is
+# not permitted any of them by default.
+#
+# The usual answer is `setsebool -P httpd_can_network_connect on`. That
+# boolean grants name_connect on the `port_type` ATTRIBUTE -- which is to
+# say, every port type in the policy. Turning it on to reach three ports
+# grants several hundred, permanently, to a network-facing daemon that
+# serves user-supplied PHP. For a product whose whole job is imaging
+# machines on a trusted network, that is a poor trade.
+#
+# The narrower booleans do not cover it either:
+#
+#   httpd_graceful_shutdown   http_port_t only -- but it is named for, and
+#                             documented as, something else entirely
+#   httpd_can_connect_ftp     ftp_port_t + ephemeral (passive data channel)
+#   httpd_can_network_relay   7 port types, http and ftp among them
+#   ssh_port_t                NO boolean exists. Only the blanket one.
+#
+# So SSH alone forces the choice between a module and granting everything.
+# Given that, the module carries all three rather than leaving FOG half
+# configured by booleans it has to document and half by policy.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+# --------------------------------
+# No file contexts. Those are handled by setSELinuxContext() in the
+# installer via semanage fcontext, which works on a stock system with no
+# policy-development tooling installed. Keeping this module to the rules
+# that genuinely have no other expression keeps the thing FOG has to
+# maintain across distro policy versions as small as possible.
+#
+# BUILDING
+# --------
+# Built from source at install time, never shipped precompiled: a .pp is
+# tied to the policy version of the machine that built it and will refuse
+# to load on an older one. Compiling against the target's own policy is
+# what makes one source file work on RHEL, Rocky, Alma and Fedora alike.
+#
+#   checkmodule -M -m -o fog.mod fog.te
+#   semodule_package -o fog.pp -m fog.mod
+#   semodule -i fog.pp
+#
+# Note the plain `module` declaration above rather than refpolicy's
+# `policy_module()`. That macro would pull in refpolicy's headers and so
+# require selinux-policy-devel, which is not installed by default on any
+# distro FOG supports. Nothing here needs a refpolicy macro -- these are
+# three flat allow rules -- so the module is written to build with
+# checkmodule and semodule_package alone, both of which come from
+# checkpolicy and policycoreutils and are already present anywhere
+# semanage is.
+#
+# checkmodule does NOT resolve the require{} block against the running
+# policy; that happens when semodule links it. A type renamed by a future
+# distro policy would therefore compile cleanly here and fail at load,
+# which is why the installer reports a load failure rather than assuming
+# a successful build means a successful install.
+#
+# The installer does this only when SELinux is actually enabled, and never
+# fails an install over it.
+#
+########################################################################
+
+require {
+    type httpd_t;
+    type http_port_t;
+    type ftp_port_t;
+    type ssh_port_t;
+    class tcp_socket name_connect;
+}
+
+#
+# HTTP: the web tier calls its own API and its storage nodes' APIs.
+#
+allow httpd_t http_port_t:tcp_socket name_connect;
+
+#
+# FTP: image and snapin replication between storage nodes.
+#
+# Only the control channel is granted here. Passive-mode data connections
+# land on ephemeral ports, which would need a much wider grant -- FOG's
+# replicators use lftp from a CLI daemon, not from httpd_t, so the web
+# tier does not need the data channel and is not given it.
+#
+allow httpd_t ftp_port_t:tcp_socket name_connect;
+
+#
+# SSH: php-pecl-ssh2, used for storage node management.
+#
+# This is the rule with no boolean equivalent at any width, and therefore
+# the reason this module exists rather than a setsebool line in the
+# installer.
+#
+allow httpd_t ssh_port_t:tcp_socket name_connect;


### PR DESCRIPTION
Closes #964 (pending the enforcing-host check noted below).

Two halves, both driven by the lab's audit log.

## Labels

`/opt/fog/cache`, the snapin directory and the image storage location were never labelled, so they inherited whatever their parent had — `usr_t` for the first two, `unlabeled_t` for `/images`.

`httpd_t` may **read** `usr_t` but not write it, and that asymmetry is what kept this hidden. Nothing fails at install time, nothing fails on a page that only reads, and the failure surfaces much later as a write that quietly does not happen. The lab carried **74,406** `httpd_t→usr_t:file` denials and every one of them was a write.

`unlabeled_t` is worse than merely wrong: `httpd_t` gets `getattr/open/search` and nothing more, so the web UI cannot list an image directory, and the label masks whatever the real denial would have been.

All three are now labelled `httpd_sys_rw_content_t` **at the point each directory is created**, not in a sweep at the end, so a relocated `$fogprogramdir` or `$storageLocation` is labelled wherever it actually landed.

NFS is deliberately not addressed. `nfsd_t` reads any label while `nfs_export_all_ro`/`_rw` are on, they are on by default, and the audit log agrees — zero `nfsd_t` denials. The capture/deploy data path never needed this; only the web tier did.

## Policy module

FOG's web tier also makes outbound HTTP, FTP and SSH connections, none of which `httpd_t` is allowed by default. The usual fix is `setsebool -P httpd_can_network_connect on`, but that boolean grants `name_connect` on the `port_type` **attribute** — every port type in the policy. Several hundred ports granted permanently to the daemon serving the web UI, in order to reach three.

The narrower booleans do not cover it:

| boolean | covers |
|---|---|
| `httpd_can_connect_ftp` | `ftp_port_t` + ephemeral |
| `httpd_graceful_shutdown` | `http_port_t`, under a name that means something else entirely |
| `httpd_can_network_relay` | 7 port types |
| *(none exists)* | `ssh_port_t` |

SSH alone forces the choice between a module and granting everything, so the module carries all three rather than leaving FOG half configured by booleans and half by policy.

`packages/selinux/fog.te` is three `allow` rules and **no file contexts** — the labels above use `semanage fcontext`, which needs no policy tooling.

Two things worth calling out:

- **It does not require `selinux-policy-devel`.** It uses a plain `module fog 1.0.0;` declaration rather than refpolicy's `policy_module()`, so it builds with `checkmodule` + `semodule_package` alone — both already present anywhere `semanage` is. That package isn't installed by default on any distro FOG supports, so depending on it would have meant the module silently never getting built on exactly the enforcing hosts that need it.
- **It rebuilds every run** rather than skipping when `semodule -l` already lists `fog`, so a later version of `fog.te` actually reaches a server running an older one. `semodule -i` is idempotent.

Built from source at install time rather than shipped as a `.pp`, because a compiled module is tied to the policy version of the machine that built it.

Never fatal — an otherwise good install does not abort over a policy module, and on a permissive or SELinux-less host none of it matters. Every skip path names what was skipped and what to install.

## Verification

- Module builds with `checkmodule` + `semodule_package`; resulting `.pp` carries all three rules
- `httpd_t`, `http_port_t`, `ftp_port_t`, `ssh_port_t`, `tcp_socket`, `name_connect` all resolve against a live targeted policy
- Builder leaves no temp directory and drops no `fog.mod`/`fog.pp` into the source tree
- `bash -n` clean on both shell files

## Not verified

- **A genuinely enforcing host.** This is the remaining open item on #964.
- `checkmodule` does **not** resolve `require{}` against the running policy — that only happens when `semodule` links it. A type renamed by a future distro policy would compile cleanly and fail at load, which is why the installer reports load failure separately from build failure.

Refs #963
