### PR TITLE
Label FOG's directories and ship a policy module instead of a blanket boolean (dev-branch port)

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -605,6 +605,10 @@ while [[ -z $blGo ]]; do
                 esac
             fi
             configureUsers
+            # GH-964: before either branch configures a web tier. Storage nodes
+            # get this too -- configureMinHttpd still runs as httpd_t and still
+            # has to reach the master over HTTP.
+            installSELinuxModule
             case $installtype in
                 [Ss])
                     checkDatabaseConnection

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1421,6 +1421,71 @@ confirmPackageInstallation() {
         echo "OK"
     fi
 }
+installSELinuxModule() {
+    # GH-964: FOG's web tier needs outbound HTTP, FTP and SSH. httpd_t gets
+    # none of them by default, and the boolean everyone reaches for --
+    # httpd_can_network_connect -- grants name_connect on the `port_type`
+    # ATTRIBUTE, i.e. every port type in the policy. Three ports wanted,
+    # several hundred granted, permanently, to the daemon serving the web UI.
+    #
+    # ssh_port_t has no narrow boolean at any width, so there is no
+    # combination of setsebool calls that covers FOG without the blanket one.
+    # A three-rule policy module does, and FOG owns it. See packages/selinux.
+    #
+    # Built from source rather than shipped as a .pp, because a compiled
+    # module is tied to the policy version of the machine that built it and
+    # refuses to load on an older one. Compiling against the target's own
+    # policy is what makes one source file work across Fedora, RHEL, Rocky
+    # and Alma.
+    #
+    # checkmodule and semodule_package come from checkpolicy and
+    # policycoreutils, so this needs nothing beyond what a host already has
+    # to have for semanage to exist. fog.te is deliberately written without
+    # refpolicy macros so that selinux-policy-devel -- which is not installed
+    # by default on any distro FOG supports -- is not required.
+    local src="../packages/selinux/fog.te"
+    local workdir
+    command -v selinuxenabled >>$error_log 2>&1 || return 0
+    selinuxenabled || return 0
+    [[ -f $src ]] || return 0
+    dots "Installing FOG SELinux policy module"
+    if ! command -v semodule >>$error_log 2>&1 \
+        || ! command -v checkmodule >>$error_log 2>&1 \
+        || ! command -v semodule_package >>$error_log 2>&1; then
+        echo "Skipped (no policy tooling)"
+        echo " * FOG's web tier needs outbound HTTP/FTP/SSH, which SELinux"
+        echo " *   denies by default. Under enforcing this presents as storage"
+        echo " *   node operations failing with nothing in FOG's own logs."
+        echo " * Install checkpolicy and policycoreutils, then re-run the"
+        echo " *   installer."
+        return 0
+    fi
+    # Deliberately rebuilt and reinstalled every run rather than skipped when
+    # `semodule -l` already lists fog. Skipping would mean a later version of
+    # fog.te never reaches a server that has the old one -- the same
+    # silently-not-upgraded failure the kernel re-signing exists to prevent.
+    # semodule -i is idempotent and this costs a couple of seconds on an
+    # operation nobody runs in a loop.
+    workdir=$(mktemp -d) || { echo "Failed"; return 0; }
+    # checkmodule writes its outputs beside its input, so build in the temp
+    # directory rather than dropping fog.mod/fog.pp into the source tree.
+    cp -f "$src" "$workdir/fog.te" >>$error_log 2>&1
+    if ! (cd "$workdir" && checkmodule -M -m -o fog.mod fog.te \
+        && semodule_package -o fog.pp -m fog.mod) >>$error_log 2>&1 \
+        || ! semodule -i "$workdir/fog.pp" >>$error_log 2>&1; then
+        rm -rf "$workdir"
+        # Not fatal, for the same reason downloadipxesecureboot is not: an
+        # otherwise good install should not abort over a policy module, and
+        # on a permissive host none of this matters anyway.
+        echo "Failed"
+        echo " * Could not build or load the FOG SELinux module. See $error_log."
+        echo " * Under SELinux enforcing, storage node operations over HTTP,"
+        echo " *   FTP and SSH will be denied until this is resolved."
+        return 0
+    fi
+    rm -rf "$workdir"
+    errorStat 0
+}
 setSELinuxContext() {
     # setSELinuxContext <directory> <type-to-register> <acceptable-type>...
     #
@@ -2137,6 +2202,11 @@ configureSnapins() {
         chown -R $username:$apacheuser $snapindir
     fi
     errorStat $?
+    # GH-964: this directory inherits usr_t, which httpd_t may READ but not
+    # write. That asymmetry is what hides it -- the snapin list renders fine
+    # and only an upload through the web UI, which is a write by httpd_t,
+    # actually fails.
+    setSELinuxContext "$snapindir" httpd_sys_rw_content_t
 }
 configureUsers() {
     userexists=0
@@ -2302,6 +2372,19 @@ configureStorage() {
     chmod -R 775 $storageLocation $storageLocationCapture >>$error_log 2>&1
     chown -R $username:$username $storageLocation $storageLocationCapture >>$error_log 2>&1
     errorStat $?
+    # GH-964: on the lab this directory was unlabeled_t, which is worse than
+    # merely wrong -- httpd_t gets getattr/open/search on it and nothing else,
+    # so the web UI could not list an image directory, and unlabeled_t masks
+    # whatever the real denial would have been.
+    #
+    # httpd_sys_rw_content_t rather than a read-only type: the web tier renames
+    # and removes files here (image uploads, replication bookkeeping).
+    #
+    # NFS is deliberately NOT a consideration. nfsd_t reads any label with
+    # nfs_export_all_ro/_rw, which are on by default, and the lab's audit log
+    # confirms it -- zero nfsd_t denials across months of imaging. So this is
+    # about the web tier only; the capture/deploy data path never needed it.
+    setSELinuxContext "$storageLocation" httpd_sys_rw_content_t
 }
 clearScreen() {
     clear

--- a/packages/selinux/fog.te
+++ b/packages/selinux/fog.te
@@ -1,0 +1,102 @@
+module fog 1.0.0;
+
+########################################################################
+#
+# FOG's SELinux policy module.
+#
+# WHY THIS EXISTS
+# ---------------
+# FOG's web tier makes three kinds of outbound connection: HTTP to itself
+# and to storage nodes, FTP to storage nodes for image replication, and
+# SSH (via php-pecl-ssh2) for node management. Under SELinux, httpd_t is
+# not permitted any of them by default.
+#
+# The usual answer is `setsebool -P httpd_can_network_connect on`. That
+# boolean grants name_connect on the `port_type` ATTRIBUTE -- which is to
+# say, every port type in the policy. Turning it on to reach three ports
+# grants several hundred, permanently, to a network-facing daemon that
+# serves user-supplied PHP. For a product whose whole job is imaging
+# machines on a trusted network, that is a poor trade.
+#
+# The narrower booleans do not cover it either:
+#
+#   httpd_graceful_shutdown   http_port_t only -- but it is named for, and
+#                             documented as, something else entirely
+#   httpd_can_connect_ftp     ftp_port_t + ephemeral (passive data channel)
+#   httpd_can_network_relay   7 port types, http and ftp among them
+#   ssh_port_t                NO boolean exists. Only the blanket one.
+#
+# So SSH alone forces the choice between a module and granting everything.
+# Given that, the module carries all three rather than leaving FOG half
+# configured by booleans it has to document and half by policy.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+# --------------------------------
+# No file contexts. Those are handled by setSELinuxContext() in the
+# installer via semanage fcontext, which works on a stock system with no
+# policy-development tooling installed. Keeping this module to the rules
+# that genuinely have no other expression keeps the thing FOG has to
+# maintain across distro policy versions as small as possible.
+#
+# BUILDING
+# --------
+# Built from source at install time, never shipped precompiled: a .pp is
+# tied to the policy version of the machine that built it and will refuse
+# to load on an older one. Compiling against the target's own policy is
+# what makes one source file work on RHEL, Rocky, Alma and Fedora alike.
+#
+#   checkmodule -M -m -o fog.mod fog.te
+#   semodule_package -o fog.pp -m fog.mod
+#   semodule -i fog.pp
+#
+# Note the plain `module` declaration above rather than refpolicy's
+# `policy_module()`. That macro would pull in refpolicy's headers and so
+# require selinux-policy-devel, which is not installed by default on any
+# distro FOG supports. Nothing here needs a refpolicy macro -- these are
+# three flat allow rules -- so the module is written to build with
+# checkmodule and semodule_package alone, both of which come from
+# checkpolicy and policycoreutils and are already present anywhere
+# semanage is.
+#
+# checkmodule does NOT resolve the require{} block against the running
+# policy; that happens when semodule links it. A type renamed by a future
+# distro policy would therefore compile cleanly here and fail at load,
+# which is why the installer reports a load failure rather than assuming
+# a successful build means a successful install.
+#
+# The installer does this only when SELinux is actually enabled, and never
+# fails an install over it.
+#
+########################################################################
+
+require {
+    type httpd_t;
+    type http_port_t;
+    type ftp_port_t;
+    type ssh_port_t;
+    class tcp_socket name_connect;
+}
+
+#
+# HTTP: the web tier calls its own API and its storage nodes' APIs.
+#
+allow httpd_t http_port_t:tcp_socket name_connect;
+
+#
+# FTP: image and snapin replication between storage nodes.
+#
+# Only the control channel is granted here. Passive-mode data connections
+# land on ephemeral ports, which would need a much wider grant -- FOG's
+# replicators use lftp from a CLI daemon, not from httpd_t, so the web
+# tier does not need the data channel and is not given it.
+#
+allow httpd_t ftp_port_t:tcp_socket name_connect;
+
+#
+# SSH: php-pecl-ssh2, used for storage node management.
+#
+# This is the rule with no boolean equivalent at any width, and therefore
+# the reason this module exists rather than a setsebool line in the
+# installer.
+#
+allow httpd_t ssh_port_t:tcp_socket name_connect;


### PR DESCRIPTION
Port of #966 to `dev-branch`. Refs #964.

Two of the three labels and the policy module apply here unchanged; the third does not — see below.

## Labels

The snapin directory and the image storage location were never labelled, so they inherited their parent's context — `usr_t` and `unlabeled_t` respectively.

`httpd_t` may **read** `usr_t` but not write it, and that asymmetry is what keeps it hidden: the snapin list renders fine and only an upload — a write by `httpd_t` — actually fails. `unlabeled_t` is worse than merely wrong: `httpd_t` gets `getattr/open/search` and nothing else, so the web UI cannot list an image directory, and the label masks whatever the real denial would have been.

Both are now labelled `httpd_sys_rw_content_t` where the directory is created, so a relocated `$storageLocation` is labelled wherever it landed.

**The `$fogprogramdir/cache` label from #966 is deliberately NOT ported.** This branch has no settings cache and `installFOGServices()` never creates that directory, so a label call there would be labelling something that does not exist.

> Noted while in there: `writeUpdateFile` still carries a GH-632 comment referring to `mkdir -p $fogprogramdir/cache` happening "much later". On this branch that `mkdir` does not exist at all. Left alone rather than churning this diff — worth a separate cleanup.

NFS is deliberately not addressed. `nfsd_t` reads any label while `nfs_export_all_ro`/`_rw` are on, they are on by default, and the lab's audit log agrees — zero `nfsd_t` denials. Only the web tier ever needed this.

## Policy module

Identical to #966. FOG's web tier makes outbound HTTP, FTP and SSH connections, none of which `httpd_t` is allowed by default. `setsebool -P httpd_can_network_connect on` grants `name_connect` on the `port_type` **attribute** — every port type in the policy — to reach three. `ssh_port_t` has no narrow boolean at any width, so SSH alone forces the choice between a module and granting everything.

`packages/selinux/fog.te` is three `allow` rules and no file contexts. It uses a plain `module` declaration rather than refpolicy's `policy_module()`, so it builds with `checkmodule` + `semodule_package` and does **not** need `selinux-policy-devel` — which isn't installed by default on any distro FOG supports, and depending on it would have meant the module silently never getting built on exactly the enforcing hosts that need it.

Rebuilt every run rather than skipped when `semodule -l` already lists `fog`, so a later `fog.te` actually reaches a server running an older one. Never fatal, and every skip path says what to install.

## Verification

- `fog.te` is byte-identical to the working-1.6 copy
- The extracted `installSELinuxModule()` is byte-identical to the working-1.6 one
- Builds with `checkmodule` + `semodule_package`; resulting `.pp` carries all three rules
- `bash -n` clean on both shell files

## Not verified

A genuinely enforcing host — the remaining open item on #964. Also note `checkmodule` does not resolve `require{}` against the running policy; only `semodule -i` does.

Refs #963
