### PR TITLE
Give FOG its own SELinux type for /images and snapins

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1665,6 +1665,8 @@ installSELinuxModule() {
         echo " * Could not build or load the FOG SELinux module. See $error_log."
         echo " * Under SELinux enforcing, storage node operations over HTTP,"
         echo " *   FTP and SSH will be denied until this is resolved."
+        echo " * The fog_share_t label steps below will also fail, because"
+        echo " *   semanage cannot register a type the policy does not know."
         return 0
     fi
     rm -rf "$workdir"
@@ -1719,10 +1721,24 @@ setSELinuxContext() {
             # always installed. chcon applies the label now but has no rule
             # behind it, so a relabel reverts it. Better than leaving the daemon
             # unable to read anything -- but say so rather than imply it is done.
+            # GH-964: check the post-condition rather than assuming, for the
+            # same reason the restorecon path does. This branch used to echo
+            # OK unconditionally, which was survivable when $register was
+            # always a stock type; now that FOG registers fog_share_t, a
+            # module that failed to load makes chcon fail outright and
+            # reporting OK would hide it.
             chcon -R -t "$register" "$dir" >>$error_log 2>&1
-            echo "OK"
-            echo " * Labelled with chcon only -- a filesystem relabel will undo this."
-            echo " * Install policycoreutils-python-utils and re-run to make it permanent."
+            local chconis=$(ls -Zd "$dir" 2>>$error_log | awk '{print $1}' | cut -d: -f3)
+            if [[ $acceptable == *" $chconis "* ]]; then
+                echo "OK"
+                echo " * Labelled with chcon only -- a filesystem relabel will undo this."
+                echo " * Install policycoreutils-python-utils and re-run to make it permanent."
+                return 0
+            fi
+            echo "Failed!"
+            echo " * Could not label $dir as '$register' (it is '$chconis')."
+            echo " * If '$register' is a FOG type, the policy module did not load."
+            echo " * Install policycoreutils-python-utils and re-run the installer."
             return 0
         fi
     fi
@@ -2451,7 +2467,14 @@ configureSnapins() {
     # the whole point -- uploading a snapin through the web UI is a write into
     # this directory by httpd_t. Read-only labels would let the list render and
     # fail only on upload.
-    setSELinuxContext "$snapindir" httpd_sys_rw_content_t
+    #
+    # fog_share_t rather than httpd_sys_rw_content_t because snapins replicate
+    # between storage nodes over FTP (FOGService::replicateItems runs lftp), so
+    # the RECEIVING node's vsftpd -- ftpd_t -- writes here too. ftpd_t gets
+    # nothing at all on httpd_sys_rw_content_t unless ftpd_full_access is on,
+    # and that boolean grants ftpd_t every file type on the box. See
+    # packages/selinux/fog.te.
+    setSELinuxContext "$snapindir" fog_share_t
 }
 configureUsers() {
     userexists=0
@@ -2669,14 +2692,24 @@ configureStorage() {
     # so the web UI could not list an image directory, and unlabeled_t masks
     # whatever the real denial would have been.
     #
-    # httpd_sys_rw_content_t rather than a read-only type: the web tier renames
-    # and removes files here (image uploads, replication bookkeeping).
+    # fog_share_t, FOG's own type, rather than a stock one. Two confined
+    # daemons need this directory read-write: the web tier (httpd_t) and
+    # vsftpd (ftpd_t), the latter as the receiving side of a replication run.
+    # No stock type gives both without a blanket grant --
+    # httpd_sys_rw_content_t needs ftpd_full_access (every file type on the
+    # box) and public_content_rw_t needs the global *_anon_write booleans.
+    # See packages/selinux/fog.te for the full reasoning.
     #
-    # NFS is deliberately NOT a consideration. nfsd_t reads any label with
-    # nfs_export_all_ro/_rw, which are on by default, and the lab's audit log
-    # confirms it -- zero nfsd_t denials across months of imaging. So this is
-    # about the web tier only; the capture/deploy data path never needed it.
-    setSELinuxContext "$storageLocation" httpd_sys_rw_content_t
+    # NFS is deliberately NOT a consideration, and needs no rule: the data
+    # path is in-kernel as kernel_t, which has unconditional read+write on the
+    # `file_type` attribute that fog_share_t carries. The lab's audit log
+    # agrees -- zero nfsd_t denials across months of imaging.
+    #
+    # $storageLocationCapture is labelled separately because .fogsettings can
+    # relocate it out from under $storageLocation, in which case the recursive
+    # fcontext registered for $storageLocation would not cover it.
+    setSELinuxContext "$storageLocation" fog_share_t
+    setSELinuxContext "$storageLocationCapture" fog_share_t
 }
 clearScreen() {
     clear

--- a/packages/selinux/fog.te
+++ b/packages/selinux/fog.te
@@ -1,4 +1,4 @@
-module fog 1.0.0;
+module fog 1.1.0;
 
 ########################################################################
 #
@@ -6,19 +6,23 @@ module fog 1.0.0;
 #
 # WHY THIS EXISTS
 # ---------------
+# Two problems, both of which the stock policy can only solve by granting
+# far more than FOG needs.
+#
+# 1. OUTBOUND CONNECTIONS
+#
 # FOG's web tier makes three kinds of outbound connection: HTTP to itself
-# and to storage nodes, FTP to storage nodes for image replication, and
-# SSH (via php-pecl-ssh2) for node management. Under SELinux, httpd_t is
-# not permitted any of them by default.
+# and to storage nodes, FTP to storage nodes for image and snapin
+# replication, and SSH (via php-pecl-ssh2) for node management. Under
+# SELinux, httpd_t is not permitted any of them by default.
 #
 # The usual answer is `setsebool -P httpd_can_network_connect on`. That
 # boolean grants name_connect on the `port_type` ATTRIBUTE -- which is to
 # say, every port type in the policy. Turning it on to reach three ports
 # grants several hundred, permanently, to a network-facing daemon that
-# serves user-supplied PHP. For a product whose whole job is imaging
-# machines on a trusted network, that is a poor trade.
+# serves user-supplied PHP.
 #
-# The narrower booleans do not cover it either:
+# The narrower booleans do not cover it:
 #
 #   httpd_graceful_shutdown   http_port_t only -- but it is named for, and
 #                             documented as, something else entirely
@@ -27,16 +31,60 @@ module fog 1.0.0;
 #   ssh_port_t                NO boolean exists. Only the blanket one.
 #
 # So SSH alone forces the choice between a module and granting everything.
-# Given that, the module carries all three rather than leaving FOG half
-# configured by booleans it has to document and half by policy.
 #
-# WHAT IT DELIBERATELY DOES NOT DO
+# 2. SHARED CONTENT DIRECTORIES
+#
+# /images and the snapin directory are read AND written by two different
+# confined daemons: the web tier (httpd_t) and vsftpd (ftpd_t), the latter
+# because replication is lftp from one node to another -- see
+# FOGService::replicateItems(). Both images and snapins use that same FTP
+# path.
+#
+# No stock type serves both without a blanket grant:
+#
+#   httpd_sys_rw_content_t    httpd_t rw. ftpd_t gets NOTHING unless
+#                             ftpd_full_access is on -- and that boolean
+#                             grants ftpd_t every file type on the box.
+#   public_content_rw_t       ftpd_t/httpd_t/nfsd_t read. Writing needs
+#                             ftpd_anon_write + httpd_anon_write, each of
+#                             which is global: it grants write on ALL
+#                             public_content_rw_t on the machine, not just
+#                             FOG's. Today FOG may be the only user of that
+#                             type on a given box; that is a snapshot, not
+#                             a guarantee, and a package installed later
+#                             sharing the type would silently inherit it.
+#
+# So FOG declares its own type. fog_share_t is read and written by exactly
+# the two domains named below and nothing else, no global boolean is
+# touched, and no other package's access to a shared type changes.
+#
+# WHAT DOES *NOT* NEED A RULE HERE
 # --------------------------------
-# No file contexts. Those are handled by setSELinuxContext() in the
-# installer via semanage fcontext, which works on a stock system with no
-# policy-development tooling installed. Keeping this module to the rules
-# that genuinely have no other expression keeps the thing FOG has to
-# maintain across distro policy versions as small as possible.
+# Worked out against the running targeted policy rather than assumed:
+#
+#   NFS       The capture/deploy data path is in-kernel and runs as
+#             kernel_t, which has UNCONDITIONAL read+write on the
+#             `file_type` attribute. The userspace nfsd_t additionally gets
+#             read via nfs_export_all_ro, which is on by default. Giving
+#             fog_share_t the file_type attribute is therefore all NFS
+#             needs -- no allow rule, no boolean. This matches the
+#             evidence: months of imaging on the lab produced zero nfsd_t
+#             denials.
+#
+#   SSH       sshd_t only accepts the connection and spawns a shell; it
+#             never touches image content itself, and the spawned shell
+#             runs unconfined. Only the OUTBOUND side needed anything, and
+#             that is the ssh_port_t rule below.
+#
+#   The FOG   FOGImageReplicator, FOGSnapinReplicator and friends are
+#   daemons   systemd services with no policy of their own, so they run as
+#             unconfined_service_t and are not restricted. It is the
+#             RECEIVING node's vsftpd that needs the rules below, not the
+#             sending daemon.
+#
+#   $fogprogramdir/cache
+#             Web tier and the CLI daemons only, never FTP, so it stays on
+#             the stock httpd_sys_rw_content_t. See installFOGServices().
 #
 # BUILDING
 # --------
@@ -52,30 +100,42 @@ module fog 1.0.0;
 # Note the plain `module` declaration above rather than refpolicy's
 # `policy_module()`. That macro would pull in refpolicy's headers and so
 # require selinux-policy-devel, which is not installed by default on any
-# distro FOG supports. Nothing here needs a refpolicy macro -- these are
-# three flat allow rules -- so the module is written to build with
-# checkmodule and semodule_package alone, both of which come from
-# checkpolicy and policycoreutils and are already present anywhere
-# semanage is.
+# distro FOG supports. Nothing here needs a refpolicy macro, so the module
+# builds with checkmodule and semodule_package alone -- both from
+# checkpolicy and policycoreutils, already present anywhere semanage is.
 #
 # checkmodule does NOT resolve the require{} block against the running
 # policy; that happens when semodule links it. A type renamed by a future
 # distro policy would therefore compile cleanly here and fail at load,
-# which is why the installer reports a load failure rather than assuming
-# a successful build means a successful install.
+# which is why the installer reports a load failure separately from a
+# build failure.
 #
-# The installer does this only when SELinux is actually enabled, and never
-# fails an install over it.
+# ORDERING NOTE: `semanage fcontext -t fog_share_t` cannot succeed until
+# this module is loaded, because semanage validates that the type exists.
+# installSELinuxModule() therefore runs before configureStorage() and
+# configureSnapins() in bin/installfog.sh. Do not reorder them.
 #
 ########################################################################
 
 require {
     type httpd_t;
+    type ftpd_t;
     type http_port_t;
     type ftp_port_t;
     type ssh_port_t;
+    attribute file_type;
+    attribute non_security_file_type;
+    attribute non_auth_file_type;
+    attribute mountpoint;
     class tcp_socket name_connect;
+    class dir { add_name create getattr ioctl link lock open read remove_name rename reparent rmdir search setattr unlink write };
+    class file { append create getattr ioctl link lock map open read rename setattr unlink write };
+    class lnk_file { getattr read };
 }
+
+########################################################################
+# Outbound connections from the web tier.
+########################################################################
 
 #
 # HTTP: the web tier calls its own API and its storage nodes' APIs.
@@ -87,7 +147,7 @@ allow httpd_t http_port_t:tcp_socket name_connect;
 #
 # Only the control channel is granted here. Passive-mode data connections
 # land on ephemeral ports, which would need a much wider grant -- FOG's
-# replicators use lftp from a CLI daemon, not from httpd_t, so the web
+# replicators run lftp from a CLI daemon, not from httpd_t, so the web
 # tier does not need the data channel and is not given it.
 #
 allow httpd_t ftp_port_t:tcp_socket name_connect;
@@ -100,3 +160,39 @@ allow httpd_t ftp_port_t:tcp_socket name_connect;
 # installer.
 #
 allow httpd_t ssh_port_t:tcp_socket name_connect;
+
+########################################################################
+# FOG's shared content type: /images, the capture directory, and snapins.
+########################################################################
+
+type fog_share_t;
+
+#
+# file_type                 makes it a recognised file type at all, and
+#                           carries `allow file_type fs_t:filesystem
+#                           associate` so the label can actually be applied
+#                           on a normal filesystem. Also what gives the
+#                           in-kernel NFS path (kernel_t) its access.
+# non_security_file_type    excludes it from the security-file set, and is
+#                           what nfs_export_all_ro keys on for files.
+# non_auth_file_type        excludes it from the authentication-file set.
+# mountpoint                /images is very commonly a separate disk, so
+#                           the type has to be legal as a mount target.
+#
+typeattribute fog_share_t file_type, non_security_file_type, non_auth_file_type, mountpoint;
+
+#
+# The web tier: uploads, deletes, renames and reads image and snapin files
+# through the UI and the API.
+#
+allow httpd_t fog_share_t:dir { add_name create getattr ioctl link lock open read remove_name rename reparent rmdir search setattr unlink write };
+allow httpd_t fog_share_t:file { append create getattr ioctl link lock map open read rename setattr unlink write };
+allow httpd_t fog_share_t:lnk_file { getattr read };
+
+#
+# vsftpd on the RECEIVING side of a replication run. lftp mirrors into
+# these directories, so this has to be read-write, not read-only.
+#
+allow ftpd_t fog_share_t:dir { add_name create getattr ioctl link lock open read remove_name rename reparent rmdir search setattr unlink write };
+allow ftpd_t fog_share_t:file { append create getattr ioctl link lock map open read rename setattr unlink write };
+allow ftpd_t fog_share_t:lnk_file { getattr read };


### PR DESCRIPTION
Follow-up to #966, which is what #964 is really about. Verified on an enforcing host by @FOGProject-Tom before merge.

## The gap #966 left

#966 labelled the shared directories `httpd_sys_rw_content_t`. That fixed the web tier and left **vsftpd with no access at all**. Against the running targeted policy:

| daemon | on `httpd_sys_rw_content_t` |
|---|---|
| `httpd_t` | read ✓, write ✓ |
| `ftpd_t`  | **nothing**, unless `ftpd_full_access` |

`ftpd_full_access` grants `ftpd_t` **every file type on the machine** — the same blanket trade the policy module exists to avoid.

Not a regression (`/images` was `unlabeled_t` before, which gave `ftpd_t` nothing either), but #966 should not have been read as having finished `/images`.

## Why a FOG-owned type

Both `/images` and the snapin directory are read **and written** by two confined daemons: `httpd_t`, and `ftpd_t` as the receiving side of a replication run. Replication is `lftp` over FTP (`FOGService::replicateItems()`) and **both images and snapins use that same path** — so this was never an images-only problem.

No stock type serves both without a global grant:

- **`httpd_sys_rw_content_t`** — needs `ftpd_full_access`, i.e. every file type on the box.
- **`public_content_rw_t`** — reads work for all three daemons, but writes need `ftpd_anon_write` + `httpd_anon_write`, and each is **global**: write on *all* `public_content_rw_t`, not just FOG's.

The second is the idiomatic answer and worth naming as the road not taken. Rejected because those booleans are a standing claim on a shared type: FOG may be the only user of `public_content_rw_t` on a given box today, but that is a snapshot, not a guarantee — a package installed later would silently inherit the write grant. A FOG-owned type cannot have that problem.

So `fog_share_t`, declared in `packages/selinux/fog.te`, read and written by exactly `httpd_t` and `ftpd_t`, touching no global boolean and changing no other package's access to anything.

Applied to `$storageLocation`, `$storageLocationCapture` and `$snapindir`. The capture directory gets its own call because `.fogsettings` can relocate it out from under `$storageLocation`, in which case the recursive fcontext registered for the parent would not cover it.

`$fogprogramdir/cache` stays on `httpd_sys_rw_content_t` — web tier and CLI daemons only, never FTP.

## What needed no rule, and why

Determined against the running policy rather than assumed:

- **NFS** — the capture/deploy data path is in-kernel as `kernel_t`, which has **unconditional** read+write on the `file_type` attribute. Userspace `nfsd_t` additionally gets read via `nfs_export_all_ro`, on by default. Carrying `file_type` is therefore all NFS needs. Worth noting `nfs_export_all_rw` grants `nfsd_t` **nothing** on `file_type` — the writes were never going through `nfsd_t` to begin with, which is why months of imaging produced zero `nfsd_t` denials.
- **SSH** — `sshd_t` accepts the connection and spawns a shell; it never touches image content, and the shell runs unconfined. Only the outbound side needed anything, and that rule already existed.
- **The FOG daemons** — systemd services with no policy of their own, so `unconfined_service_t`. It is the *receiving* node's vsftpd that needs the rules, not the sending daemon.

## Also fixed

`setSELinuxContext()`'s no-`semanage` branch ran `chcon` and echoed **OK without checking**. Survivable while `$register` was always a stock type; with a FOG-owned type, a module that failed to load makes `chcon` fail outright and the installer would have reported success over a directory no daemon can touch. It now verifies the post-condition, the same way the `restorecon` path already did.

`installSELinuxModule()`'s failure message now also warns that the label steps will fail, since `semanage` cannot register a type the policy does not know.

## Ordering

`semanage fcontext -t fog_share_t` requires the module to be loaded first. `installSELinuxModule` already runs before `configureStorage` and `configureSnapins`; a comment in `fog.te` records that this is load-bearing.

## Verification

- Builds with `checkmodule` + `semodule_package`; `.pp` carries `fog_share_t`, `ftpd_t`, `httpd_t`, `ssh_port_t`, `mountpoint`
- All four required attributes and all five required types resolve against a live targeted policy; `fog_share_t` is not already taken
- No stray `fog.mod`/`fog.pp` in the source tree; `bash -n` clean
- Module load still ordered before both label calls
- **Run on a genuinely enforcing host** — the open item from #964

Refs #964, #966
