### PR TITLE
Stop recommending permissive SELinux, and stop setting it under -y (dev-branch port)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1594,32 +1594,52 @@ checkSELinux() {
     currentmode=$(LANG=C sestatus | grep "^Current mode" | awk '{print $3}')
     configmode=$(LANG=C sestatus | grep "^Mode from config file" | awk '{print $5}')
     [[ "x$currentmode" != "xenforcing" && "x$configmode" != "xenforcing" ]] && return
-    # GH-963: the headline reason this prompt existed -- an unlabelled TFTP root
-    # that no confined tftpd could read -- is fixed; setSELinuxContext() now
-    # labels $tftpdirdst properly, so declining here leaves a server that PXE
-    # boots. The prompt and its default are deliberately UNCHANGED: FOG's NFS
-    # and FTP image storage has not been validated under enforcing mode, and
-    # flipping the default would silently change the security posture of every
-    # existing unattended (-y) install. Reworded only, so it no longer blames a
-    # cause that has been fixed.
-    echo " * SELinux is currently enabled on your system."
-    echo " * FOG now sets the correct SELinux context on its TFTP directory, so"
-    echo " * PXE booting works under enforcing mode. Image storage over NFS and"
-    echo " * FTP has not yet been validated enforcing, so permissive is still"
-    echo " * what we recommend and test against."
-    echo -n " * Should the installer set this for you now? (Y/n) "
+    # GH-964 step 5. This prompt used to recommend permissive and default to
+    # YES, which meant every unattended (-y) install switched SELinux off
+    # machine-wide without anyone deciding to. That was defensible only while
+    # FOG genuinely did not work enforcing. It now does:
+    #
+    #   GH-963       $tftpdirdst is labelled, so PXE boots
+    #   GH-966/967   $fogprogramdir/cache, $snapindir and $storageLocation are
+    #                labelled, so the web tier can write
+    #   GH-968/969   fog_share_t, so vsftpd can read and write image and
+    #                snapin storage as well as the web tier
+    #   GH-966/967   packages/selinux/fog.te, so httpd_t may reach its own
+    #                API, its nodes' FTP, and SSH
+    #
+    # and capture, deploy and replication have all been run on an enforcing
+    # host. NFS never needed anything: its data path is in-kernel as kernel_t,
+    # which has unconditional access to the file_type attribute.
+    #
+    # So the recommendation is inverted. Note this does NOT need to remember
+    # the answer the way configureFirewall() does -- if the admin chooses
+    # permissive, /etc/selinux/config says so, and the early return above
+    # means this function never asks again. The system state is the memory.
+    echo " * SELinux is enabled and enforcing on your system."
+    echo " * FOG supports this. The installer labels its directories, installs"
+    echo " * a small policy module for the ports the web tier needs, and has"
+    echo " * been tested capturing, deploying and replicating under enforcing."
+    echo " * Leaving it on is recommended and is now the default."
+    echo " * If you hit trouble later, SELinux denials never appear in FOG's"
+    echo " * own logs -- check for them with: ausearch -m avc -ts recent"
+    echo -n " * Set SELinux permissive anyway? (y/N) "
     sedisable=""
     while [[ -z $sedisable ]]; do
-        [[ -n $autoaccept ]] && sedisable="Y" || read -r sedisable
+        # Unattended installs keep enforcing. This is the half of GH-964 that
+        # mattered most: -y used to answer "Y" here, so an admin who never saw
+        # a prompt ended up with SELinux off across the whole machine.
+        [[ -n $autoaccept ]] && sedisable="N" || read -r sedisable
         case $sedisable in
-            [Yy]|[Yy][Ee][Ss]|"")
+            [Yy]|[Yy][Ee][Ss])
                 sedisable="Y"
                 setenforce 0
                 sed -i 's/^SELINUX=.*$/SELINUX=permissive/' /etc/selinux/config
                 echo -e " * SELinux set permissive -- proceeding with installation...\n"
                 ;;
-            [Nn]|[Nn][Oo])
-                echo -e " * You sure know what you're doing, just keep in mind we told you! :-)\n"
+            [Nn]|[Nn][Oo]|"")
+                sedisable="N"
+                echo "N"
+                echo -e " * Leaving SELinux enforcing.\n"
                 ;;
             *)
                 sedisable=""


### PR DESCRIPTION
Port of #972 to `dev-branch`. **#964 step 5.**

The prompt recommended permissive and defaulted to **YES**. Under `-y` it answered YES for you, so **every unattended install switched SELinux off machine-wide** without anyone deciding to — an admin who never saw a prompt got a server with its mandatory access control disabled.

Enforcing is now the default, `-y` leaves SELinux alone, and setting permissive is an explicit `y`.

**Why it is safe now** — FOG works enforcing, verified on an enforcing host rather than assumed:

- #963 — `$tftpdirdst` labelled, so PXE boots
- #967 — cache, snapin and image directories labelled, so the web tier can write
- #969 — `fog_share_t`, so vsftpd can read and write image and snapin storage as well as the web tier
- #967 — `packages/selinux/fog.te`, granting `httpd_t` the three ports it needs rather than the several hundred `httpd_can_network_connect` would

**NFS never needed anything** — its data path is in-kernel as `kernel_t`, which has unconditional access to the `file_type` attribute every FOG type carries.

**Nothing is disrupted for anyone already running permissive**: the early return at the top fires and the function never asks. That is also why this does *not* persist the answer the way `configureFirewall()` does — the system state is the memory. Only installs currently enforcing are affected, which is the entire point, and the labels and policy module are applied on every install and upgrade before this decision matters.

The only difference between this branch's old `checkSELinux()` and working-1.6's was a single `echo "N"`, which the replacement includes, so the two are now byte-identical.

**Verified on this branch:** `-y` keeps enforcing (`sedisable=N`); pressing Enter keeps enforcing; typing `y` still sets permissive, so the capability is not removed; an already-permissive host, a disabled host, and a host with no `sestatus` at all each return silently without prompting. `bash -n` clean.