### PR TITLE
docs: new features land on working-1.6 first (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,19 @@ FOG Project is an open-source network imaging and endpoint management system. It
 
 ---
 
+## Feature development order
+
+**New features land here first.** Until this branch is promoted to become
+the project's stable/patches line (superseding `dev-branch`), develop new
+capability against `working-1.6` and open the PR here before porting it to
+`dev-branch`. `dev-branch` is the actively-patched 1.5.x line today, but this
+branch is where the project's future lives — landing new features here
+first, then porting backward, keeps it from falling further behind and
+avoids reconciling divergence after the fact instead of designing around it
+from the start.
+
+---
+
 ## Development Workflow
 
 ### Sync Scripts


### PR DESCRIPTION
## Summary

Codifies a convention discussed during the Secure Boot signing work
(`#961`, later ported to `working-1.6` in `8226cd9`): until this branch
is promoted to become the project's stable/patches line (superseding
`dev-branch`), new features should be developed here first and opened
as a PR against `working-1.6` before being ported to `dev-branch`.

This session did the Secure Boot work backwards, and the port to
`working-1.6` had to reconcile real divergence after the fact rather
than being designed around it from the start. Writing the convention
down so it's followed going forward.

## What changed

- Added a new "Feature development order" section to `CLAUDE.md`, right
  after the "What This Is" section.

A companion PR adds the mirrored guidance to `dev-branch`'s own
`CLAUDE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw)_