### PR TITLE
Add "Enroll Secure Boot Key" PXE menu item

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4533,9 +4533,31 @@ _publishSecureBootKit() {
     fi
     cp -f ../packages/secureboot/fog-enroll-mok.sh "${kitdir}/" >>$error_log 2>&1
     cp -f ../packages/secureboot/fog-enroll-mok.desktop "${kitdir}/" >>$error_log 2>&1
+    # MokManager, for the "Enroll Secure Boot Key" PXE menu item. BootMenu
+    # chains to it over $_booturl, which is the WEB root
+    # (http://<server>/fog/service) -- but downloadipxesecureboot stages these
+    # binaries under $tftpdirdst/secureboot, which the web server does not
+    # serve. Without this copy the menu item resolves to a 403/404 on every
+    # architecture and falls straight into its own error branch.
+    #
+    # Copied rather than linked: the TFTP tree may be on a different
+    # filesystem, and it is two small binaries.
+    local mmsrc="${tftpdirdst%/}/secureboot"
+    if [[ -f ${mmsrc}/mmx64.efi ]]; then
+        cp -f "${mmsrc}/mmx64.efi" "${kitdir}/" >>$error_log 2>&1
+    fi
+    if [[ -f ${mmsrc}/arm64-efi/mmaa64.efi ]]; then
+        mkdir -p "${kitdir}/arm64-efi" >>$error_log 2>&1
+        cp -f "${mmsrc}/arm64-efi/mmaa64.efi" "${kitdir}/arm64-efi/" >>$error_log 2>&1
+    fi
     # Keep the directory from being browsable, matching service/ipxe.
     echo '<?php header("HTTP/1.1 404 Not Found");' > "${kitdir}/index.php"
     chmod 0644 "${kitdir}"/MOK.der "${kitdir}"/*.desktop "${kitdir}"/index.php >>$error_log 2>&1
+    # Guarded rather than globbed blind: an HTTPS install stages no Secure Boot
+    # binaries at all (downloadipxesecureboot skips it), so an unguarded
+    # chmod would log a "No such file" for every run on those servers.
+    [[ -f ${kitdir}/mmx64.efi ]] && chmod 0644 "${kitdir}/mmx64.efi" >>$error_log 2>&1
+    [[ -f ${kitdir}/arm64-efi/mmaa64.efi ]] && chmod 0644 "${kitdir}/arm64-efi/mmaa64.efi" >>$error_log 2>&1
     chmod 0755 "${kitdir}/fog-enroll-mok.sh" >>$error_log 2>&1
     chown -R "${apacheuser}":"${apacheuser}" "$kitdir" >>$error_log 2>&1
     echo "Done"

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4868,3 +4868,23 @@ $this->schema[] = [
     . "AND CAST(`settingValue` AS UNSIGNED) % 2 = 0 "
     . "AND CAST(`settingValue` AS UNSIGNED) NOT BETWEEN 63100 AND 63228",
 ];
+// 321
+$this->schema[] = [
+    // Adds the "Enroll Secure Boot Key" PXE menu item, always visible
+    // (pxeRegOnly=2, same grouping as fog.local/fog.memtest) regardless of
+    // registration state -- a machine needing its MOK enrolled has usually
+    // never registered yet.
+    //
+    // pxeID 14 is the next free id: 1-13 are already taken (8 and 13 were
+    // later removed by name in earlier schema steps, but their ids are not
+    // reused). BootMenu::_menuOpt() keys its special-cased (non-kernel-chain)
+    // items on this id the same way it already does for 1 (fog.local), 2
+    // (fog.memtest) and 11 (fog.advanced).
+    //
+    // No pxeArgs/pxeParams: this item never reaches BootMenu's default
+    // (login + kernel chain) branch, so neither is read.
+    "INSERT IGNORE INTO `pxeMenu` "
+    . "(`pxeID`,`pxeName`,`pxeDesc`,`pxeDefault`,`pxeRegOnly`,`pxeArgs`) "
+    . "VALUES "
+    . "(14, 'fog.enrollsecureboot', 'Enroll Secure Boot Key', '0', '2', NULL)",
+];

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2024,10 +2024,25 @@ class BootMenu extends FOGBase
                 'goto MENU'
             ];
         }
+        // arm64's MokManager is mmaa64.efi, NOT mmx64.efi -- the binary is
+        // named for the architecture it runs on, and fog-ipxe stages it under
+        // that name. Chaining to arm64-efi/mmx64.efi is a file that has never
+        // existed, so every arm64 client fell into the error branch below.
         $mmTarget = (false !== stripos(($_REQUEST['arch'] ?? ''), 'arm'))
-            ? "$this->_booturl/secureboot/arm64-efi/mmx64.efi"
+            ? "$this->_booturl/secureboot/arm64-efi/mmaa64.efi"
             : "$this->_booturl/secureboot/mmx64.efi";
+        // MokManager can only read a certificate off a FAT filesystem it can
+        // see -- it has no network stack, so booting it over the network does
+        // NOT deliver MOK.der with it. Say so before chaining, or the tech
+        // arrives at "Enroll key from disk" with nothing to select and no
+        // indication of why.
         return [
+            'echo Have MOK.der on a FAT-formatted USB stick in this machine.',
+            'echo MokManager reads it from local media, not from the network.',
+            // No quotes in the text: iPXE's tokenizer treats them as quoting
+            // and strips them, so they would vanish from the output anyway.
+            'echo Choose Enroll key from disk, then find MOK.der on the stick.',
+            'sleep 5',
             "chain -ar $mmTarget || "
             . "echo Could not load the Secure Boot enrolment menu. && "
             . "sleep 5 && goto MENU"

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1971,6 +1971,9 @@ class BootMenu extends FOGBase
                     ]
                 );
                 break;
+            case 14:
+                $Send = self::fastmerge($Send, $this->_enrollSecureBootChoice());
+                break;
             default:
                 if (!$params) {
                     $Send = self::fastmerge(
@@ -1984,6 +1987,51 @@ class BootMenu extends FOGBase
                 }
         }
         return $Send;
+    }
+    /**
+     * Builds the iPXE choice for pxeID 14, "Enroll Secure Boot Key".
+     *
+     * Always shown (pxeRegOnly=2), so a technician never has to repoint a
+     * client's boot file just to enroll its MOK -- the same signed
+     * snponly.efi/shim chain every other client reaches already gets them
+     * here. If this server never configured kernel signing there is
+     * nothing to enroll, so this returns a message rather than attempting
+     * a chain to a target that was never staged.
+     *
+     * MokManager (mmx64.efi) only shows its "Enroll key from disk" menu
+     * when it is the boot target itself -- shim only invokes it when a
+     * pending MOK request already exists, which nothing here stages -- so
+     * this chains to it directly rather than through the normal shim gate.
+     *
+     * @return array
+     */
+    private function _enrollSecureBootChoice()
+    {
+        if (!file_exists(BASEPATH . 'service/secureboot' . DS . 'MOK.der')) {
+            return [
+                'echo Secure Boot signing is not configured on this FOG '
+                . 'server.',
+                'echo Nothing to enroll -- returning to the menu...',
+                'sleep 5',
+                'goto MENU'
+            ];
+        }
+        if (($_REQUEST['arch'] ?? '') === 'i386') {
+            return [
+                'echo No signed Secure Boot shim exists for 32-bit UEFI.',
+                'echo Returning to the menu...',
+                'sleep 5',
+                'goto MENU'
+            ];
+        }
+        $mmTarget = (false !== stripos(($_REQUEST['arch'] ?? ''), 'arm'))
+            ? "$this->_booturl/secureboot/arm64-efi/mmx64.efi"
+            : "$this->_booturl/secureboot/mmx64.efi";
+        return [
+            "chain -ar $mmTarget || "
+            . "echo Could not load the Secure Boot enrolment menu. && "
+            . "sleep 5 && goto MENU"
+        ];
     }
     /**
      * Print the default information for all hosts

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -61,7 +61,7 @@ class System
         self::_versionCompare();
         define('FOG_VERSION', '1.6.0-beta.3137');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 320);
+        define('FOG_SCHEMA', 321);
         define('FOG_BCACHE_VER', 269);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
## Summary

Following the `working-1.6`-first convention, this implements the "dedicated
enrolment boot option" designed as a follow-up to the Secure Boot signing
work (`#961`/`8226cd9`).

Today, enrolling a MOK via MokManager's "Enroll key from disk" requires
repointing DHCP at `secureboot/mmx64.efi` directly, because shim only
invokes MokManager when a pending enrolment request already exists
(normally staged by `mokutil --import`) — a plain boot through the shim
never shows it. That's an awkward manual dance for a one-time-per-machine
visit, and the currently-shipped docs describe a route ("PXE-boot the
shim, then Enroll key from disk") that doesn't actually work, since it
never triggers shim's MOK-request gate.

This adds a menu item — **"Enroll Secure Boot Key"** — to the normal FOG
PXE boot menu that chains directly to `secureboot/mmx64.efi` (bypassing
shim's gate on purpose), so a tech never has to touch DHCP or firmware
settings to enrol a machine.

## Design

- New `pxeMenu` row (id 14, schema step 321), grouped with `fog.local`/
  `fog.memtest` (`pxeRegOnly=2`) so it's **always** listed regardless of
  a host's registration state — the common case is a machine that has
  never registered yet.
- New `case 14` in `BootMenu::_menuOpt()` (`_enrollSecureBootChoice()`)
  builds the iPXE chain.
- **No per-client boot-file changes, no client-side Secure Boot state
  detection.** Every client already reaches this same menu via
  `boot.php` regardless of which `.efi` or which DHCP server got it
  there — a client can only be running this menu with Secure Boot
  actually enforced by having already gone through the signed shim
  chain to load it, so there's nothing to distinguish client-side.
- Two independent checks, since "kernel signing is configured" and "the
  shim/MokManager chain is staged" are not the same fact:
  - PHP-side: if `MOK.der` (the enrolled cert, same file the FOG
    Configuration → Secure Boot page already checks) doesn't exist,
    skip straight to a "Secure Boot is not configured" message.
  - iPXE-side: the `chain` command itself falls back to the same
    message if the binary isn't actually there — covers HTTPS installs,
    where `downloadipxesecureboot()` is skipped entirely (a signed
    binary can't carry this server's own CA) even when kernel signing
    is configured.
- 32-bit UEFI gets its own message rather than attempting a chain — no
  signed 32-bit shim/MokManager exists upstream.

## Verified

- `php -l` clean on both changed files.
- Traced the schema step against the existing `pxeMenu` history: ids
  1–13 are taken (8 and 13 were later removed by name in earlier steps,
  ids not reused), so 14 is free; `pxeRegOnly=2` matches how
  `fog.local`/`fog.memtest` stay unconditionally visible in
  `printDefault()`'s `$RegArrayOfStuff`.
- Confirmed `$_REQUEST['arch']` is already populated server-side from
  iPXE's own `${buildarch}` by the time `_menuOpt()` runs (same value
  `BootMenu`'s constructor uses to pick `bzImage`/`bzImage32`/
  `bzImageArm`), so no new plumbing was needed for the arch branch.
- Confirmed `secureboot/arm64-efi/` is the actual staging path
  `downloadipxesecureboot()`'s installer-side copy loop produces for
  arm64 (`lib/common/functions.sh`), not an assumed path.

**Not verified — flagging rather than asserting:**
- Whether chaining from a running signed `snponly.efi` to a non-iPXE
  EFI target (`mmx64.efi`) via shim's `LoadImage()` hook behaves the
  same as the original shim→snponly chain. Architecturally this should
  hold (shim installs itself as a `LoadImage()`/`StartImage()` override
  the firmware consults for any subsequent load, not something
  iPXE-specific), but nothing in this codebase exercises that pattern
  today, and it hasn't been tried on real hardware or in a VM.
- Whether the `fog-ipxe-secureboot-<ver>.tar.gz` asset
  `downloadipxesecureboot()` fetches is actually being published today —
  the `fog-ipxe` repo's release workflow only builds and publishes the
  plain `fog-ipxe-<ver>.tar.gz`. If that asset is missing on a given
  release, this item's iPXE-side fallback still degrades gracefully to
  the friendly message rather than a raw chain-failure error, but the
  feature would be silently unreachable regardless of `MOK.der` state —
  worth checking against the actual release before relying on this.

Refs #960, #961


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw)_