### PR TITLE
Add "Enroll Secure Boot Key" PXE menu item (dev-branch port)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3684,9 +3684,31 @@ _publishSecureBootKit() {
     fi
     cp -f ../packages/secureboot/fog-enroll-mok.sh "${kitdir}/" >>$error_log 2>&1
     cp -f ../packages/secureboot/fog-enroll-mok.desktop "${kitdir}/" >>$error_log 2>&1
+    # MokManager, for the "Enroll Secure Boot Key" PXE menu item. BootMenu
+    # chains to it over $_booturl, which is the WEB root
+    # (http://<server>/fog/service) -- but downloadipxesecureboot stages these
+    # binaries under $tftpdirdst/secureboot, which the web server does not
+    # serve. Without this copy the menu item resolves to a 403/404 on every
+    # architecture and falls straight into its own error branch.
+    #
+    # Copied rather than linked: the TFTP tree may be on a different
+    # filesystem, and it is two small binaries.
+    local mmsrc="${tftpdirdst%/}/secureboot"
+    if [[ -f ${mmsrc}/mmx64.efi ]]; then
+        cp -f "${mmsrc}/mmx64.efi" "${kitdir}/" >>$error_log 2>&1
+    fi
+    if [[ -f ${mmsrc}/arm64-efi/mmaa64.efi ]]; then
+        mkdir -p "${kitdir}/arm64-efi" >>$error_log 2>&1
+        cp -f "${mmsrc}/arm64-efi/mmaa64.efi" "${kitdir}/arm64-efi/" >>$error_log 2>&1
+    fi
     # Keep the directory from being browsable, matching service/ipxe.
     echo '<?php header("HTTP/1.1 404 Not Found");' > "${kitdir}/index.php"
     chmod 0644 "${kitdir}"/MOK.der "${kitdir}"/*.desktop "${kitdir}"/index.php >>$error_log 2>&1
+    # Guarded rather than globbed blind: an HTTPS install stages no Secure Boot
+    # binaries at all (downloadipxesecureboot skips it), so an unguarded
+    # chmod would log a "No such file" for every run on those servers.
+    [[ -f ${kitdir}/mmx64.efi ]] && chmod 0644 "${kitdir}/mmx64.efi" >>$error_log 2>&1
+    [[ -f ${kitdir}/arm64-efi/mmaa64.efi ]] && chmod 0644 "${kitdir}/arm64-efi/mmaa64.efi" >>$error_log 2>&1
     chmod 0755 "${kitdir}/fog-enroll-mok.sh" >>$error_log 2>&1
     chown -R "${apacheuser}":"${apacheuser}" "$kitdir" >>$error_log 2>&1
     echo "Done"

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -3950,3 +3950,21 @@ $this->schema[] = array(
     . "AND CAST(`settingValue` AS UNSIGNED) % 2 = 0 "
     . "AND CAST(`settingValue` AS UNSIGNED) NOT BETWEEN 63100 AND 63228",
 );
+// 279
+$this->schema[] = array(
+    // Adds the "Enroll Secure Boot Key" PXE menu item, always visible
+    // (pxeRegOnly=2, same grouping as fog.local/fog.memtest) regardless of
+    // registration state -- a machine needing its MOK enrolled has usually
+    // never registered yet.
+    //
+    // pxeID 14 is the next free id: 1-13 are already taken. BootMenu::_menuOpt()
+    // keys its special-cased (non-kernel-chain) items on this id the same way
+    // it already does for 1 (fog.local), 2 (fog.memtest) and 11 (fog.advanced).
+    //
+    // No pxeArgs/pxeParams: this item never reaches BootMenu's default
+    // (login + kernel chain) branch, so neither is read.
+    "INSERT IGNORE INTO `pxeMenu` "
+    . "(`pxeID`,`pxeName`,`pxeDesc`,`pxeDefault`,`pxeRegOnly`,`pxeArgs`) "
+    . "VALUES "
+    . "(14, 'fog.enrollsecureboot', 'Enroll Secure Boot Key', '0', '2', NULL)",
+);

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1948,6 +1948,9 @@ class BootMenu extends FOGBase
                     )
                 );
                 break;
+            case 14:
+                $Send = self::fastmerge($Send, $this->_enrollSecureBootChoice());
+                break;
             default:
                 if (!$params) {
                     $Send = self::fastmerge(
@@ -1961,6 +1964,66 @@ class BootMenu extends FOGBase
                 }
         }
         return $Send;
+    }
+    /**
+     * Builds the iPXE choice for pxeID 14, "Enroll Secure Boot Key".
+     *
+     * Always shown (pxeRegOnly=2), so a technician never has to repoint a
+     * client's boot file just to enroll its MOK -- the same signed
+     * snponly.efi/shim chain every other client reaches already gets them
+     * here. If this server never configured kernel signing there is
+     * nothing to enroll, so this returns a message rather than attempting
+     * a chain to a target that was never staged.
+     *
+     * MokManager (mmx64.efi) only shows its "Enroll key from disk" menu
+     * when it is the boot target itself -- shim only invokes it when a
+     * pending MOK request already exists, which nothing here stages -- so
+     * this chains to it directly rather than through the normal shim gate.
+     *
+     * @return array
+     */
+    private function _enrollSecureBootChoice()
+    {
+        if (!file_exists(BASEPATH . 'service/secureboot' . DS . 'MOK.der')) {
+            return array(
+                'echo Secure Boot signing is not configured on this FOG '
+                . 'server.',
+                'echo Nothing to enroll -- returning to the menu...',
+                'sleep 5',
+                'goto MENU'
+            );
+        }
+        if (($_REQUEST['arch'] ?? '') === 'i386') {
+            return array(
+                'echo No signed Secure Boot shim exists for 32-bit UEFI.',
+                'echo Returning to the menu...',
+                'sleep 5',
+                'goto MENU'
+            );
+        }
+        // arm64's MokManager is mmaa64.efi, NOT mmx64.efi -- the binary is
+        // named for the architecture it runs on, and fog-ipxe stages it under
+        // that name. Chaining to arm64-efi/mmx64.efi is a file that has never
+        // existed, so every arm64 client fell into the error branch below.
+        $mmTarget = (false !== stripos(($_REQUEST['arch'] ?? ''), 'arm'))
+            ? "$this->_booturl/secureboot/arm64-efi/mmaa64.efi"
+            : "$this->_booturl/secureboot/mmx64.efi";
+        // MokManager can only read a certificate off a FAT filesystem it can
+        // see -- it has no network stack, so booting it over the network does
+        // NOT deliver MOK.der with it. Say so before chaining, or the tech
+        // arrives at "Enroll key from disk" with nothing to select and no
+        // indication of why.
+        return array(
+            'echo Have MOK.der on a FAT-formatted USB stick in this machine.',
+            'echo MokManager reads it from local media, not from the network.',
+            // No quotes in the text: iPXE's tokenizer treats them as quoting
+            // and strips them, so they would vanish from the output anyway.
+            'echo Choose Enroll key from disk, then find MOK.der on the stick.',
+            'sleep 5',
+            "chain -ar $mmTarget || "
+            . "echo Could not load the Secure Boot enrolment menu. && "
+            . "sleep 5 && goto MENU"
+        );
     }
     /**
      * Print the default information for all hosts

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -54,7 +54,7 @@ class System
     {
         self::_versionCompare();
         define('FOG_VERSION', '1.5.10.2191');
-        define('FOG_SCHEMA', 278);
+        define('FOG_SCHEMA', 279);
         define('FOG_BCACHE_VER', 141);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
Ports #976 to `dev-branch`. The signing-key half is already here from `5d23f2030`; this is the client-side half — enrolling that key on a machine without needing a live Linux image.

### What it does

Adds `pxeID` 14 (`fog.enrollsecureboot`) as schema step **279**, always visible (`pxeRegOnly=2`) because a machine that needs its MOK enrolled has usually never registered. `BootMenu::_menuOpt()` special-cases the id the same way it already does for 1, 2 and 11, so the item never reaches the default login-and-chain-a-kernel branch and needs no `pxeArgs`/`pxeParams`.

### The installer change is the part that makes it work

`downloadipxesecureboot` stages MokManager under `$tftpdirdst/secureboot`, which the web server does not serve — but `BootMenu` chains over the **web** root. Without copying those binaries into the enrolment kit the item resolves to a 403/404 on every architecture and falls into its own error branch, which reads like the feature half-working rather than like a missing file.

arm64 gets `mmaa64.efi`, not `mmx64.efi`; the binary is named for the architecture it runs on.

### Divergences from the 1.6 version

Not a cherry-pick — three things differ:

- `schema.php` uses `array()` and its next step is 279, not 321. Confirmed `count($this->schema) == FOG_SCHEMA` still holds (244 line-start appends + 35 from the `keySequences` loop = 279).
- `bootmenu.class.php` uses `array()` throughout, so the method was rewritten to match. It keeps `??`, which this file already uses for exactly this `$_REQUEST['arch']` lookup a few hundred lines up.
- `pxeID` 14 was independently confirmed free here; 1–13 are taken by the same seed insert plus step 129.

### Verification

- `php -l` clean on all three PHP files; `bash -n` clean on `functions.sh`.
- Executed `_enrollSecureBootChoice()` across all five branches (no key staged, i386, arm64, x86_64, arch absent) and diffed against working-1.6's method — **byte-identical iPXE output**.
- `count($this->schema)` == `FOG_SCHEMA` == 279.

### Not verified

**This has not been run on a live 1.5 server.** The 1.6 version was confirmed end to end on real firmware — PXE → menu item → MokManager → `Enroll key from disk` → reboot → MOK-signed `bzImage` boots — but the schema migration and menu render have not been exercised here. Worth a lab run before merging.

Docs: FOGProject/fog-docs#89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)