### PR TITLE
Secure Boot: publish and document the ipxe.efi fallback chain

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -69,7 +69,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.2');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.3');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -438,6 +438,25 @@ class FOGConfigurationPage extends FOGPage
                 . 'boot file is unsigned and a Secure Boot client will refuse it'
             )
         ) . '</p>';
+        // Two signed chains are staged, mirroring the snponly/ipxe choice
+        // every non-Secure-Boot install already has. shim resolves its second
+        // stage from its OWN filename, so switching chains is purely a DHCP
+        // change -- there is nothing to rename server-side. Documented here
+        // because a site whose firmware SNP is broken otherwise has no way to
+        // know a fallback exists.
+        $steps .= '<p>' . sprintf(
+            '%s <code>secureboot/ipxe-shimx64.efi</code> %s.',
+            _(
+                'If that chain loads but the network never comes up, the '
+                . 'firmware\'s own UEFI network stack is at fault. Point the '
+                . 'boot filename at'
+            ),
+            _(
+                'instead, which uses iPXE\'s built-in NIC drivers rather than '
+                . 'the firmware\'s. Arm64 clients use the files under '
+                . 'secureboot/arm64-efi/'
+            )
+        ) . '</p>';
         // Stated rather than detected: the web request's own scheme says
         // nothing about the install's $httpproto, so guessing here would be
         // worse than telling the admin what to check. See

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3136,6 +3136,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr "Falls dies ein Upgrade ist,"
 
@@ -8396,6 +8401,11 @@ msgid "in seconds"
 msgstr "in Sekunden"
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3135,6 +3135,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -8387,6 +8392,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3203,6 +3203,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -8544,6 +8549,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3136,6 +3136,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr "Falls dies ein Upgrade ist,"
 
@@ -8397,6 +8402,11 @@ msgid "in seconds"
 msgstr "in Sekunden"
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3139,6 +3139,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -8395,6 +8400,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3028,6 +3028,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr "Se questo è un aggiornamento"
 
@@ -8039,6 +8044,11 @@ msgid "in seconds"
 msgstr "in secondi"
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2999,6 +2999,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr "アップグレードの場合"
 
@@ -7964,6 +7969,11 @@ msgid "in seconds"
 msgstr "秒単位"
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2645,6 +2645,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -7098,6 +7103,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 msgid "is already being sent by another node"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3138,6 +3138,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -8391,6 +8396,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3136,6 +3136,11 @@ msgid ""
 "If disabled, the client will not make changes until all users are logged off"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If this is an upgrade"
 msgstr ""
 
@@ -8378,6 +8383,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "initrd (Initial Ramdisk) Update"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 #, fuzzy


### PR DESCRIPTION
## Summary

Secure Boot was the one boot path in FOG with **no fallback loader**. [fog-ipxe#2](https://github.com/FOGProject/fog-ipxe/pull/2) (released as [v2.0.0-fog.3](https://github.com/FOGProject/fog-ipxe/releases/tag/v2.0.0-fog.3)) stages a second signed chain; this points the installer at that release and tells the admin the fallback exists.

## Why a fallback was needed

The two signed loaders fail on disjoint hardware:

- **`snponly.efi`** drives the NIC through the firmware's own UEFI SNP protocol. Right default — it's whatever the vendor shipped and tested — but dead in the water where SNP is broken or absent.
- **`ipxe.efi`** carries iPXE's native drivers and takes the NIC over from the firmware. Recovers exactly those machines, and hangs where the takeover fails.

Non-Secure-Boot installs have always had that choice via DHCP option 67. A Secure Boot site had nothing to move to.

## What changed

**1. `FOG_IPXE_VERSION` → `v2.0.0-fog.3`** — the release that first carries the new chain. Without the bump the paragraph below names a boot file the installer never downloads, which is worse than not documenting it: the admin points DHCP at a path that TFTP 404s and cannot tell that from a broken chain. iPXE itself is unchanged at v2.0.0; only the fog-ipxe packaging moved.

**2. One paragraph on the Secure Boot configuration page**, framed **by symptom rather than by binary**:

> If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at `secureboot/ipxe-shimx64.efi` instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under `secureboot/arm64-efi/`.

An admin hitting this has no way to know the fault is in their firmware's network stack, and "loads but no network" is the only signal that distinguishes the two chains. shim resolves its second stage from its own filename, so switching is purely a DHCP change with nothing to rename server-side.

## Verification

Against the **published** `fog-ipxe-secureboot-v2.0.0-fog.3.tar.gz`:

- Tarball matches its `.sha256` asset.
- Contains all four loaders and both shim names, for x86_64 and arm64.
- Every loader is **byte-identical** to its upstream source in `ipxeboot.tar.gz` (compared against a separately downloaded copy).

No installer logic change: `configureTFTPandPXE` copies the staged tree wholesale, and the `autoexec.ipxe` hard-link loop already covers `secureboot/` and `secureboot/arm64-efi/`.

`php -l` clean. No `FOG_BCACHE_VER` bump needed — PHP only, no JS/CSS touched.

`dev-branch` needs the same two changes and follows as its own PR per the branch convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)