### PR TITLE
Secure Boot: document the ipxe.efi fallback chain, bump fog-ipxe pin

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,6 +62,6 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.2');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.3');
     }
 }

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -495,6 +495,27 @@ class FOGConfigurationPage extends FOGPage
             )
         );
         echo '</p>';
+        // Two signed chains are staged, mirroring the snponly/ipxe choice
+        // every non-Secure-Boot install already has. shim resolves its second
+        // stage from its OWN filename, so switching chains is purely a DHCP
+        // change -- there is nothing to rename server-side. Documented here
+        // because a site whose firmware SNP is broken otherwise has no way to
+        // know a fallback exists.
+        echo '<p>';
+        printf(
+            '%s <code>secureboot/ipxe-shimx64.efi</code> %s.',
+            _(
+                'If that chain loads but the network never comes up, the '
+                . 'firmware\'s own UEFI network stack is at fault. Point the '
+                . 'boot filename at'
+            ),
+            _(
+                'instead, which uses iPXE\'s built-in NIC drivers rather than '
+                . 'the firmware\'s. Arm64 clients use the files under '
+                . 'secureboot/arm64-efi/'
+            )
+        );
+        echo '</p>';
         // Stated rather than detected: the web request's own scheme says
         // nothing about the install's $httpproto, so guessing here would be
         // worse than telling the admin what to check. An HTTPS install skips

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2849,6 +2849,11 @@ msgstr "falls deaktiviert, "
 msgid "If on"
 msgstr "Falls aktiviert,"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 #, fuzzy
 msgid "If there is not a task set"
 msgstr "Wenn keine Aufgabe (Task) aktiviert ist, "
@@ -7684,6 +7689,11 @@ msgstr "in Sekunden"
 #, fuzzy
 msgid "install or update the FOG database"
 msgstr "installieren oder aktualisieren möchten?"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 #, fuzzy
 msgid "is already running with pid: "

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2842,6 +2842,11 @@ msgstr ""
 msgid "If on"
 msgstr "Icon"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 #, fuzzy
 msgid "If there is not a task set"
 msgstr "There is a host in a tasking"
@@ -7670,6 +7675,11 @@ msgstr ""
 #, fuzzy
 msgid "install or update the FOG database"
 msgstr "Are you sure you wish to install or update the FOG database?"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 #, fuzzy
 msgid "is already running with pid: "

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2855,6 +2855,11 @@ msgstr ""
 msgid "If on"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 #, fuzzy
 msgid "If there is not a task set"
 msgstr "Gestión de tareas"
@@ -7604,6 +7609,11 @@ msgstr ""
 #, fuzzy
 msgid "install or update the FOG database"
 msgstr "Fallo al actualziar la base de datos"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 #, fuzzy
 msgid "is already running with pid: "

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2522,6 +2522,11 @@ msgstr "Si c'est désactivé"
 msgid "If on"
 msgstr "Sinon"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr "S'il n'y a pas de tâche définie"
 
@@ -6797,6 +6802,11 @@ msgstr "en secondes"
 
 msgid "install or update the FOG database"
 msgstr "installer ou mettre à jour la base de données du FOG"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 msgid "is already running with pid: "
 msgstr "est déjà en cours d'exécution avec le pid : "

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2576,6 +2576,11 @@ msgstr "Se disabilitato"
 msgid "If on"
 msgstr "Se abilitato"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr "Non c'è alcuna attività impostata"
 
@@ -6916,6 +6921,11 @@ msgstr "in secondi"
 
 msgid "install or update the FOG database"
 msgstr "Installare o aggiornare il database FOG"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 #, fuzzy
 msgid "is already running with pid: "

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2484,6 +2484,11 @@ msgstr "オフの場合"
 msgid "If on"
 msgstr "オンの場合"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr "タスクが設定されていない場合"
 
@@ -6695,6 +6700,11 @@ msgstr "秒単位"
 
 msgid "install or update the FOG database"
 msgstr "FOG データベースをインストールまたは更新"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 msgid "is already running with pid: "
 msgstr "は既に次の PID で実行中です: "

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2468,6 +2468,11 @@ msgstr ""
 msgid "If on"
 msgstr ""
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr ""
 
@@ -6651,6 +6656,11 @@ msgid "in seconds"
 msgstr ""
 
 msgid "install or update the FOG database"
+msgstr ""
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
 msgid "is already running with pid: "

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2503,6 +2503,11 @@ msgstr "Se desligado"
 msgid "If on"
 msgstr "Se ligado"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr "Se não houver uma tarefa definida"
 
@@ -6729,6 +6734,11 @@ msgstr "em segundos"
 
 msgid "install or update the FOG database"
 msgstr "instalar ou atualizar o banco de dados FOG"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 msgid "is already running with pid: "
 msgstr "já está rodando com pid: "

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2498,6 +2498,11 @@ msgstr "如果关机"
 msgid "If on"
 msgstr "如果开机"
 
+msgid ""
+"If that chain loads but the network never comes up, the firmware's own UEFI "
+"network stack is at fault. Point the boot filename at"
+msgstr ""
+
 msgid "If there is not a task set"
 msgstr "如果没有设置任务"
 
@@ -6706,6 +6711,11 @@ msgstr "几秒钟内"
 
 msgid "install or update the FOG database"
 msgstr "安装或更新FOG数据库"
+
+msgid ""
+"instead, which uses iPXE's built-in NIC drivers rather than the firmware's. "
+"Arm64 clients use the files under secureboot/arm64-efi/"
+msgstr ""
 
 msgid "is already running with pid: "
 msgstr "已在运行，PID："


### PR DESCRIPTION
## Summary

Port of #979 to `dev-branch`. [fog-ipxe v2.0.0-fog.3](https://github.com/FOGProject/fog-ipxe/releases/tag/v2.0.0-fog.3) stages a second signed Secure Boot chain, ending the situation where Secure Boot was the one boot path in FOG with **no fallback loader**.

The two signed loaders fail on disjoint hardware:

- **`snponly.efi`** drives the NIC through the firmware's own UEFI SNP protocol. Right default — whatever the vendor shipped and tested — but dead in the water where SNP is broken or absent.
- **`ipxe.efi`** carries iPXE's native drivers and takes the NIC over from the firmware. Recovers exactly those machines, and hangs where the takeover fails.

Non-Secure-Boot installs have always had that choice via DHCP option 67.

## What changed

**1. `FOG_IPXE_VERSION` → `v2.0.0-fog.3`.** Without it the paragraph below names a boot file the installer never downloads — the admin points DHCP at a path that TFTP 404s and cannot tell that from a broken chain. iPXE itself is unchanged at v2.0.0; only the fog-ipxe packaging moved.

**2. One paragraph on the Secure Boot configuration page**, framed by symptom rather than by binary:

> If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at `secureboot/ipxe-shimx64.efi` instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under `secureboot/arm64-efi/`.

## Port notes

Verified this branch actually needs it before porting:

- `downloadipxesecureboot()` exists here (`lib/common/functions.sh:935`) and stages into the same `secureboot/` tree, so the paths named are real on this branch too.
- `FOG_IPXE_VERSION` was on the same `v2.0.0-fog.2` pin.
- The page lives at `fogconfigurationpage.class.php` here vs `.page.php` on 1.6, and emits with successive `echo`/`printf` calls rather than 1.6's accumulated `$steps` string. **Rewritten in this branch's idiom rather than transplanted.**

`php -l` clean. No `FOG_BCACHE_VER` bump needed — PHP only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)