### PR TITLE
Fix doubled slash in the HTTP-to-HTTPS redirect (GH-978)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3681,7 +3681,16 @@ EOF
                         echo "    RewriteRule .* - [F]" >> "$etcconf"
                         echo "    RewriteRule /management/other/ca.cert.der$ - [L]" >> "$etcconf"
                         echo "    RewriteCond %{HTTPS} off" >> "$etcconf"
-                        echo "    RewriteRule (.*) https://%{HTTP_HOST}/\$1 [R,L]" >> "$etcconf"
+                        # GH-978: ^/?(.*)$ rather than (.*). In vhost context a
+                        # RewriteRule pattern is matched against the URL-path
+                        # WITH its leading slash, so (.*) captured "/fog/..."
+                        # and the substitution emitted a Location of
+                        # https://host//fog/... -- a doubled slash. The bare
+                        # (.*) form is .htaccess idiom, where the leading slash
+                        # is stripped for you; it has been wrong here since
+                        # 2017. Apache's MergeSlashes normally hides it, which
+                        # is why it went unreported for so long.
+                        echo "    RewriteRule ^/?(.*)\$ https://%{HTTP_HOST}/\$1 [R,L]" >> "$etcconf"
                         echo "</VirtualHost>" >> "$etcconf"
                         echo "<VirtualHost *:443>" >> "$etcconf"
                         echo "    KeepAlive Off" >> "$etcconf"


### PR DESCRIPTION
## Summary

Reported by @RogerioKoglin in #978 while diagnosing an unrelated boot failure. **Not the cause of that failure** — see the issue for the actual root cause — but a real defect in its own right.

The generated port-80 vhost emitted:

```apache
RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
```

In **virtual-host context** a `RewriteRule` pattern is matched against the URL-path *including* its leading slash. So `$1` captured `/fog/service/...` and the redirect came back as:

```
Location: https://<server>//fog/service/ipxe/boot.php
```

## Why it survived nine years

The bare `(.*)` form is **`.htaccess` idiom**, where Apache strips the leading slash for you. It has been wrong in vhost context since 2b8bacfed (2017), which replaced a `/management/`-only redirect with a blanket one. Apache's `MergeSlashes` (default `On` since 2.4.39) normalises the doubled slash on the way back in, so a visibly wrong `Location` header never became a visibly broken request.

## Fix

```apache
RewriteRule ^/?(.*)$ https://%{HTTP_HOST}/$1 [R,L]
```

Verified the emitted line renders correctly after shell escaping, and `bash -n` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)