### PR TITLE
Add --no-force-https so -S can be undone (GH-978)

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -103,6 +103,8 @@ usage() {
     echo -e "\t-U    --no-upgrade\t\tDon't attempt to upgrade"
     echo -e "\t-H    --no-htmldoc\t\tNo htmldoc, means no PDFs"
     echo -e "\t-S    --force-https\t\tForce HTTPS for all comunication"
+    echo -e "\t      --no-force-https\t\tUndo --force-https: serve both HTTP and"
+    echo -e "\t                     \t\t\tHTTPS without redirecting"
     echo -e "\t-C    --recreate-CA\t\tRecreate the CA Keys"
     echo -e "\t-K    --recreate-keys\t\tRecreate the SSL Keys"
     echo -e "\t      --external-ca\t\tSign FOG's server certificate with an"
@@ -162,7 +164,7 @@ usage() {
 }
 
 shortopts="h?odEUHSCKYyXTFf:c:W:D:B:s:e:N:l"
-longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot"
+longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,no-force-https,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot"
 
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
@@ -241,6 +243,17 @@ while :; do
             ;;
         -S | --force-https)
             shttpproto="https"
+            shift
+            ;;
+        --no-force-https)
+            # GH-978: the counterpart to -S, and the only way back out of it.
+            # httpproto is a managed key, so once -S writes https into
+            # .fogsettings the `[[ -z $httpproto ]] && httpproto="http"` default
+            # can never fire again -- .fogsettings is sourced first. Re-running
+            # without -S therefore kept forcing HTTPS, and hand-editing
+            # .fogsettings was the only escape. Setting shttpproto routes this
+            # through the same override that -S uses, so the two are symmetric.
+            shttpproto="http"
             shift
             ;;
         -K | --recreate-keys)


### PR DESCRIPTION
## Summary

`-S`/`--force-https` had no counterpart, and `httpproto` is a persisted key in `.fogsettings` (see `managedKeys` in `functions.sh`). Once `-S` wrote `https` there, `installfog.sh`'s `[[ -z $httpproto ]] && httpproto="http"` default could **never fire again** — `.fogsettings` is sourced before it.

So re-running the installer *without* `-S` kept forcing HTTPS, and hand-editing `.fogsettings` was the only way back.

That is how #978's reporter ended up hand-patching a hole into the generated Apache vhost: from their side the installer offered no way to say "serve both again", so the only lever left was the config file the installer regenerates.

## Implementation

Routed through `shttpproto` so it uses the same override path `-S` already uses (`[[ -n $shttpproto ]] && httpproto=$shttpproto`) rather than new machinery. The two are now symmetric, and last flag wins.

On this branch it restores the default **dual stack**: `:80` serving content with no redirect, plus a `:443` vhost with `SSLEngine On`. It also flips everything else keyed on `httpproto` — `default.ipxe` goes back to chaining over `http`, and the Secure Boot binaries resume staging (they are skipped on HTTPS installs, since a signed binary cannot be rebuilt to carry a local CA).

## Verification

- `bash -n` clean.
- `getopt` accepts the flag alone, and in either order with `-S`.
- Simulated the `.fogsettings`-sourced startup state:

```
Starting state: .fogsettings has httpproto='https'
  (no flag)          -> httpproto=https   sticky - this was the bug
  -S                 -> httpproto=https   still forced, as intended
  --no-force-https   -> httpproto=http    NOW CLEARED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)