### PR TITLE
Secure Boot enrolment: deliver MOK.der over the network, make it schedulable

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4911,6 +4911,9 @@ $this->schema[] = [
     . "(25, 'Enroll Secure Boot Key', 'Enroll Secure Boot Key will "
     . "chain the client straight to the Secure Boot enrolment menu "
     . "so a technician can enrol this FOG server\'s MOK without "
-    . "hunting for it in the PXE boot menu.', 'lock', '', '', 'fog', "
-    . "'1', 'both')",
+    . "hunting for it in the PXE boot menu. A technician still has "
+    . "to be at the console: MokManager gives up after about 10 "
+    . "seconds with no keypress and boots normally, and reboots if "
+    . "left idle partway through for a few minutes.', 'lock', '', "
+    . "'', 'fog', '1', 'both')",
 ];

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4888,3 +4888,29 @@ $this->schema[] = [
     . "VALUES "
     . "(14, 'fog.enrollsecureboot', 'Enroll Secure Boot Key', '0', '2', NULL)",
 ];
+// 322
+$this->schema[] = [
+    // Lets "Enroll Secure Boot Key" be scheduled like any other task
+    // (against a host or a group) instead of only being reachable by
+    // manually picking pxeID 14 from the boot menu every time. 25 is the
+    // next free ttID -- 23 and 24 were used and later fully removed (see
+    // the two DELETE FROM `taskTypes` steps above), so their ids are not
+    // reused.
+    //
+    // Empty ttKernel/ttKernelArgs: this task type never reaches the
+    // generic kernel-chain path in BootMenu::getTasking() -- it is
+    // special-cased there, the same way ttID 4 (Memtest) already is, to
+    // reuse BootMenu::_enrollSecureBootChoice() instead. Leaving
+    // ttKernelArgs empty also avoids accidentally matching the
+    // type=/mode= regex fallbacks TaskType::isDeploy()/isCapture()/etc.
+    // use for tasks created before those columns existed.
+    "INSERT IGNORE INTO `taskTypes` "
+    . "(`ttID`,`ttName`,`ttDescription`,`ttIcon`,`ttKernel`,"
+    . "`ttKernelArgs`,`ttType`,`ttIsAdvanced`,`ttIsAccess`) "
+    . "VALUES "
+    . "(25, 'Enroll Secure Boot Key', 'Enroll Secure Boot Key will "
+    . "chain the client straight to the Secure Boot enrolment menu "
+    . "so a technician can enrol this FOG server\'s MOK without "
+    . "hunting for it in the PXE boot menu.', 'lock', '', '', 'fog', "
+    . "'1', 'both')",
+];

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2044,10 +2044,9 @@ class BootMenu extends FOGBase
         // app that enumerates SimpleFileSystemProtocol handles. MokManager's
         // own "Enroll key from disk" browser does exactly that, and a normal
         // netboot already puts bzImage/init.xz in front of it this way, so
-        // fetching MOK.der here should make it selectable too, without a USB
-        // stick. Unconfirmed across firmware/iPXE builds for a bare
-        // certificate rather than a kernel/initrd -- keep the USB fallback
-        // text below in case a given machine's MokManager only walks handles
+        // fetching MOK.der here makes it selectable too, without a USB stick
+        // -- confirmed on physical hardware. Keep the USB fallback text below
+        // regardless, in case a given machine's MokManager only walks handles
         // backed by a real block device.
         return [
             "imgfetch $this->_booturl/secureboot/MOK.der MOK.der || "
@@ -2056,9 +2055,12 @@ class BootMenu extends FOGBase
             // and strips them, so they would vanish from the output anyway.
             'echo MOK.der has been downloaded into memory as MOK.der --',
             'echo look for it under Enroll key from disk.',
+            'echo MokManager gives up after about 10 seconds with no',
+            'echo keypress, and reboots if left idle for a few minutes --',
+            'echo be ready before it appears.',
             'echo If it is not listed there, have MOK.der on a',
             'echo FAT-formatted USB stick in this machine instead.',
-            'sleep 5',
+            'sleep 8',
             "chain -ar $mmTarget || "
             . "echo Could not load the Secure Boot enrolment menu. && "
             . "sleep 5 && goto MENU"

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1877,6 +1877,14 @@ class BootMenu extends FOGBase
                     "boot",
                 ];
                 $this->_parseMe($Send);
+            } elseif ($Task->get('typeID') == TaskType::ENROLL_SECUREBOOT) {
+                // Same non-kernel-chain special case as Memtest above --
+                // reuse the exact iPXE lines the manual "Enroll Secure Boot
+                // Key" menu item (pxeID 14) already chains to, so a
+                // scheduled task and a manually-picked menu item can never
+                // drift apart.
+                $Send['secureboot-enroll'] = $this->_enrollSecureBootChoice();
+                $this->_parseMe($Send);
             } else {
                 $this->_printTasking($kernelArgsArray);
             }

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2031,17 +2031,25 @@ class BootMenu extends FOGBase
         $mmTarget = (false !== stripos(($_REQUEST['arch'] ?? ''), 'arm'))
             ? "$this->_booturl/secureboot/arm64-efi/mmaa64.efi"
             : "$this->_booturl/secureboot/mmx64.efi";
-        // MokManager can only read a certificate off a FAT filesystem it can
-        // see -- it has no network stack, so booting it over the network does
-        // NOT deliver MOK.der with it. Say so before chaining, or the tech
-        // arrives at "Enroll key from disk" with nothing to select and no
-        // indication of why.
+        // iPXE's EFI filesystem driver exposes every image it has downloaded
+        // -- kernel, initrd, or a plain imgfetch like this one -- to any EFI
+        // app that enumerates SimpleFileSystemProtocol handles. MokManager's
+        // own "Enroll key from disk" browser does exactly that, and a normal
+        // netboot already puts bzImage/init.xz in front of it this way, so
+        // fetching MOK.der here should make it selectable too, without a USB
+        // stick. Unconfirmed across firmware/iPXE builds for a bare
+        // certificate rather than a kernel/initrd -- keep the USB fallback
+        // text below in case a given machine's MokManager only walks handles
+        // backed by a real block device.
         return [
-            'echo Have MOK.der on a FAT-formatted USB stick in this machine.',
-            'echo MokManager reads it from local media, not from the network.',
+            "imgfetch $this->_booturl/secureboot/MOK.der MOK.der || "
+            . "echo Could not fetch MOK.der over the network.",
             // No quotes in the text: iPXE's tokenizer treats them as quoting
             // and strips them, so they would vanish from the output anyway.
-            'echo Choose Enroll key from disk, then find MOK.der on the stick.',
+            'echo MOK.der has been downloaded into memory as MOK.der --',
+            'echo look for it under Enroll key from disk.',
+            'echo If it is not listed there, have MOK.der on a',
+            'echo FAT-formatted USB stick in this machine instead.',
             'sleep 5',
             "chain -ar $mmTarget || "
             . "echo Could not load the Secure Boot enrolment menu. && "

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2109,7 +2109,7 @@ abstract class FOGPage extends FOGBase
                     );
                     // Sign before upload, not after: the TFTP target may be a
                     // remote storage node, and the key never leaves this host.
-                    self::secureBootSign($tmpfile);
+                    $resigned = self::secureBootSign($tmpfile);
                     $orig = sprintf(
                         '/%s/%s',
                         trim(self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'), '/'),
@@ -2181,7 +2181,10 @@ abstract class FOGPage extends FOGBase
                     $code = HTTPResponseCodes::HTTP_SUCCESS;
                     $this->jsonSend($code, json_encode(
                         [
-                            'msg' => _('File uploaded to storage node!'),
+                            'msg' => $resigned
+                                ? _('File uploaded to storage node and '
+                                    . 're-signed for Secure Boot!')
+                                : _('File uploaded to storage node!'),
                             'title' => _('Update Kernel Success')
                         ]
                     ));
@@ -2234,13 +2237,16 @@ abstract class FOGPage extends FOGBase
      *
      * @throws Exception
      *
-     * @return void
+     * @return bool true if the kernel was actually signed, false if signing
+     *              is not configured on this server -- lets the caller tell
+     *              the admin which one happened rather than a message that
+     *              is true either way.
      */
     protected static function secureBootSign($tmpfile)
     {
         $stagedir = self::secureBootStagingDir();
         if (!$stagedir || dirname($tmpfile) !== $stagedir) {
-            return;
+            return false;
         }
         $output = array();
         $retVal = 1;
@@ -2262,6 +2268,7 @@ abstract class FOGPage extends FOGBase
                 )
             );
         }
+        return true;
     }
     /**
      * Fetches the initrds

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.3143');
+        define('FOG_VERSION', '1.6.0-beta.3144');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 322);
         define('FOG_BCACHE_VER', 269);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -61,7 +61,7 @@ class System
         self::_versionCompare();
         define('FOG_VERSION', '1.6.0-beta.3143');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 321);
+        define('FOG_SCHEMA', 322);
         define('FOG_BCACHE_VER', 269);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -40,6 +40,7 @@ class TaskType extends FOGController
     const FAST_WIPE = 18;
     const NORMAL_WIPE = 19;
     const FULL_WIPE = 20;
+    const ENROLL_SECUREBOOT = 25;
     const DEBUGTASKS = [
         self::DEBUG,
         self::MULTICAST,
@@ -241,12 +242,13 @@ class TaskType extends FOGController
         if ($nums) {
             return array_values(
                 array_diff(
-                    range(1, 24),
+                    range(1, 25),
                     [
                         self::MEMTEST,
                         self::ALL_SNAPINS,
                         self::SINGLE_SNAPIN,
-                        self::WAKE_UP
+                        self::WAKE_UP,
+                        self::ENROLL_SECUREBOOT
                     ]
                 )
             );
@@ -259,7 +261,8 @@ class TaskType extends FOGController
                     self::MEMTEST,
                     self::ALL_SNAPINS,
                     self::SINGLE_SNAPIN,
-                    self::WAKE_UP
+                    self::WAKE_UP,
+                    self::ENROLL_SECUREBOOT
                 ]
             );
     }

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -348,19 +348,17 @@ class FOGConfigurationPage extends FOGPage
         $body .= '<p><strong>' . _('Certificate SHA-256') . '</strong></p>';
         $body .= '<pre>' . Initiator::e($fingerprint) . '</pre>';
         $body .= '<p>' . _(
-            'Check this value matches what the enrolment script prints before '
-            . 'confirming. That comparison is what stops the wrong key being '
-            . 'trusted.'
+            'Check this value against what the enrolment tool shows before '
+            . 'confirming, whether the certificate reached the client on a '
+            . 'USB stick or over the network. That comparison is what stops '
+            . 'the wrong key being trusted.'
         ) . '</p>';
         $body .= '<p><strong>' . _('Enrolment kit') . '</strong></p>';
-        $body .= '<p>' . sprintf(
-            '%s. %s.',
-            _(
-                'Copy all three files onto a USB stick, boot the client from a '
-                . 'stock Ubuntu or Debian live image with Secure Boot left ON, '
-                . 'and run the launcher'
-            ),
-            _('No firmware changes are needed')
+        $body .= '<p>' . _(
+            'For a live-USB enrolment, copy all three files onto a USB '
+            . 'stick, boot the client from a stock Ubuntu or Debian live '
+            . 'image with Secure Boot left ON, and run the launcher. No '
+            . 'firmware changes are needed.'
         ) . '</p>';
         $body .= '<ul>';
         $kitfiles = ['MOK.der', 'fog-enroll-mok.sh', 'fog-enroll-mok.desktop'];
@@ -375,58 +373,53 @@ class FOGConfigurationPage extends FOGPage
             );
         }
         $body .= '</ul>';
+        $body .= '<p>' . sprintf(
+            '%s <a href="%s" target="_blank">%s</a>.',
+            _(
+                'Full step-by-step instructions for this and for enrolling '
+                . 'straight from the PXE boot menu, with no USB stick, are '
+                . 'in the Secure Boot guide:'
+            ),
+            Initiator::e('https://docs.fogproject.org/en/latest/secure-boot-signing'),
+            _('Secure Boot: signing FOS with your own key')
+        ) . '</p>';
         echo $this->_box(_('Secure Boot'), $body, ['color' => 'info']);
 
         // Second card: the actual procedure. The card above answers "is this
-        // configured and what is the key", which is the reference half; on its
-        // own it left an admin holding three files and no idea what to do with
-        // them. The steps below track fog-enroll-mok.sh exactly -- if that
-        // script's prompts change, change these with it.
+        // configured and what is the key", which is the reference half. Full
+        // per-client steps for both enrolment routes live in the linked guide
+        // now rather than being duplicated here -- this card is the summary
+        // and the gotchas that matter regardless of which route is used.
         $steps = '<p>' . _(
             'Signing is already done on this server. The remaining work is '
             . 'per-client and has to be done by someone at the machine -- that '
             . 'is what makes enrolment a deliberate act rather than something '
             . 'a server can do to a client remotely.'
         ) . '</p>';
-        $steps .= '<p><strong>' . _('On each client, once') . '</strong></p>';
-        $steps .= '<ol>';
-        $clientSteps = [
-            _(
-                'Copy the three files above onto a USB stick, keeping them in '
-                . 'the same folder -- the script expects MOK.der beside it.'
-            ),
-            _(
-                'Boot the client from a stock Ubuntu or Debian live image with '
-                . 'Secure Boot left ON. Those images boot under Secure Boot on '
-                . 'their own signed shim, so no firmware changes are needed.'
-            ),
-            _(
-                'Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh '
-                . 'directly). It re-runs itself with sudo.'
-            ),
-            _(
-                'Compare the SHA-256 it prints against the one shown above. If '
-                . 'they differ, stop -- that comparison is the whole security '
-                . 'of this step.'
-            ),
-            _(
-                'Enter a one-time password twice when asked. It only proves at '
-                . 'the next reboot that you are the same person; it is not '
-                . 'stored and does not need to be strong.'
-            ),
-            _(
-                'Reboot. The machine stops on the blue MOK Manager screen: '
-                . 'Enroll MOK, View key 0, Continue, Yes, then the password, '
-                . 'then Reboot.'
-            )
-        ];
-        foreach ($clientSteps as $step) {
-            $steps .= '<li>' . $step . '</li>';
-        }
-        $steps .= '</ol>';
         $steps .= '<p>' . _(
-            'If MOK Manager does not appear, the machine did not boot through '
-            . 'a shim and nothing was enrolled.'
+            'Two routes are covered in the guide linked above: a live USB '
+            . 'with the kit above, or PXE-booting the client and choosing '
+            . 'Enroll Secure Boot Key, which now fetches MOK.der over the '
+            . 'network on its own, with no USB stick needed.'
+        ) . '</p>';
+        $steps .= '<p>' . _(
+            'Secure Boot does not need to be enabled on a client to enrol '
+            . 'its key -- either route works the same way with it off, '
+            . 'which lets you stage enrolment fleet-wide before ever '
+            . 'turning it on.'
+        ) . '</p>';
+        $steps .= '<p>' . _(
+            'Enroll Secure Boot Key is also a task type: schedule it '
+            . 'against a host or a group from Task Scheduling to skip '
+            . 'hunting for the menu item on each machine.'
+        ) . '</p>';
+        $steps .= '<p>' . _(
+            'Whichever route is used, MokManager -- the blue enrolment '
+            . 'screen -- has its own timeouts FOG cannot change: it gives '
+            . 'up and boots normally if nothing is pressed within about 10 '
+            . 'seconds of appearing, and reboots if left idle partway '
+            . 'through for a few minutes. Be at the console before '
+            . 'starting.'
         ) . '</p>';
         $steps .= '<p><strong>' . _('To PXE boot with Secure Boot on')
             . '</strong></p>';


### PR DESCRIPTION
## Summary
- Fetches `MOK.der` into iPXE memory (`imgfetch`) before chaining to MokManager in the "Enroll Secure Boot Key" menu item, so the cert is selectable from "Enroll key from disk" without a USB stick. **Confirmed on physical hardware** -- with Secure Boot both on and off.
- Adds "Enroll Secure Boot Key" as a schedulable task type (ttID 25), so it can be pushed to a host or group like any other task instead of only being reachable by manually picking pxeID 14 from the boot menu every time.
- Updates the Secure Boot config page to link out to the companion doc guide ([fog-docs#91](https://github.com/FOGProject/fog-docs/pull/91)) instead of duplicating the walkthrough, and to surface MokManager's own timeouts and the fact that Secure Boot doesn't need to be enabled to enrol.

## Details
`_enrollSecureBootChoice()` already chains straight to `mmx64.efi`/`mmaa64.efi`; the only change there is imgfetch-ing `MOK.der` first, since iPXE's EFI filesystem driver exposes every downloaded image (kernel, initrd, or a plain imgfetch) to any EFI app -- including MokManager's own file browser -- that enumerates `SimpleFileSystemProtocol` handles. Verified on hardware: the cert shows up and enrolls from there, and it makes no difference whether Secure Boot is currently on or off. The USB-stick instructions stay as a fallback in the echoed text in case a given firmware/MokManager build doesn't expose it this way for a bare certificate.

The new task type is excluded from the generic kernel-chain path in `TaskType::isInitNeededTasking()` (same exclusion list as Memtest/Wake-Up/snapin-only tasks) and special-cased in `BootMenu::getTasking()` right next to the existing Memtest special case, calling the exact same `_enrollSecureBootChoice()` the manual menu item uses -- so a scheduled task and a manually-picked menu item can never drift apart.

`FOG_SCHEMA` is bumped from 321 to 322 alongside the new schema step. The immediately preceding Secure Boot commit hit exactly this bug (schema step added, constant not bumped, so its INSERT silently never ran) -- calling it out here since it's easy to repeat.

MokManager's own timeouts (confirmed on hardware, not timed precisely) are now called out in the echoed iPXE text, the task's description, and the linked doc: roughly 10 seconds to press a key before it gives up and boots normally, and a multi-minute idle timeout that reboots the machine if left partway through. Neither is something FOG controls.

## Not automatable, by design
Investigated whether MokManager's confirmation step itself could be scripted/automated further. It can't, without patching out shim's own security check: `MokManager.c` is a self-contained static binary with no `LoadImage()`/file-execution/scripting capability, and its enrollment path is gated by blocking keyboard reads (`console_get_keystroke`, `console_yes_no`) with no bypass flag or staged variable that skips them. That's the physical-presence requirement Secure Boot MOK enrollment is built around, not a gap in this implementation. The one legitimate way to remove the manual step entirely is architectural (a custom Microsoft-signed shim with FOG's cert baked in as `vendor_cert`), which is a separate, much larger effort outside this PR's scope.

Also considered and deliberately not implemented: having iPXE verify the fetched `MOK.der` against a checksum the server also serves. That check can't mean anything from within iPXE -- a value delivered over the same unauthenticated network path as the file itself is exactly as spoofable as the file. The fingerprint comparison against the FOG web UI (a separate, already-trusted screen) remains the actual security boundary, and is called out more prominently in the updated UI text and docs now that automatic delivery removes the "I carried this file myself" assurance a USB stick gave.

## Test plan
- [x] Manually tested on hardware: Secure Boot on, MOK not yet enrolled, boot to signed shim, select "Enroll Secure Boot Key", confirm MOK.der is listed in "Enroll key from disk" and enrolls successfully.
- [x] Manually tested on hardware: enrolling with Secure Boot off, then switching it on afterward -- no difference in behaviour.
- [x] Confirmed on hardware: full sign -> boot -> deploy chain end to end.
- [x] Run the schema updater against an existing 1.6 install and confirm ttID 25 / pxeID 14 both land correctly and `FOG_SCHEMA` reports 322.
- [ ] Schedule the new "Enroll Secure Boot Key" task type against a host from the Task Scheduling UI and confirm it auto-chains past the boot menu into the same enrolment flow on next PXE boot.

## Also in this PR
- The Kernel Update page's success toast now says explicitly when a downloaded kernel was re-signed for Secure Boot (`FOGPage::secureBootSign()` now returns whether it actually signed vs. no-op'd), instead of the same generic "File uploaded to storage node!" message regardless of whether signing is configured.