### PR TITLE
host: restore the enforce setting's explanation, lost when it left its card

### DIFF
--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -1329,7 +1329,7 @@ class GroupManagement extends FOGPage
             echo _('Auto Logout Settings');
             echo '</h4>';
             echo '<p class="form-text">';
-            echo _('Minimum time limmit for Auto Logout to become active is 5 minutes.');
+            echo _('Minimum time limit for Auto Logout to become active is 5 minutes.');
             echo '</p>';
             echo '</div>';
             echo '<div class="card-body">';

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -469,6 +469,51 @@ class HostManagement extends FOGPage
         $this->jsonSend($code, $msg);
     }
     /**
+     * Builds the enforce checkbox together with its explanatory help text.
+     *
+     * The group page states what this setting actually does in the header of
+     * its own "Enforce Hostname | AD Join Reboots" card (groupModules()). The
+     * host used to carry the same card on its Service Settings tab, but when
+     * the control moved onto the General/Add field lists (9f0e1a3, to line Add
+     * and Edit up) the card went with it -- and the description was the only
+     * place either page explained the setting. A flat field row has no header
+     * to hang that on, so the text rides under the checkbox instead. Keep the
+     * wording byte-identical to groupModules() so the two pages say the same
+     * thing and share one gettext msgid.
+     *
+     * @param mixed $enforce Truthy if the box should render checked.
+     *
+     * @return string
+     */
+    private function _enforceControl($enforce)
+    {
+        return self::makeInput(
+            '',
+            'enforce',
+            '',
+            'checkbox',
+            'enforce',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            ($enforce ? 'checked' : '')
+        )
+        . '<p class="form-text help-block-tight">'
+        . _(
+            'This tells the client to force reboots for host name '
+            . 'changing and AD Joining.'
+        )
+        . '</p>'
+        . '<p class="form-text help-block-tight">'
+        . _(
+            'If disabled, the client will not make changes until all users '
+            . 'are logged off'
+        )
+        . '</p>';
+    }
+    /**
      * Creates a new host.
      *
      * @return void
@@ -618,19 +663,7 @@ class HostManagement extends FOGPage
                 $labelClass,
                 'enforce',
                 _('Enforce Hostname | AD Join Reboots')
-            ) => self::makeInput(
-                '',
-                'enforce',
-                '',
-                'checkbox',
-                'enforce',
-                '',
-                false,
-                false,
-                -1,
-                -1,
-                ($enforce ? 'checked' : '')
-            ),
+            ) => $this->_enforceControl($enforce),
             self::makeLabel(
                 $labelClass,
                 'bootTypeExit',
@@ -880,19 +913,7 @@ class HostManagement extends FOGPage
                 $labelClass,
                 'enforce',
                 _('Enforce Hostname | AD Join Reboots')
-            ) => self::makeInput(
-                '',
-                'enforce',
-                '',
-                'checkbox',
-                'enforce',
-                '',
-                false,
-                false,
-                -1,
-                -1,
-                ($enforce ? 'checked' : '')
-            ),
+            ) => $this->_enforceControl($enforce),
             self::makeLabel(
                 $labelClass,
                 'bootTypeExit',
@@ -1185,19 +1206,7 @@ class HostManagement extends FOGPage
                 $labelClass,
                 'enforce',
                 _('Enforce Hostname | AD Join Reboots')
-            ) => self::makeInput(
-                '',
-                'enforce',
-                '',
-                'checkbox',
-                'enforce',
-                '',
-                false,
-                false,
-                -1,
-                -1,
-                ($enforce ? 'checked' : '')
-            ),
+            ) => $this->_enforceControl($enforce),
             self::makeLabel(
                 $labelClass,
                 'bootTypeExit',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4379,9 +4379,6 @@ msgstr "Mitternacht"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "Minutenwert ist nicht gültig"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4376,9 +4376,6 @@ msgstr "Midnight"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "Minute value is not valid"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4480,9 +4480,6 @@ msgstr "Medianoche"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 #, fuzzy
 msgid "Minute value is not valid"
 msgstr "tipo de tarea no es válida"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4380,9 +4380,6 @@ msgstr "Mitternacht"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "Minutenwert ist nicht gültig"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4381,9 +4381,6 @@ msgstr "Minuit"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "valeur de la minute est pas valide"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4205,9 +4205,6 @@ msgstr "Mezzanotte"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "valore dei minuti non è valido"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4163,9 +4163,6 @@ msgstr "午前 0 時"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "分の値が無効です"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3687,9 +3687,6 @@ msgstr ""
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4380,9 +4380,6 @@ msgstr "meia-noite"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "valor do minuto não é válido"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4376,9 +4376,6 @@ msgstr "午夜"
 msgid "Minimum time limit for Auto Logout to become active is 5 minutes."
 msgstr ""
 
-msgid "Minimum time limmit for Auto Logout to become active is 5 minutes."
-msgstr ""
-
 msgid "Minute value is not valid"
 msgstr "分钟值无效"
 


### PR DESCRIPTION
## What

The **Enforce Hostname | AD Join Reboots** setting on the host page has had no explanation of what it does since 9f0e1a3. This restores it.

## Why

The group page explains the setting in the header of its own card on **Client Settings** (`groupModules()`):

> This tells the client to force reboots for host name changing and AD Joining.
> If disabled, the client will not make changes until all users are logged off.

The host page carried the same card until 9f0e1a3 moved the control onto the General/Add field lists so Add and Edit would line up. The checkbox came across; the card's description did not — and that description was the only place either page said what the setting means. A flat field row has no header to hang it on, so the text now rides under the checkbox as `form-text help-block-tight`, the same pattern the group page already uses for its inline hints.

The two pages keeping *different shapes* is correct and unchanged here: a group's control is a tri-state pusher (No change / Enable on all / Disable on all) with a "Hosts: (varies)" readout, which has no meaning for a single host.

## Changes

- Add `HostManagement::_enforceControl()` — builds the checkbox plus the two help paragraphs. Wording is byte-identical to `groupModules()` so both pages share one gettext msgid.
- Use it in all three host sites that carried byte-identical copies of that input: `add()`, `_addFields()` (the create-and-associate modal), and `hostGeneral()`.
- Fix `limmit` → `limit` in the group Auto Logout card. The host card already said `limit`, so the typo was silently forking one sentence into two msgids and stranding the translation — the pre-commit hook confirms it, the stale msgid drops out of all 9 `.po` files.

No behaviour change: the control, its name, its POST handling and the `HOST_ENFORCE_FIELDS` hook are all untouched.

## Notes

If both `FOG_CLIENT_DISPLAYMANAGER_ENABLED` and `FOG_CLIENT_AUTOLOGOFF_ENABLED` are disabled, the host's Client Settings tab is now just the module grid with empty space below — the enforce card used to fill it. Pre-existing consequence of 9f0e1a3, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)