### PR TITLE
group: send the enforce tri-state's value, not a checkbox's .checked

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         define('FOG_VERSION', '1.6.0-beta.3157');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 322);
-        define('FOG_BCACHE_VER', 269);
+        define('FOG_BCACHE_VER', 270);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -635,7 +635,14 @@
             action = $(this).attr('action'),
             opts = {
                 confirmenforcesend: 1,
-                enforce: $('#enforce')[0].checked ? 1 : 0
+                // #enforce is a tri-state <select> here ('' = no change,
+                // '1'/'0' = force on every host), matching #adEnabled above.
+                // This read was left over from when it was a checkbox: .checked
+                // is undefined on a <select>, so the ternary posted 0 for every
+                // choice -- "Enable on all hosts" disabled them instead, and
+                // "No change" clobbered the whole group. Send the raw value and
+                // let groupModulePost() decide; it already ignores ''.
+                enforce: $('#enforce').val()
             };
         $.apiCall(method,action,opts,function(err) {
             disableModuleEnforceButtons(false);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -864,12 +864,6 @@ msgstr "Boot-Optionen:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1156,8 +1150,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1227,11 +1222,6 @@ msgstr ""
 msgid "Command"
 msgstr "Befehl"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Vollständig"
 
@@ -1286,19 +1276,9 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "Kopie von bereits existierenden"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1927,13 +1907,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingenieur"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2353,6 +2332,10 @@ msgid "File upload stopped by an extension"
 msgstr "Datei-Upload durch eine Erweiterung gestoppt"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Zerstören des Speicherknotens fehlgeschlagen"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Zerstören des Speicherknotens fehlgeschlagen"
 
@@ -2381,6 +2364,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "FOG Einstellungen"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2445,6 +2434,11 @@ msgstr "nutzerfreundlicher Name"
 #, fuzzy
 msgid "Full History"
 msgstr "Login-Verlauf"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3123,11 +3117,6 @@ msgstr "Symbol"
 
 msgid "Icon File not found"
 msgstr "Icon-Datei nicht gefunden"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr "Falls die Zugangsdaten korrekt sind,"
@@ -4678,9 +4667,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4969,9 +4955,6 @@ msgstr "auf dem Dashboard"
 #, fuzzy
 msgid "On Server Size"
 msgstr "Server-Shell"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr "Beim Neustart versuchen wir, automatisch"
@@ -5568,11 +5551,6 @@ msgstr "Neustarten"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Erhalten"
 
@@ -5791,11 +5769,6 @@ msgstr "Routen sollten ein Array oder eine Instanz von Traversable sein"
 msgid "Row"
 msgstr "Zeile"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "Laufende Version"
@@ -5940,8 +5913,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
@@ -7365,6 +7348,12 @@ msgstr "Versuche Snapin-Hash für"
 msgid "Trying image size for"
 msgstr "Versuche Imagegröße für"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Txt muss eine Zeichenfolge sein."
@@ -7936,6 +7925,13 @@ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
+msgstr ""
 
 msgid "Width must be 650 pixels."
 msgstr "Breite muss 650 Pixel betragen"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -866,12 +866,6 @@ msgstr "Boot Options:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1158,8 +1152,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1228,11 +1223,6 @@ msgstr ""
 msgid "Command"
 msgstr "Snapin Command"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Complete"
 
@@ -1287,19 +1277,9 @@ msgstr "Error: Failed to download kernel"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Error: Failed to download kernel"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "Could not create printer"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1927,13 +1907,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Engineer"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2353,6 +2332,10 @@ msgid "File upload stopped by an extension"
 msgstr "File upload stopped by an extension"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Failed to destroy Storage Node"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Failed to destroy Storage Node"
 
@@ -2381,6 +2364,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "FOG Settings"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2445,6 +2434,11 @@ msgstr "Kernel Name"
 #, fuzzy
 msgid "Full History"
 msgstr "Login History"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3122,11 +3116,6 @@ msgstr "Icon"
 
 msgid "Icon File not found"
 msgstr "Icon File not found"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr ""
@@ -4675,9 +4664,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4967,9 +4953,6 @@ msgstr "On Dashboard"
 #, fuzzy
 msgid "On Server Size"
 msgstr "Server Shell"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr ""
@@ -5566,11 +5549,6 @@ msgstr "Reboot"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Receive"
 
@@ -5789,11 +5767,6 @@ msgstr ""
 msgid "Row"
 msgstr "Row"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "Running Version"
@@ -5938,8 +5911,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "There are no images on this server."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "There are no images on this server."
 
 #, fuzzy
@@ -7359,6 +7342,12 @@ msgstr "Snapin Path"
 msgid "Trying image size for"
 msgstr "Snapin Path"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Event must be a string"
@@ -7928,6 +7917,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -878,12 +878,6 @@ msgstr "Opciones de arranque:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1169,8 +1163,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1242,11 +1237,6 @@ msgstr ""
 msgid "Command"
 msgstr ""
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr ""
 
@@ -1303,19 +1293,9 @@ msgstr "Error: No se pudo descargar kernel"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Error: No se pudo descargar kernel"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "No se pudo crear la impresora"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1959,13 +1939,12 @@ msgstr ""
 msgid "Engineer"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2401,6 +2380,10 @@ msgid "File upload stopped by an extension"
 msgstr "Archivo de carga detenido por una prolongación"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "No se ha podido destruir nodo de almacenamiento"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "No se ha podido destruir nodo de almacenamiento"
 
@@ -2429,6 +2412,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "Ajustes del sistema FOG"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2493,6 +2482,11 @@ msgstr "Nombre del núcleo"
 #, fuzzy
 msgid "Full History"
 msgstr "replicador de imagen"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3190,11 +3184,6 @@ msgstr "En "
 
 msgid "Icon File not found"
 msgstr "Icono de archivo no encontrado"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr ""
@@ -4788,9 +4777,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5083,9 +5069,6 @@ msgstr ""
 #, fuzzy
 msgid "On Server Size"
 msgstr "servidor TFTP"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr ""
@@ -5692,11 +5675,6 @@ msgstr "Reiniciar"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 #, fuzzy
 msgid "Receive"
 msgstr "retirar"
@@ -5920,11 +5898,6 @@ msgstr ""
 msgid "Row"
 msgstr "Fila"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "ejecutando la versión"
@@ -6071,8 +6044,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "No hay grupos en este servidor."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "No hay grupos en este servidor."
 
 #, fuzzy
@@ -7509,6 +7492,12 @@ msgstr "Camino snapin"
 msgid "Trying image size for"
 msgstr ""
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Evento debe ser una cadena"
@@ -8082,6 +8071,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -864,12 +864,6 @@ msgstr "Boot-Optionen:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1156,8 +1150,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1227,11 +1222,6 @@ msgstr ""
 msgid "Command"
 msgstr "Befehl"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Vollständig"
 
@@ -1286,19 +1276,9 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "Kopie von bereits existierenden"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1927,13 +1907,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingenieur"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2353,6 +2332,10 @@ msgid "File upload stopped by an extension"
 msgstr "Datei-Upload durch eine Erweiterung gestoppt"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Zerstören des Speicherknotens fehlgeschlagen"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Zerstören des Speicherknotens fehlgeschlagen"
 
@@ -2381,6 +2364,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "FOG Einstellungen"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2445,6 +2434,11 @@ msgstr "nutzerfreundlicher Name"
 #, fuzzy
 msgid "Full History"
 msgstr "Login-Verlauf"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3123,11 +3117,6 @@ msgstr "Symbol"
 
 msgid "Icon File not found"
 msgstr "Icon-Datei nicht gefunden"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr "Falls die Zugangsdaten korrekt sind,"
@@ -4679,9 +4668,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4970,9 +4956,6 @@ msgstr "auf dem Dashboard"
 #, fuzzy
 msgid "On Server Size"
 msgstr "Server-Shell"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr "Beim Neustart versuchen wir, automatisch"
@@ -5569,11 +5552,6 @@ msgstr "Neustarten"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Erhalten"
 
@@ -5792,11 +5770,6 @@ msgstr "Routen sollten ein Array oder eine Instanz von Traversable sein"
 msgid "Row"
 msgstr "Zeile"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "Laufende Version"
@@ -5941,8 +5914,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
@@ -7366,6 +7349,12 @@ msgstr "Versuche Snapin-Hash für"
 msgid "Trying image size for"
 msgstr "Versuche Imagegröße für"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Txt muss eine Zeichenfolge sein."
@@ -7937,6 +7926,13 @@ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
+msgstr ""
 
 msgid "Width must be 650 pixels."
 msgstr "Breite muss 650 Pixel betragen"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -867,12 +867,6 @@ msgstr "Options de démarrage:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1160,8 +1154,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1231,11 +1226,6 @@ msgstr ""
 msgid "Command"
 msgstr "commande snapin"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Achevée"
 
@@ -1290,19 +1280,9 @@ msgstr "Erreur: Impossible de télécharger le noyau"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Erreur: Impossible de télécharger le noyau"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "Impossible de créer l'imprimante"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1931,13 +1911,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingénieur"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2357,6 +2336,10 @@ msgid "File upload stopped by an extension"
 msgstr "File Upload arrêté par une extension"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Impossible de détruire le nœud de stockage"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Impossible de détruire le nœud de stockage"
 
@@ -2385,6 +2368,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "Paramètres BROUILLARD"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2449,6 +2438,11 @@ msgstr "Nom Kernel"
 #, fuzzy
 msgid "Full History"
 msgstr "Historique de connexion"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3126,11 +3120,6 @@ msgstr "Icône"
 
 msgid "Icon File not found"
 msgstr "Icône Fichier introuvable"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr ""
@@ -4680,9 +4669,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4973,9 +4959,6 @@ msgstr "Le tableau de bord"
 #, fuzzy
 msgid "On Server Size"
 msgstr "serveur Shell"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr ""
@@ -5574,11 +5557,6 @@ msgstr "Réinitialiser"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Recevoir"
 
@@ -5797,11 +5775,6 @@ msgstr ""
 msgid "Row"
 msgstr "Rangée"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "Exécution Version"
@@ -5946,8 +5919,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Il n'y a pas d'images sur ce serveur."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
@@ -7367,6 +7350,12 @@ msgstr "snapin Chemin"
 msgid "Trying image size for"
 msgstr "snapin Chemin"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Événement doit être une chaîne"
@@ -7936,6 +7925,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -834,12 +834,6 @@ msgstr "Opzioni di avvio:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1114,8 +1108,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1179,11 +1174,6 @@ msgstr ""
 msgid "Command"
 msgstr "Comando"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Completare"
 
@@ -1235,18 +1225,8 @@ msgstr "Errore: Impossibile scaricare il kernel"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Errore: Impossibile scaricare il kernel"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 msgid "Copy from existing"
 msgstr "Copia da esistenti"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1861,13 +1841,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Ingegnere"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2272,6 +2251,10 @@ msgid "File upload stopped by an extension"
 msgstr "File di caricamento fermato da una estensione"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Impossibile per distruggere il nodo di archiviazione"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Impossibile per distruggere il nodo di archiviazione"
 
@@ -2297,6 +2280,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "Impostazioni FOG"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2359,6 +2348,11 @@ msgstr "Nome amichevole"
 #, fuzzy
 msgid "Full History"
 msgstr "Accesso Storia"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 msgid "Function"
 msgstr "Funzione"
@@ -3015,11 +3009,6 @@ msgstr "Icona"
 
 msgid "Icon File not found"
 msgstr "File Icona non trovato"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr "Se le credenziali sono corrette"
@@ -4498,9 +4487,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4775,9 +4761,6 @@ msgstr "sul cruscotto"
 #, fuzzy
 msgid "On Server Size"
 msgstr "Server Shell"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr "Al riavvio cercheremo di trovare un nuovo nodo"
@@ -5353,11 +5336,6 @@ msgstr "Riavvio"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Ricevere"
 
@@ -5567,11 +5545,6 @@ msgstr "I percorsi devono essere un array o un'istanza di Traversable"
 msgid "Row"
 msgstr "Riga"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 msgid "Running Windows"
 msgstr "Running Windows"
 
@@ -5708,8 +5681,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Non ci sono immagini su questo server"
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "Non ci sono immagini su questo server"
 
 #, fuzzy
@@ -7061,6 +7044,12 @@ msgstr "Cercando hash di Snapin per"
 msgid "Trying image size for"
 msgstr "Prova della dimensione dell'immagine per"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 msgid "Txt must be a string"
 msgstr "Txt deve essere una stringa"
 
@@ -7610,6 +7599,13 @@ msgstr "Quando il plugin viene rimosso, il tasto assegnato rimarrà"
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Dove ottenere aiuto"
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
+msgstr ""
 
 msgid "Width must be 650 pixels."
 msgstr "Larghezza deve essere di 650 pixel."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -820,12 +820,6 @@ msgstr "ブートオプション"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1099,8 +1093,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1164,11 +1159,6 @@ msgstr ""
 msgid "Command"
 msgstr "コマンド"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "完了"
 
@@ -1220,18 +1210,8 @@ msgstr "エラー: initrd のダウンロードに失敗しました"
 msgid "Confirm you would like to download a new kernel"
 msgstr "エラー: カーネルのダウンロードに失敗しました"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 msgid "Copy from existing"
 msgstr "既存の項目からコピー"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1846,13 +1826,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "担当者"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2248,6 +2227,10 @@ msgid "File upload stopped by an extension"
 msgstr "拡張機能によってファイルのアップロードが停止されました"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "ストレージノードの破棄に失敗しました"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "ストレージノードの破棄に失敗しました"
 
@@ -2273,6 +2256,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "FOG 設定"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2336,6 +2325,11 @@ msgstr "表示名"
 #, fuzzy
 msgid "Full History"
 msgstr "全履歴をエクスポート"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 msgid "Function"
 msgstr "関数"
@@ -2986,11 +2980,6 @@ msgstr "アイコン"
 
 msgid "Icon File not found"
 msgstr "アイコンファイルが見つかりません"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr "認証情報が正しい場合"
@@ -4458,9 +4447,6 @@ msgstr ""
 "\"snapinfiles[]\" マルチパートフィールドを使用して、1 つ以上のファイルをアッ"
 "プロードする必要があります"
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 #, fuzzy
 msgid "No groups are being created or selected"
 msgstr "削除するグループが選択されていません"
@@ -4734,9 +4720,6 @@ msgstr "ダッシュボードに表示"
 #, fuzzy
 msgid "On Server Size"
 msgstr "サーバーシェル"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr "再起動後、新しいノードの検出を試みます"
@@ -5314,11 +5297,6 @@ msgstr "再起動"
 msgid "Reboot after deploy"
 msgstr "展開後に再起動"
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "受信"
 
@@ -5520,11 +5498,6 @@ msgstr "ルートは配列または Traversable のインスタンスである�
 msgid "Row"
 msgstr "行"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 msgid "Running Windows"
 msgstr "Windows 実行中"
 
@@ -5666,7 +5639,16 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr ""
+
+msgid "Secure Boot: signing FOS with your own key"
 msgstr ""
 
 #, fuzzy
@@ -6995,6 +6977,12 @@ msgstr "次のスナップインのハッシュを取得しています:"
 msgid "Trying image size for"
 msgstr "次のイメージサイズを取得しています:"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 msgid "Txt must be a string"
 msgstr "Txt は文字列で指定してください"
 
@@ -7544,6 +7532,13 @@ msgstr "プラグインを削除しても、割り当てられたキーは保持
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "ヘルプの入手先"
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
+msgstr ""
 
 msgid "Width must be 650 pixels."
 msgstr "幅は 650 ピクセルである必要があります。"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -721,12 +721,6 @@ msgstr ""
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -968,8 +962,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1032,11 +1027,6 @@ msgstr ""
 msgid "Command"
 msgstr ""
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr ""
 
@@ -1082,17 +1072,7 @@ msgstr ""
 msgid "Confirm you would like to download a new kernel"
 msgstr ""
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 msgid "Copy from existing"
-msgstr ""
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
 msgstr ""
 
 msgid "Copyright"
@@ -1622,13 +1602,12 @@ msgstr ""
 msgid "Engineer"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -1990,6 +1969,9 @@ msgstr ""
 msgid "File upload stopped by an extension"
 msgstr ""
 
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr ""
+
 msgid "File uploaded to storage node!"
 msgstr ""
 
@@ -2012,6 +1994,12 @@ msgid "First row is a header"
 msgstr ""
 
 msgid "Flush Settings Cache"
+msgstr ""
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -2072,6 +2060,11 @@ msgid "Friendly Name"
 msgstr ""
 
 msgid "Full History"
+msgstr ""
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
 msgstr ""
 
 msgid "Function"
@@ -2631,11 +2624,6 @@ msgid "Icon"
 msgstr ""
 
 msgid "Icon File not found"
-msgstr ""
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
 msgstr ""
 
 msgid "If credentials are correct"
@@ -3950,9 +3938,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4194,9 +4179,6 @@ msgid "On Dashboard"
 msgstr ""
 
 msgid "On Server Size"
-msgstr ""
-
-msgid "On each client, once"
 msgstr ""
 
 msgid "On reboot we will try to find a new node"
@@ -4716,11 +4698,6 @@ msgstr ""
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr ""
 
@@ -4907,11 +4884,6 @@ msgstr ""
 msgid "Row"
 msgstr ""
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 msgid "Running Windows"
 msgstr ""
 
@@ -5034,7 +5006,16 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr ""
+
+msgid "Secure Boot: signing FOS with your own key"
 msgstr ""
 
 msgid "See all results"
@@ -6234,6 +6215,12 @@ msgstr ""
 msgid "Trying image size for"
 msgstr ""
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 msgid "Txt must be a string"
 msgstr ""
 
@@ -6709,6 +6696,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -866,12 +866,6 @@ msgstr "Opções de inicialização:"
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1158,8 +1152,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1229,11 +1224,6 @@ msgstr ""
 msgid "Command"
 msgstr "Snapin Command"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "Completo"
 
@@ -1288,19 +1278,9 @@ msgstr "Erro: falha ao baixar do kernel"
 msgid "Confirm you would like to download a new kernel"
 msgstr "Erro: falha ao baixar do kernel"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "Não foi possível criar impressora"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1930,13 +1910,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "Engenheiro"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2356,6 +2335,10 @@ msgid "File upload stopped by an extension"
 msgstr "De upload de arquivos parado por uma extensão"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "Falha ao destruir Storage Node"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "Falha ao destruir Storage Node"
 
@@ -2384,6 +2367,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "Configurações FOG"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2448,6 +2437,11 @@ msgstr "Nome Kernel"
 #, fuzzy
 msgid "Full History"
 msgstr "História de login"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3125,11 +3119,6 @@ msgstr "Ícone"
 
 msgid "Icon File not found"
 msgstr "Ícone do Arquivo não encontrado"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr ""
@@ -4679,9 +4668,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4972,9 +4958,6 @@ msgstr "No Painel"
 #, fuzzy
 msgid "On Server Size"
 msgstr "Shell servidor"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr ""
@@ -5571,11 +5554,6 @@ msgstr "reinicialização"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "Receber"
 
@@ -5794,11 +5772,6 @@ msgstr ""
 msgid "Row"
 msgstr "Linha"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "executando a Versão"
@@ -5943,8 +5916,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "Não há imagens neste servidor."
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "Não há imagens neste servidor."
 
 #, fuzzy
@@ -7363,6 +7346,12 @@ msgstr "Caminho Snapin"
 msgid "Trying image size for"
 msgstr "Caminho Snapin"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "Evento deve ser uma string"
@@ -7932,6 +7921,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -866,12 +866,6 @@ msgstr "启动选项："
 msgid "Boot files from"
 msgstr ""
 
-msgid ""
-"Boot the client from a stock Ubuntu or Debian live image with Secure Boot "
-"left ON. Those images boot under Secure Boot on their own signed shim, so no "
-"firmware changes are needed."
-msgstr ""
-
 msgid "Both"
 msgstr ""
 
@@ -1158,8 +1152,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Check this value matches what the enrolment script prints before confirming. "
-"That comparison is what stops the wrong key being trusted."
+"Check this value against what the enrolment tool shows before confirming, "
+"whether the certificate reached the client on a USB stick or over the "
+"network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -1229,11 +1224,6 @@ msgstr ""
 msgid "Command"
 msgstr "管理单元命令"
 
-msgid ""
-"Compare the SHA-256 it prints against the one shown above. If they differ, "
-"stop -- that comparison is the whole security of this step."
-msgstr ""
-
 msgid "Complete"
 msgstr "完成"
 
@@ -1288,19 +1278,9 @@ msgstr "错误：无法下载内核"
 msgid "Confirm you would like to download a new kernel"
 msgstr "错误：无法下载内核"
 
-msgid ""
-"Copy all three files onto a USB stick, boot the client from a stock Ubuntu "
-"or Debian live image with Secure Boot left ON, and run the launcher"
-msgstr ""
-
 #, fuzzy
 msgid "Copy from existing"
 msgstr "无法创建打印机"
-
-msgid ""
-"Copy the three files above onto a USB stick, keeping them in the same folder "
-"-- the script expects MOK.der beside it."
-msgstr ""
 
 msgid "Copyright"
 msgstr ""
@@ -1928,13 +1908,12 @@ msgstr ""
 msgid "Engineer"
 msgstr "工程师"
 
-msgid "Enrolment kit"
+msgid ""
+"Enroll Secure Boot Key is also a task type: schedule it against a host or a "
+"group from Task Scheduling to skip hunting for the menu item on each machine."
 msgstr ""
 
-msgid ""
-"Enter a one-time password twice when asked. It only proves at the next "
-"reboot that you are the same person; it is not stored and does not need to "
-"be strong."
+msgid "Enrolment kit"
 msgstr ""
 
 msgid "Equipment Loan"
@@ -2354,6 +2333,10 @@ msgid "File upload stopped by an extension"
 msgstr "上传文件通过一个扩展停止"
 
 #, fuzzy
+msgid "File uploaded to storage node and re-signed for Secure Boot!"
+msgstr "未能摧毁存储节点"
+
+#, fuzzy
 msgid "File uploaded to storage node!"
 msgstr "未能摧毁存储节点"
 
@@ -2382,6 +2365,12 @@ msgstr ""
 #, fuzzy
 msgid "Flush Settings Cache"
 msgstr "FOG设置"
+
+msgid ""
+"For a live-USB enrolment, copy all three files onto a USB stick, boot the "
+"client from a stock Ubuntu or Debian live image with Secure Boot left ON, "
+"and run the launcher. No firmware changes are needed."
+msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
 msgstr ""
@@ -2446,6 +2435,11 @@ msgstr "内核名称"
 #, fuzzy
 msgid "Full History"
 msgstr "登录历史记录"
+
+msgid ""
+"Full step-by-step instructions for this and for enrolling straight from the "
+"PXE boot menu, with no USB stick, are in the Secure Boot guide:"
+msgstr ""
 
 #, fuzzy
 msgid "Function"
@@ -3123,11 +3117,6 @@ msgstr "图标"
 
 msgid "Icon File not found"
 msgstr "图标文件未找到"
-
-msgid ""
-"If MOK Manager does not appear, the machine did not boot through a shim and "
-"nothing was enrolled."
-msgstr ""
 
 msgid "If credentials are correct"
 msgstr ""
@@ -4675,9 +4664,6 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
-msgid "No firmware changes are needed"
-msgstr ""
-
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -4966,9 +4952,6 @@ msgstr "仪表板上"
 #, fuzzy
 msgid "On Server Size"
 msgstr "服务器外壳"
-
-msgid "On each client, once"
-msgstr ""
 
 msgid "On reboot we will try to find a new node"
 msgstr ""
@@ -5565,11 +5548,6 @@ msgstr "重启"
 msgid "Reboot after deploy"
 msgstr ""
 
-msgid ""
-"Reboot. The machine stops on the blue MOK Manager screen: Enroll MOK, View "
-"key 0, Continue, Yes, then the password, then Reboot."
-msgstr ""
-
 msgid "Receive"
 msgstr "接收"
 
@@ -5788,11 +5766,6 @@ msgstr ""
 msgid "Row"
 msgstr "行"
 
-msgid ""
-"Run the launcher (fog-enroll-mok.desktop, or fog-enroll-mok.sh directly). It "
-"re-runs itself with sudo."
-msgstr ""
-
 #, fuzzy
 msgid "Running Windows"
 msgstr "运行版本"
@@ -5937,8 +5910,18 @@ msgid ""
 "server's CA would invalidate the signature that makes them bootable."
 msgstr ""
 
+msgid ""
+"Secure Boot does not need to be enabled on a client to enrol its key -- "
+"either route works the same way with it off, which lets you stage enrolment "
+"fleet-wide before ever turning it on."
+msgstr ""
+
 #, fuzzy
 msgid "Secure Boot kernel signing is not configured on this server"
+msgstr "有此服务器上没有图像。"
+
+#, fuzzy
+msgid "Secure Boot: signing FOS with your own key"
 msgstr "有此服务器上没有图像。"
 
 #, fuzzy
@@ -7352,6 +7335,12 @@ msgstr "管理单元路径"
 msgid "Trying image size for"
 msgstr "管理单元路径"
 
+msgid ""
+"Two routes are covered in the guide linked above: a live USB with the kit "
+"above, or PXE-booting the client and choosing Enroll Secure Boot Key, which "
+"now fetches MOK.der over the network on its own, with no USB stick needed."
+msgstr ""
+
 #, fuzzy
 msgid "Txt must be a string"
 msgstr "事件必须是字符串"
@@ -7921,6 +7910,13 @@ msgid "When the plugin is removed, the assigned key will remain"
 msgstr ""
 
 msgid "Where to get help and guides"
+msgstr ""
+
+msgid ""
+"Whichever route is used, MokManager -- the blue enrolment screen -- has its "
+"own timeouts FOG cannot change: it gives up and boots normally if nothing is "
+"pressed within about 10 seconds of appearing, and reboots if left idle "
+"partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Width must be 650 pixels."


### PR DESCRIPTION
## Symptom

Applying **Enforce Hostname | AD Join Reboots** on a group's Client Settings tab reports success but doesn't set what you picked.

## Cause

The control became a tri-state `<select>` (`''` = no change, `'1'`/`'0'` = force on every host) when `groupModules()` gained its no-clobber handling. The click handler in `fog.group.edit.js` still read it as the checkbox it used to be:

```js
enforce: $('#enforce')[0].checked ? 1 : 0
```

`.checked` is `undefined` on a `<select>`, so the ternary posted `0` for **every** choice:

| You pick | Posted | Result |
|---|---|---|
| No change | `0` | **disables every host in the group** |
| Enable on all hosts | `0` | **disables every host in the group** |
| Disable on all hosts | `0` | works, by accident |

The POST itself succeeded either way, which is why it toasts success. Worth noting this is a silent clobber, not just a no-op — "No change" was the one option guaranteed to be safe and it was overwriting the whole group.

## Fix

Send `$('#enforce').val()` and let `groupModulePost()` decide — it already ignores `''` and only acts on `'1'`/`'0'`, so no server change is needed.

The neighbouring `#adEnabled` tri-state never hit this because its form goes through `processForm()`, which serializes the select. This handler hand-builds its payload instead, so the checkbox→select change never reached it.

Also bumps `FOG_BCACHE_VER` 269 → 270 so browsers don't keep serving the stale JS.

## Verified

- `databaseFields['enforce']` → `hostEnforce` maps correctly in `FOGManagerController::perform_update()`, so the server side was never at fault.
- Swept the rest of `fog.group.edit.js` for the same mismatch — the remaining `.checked` reads are all on genuine checkboxes (DataTables row-select handlers, and the AD clear restore map, which explicitly filters `input[type=checkbox]`).
- Host side is unaffected: its enforce is a real checkbox submitted through the general form, where an unchecked box posting nothing is exactly what `filter_has_var()` expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)