### PR TITLE
group: refresh the enforce "Hosts:" readout after applying the tri-state

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         define('FOG_VERSION', '1.6.0-beta.3157');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 322);
-        define('FOG_BCACHE_VER', 270);
+        define('FOG_BCACHE_VER', 271);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -1371,7 +1371,17 @@ class GroupManagement extends FOGPage
             . '<option value="1">' . _('Enable on all hosts') . '</option>'
             . '<option value="0">' . _('Disable on all hosts') . '</option>'
             . '</select>'
-            . '<p class="form-text help-block-tight">'
+            // The hint is server-rendered from the members' current values, so
+            // it goes stale the moment the tri-state is applied over AJAX (the
+            // tab is never re-rendered). Applying '1'/'0' forces every member to
+            // that value, so the resulting state is known without a round trip
+            // -- carry both translated readouts as data-* for the JS to swap in,
+            // the same way makeReloadToggle() hands its labels over. Translation
+            // stays here; the JS only picks.
+            . '<p class="form-text help-block-tight" id="enforce-shared-hint"'
+            . ' data-hosts-label="' . Initiator::e(_('Hosts:')) . '"'
+            . ' data-enabled-label="' . Initiator::e(_('enabled (all)')) . '"'
+            . ' data-disabled-label="' . Initiator::e(_('disabled (all)')) . '">'
             . _('Hosts:') . ' ' . $enfText
             . '</p>';
         $fields = [

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -646,6 +646,26 @@
             };
         $.apiCall(method,action,opts,function(err) {
             disableModuleEnforceButtons(false);
+            // '' was a no-op server-side, so nothing moved; a failure leaves the
+            // members as they were. Only a successful '1'/'0' changes state.
+            if (err || (opts.enforce !== '1' && opts.enforce !== '0')) {
+                return;
+            }
+            // Every member was just forced to the same value, so the readout is
+            // known -- no round trip needed. Translated text comes from the
+            // server via data-*; this only chooses between them.
+            var hint = $('#enforce-shared-hint');
+            hint.text(
+                hint.data('hosts-label') + ' ' + (
+                    opts.enforce === '1' ?
+                    hint.data('enabled-label') :
+                    hint.data('disabled-label')
+                )
+            );
+            // The select is a pending action, not a value display. Leaving it
+            // armed makes the card claim a change is still queued when it has
+            // already been applied, so put it back to the no-clobber default.
+            $('#enforce').val('');
         });
     });
 


### PR DESCRIPTION
## Symptom

Follow-up to #987. With the tri-state now posting correctly, setting **Enable on all hosts** applies fine — but the `Hosts: …` readout under the selector still says `disabled (all)` until you reload the page.

## Cause

The hint is rendered server-side from `_uniformHostValues()`, but the apply goes over AJAX and the tab is never re-rendered. So it keeps showing the state the members were in *before* the change — reporting stale truth, which is worse than reporting nothing.

## Fix

Applying `'1'`/`'0'` forces every member to that value, so the resulting state is known without a round trip. Give the hint an id, carry both translated readouts on it as `data-*`, and let the click handler pick between them:

```php
. '<p class="form-text help-block-tight" id="enforce-shared-hint"'
. ' data-hosts-label="'    . Initiator::e(_('Hosts:'))         . '"'
. ' data-enabled-label="'  . Initiator::e(_('enabled (all)'))  . '"'
. ' data-disabled-label="' . Initiator::e(_('disabled (all)')) . '">'
```

This is the same handoff `FOGPage::makeReloadToggle()` already uses for its pause/resume labels (`fog.common.js:1095`), so translation stays in PHP and the JS only chooses between strings — no English hardcoded in the client.

The update is skipped when the POST failed or the selection was `''` (a server-side no-op), since in neither case did anything move.

Also resets the select to **No change** afterwards. It's a pending action, not a value display; leaving it armed makes the card claim a change is still queued when it's already been applied.

Bumps `FOG_BCACHE_VER` 270 → 271 for the JS change.

## Note

The Auto Logout card's `_sharedAloHint()` on the same tab has the identical staleness, but its fix isn't symmetric — a blank `tme` is a genuine no-op while a number pushes to all, and the "(default on all)" vs "N min (all)" branch depends on the value posted. Left alone here rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)