### PR TITLE
group: refresh the auto-logout "Hosts:" readout after applying

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         define('FOG_VERSION', '1.6.0-beta.3157');
         define('FOG_CHANNEL', 'Beta');
         define('FOG_SCHEMA', 322);
-        define('FOG_BCACHE_VER', 271);
+        define('FOG_BCACHE_VER', 272);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -32,6 +32,18 @@ class GroupManagement extends FOGPage
      */
     public $node = 'group';
     /**
+     * Fewest minutes an auto-logout value can be and still take effect;
+     * anything below this saves as 0 (disabled). Named here because
+     * groupModulePost() enforces it, groupModules() hands it to the JS so the
+     * "Hosts:" readout can predict the result without a round trip, and the two
+     * must agree. The card's own "...is 5 minutes." sentence is deliberately
+     * left as a literal -- folding it in would change the gettext msgid and
+     * strand every existing translation of it.
+     *
+     * @var int
+     */
+    const ALO_MIN_MINUTES = 5;
+    /**
      * Initializes the group page
      *
      * @param string $name the name to construct with
@@ -388,7 +400,18 @@ class GroupManagement extends FOGPage
         } else {
             $text = Initiator::e($info['value']) . ' ' . _('min (all)');
         }
-        return '<p class="form-text help-block-tight">'
+        // Server-rendered from the members' current values, so it goes stale as
+        // soon as the card is applied over AJAX (the tab is never re-rendered).
+        // groupModulePost() forces every member to one value, so the outcome is
+        // predictable client-side -- hand over the translated readouts and the
+        // threshold as data-*, the same way the enforce hint and
+        // makeReloadToggle() do, so translation stays here and the JS only
+        // picks. data-alo-min is what keeps the JS from hardcoding the rule.
+        return '<p class="form-text help-block-tight" id="alo-shared-hint"'
+            . ' data-alo-min="' . self::ALO_MIN_MINUTES . '"'
+            . ' data-hosts-label="' . Initiator::e(_('Hosts:')) . '"'
+            . ' data-default-label="' . Initiator::e(_('(default on all)')) . '"'
+            . ' data-min-label="' . Initiator::e(_('min (all)')) . '">'
             . _('Hosts:') . ' ' . $text
             . '</p>';
     }
@@ -1463,11 +1486,11 @@ class GroupManagement extends FOGPage
         }
         if (isset($_POST['confirmalosend'])) {
             // No-clobber: blank = leave each host's auto-logout alone. A number
-            // pushes to all (under 5 minutes disables it, as before).
+            // pushes to all (below ALO_MIN_MINUTES disables it, as before).
             $raw = filter_input(INPUT_POST, 'tme');
             if ($raw !== null && trim((string)$raw) !== '') {
                 $tme = (int)$raw;
-                if (!($tme > 4)) {
+                if ($tme < self::ALO_MIN_MINUTES) {
                     $tme = 0;
                 }
                 $this->obj->setAlo($tme);

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -613,6 +613,33 @@
             };
         $.apiCall(method,action,opts,function(err) {
             disableModuleAloButtons(false);
+            // Blank is a no-op server-side (no-clobber), and a failure left the
+            // members alone -- in neither case did anything move.
+            var raw = $.trim(String(opts.tme));
+            if (err || raw === '') {
+                return;
+            }
+            // Mirror groupModulePost(): (int) the value, and anything below the
+            // minimum saves as 0 (disabled). The threshold rides in on
+            // data-alo-min from GroupManagement::ALO_MIN_MINUTES rather than
+            // being repeated here, so the two cannot disagree.
+            var hint = $('#alo-shared-hint'),
+                mins = parseInt(raw, 10);
+            if (isNaN(mins) || mins < parseInt(hint.data('alo-min'), 10)) {
+                mins = 0;
+            }
+            hint.text(
+                hint.data('hosts-label') + ' ' + (
+                    mins === 0 ?
+                    hint.data('default-label') :
+                    mins + ' ' + hint.data('min-label')
+                )
+            );
+            // Same reasoning as the enforce select: the field is a pending
+            // action (blank = leave alone), not a display of the current value,
+            // which the hint above now carries. Leaving the number in it reads
+            // as a change still queued.
+            $('#tme').val('');
         });
     });
 


### PR DESCRIPTION
## Symptom

The same staleness #988 fixed for the enforce hint, on the Auto Logout card directly above it. `_sharedAloHint()` renders from the members' current values, but the card applies over AJAX and the tab is never re-rendered — so the readout kept describing the state from *before* the change until a manual reload.

## Fix

`groupModulePost()` forces every member to one value, so the outcome is predictable client-side. Give the hint an id, carry the translated readouts on it as `data-*`, let the click handler pick between them. Translation stays in PHP; the JS only chooses.

## The part that wasn't symmetric

Enforce was a straight mapping (`'1'` → enabled, `'0'` → disabled). Auto Logout is real logic:

- blank → server-side no-op (no-clobber), nothing to update
- `n` below the minimum → saves as **0** (default/disabled), not as `n`
- `n` at or above → saves as `n`

Mirroring that in JS means the `5` threshold would exist in two places and could drift. So instead:

- Added `GroupManagement::ALO_MIN_MINUTES = 5`
- `groupModulePost()` now reads `$tme < self::ALO_MIN_MINUTES` in place of the bare `!($tme > 4)` (behaviour-identical)
- The hint publishes it as `data-alo-min`, and the JS reads it rather than hardcoding

The threshold now lives in exactly one place.

**The card's own "…is 5 minutes." sentence is deliberately left as a literal.** Folding the constant in via `sprintf` would change the gettext msgid and strand every existing translation — and that's the same string #986 just finished repairing after the `limmit` typo had forked it. Not worth re-breaking to remove one cosmetic duplicate.

## Also

Clears the `tme` field after a successful apply, matching the enforce select. It's a pending action (blank = leave alone), not a display of the current value — which the hint now carries.

Bumps `FOG_BCACHE_VER` 271 → 272.

## Checked

- `_sharedAloHint()` has exactly one call site, so the new `id` stays unique.
- The generic `_sharedHint()` used by other cards is untouched.
- `if (isNaN(mins) || …)` guards a non-numeric `tme`, matching PHP's `(int)"abc" === 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)