### PR TITLE
Bump FOG_SCHEMA so the enrollsb task-type step actually runs

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -61,7 +61,18 @@ class System
         self::_versionCompare();
         define('FOG_VERSION', '1.6.0-beta.3157');
         define('FOG_CHANNEL', 'Beta');
-        define('FOG_SCHEMA', 322);
+        // Every added element of $this->schema in commons/schema.php must bump
+        // this by one. It is what DatabaseManager and schemaNeedsDeploy() test
+        // (`mySchema < FOG_SCHEMA`) to decide an update is outstanding; the
+        // updater page's own `count($this->schema) <= mySchema` check only ever
+        // runs once something has sent the admin (or the installer's token)
+        // there. Leaving it behind therefore does not half-apply a step -- it
+        // silently applies nothing at all, on every already-installed server,
+        // while a fresh install still gets the step and looks fine. That is
+        // what happened to schema step 323 (task type 25 -> mode=enrollsb):
+        // added without this bump, so no existing 1.6 server would have picked
+        // it up.
+        define('FOG_SCHEMA', 323);
         define('FOG_BCACHE_VER', 272);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
Follow-up to #990.

Schema step 323 — the `UPDATE taskTypes` that turns task type 25 into the FOS-based **Enroll Secure Boot** (`mode=enrollsb`) — was added without bumping `FOG_SCHEMA`, which is what `DatabaseManager::init()` and `FOGBase::schemaNeedsDeploy()` compare the stored `schemaVersion` against:

```php
if (self::$mySchema >= FOG_SCHEMA) { return new self; }   // databasemanager.class.php:97
return self::$mySchema < FOG_SCHEMA;                       // schemaNeedsDeploy()
```

With the constant left at 322 and an already-updated server storing 323, that short-circuits: the admin is never redirected to the schema updater, and the installer's token bootstrap reports nothing outstanding. The updater page's own `count($this->schema) <= mySchema` guard is downstream of that — it only runs once something has sent you there — so the step never executes.

A fresh install replays the whole array and looks correct, which is why it wasn't obvious. The servers that miss the step are precisely the existing ones it was written for.

Found on the 1.6 lab server: schema at 323, task type 25 still holding the old `working-1.6` "Enroll Secure Boot Key" (MokManager-chaining) definition with an empty `ttKernelArgs`, after a full installer re-run.

Precedent checked rather than assumed — the commit that added the step-322 element (`999ddb818`) bumped the constant 321 → 322 in the same change. One added element, one increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsG8G5CPezfAFFsYiXavEK