### PR TITLE
Correct the FOG_SCHEMA comment from #991

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -61,17 +61,23 @@ class System
         self::_versionCompare();
         define('FOG_VERSION', '1.6.0-beta.3157');
         define('FOG_CHANNEL', 'Beta');
-        // Every added element of $this->schema in commons/schema.php must bump
-        // this by one. It is what DatabaseManager and schemaNeedsDeploy() test
-        // (`mySchema < FOG_SCHEMA`) to decide an update is outstanding; the
-        // updater page's own `count($this->schema) <= mySchema` check only ever
-        // runs once something has sent the admin (or the installer's token)
-        // there. Leaving it behind therefore does not half-apply a step -- it
-        // silently applies nothing at all, on every already-installed server,
-        // while a fresh install still gets the step and looks fine. That is
-        // what happened to schema step 323 (task type 25 -> mode=enrollsb):
-        // added without this bump, so no existing 1.6 server would have picked
-        // it up.
+        // Bumped by one for every element added to $this->schema in
+        // commons/schema.php. It is NOT the element count -- it has drifted
+        // well above it (289 elements at the time of writing) -- and nothing
+        // requires the two to agree. What it must never do is fall BELOW the
+        // element count: DatabaseManager::init() and schemaNeedsDeploy() test
+        // `mySchema < FOG_SCHEMA` to decide whether to send the admin (or the
+        // installer's token bootstrap) to the schema updater, and the updater
+        // then does the real work with `count($this->schema) <= mySchema`. So
+        // this is the coarse gate and the count is the precise one; keeping the
+        // gate comfortably above the count is what makes a genuinely behind
+        // server get there at all.
+        //
+        // Corollary worth knowing before chasing a step that "did not run": a
+        // database storing a vValue ABOVE the element count -- which is what a
+        // 1.5.x carried count does, see SchemaReconciler's docstring -- is
+        // permanently "up to date" from the updater's point of view and will
+        // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 323);
         define('FOG_BCACHE_VER', 272);
         define('FOG_CLIENT_VERSION', '0.13.0');


### PR DESCRIPTION
Corrects the comment I added in #991, which claimed a missed `FOG_SCHEMA` bump means a schema step "silently applies nothing at all, on every already-installed server". That is not how the two checks interact.

`FOG_SCHEMA` (323) has drifted well above the actual element count of `$this->schema` (289). So:

- `mySchema < FOG_SCHEMA` — `DatabaseManager::init()` / `schemaNeedsDeploy()` — trips for any server genuinely behind, with or without a single missed bump. It is the coarse gate that gets you to the updater.
- `count($this->schema) <= mySchema` — the updater page — is what actually decides which elements run.

So the bump in #991 is convention (one element, one increment), not the fix it was described as. The constant is left at 323; only the explanation changes.

The comment now records the condition that *does* strand an indexed step, which is the reverse of what I first wrote: a database whose stored `vValue` is **above** the element count — exactly what a carried 1.5.x count produces, per `SchemaReconciler`'s docstring — is permanently "up to date" and will never run another indexed step. That is the actual reason task type 25 stayed stale on the 1.6 lab server (vValue 323, 289 elements), and it is not visible from either check in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsG8G5CPezfAFFsYiXavEK