### PR TITLE
Pin iPXE to v2.0.0-fog.4 for the restored BIOS command set

### DIFF
--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -29,7 +29,7 @@
 # a given FOG release ships a known iPXE, and bumping it is a deliberate edit
 # rather than whatever happened to be tagged the day someone installed.
 [[ -z $ipxeVer ]] && ipxeVer="$(awk -F\' /"define\('FOG_IPXE_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php 2>/dev/null | tr -d '[[:space:]]')"
-[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.1"
+[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.4"
 fog_udpversion="20250223"
 [[ -z $udpcastsrc ]] && udpcastsrc="../packages/udpcast-${fog_udpversion}.tar.gz"
 [[ -z $udpcastout ]] && udpcastout="udpcast-${fog_udpversion}"

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -86,7 +86,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.3');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.4');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Picks up FOGProject/fog-ipxe#3, which restores the eight commands upstream's `/* Disable commands not historically included in BIOS builds */` block turns off for `PLATFORM_pcbios`.

**Every legacy-BIOS PXE boot currently fails.** `default.ipxe` is generated with `params`, ten `param` lines and a `boot.php##params` chain, and `bootmenu.class.php` emits `param`/`params` 46 more times. Without `PARAM_CMD` the client prints `params: command not found` and dies on `Could not boot: Exec format error`. `CONSOLE_CMD` is the same block: `console --picture` (boot-menu background) and the `console && sanboot --drive 0` gate both silently stop working.

The drift arrived with `f61a90d97`, which copied upstream master's headers wholesale; `a02a2c2cd` caught three other flips from that copy but not these. It only reached users once `182701dd6` stopped shipping committed prebuilt binaries — before that, only `-S/--force-https` installs rebuilt iPXE.

Also bumps the last-resort fallback in `lib/common/config.sh`, still pinned to `v2.0.0-fog.1`, three releases back. It only fires when the `awk` against `system.class.php` returns nothing, but when it fires it should not install a known-broken iPXE.

Servers do not self-heal — `/tftpboot/undionly.kkpxe` is replaced only when the installer re-runs.

**Merge after `v2.0.0-fog.4` is tagged and its release assets are published**, or installs will look for a tarball that does not exist yet.

Verified on a VirtualBox BIOS client against a 1.6 server: fog.3 binary → `params: command not found`; fog.4 binary → full registered-host FOG boot menu.

dev-branch carries the identical bug; ported separately.