### PR TITLE
Pin iPXE to v2.0.0-fog.4 for the restored BIOS command set (1.5)

### DIFF
--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -26,7 +26,7 @@
 # a given FOG release ships a known iPXE, and bumping it is a deliberate edit
 # rather than whatever happened to be tagged the day someone installed.
 [[ -z $ipxeVer ]] && ipxeVer="$(awk -F\' /"define\('FOG_IPXE_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php 2>/dev/null | tr -d '[[:space:]]')"
-[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.1"
+[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.4"
 [[ -z $udpcastsrc ]] && udpcastsrc="../packages/udpcast-20250223.tar.gz"
 [[ -z $udpcastout ]] && udpcastout="udpcast-20250223"
 [[ -z $servicesrc ]] && servicesrc="../packages/service"

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,6 +62,6 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.3');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.4');
     }
 }


### PR DESCRIPTION
Port of #996 to the 1.5 line. Picks up FOGProject/fog-ipxe#3.

1.5 consumes the same fog-ipxe release assets and generates the same `default.ipxe`, so it fails identically — verified against this branch, not assumed: its `default.ipxe` generation emits `params` / `param mac0` / `boot.php##params`, and its `bootmenu.class.php` emits `param`/`params` 73 times. Without `PARAM_CMD` a legacy-BIOS client prints `params: command not found` and dies on `Could not boot: Exec format error`. **Every BIOS PXE boot fails.**

`CONSOLE_CMD` comes from the same upstream block: `console --picture` (boot-menu background) and the `console && sanboot --drive 0` gate both silently stop working.

Also bumps the last-resort fallback in `lib/common/config.sh`, still pinned to `v2.0.0-fog.1`, so a fallback install cannot silently pick a known-broken iPXE.

Servers do not self-heal — `/tftpboot/undionly.kkpxe` is replaced only when the installer re-runs.

**Merge after `v2.0.0-fog.4` is tagged and published.**