### PR TITLE
Hide the Secure Boot enrolment menu item on legacy BIOS boots

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2199,6 +2199,40 @@ class BootMenu extends FOGBase
         $Menus = json_decode(
             Route::getData()
         );
+        // pxeID 14 ("Enroll Secure Boot Key") is meaningless on a legacy BIOS
+        // boot: there is no UEFI variable store to enrol into, so both routes
+        // out of it -- the FOS task (mode=enrollsb) and the direct MokManager
+        // chain -- can only fail. It carries pxeRegOnly=2 so that a technician
+        // never has to repoint a client's boot file to reach it, and that
+        // "always shown" is what put it in front of BIOS clients too.
+        //
+        // Gate on platform, not arch: ia32 UEFI is still UEFI (it gets a
+        // different refusal, with its own reason), and a 64-bit CPU booted in
+        // CSM mode is not UEFI at all -- so arch answers a different question
+        // than the one being asked here.
+        //
+        // Only hide when the platform is positively known not to be EFI.
+        // default.ipxe and every menu emission below post
+        // "param platform ${platform}", so it is reliably present; but an
+        // absent value means unknown, and hiding a working option from a UEFI
+        // client is a worse failure than showing a dead one to a BIOS client.
+        //
+        // FOS keeps its own check (fog.enrollsb refuses BIOS/CSM explicitly).
+        // This is not redundant: a task scheduled server-side cannot know how
+        // the host will next boot, and a host that is BIOS today may be UEFI
+        // tomorrow. This hides what cannot work; FOS explains what happened.
+        if (isset($_REQUEST['platform'])
+            && $_REQUEST['platform'] != 'efi'
+        ) {
+            $Menus->data = array_values(
+                array_filter(
+                    $Menus->data,
+                    function ($Menu) {
+                        return (int)$Menu->id !== 14;
+                    }
+                )
+            );
+        }
         array_map(
             function ($Menu) use (&$Send) {
                 $desc = trim($Menu->description);


### PR DESCRIPTION
pxeID 14 ("Enroll Secure Boot Key") carries `pxeRegOnly=2` so a technician never has to repoint a client's boot file to reach it. "Always shown" also meant always shown to **BIOS-booted clients, where it cannot work** — there is no UEFI variable store to enrol into, so both routes out of the item (the FOS task `mode=enrollsb`, and the direct MokManager chain) can only fail.

Reproduced against a live 1.6 server — POSTing `boot.php` with each platform returns byte-identical menus:

```
platform=pcbios  ->  item fog.enrollsecureboot Enroll Secure Boot Key
platform=efi     ->  item fog.enrollsecureboot Enroll Secure Boot Key
```

**Gate on platform, not arch.** ia32 UEFI is still UEFI and gets its own refusal for its own reason (no Microsoft-signed 32-bit shim); a 64-bit CPU booted in CSM mode is not UEFI at all. `default.ipxe` already posts `param platform ${platform}` and this file already reads it elsewhere.

**Hide only when positively known not to be EFI.** The parameter is reliably present, but absent means unknown — hiding a working option from a UEFI client is a worse failure than showing a dead one to a BIOS client.

| `platform` | item 14 |
|---|---|
| `pcbios` | hidden |
| `efi` | shown |
| absent | shown |

FOS keeps its own check (`fog.enrollsb` refuses BIOS/CSM explicitly). Not redundant: a server-side scheduled task cannot know how the host will next boot, and a host that is BIOS today may be UEFI tomorrow. This hides what cannot work; FOS explains what happened when something reaches it anyway.

Ported to dev-branch separately.