### PR TITLE
Gate the API on uType and stop building the lftp command in a shell (GHSA-2hqx-5ffg-w4c3)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2939,16 +2939,21 @@ abstract class FOGBase
             || (self::schemaNeedsDeploy() && self::installTokenParam());
     }
     /**
-     * Is the current session a FOG administrator?
+     * Is the acting user a FOG administrator (uType 0)?
      *
      * Deliberately not is_authorized(), which is true for any valid user --
      * including uType 1 mobile users -- and whose third clause nominally
-     * admits a registered fog-client. Schema deploys need to mean "an admin is
-     * driving this", nothing looser.
+     * admits a registered fog-client. "An administrator is driving this"
+     * needs to mean exactly that, nothing looser.
+     *
+     * This is the whole of 1.5's authorization model. There is no RBAC on
+     * this branch, so uType 0 vs anything else is the only boundary
+     * available; GHSA-2hqx-5ffg-w4c3 was reported because the API never
+     * consulted it at all.
      *
      * @return bool
      */
-    public static function isSchemaAdmin()
+    public static function isAdminUser()
     {
         if (!self::$FOGUser || !self::$FOGUser->isValid()) {
             return false;
@@ -2967,6 +2972,18 @@ abstract class FOGBase
             );
         }
         return (int)$type === 0;
+    }
+    /**
+     * Is the current session a FOG administrator?
+     *
+     * Kept as the name the schema-deploy path asks the question by; the test
+     * itself is the generic one above, which the API gate shares.
+     *
+     * @return bool
+     */
+    public static function isSchemaAdmin()
+    {
+        return self::isAdminUser();
     }
     /**
      * Does this install have any FOG user rows yet?

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -153,6 +153,61 @@ class Route extends FOGBase
         'task'
     );
     /**
+     * Classes a non-administrator (uType != 0) may reach.
+     *
+     * The uType 1 "mobile" account exists to look at hosts and images and
+     * task them; that is the whole of what this list covers, plus the
+     * association and lookup tables needed to render those objects.
+     *
+     * Everything absent is administrator-only, and absence is the default --
+     * notably storagenode and storagegroup (their ftpUser/ftpPass reach the
+     * root-running replicator and are returned in cleartext by the read
+     * routes), service (the globalSettings table), plugin, ipxe and
+     * pxemenuoptions (boot configuration), and anything a plugin injects via
+     * API_VALID_CLASSES. See _requireAuthorized(); GHSA-2hqx-5ffg-w4c3.
+     *
+     * @var array
+     */
+    public static $nonAdminClasses = array(
+        'group',
+        'groupassociation',
+        'host',
+        'image',
+        'imageassociation',
+        'imagepartitiontype',
+        'imagetype',
+        'macaddressassociation',
+        'multicastsession',
+        'os',
+        'scheduledtask',
+        'snapin',
+        'snapinassociation',
+        'snapingroupassociation',
+        'snapinjob',
+        'snapintask',
+        'task',
+        'taskstate',
+        'tasktype'
+    );
+    /**
+     * Route names a non-administrator (uType != 0) may reach, subject to the
+     * class allowlist above. Read-only: every route that creates, edits or
+     * deletes a record requires an administrator, as does /system/export.
+     * Tasking ('task', 'cancel') is added separately in _requireAuthorized()
+     * because it writes but is the mobile account's entire purpose.
+     *
+     * @var array
+     */
+    public static $nonAdminRoutes = array(
+        'active',
+        'ids',
+        'indiv',
+        'list',
+        'listdetails',
+        'names',
+        'search'
+    );
+    /**
      * Initialize element.
      *
      * @return void
@@ -386,6 +441,12 @@ class Route extends FOGBase
         if (self::$matches
             && is_callable(self::$matches['target'])
         ) {
+            self::_requireAuthorized(
+                isset(self::$matches['name']) ? self::$matches['name'] : '',
+                isset(self::$matches['params']['class'])
+                ? self::$matches['params']['class']
+                : ''
+            );
             call_user_func_array(
                 self::$matches['target'],
                 array_values(self::$matches['params'])
@@ -394,6 +455,61 @@ class Route extends FOGBase
         }
         self::sendResponse(
             HTTPResponseCodes::HTTP_NOT_IMPLEMENTED
+        );
+    }
+    /**
+     * Gates the matched route on the acting user's uType.
+     *
+     * GHSA-2hqx-5ffg-w4c3: authentication was the only test the API ever
+     * made. Any account with a valid token and uAllowAPI set reached every
+     * route on every class -- including PUT /storagenode/<id>/edit, whose
+     * ftpUser/ftpPass/ip land in the root-running replicator's lftp
+     * invocation, and GET /storagenode/<id>, which returns that password in
+     * cleartext. `service` is the globalSettings table, so the same account
+     * could rewrite every FOG setting.
+     *
+     * 1.5 has no RBAC, so uType 0 is the only boundary there is. Rather than
+     * make the API admin-only outright, this keeps the one thing a uType 1
+     * "mobile" account was ever meant to do -- look at hosts and images and
+     * task them -- and requires an administrator for everything else.
+     *
+     * The policy is deliberately deny-by-default: a class absent from
+     * $nonAdminClasses (anything a plugin injects through API_VALID_CLASSES
+     * included) is administrator-only for non-admins. Widening it is a
+     * deliberate edit here, never something a plugin can do by accident.
+     *
+     * Enforced at dispatch rather than per-handler so there is exactly one
+     * place to audit, matching where 1.6 puts its RBAC check.
+     *
+     * @param string $name  The matched route's name.
+     * @param string $class The class the route is acting on, if any.
+     *
+     * @return void
+     */
+    private static function _requireAuthorized($name, $class)
+    {
+        if (self::isAdminUser()) {
+            return;
+        }
+        /**
+         * Dashboard polling. Note this covers /system/status and
+         * /system/info only -- /system/export is a full database dump and
+         * is a separate route, so it falls through to the denial below.
+         */
+        if ($name === 'status') {
+            return;
+        }
+        $allowed = self::fastmerge(
+            self::$nonAdminRoutes,
+            array('task', 'cancel')
+        );
+        if (in_array($name, $allowed, true)
+            && in_array(strtolower((string)$class), self::$nonAdminClasses, true)
+        ) {
+            return;
+        }
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_FORBIDDEN
         );
     }
     /**
@@ -426,6 +542,12 @@ class Route extends FOGBase
             ->set('token', $usertoken)
             ->load('token');
         if ($pwtoken->isValid() && $pwtoken->get('api')) {
+            /**
+             * Bind the token's owner as the acting user. Without this the
+             * request runs with no identity at all, so _requireAuthorized()
+             * below has nothing to test uType against. GHSA-2hqx-5ffg-w4c3.
+             */
+            self::$FOGUser = $pwtoken;
             return;
         }
         $auth = self::$FOGUser->passwordValidate(

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -825,41 +825,57 @@ abstract class FOGService extends FOGBase
                     $itemType,
                     $name
                 );
-                $myAddItem = escapeshellarg($myAddItem);
-                $remItem = escapeshellarg($remItem);
-                $logname = escapeshellarg($logname);
-                $myAddItem = trim($myAddItem, "'");
-                $myAddItem = sprintf(
-                    '"%s"',
-                    $myAddItem
-                );
-                $remItem = trim($remItem, "'");
-                $remItem = sprintf(
-                    '"%s"',
-                    $remItem
-                );
-                $logname = trim($logname, "'");
-                $cmd = "lftp -e 'set xfer:log 1; set xfer:log-file $logname;";
-                $cmd .= "set ftp:list-options -a;set net:max-retries ";
-                $cmd .= "10;set net:timeout 30; $limit mirror -c --parallel=20 ";
-                $cmd .= "$opts ";
+                /**
+                 * GHSA-2hqx-5ffg-w4c3: this used to build one shell string
+                 * and hand it to proc_open(), which runs it through
+                 * `/bin/sh -c`. The storage node's ftpUser, ftpPass and ip
+                 * went in raw -- `-u $username,'$password' $ip` -- so a
+                 * single quote in the password, or anything at all in the
+                 * username or ip, escaped into the shell and executed as
+                 * root, the uid this daemon runs under.
+                 *
+                 * The argv is built as an ARRAY instead, so proc_open()
+                 * execs lftp directly and no shell ever parses these values.
+                 * That removes the class of bug rather than escaping this
+                 * one instance of it.
+                 *
+                 * The paths still need quoting, but for lftp's own script
+                 * parser -- see _lftpQuote(). The previous code called
+                 * escapeshellarg(), stripped the single quotes it had just
+                 * added and re-wrapped the result in double quotes, which
+                 * threw the escaping away and left `$`, backtick and
+                 * backslash live again.
+                 */
+                $script = "set xfer:log 1; set xfer:log-file "
+                    . self::_lftpQuote($logname) . ";";
+                $script .= "set ftp:list-options -a;set net:max-retries ";
+                $script .= "10;set net:timeout 30; $limit mirror -c --parallel=20 ";
+                $script .= "$opts ";
                 if (!empty($includeFile)) {
-                    $includeFile = escapeshellarg($includeFile);
-                    $includeFile = trim($includeFile, "'");
-                    $includeFile = sprintf(
-                        '"%s"',
-                        $includeFile
-                    );
-                    $cmd .= "$includeFile ";
+                    $script .= self::_lftpQuote($includeFile) . ' ';
                 }
-                $cmd .= "--ignore-time -vvv --exclude \".srvprivate\" ";
-                $cmd .= "$myAddItem $remItem;";
-                $cmd2 = sprintf(
-                    "%s exit' -u $username,[Protected] $ip",
-                    $cmd
+                $script .= "--ignore-time -vvv --exclude \".srvprivate\" ";
+                $script .= self::_lftpQuote($myAddItem)
+                    . ' '
+                    . self::_lftpQuote($remItem)
+                    . ';';
+                $script .= 'exit';
+                $cmd = array(
+                    'lftp',
+                    '-e',
+                    $script,
+                    '-u',
+                    "$username,$password",
+                    $ip
                 );
-                $cmd .= "exit' -u $username,'$password' $ip";
-                self::outall(" | CMD: $cmd2");
+                self::outall(
+                    sprintf(
+                        " | CMD: lftp -e '%s' -u %s,[Protected] %s",
+                        $script,
+                        $username,
+                        $ip
+                    )
+                );
                 unset($includeFile, $remItem, $myAddItem);
                 $this->startTasking(
                     $cmd,
@@ -882,9 +898,38 @@ abstract class FOGService extends FOGBase
         }
     }
     /**
+     * Quotes a value for lftp's own script parser.
+     *
+     * The replication script passed to `lftp -e` is parsed by lftp, not by
+     * a shell, so shell escaping is the wrong tool for it (and was actively
+     * harmful -- see replicate_items). lftp treats a double-quoted string as
+     * one word and honours backslash escapes inside it, so escaping the
+     * backslash and the double quote is sufficient to keep a path with
+     * spaces, quotes or metacharacters from splitting into extra lftp
+     * commands. Introduced with GHSA-2hqx-5ffg-w4c3.
+     *
+     * @param string $value the value to quote
+     *
+     * @return string
+     */
+    protected static function _lftpQuote($value)
+    {
+        return sprintf(
+            '"%s"',
+            str_replace(
+                array('\\', '"'),
+                array('\\\\', '\\"'),
+                (string)$value
+            )
+        );
+    }
+    /**
      * Starts taskings
      *
-     * @param string $cmd      The command to start
+     * @param string|array $cmd The command to start. An array is exec'd
+     *                          directly by proc_open() with no shell,
+     *                          which is how any command built from
+     *                          user-controlled values must be passed.
      * @param string $logname  The name of the log to write to
      * @param int    $index    The index to store tasking reference
      * @param mixed  $itemType The type of the item


### PR DESCRIPTION
Fixes the two defects reported in GHSA-2hqx-5ffg-w4c3 (reporter @404-pkj).

## Missing authorization (CWE-862)

`Route::_testAuth()` checked "valid token + `uAllowAPI`" and that was the whole test — `runMatches()` dispatched with no authorization check at all. Any API-enabled account, `uType` 1 included, reached every route on every class:

- `PUT /storagenode/N/edit` as reported, whose `ftpUser`/`ftpPass`/`ip` land in the root-running replicator
- `GET /storagenode/N`, which returns `ftpPass` in cleartext — read access alone is credential disclosure
- the `service` class, i.e. the whole `globalSettings` table
- `GET /system/export`, a full database dump

1.5 has no RBAC, so `uType` 0 is the only boundary available. `Route::_requireAuthorized()` now runs at dispatch: a non-admin gets the read routes plus `task`/`cancel` on hosts, groups, images and snapins — what a `uType` 1 "mobile" account was ever meant to do — and an administrator is required for everything else. The class list is deny-by-default, so anything a plugin injects through `API_VALID_CLASSES` is administrator-only until it is deliberately added here.

`_testAuth()` also binds the token's owner as the acting user. Without that a token request carried no identity for the gate to test; it also means the audit log finally attributes API actions to somebody.

`isSchemaAdmin()` is renamed `isAdminUser()` with the schema-facing name kept as a one-line delegate — the test was already exactly "uType 0, resolved through `USER_TYPE_HOOK` so LDAP admins count".

## Command injection (CWE-78)

`FOGService::replicate_items()` built one shell string and handed it to `proc_open()`, i.e. `/bin/sh -c`. The storage node's `ftpUser`, `ftpPass` and `ip` went in raw — `-u $username,'$password' $ip` — so a quote in the password, or anything at all in the username or ip, ran as root, the uid the replicator runs under. The argv is an array now, so lftp is exec'd directly and no shell parses those values.

The path arguments were not safe either: `escapeshellarg()` was called, the single quotes it added were trimmed off and the result re-wrapped in double quotes, which discarded the escaping and left `$`, backtick and backslash live. They go through `_lftpQuote()` now, which quotes for lftp's own parser — the correct one, since that string is an lftp script.

## Verification

- Decision-table harness over every route name in `defineRoutes()`: 31/31, covering the reported request, the credential-leaking read, `/system/export`, `service`, plugin-injected classes, writes on allowlisted classes, and the mobile read/task surface that must keep working.
- Injection reproduced against the pre-fix string form (marker file created) and confirmed blocked under the array form, with the argv dumped to check lftp receives the script as a single argument and the credential with its metacharacters inert.
- The 1.5 web UI does not call the `/fog/` API router, so the gate's blast radius is headless clients only.

## Known gaps, deliberately not in this PR

- 1.5 does not gate `uType` in the web UI anywhere — no admin test in `attemptLogin()`, no type check in `management/index.php`, and the accesscontrol plugin only hides menu entries with nothing server-side behind them. A `uType` 1 user still gets the full management UI. Closing that means denying login to `uType != 0`, which locks out LDAP 991 accounts.
- Basic auth does not check `uAllowAPI` here the way the token branch does (working-1.6 already fixed this). Reachable in principle, though `PHP_AUTH_USER` usually never reaches PHP under FastCGI.

The CWE-78 half is fixed for working-1.6 separately — RBAC gates who may edit a storage node there, so the reported `uType` path does not exist, but that only raises the bar to reach the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)