### PR TITLE
Stop building the lftp replication command in a shell (GHSA-2hqx-5ffg-w4c3)

### DIFF
--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -738,31 +738,54 @@ abstract class FOGService extends FOGBase
                 $itemType,
                 $name
             );
-            $myAddItem = escapeshellarg($myAddItem);
-            $myAddItem = trim($myAddItem, "'");
-            $myAddItem = '"' . $myAddItem . '"';
-            $remItem = escapeshellarg($remItem);
-            $remItem = trim($remItem, "'");
-            $remItem = '"' . $remItem . '"';
-            $logname = escapeshellarg($logname);
-            $logname = trim($logname, "'");
-            $logname = '"' . $logname . '"';
-            $cmd = "lftp -e 'set xfer:log 1; set xfer:log-file $logname;";
-            $cmd .= "set ftp:list-options -a;set net:max-retries ";
-            $cmd .= "10;set net:timeout 30;$limit mirror -c --parallel=20 ";
-            $cmd .= "$opts ";
+            /**
+             * GHSA-2hqx-5ffg-w4c3: this used to build one shell string and
+             * hand it to proc_open(), which runs it through `/bin/sh -c`.
+             * The storage node's ftpUser, ftpPass and ip went in raw --
+             * `-u {$username},'{$password}' $ip` -- so a single quote in the
+             * password, or anything at all in the username or ip, escaped
+             * into the shell and executed as root, the uid this daemon runs
+             * under. RBAC gates who may edit a storage node on this branch,
+             * but that only raises the bar to reach the primitive; it does
+             * not remove it.
+             *
+             * The argv is built as an ARRAY instead, so proc_open() execs
+             * lftp directly and no shell ever parses these values. That
+             * removes the class of bug rather than escaping this instance.
+             *
+             * The paths still need quoting, but for lftp's own script
+             * parser -- see _lftpQuote(). The previous code called
+             * escapeshellarg(), stripped the single quotes it had just added
+             * and re-wrapped the result in double quotes, which threw the
+             * escaping away and left `$`, backtick and backslash live again.
+             * $logname keeps its bare form now, which also stops wlog()
+             * creating transfer logs with literal double quotes in the name.
+             */
+            $script = 'set xfer:log 1; set xfer:log-file '
+                . self::_lftpQuote($logname) . ';';
+            $script .= "set ftp:list-options -a;set net:max-retries ";
+            $script .= "10;set net:timeout 30;$limit mirror -c --parallel=20 ";
+            $script .= "$opts ";
             if (!empty($includeFile)) {
-                $includeFile = escapeshellarg($includeFile);
-                $includeFile = trim($includeFile, "'");
-                $includeFile = '"' . $includeFile . '"';
-                $cmd .= $includeFile . ' ';
-                ;
+                $script .= self::_lftpQuote($includeFile) . ' ';
             }
-            $cmd .= "--ignore-time -vvv --exclude \".srvprivate\" ";
-            $cmd .= "$myAddItem $remItem;";
-            $cmd2 = $cmd . "exit' -u $username,[redacted] $ip";
-            $cmd .= "exit' -u {$username},'{$password}' $ip";
-            self::outall(" | CMD: $cmd2");
+            $script .= "--ignore-time -vvv --exclude \".srvprivate\" ";
+            $script .= self::_lftpQuote($myAddItem)
+                . ' '
+                . self::_lftpQuote($remItem)
+                . ';';
+            $script .= 'exit';
+            $cmd = [
+                'lftp',
+                '-e',
+                $script,
+                '-u',
+                "{$username},{$password}",
+                $ip
+            ];
+            self::outall(
+                " | CMD: lftp -e '$script' -u $username,[redacted] $ip"
+            );
             unset($includeFile, $remItem, $myAddItem);
             $this->startTasking(
                 $cmd,
@@ -785,9 +808,37 @@ abstract class FOGService extends FOGBase
         }
     }
     /**
+     * Quotes a value for lftp's own script parser.
+     *
+     * The replication script passed to `lftp -e` is parsed by lftp, not by
+     * a shell, so shell escaping is the wrong tool for it (and was actively
+     * harmful -- see replicate_items). lftp treats a double-quoted string as
+     * one word and honours backslash escapes inside it, so escaping the
+     * backslash and the double quote is sufficient to keep a path with
+     * spaces, quotes or metacharacters from splitting into extra lftp
+     * commands. Introduced with GHSA-2hqx-5ffg-w4c3.
+     *
+     * @param string $value the value to quote
+     *
+     * @return string
+     */
+    protected static function _lftpQuote($value)
+    {
+        return '"'
+            . str_replace(
+                ['\\', '"'],
+                ['\\\\', '\\"'],
+                (string)$value
+            )
+            . '"';
+    }
+    /**
      * Starts taskings
      *
-     * @param string $cmd      The command to start
+     * @param string|array $cmd The command to start. An array is exec'd
+     *                          directly by proc_open() with no shell,
+     *                          which is how any command built from
+     *                          user-controlled values must be passed.
      * @param string $logname  The name of the log to write to
      * @param int    $index    The index to store tasking reference
      * @param mixed  $itemType The type of the item


### PR DESCRIPTION
The CWE-78 half of GHSA-2hqx-5ffg-w4c3 (reporter @404-pkj), which affects this branch too.

`FOGService::replicate_items()` built one shell string and handed it to `proc_open()`, i.e. `/bin/sh -c`. The storage node's `ftpUser`, `ftpPass` and `ip` went in raw — `-u {$username},'{$password}' $ip` — so a quote in the password, or anything at all in the username or ip, ran as root, the uid the replicator runs under.

The reported `uType` 1 path does **not** exist on this branch: `runMatches()` already calls `Authorization::requireApiPermission()` and `storagenode` maps to a `storagenode.edit` node, so the missing-authorization half (CWE-862) is dev-branch only. But RBAC only raises the bar to *reach* the primitive — a `storagenode.edit` holder, or anything else that can write the row, still gets root. So the primitive goes.

The argv is an array now, so lftp is exec'd directly and no shell parses those values.

The path arguments were not safe either: `escapeshellarg()` was called, the single quotes it added were trimmed off and the result re-wrapped in double quotes, which discarded the escaping and left `$`, backtick and backslash live. They go through `_lftpQuote()` now, which quotes for lftp's own parser — the correct one, since that string is an lftp script.

Dropping the double quotes off `$logname` also stops `wlog()` creating transfer logs with literal quote characters in the filename.

## Verification

Injection reproduced against the pre-fix string form (marker file created by a password of `x';touch <marker>;'`) and confirmed blocked under the array form, with the argv dumped to check lftp receives the script as a single argument and the credential with its metacharacters inert.

Not deployed — replication is worth a live run before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)