### PR TITLE
Stop publishing autoexec.ipxe to the TFTP root, and pin iPXE v2.0.0-fog.5

### DIFF
--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -26,7 +26,7 @@
 # a given FOG release ships a known iPXE, and bumping it is a deliberate edit
 # rather than whatever happened to be tagged the day someone installed.
 [[ -z $ipxeVer ]] && ipxeVer="$(awk -F\' /"define\('FOG_IPXE_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php 2>/dev/null | tr -d '[[:space:]]')"
-[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.4"
+[[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.5"
 [[ -z $udpcastsrc ]] && udpcastsrc="../packages/udpcast-20250223.tar.gz"
 [[ -z $udpcastout ]] && udpcastout="udpcast-20250223"
 [[ -z $servicesrc ]] && servicesrc="../packages/service"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1003,20 +1003,21 @@ configureTFTPandPXE() {
     cd $workingdir
     # iPXE resolves the bare name "autoexec.ipxe" against its current working
     # URI -- the TFTP directory the running .efi was itself fetched from -- not
-    # against a fixed path. So a binary booted from the root of $tftpdirdst
-    # looks for the script beside itself in the root, while our EMBED-less
-    # binaries under autoexec/ look inside autoexec/. Publish every such path.
+    # against a fixed path. So our EMBED-less binaries under autoexec/ look
+    # inside autoexec/, and the Secure Boot chain's under secureboot/ look
+    # inside secureboot/. Publish every such path.
     #
     # This is what the Secure Boot chain needs: upstream's signed snponly.efi
     # has no script compiled in, so without this it asks for a file that was
     # never created. See GH-960.
     #
     # Every directory an EMBED-less binary can be booted from therefore needs
-    # its own copy, and there are six. Hard link, not copies: they are meant to
-    # be one script, and a link keeps them from drifting -- an admin who edits
-    # the boot logic should not have to know how many copies exist. Only the
-    # root one was linked before, so the four under autoexec/<arch>/ and
-    # secureboot/ silently kept the shipped script after such an edit.
+    # its own copy. Hard link, not copies: they are meant to be one script, and
+    # a link keeps them from drifting -- an admin who edits the boot logic
+    # should not have to know how many copies exist.
+    #
+    # The root of $tftpdirdst is deliberately NOT in this list, and any root
+    # copy left by an earlier release is removed below.
     #
     # Not a symlink -- some TFTP daemons refuse to follow those, and a hard link
     # is indistinguishable from a regular file to every daemon.
@@ -1030,7 +1031,6 @@ configureTFTPandPXE() {
     if [[ -f $tftpdirdst/autoexec/autoexec.ipxe ]]; then
         local autoexecpath
         for autoexecpath in \
-            $tftpdirdst/autoexec.ipxe \
             $tftpdirdst/autoexec/i386-efi/autoexec.ipxe \
             $tftpdirdst/autoexec/arm64-efi/autoexec.ipxe \
             $tftpdirdst/secureboot/autoexec.ipxe \
@@ -1042,6 +1042,34 @@ configureTFTPandPXE() {
             ln -f $tftpdirdst/autoexec/autoexec.ipxe $autoexecpath >>$error_log 2>&1
         done
     fi
+    # Remove any autoexec.ipxe at the root of $tftpdirdst. Earlier releases
+    # linked one there. Dropping it from the list above is not enough on its
+    # own -- an upgrade would leave the existing file in place and the install
+    # would stay broken -- so it is deleted here.
+    #
+    # Nothing we ship at the root reads it. The root holds the EMBED-marked
+    # binaries, which run their compiled-in script; only the EMBED-less ones
+    # under autoexec/ and secureboot/ ever execute a downloaded autoexec.ipxe.
+    #
+    # Every EFI binary nonetheless *downloads* it. efi_probe() calls
+    # efi_autoexec_load() unconditionally, which registers the script before any
+    # driver is connected. An EMBED-marked binary then never executes it --
+    # first_image() returns the embedded script, which sorts ahead of it -- so
+    # nothing ever unregisters it. iPXE has no notion of an image that was
+    # loaded but not wanted, and only fdt/shim images are ever hidden.
+    #
+    # At "boot", initrd_load_all() concatenates every registered non-hidden
+    # image into the ramdisk in registration order. autoexec.ipxe registered
+    # first, so the kernel is handed 2 KB of iPXE script where it expects the
+    # head of init.xz, does not find the compression magic, falls back to
+    # treating the blob as a legacy initrd, and panics with
+    #
+    #     VFS: Unable to mount root fs on "/dev/ram0" or unknown-block(1,0)
+    #
+    # See forums #18213. This costs nothing: the file is a hard link to
+    # autoexec/autoexec.ipxe, so its content -- including any local edit, which
+    # the link shares -- survives in every other published path.
+    rm -f $tftpdirdst/autoexec.ipxe >>$error_log 2>&1
     chown -R $username $tftpdirdst >>$error_log 2>&1
     chown -R $username $webdirdest/service/ipxe >>$error_log 2>&1
     find $tftpdirdst -type d -exec chmod 755 {} \; >>$error_log 2>&1

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.4');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.5');
         // GH-850: the base path is installer-driven. Initiator loads the
         // generated commons/fogpaths.php (written from the installer's
         // $fogprogramdir) before the autoloader runs, so in a normal boot this


### PR DESCRIPTION
A UEFI client booting the default `snponly.efi` or `ipxe.efi` loads the FOS kernel and then dies:

```
Kernel panic - not syncing:
VFS: Unable to mount root fs on "/dev/ram0" or unknown-block(1,0)
```

The kernel is fine and the download is fine. The initrd it is handed is not `init.xz` — it is `autoexec.ipxe` with `init.xz` glued on behind it.

### Mechanism (all of it in iPXE v2.0.0)

1. `efi_probe()` (`interface/efi/efiprefix.c:127`) calls `efi_autoexec_load()` unconditionally, before connecting any driver, embedded script or not.
2. `efi_autoexec_network()` resolves the bare name `autoexec.ipxe` against the current working URI — for a binary booted from the TFTP root, that is the TFTP root — and registers whatever it finds.
3. Embedded images register at `INIT_LATE`, ahead of device probing, so `first_image()` (`usr/autoboot.c:612`) returns the compiled-in `ipxescript` and the autoexec image is **never executed**. `core/image.c:455` unregisters a script only for the duration of its own execution, so an unexecuted one is never unregistered. Nothing hides it either — `image_hide()` has two callers in the tree, `fdtmgmt` and `shimmgmt`.
4. At `boot`, `image/initrd.c:initrd_load_all()` concatenates every registered non-hidden image into the ramdisk in registration order. `autoexec.ipxe` registered first, so it lands at offset 0.

The kernel looks for the XZ magic at the start of the ramdisk, finds `#!ipxe\n# Boot script for...`, gives up on initramfs, falls back to treating the blob as a legacy initrd, cannot mount it as ext4, and panics.

Only binaries with an embedded script are affected — which is precisely the ones we publish at the TFTP root, and precisely the default bootfile. The EMBED-less binaries under `autoexec/` and `secureboot/` *execute* the script, which unregisters it for the duration, so it never reaches the initrd. That is why booting `secureboot/snponly.efi` was a clean workaround.

### Fix

The root copy was never read by anything we ship: the root holds the EMBED-marked binaries, which run their compiled-in script. It only ever armed the trap. Removed from the publish list, and **deleted outright** rather than merely no longer created — an upgrade would otherwise leave every already-broken install broken.

Nothing is lost: it is a hard link to `autoexec/autoexec.ipxe`, so the content, including any local edit the link shares, survives in every other published path. Verified on a live 1.6 tree — all six paths are one inode.

### Behaviour change worth stating plainly

An EMBED-less binary that an admin has manually copied to the TFTP root will stop finding its script and fall through to `netboot()`. No shipped configuration does that; the documented Secure Boot bootfile is `secureboot/snponly.efi`, which keeps its own copy beside it.

### Also in this PR

Pins iPXE to `v2.0.0-fog.5`, which carries the fix for the *other* half of #18213: every EFI binary since the v2.0.0 pin was built without a USB keyboard driver, leaving `ipxe.efi` with no keyboard at the boot menu. Bumped in both places the installer reads — `FOG_IPXE_VERSION` and the `config.sh` fallback, since leaving the fallback behind would silently install the previous release wherever that awk fails.

### Verification

The installer block was run against a simulated TFTP tree seeded the way beta.3187 leaves one: root copy removed, the five legitimate paths still present and still one inode. Not yet verified by a full netboot on affected hardware.

### Upstream

The underlying leak is iPXE's: it should hide or discard an autoexec image it loaded but did not execute, rather than letting it fall into the initrd. This is the server-side fix, which is what matters here — it repairs installs that already have the affected binaries.

Refs GH-960, [forums #18213](https://forums.fogproject.org/topic/18213/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
