### PR TITLE
Add bin/updatefog.sh and fog_git_path/fog_update_channel settings

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -543,6 +543,12 @@ fogprogramdir="${fogprogramdir%/}"
 # file must not silently relocate the install half-way through a run, after
 # config.sh has already derived servicedst/servicelogs from it.
 resolvedfogprogramdir="$fogprogramdir"
+# Same reasoning as resolvedfogprogramdir immediately above: fog_git_path is
+# where THIS run of installfog.sh actually lives, computed by config.sh from
+# $workingdir. Captured here so it can be re-asserted after .fogsettings is
+# sourced below, the same way resolvedfogprogramdir is -- otherwise a stale
+# path recorded from a moved/re-cloned checkout would silently win.
+resolvedfoggitpath="$fog_git_path"
 [[ -z $dnsaddress ]] && dnsaddress=""
 [[ -z $username ]] && username=""
 [[ -z $password ]] && password=""
@@ -585,6 +591,7 @@ case $doupdate in
             # it (see writeFogSettings). Re-assert before doOSSpecificIncludes,
             # which derives snapindir from it.
             fogprogramdir="$resolvedfogprogramdir"
+            fog_git_path="$resolvedfoggitpath"
             doOSSpecificIncludes
             # This was `blexports=$blexports` -- a self-assignment that did
             # nothing, so -E was silently discarded on upgrades: the handler
@@ -926,6 +933,7 @@ while [[ -z $blGo ]]; do
                     linkOptFogDir
                     installUtilities
                     updateStorageNodeCredentials
+                    recordGitUpdateSettings
                     setupFogReporting
                     echo
                     echo " * Setup complete"

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Updates an EXISTING FOG install in place: fetches/checks out the branch
+# mapped from the configured (or given) channel, backs up the handful of
+# files installfog.sh's asset sync can overwrite, re-runs installfog.sh, and
+# reverts on failure. See docs/superpowers or issue #1005 for the design.
+bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
+cd $bindir
+workingdir=$(pwd)
+
+if [[ ! $EUID -eq 0 ]]; then
+    echo "FOG updates must be run as root user"
+    exit 1
+fi
+
+for sbindir in /usr/local/sbin /usr/sbin /sbin; do
+    [[ -d $sbindir ]] || continue
+    case ":${PATH}:" in
+        *:"${sbindir}":*) ;;
+        *) PATH="${PATH}:${sbindir}" ;;
+    esac
+done
+export PATH
+
+usage() {
+    echo -e "Usage: $0 [-h?y] [--channel stable|dev|beta] [--git-path </path>] [--no-revert]"
+    echo -e "\t-h -? --help\t\tDisplay this info"
+    echo -e "\t      --channel\tUpdate channel to track: stable, dev, or beta"
+    echo -e "\t               \t\tdefaults to whatever this server already tracks"
+    echo -e "\t      --git-path\tOverride the git checkout path this server records"
+    echo -e "\t      --no-revert\tOn failure, leave the system as-is instead of"
+    echo -e "\t                 \t\tautomatically reverting to the previous commit"
+    echo -e "\t-y    --yes\t\tSkip the confirmation prompt (for cron/GUI use)"
+    exit 0
+}
+
+shortopts="h?y"
+longopts="help,channel:,git-path:,no-revert,yes"
+optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
+[[ $? -ne 0 ]] && usage
+eval set -- "$optargs"
+
+autoRevert=1
+autoYes=""
+while :; do
+    case $1 in
+        -h | -\? | --help)
+            usage
+            ;;
+        --channel)
+            schannel="$2"
+            shift 2
+            ;;
+        --git-path)
+            if [[ -n "${2}" && "${2}" == /* ]]; then
+                sgitpath="${2%/}"
+            else
+                echo "Error: --git-path requires an absolute path"
+                usage
+            fi
+            shift 2
+            ;;
+        --no-revert)
+            autoRevert=0
+            shift
+            ;;
+        -y | --yes)
+            autoYes="1"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Error: unhandled option '$1'. This is an updater bug --"
+            echo "please report it at https://github.com/FOGProject/fogproject/issues"
+            exit 10
+            ;;
+    esac
+done
+
+[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
+error_log="${workingdir}/error_logs/fog_update_error.log"
+: > "$error_log"
+
+# errorStat (lib/common/functions.sh) exits the process on any non-zero
+# status unless $exitFail is set -- installfog.sh's default, since a failed
+# install step should stop it. updatefog.sh needs the opposite: a failed git
+# fetch/checkout/reset must return control to gitUpdateToChannel() so
+# revertUpdate() can run, not kill the script out from under it. Deliberately
+# NOT exported: the nested `bash installfog.sh` call below is a separate
+# process and should keep errorStat's normal exit-on-failure behavior there.
+exitFail=1
+
+. ../lib/common/functions.sh
+
+# Resolve which install this is updating -- same fog.conf pointer
+# installfog.sh itself reads (GH-850), so this always finds the same install
+# a fresh installfog.sh run on this box would.
+[[ -z $fogprogramdir && -r /etc/fog/fog.conf ]] && . /etc/fog/fog.conf
+[[ -z $fogprogramdir ]] && fogprogramdir="/opt/fog"
+fogprogramdir="${fogprogramdir%/}"
+
+if [[ ! -r "$fogprogramdir/.fogsettings" ]]; then
+    echo " * No existing FOG install found at $fogprogramdir (.fogsettings missing)."
+    echo " * updatefog.sh updates an EXISTING install -- run installfog.sh first."
+    exit 1
+fi
+
+# .fogsettings before config.sh (the opposite order installfog.sh uses on a
+# fresh install): there is always a prior install here, so its recorded
+# osid/osname/docroot/etc. should win over config.sh's first-run defaults,
+# not the other way around. linuxReleaseName_lower is derived from osname
+# rather than re-detected, since only doOSSpecificIncludes' per-distro
+# config.sh actually needs it here.
+. "$fogprogramdir/.fogsettings"
+linuxReleaseName_lower="${osname,,}"
+. ../lib/common/config.sh
+[[ -n $osid ]] && doOSSpecificIncludes >/dev/null
+. ../lib/common/update.sh
+
+[[ -n $sgitpath ]] && fog_git_path="$sgitpath"
+[[ -n $schannel ]] && fog_update_channel="$schannel"
+
+if [[ -z $fog_update_channel ]]; then
+    echo " * No update channel configured for this server, and none given via --channel."
+    echo " * Pass --channel stable|dev|beta."
+    exit 1
+fi
+
+branch=$(channelToBranch "$fog_update_channel") || {
+    echo " * Unknown update channel: $fog_update_channel (expected stable, dev, or beta)"
+    exit 1
+}
+
+echo " * FOG Update"
+echo "   Git path: $fog_git_path"
+echo "   Channel:  $fog_update_channel ($branch)"
+echo
+
+if [[ -z $autoYes ]]; then
+    echo -n " * Continue with this update? (Y/N) "
+    read confirmGo
+    case $confirmGo in
+        [Yy] | [Yy][Ee][Ss]) ;;
+        *)
+            echo " * Update cancelled."
+            exit 0
+            ;;
+    esac
+fi
+
+backupCustomizations
+if ! gitUpdateToChannel; then
+    echo " * Git update failed -- nothing was installed. See $error_log."
+    exit 1
+fi
+
+(cd "$fog_git_path/bin" && bash installfog.sh -Y >>$error_log 2>&1)
+installStatus=$?
+cd "$workingdir"
+
+if [[ $installStatus -eq 0 ]]; then
+    restoreCustomizations
+    echo " * Update completed successfully."
+    exit 0
+fi
+
+echo " * installfog.sh failed (exit $installStatus)."
+if [[ $autoRevert -eq 1 ]]; then
+    revertUpdate
+    echo " * Reverted to the previous commit -- see $error_log for what failed."
+    exit $installStatus
+fi
+echo " * --no-revert given; leaving the system as-is. See $error_log."
+exit $installStatus

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -140,3 +140,18 @@ serviceList="$initdMCfullname $initdIRfullname $initdSRfullname $initdSDfullname
 # from the base, so the window is base .. base + 2 * sessions.
 [[ -z $mcastportmin ]] && mcastportmin=63100
 [[ -z $mcastportmax ]] && mcastportmax=$((mcastportmin + 128))
+# fog_git_path is where THIS running copy of the installer/updater actually
+# lives -- not a memory of a prior location. $workingdir is already this
+# checkout's bin/ directory by the time config.sh is sourced (both
+# installfog.sh and updatefog.sh cd there and set it before sourcing this
+# file), so the checkout root is always workingdir's parent. Recomputed
+# unconditionally (no `[[ -z ]]` guard) because, like fogprogramdir, it is a
+# RECORD once persisted to .fogsettings, not a control -- see writeUpdateFile.
+[[ -n $workingdir ]] && fog_git_path="$(cd "$workingdir/.." && pwd)"
+# fog_update_channel IS a genuine persisted preference (see writeUpdateFile),
+# so this default only matters on a first install -- .fogsettings carries an
+# admin's actual choice forward on every upgrade after that. Derived from
+# whatever branch is already checked out; left unset if that is not one of
+# the three known channel branches (e.g. a feature/PR branch, or no git repo
+# at all for a tarball install) rather than guessing.
+[[ -z $fog_update_channel ]] && fog_update_channel="$(branchToChannel "$(git -C "$fog_git_path" rev-parse --abbrev-ref HEAD 2>/dev/null)" 2>/dev/null)"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -44,6 +44,30 @@ linkIfAbsent() {
     [[ -e $link || -L $link ]] && return 0
     ln -s "$target" "$link" >>$error_log 2>&1
 }
+# Maps a FOG update channel name to the git branch it tracks. Mirrors
+# fog-docs/docs/installation/server/install-fog-server.md's "Choosing a FOG
+# version" section -- codified here so bin/updatefog.sh and lib/common/config.sh
+# share one mapping instead of each guessing at it.
+channelToBranch() {
+    case "$1" in
+        stable) echo "stable" ;;
+        dev) echo "dev-branch" ;;
+        beta) echo "working-1.6" ;;
+        *) return 1 ;;
+    esac
+}
+# The inverse of channelToBranch(), used to derive a sensible fog_update_channel
+# default from whatever branch happens to be checked out. Echoes nothing for a
+# branch that is not one of the three channels -- a feature/PR branch has no
+# channel, and guessing one would be worse than leaving it for the admin to set.
+branchToChannel() {
+    case "$1" in
+        stable) echo "stable" ;;
+        dev-branch) echo "dev" ;;
+        working-1.6) echo "beta" ;;
+        *) return 1 ;;
+    esac
+}
 backupReports() {
     dots "Backing up user reports"
     [[ ! -d ../rpttmp/ ]] && mkdir ../rpttmp/ >>$error_log
@@ -119,6 +143,17 @@ updateStorageNodeCredentials() {
     dots "Ensuring node username and passwords match"
     curl -s -k -X POST -d "nodePass" -d "ip=$(echo -n $ipaddress|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "fogverified" $httpproto://$ipaddress${webroot}/maintenance/create_update_node.php
     echo "Done"
+}
+# Mirrors fog_git_path/fog_update_channel into globalSettings so the GUI can
+# show them without SSH. Like fogprogramdir's mirror into /etc/fog/fog.conf
+# (GH-850), these are RECORDS, not controls: .fogsettings stays the source of
+# truth, and the next installfog.sh/updatefog.sh run overwrites whatever an
+# admin may have hand-edited here through the generic Settings tab.
+recordGitUpdateSettings() {
+    dots "Recording fog_git_path/update channel"
+    mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_GIT_PATH', 'Filesystem path of the FOG git checkout on this server. Recorded automatically by installfog.sh/updatefog.sh -- editing it here has no effect on the next update.', \"$fog_git_path\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"$fog_git_path\"" $mysqldbname >>$error_log 2>&1
+    mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_UPDATE_CHANNEL', 'Update channel this server tracks: stable, dev, or beta.', \"$fog_update_channel\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"$fog_update_channel\"" $mysqldbname >>$error_log 2>&1
+    errorStat $?
 }
 backupDB() {
     # ---------------------------------------------------------
@@ -3092,6 +3127,17 @@ writeUpdateFile() {
         # decision. Without it, an admin who answered "leave it alone" would
         # be re-asked every upgrade, and under -y would simply be overridden.
         fwconfigure
+        # fog_git_path is a RECORD like fogprogramdir (GH-850), not a control --
+        # installfog.sh re-asserts the value it actually resolved after sourcing
+        # this file (see resolvedfoggitpath), so a stale path left over from a
+        # moved/re-cloned checkout does not silently point bin/updatefog.sh at a
+        # directory that may no longer exist.
+        #
+        # fog_update_channel IS a genuine persisted preference -- which channel
+        # to track -- closer to secureboot/fwconfigure above than to
+        # fogprogramdir: an admin's choice of stable/dev/beta must carry forward
+        # on every upgrade, not just on the run it was made.
+        fog_git_path fog_update_channel
     )
     # Keys written by older installers that must be stripped on upgrade.
     local -a deprecatedKeys=( storageftpuser storageftppass bootfilename notpxedefaultfile php_verAdds )

--- a/lib/common/update.sh
+++ b/lib/common/update.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Functions used only by bin/updatefog.sh: backing up/restoring the handful of
+# files installfog.sh's ipxe asset sync can overwrite, and the git
+# fetch/checkout/revert cycle around a channel update. Kept out of
+# functions.sh, which installfog.sh alone already runs to nearly 5000 lines.
+#
+# All paths below are derived from $webdirdest (set by lib/common/utils.sh
+# from docroot/webroot, both restored from .fogsettings before this file is
+# sourced), never hardcoded -- see fog_git_updater.sh's history of assuming
+# /var/www/html/fog for why that matters.
+[[ -z $updateBackupDir ]] && updateBackupDir="${fogprogramdir}/update-backup"
+
+# The custom PXE background and the kernel/init set installfog.sh's ipxe
+# asset sync can silently overwrite with FOG's own defaults. refind is
+# optional/legacy -- only backed up if actually present.
+_updateAssetFiles() {
+    echo "bg.png bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz refind.conf refind.efi refind_x64.efi refind_ia32.efi refind_aa64.efi"
+}
+
+backupCustomizations() {
+    dots "Backing up customizations before update"
+    local ipxedir="${webdirdest}service/ipxe" f st=0
+    mkdir -p "$updateBackupDir" >>$error_log 2>&1 || st=1
+    for f in $(_updateAssetFiles); do
+        [[ -f "$ipxedir/$f" ]] && { cp -f "$ipxedir/$f" "$updateBackupDir/$f" >>$error_log 2>&1 || st=1; }
+    done
+    errorStat $st
+}
+
+# Success path: put the custom background and any refind files back over
+# whatever installfog.sh just installed. The kernel set is deliberately left
+# alone here -- the point of an update is to pick up the latest kernel; the
+# backup stays on disk purely as the manual/revert fallback below.
+restoreCustomizations() {
+    dots "Restoring customizations after update"
+    local ipxedir="${webdirdest}service/ipxe" f st=0
+    for f in bg.png refind.conf refind.efi refind_x64.efi refind_ia32.efi refind_aa64.efi; do
+        [[ -f "$updateBackupDir/$f" ]] && { cp -f "$updateBackupDir/$f" "$ipxedir/$f" >>$error_log 2>&1 || st=1; }
+    done
+    chown -R ${username}:${apacheuser} "$ipxedir" >>$error_log 2>&1
+    errorStat $st
+}
+
+# Revert path only: puts the previous kernel/init set back, on top of
+# whatever restoreCustomizations() already restored.
+_restorePreviousKernel() {
+    dots "Restoring previous kernel set"
+    local ipxedir="${webdirdest}service/ipxe" f st=0
+    for f in bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz; do
+        [[ -f "$updateBackupDir/$f" ]] && { cp -f "$updateBackupDir/$f" "$ipxedir/$f" >>$error_log 2>&1 || st=1; }
+    done
+    chown -R ${username}:${apacheuser} "$ipxedir" >>$error_log 2>&1
+    errorStat $st
+}
+
+# Fetches, checks out, and hard-resets $fog_git_path to the branch mapped
+# from $fog_update_channel. Sets $updatePrevCommit (module-global, read by
+# revertUpdate below) to the commit HEAD was at before touching anything.
+gitUpdateToChannel() {
+    local branch st
+    branch=$(channelToBranch "$fog_update_channel") || {
+        echo " * Unknown update channel: $fog_update_channel (expected stable, dev, or beta)"
+        return 1
+    }
+    updatePrevCommit=$(git -C "$fog_git_path" rev-parse HEAD 2>>$error_log)
+    dots "Fetching FOG (${fog_update_channel} / ${branch})"
+    git -C "$fog_git_path" fetch --all >>$error_log 2>&1
+    st=$?
+    errorStat $st
+    [[ $st -ne 0 ]] && return 1
+    dots "Checking out ${branch}"
+    git -C "$fog_git_path" checkout "$branch" >>$error_log 2>&1
+    st=$?
+    errorStat $st
+    [[ $st -ne 0 ]] && return 1
+    dots "Resetting to origin/${branch}"
+    git -C "$fog_git_path" reset --hard "origin/${branch}" >>$error_log 2>&1
+    st=$?
+    errorStat $st
+    return $st
+}
+
+# Failure path: put the git checkout back where it was, re-run installfog.sh
+# against the reverted commit, and ONLY THEN restore every backed up file
+# (including the kernel set, unlike the success path).
+#
+# The restore must come AFTER the re-install, not before: installfog.sh's own
+# asset sync is what can overwrite bg.png/the kernel set in the first place,
+# and that re-install attempt can itself fail partway through -- after it has
+# already re-overwritten those files but before it finishes. Restoring first
+# and re-installing second left exactly that case with the fresh defaults
+# still in place instead of the admin's customizations, which defeats the
+# entire point of a revert. Restoring last guarantees the final state on disk
+# has the customizations back no matter how the re-install attempt goes.
+revertUpdate() {
+    echo " * Reverting to the previous commit ($updatePrevCommit)"
+    dots "Reverting git checkout"
+    git -C "$fog_git_path" reset --hard "$updatePrevCommit" >>$error_log 2>&1
+    errorStat $?
+    dots "Re-running installfog.sh against the reverted commit"
+    (cd "$fog_git_path/bin" && bash installfog.sh -Y >>$error_log 2>&1)
+    errorStat $?
+    _restorePreviousKernel
+    restoreCustomizations
+}


### PR DESCRIPTION
## Summary

Part of #1005 (Phase 1 of a 6-phase install/update roadmap — see that issue for the full roadmap and design notes).

- Adds `bin/updatefog.sh`: fetches/checks out the branch mapped from a `stable`/`dev`/`beta` channel, backs up the custom PXE background, kernel set, and refind files that `installfog.sh`'s asset sync can overwrite, re-runs `installfog.sh`, and auto-reverts (git + files + re-install) on failure.
- Adds `fog_git_path`/`fog_update_channel`, persisted in `.fogsettings` (following the existing `writeUpdateFile()` managed-keys pattern) and mirrored into `globalSettings` for a future GUI (#1009) to read without SSH.
- Adds `channelToBranch()`/`branchToChannel()` in `lib/common/functions.sh`, matching the channel/branch mapping already documented in `fog-docs`.

Two corrections made from the original issue design, called out in the issue and in `lib/common/update.sh`'s comments:
1. Settings live in `.fogsettings`, not `/etc/fog/fog.conf` — `fog.conf` has an explicit existing comment that it holds only `fogprogramdir`.
2. `revertUpdate()` restores customizations **after** re-running `installfog.sh`, not before — the re-install itself can re-overwrite those files on its way to a second failure.

## Test plan

Verified via a synthetic dry run (fake `.fogsettings`, fake git repo with a local `origin` remote, a stubbed `installfog.sh`, and a stubbed `dnf` on `PATH` so the real `doOSSpecificIncludes` → `lib/redhat/config.sh` path ran unmodified):
- [x] `channelToBranch`/`branchToChannel` round-trip correctly for all 3 channels, reject unknown input
- [x] Flag parsing (`--channel`, `--git-path`, `--no-revert`, `-y`) handles valid and invalid input
- [x] Success path: backup → fetch/checkout/reset → install → `bg.png` restored, kernel left as the new one (by design)
- [x] Failure path: install fails → git reset to prior commit → re-install → `bg.png` **and** kernel restored to the pre-update backup, original exit code preserved — including when the failing re-install itself overwrites the assets again on its way to failing a second time

Not yet done (tracked in #1005):
- [x] Run against a real Linux FOG server with a real upstream commit to pull
- [x] Confirm `globalSettings` picks up `FOG_GIT_PATH`/`FOG_UPDATE_CHANNEL` via a real `mysql` client (SQL hand-written against the existing `FOG_STORAGENODE_MYSQLPASS` pattern, never executed for real)
- [ ] `fog-docs` mention of `updatefog.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)