### PR TITLE
Port the multi-server CA bundle transfer steps to dev-branch, and drop flags this line lacks

### DIFF
--- a/docs/MULTI_SERVER_CA.md
+++ b/docs/MULTI_SERVER_CA.md
@@ -64,7 +64,7 @@ means case 2, and the rest of this document applies.
 | | Effort | Servers must trust each other | Best when |
 |---|---|---|---|
 | **A. Import each root** | One import per server, forever | no | 2–3 stable servers |
-| **B. Hub FOG server issues** | One-time per server | yes — a hub key is copied out | several FOG servers, no existing PKI |
+| **B. Hub FOG server issues** | One-time per server | yes — each satellite holds a CA the hub issued it (never the hub's own key) | several FOG servers, no existing PKI |
 | **C. Your own PKI / ACME** | Depends on your PKI | no | you already run a CA |
 
 There is no option where the servers keep their independence *and* share an
@@ -103,9 +103,24 @@ root, so one anchor covers the fleet.
          └── FOG Web CA - fog3.lan   → fog3's web certificate
 ```
 
-**Requires** a FOG version with `--web-ca-cert/--web-ca-key/--web-ca-root`. Both
-the 1.6 line and the 1.5 line have them; update the installer on every server
-first (`git pull`) or the flags will not parse.
+### 0. Check that your version can do this
+
+Option B needs `--web-ca-cert/--web-ca-key/--web-ca-root` on every satellite's
+installer, and `packages/pki/fog-mint-web-ca` on the hub. `dev-branch` carries
+both, and so does the 1.6 line. A **released 1.5.x `stable` carries neither** —
+there is no `packages/pki` on it at all — so `git pull` on a `stable` checkout
+will not produce these flags however many times you run it; you have to be on a
+line that ships them.
+
+From each checkout:
+
+```bash
+test -x packages/pki/fog-mint-web-ca && grep -q web-ca-cert bin/installfog.sh \
+    && echo "Option B available" \
+    || echo "not on this line — Option A or C only"
+```
+
+A server without them can be neither hub nor satellite.
 
 ### 1. Issue a CA per server, on the hub
 
@@ -124,23 +139,46 @@ rather than on the far server.
 Each run writes `/root/fog-web-cas/<short>-webca.tar.gz` containing
 `webca.pem`, `webca.key`, `fog-root.pem`.
 
-### 2. Install on each server
+### 2. Copy the bundle to each server
+
+The bundle sits under `/root` because it carries a CA private key. Push it from
+the hub rather than pulling it — `sshd` ships `PermitRootLogin
+prohibit-password` on most distributions, and an unprivileged account cannot
+write to `/root` on the far end either, so the obvious
+`scp root@<hub>:/root/... /root/` fails at both ends with nothing more
+informative than `Permission denied`:
 
 ```bash
-scp root@<hub>:/root/fog-web-cas/<short>-webca.tar.gz /root/
-cd /root && tar -xzf <short>-webca.tar.gz
-
-cd ~/fogproject/bin
-sudo ./installfog.sh --web-ca-cert /root/webca.pem \
-                     --web-ca-key  /root/webca.key \
-                     --web-ca-root /root/fog-root.pem
+# on the hub
+sudo cp /root/fog-web-cas/<short>-webca.tar.gz ~/
+sudo chown $USER: ~/<short>-webca.tar.gz
+scp ~/<short>-webca.tar.gz <you>@<far-server>:~/
+rm -f ~/<short>-webca.tar.gz
 ```
 
-`--external-ca` is not needed; any one of the three implies it. You pass these
-**once** — the files are imported into the web zone and later upgrades reuse the
-import without the flags.
+### 3. Install on each server
 
-### 3. Anchor the hub root wherever you need it
+```bash
+# on the far server
+sudo mkdir -p /root/webca
+sudo tar -xzf ~/<short>-webca.tar.gz -C /root/webca
+
+cd ~/fogproject/bin
+sudo ./installfog.sh --web-ca-cert /root/webca/webca.pem \
+                     --web-ca-key  /root/webca/webca.key \
+                     --web-ca-root /root/webca/fog-root.pem
+```
+
+Unpacking as root keeps `webca.key` unreadable to other accounts; it stays on
+this server permanently, so where it lands matters. Remove the tarball from your
+home directory afterwards.
+
+Passing any one of the three is what marks the install as using an external CA;
+there is no separate flag to set. You pass them **once** — the files are
+imported into the web zone and later upgrades reuse the import without the
+flags.
+
+### 4. Anchor the hub root wherever you need it
 
 One certificate now covers every server. On a Linux client:
 
@@ -192,7 +230,7 @@ questions.
 |---|---|---|
 | Web (HTTPS vhost) | **yes** | what `--web-ca-*` targets |
 | Client communication | **no** | each server keeps its own root; fog-client pins per server |
-| Secure Boot | **no** | see `--secureboot-ca-cert` and [PKI_ZONES.md](PKI_ZONES.md) |
+| Secure Boot | **no** | its own zone. On this line you supply a key with `--secure-boot-key`/`--secure-boot-cert`; there is no `--secureboot-ca-cert` here, that is 1.6 only. See [PKI_ZONES.md](PKI_ZONES.md) |
 
 **fog-client is deliberately untouched.** It pins the root of the server it
 registered against, and that root is not replaced by `--web-ca-*` — which is

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.2258');
+        define('FOG_VERSION', '1.5.10.2259');
         define('FOG_SCHEMA', 279);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');


### PR DESCRIPTION
Ports #1022's ground to `dev-branch`'s own copy of `docs/MULTI_SERVER_CA.md`, tailored to what this line actually ships.

## The transfer steps (straight port of `dbeb21bc1`)

Step 2 said:

```bash
scp root@<hub>:/root/fog-web-cas/<short>-webca.tar.gz /root/
```

That cannot work at either end — `sshd` ships `PermitRootLogin prohibit-password` on most distributions, and an unprivileged local account cannot write to `/root` anyway. Both failures read `Permission denied`, which is easy to misread as the file not existing. It is now a push from the hub, staged through your own account, with extraction into `/root/webca` on the far side.

## Two flag claims that were wrong for this line

This matters more here than on 1.6, because `dev-branch` is the line a 1.5 user gets told to move to.

- **"Both the 1.6 line and the 1.5 line have them; update the installer first (`git pull`)."** A released 1.5.x `stable` has no `packages/pki` at all, so `git pull` on a `stable` checkout never produces `--web-ca-*` however many times it is run. Replaced with a check the reader can run against the checkout, and a plain statement that such a server can be neither hub nor satellite.
- **The zone table pointed at `--secureboot-ca-cert`**, which does not exist on `dev-branch` (`longopts` has `secure-boot-key:`/`secure-boot-cert:` and no `secureboot-ca-cert`). On this line you supply a Secure Boot key with `--secure-boot-key`/`--secure-boot-cert`.

## Smaller corrections

- Dropped "`--external-ca` is not needed" — there is no such flag on this line to not need. Replaced with what is actually true: passing any one of the three marks the install as using an external CA (`bin/installfog.sh:521`).
- The options table described Option B as copying a hub key out, the one thing the document later tells you never to do. What leaves the hub is an intermediate the hub *issued*.

Deliberately **not** ported: the duplicate-vhost, CA-path-prompt, `pathlen:0` and offline-root troubleshooting entries from the 1.6 copy. Those describe fixes I have not confirmed exist on this line, and a troubleshooting entry saying "Fixed" about a fix that is not here would be worse than its absence.

The storage-node callout is left as-is — this line's version is already correct for it (nodes generate their own CA here; automatic issuance is a 1.6 feature).

Documentation only. The `system.class.php` change is the pre-commit hook's version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)