### PR TITLE
Track the ADRs, and add 0009 on the plugin architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,8 @@ packages/web/lib/plugins/hostext
 docs/agents/
 CONTEXT.md
 CONTEXT-MAP.md
-docs/adr/
+# docs/adr/ is deliberately NOT ignored. ADRs record why a decision was
+# taken, which is only useful to a contributor if it ships with the code.
 skills-lock.json
 # GH-959: iPXE binaries now come from FOGProject/fog-ipxe as a release asset.
 # packages/tftp is a staging directory the installer fills at runtime.

--- a/docs/adr/0001-group-association-state.md
+++ b/docs/adr/0001-group-association-state.md
@@ -1,0 +1,46 @@
+# Group association state is a derived tri-state; modules count only *enabled* hosts
+
+## Status
+
+accepted
+
+## Context
+
+A group owns no associations of its own — it is a lens over its member hosts.
+The group edit page therefore has to *derive* how to show each item (snapin,
+printer, module) from the union of its member hosts' associations. We show one
+of three states per item — **All**, **Some**, or **None** member hosts have it —
+rendered as a checked / indeterminate / unchecked checkbox, with an on-demand
+drill-down into the Has/Missing host sets.
+
+## Decision
+
+"Has it" is defined per item type, and **modules are deliberately not uniform**
+with snapins and printers:
+
+- **Snapins, printers:** a host "has it" when an association row exists
+  (printers ignore `paIsDefault`).
+- **Modules:** a host "has it" only when the `moduleStatusByHost` row exists
+  **and** `msState = 1` (enabled). A disabled override (`msState = 0`) counts as
+  *not having it*, so such a host pulls the item out of **All** into **Some**.
+
+Toggling an item to **All** writes the missing rows on every host (for modules,
+this also flips `state = 0 → 1`); toggling to **None** deletes the rows.
+
+Per-host configuration *shared values* (Active Directory, auto-logout,
+force-reboot, the printer **default** flag) are explicitly **out of scope** for
+this work and deferred to a later phase.
+
+## Why
+
+Showing a module as "All hosts have it" while a third of them have it disabled
+would be a lie to the operator — the checkbox must mean what an admin reads it to
+mean. Modules are the only one of the three that carries an enabled/disabled
+state, so the asymmetry is intrinsic to the data, not an oversight. We rejected
+the simpler "uniform row-exists for all three" because it would misreport modules.
+
+## Consequences
+
+A future reader will see modules computed differently from snapins/printers and
+might assume a bug — it is intentional. If snapins or printers ever gain a
+per-host enabled/disabled state, they should converge on the module rule.

--- a/docs/adr/0002-kea-dhcp-engine-selection.md
+++ b/docs/adr/0002-kea-dhcp-engine-selection.md
@@ -1,0 +1,88 @@
+# DHCP engine: detect-and-prefer Kea, fall back to ISC, never auto-switch an existing install
+
+## Status
+
+accepted
+
+## Context
+
+ISC-DHCP reached end-of-life in 2022 and Debian 13 (Trixie) dropped the
+`isc-dhcp-server` package entirely (issue #730). FOG can optionally run the
+DHCP service itself (the installer's `bldhcp=1` path), and that service must
+hand each PXE client the architecture-appropriate iPXE binary — BIOS gets
+`undionly.kkpxe`, the various UEFI arches and ARM64 get the right `snponly.efi`.
+Today `configureDHCP()` does this by writing an ISC `dhcpd.conf` whose `class`
+blocks match `vendor-class-identifier` substrings.
+
+Kea is ISC's replacement, but it is not a drop-in: its config is JSON, and
+per-architecture bootfile selection is expressed as `client-classes` with `test`
+expressions rather than `class … filename`. We need Kea support without breaking
+the large installed base still on ISC, and without orphaning distros that do not
+yet ship Kea in their default repositories.
+
+## Decision
+
+The installer **detects available DHCP engines and prefers Kea, falling back to
+ISC**, resolved with the existing candidate-list pattern (as used for the SQL
+server/client packages). The resolved engine drives the package, service name,
+and config path per distro.
+
+Engine selection is **stable across re-runs and never silently switches a
+working install**:
+
+1. An explicit `dhcpengine=` in `.fogsettings` is honored (and is the admin's
+   supported opt-in path — set `dhcpengine='kea'` by hand to migrate an existing
+   ISC box).
+2. Otherwise, if a prior `.fogsettings` already configured DHCP (a pre-Kea
+   install), the engine is treated as `isc` — existing boxes are not switched.
+3. Otherwise (fresh install), the engine resolves to the preferred available
+   one (Kea, else ISC). The result is persisted as `dhcpengine`.
+
+A fresh install on a distro lacking Kea (or where it is not in a configured
+repo) correctly lands on ISC; if neither is available the install hard-fails
+rather than guessing. We do **not** auto-enable EPEL/COPR/remi for Kea — but the
+installer already enables EPEL/remi on RHEL-family for other reasons, so Kea is
+reachable there without any new repo work.
+
+The per-architecture arch→bootfile mapping is **deliberately duplicated** between
+the untouched ISC generator and the new Kea generator rather than refactored into
+a shared table; the working ISC path is left as-is, with a cross-reference
+comment in both spots.
+
+The Kea config is generated and validated in **two tiers** via `kea-dhcp4 -t`:
+the base subnet plus standard arch classes (BIOS / UEFI / ARM64 / Surface Pro 4)
+must validate or the install **hard-fails**; the legacy Apple-Intel BSDP block is
+then appended and re-validated, and **dropped with a visible warning** if it does
+not validate. (Apple BSDP relies on stateful `vendor-encapsulated-options` reply
+logic that does not translate cleanly to Kea client-classes.) The ISC path gains
+an optional, **non-fatal** `dhcpd -t` check that warns but still starts the
+daemon, preserving its long-standing behavior.
+
+When the installer owns DHCP (`bldhcp=1`), bringing up one engine **stops and
+disables the other FOG-relevant DHCP daemon** if present, symmetrically, so the
+two never contend for port 67. When `bldhcp=0`, the installer touches no DHCP
+service at all.
+
+## Why
+
+ISC-DHCP is dead upstream and gone from current Debian, so FOG must move; but the
+DHCP server on a FOG box is load-bearing infrastructure, and silently swapping a
+running engine on upgrade is the kind of surprise that breaks production networks.
+Preferring Kea for new installs while pinning existing ones (and offering an
+explicit opt-in) gets the migration without the ambush. Hard-failing the base Kea
+config but degrading the Apple block keeps the 99.9% PXE case provably valid
+before the daemon starts, while not letting obsolete Apple-Intel netboot block an
+otherwise-good install. The duplication of the arch table is the cheaper, lower-
+risk choice than rewriting a field-tested generator for a mapping that changes
+once every few years.
+
+## Consequences
+
+- `.fogsettings` gains a `dhcpengine` variable; its absence on an older install
+  is meaningful (implies ISC) and must be preserved by the inference rule above.
+- The arch→bootfile mapping now lives in two places; a new firmware arch code
+  must be added to both the ISC and Kea generators (comments flag this).
+- Apple-Intel BSDP netboot is best-effort under Kea and may be silently absent;
+  this is logged, not hidden.
+- On RHEL-family, Kea availability depends on EPEL, which the installer already
+  enables — the engine-availability probe must therefore run after repo setup.

--- a/docs/adr/0003-settings-cache-flush-dir-perms.md
+++ b/docs/adr/0003-settings-cache-flush-dir-perms.md
@@ -1,0 +1,52 @@
+# The settings-cache flush dir is sticky world-writable, not owned by one web user
+
+## Status
+
+accepted
+
+## Context
+
+The TTL settings cache (#849) coordinates across processes with a single zero-byte
+beacon file, `FOG_CACHE_DIR/.settings_cache_flush` (i.e. `/opt/fog/cache/...`).
+Whatever process triggers a flush/refresh `touch`es it; every `getSetting()` caller
+reads its mtime to decide whether to drop cached values. This is the **first time the
+FOG web tier writes into `/opt/fog`** — every existing path under `/opt/fog` is written
+by FTP or the CLI daemons as `fogproject`, never by the web request.
+
+The web request runs as the **php-fpm pool user**, which is **not guaranteed to equal
+`$apacheuser`**. FOG never sets the pool `user`/`group` (it relies on each distro's
+package default), so on RedHat/nginx php-fpm keeps `user = apache` while FOG sets
+`$apacheuser = nginx`. An `$apacheuser`-owned directory at mode `775` is therefore not
+reliably writable by the process that must touch the beacon: the `@touch` is denied,
+the flush action still returns `200`, and no file ever appears.
+
+## Decision
+
+The installer creates `/opt/fog/cache` **sticky world-writable (`1777`)**, `/tmp`-style,
+and the beacon lives there. We do **not** force the php-fpm pool to run as `$apacheuser`.
+
+## Why
+
+- The beacon carries **no secrets** — it is an mtime signal meaning "re-read settings on
+  next access." Read access (the common path, used by every web request and daemon) only
+  needs `r-x` on the dir, which `1777` keeps.
+- The set of *writers* (the php-fpm worker today; any future CLI/daemon flush) is not a
+  single user that is knowable at install time across web servers (nginx, apache,
+  lighttpd, …) and distros. Sticky world-writable sidesteps that without hardcoding a user.
+- The "correct-looking" alternative — set the php-fpm pool `user`/`group` to `$apacheuser`
+  — has **high blast radius**. FOG sets neither today, and the PHP `session.save_path`
+  (e.g. `/var/lib/php/session`, owned `root:apache` mode `770` on RedHat; a different path
+  and owner on Debian/Arch/Alpine) is owned by the *package-default* user. Repointing
+  php-fpm at `$apacheuser` makes that directory unwritable and **breaks login** unless the
+  session dir is also migrated per distro. That is out of proportion to a non-secret
+  coordination beacon, and the kind of OS-state change that needs cross-distro install
+  validation before it can be trusted.
+- The sticky bit (`1777`) stops one user deleting another user's files, matching `/tmp`.
+
+## Note
+
+Only the web tier writes the beacon today; daemons just read its mtime. If a
+CLI/daemon-initiated flush is ever added, the beacon (created ~`644` by its first writer)
+may not be mtime-updatable by a *different* user — at that point
+`clearSettingsCache()` / `refreshSettingsCache()` should `chmod 0666` the file after
+`touch`. Left out now (no such caller), to avoid speculative code.

--- a/docs/adr/0004-ajax-refresh-server-chrome.md
+++ b/docs/adr/0004-ajax-refresh-server-chrome.md
@@ -1,0 +1,78 @@
+# Server-rendered chrome is refreshed via a second fragment request, not rebuilt in-place
+
+## Status
+
+accepted
+
+## Context
+
+The persistent page chrome — the sidebar menu, its "PLUGIN OPTIONS" section, the
+top navigation — is **server-rendered once per full page load** in
+`management/other/index.php`. FOG's pjax-style navigation (`.ajax-page-link` →
+`?contentOnly=1`) only swaps `#ajaxPageWrapper`; it never re-renders the chrome.
+So when an action changes what the chrome should show (the first case: installing,
+activating, deactivating, or removing a plugin on the Plugin Management page,
+#852), the change is invisible until a manual full-page reload.
+
+Two boot-time facts make this harder than it looks:
+
+- **Menu state is fixed at boot.** Plugin menu items are added by each plugin's
+  `add*menuitem.hook.php` via the `MAIN_MENU_DATA` hook, and that hook only
+  registers if the plugin is in `self::$pluginsinstalled` — a snapshot taken in
+  `FOGCore::setEnv()` at boot, *before* the current request's mutation ran. Hooks
+  cannot un-register. So rebuilding the menu **inside the mutating request** sees
+  stale state; it cannot reflect the change just made.
+- This is **not** a caching problem. `getActivePlugins()` reads plugin state live
+  from the DB each request; the settings cache (#849, ADR 0003) does not gate it.
+  A plain browser reload already shows the change — the gap is purely that the SPA
+  never re-renders the chrome.
+
+## Decision
+
+To refresh server-rendered chrome after an AJAX state change, do **all** of:
+
+1. **Fetch a rebuilt fragment in a separate request** after the mutation
+   completes. Reuse the same server-side build path the full page uses
+   (e.g. `FOGPage::buildMainMenuItems()`), so the fragment is byte-identical to
+   what a reload renders. A fresh request re-runs `setEnv()` and re-registers
+   hooks, so state is current.
+2. **Swap inner HTML, keep the delegating ancestor.** Replace only the inside of
+   the changed container (e.g. `.plugin-options`) and leave the
+   `<ul data-widget="tree">` in place. AdminLTE's treeview handler is **delegated**
+   on that `<ul>` (`_setUpListeners` → `$(ul).on('click', '.treeview a', …)`), so
+   expand/collapse on swapped-in items keeps working with no re-init.
+3. **Delegate click bindings that must survive a swap.** `.ajax-page-link` was
+   directly bound at `$(document).ready`; injected links lost it and full-reloaded.
+   It is now `$(document).on('click', '.ajax-page-link', …)`.
+
+The fragment endpoint pattern: a sub needs **both** an empty `foo()` placeholder
+(otherwise the dispatcher's `!method_exists($class, $sub)` check falls back to
+`index()`) **and** a `fooAjax()` that emits the markup. The dispatcher appends
+`Ajax` for XHR requests (`X-Requested-With: xmlhttprequest`) and gates auth +
+CSRF there. A GET fragment is not state-changing, so
+`CSRF::requireForStateChanging()` passes.
+
+## Why
+
+- **The second request is not avoidable**, given boot-fixed hook registration and
+  the `pluginsinstalled` snapshot. Trying to rebuild in the mutating request is the
+  obvious-looking approach and is wrong — it silently renders stale chrome.
+- **Reusing the full-page build path** is the correctness guarantee: the fragment
+  is defined as "what a reload would show," not a parallel reimplementation that
+  can drift.
+- **Inner-HTML swap + delegation** avoids re-initializing third-party widgets
+  (AdminLTE tree, etc.) and rebinding handlers by hand — the fragile part of any
+  in-place SPA update. Replacing the delegating ancestor itself would break it.
+- A full `window.location.reload()` was the cheaper alternative and was rejected:
+  the project is deliberately AJAX-first, and these are exactly the surfaces where
+  a reload flash is most jarring.
+
+## Note
+
+First applied to the plugin sidebar (#852): `pluginmanagement.page.php`
+(`sidebar()` + `sidebarAjax()`), `js/fog/plugin/fog.plugin.list.js`
+(`refreshSidebar()` on the four state-changing actions, **not** the schema-update
+actions, which don't change the menu), `js/fog/fog.common.js` (the delegation
+change). This ADR is the convention for any future chrome refresh; the delegation
+change in `fog.common.js` is global, so new injected `.ajax-page-link`s already
+work without further wiring.

--- a/docs/adr/0005-native-rbac-retires-accesscontrol-plugin.md
+++ b/docs/adr/0005-native-rbac-retires-accesscontrol-plugin.md
@@ -1,0 +1,69 @@
+# Role-based permissions are native; the accesscontrol plugin is retired
+
+## Status
+
+accepted
+
+## Context
+
+FOG's only permission mechanism was the accesscontrol plugin, and it never
+actually enforced anything: its "rules" mapped roles to menu keys but no
+choke point consulted them, so every logged-in user (and every API token)
+had full administrative power. Proper multi-user operation needs real
+authorization, and it should be something FOG simply *has*, not an optional
+plugin.
+
+Native RBAC landed in four phases on `working-1.6`:
+
+- **P1** — data model (`roles`, `roleUserAssoc`, `rolePermissions`, schema
+  302–306) and the `Authorization` service.
+- **P2** — Role Management UI and per-user role assignment.
+- **P3** — UI enforcement at the single page-dispatch choke point
+  (`FOGPageManager::render()`), menu filtering, and a warning banner for
+  role-less users.
+- **P4** — API enforcement in `Route::runMatches()`, with token-authenticated
+  requests bound to the token's owner.
+
+This ADR covers the final phase (P5): what happens to the plugin.
+
+## Decision
+
+Delete `lib/plugins/accesscontrol/` from the tree and remove its
+`plugins`-table row via schema step 307.
+
+Migration semantics (decided with the feature, recorded here):
+
+- **Permissions are `<node>.<action>` strings** (`host.edit`, `image.*`,
+  global `*`); actions are view/create/edit/delete/task. No per-instance
+  scoping in v1.
+- **Roles and user↔role assignments carry over.** The native tables are the
+  plugin's own `roles`/`roleUserAssoc` tables, adopted in place (same IDs,
+  same names). Schema 303 relaxes the plugin's one-role-per-user unique
+  index to a composite (role,user) unique, so users can now hold multiple
+  roles; permissions are the union.
+- **Menu-key rules do NOT migrate.** They were cosmetic-only (never
+  enforced), so any pre-existing role with no permission rows is seeded
+  with `*` — preserving its prior *effective* (full) access rather than
+  inventing restrictions the admin never chose. The plugin's `rules` and
+  `roleRuleAssoc` tables are left in the database untouched; admins may
+  drop them manually.
+- **Users with no role at all are implicit administrators** and see a
+  warning banner. Upgrades therefore change nobody's access until an admin
+  assigns roles.
+- **Unknown nodes / API classes default to allow** — a single, deliberate
+  compatibility stance for plugin pages and future entities, flippable in
+  one place (`Authorization`).
+
+## Consequences
+
+- The plugin's uninstall path (which dropped the shared tables — a standing
+  footgun) dies in the same release the tables go native, so there is no
+  window where "uninstall plugin" can destroy native role data.
+- Headless integrations authenticating with a user API token now inherit
+  that user's role permissions. Scripts that must remain unrestricted
+  should use a role-less or Administrator API user (release-notes item).
+- The `site` plugin still probes `in_array('accesscontrol',
+  $pluginsinstalled)` in `addsitefiltersearch.hook.php`; the result feeds a
+  dead local variable, so it now just evaluates false. Left as-is.
+- Databases that never installed the plugin get identical tables from the
+  same schema steps; step 307's DELETE is a no-op there.

--- a/docs/adr/0006-site-object-scope-boundary.md
+++ b/docs/adr/0006-site-object-scope-boundary.md
@@ -1,0 +1,87 @@
+# Per-object scoping is a plugin boundary layered on native RBAC
+
+## Status
+
+accepted
+
+## Context
+
+Native RBAC (ADR 0005) grants **verb-level** permissions — `host.edit`,
+`image.*`, global `*` — and deliberately shipped with "no per-instance
+scoping in v1": a user who can edit hosts can edit *every* host. Multi-team
+and multi-site deployments need a narrower boundary, where a site-scoped
+admin only sees and touches the hosts, users, groups and user groups that
+belong to their site.
+
+That boundary is inherently about *which objects*, not *which verbs*, and it
+is site-specific knowledge. Core should not learn about sites, and an
+installation that does not care about site scoping should pay nothing for it.
+So the boundary lives in the existing `site` plugin, and core exposes only a
+generic seam the plugin fills in.
+
+## Decision
+
+Add a generic, **default-allow** object-scope seam to `Authorization`,
+consulted *after* the verb check has already passed. Core owns the seam; the
+`site` plugin owns the meaning.
+
+**Core (generic, no site knowledge):**
+
+- `Authorization::objectInScope($node, $id, $userID)` returns true for
+  `$id < 1` (list/create/mass — nothing to scope yet), true for unrestricted
+  users, otherwise fires the `OBJECT_SCOPE_CHECK` hook with a
+  `&$allowed` (default true) and returns it. With no listener the boundary
+  does not exist and behaviour is unchanged.
+- "Unrestricted" (`Authorization::isUnrestricted`) = an implicit admin (no
+  role) **or** a holder of global `*`. These bypass scoping entirely.
+- Four choke points enforce it:
+  1. **Single-object web** — `FOGPageManager::render()` →
+     `requirePageObjectScope($node, $id)`.
+  2. **Single-object REST** — `Route::runMatches()` →
+     `requireApiObjectScope($class, $id)`.
+  3. **Mass delete** — `FOGPage` deletemulti →
+     `requirePageObjectScopeMass($node, $ids)`.
+  4. **List/search visibility** — web AJAX lists via `AJAX_DATA_DISPLAY_CHANGE`;
+     REST list/search via `API_MASSDATA_MAPPING`.
+
+**Site plugin (the meaning):**
+
+- Scope covers four object types: `host`, `user`, `group`, `usergroup`.
+  Assignment is explicit, via its own association tables
+  (`sitehostassociation`, `siteuserassociation`, `sitegroupassociation`,
+  `siteusergroupassociation`) — a group's or user group's site is its *own*
+  row, not inferred from its member hosts/users.
+- Scope logic is single-sourced on the `Site` model: `userSiteIDs($userID)`
+  (cached; **empty = deny-all**), `inScope()`, `filterInScope()`.
+- `SiteScopeCheck` (on `OBJECT_SCOPE_CHECK`) enforces the single-object and
+  mass-delete boundary; `ListSiteHosts` (web) and `FilterSiteMassData` (REST)
+  enforce list/search visibility.
+- **Deny-all is strict:** a restricted user with no site assignment sees an
+  empty list and is denied every scoped object.
+
+**Web-vs-REST gate.** The REST list filter must run on genuine REST calls but
+not double-filter the web AJAX path. It is gated on `Route::$apiRequest`
+(set only when `api/index.php` constructs a `Route`), **not** `self::$ajax`:
+`$ajax` is derived from the client-set `X-Requested-With` header, so a REST
+client could flip it and escape filtering; `$apiRequest` cannot be spoofed.
+
+## Consequences
+
+- Default-allow keeps core site-agnostic: uninstalling the `site` plugin
+  removes the object boundary and leaves the verb permissions (ADR 0005)
+  intact. Unknown nodes/classes stay allowed, matching the RBAC stance.
+  > **Superseded in part by ADR 0009.** The second sentence no longer holds:
+  > unknown nodes and classes now fail *closed* on both the API and page
+  > paths. The default-allow **object-scope** seam described here is
+  > unchanged — it is the verb layer that changed stance, not this one.
+- Group and user-group scope is deliberately explicit (own association rows).
+  Deleting a site clears all four association types; deleting a scoped object
+  clears its association via `DELETEMASS_API`.
+- The REST list path is unpaginated by default
+  (`FOGManagerController::limit` adds no `LIMIT` unless the caller sends
+  DataTables `start`/`length`, which only the web UI does), so
+  `FilterSiteMassData` trims the whole result set and the kept-row count is
+  the true total. A custom REST client that *does* send paging params would
+  get an off record count — never out-of-scope data, only a wrong total.
+- Unrestricted users (implicit admins, `*` holders) are unaffected; the
+  boundary only ever narrows a user who already holds a restricting role.

--- a/docs/adr/0007-external-identity-provenance-and-directory-group-mapping.md
+++ b/docs/adr/0007-external-identity-provenance-and-directory-group-mapping.md
@@ -1,0 +1,114 @@
+# External identity is provenance; authority comes from roles, mapped per directory group
+
+## Status
+
+accepted
+
+## Context
+
+Native RBAC (ADR 0005) made two compatibility choices that were safe on
+their own: a user with no role rows is an implicit administrator, and an
+API class absent from the registry is allowed. The LDAP plugin predates
+RBAC and had always created users with no roles, because before RBAC the
+privilege tier lived in `users.uType` (990/991 for LDAP admin/user).
+After RBAC nothing read `uType` for authorization.
+
+Those two facts met, and the result was that **every LDAP-authenticated
+user was a full FOG administrator** — UI and API. With "Use Group Match"
+off, which was the shipped default, that included every account that
+could bind to the directory at all. The plugin's three defensive
+mechanisms (hide LDAP users from lists, filter them out of role
+membership, destroy the row at logout) were written for the two-tier
+`uType` model and, under RBAC, combined into a guarantee that an LDAP
+user could never *hold* a role — so the escalation could not be fixed by
+hand either. Separately, the user's real directory password was
+bcrypt-stored in `users.uPass`, and the LDAP bind password was readable
+in cleartext over `/api/`.
+
+Root cause in one sentence: a fail-open authorization default met an
+identity provider that produces users with no roles, and nothing
+connected the two.
+
+## Decision
+
+**Provenance is a core fact; authority is not.** `users.uAuthSource`
+records which identity provider created an account. `Authorization`
+denies by default for any user whose `uAuthSource` is non-empty and who
+holds no roles, instead of treating them as an implicit administrator.
+Local users keep the pre-existing stance. `uType` is retired as an
+authority: 990/991 remain in the column but are inert, and
+`isSchemaAdmin()` now keys on RBAC with a self-retiring pre-316 fallback.
+
+**An externally-sourced account cannot be authenticated by a local
+password compare.** `USER_LOGGING_IN` carries `&$authenticated`, and the
+plugin no longer writes the directory password at all. This replaces a
+guard (`isLdapType()`) that was provably dead code.
+
+**A directory group is a first-class entity, and what it grants is an
+ordinary association.** `LDAPGroups` rows are scoped to one LDAP server;
+`ldapGroupRoleAssoc` and `ldapGroupUserGroupAssoc` map them to roles and
+user groups through the same association tabs every other entity uses,
+editable from either end. When group matching is off, a bindable account
+receives one configured fallback role
+(`FOG_PLUGIN_LDAP_NOMATCH_ROLE`) — never administrator.
+
+**The sync is authoritative only over what it granted.** `ldapUserGrant`
+records each grant per user. On sign-in the managed set is *what was
+previously recorded* ∪ *what the directory grants now*; anything an
+admin attached by hand is untouched.
+
+## Why
+
+Provenance had to be its own column rather than reusing `uType`. 990/991
+is a global claim on a shared generic field: it is admin-editable at
+runtime, writable over the API and CSV import, and the next auth plugin
+would have to invent its own magic numbers and hope they did not
+collide. `uAuthSource` is namespaced per provider and is a *standing*
+property of the resolver rather than a check that runs once at login —
+so the fix does not depend on the plugin never having a bug.
+
+Recording grants, rather than inferring them from the mapping tables,
+closes the hole an admin is most likely to hit. "Managed" used to mean
+"appears as a mapping target", so removing the **last** mapping to a
+role took that role out of the managed set entirely and everyone holding
+it kept it forever. Removing a mapping reads as "revoke this", and it
+silently did not.
+
+Two deviations from the original recommendation, both from review:
+
+- **Per-directory-group mapping, not install-wide settings.** The
+  original plan was two globalSettings (admin role, user role) on the
+  grounds that the old code collapsed every server into one access tier,
+  so per-server mapping would be a new feature rather than a fix. That
+  reasoning held for the *tier ladder* but not for the shape admins
+  actually want, which is "this AD group gets this role". Mapping per
+  group also removes the tier concept entirely instead of re-encoding
+  it, and scoping each group to a server keeps two same-named groups on
+  different directories distinct.
+- **Group-matching-off yields the fallback role, not administrator.**
+  "Authentication implies administration" is not a defensible default,
+  and this was the single highest-impact line in the report.
+
+## Consequences
+
+- Upgrades change local users' access not at all. LDAP users lose
+  implicit administrator on first sign-in after the upgrade and hold
+  exactly what their mapped groups grant, so **mappings must be
+  configured before or immediately after upgrading** or LDAP admins will
+  find themselves without access. The plugin's schema step seeds
+  `ldapUserGrant` from existing assignments so the first post-upgrade
+  sign-in revokes correctly rather than silently keeping stale access.
+- Plugin schema lists are strictly **append-only**: `Plugin::installdb()`
+  passes the stored `pSchema` as `$applied`, so rewriting an existing
+  step means it is skipped on installs that already ran it. Repairing an
+  in-place rewrite costs additional idempotent steps.
+- Directory group names may contain `+`, which `Route::_buildSql()`
+  rewrites into a SQL wildcard in a scalar filter value. Every LDAP
+  mapping lookup therefore uses raw bound SQL, not `Route::getIds()`.
+- LDAP users are now visible and manageable in User Management. The hook
+  that hid them was removed; it also carried a latent double-`WHERE` bug
+  when stacked with the site plugin.
+- Still open, deliberately deferred: dropping the `users.uType` column
+  (an API/CSV contract break), removing the now-inert `USER_TYPES_FILTER`
+  firings, encrypting `lsBindPwd` at rest, and nested/transitive
+  directory groups.

--- a/docs/adr/0009-plugins-become-installable-artifacts.md
+++ b/docs/adr/0009-plugins-become-installable-artifacts.md
@@ -1,0 +1,173 @@
+# Plugins become installable artifacts with a lifecycle of their own
+
+## Status
+
+accepted
+
+## Context
+
+What FOG calls a plugin system is really an extension system, and a good one:
+core fires ~131 named hook events, and a plugin uses them to register a sidebar
+entry, a permission node, REST classes, host/group tabs, JS files and its own
+append-only schema migrations. `Hook::registerInstalled()` and
+`Hook::injectPluginJS()` already absorb most of the per-plugin boilerplate.
+Extensibility is not the gap.
+
+The gap is that a plugin has no existence independent of this repository.
+
+**Upgrades delete plugins.** `configureHttpd()` does `rm -rf $webdirdest` and
+then re-lays the tree from the tarball. `backupPreservedCustomizations()`
+rescues the iPXE background, the legacy refind blobs and user reports — not
+`lib/plugins/`. So a plugin survives an upgrade only if it ships in
+`FOGProject/fogproject`. Everything else below is secondary to this: it is the
+reason no third party has ever shipped a FOG plugin.
+
+**The manifest is a stub.** `plugin.config.php` carries a name, a description
+and a menu icon, plus an `entrypoint` pointing at `html/run.php` — a file *no*
+plugin ships and nothing loads. There is no version (the `plugins.pVersion`
+column exists and discovery never writes it), no FOG compatibility range, no
+dependencies, no author or homepage. `FOG_PLUGINSYS_DIR` looks like a setting
+but `Plugin::_getDirs()` overwrites it back to `../lib/plugins/` on every call.
+
+**The contracts are conventions.** Class name must equal filename; directory
+name must equal the routing node; JS must be `fog.<node>.<sub>.js`. Real rules,
+enforced by silent failure.
+
+Two places where core had been hand-edited on a plugin's behalf — an
+`API_CLASS_ENTITIES` entry and a `$sensitiveAlwaysFields` entry, both for LDAP —
+were closed separately as a prerequisite (PR #1025, `API_SENSITIVE_FIELDS` plus
+page-level fail-closed permissions). A plugin can now declare its own permission
+node and its own secret columns. Nothing in core names a plugin any more.
+
+## Decision
+
+Plugins become artifacts with their own lifecycle: distributed, versioned and
+installed independently of the FOG tarball.
+
+### 1. Two plugin roots
+
+| Root | Holds | Installer |
+|---|---|---|
+| `$webdirdest/lib/plugins/` | the bundled plugins | wiped and re-laid every upgrade |
+| `$fogprogramdir/plugins/` (default `/opt/fog/plugins`) | third-party plugins | never touched |
+
+`Plugin::_getDirs()` and the class-file list behind `Initiator::classFileList()`
+/ `FOGBase::fileitems()` scan both. The external root sits under
+`$fogprogramdir` for the same reason `$customizationsDir` does: it survives the
+wipe *by construction*, rather than by a backup-and-restore step that has to be
+re-made correctly on every upgrade.
+
+A third-party plugin whose directory name collides with a bundled one is
+**refused, and logged — never shadowed**. Silent shadowing of a bundled plugin
+by an external one is a supply-chain attack, not a feature.
+
+`FOG_PLUGINSYS_DIR` is retired rather than made real. The two roots are fixed;
+a setting that discovery rewrites on every read is worse than no setting.
+
+### 2. A manifest that means something
+
+`plugin.config.php` gains, and `Plugin::getPlugins()` reads:
+
+- `version` — written through to `plugins.pVersion`, which is currently dead.
+- `fog_min` / `fog_max` — the FOG version range this plugin claims. A plugin
+  outside the range **cannot be activated**, and an installed one deactivates
+  itself with a message on upgrade rather than fataling a page.
+- `author`, `homepage` — attribution and where to report a bug.
+- `requires[]` — other plugin nodes that must be installed first.
+- `entity`, `sensitive_fields` — the RBAC and secret-column declarations, so a
+  plugin's security posture is in one readable place instead of spread across
+  hook methods. These *feed* `PERMISSION_REGISTRY_DATA` and
+  `API_SENSITIVE_FIELDS`; they do not replace them, because a plugin sometimes
+  needs to register more than one node (LDAP registers `ldap` and `ldapgroup`).
+
+`entrypoint` is dropped. It has never pointed at a file that exists.
+
+The compatibility range is the single highest-value field. "I upgraded FOG and
+it broke" is the support cost that a plugin ecosystem generates, and a declared
+range converts most of it into a clear message at activation time.
+
+### 3. Install from the UI
+
+Plugin Management gains an install-from-archive flow. This is genuinely
+dangerous — it accepts PHP that will execute as the web user — and is therefore
+constrained:
+
+- Requires a new `install` action on the `plugin` node — the registry
+  currently declares only `['view', 'edit']`. Deliberately not folded into
+  `plugin.edit`: activating a plugin that is already on disk and introducing
+  new executable code to the server are not the same authority, and a role
+  that can do the first should not automatically do the second.
+- Off by default, behind a `globalSettings` flag an admin must deliberately set.
+- Installs to the external root only; never writes into `$webdirdest`.
+- Displays the archive checksum and the parsed manifest for confirmation
+  **before** extraction, and refuses an archive whose manifest is absent,
+  unparseable, or outside the compatibility range.
+- No auto-update and no remote plugin index. Updating is an explicit act.
+
+The risk was raised and accepted deliberately: the alternative is that every
+admin who wants a plugin untars it by hand as root, which is strictly worse and
+is what happens today.
+
+### 4. `FOGProject/fog-plugins`, one repository
+
+The 15 bundled plugins move to a single `FOGProject/fog-plugins` monorepo, with
+history preserved via `git subtree split`. Per-plugin versions live in each
+manifest; the repository releases as one artifact that the FOG build consumes.
+
+One repo per plugin was the earlier sketch (#848) and is rejected for the
+bundled set: one maintainer with 15 repositories is 15 release chores for no
+user-visible gain. Third-party plugins own their own repositories — this is the
+Home Assistant split, core integrations in-tree and everything else out.
+
+### What stays in core, and why
+
+`site` remains bundled and is **not** a candidate for the external root. It is
+the best-decoupled plugin in the tree — core names it nowhere, and it works
+entirely through `OBJECT_SCOPE_CHECK`, `AJAX_DATA_DISPLAY_CHANGE`,
+`API_MASSDATA_MAPPING` and the public `Authorization::isUnrestricted()`. The
+reason to keep it is not coupling but consequence: per ADR 0006 the object-scope
+boundary is default-allow, so **with no listener the boundary does not exist**.
+A security boundary that disappears silently when a plugin is absent must not be
+something an admin can uninstall, or that a half-failed upgrade can remove.
+
+Moving scope *enforcement* into core, leaving `site` as the data model for
+scopes, is the eventual fix. It is out of scope here and is not a prerequisite.
+
+## Consequences
+
+- A third party can ship a FOG plugin for the first time. `git clone` into
+  `/opt/fog/plugins` is the baseline distribution mechanism; the UI installer is
+  a convenience on top of it, not the only route.
+- **PHP must be able to read a tree outside the docroot.** `open_basedir`, if
+  set, must include the external root, and on SELinux systems the directory
+  needs a context the web server can read. This is the real implementation cost
+  of the two-root decision and it is a per-distro problem, not a code one.
+- **For the UI installer, that directory must also be web-server-writable** — a
+  writable PHP directory reachable by the interpreter is exactly the shape that
+  turns any file-write bug into remote code execution. It is why the installer
+  is opt-in and permission-gated rather than on by default.
+- ADR 0006's consequence that "unknown nodes/classes stay allowed, matching the
+  RBAC stance" no longer holds: PR #1025 made both the API and page paths fail
+  closed. A plugin that does not register a permission node is now unreachable
+  rather than ungated.
+- Bundled plugins keep working untouched. All 14 that have a page already
+  register their permission node, own their tables through the `schema()`
+  contract, and declare their API classes; the port is adding manifest fields.
+  The fifteenth, `persistentgroups`, is model classes and a config file with no
+  page, no hooks and nothing to register — a useful reminder that the manifest
+  must not make page-shaped fields mandatory.
+- The FOG tarball and `fog-plugins` can now disagree about a plugin's version.
+  The build pins a `fog-plugins` revision; the manifest range is what actually
+  gates activation.
+- Uninstall still does not drop a plugin's tables. `schema()` is an append-only
+  forward migration list with no down-steps, and that stays true — losing an
+  admin's data on an uninstall is worse than leaving orphan tables.
+
+## Open
+
+- Whether `requires[]` needs real dependency resolution (ordering, cycles) or
+  can stay a flat "these must already be installed" assertion. Flat is assumed
+  until a plugin needs more.
+- Whether bundled plugins should also be installable from the external root, so
+  an admin can run a newer `site` than the tarball shipped. Deferred; it
+  reintroduces the shadowing question the collision rule exists to close.

--- a/docs/adr/0009-plugins-become-installable-artifacts.md
+++ b/docs/adr/0009-plugins-become-installable-artifacts.md
@@ -97,7 +97,25 @@ constrained:
   `plugin.edit`: activating a plugin that is already on disk and introducing
   new executable code to the server are not the same authority, and a role
   that can do the first should not automatically do the second.
-- Off by default, behind a `globalSettings` flag an admin must deliberately set.
+- **Two independent switches, both required.** `FOG_PLUGIN_UI_INSTALL_ENABLED`
+  in `globalSettings`, off by default, is the half an admin turns on in the UI.
+  The external root being writable by the web user is the other half, and it is
+  a root act outside the web tier: `bin/fog-plugin-uploads.sh enable`, which
+  also sets the SELinux context. Neither alone is sufficient.
+
+  The split is the point. If the setting alone were enough, the UI would be
+  able to grant itself a web-writable directory that PHP autoloads code from —
+  the server handing itself the precondition for remote code execution, on the
+  say-so of a single database row. Requiring a shell as root means the
+  dangerous state cannot be reached from inside the application at all, and an
+  admin who wants the feature off permanently can revoke the directory and
+  ignore the setting entirely.
+
+  The cost is a worse first-run experience: the button is visible to any
+  `plugin.install` holder whether or not uploads are usable, and the modal
+  reports which half is missing when it is opened. Hiding the button was
+  rejected — an admin hunting for a feature they have permission to use and
+  cannot find is a worse failure than one being told what to switch on.
 - Installs to the external root only; never writes into `$webdirdest`.
 - Displays the archive checksum and the parsed manifest for confirmation
   **before** extraction, and refuses an archive whose manifest is absent,
@@ -145,7 +163,15 @@ scopes, is the eventual fix. It is out of scope here and is not a prerequisite.
 - **For the UI installer, that directory must also be web-server-writable** — a
   writable PHP directory reachable by the interpreter is exactly the shape that
   turns any file-write bug into remote code execution. It is why the installer
-  is opt-in and permission-gated rather than on by default.
+  needs both switches above, and why the writable half is deliberately not
+  something the application can grant itself.
+- **Code can now appear under a scanned root while the server is running**,
+  which was never previously possible: the class-file list is TTL-cached, so
+  without an explicit invalidation on install a freshly uploaded plugin stays
+  invisible to the autoloader for the length of the TTL. Everything downstream
+  then silently no-ops — no manager class, so no schema runs, no hooks
+  register, no page renders — while reporting success. Any future writer to a
+  scanned root has to invalidate the same cache.
 - ADR 0006's consequence that "unknown nodes/classes stay allowed, matching the
   RBAC stance" no longer holds: PR #1025 made both the API and page paths fail
   closed. A plugin that does not register a permission node is now unreachable


### PR DESCRIPTION
Docs only. No code changes.

> **Merge after #1025.** ADR 0009 cites that PR as a completed prerequisite and
> the annotation on 0006 describes what it changed. Nothing breaks if this lands
> first — the docs would just briefly describe behaviour the branch does not yet
> have.

## Tracking the ADRs

`docs/adr/` was ignored as part of the local agent-scaffolding block, alongside
`docs/agents/` and `CONTEXT.md`. ADRs do not belong in that set: they record
*why* a decision was taken, which is only worth anything to a contributor if it
ships with the code.

0008 was already tracked, having gone in with the Secure Boot work, so the split
meant one ADR was discoverable in the repo and the seven around it were not.
This drops the ignore rule and adds 0001–0007 as they stood.

## ADR 0009 — plugins become installable artifacts

Records the plugin-architecture decisions:

- **Two plugin roots.** Bundled plugins stay in `$webdirdest/lib/plugins/` and
  are re-laid from the tarball each upgrade; third-party plugins live in
  `$fogprogramdir/plugins/`, which the installer never touches. Today
  `configureHttpd()` does `rm -rf $webdirdest` and
  `backupPreservedCustomizations()` rescues the iPXE background and refind blobs
  but not `lib/plugins/` — so a plugin survives an upgrade only if it ships in
  this repo. That is the reason no third party has ever shipped a FOG plugin.
  A name collision between roots is refused and logged, never shadowed.
- **A manifest that means something.** `version` (written through to the
  currently-dead `plugins.pVersion`), `fog_min`/`fog_max`, `author`, `homepage`,
  `requires[]`, `entity`, `sensitive_fields`. The dead `entrypoint` is dropped.
  The compatibility range is the highest-value field: it converts most of "I
  upgraded FOG and my plugin broke" into a message at activation time.
- **Install from the UI**, gated behind a new `plugin.install` action, off by
  default, external root only, manifest and checksum shown before extraction.
  The RCE surface is acknowledged explicitly rather than glossed.
- **`FOGProject/fog-plugins` as one monorepo** for the bundled set, via
  `git subtree split`. One repo per plugin (#848) is rejected for the bundled
  plugins — 15 repos is 15 release chores for one maintainer — but third-party
  plugins own their own.

It also records **what does not move**. `site` stays bundled, and the reason is
consequence rather than coupling: core names it nowhere and it is the
best-decoupled plugin in the tree, but per ADR 0006 the object-scope seam is
default-allow, so **with no listener the boundary does not exist**. A security
boundary that vanishes silently must not be uninstallable. Worth stating
explicitly, because "it's tightly coupled" would lead someone to decouple it and
conclude it was safe to move.

Two **Open** items are marked as such rather than decided: whether `requires[]`
needs real dependency resolution, and whether bundled plugins should also be
installable from the external root.

## ADR 0006 annotation

Its consequence that "unknown nodes/classes stay allowed, matching the RBAC
stance" no longer holds — #1025 made both paths fail closed. Annotated in place
rather than rewritten, and scoped narrowly to the verb layer: 0006's
object-scope seam is still default-allow and still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)