### PR TITLE
Fix plugin discovery, which has been finding nothing

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5020,3 +5020,19 @@ $this->schema[] = [
     . "(Unattended - secure boot in setup mode required)', '0', '2', "
     . "'mode=enrollsb')",
 ];
+// 326
+$this->schema[] = [
+    // Removes FOG_PLUGINSYS_DIR. The setting only ever pretended to be
+    // configurable: Plugin::_getDirs() read it and, whenever it was not
+    // exactly '../lib/plugins/', wrote that value straight back before
+    // using it -- so editing it in FOG Configuration changed nothing and
+    // was silently reverted on the next boot. _getDirs() no longer reads
+    // it at all, which leaves an editable row in the UI that does nothing,
+    // and a setting that lies is worse than no setting.
+    //
+    // The plugin roots are fixed in code instead (BASEPATH/lib/plugins,
+    // plus FOG_PLUGIN_DIR for third-party plugins -- see ADR 0009).
+    // FOG_PLUGINSYS_ENABLED is deliberately NOT touched: that one is a real
+    // on/off switch getActivePlugins() still honours.
+    "DELETE FROM `globalSettings` WHERE `settingKey` = 'FOG_PLUGINSYS_DIR'",
+];

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -64,49 +64,63 @@ class Plugin extends FOGController
     /**
      * Gets the directories of plugins.
      *
+     * Globs the plugin root one level deep for <root>/<name>/config/
+     * plugin.config.php. This used to filter self::fileitems(), which since
+     * 698b6dc6c ("cache the BASEPATH class-file scan") filters
+     * Initiator::classFileList() -- a list built from a regex matching only
+     * *.class.php, *.page.php, *.hook.php, *.event.php and *.report.php.
+     * plugin.config.php matches none of those, so the filter could never
+     * return anything and discovery had been silently finding zero plugins:
+     * a fresh install offered none to install at all, and a newly added
+     * directory was never picked up. Existing installs kept working only
+     * because the `plugins` rows written before that commit still described
+     * them, which also left those rows frozen at whatever they said then.
+     *
+     * A targeted glob is also cheaper than what it replaced -- one shallow
+     * glob instead of a filter over a recursive walk of the whole tree.
+     *
      * @return array
      */
     private function _getDirs()
     {
-        $dir = trim(self::getSetting('FOG_PLUGINSYS_DIR'));
-        if ($dir != '../lib/plugins/') {
-            self::setSetting('FOG_PLUGINSYS_DIR', '../lib/plugins/');
-            $dir = '../lib/plugins/';
+        $root = rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins' . DS;
+        $dirs = [];
+        foreach ((array)glob($root . '*' . DS . 'config' . DS . 'plugin.config.php') as $config) {
+            $dirs[] = dirname(dirname($config)) . DS;
         }
-        $patternReplacer = function ($element) {
-            return preg_replace('#config/plugin\.config\.php$#i', '', $element[0]);
-        };
-        $regext = '#^.+/config/plugin\.config\.php$#i';
-        return array_values(
-            array_unique(
-                array_filter(
-                    array_map(
-                        $patternReplacer,
-                        self::fileitems(
-                            '.config.php',
-                            'config',
-                            false,
-                            false
-                        )
-                    )
-                )
-            )
-        );
+        return $dirs;
     }
     /**
      * Gets plugins.
+     *
+     * Reads every existing `plugins` row up front, in ONE query, and keys it
+     * by name. What this replaced did seven queries per plugin -- an id
+     * lookup, a load, and five separate exists() calls, one per field it
+     * wanted to compare -- and getActivePlugins() calls this on every boot.
+     * At fifteen bundled plugins that is over a hundred queries on every page
+     * load. The cost never showed up only because discovery was returning
+     * nothing at all (see _getDirs()), so fixing that without this would have
+     * traded a silent breakage for a loud slowdown.
+     *
+     * Comparing the row in PHP is also a truer test than exists() was.
+     * exists() asks "does ANY row hold this value in this column", so two
+     * plugins sharing a description each looked unchanged even when one of
+     * them genuinely had drifted.
      *
      * @return array
      */
     public function getPlugins()
     {
         $Plugins = [];
-        foreach ((array) $this->_getDirs() as &$file) {
-            $pluginID = Route::getIds(
-                'plugin',
-                ['name' => basename($file)]
-            );
-            $pluginID = count($pluginID ?: []) ? @min($pluginID) : 0;
+        $existing = [];
+        Route::listem('plugin');
+        $rows = json_decode(Route::getData());
+        foreach ((array)($rows->data ?? []) as $row) {
+            $existing[strtolower((string)$row->name)] = $row;
+        }
+        foreach ((array) $this->_getDirs() as $file) {
+            $name = strtolower(basename($file));
+            $row = $existing[$name] ?? null;
             $configFile = sprintf(
                 '%s/config/plugin.config.php',
                 rtrim($file, '/')
@@ -132,48 +146,49 @@ class Plugin extends FOGController
                     $fog_plugin['menuicon']
                 );
             }
-            $plugin = self::getClass('Plugin', $pluginID)
-                ->set('name', strtolower(basename($file)))
-                ->set('description', $fog_plugin['description'])
-                ->set('location', $file)
-                ->set('runfile', $runFile)
-                ->set('icon', $icon);
-            $plugman = self::getClass('PluginManager');
-            $nameexists = $plugman->exists(
-                $plugin->get('name'),
-                '',
-                'name'
-            );
-            $descexists = $plugman->exists(
-                $plugin->get('description'),
-                '',
-                'description'
-            );
-            $locexists = $plugman->exists(
-                $plugin->get('location'),
-                '',
-                'location'
-            );
-            $runfileexists = $plugman->exists(
-                $plugin->get('runfile'),
-                '',
-                'runfile'
-            );
-            $iconexists = $plugman->exists(
-                $plugin->get('icon'),
-                '',
-                'icon'
-            );
-            if (!$nameexists
-                || !$descexists
-                || !$locexists
-                || !$runfileexists
-                || !$iconexists
-            ) {
+            $fields = [
+                'name' => $name,
+                'description' => $fog_plugin['description'],
+                'location' => $file,
+                'runfile' => $runFile,
+                'icon' => $icon,
+            ];
+            // Some plugins wrap their description in _(), so the value
+            // compared here is locale-dependent and the stored one is
+            // whatever locale last ran discovery. That settles after a single
+            // write per locale change rather than rewriting every boot, which
+            // is why it is left alone: excluding description from the compare
+            // would mean an edited description never reached the row at all.
+            $changed = null === $row;
+            foreach ($fields as $field => $value) {
+                if (!$changed && (string)($row->{$field} ?? '') !== (string)$value) {
+                    $changed = true;
+                }
+            }
+            $id = (int)($row->id ?? 0);
+            if ($changed) {
+                // Constructed WITH the id, so the row is loaded before the
+                // save. save() writes every databaseField, so saving an
+                // unloaded object would blank the columns discovery does not
+                // set -- state, installed, version, pSchema -- silently
+                // uninstalling every plugin. The load costs a query, which is
+                // why it is on this branch and not the common one.
+                $plugin = self::getClass('Plugin', $id);
+                foreach ($fields as $field => $value) {
+                    $plugin->set($field, $value);
+                }
                 $plugin->save();
+            } else {
+                // Nothing to write, so skip the load entirely and hydrate
+                // from the row already in hand. Keeps steady-state discovery
+                // at the single listem() above.
+                $plugin = self::getClass('Plugin');
+                $plugin->set('id', $id);
+                foreach ($fields as $field => $value) {
+                    $plugin->set($field, $value);
+                }
             }
             $Plugins[] = $plugin;
-            unset($file);
         }
 
         return $Plugins;

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -113,7 +113,14 @@ class Plugin extends FOGController
     {
         $Plugins = [];
         $existing = [];
-        Route::listem('plugin');
+        // inputoverride = true. Without it listem() parses php://input for
+        // DataTables `start`/`length` and paginates THIS query with whatever
+        // grid the current request happens to be drawing. Discovery runs on
+        // every boot, including the boot inside a grid's own AJAX POST, so a
+        // page size below the plugin count returned a short list -- and every
+        // plugin past it looked new (see the id lookup below for what that
+        // then did). Discovery wants every row, always.
+        Route::listem('plugin', false, true);
         $rows = json_decode(Route::getData());
         foreach ((array)($rows->data ?? []) as $row) {
             $existing[strtolower((string)$row->name)] = $row;
@@ -166,6 +173,19 @@ class Plugin extends FOGController
                 }
             }
             $id = (int)($row->id ?? 0);
+            if ($changed && !$id) {
+                // Never insert on the strength of the row being absent from
+                // $existing. plugins.pName is UNIQUE and save() issues
+                // INSERT ... ON DUPLICATE KEY UPDATE, so an "insert" for a
+                // name that already exists silently OVERWRITES that row --
+                // blanking state, installed and pSchema, which presents to
+                // the admin as plugins uninstalling themselves. A single
+                // short list is all it takes, so confirm the row is really
+                // absent rather than trusting the list to be complete. One
+                // query, and only for a plugin that looks new.
+                $found = Route::getIds('plugin', ['name' => $name], 'id');
+                $id = (int)(reset($found) ?: 0);
+            }
             if ($changed) {
                 // Constructed WITH the id, so the row is loaded before the
                 // save. save() writes every databaseField, so saving an

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -33,7 +33,11 @@ class PluginManager extends FOGManagerController
     public function getPluginsNeedingUpdate()
     {
         $needing = [];
-        Route::listem('plugin', ['installed' => 1]);
+        // inputoverride = true so the caller's DataTables pagination cannot
+        // truncate this list -- see Plugin::getPlugins(). Read-only here, so
+        // the worst case was a missing "needs update" badge rather than a
+        // damaged row, but it is the same mistake.
+        Route::listem('plugin', ['installed' => 1], true);
         $plugins = json_decode(Route::getData());
         foreach ((array)$plugins->data as $row) {
             $plugin = self::getClass('Plugin', $row->id);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -78,7 +78,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 325);
+        define('FOG_SCHEMA', 326);
         define('FOG_BCACHE_VER', 274);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
A live bug on `working-1.6`, split out of the plugin-architecture work
(ADR 0009) so it can land without waiting on that review.

## The bug

`Plugin::_getDirs()` filtered `FOGBase::fileitems()`, and since **698b6dc6c**
("cache the BASEPATH class-file scan") `fileitems()` filters
`Initiator::classFileList()` — a list built from a regex matching only
`*.class.php`, `*.page.php`, `*.hook.php`, `*.event.php` and `*.report.php`.
`plugin.config.php` matches none of them, so the filter could never return a
single row.

On a running server:

- a **fresh install** discovers no plugins at all — Plugin Management is empty
  and nothing can ever be installed;
- a **newly dropped-in** plugin directory is never picked up;
- existing installs look fine only because the `plugins` rows written *before*
  that commit still describe them — and those rows are frozen at whatever they
  said then.

Verified against a 1.6 lab tree: **390 files in the class list, 0 of them a
plugin config.** The frozen-row symptom showed there too — the `site` row still
carried a description the source had long since replaced.

`_getDirs()` now globs `<root>/*/config/plugin.config.php` directly: correct,
and cheaper than filtering a recursive walk. It was the only broken consumer;
the other three `fileitems()` callers ask for class-type extensions, which are
in the list.

## The query storm it was hiding

`getPlugins()` runs on **every boot** via `getActivePlugins()` and did seven
queries per plugin — an id lookup, a load, and five `exists()` calls, one per
compared field. At fifteen plugins that is 100+ queries per page load,
unnoticed only because the loop never ran. Fixing discovery alone would have
traded a silent breakage for a loud slowdown.

It now reads every row in one `listem()` and compares in PHP, loading a row
only on the branch that actually writes. That load is load-bearing: `save()`
writes every `databaseField`, so saving an unloaded object would blank
`state`/`installed`/`version`/`pSchema` and silently uninstall everything.

Comparing in PHP is also a truer test than `exists()`, which asked "does ANY
row hold this value in this column" — so two plugins sharing a description each
read as unchanged even when one had genuinely drifted.

## Schema 326

Drops `FOG_PLUGINSYS_DIR`. It only ever pretended to be configurable:
`_getDirs()` read it and wrote `'../lib/plugins/'` straight back whenever it
differed, so editing it in FOG Configuration changed nothing and was reverted
on the next boot. Nothing reads it now, and an editable row that does nothing
is worse than no row. `FOG_PLUGINSYS_ENABLED` is untouched — that one is a real
switch `getActivePlugins()` still honours.

**326 is free.** Checked rather than assumed: `secureboot-enrollment-task` is
fully merged into `working-1.6` and its 322 is byte-identical (so the old
collision is settled), `pki-three-zone-phase1` adds no schema step of its own
and its 323 is working-1.6's, and no other unmerged branch goes above 325.

## Verification

Deployed to the 1.6 lab via a full install. All 15 plugins discovered; the
`site` row corrected itself to the current description on first boot; every
plugin's `state`, `installed` and `schema` values survived intact, confirming
the load-before-save guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)