### PR TITLE
Pin the plugins to v1.6.1 (file modes only)

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -92,7 +92,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.0');
+        define('FOG_PLUGINS_VERSION', 'v1.6.1');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Bumps `FOG_PLUGINS_VERSION` to [`v1.6.1`](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.1).

**Content is byte-for-byte identical to v1.6.0.** The only change is file modes: 30 files — PHP, JS and two `plugin.config.php` — were recorded `100755`. They came out of this repository that way, where `core.fileMode=false` means a stray `+x` is never noticed or corrected, and the release tarball carried those modes into every FOG web root. Nothing in the plugin tree is executed directly; it is all included by PHP or fetched by the browser.

## Verified

Both assets extracted and compared:

| | v1.6.0 | v1.6.1 |
|---|---|---|
| `diff -r` | — | **no differences** |
| Executable files | 30 | **0** |

And the upgrade path itself, which this is the first real exercise of: with the tree stamped `v1.6.0`, bumping the pin and running `bin/fetch-plugins.sh` (no `--force`) replaced the tree, restamped it `v1.6.1`, and left the content hash unchanged.

## Upstream change worth knowing about

`fog-plugins` now builds its release asset with a `make-release.sh` rather than by hand, because both obvious ways of doing it are wrong in opposite directions:

- **plain tar** carries the working tree's modes — that is how the `+x` shipped in v1.6.0;
- **`git archive`** carries git's modes, which is better, but its tar writer hardcodes `0664`/`0775`, and group-writable is a worse thing to unpack into a web root than a pointless `+x`.

So: `git archive` for the content (honours `export-ignore`, cannot drift from the tag), then explicit 755/644, then a deterministic tar. Two builds of a tag now produce identical bytes, which is what makes the published sha256 worth checking.