### PR TITLE
Refuse to regenerate the translation catalogue without the plugin tree

### DIFF
--- a/.githooks/lib/update-language.sh
+++ b/.githooks/lib/update-language.sh
@@ -31,6 +31,25 @@ pot="$langdir/messages.pot"
 # strings: without them every regeneration rewrites the POT-Creation-Date and
 # every source line number, so the file differs on every run even when no
 # translatable string changed.
+# The plugin tree is fetched, not committed (ADR 0009), and the find below is a
+# filesystem walk -- so regenerating from a clone that has not run
+# bin/fetch-plugins.sh quietly produces a catalogue with every plugin string
+# missing. Measured on the first commit that hit it: 528 msgids gone, the whole
+# of LDAP, Windows Key and WOL Broadcast among them, and the only symptom was a
+# large diff in a file nobody reads closely.
+#
+# Refusing is right rather than fetching here: this script is deliberately
+# side-effect free -- it stages nothing, commits nothing and touches no network
+# -- and a translation regeneration is not the place to start downloading
+# releases. The caller knows whether it can fetch.
+plugindir="$project_dir/packages/web/lib/plugins"
+if [ ! -d "$plugindir" ] || [ -z "$(ls -A "$plugindir" 2>/dev/null)" ]; then
+    echo "update-language.sh: $plugindir is empty or missing." >&2
+    echo "Regenerating now would drop every plugin string from the catalogue." >&2
+    echo "Run bin/fetch-plugins.sh first." >&2
+    exit 1
+fi
+
 xgettext --language=PHP --from-code=UTF-8 --output="$pot" \
     --omit-header --no-location \
     $(find "$project_dir/packages/web/" -name "*.php")


### PR DESCRIPTION
Fallout from #1029, found while unblocking #1025.

The plugin tree is fetched rather than committed now, and `update-language.sh` feeds `xgettext` from `find packages/web/ -name '*.php'` — a filesystem walk. Regenerating from a clone that has not run `bin/fetch-plugins.sh` therefore produces a catalogue with **every plugin string missing**, silently.

Not hypothetical. The first commit that hit it dropped **528 msgids** — the whole of LDAP, Windows Key and WOL Broadcast among them — and turned a 210-line PR into a `+15306/-19176` diff. It was caught by the size of that diff, not by anything checking.

The script now refuses if `packages/web/lib/plugins` is missing or empty, and says what to run.

**Refusing rather than fetching** is deliberate: this script is side-effect free by design — it stages nothing, commits nothing, touches no network — and a translation regeneration is not the place to start downloading releases. The caller knows whether it can fetch.

Verified both ways: with the tree parked aside it exits 1 and leaves the catalogue untouched; with it present it exits 0 and produces no churn.

## One thing to check before this lands

The header says CI runs these identical commands. If the `update-lang-fix-psr-and-sync-version` workflow in `fog-workflows` regenerates without fetching plugins first, this guard turns a silent truncation into a failed job — which is the right outcome, but that workflow will need a `bin/fetch-plugins.sh` step adding. I have not touched `fog-workflows`.