### PR TITLE
Fix #1036: inventory empty after Quick Registration (mac encoding in getHostItem)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -534,7 +534,7 @@ abstract class FOGBase
                     file_get_contents('php://input'),
                     $vars
                 );
-                $mac = $vars['mac'];
+                $mac = $vars['mac'] ?? '';
             }
         }
         // disabling sysuuid detection code for now as it is causing
@@ -545,11 +545,12 @@ abstract class FOGBase
                     $sysuuid = filter_input(INPUT_GET, 'sysuuid');
                 }
          */
-        // If encoded decode and store value
-        if ($encoded === true) {
-            $mac = base64_decode($mac);
-            //            $sysuuid = base64_decode($sysuuid);
-        }
+        // Normalize the mac. stripAndDecode() rewrites $_REQUEST, but the mac
+        // is read here from the raw request via filter_input() (or passed in
+        // explicitly), which that rewrite never touches, so the encoding has
+        // to be resolved here. The legacy $encoded flag is now redundant but
+        // kept for call-signature compatibility.
+        $mac = self::stripAndDecodeMac($mac);
         // See if we can find the host by system uuid rather than by mac's first.
         /*        if ($sysuuid) {
                     $Inventory = self::getClass('Inventory')
@@ -2403,6 +2404,65 @@ abstract class FOGBase
         }
 
         return $item;
+    }
+    /**
+     * Strips and decodes a mac, or a '|' separated list of macs.
+     *
+     * FOS base64-encodes the mac on some paths (registration, deploy) and
+     * sends it plain on others (checkin, the standalone inventory task), so
+     * the encoding has to be sniffed. The sniff cannot be the one
+     * stripAndDecode() uses -- "do the decoded bytes happen to be valid
+     * UTF-8" -- because a hex mac is built entirely out of base64 alphabet
+     * characters, so a plain mac decodes to accidentally-valid UTF-8 roughly
+     * once in every few hundred (measured: 0.26% lowercase, 0.84% upper) and
+     * that host would then silently fail to resolve, intermittently and per
+     * mac. Sniff on shape instead: keep the plain value when it is already a
+     * well formed mac list, and accept the decoded value only when it is one.
+     *
+     * @param mixed $mac the raw mac value
+     *
+     * @return string
+     */
+    public static function stripAndDecodeMac($mac)
+    {
+        $mac = trim((string) ($mac ?? ''));
+        if ($mac === '' || self::isMacList($mac)) {
+            return Initiator::e($mac);
+        }
+        $decoded = trim(base64_decode(str_replace(' ', '+', $mac)));
+        if (self::isMacList($decoded)) {
+            return Initiator::e($decoded);
+        }
+
+        // Neither shape matched; hand back the plain value so the caller
+        // reports the mac it was actually sent.
+        return Initiator::e($mac);
+    }
+    /**
+     * Tests whether a string is a '|' separated list of mac addresses.
+     *
+     * @param string $macs the string to test
+     *
+     * @return bool
+     */
+    private static function isMacList($macs)
+    {
+        $parts = array_filter(
+            array_map(
+                'trim',
+                explode('|', $macs)
+            )
+        );
+        if (count($parts) < 1) {
+            return false;
+        }
+        foreach ($parts as $part) {
+            if (!preg_match(MACAddress::PATTERN, $part)) {
+                return false;
+            }
+        }
+
+        return true;
     }
     /**
      * Gets the master interface based on the ip found.

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -24,9 +24,17 @@ class MACAddress extends FOGBase
     /**
      * Pattern to validate MACAddresses.
      *
+     * Accepts the three formats a mac may arrive in: colon or hyphen
+     * separated octets, twelve bare hex digits, or dot separated quads.
+     * Public so code that needs to recognise a mac without building a
+     * MACAddress (see FOGBase::stripAndDecodeMac) shares this one definition.
+     *
      * @var string
      */
-    private static $_pattern = '';
+    public const PATTERN = '/^(?:[[:xdigit:]]{2}([-:]))'
+        . '(?:[[:xdigit:]]{2}\1){4}[[:xdigit:]]{2}$'
+        . '|^(?:[[:xdigit:]]{12})$|^(?:[[:xdigit:]]'
+        . '{4}([.])){2}[[:xdigit:]]{4}$/';
     /**
      * This msg packet.
      *
@@ -64,17 +72,6 @@ class MACAddress extends FOGBase
      */
     public function __construct($mac)
     {
-        /**
-         * Defines our grep/search patterns for
-         * validating a MAC Address.
-         */
-        self::$_pattern = sprintf(
-            '%s%s%s%s',
-            '/^(?:[[:xdigit:]]{2}([-:]))',
-            '(?:[[:xdigit:]]{2}\1){4}[[:xdigit:]]{2}$',
-            '|^(?:[[:xdigit:]]{12})$|^(?:[[:xdigit:]]',
-            '{4}([.])){2}[[:xdigit:]]{4}$/'
-        );
         /**
          * Pull in our base initialized items.
          */
@@ -180,7 +177,7 @@ class MACAddress extends FOGBase
          */
         $mac = array_values(
             preg_grep(
-                self::$_pattern,
+                self::PATTERN,
                 (array) $mac
             )
         );
@@ -275,7 +272,7 @@ class MACAddress extends FOGBase
          * Returns as bool.
          */
         return (bool) preg_match(
-            self::$_pattern,
+            self::PATTERN,
             $this->MAC
         );
     }

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -26,8 +26,11 @@ header('Content-Type: text/plain');
 FOGCore::stripAndDecode($_REQUEST);
 try {
     // Authenticate by host/MAC the same way the other FOS-facing service
-    // endpoints do; getHostItem() reads the mac itself and throws on an
-    // unknown/invalid host.
+    // endpoints do; getHostItem() reads the mac itself (via filter_input on
+    // the raw request) and normalizes it, so it handles the base64-encoded
+    // mac fog.inventory sends on registration/deploy as well as the plain mac
+    // the standalone inventory task sends. It throws on an unknown/invalid
+    // host.
     FOGCore::getHostItem(false);
     if (!FOGCore::$Host->isValid()) {
         throw new Exception(_('Invalid Host'));


### PR DESCRIPTION
Fixes #1036.

## The bug

Quick Registration creates the host but leaves the Inventory tab blank, with no error surfaced to the user.

`service/inventory.php` calls `FOGCore::getHostItem(false)`, and `getHostItem()` reads the mac with `filter_input()` on the **raw** request — which `stripAndDecode()`'s rewrite of `$_REQUEST` never touches. FOS posts the mac base64-encoded from `fog.man.reg`, so the host lookup ran against the still-encoded blob, threw `Invalid MAC Address!`, and never reached `$Inventory->save()`.

This is a regression from 7251c3c6b, which replaced `getHostItem(false, false, false, false, false, $_REQUEST['mac'])` (a mac `stripAndDecode()` had already decoded) with the bare `getHostItem(false)`.

Reproduced on the lab at 1.5.10.2259, no writes needed — the error echoes back the mac it looked up:

```
$ curl -sk --data "mac=02:1f:3e:4d:5a:6b" .../service/inventory.php
Invalid Host                                       <- mac parsed, host genuinely unknown

$ curl -sk --data "mac=MDI6MWY6M2U6NGQ6NWE6NmI=" .../service/inventory.php
Invalid MAC Address! MDI6MWY6M2U6NGQ6NWE6NmI=      <- never decoded
```

## Why not the one-liner from the issue

`getHostItem(false, true)` only moves the failure. FOS sends the mac **base64-encoded** from `fog.man.reg`, `fog.auto.reg` and `fog.download`, but **plain** from `bin/fog` and `fog.sysinfo` — so forcing a decode breaks the standalone inventory task instead. No endpoint can know in advance which encoding it will get, so the encoding is resolved in the single place that reads the mac.

## The fix

`FOGBase::stripAndDecodeMac()` sniffs on **shape**, not on "do the decoded bytes happen to be valid UTF-8":

- keep the plain value when it is already a well formed mac list;
- accept the decoded value only when *it* is one.

The UTF-8 test that `stripAndDecode()` uses is unsafe for a mac specifically: a hex mac is built entirely out of base64 alphabet characters, so a plain mac decodes to accidentally-valid UTF-8 about **once in every few hundred** — measured 0.26% of lowercase macs and 0.84% of uppercase over 500k samples. (working-1.6 shipped that variant and is affected; see the companion PR.)

`MACAddress`'s validation pattern becomes a `public const` so the sniff and the class share one definition instead of duplicating the regex. It was being rebuilt with `sprintf` on every construction; `normalizeMAC()` and `isValid()` now read the constant.

Also hardened `$vars['mac']` against an `Undefined array key` warning on the `php://input` fallback, in the same lines.

## Verification

- Live reproduction above against 1.5.10.2259.
- The new `stripAndDecodeMac()` / `isMacList()` bodies were lifted verbatim out of the committed source and executed against a case matrix: plain mac, `|`-separated list (the `boot.php` shape), base64 single and list, base64 with trailing newline, GNU-`base64`-wrapped output for a multi-NIC host, `+` arriving as a space, bare 12-hex, dotted-quad, hyphenated, uppercase, empty/null/`false`, garbage, and HTML injection. Plus a 200k-sample sweep: **0** plain macs mangled, **0** encoded macs failing round-trip.
- All `getHostItem()` callers audited. Only `service/ipxe/boot.php` passes a mac explicitly, and it passes a `|`-joined list of plain macs, which is preserved untouched.

## Companion

working-1.6 needs the same shape-based sniff for a different reason — it already decodes, but with the UTF-8 test. Filed separately against `working-1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)