### PR TITLE
Don't let a plain mac get mistaken for base64 in getHostItem

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -625,13 +625,10 @@ abstract class FOGBase
         //}
         // Normalize the mac. stripAndDecode() rewrites $_REQUEST, but the mac
         // is read here from the raw request via filter_input() (or passed in
-        // explicitly), which that rewrite never touches. FOS base64-encodes
-        // the mac on some paths (registration, deploy) and sends it plain on
-        // others (checkin, inventory task), so decode it conditionally the
-        // same way stripAndDecode() does: use the decoded value only when it
-        // is valid, else keep the plain value. The legacy $encoded flag is now
-        // redundant but kept for call-signature compatibility.
-        $mac = self::stripAndDecodeItem($mac);
+        // explicitly), which that rewrite never touches, so the encoding has
+        // to be resolved here. The legacy $encoded flag is now redundant but
+        // kept for call-signature compatibility.
+        $mac = self::stripAndDecodeMac($mac);
         // See if we can find the host by system uuid rather than by mac's first.
         /*if ($sysuuid) {
             $Inventory = self::getClass('Inventory')
@@ -3059,6 +3056,65 @@ abstract class FOGBase
         }
 
         return Initiator::e(trim($val));
+    }
+    /**
+     * Strips and decodes a mac, or a '|' separated list of macs.
+     *
+     * FOS base64-encodes the mac on some paths (registration, deploy) and
+     * sends it plain on others (checkin, the standalone inventory task), so
+     * the encoding has to be sniffed. The sniff cannot be the one
+     * stripAndDecodeItem() uses -- "do the decoded bytes happen to be valid
+     * UTF-8" -- because a hex mac is built entirely out of base64 alphabet
+     * characters, so a plain mac decodes to accidentally-valid UTF-8 roughly
+     * once in every few hundred (measured: 0.26% lowercase, 0.84% upper) and
+     * that host would then silently fail to resolve, intermittently and per
+     * mac. Sniff on shape instead: keep the plain value when it is already a
+     * well formed mac list, and accept the decoded value only when it is one.
+     *
+     * @param mixed $mac the raw mac value
+     *
+     * @return string
+     */
+    public static function stripAndDecodeMac($mac)
+    {
+        $mac = trim((string) ($mac ?? ''));
+        if ($mac === '' || self::isMacList($mac)) {
+            return Initiator::e($mac);
+        }
+        $decoded = trim(base64_decode(str_replace(' ', '+', $mac)));
+        if (self::isMacList($decoded)) {
+            return Initiator::e($decoded);
+        }
+
+        // Neither shape matched; hand back the plain value so the caller
+        // reports the mac it was actually sent.
+        return Initiator::e($mac);
+    }
+    /**
+     * Tests whether a string is a '|' separated list of mac addresses.
+     *
+     * @param string $macs the string to test
+     *
+     * @return bool
+     */
+    private static function isMacList($macs)
+    {
+        $parts = array_filter(
+            array_map(
+                'trim',
+                explode('|', $macs)
+            )
+        );
+        if (count($parts) < 1) {
+            return false;
+        }
+        foreach ($parts as $part) {
+            if (!preg_match(MACAddress::PATTERN, $part)) {
+                return false;
+            }
+        }
+
+        return true;
     }
     /**
      * Gets the master interface based on the ip found.

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -24,9 +24,17 @@ class MACAddress extends FOGBase
     /**
      * Pattern to validate MACAddresses.
      *
+     * Accepts the three formats a mac may arrive in: colon or hyphen
+     * separated octets, twelve bare hex digits, or dot separated quads.
+     * Public so code that needs to recognise a mac without building a
+     * MACAddress (see FOGBase::stripAndDecodeMac) shares this one definition.
+     *
      * @var string
      */
-    private static $_pattern = '';
+    public const PATTERN = '/^(?:[[:xdigit:]]{2}([\-:]))'
+        . '(?:[[:xdigit:]]{2}\1){4}[[:xdigit:]]{2}$'
+        . '|^(?:[[:xdigit:]]{12})$|^(?:[[:xdigit:]]'
+        . '{4}([.])){2}[[:xdigit:]]{4}$/';
     /**
      * This msg packet.
      *
@@ -64,17 +72,6 @@ class MACAddress extends FOGBase
      */
     public function __construct($mac)
     {
-        /**
-         * Defines our grep/search patterns for
-         * validating a MAC Address.
-         */
-        self::$_pattern = sprintf(
-            '%s%s%s%s',
-            '/^(?:[[:xdigit:]]{2}([\-:]))',
-            '(?:[[:xdigit:]]{2}\1){4}[[:xdigit:]]{2}$',
-            '|^(?:[[:xdigit:]]{12})$|^(?:[[:xdigit:]]',
-            '{4}([.])){2}[[:xdigit:]]{4}$/'
-        );
         /**
          * Pull in our base initialized items.
          */
@@ -180,7 +177,7 @@ class MACAddress extends FOGBase
          */
         $mac = array_values(
             preg_grep(
-                self::$_pattern,
+                self::PATTERN,
                 (array) $mac
             )
         );
@@ -387,7 +384,7 @@ class MACAddress extends FOGBase
          * Returns as bool.
          */
         return (bool) preg_match(
-            self::$_pattern,
+            self::PATTERN,
             $this->MAC
         );
     }


### PR DESCRIPTION
Companion to #1037 (the `dev-branch` / 1.5 half of #1036). The 1.6 inventory bug in that issue is already fixed here by b92393065 — this PR fixes a latent bug that fix introduced.

## The bug

b92393065 normalizes the mac inside `getHostItem()` with `stripAndDecodeItem()`, which decides "is this base64?" by asking whether the decoded bytes happen to be valid UTF-8. That is the right test for the inventory fields it was written for. It is the wrong test for a mac.

A hex mac is built entirely out of base64 alphabet characters, so a plain mac decodes to accidentally-valid UTF-8 **about once in every few hundred** — measured 0.26% of lowercase macs and 0.84% of uppercase over 500k samples. The mac then turns into binary garbage and the host does not resolve. It is not intermittent per request: it is permanent for whichever hosts happen to own an unlucky mac.

Confirmed against the lab at 1.6.0-beta.3354, zero writes — the error echoes back the mac it looked up:

```
$ curl -sk --data "mac=14:59:d1:c9:f3:9b" .../service/inventory.php
Invalid MAC Address! ׎}wW=[             <- plain mac eaten

$ curl -sk --data "mac=2a:91:15:18:16:02" .../service/inventory.php
Invalid MAC Address! ٯuם|׭6            <- same

$ curl -sk --data "mac=02:1f:3e:4d:5a:6b" .../service/inventory.php
Invalid Host                              <- neighboring mac, parsed fine
```

Every FOS-facing endpoint funnels through `getHostItem()`, so all of them are affected — including `service/ipxe/boot.php`. An affected host silently boots the default menu instead of its assigned task, which is about as hard to diagnose from a bug report as it gets.

## The fix

`stripAndDecodeMac()` sniffs on **shape** rather than on encoding validity: keep the plain value when it is already a well formed mac list, and accept the decoded value only when *it* is one. Neither encoding can be misread.

`MACAddress`'s validation pattern becomes a `public const` so the sniff and the class share a single definition rather than duplicating the regex. It was being rebuilt with `sprintf` on every construction; `normalizeMAC()` and `isValid()` now read the constant. Verified byte-identical to the string the old `sprintf` produced.

`stripAndDecodeItem()` is unchanged and still used by `stripAndDecode()` for ordinary request values, where the UTF-8 test is the right one.

## Verification

- Live reproduction above against 1.6.0-beta.3354.
- The new `stripAndDecodeMac()` / `isMacList()` bodies were lifted verbatim out of the committed source and executed against a case matrix: plain mac, `|`-separated list (the `boot.php` shape), base64 single and list, base64 with trailing newline, GNU-`base64`-wrapped output for a multi-NIC host, `+` arriving as a space, bare 12-hex, dotted-quad, hyphenated, uppercase, empty/null/`false`, garbage, HTML injection, and the three macs proven mangled on the live lab. Plus a 200k-sample sweep: **0** plain macs mangled, **0** encoded macs failing round-trip.
- All `getHostItem()` callers audited. Only `service/ipxe/boot.php` passes a mac explicitly, and it passes a `|`-joined list of plain macs, preserved untouched.
- No overlap with the `fogbase.class.php` hunks in #1015 (that PR touches `certDecrypt()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)