### PR TITLE
Fix #1039: installer fails with DHCP enabled on Debian 13 / Ubuntu 26 (Kea + AppArmor)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5497,6 +5497,42 @@ _keaAppleClass() {
         }
 EOFAPL
 }
+_keaRunAs() {
+    # Print the account "kea-dhcp4 -t" must run as to read $1, or nothing for root.
+    #
+    # Debian/Ubuntu ship /etc/kea as 0750 owned by the service account (_kea),
+    # and their AppArmor profile grants kea-dhcp4 "/etc/kea/** r" while
+    # deliberately withholding cap_dac_read_search and cap_dac_override. Root is
+    # neither the directory's owner nor in its group, so a root-run validation
+    # cannot even traverse the directory: Kea reports "Unable to open file
+    # <path>" for a file that plainly exists, and the install aborts (#1039).
+    # The daemon itself was never affected because systemd runs it as _kea.
+    #
+    # Validating as the directory's owner needs no DAC bypass at all, so it
+    # succeeds with the AppArmor profile intact. Do NOT "fix" this by putting the
+    # profile into complain mode or deleting it -- that disables a protection the
+    # distro shipped on purpose, on a box the admin did not ask us to weaken.
+    # Where /etc/kea is root-owned (RedHat, Arch, Alpine) this returns nothing
+    # and the validation runs as root exactly as before.
+    local owner
+    owner=$(stat -c '%U' "$(dirname "$1")" 2>/dev/null)
+    [[ -z $owner || $owner == root || $owner == UNKNOWN ]] && return 0
+    id -u "$owner" >/dev/null 2>&1 || return 0
+    printf '%s' "$owner"
+}
+_keaValidate() {
+    # Syntax-check $1, dropping to the config directory's owner when root cannot
+    # read it (see _keaRunAs). Returns kea-dhcp4's exit status.
+    local runas
+    runas=$(_keaRunAs "$1")
+    if [[ -z $runas ]]; then
+        kea-dhcp4 -t "$1" >>$error_log 2>&1
+    elif command -v runuser >/dev/null 2>&1; then
+        runuser -u "$runas" -- kea-dhcp4 -t "$1" >>$error_log 2>&1
+    else
+        su -s /bin/sh -c "kea-dhcp4 -t '$1'" "$runas" >>$error_log 2>&1
+    fi
+}
 _writeKeaConfig() {
     # $1 = target file, $2 = client-classes block. Reads $interface, $ipaddress,
     # $network, $cidr, $startrange, $endrange and $optdata from the caller's scope.
@@ -5527,6 +5563,12 @@ $2
     }
 }
 EOFKEA
+    # The service account has to be able to read this, and a hardened root umask
+    # (027/077) would otherwise leave it unreadable to anyone but root -- which
+    # breaks the daemon, not just the syntax check. 0644 is the mode the distro
+    # packages ship this file with; the generated config holds no credentials
+    # (the lease database is memfile).
+    chmod 0644 "$1" >>$error_log 2>&1
 }
 configureKeaDHCP() {
     local cidr=$(mask2cidr $submask)
@@ -5551,15 +5593,28 @@ configureKeaDHCP() {
         return 1
     fi
     if command -v kea-dhcp4 >/dev/null 2>&1; then
-        if ! kea-dhcp4 -t "$target" >>$error_log 2>&1; then
+        if ! _keaValidate "$target"; then
             echo "Failed"
             echo "Kea base configuration failed validation (kea-dhcp4 -t); see $error_log"
+            # "Unable to open file" against a file we just wrote and can stat is
+            # never a syntax error -- it is a mandatory access control denial
+            # (AppArmor on Debian/Ubuntu, SELinux on RedHat) stopping kea-dhcp4
+            # from reading it. Say so, because the generic message sends people
+            # hunting for a JSON typo that isn't there (#1039).
+            if [[ -s $target ]] && tail -n 20 "$error_log" 2>/dev/null | grep -q 'Unable to open file'; then
+                echo ""
+                echo " * $target exists and is readable, so this is not a syntax error."
+                echo "   Something is denying kea-dhcp4 access to it. Check:"
+                echo "     dmesg | grep -i 'apparmor.*kea'      (Debian/Ubuntu)"
+                echo "     ausearch -m avc -c kea-dhcp4         (RedHat/Rocky)"
+                echo "   Please report this with that output rather than disabling AppArmor."
+            fi
             return 1
         fi
         # Tier 2: best-effort Apple BSDP; drop if Kea rejects it.
         _writeKeaConfig "$tmp" "${baseclasses},
 ${appleclass}"
-        if kea-dhcp4 -t "$tmp" >>$error_log 2>&1; then
+        if _keaValidate "$tmp"; then
             mv -f "$tmp" "$target"
         else
             rm -f "$tmp"


### PR DESCRIPTION
Fixes #1039.

## The bug

Installing with DHCP enabled aborts at *"Setting up and starting DHCP Server (Kea)"*:

```
Syntax check failed with: Unable to open file /etc/kea/kea-dhcp4.conf
```

The config is fine. It isn't a syntax error at all.

Debian 13 and Ubuntu 26 changed the kea package to ship `/etc/kea` as **`0750 _kea:_kea`**:

| release | `/etc/kea` | affected |
|---|---|---|
| debian:12 | `755 root:root` | no |
| ubuntu:24.04 | `755 root:root` | no |
| **debian:13** | **`750 _kea:_kea`** | **yes** |
| **ubuntu:26.04** | **`750 _kea:_kea`** | **yes** |

Their AppArmor profile grants `kea-dhcp4` read access to the config but withholds the capabilities that let root ignore file permissions:

```
  /etc/kea/ r,
  /etc/kea/** r,
  capability net_bind_service,
  capability net_raw,
```

`configureKeaDHCP` runs `kea-dhcp4 -t` **as root**, and root is neither the directory's owner nor in its group — so it needs `cap_dac_read_search` just to traverse `/etc/kea`. AppArmor refuses, and Kea reports the file as unopenable. The daemon was never affected, because systemd runs it as `User=_kea`, which owns the directory. That mismatch is the whole bug.

This is why the Kea support added for #730 tested clean: every release available at the time shipped `/etc/kea` as `755 root:root`.

## The fix

Run the syntax check as the config directory's owner. That needs no DAC bypass, so it succeeds **with the AppArmor profile intact and unmodified**. Where `/etc/kea` is root-owned (RedHat, Arch, Alpine) the helper returns nothing and the check runs as root exactly as before.

**Not adopting the reported workaround.** `aa-complain` or deleting the profile would have the installer switch off a mandatory access control the distro shipped on purpose, on a machine the admin didn't ask us to weaken — and it's unnecessary once the check runs as the right user.

Two smaller changes, one of them requested in the report:

- **`chmod 0644` the generated config.** A hardened root umask (027/077) would otherwise leave it unreadable to `_kea`, which breaks the *running daemon*, not just the syntax check. 0644 is the mode the distro packages ship it with, and the generated config holds no credentials (memfile lease database).
- **Say what to look at on an "Unable to open file" failure** — `dmesg` for the AppArmor denial, `ausearch` for the SELinux one — instead of the generic validation message, so the next person doesn't go hunting for a JSON typo that isn't there.

## Verification

Containers on `debian:13`, `ubuntu:26.04`, `debian:12`, `ubuntu:24.04`, running `kea-dhcp4` with `cap_dac_override` and `cap_dac_read_search` dropped via `capsh` — exactly the capability set AppArmor leaves it with:

```
=== OLD behaviour: validate as root, dac caps dropped (= AppArmor) ===
    Syntax check failed with: Unable to open file /etc/kea/kea-dhcp4.conf
  -> reproduced #1039

=== NEW behaviour: _keaValidate, same dropped caps ===
ok   _keaValidate exit status
ok   _keaRunAs -> (empty, stays root)        # root-owned /etc/kea unchanged
ok   _keaValidate as root
ok   broken config rejected                  # malformed config still fails
ok   umask-077 config validates              # chmod guard works

passed=7 failed=0
```

Old code reproduces the reported message verbatim on the two affected releases; new code validates on all four.

**Limitation:** containers don't enforce AppArmor, so `capsh` reproduces the *mechanism* (the missing DAC capabilities) rather than the LSM itself. The profile is attached to the binary path and not the user, so dropping to `_kea` leaves `kea-dhcp4` equally confined — it just no longer needs a bypass. A run on a real AppArmor-enforcing Debian 13 box would still be worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)