### PR TITLE
Fix #1039: installer fails with DHCP enabled on Debian 13 / Ubuntu 26 (Kea + AppArmor)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -8170,6 +8170,42 @@ _keaAppleClass() {
         }
 EOFAPL
 }
+_keaRunAs() {
+    # Print the account "kea-dhcp4 -t" must run as to read $1, or nothing for root.
+    #
+    # Debian/Ubuntu ship /etc/kea as 0750 owned by the service account (_kea),
+    # and their AppArmor profile grants kea-dhcp4 "/etc/kea/** r" while
+    # deliberately withholding cap_dac_read_search and cap_dac_override. Root is
+    # neither the directory's owner nor in its group, so a root-run validation
+    # cannot even traverse the directory: Kea reports "Unable to open file
+    # <path>" for a file that plainly exists, and the install aborts (#1039).
+    # The daemon itself was never affected because systemd runs it as _kea.
+    #
+    # Validating as the directory's owner needs no DAC bypass at all, so it
+    # succeeds with the AppArmor profile intact. Do NOT "fix" this by putting the
+    # profile into complain mode or deleting it -- that disables a protection the
+    # distro shipped on purpose, on a box the admin did not ask us to weaken.
+    # Where /etc/kea is root-owned (RedHat, Arch, Alpine) this returns nothing
+    # and the validation runs as root exactly as before.
+    local owner
+    owner=$(stat -c '%U' "$(dirname "$1")" 2>/dev/null)
+    [[ -z $owner || $owner == root || $owner == UNKNOWN ]] && return 0
+    id -u "$owner" >/dev/null 2>&1 || return 0
+    printf '%s' "$owner"
+}
+_keaValidate() {
+    # Syntax-check $1, dropping to the config directory's owner when root cannot
+    # read it (see _keaRunAs). Returns kea-dhcp4's exit status.
+    local runas
+    runas=$(_keaRunAs "$1")
+    if [[ -z $runas ]]; then
+        kea-dhcp4 -t "$1" >>$error_log 2>&1
+    elif command -v runuser >/dev/null 2>&1; then
+        runuser -u "$runas" -- kea-dhcp4 -t "$1" >>$error_log 2>&1
+    else
+        su -s /bin/sh -c "kea-dhcp4 -t '$1'" "$runas" >>$error_log 2>&1
+    fi
+}
 _writeKeaConfig() {
     # $1 = target file, $2 = client-classes block. Reads $interface, $ipaddress,
     # $network, $cidr, $startrange, $endrange and $optdata from the caller's scope.
@@ -8200,6 +8236,12 @@ $2
     }
 }
 EOFKEA
+    # The service account has to be able to read this, and a hardened root umask
+    # (027/077) would otherwise leave it unreadable to anyone but root -- which
+    # breaks the daemon, not just the syntax check. 0644 is the mode the distro
+    # packages ship this file with; the generated config holds no credentials
+    # (the lease database is memfile).
+    chmod 0644 "$1" >>$error_log 2>&1
 }
 configureKeaDHCP() {
     local cidr=$(mask2cidr $submask)
@@ -8224,15 +8266,28 @@ configureKeaDHCP() {
         return 1
     fi
     if command -v kea-dhcp4 >/dev/null 2>&1; then
-        if ! kea-dhcp4 -t "$target" >>$error_log 2>&1; then
+        if ! _keaValidate "$target"; then
             echo "Failed"
             echo "Kea base configuration failed validation (kea-dhcp4 -t); see $error_log"
+            # "Unable to open file" against a file we just wrote and can stat is
+            # never a syntax error -- it is a mandatory access control denial
+            # (AppArmor on Debian/Ubuntu, SELinux on RedHat) stopping kea-dhcp4
+            # from reading it. Say so, because the generic message sends people
+            # hunting for a JSON typo that isn't there (#1039).
+            if [[ -s $target ]] && tail -n 20 "$error_log" 2>/dev/null | grep -q 'Unable to open file'; then
+                echo ""
+                echo " * $target exists and is readable, so this is not a syntax error."
+                echo "   Something is denying kea-dhcp4 access to it. Check:"
+                echo "     dmesg | grep -i 'apparmor.*kea'      (Debian/Ubuntu)"
+                echo "     ausearch -m avc -c kea-dhcp4         (RedHat/Rocky)"
+                echo "   Please report this with that output rather than disabling AppArmor."
+            fi
             return 1
         fi
         # Tier 2: best-effort Apple BSDP; drop if Kea rejects it.
         _writeKeaConfig "$tmp" "${baseclasses},
 ${appleclass}"
-        if kea-dhcp4 -t "$tmp" >>$error_log 2>&1; then
+        if _keaValidate "$tmp"; then
             mv -f "$tmp" "$target"
         else
             rm -f "$tmp"


### PR DESCRIPTION
The `working-1.6` half of #1039. Identical patch to #1040 — the `configureKeaDHCP` block is byte-identical on both branches (verified by hash), and the same patch applies cleanly to each.

## The bug

Installing with DHCP enabled aborts at *"Setting up and starting DHCP Server (Kea)"*:

```
Syntax check failed with: Unable to open file /etc/kea/kea-dhcp4.conf
```

Not a syntax error. Debian 13 and Ubuntu 26 changed the kea package to ship `/etc/kea` as **`0750 _kea:_kea`**:

| release | `/etc/kea` | affected |
|---|---|---|
| debian:12 | `755 root:root` | no |
| ubuntu:24.04 | `755 root:root` | no |
| **debian:13** | **`750 _kea:_kea`** | **yes** |
| **ubuntu:26.04** | **`750 _kea:_kea`** | **yes** |

Their AppArmor profile grants `kea-dhcp4` `/etc/kea/** r` but withholds `cap_dac_read_search` / `cap_dac_override`. `configureKeaDHCP` validates **as root**, which is neither the directory's owner nor in its group — so it needs a DAC bypass just to traverse `/etc/kea`, AppArmor refuses, and Kea calls the file unopenable. The daemon was never affected: systemd runs it as `User=_kea`, which owns the directory.

This is why the Kea support added for #730 tested clean — every release available then shipped `/etc/kea` as `755 root:root`.

## The fix

Validate as the config directory's owner: no DAC bypass needed, so it works **with the AppArmor profile intact**. Root-owned `/etc/kea` (RedHat, Arch, Alpine) is unchanged and still validates as root.

**Not adopting the reported workaround** (`aa-complain` / removing the profile) — the installer shouldn't switch off a mandatory access control the distro shipped deliberately, and it's unnecessary once the check runs as the right user.

Plus `chmod 0644` on the generated config (a hardened root umask would otherwise leave it unreadable to `_kea`, breaking the *daemon*, not just the check), and a targeted diagnostic pointing at `dmesg`/`ausearch` on an "Unable to open file" failure — requested in the report.

## Verification

`debian:13`, `ubuntu:26.04`, `debian:12`, `ubuntu:24.04`, with `cap_dac_override` and `cap_dac_read_search` dropped via `capsh` — the capability set AppArmor leaves `kea-dhcp4` with. Old code reproduces the reported message verbatim on the two affected releases; new code passes 7/7 on all four (including: root-owned dir still runs as root, malformed config still rejected, umask-077 config still readable).

**Limitation:** containers don't enforce AppArmor, so `capsh` reproduces the mechanism rather than the LSM. The profile keys off the binary path, not the user, so running as `_kea` leaves `kea-dhcp4` equally confined — it just no longer needs a bypass. A real AppArmor-enforcing Debian 13 run would still be worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)