### PR TITLE
Fix the API docs page: script race, and a menu it should never have had

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -828,6 +828,11 @@ abstract class FOGPage extends FOGBase
             case 'schema':
             case 'service':
             case 'hwinfo':
+            // A single read-only page, not a managed entity. Without this it
+            // takes the default list/add pair above and advertises "List All
+            // Apidocss" and "Create New Apidocs" -- two subs that do not
+            // exist, on a node with nothing to list or create.
+            case 'apidocs':
                 $menu = [];
                 break;
             case 'about':

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
@@ -1,6 +1,15 @@
 /**
  * Renders this server's OpenAPI document in the API Documentation page.
  *
+ * Waits for SwaggerUIBundle rather than assuming it is already there, and the
+ * reason is FOG's own navigation. Clicking the menu item does not reload the
+ * page: fog.common.js reads X-FOG-JavaScripts off the response and appends the
+ * scripts for the new node. On that path document.readyState is already
+ * 'complete', so a DOMContentLoaded handler never fires and the naive fallback
+ * -- run immediately instead -- runs before the sibling script has finished
+ * executing. swagger-ui-bundle.js is 1.5MB, so it loses that race every time,
+ * and the page then reported a missing file when the file was there all along.
+ *
  * The spec URL comes from a data attribute rather than being templated into
  * the script, so it is escaped once, by PHP, as part of the markup.
  *
@@ -12,7 +21,72 @@
 (function () {
     'use strict';
 
-    function render() {
+    // 1.5MB over a slow link takes a moment; 20s is generous without spinning
+    // forever when the asset really is absent.
+    var POLL_MS = 100;
+    var MAX_TRIES = 200;
+
+    function report(container, specUrl, waitedMs) {
+        // Name which of the two things went wrong rather than always blaming
+        // the file, which sent someone looking for an asset that was present.
+        var heading = document.createElement('div');
+        heading.className = 'alert alert-warning';
+        heading.textContent = 'The API reference could not be displayed.';
+        container.appendChild(heading);
+
+        var detail = document.createElement('p');
+        detail.textContent = 'Working out why...';
+        container.appendChild(detail);
+
+        var link = document.createElement('p');
+        var anchor = document.createElement('a');
+        anchor.href = specUrl;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener';
+        anchor.textContent = 'The raw OpenAPI document is still available here.';
+        link.appendChild(anchor);
+        container.appendChild(link);
+
+        var bundleUrl = '../management/js/swagger-ui-bundle.js';
+        window.fetch(bundleUrl, { method: 'HEAD', credentials: 'same-origin' })
+            .then(function (response) {
+                if (response.ok) {
+                    detail.textContent = 'swagger-ui-bundle.js is present but had not finished '
+                        + 'loading after ' + Math.round(waitedMs / 1000) + ' seconds. Reload the '
+                        + 'page; if it keeps happening, check the browser console for a script '
+                        + 'error.';
+                } else {
+                    detail.textContent = 'swagger-ui-bundle.js is missing from the web root '
+                        + '(HTTP ' + response.status + '). Re-run the installer so the '
+                        + 'management assets are copied into place.';
+                }
+            })
+            .catch(function () {
+                detail.textContent = 'swagger-ui-bundle.js could not be fetched at all. Check '
+                    + 'that the web server serves management/js/, then reload.';
+            });
+    }
+
+    function render(specUrl) {
+        SwaggerUIBundle({
+            url: specUrl,
+            dom_id: '#apidocs-container',
+            deepLinking: true,
+            presets: [SwaggerUIBundle.presets.apis],
+            // BaseLayout deliberately, not StandaloneLayout. The latter adds
+            // the topbar with a spec URL box and an Explore button, which
+            // invites pointing this at some other server's document. There is
+            // one spec worth reading here and it is this server's.
+            layout: 'BaseLayout',
+            docExpansion: 'list',
+            defaultModelsExpandDepth: 1,
+            // Same-origin, so the browser sends the session cookie and try-it
+            // works against this very server.
+            withCredentials: true
+        });
+    }
+
+    function boot() {
         var container = document.getElementById('apidocs-container');
         if (!container) {
             return;
@@ -21,35 +95,31 @@
         if (!specUrl) {
             return;
         }
-        if (typeof SwaggerUIBundle === 'undefined') {
-            container.textContent =
-                'Swagger UI failed to load. Check that '
-                + 'management/js/swagger-ui-bundle.js is present.';
+        // A full page load fires DOMContentLoaded and an AJAX navigation calls
+        // boot() directly, so guard against rendering twice into one container.
+        if (container.getAttribute('data-apidocs-booted') === '1') {
             return;
         }
+        container.setAttribute('data-apidocs-booted', '1');
 
-        SwaggerUIBundle({
-            url: specUrl,
-            dom_id: '#apidocs-container',
-            deepLinking: true,
-            presets: [SwaggerUIBundle.presets.apis],
-            layout: 'BaseLayout',
-            docExpansion: 'list',
-            defaultModelsExpandDepth: 1,
-            // Same-origin, so the browser sends the session cookie and
-            // try-it works against this very server.
-            withCredentials: true,
-            // The spec names exactly one server, this one. Offering a
-            // picker would only invite calls at something else.
-            requestInterceptor: function (request) {
-                return request;
+        var tries = 0;
+        (function waitForBundle() {
+            if (typeof SwaggerUIBundle !== 'undefined') {
+                render(specUrl);
+                return;
             }
-        });
+            tries += 1;
+            if (tries >= MAX_TRIES) {
+                report(container, specUrl, POLL_MS * tries);
+                return;
+            }
+            window.setTimeout(waitForBundle, POLL_MS);
+        }());
     }
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', render);
+        document.addEventListener('DOMContentLoaded', boot);
     } else {
-        render();
+        boot();
     }
 }());


### PR DESCRIPTION
Two bugs in the API Documentation page from #1042, both found on a real install. Reported from a phone against a live server, which is the only place the first one could have surfaced.

## The page said a file was missing when it wasn't

> Swagger UI failed to load. Check that `management/js/swagger-ui-bundle.js` is present.

The file was present the whole time.

Clicking a menu item in FOG doesn't reload the page — `fog.common.js` reads `X-FOG-JavaScripts` off the response and appends the scripts for the new node. On that path `document.readyState` is already `complete`, so a `DOMContentLoaded` handler never fires and my fallback ("run immediately instead") did exactly that: it ran **before the sibling script had finished executing**. At 1.5MB, `swagger-ui-bundle.js` loses that race every time.

It only looked fine in local testing because a hard page load happens to win it. AJAX navigation — the way anyone actually reaches the page — does not.

Now it waits for `SwaggerUIBundle` rather than assuming it. If the global really is absent after 20s it HEADs the asset and reports **which** of the two things went wrong:

- present but slow → reload, check the console
- HTTP 404 → re-run the installer so management assets are copied
- unfetchable → the web server isn't serving `management/js/`

The old message sent someone hunting for a file sitting right there, so this seemed worth more than a one-liner. It also links the raw document, which is useful even when the renderer won't come up.

## The menu advertised two pages that don't exist

```
</> API Documentation
      List All Apidocss      <- doubled s
      Create New Apidocs
```

`_buildSubMenuItems()` gives every node the default `list`/`add` pair unless a `case` opts out, so a node that is one read-only page got a CRUD submenu for an entity that does not exist. The doubled **s** is the default `sprintf('%ss')` pluralisation — a good tell that nobody meant to put it there.

`apidocs` now joins `home`/`client`/`schema`/`service`/`hwinfo` in taking an empty submenu.

## Note

`installfog.sh` does `cp -Rf $webdirsrc/* $webdirdest/`, so the bundle is deployed correctly — the diagnostic in the first fix confirms that rather than assuming it.
