### PR TITLE
Register the Swagger assets where they actually reach the page

### DIFF
--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -194,6 +194,16 @@ class Page extends FOGBase
         foreach ($stylesheets as $stylesheet) {
             $this->addCSS($stylesheet);
         }
+        // Node scoped stylesheets, same reasoning as the node scoped scripts
+        // in setJavascripts(): this is the Page instance that renders, so it
+        // is the only one whose addCSS() survives. Swagger UI's stylesheet is
+        // 182KB and belongs on exactly one page, and the FOG overlay after it
+        // keys off data-bs-theme so the reference follows the dark mode toggle
+        // rather than staying white in a dark UI.
+        if ('apidocs' === $node) {
+            $this->addCSS('css/swagger-ui.css');
+            $this->addCSS('css/swagger-ui-fog.css');
+        }
         if (!$this->theme) {
             $this->theme = self::getSetting('FOG_THEME');
             if (!$this->theme) {
@@ -278,6 +288,20 @@ class Page extends FOGBase
             }
             if ($jscolorneeded) {
                 $files[] = 'js/jscolor.js';
+            }
+            // Swagger UI renders the API reference. It has to be added here,
+            // with the rest of the page's scripts, because this list is built
+            // on the Page instance that actually renders. A page class calling
+            // getClass('Page')->addJavascript() gets a fresh throwaway object
+            // -- getClass() news one up every call -- so the asset is served
+            // but never referenced, and the only symptom is a blank panel.
+            //
+            // Node scoped like jscolor above: the bundle is 1.5MB and nothing
+            // else on the site uses it. Listed before the node's own list.js
+            // so it is defined first, though fog.apidocs.list.js no longer
+            // depends on that.
+            if ('apidocs' === $node) {
+                $files[] = 'js/swagger-ui-bundle.js';
             }
         }
         if (isset($filepaths) && $filepaths && !file_exists($filepaths)) {

--- a/packages/web/lib/pages/apidocumentation.page.php
+++ b/packages/web/lib/pages/apidocumentation.page.php
@@ -61,20 +61,13 @@ class ApiDocumentation extends FOGPage
     public function index(...$args)
     {
         /**
-         * The page manager already queues js/fog/apidocs/fog.apidocs.list.js
-         * for this node; the renderer it drives has to be on the page first,
-         * since that script calls SwaggerUIBundle directly.
+         * The Swagger UI bundle and its stylesheets are registered against
+         * the apidocs node in Page, alongside every other page's assets.
+         * They were queued from here originally, through
+         * getClass('Page')->addJavascript(), which silently did nothing:
+         * getClass() news up a fresh Page every call, so the assets landed on
+         * a throwaway object and were never emitted.
          */
-        self::getClass('Page')->addJavascript('js/swagger-ui-bundle.js');
-        self::getClass('Page')->addCSS('css/swagger-ui.css');
-        /**
-         * Swagger UI ships one theme and no dark mode. This keys its colours
-         * off data-bs-theme, the same attribute FOG's own toggle sets, so the
-         * page follows the admin's existing preference instead of being the
-         * one white rectangle in a dark UI.
-         */
-        self::getClass('Page')->addCSS('css/swagger-ui-fog.css');
-
         $apiEnabled = (bool)self::getSetting('FOG_API_ENABLED');
         $specUrl = sprintf(
             '%s://%s%ssystem/openapi',


### PR DESCRIPTION
Follow-up to #1044. That PR made the failure **legible**; this one makes the page **work**. My mistake for landing them separately — the second commit missed the merge.

## What #1044 actually shipped

The waiting logic and the diagnostic. On a live server it then reported:

> swagger-ui-bundle.js is present but had not finished loading after 20 seconds.

Which was the real clue: the file is served, but `SwaggerUIBundle` never becomes defined. **A file that is served yet never executes means no script tag was ever created for it.**

## Root cause

`ApiDocumentation::index()` queued the assets like this:

```php
self::getClass('Page')->addJavascript('js/swagger-ui-bundle.js');
self::getClass('Page')->addCSS('css/swagger-ui.css');
```

`getClass()` calls `newInstance` on every invocation — there is no cache. So all three assets were added to a **throwaway `Page` object** and discarded. Nothing was ever emitted, and the only symptom was a blank panel.

`fog.apidocs.list.js` loaded fine throughout, which is what made this confusing: that one comes from `Page`'s own node convention (`js/fog/{node}/fog.{node}.list.js`), not from the page class.

## The fix

Register the assets where `Page` builds its list, against the instance that actually renders:

- **`js/swagger-ui-bundle.js`** joins the node-scoped script list, exactly as `js/jscolor.js` already does for `about`/`storagenode`. Node scoped because it is 1.5MB and nothing else uses it.
- **`css/swagger-ui.css` + `css/swagger-ui-fog.css`** get the same treatment in the constructor — 182KB that belongs on one page.

The waiting logic from #1044 stays. It is what produced the message that identified this, and it keeps the page independent of asset order rather than trading one ordering assumption for another.

## Worth knowing for the next page

`addJavascript()` and `addCSS()` look like the obvious API and are **unusable from a page class** — only `Page`'s own list survives. That is a sharp edge worth a comment, which both call sites now carry.
