### PR TITLE
Phase 0.0: make "the test suite passes" a command

### DIFF
--- a/tests/autoload.test.php
+++ b/tests/autoload.test.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Guards class resolution: the thing every other part of FOG stands on and
+ * the one thing no test has ever covered.
+ *
+ * Unlike the other tests in this directory this one is NOT a source parse --
+ * it boots the real autoloader and asks it real questions. That is possible
+ * without a database because Initiator's constructor only registers the
+ * autoloader (commons/init.php:127-135); it is Initiator::startInit() that
+ * goes on to `new System()` and `new Config()` and needs MySQL. So the
+ * constructor is called directly and startInit() deliberately is not.
+ *
+ * FOG_BASE_DIR, FOG_CACHE_DIR and FOG_PLUGIN_DIR are defined here first.
+ * init.php guards each with `if (!defined(...))` (commons/init.php:91-125),
+ * so pre-defining them redirects the file-list cache into a throwaway
+ * directory instead of writing to /opt/fog on the machine running the test.
+ *
+ * Four things are checked:
+ *   1. A representative class from each scan root resolves.
+ *   2. The Mysqldump side-effect: twelve of the thirteen types in
+ *      lib/db/mysqldump.class.php are reachable ONLY once Mysqldump itself
+ *      has loaded. Pinned deliberately -- it is the single fact that stops
+ *      the legacy autoloader ever being replaced wholesale by PSR-4, and it
+ *      should break a test rather than a customer if someone tries.
+ *   3. Every autoloadable file declares a class matching its own filename.
+ *      All four discovery paths derive the class name arithmetically from
+ *      the basename and none of them parses source for a `class` token, so
+ *      a file that breaks this is invisible to hooks, events, pages and
+ *      reports while looking perfectly fine.
+ *   4. Whether a namespaced name resolves. See EXPECT_BRIDGE below.
+ *
+ * Usage: php tests/autoload.test.php [path/to/packages/web]
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+/*
+ * Flipped by the commit that adds the FOG\ bridge to Initiator::autoload().
+ * Before it, `FOG\Host` misses silently: the map is keyed on a lowercased
+ * basename so `fog\host` can never be a key, and the bare spl_autoload()
+ * behind it probes for `fog/host.class.php`, which no include_path entry
+ * holds. After it, `FOG\Host` resolves to the same class entry as `Host`.
+ *
+ * This constant existing rather than the assertion simply being deleted is
+ * the point: the flip is the bridge's regression test.
+ */
+const EXPECT_BRIDGE = false;
+
+$webroot = rtrim(
+    $argv[1] ?? dirname(__DIR__) . '/packages/web',
+    '/'
+);
+$init = $webroot . '/commons/init.php';
+
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-autoload-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/sessions', 0700, true);
+
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($tmp, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+define('FOG_BASE_DIR', $tmp);
+define('FOG_CACHE_DIR', $tmp . '/cache');
+// Pointed at an empty directory on purpose. The external plugin root is a
+// real scan root (commons/init.php:299-306) and its contents differ per
+// install, so including whatever this machine happens to have would make the
+// test's result depend on the machine.
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+// The constructor calls session_start(). Keep it off the system session path
+// so this never depends on that directory being writable by whoever ran it.
+ini_set('session.save_path', $tmp . '/sessions');
+
+require $init;
+new Initiator();
+
+$failures = [];
+
+/*
+ * 2 first, because it is the only check whose result depends on what has
+ * already been loaded. Running it after the sample below -- which loads
+ * Mysqldump -- would make it pass for the wrong reason.
+ */
+if (class_exists('CompressGzip')) {
+    $failures[] = 'CompressGzip resolved on its own; it is declared inside '
+        . 'mysqldump.class.php and should only be reachable once Mysqldump '
+        . 'has loaded';
+}
+if (!class_exists('Mysqldump')) {
+    $failures[] = 'Mysqldump did not resolve';
+} elseif (!class_exists('CompressGzip', false)) {
+    $failures[] = 'CompressGzip is not declared after loading Mysqldump; '
+        . 'mysqldump.class.php no longer declares its twelve extra types, so '
+        . 'the one-file-many-classes constraint on PSR-4 may have lifted';
+}
+
+// 1. One name per scan root, plus the two base classes everything descends
+// from and the two traits FOGPage is built out of.
+$sample = [
+    'Host'                => 'class',   // lib/fog
+    'HostManager'         => 'class',   // lib/fog, manager
+    'FOGBase'             => 'class',   // lib/fog, root of the hierarchy
+    'FOGController'       => 'class',
+    'FOGPagePost'         => 'trait',   // lib/fog, mixed-case filename
+    'HostManagement'      => 'class',   // lib/pages
+    'UserGroupManagement' => 'class',   // lib/pages, mixed-case filename
+    'PDODB'               => 'class',   // lib/db
+    'Route'               => 'class',   // lib/router
+    'FOGClient'           => 'class',   // lib/client
+    'TaskScheduler'       => 'class',   // lib/service
+    'Registration'        => 'class',   // lib/reg-task
+];
+foreach ($sample as $name => $kind) {
+    $exists = $kind === 'trait' ? trait_exists($name) : class_exists($name);
+    if (!$exists) {
+        $failures[] = "$name did not resolve through the autoloader";
+    }
+}
+
+/*
+ * 3. Filename == declared name, checked by reading each file rather than by
+ * loading it. Loading all ~390 would execute every top-level statement in the
+ * tree to prove a property of its text, and one file that fataled would take
+ * the whole run with it.
+ */
+$mismatched = [];
+$declares = [];
+foreach (Initiator::classFileList() as $path) {
+    $stem = preg_replace(
+        '#\.(report|event|class|hook|page|task)\.php$#',
+        '',
+        basename($path)
+    );
+    $src = file_get_contents($path);
+    // Anchored to the start of a line so `class` inside a comment, a string
+    // or `::class` cannot match. Abstract/final are the only modifiers this
+    // tree uses on a first declaration.
+    if (!preg_match(
+        '/^(?:abstract\s+|final\s+)*(?:class|interface|trait)\s+([A-Za-z0-9_]+)/m',
+        $src,
+        $m
+    )) {
+        $mismatched[] = basename($path) . ' declares nothing';
+        continue;
+    }
+    $declares[] = $m[1];
+    if (strcasecmp($m[1], $stem) !== 0) {
+        $mismatched[] = basename($path) . " declares {$m[1]}";
+    }
+}
+if (count($declares) < 100) {
+    $failures[] = 'only ' . count($declares) . ' autoloadable files found; '
+        . 'the scan roots look wrong';
+}
+foreach ($mismatched as $m) {
+    $failures[] = "filename/class mismatch: $m";
+}
+
+// 4. The bridge.
+$bridged = class_exists('FOG\Host');
+if ($bridged !== EXPECT_BRIDGE) {
+    $failures[] = EXPECT_BRIDGE
+        ? 'FOG\Host did not resolve; the Initiator::autoload() bridge is '
+            . 'missing or no longer aliases short names'
+        : 'FOG\Host resolved unexpectedly; if the bridge has landed, flip '
+            . 'EXPECT_BRIDGE at the top of this file';
+}
+if (EXPECT_BRIDGE && $bridged) {
+    // An alias, not a second class: same class entry, so `instanceof` and
+    // every getClass()/Reflection consumer see one type. get_class() still
+    // reports the declared name -- that asymmetry is why namespacing the
+    // models is a separate problem from bridging their names.
+    $refFqcn = new ReflectionClass('FOG\Host');
+    $refShort = new ReflectionClass('Host');
+    if ($refFqcn->getName() !== $refShort->getName()) {
+        $failures[] = 'FOG\Host resolves to a different class entry than '
+            . 'Host (' . $refFqcn->getName() . ' vs ' . $refShort->getName()
+            . '); it should be an alias, not a copy';
+    }
+    if (!trait_exists('FOG\FOGPagePost')) {
+        $failures[] = 'the bridge does not carry traits';
+    }
+    if (!class_exists('fog\Image')) {
+        $failures[] = 'the bridge is case-sensitive on the namespace prefix; '
+            . 'PHP class names are not';
+    }
+    if (class_exists('FOG\NoSuchThingHere')) {
+        $failures[] = 'the bridge invented FOG\NoSuchThingHere';
+    }
+    if (class_exists('FOG\Model\Host')) {
+        $failures[] = 'the bridge resolved a nested name (FOG\Model\Host); '
+            . 'it must only answer for flat FOG\<Name>';
+    }
+    if (class_exists('Vendor\Host')) {
+        $failures[] = 'the bridge answered for a foreign namespace; a '
+            . 'plugin\'s Vendor\Host must not silently become core Host';
+    }
+}
+
+printf(
+    "autoload: %d classes declared in tree, %d loaded this run, bridge=%s\n",
+    count($declares),
+    count(get_declared_classes()),
+    $bridged ? 'yes' : 'no'
+);
+
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        fwrite(STDERR, "FAIL: $f\n");
+    }
+    exit(1);
+}
+
+echo "PASS\n";
+exit(0);

--- a/tests/autoload.test.php
+++ b/tests/autoload.test.php
@@ -10,10 +10,32 @@
  * goes on to `new System()` and `new Config()` and needs MySQL. So the
  * constructor is called directly and startInit() deliberately is not.
  *
- * FOG_BASE_DIR, FOG_CACHE_DIR and FOG_PLUGIN_DIR are defined here first.
+ * FOG_CACHE_DIR, FOG_LOG_DIR and FOG_PLUGIN_DIR are defined here first.
  * init.php guards each with `if (!defined(...))` (commons/init.php:91-125),
  * so pre-defining them redirects the file-list cache into a throwaway
  * directory instead of writing to /opt/fog on the machine running the test.
+ *
+ * FOG_BASE_DIR is deliberately NOT pre-defined, even though it is the parent
+ * of all three. On a deployed tree init.php pulls in commons/fogpaths.php,
+ * which the installer generates as a bare `define('FOG_BASE_DIR', ...)` with
+ * no guard of its own -- pre-defining it there produces a "Constant already
+ * defined" warning. Since every path this test could care about is overridden
+ * individually above, FOG_BASE_DIR is left for whoever normally sets it and
+ * goes unused.
+ *
+ * Two ways to run it:
+ *
+ *   php tests/autoload.test.php                    # the source tree
+ *   php tests/autoload.test.php /var/www/html/fog  # a live server
+ *
+ * The second is a deployment diagnostic, and it answers questions the source
+ * tree cannot: whether an upgrade left a duplicate class file behind, whether
+ * a hand-installed plugin declares a class its filename does not, whether the
+ * generated config.class.php is where the autoloader expects. Given an
+ * explicit path the bridge check becomes a REPORT rather than an assertion --
+ * a server legitimately runs an older FOG than the checkout you are standing
+ * in, and failing over that would make the diagnostic mode useless. Every
+ * other check still asserts: they are invariants of any tree that boots.
  *
  * Four things are checked:
  *   1. A representative class from each scan root resolves.
@@ -45,10 +67,15 @@
  */
 const EXPECT_BRIDGE = false;
 
-$webroot = rtrim(
-    $argv[1] ?? dirname(__DIR__) . '/packages/web',
-    '/'
-);
+// An explicit path means "probe that tree", which is a different job from
+// "check this checkout" -- see the header. Compared by realpath so that
+// pointing it at the source tree by hand is still strict mode.
+$default = dirname(__DIR__) . '/packages/web';
+$webroot = rtrim($argv[1] ?? $default, '/');
+$diagnostic = isset($argv[1])
+    && realpath($webroot) !== false
+    && realpath($webroot) !== realpath($default);
+
 $init = $webroot . '/commons/init.php';
 
 if (!is_readable($init)) {
@@ -58,6 +85,7 @@ if (!is_readable($init)) {
 
 $tmp = sys_get_temp_dir() . '/fog-autoload-test-' . getmypid();
 @mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
 @mkdir($tmp . '/sessions', 0700, true);
 
 register_shutdown_function(
@@ -76,13 +104,39 @@ register_shutdown_function(
     }
 );
 
-define('FOG_BASE_DIR', $tmp);
+/*
+ * FOG_CACHE_DIR is forced to a throwaway directory ALWAYS, in both modes,
+ * and this is the one line here that must never become conditional.
+ *
+ * Left alone it defaults under FOG_BASE_DIR, and classFileList() does not
+ * merely read that directory -- it WRITES filelist.<md5>.json into it
+ * (commons/init.php:195, :415-429). Point the harness at a live server
+ * without this and a test script rebuilds, or clobbers, that server's live
+ * class-file cache. FOG_BASE_DIR and FOG_CACHE_DIR are guarded separately by
+ * init.php, which is exactly what makes "real tree, harmless cache" possible.
+ *
+ * FOG_LOG_DIR goes the same way for the same reason, cheaply.
+ */
 define('FOG_CACHE_DIR', $tmp . '/cache');
-// Pointed at an empty directory on purpose. The external plugin root is a
-// real scan root (commons/init.php:299-306) and its contents differ per
-// install, so including whatever this machine happens to have would make the
-// test's result depend on the machine.
-define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+define('FOG_LOG_DIR', $tmp . '/log');
+
+/*
+ * The external plugin root is a real scan root (commons/init.php:299-306),
+ * and the two modes want opposite things from it.
+ *
+ * Checking the checkout: pin it to an empty directory. Its contents differ
+ * per machine, and a test whose result depends on what the developer happens
+ * to have installed in /opt/fog is not a test.
+ *
+ * Probing a server: leave it undefined, so fogpaths.php (or init.php's
+ * /opt/fog fallback) supplies the real one. Third-party plugins living there
+ * are half the reason to run this against a server at all -- a hand-installed
+ * plugin whose class name does not match its filename is invisible to hooks,
+ * pages and reports, and this is the only thing that would say so.
+ */
+if (!$diagnostic) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
 
 // The constructor calls session_start(). Keep it off the system session path
 // so this never depends on that directory being writable by whoever ran it.
@@ -90,6 +144,24 @@ ini_set('session.save_path', $tmp . '/sessions');
 
 require $init;
 new Initiator();
+
+/*
+ * classFileList() and the O(1) class map arrived with 1.6. A 1.5 tree has an
+ * Initiator that only sets include_path and registers the built-in resolver,
+ * so everything below either fatals on an undefined method or silently checks
+ * nothing. Caught here rather than left to blow up two hundred lines later:
+ * pointing this at a 1.5 server is a reasonable thing to try, and "that tree
+ * predates what this checks" is a useful answer where an uncaught Error is
+ * not.
+ */
+if (!method_exists('Initiator', 'classFileList')) {
+    fwrite(
+        STDERR,
+        "FAIL: $webroot has no Initiator::classFileList(), so it predates "
+        . "the 1.6 class map this checks. Nothing to test here.\n"
+    );
+    exit(1);
+}
 
 $failures = [];
 
@@ -173,16 +245,18 @@ foreach ($mismatched as $m) {
     $failures[] = "filename/class mismatch: $m";
 }
 
-// 4. The bridge.
+// 4. The bridge. Asserted against the checkout, reported against a server:
+// a server legitimately runs an older FOG than the tree you are standing in,
+// and failing over that would make the diagnostic mode useless.
 $bridged = class_exists('FOG\Host');
-if ($bridged !== EXPECT_BRIDGE) {
+if (!$diagnostic && $bridged !== EXPECT_BRIDGE) {
     $failures[] = EXPECT_BRIDGE
         ? 'FOG\Host did not resolve; the Initiator::autoload() bridge is '
             . 'missing or no longer aliases short names'
         : 'FOG\Host resolved unexpectedly; if the bridge has landed, flip '
             . 'EXPECT_BRIDGE at the top of this file';
 }
-if (EXPECT_BRIDGE && $bridged) {
+if ($bridged) {
     // An alias, not a second class: same class entry, so `instanceof` and
     // every getClass()/Reflection consumer see one type. get_class() still
     // reports the declared name -- that asymmetry is why namespacing the
@@ -214,9 +288,22 @@ if (EXPECT_BRIDGE && $bridged) {
     }
 }
 
+// In diagnostic mode say WHICH FOG was probed. "the bridge is missing" is
+// only actionable next to the version that is missing it.
+$version = '';
+$sys = $webroot . '/lib/fog/system.class.php';
+if ($diagnostic && is_readable($sys)
+    && preg_match("/FOG_VERSION',\s*'([^']+)'/", file_get_contents($sys), $vm)
+) {
+    $version = ' ' . $vm[1];
+}
+
 printf(
-    "autoload: %d classes declared in tree, %d loaded this run, bridge=%s\n",
+    "autoload%s: %d classes declared in %s%s, %d loaded this run, bridge=%s\n",
+    $diagnostic ? ' (diagnostic)' : '',
     count($declares),
+    $diagnostic ? $webroot : 'tree',
+    $version,
     count(get_declared_classes()),
     $bridged ? 'yes' : 'no'
 );

--- a/tests/pxe-secureboot-menu-gating.test.php
+++ b/tests/pxe-secureboot-menu-gating.test.php
@@ -25,24 +25,43 @@ $src = file_get_contents($file);
 
 $failures = [];
 
-// The non-EFI platform filter must hide pxeID 15 alongside pxeID 14.
+// Both filters below match on pxeName, not pxeID. pxeMenu is user-writable
+// with an auto_increment key, so these rows only sit at 14/15 on a pristine
+// install -- keyed by id, a site whose own custom entry happened to land
+// there had THAT entry hidden instead. Re-keyed by facea052b; these two
+// assertions were written against the id form and were not updated with it,
+// which nothing noticed because nothing ran them.
+
+// The non-EFI platform filter must hide the unattended item alongside the
+// attended one.
 if (!preg_match(
-    "/\\\$_REQUEST\['platform'\]\s*!=\s*'efi'.{0,400}?"
-    . "in_array\(\(int\)\\\$Menu->id,\s*\[14,\s*15\],\s*true\)/s",
+    "/\\\$_REQUEST\['platform'\]\s*!=\s*'efi'.{0,900}?"
+    . "in_array\(\s*\\\$Menu->name,.{0,200}?'fog\.enrollsecureboot',"
+    . ".{0,200}?'fog\.enrollsecurebootunattended'/s",
     $src
 )) {
-    $failures[] = "platform != efi filter does not hide pxeID 15 "
-        . "alongside pxeID 14";
+    $failures[] = "platform != efi filter does not hide "
+        . "fog.enrollsecurebootunattended alongside fog.enrollsecureboot, "
+        . "matched by pxeName";
 }
 
-// A separate filter must hide pxeID 15 unless all three .auth files exist.
+// A separate filter must hide the unattended item unless all three .auth
+// files exist.
 if (!preg_match(
-    "/'PK\.auth'.{0,200}?'KEK\.auth'.{0,200}?'db\.auth'.{0,400}?"
-    . "return\s*\(int\)\\\$Menu->id\s*!==\s*15/s",
+    "/'PK\.auth'.{0,200}?'KEK\.auth'.{0,200}?'db\.auth'.{0,600}?"
+    . "'fog\.enrollsecurebootunattended'\s*!==\s*\\\$Menu->name/s",
     $src
 )) {
-    $failures[] = "no filter hiding pxeID 15 unless PK.auth/KEK.auth/"
-        . "db.auth all exist";
+    $failures[] = "no filter hiding fog.enrollsecurebootunattended unless "
+        . "PK.auth/KEK.auth/db.auth all exist";
+}
+
+// Neither filter may go back to matching on the menu id.
+if (preg_match("/in_array\(\s*\(int\)\\\$Menu->id/s", $src)
+    || preg_match("/\(int\)\\\$Menu->id\s*!==?\s*1[45]/s", $src)
+) {
+    $failures[] = "a menu filter is keyed by \$Menu->id again -- pxeMenu is "
+        . "user-writable, match on \$Menu->name";
 }
 
 if (count($failures) > 0) {

--- a/tests/pxe-secureboot-menu-schema.test.php
+++ b/tests/pxe-secureboot-menu-schema.test.php
@@ -30,13 +30,25 @@ $flat = preg_replace('/"\s*\r?\n\s*\.\s*"/', '', $src);
 
 $failures = [];
 
+// Keyed on pxeName, not pxeID. pxeMenu is user-writable with an
+// auto_increment key, so on a site that already had a custom menu item the
+// seeding INSERT IGNORE never landed and id 14 belongs to THAT admin's entry
+// -- keyed by id this UPDATE rewrote their description. Re-keyed by
+// facea052b; this assertion was written against the id form and was not
+// updated with it, which nothing noticed because nothing ran it.
 if (strpos(
     $flat,
     "UPDATE `pxeMenu` SET `pxeDesc`='Enroll Secure Boot Key "
-    . "(MOK attended setup)' WHERE `pxeID`=14"
+    . "(MOK attended setup)' WHERE `pxeName`='fog.enrollsecureboot'"
 ) === false) {
-    $failures[] = "no UPDATE renaming pxeID 14 to "
-        . "'Enroll Secure Boot Key (MOK attended setup)'";
+    $failures[] = "no UPDATE renaming fog.enrollsecureboot to "
+        . "'Enroll Secure Boot Key (MOK attended setup)', keyed by pxeName";
+}
+
+// The id form must not come back: it is the bug facea052b fixed.
+if (preg_match('/UPDATE `pxeMenu`[^;]{0,200}WHERE `pxeID`=1[45]/', $flat)) {
+    $failures[] = "a pxeMenu UPDATE is keyed by pxeID again -- "
+        . "pxeMenu is user-writable, key on pxeName";
 }
 
 if (strpos(

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+#
+# Runs every test in this directory and reports one line each.
+#
+# The convention these tests already follow -- standalone scripts, exit 0 for
+# pass and non-zero for fail, no framework and no database (docs/adr/0008
+# -secure-boot-enrolment-task-type.md:103,144) -- was documented but had no
+# runner, so "the test suite passes" meant a human remembering four commands.
+# That is the same reason .githooks/lib/update-language.sh exists: one copy of
+# the invocation, so the hook, CI and a developer all run the identical thing.
+#
+# Deliberately NOT wired into .githooks/pre-commit. The hook's only blocking
+# gate is schemaCheck, and adding a second one is a change to how every commit
+# in this repository behaves -- a separate decision from having a runner at all.
+# CI (FOGProject/fog-workflows) is where this belongs.
+#
+# A test may skip: exit 0 having printed a line containing "SKIP".
+# secureboot-authvars.test.sh does this when efitools is absent.
+#
+# Usage: sh tests/run-all.sh
+# Exit status 0 = every test passed or skipped, 1 = at least one failed.
+
+testdir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+pass=0
+fail=0
+failed=''
+
+run_one() {
+    name=$(basename "$1")
+
+    # Output is captured rather than streamed so a passing test contributes one
+    # line instead of its own chatter; a failing one gets its output replayed in
+    # full below, which is when it is actually wanted.
+    out=$("$2" "$1" 2>&1)
+    status=$?
+
+    if [ $status -eq 0 ]; then
+        pass=$((pass + 1))
+        printf 'ok    %s\n' "$name"
+    else
+        fail=$((fail + 1))
+        failed="$failed $name"
+        printf 'FAIL  %s (exit %d)\n' "$name" "$status"
+        printf '%s\n' "$out" | sed 's/^/      /'
+    fi
+}
+
+for t in "$testdir"/*.test.php; do
+    [ -f "$t" ] || continue
+    run_one "$t" php
+done
+
+for t in "$testdir"/*.test.sh; do
+    [ -f "$t" ] || continue
+    run_one "$t" sh
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+
+if [ $fail -gt 0 ]; then
+    printf 'failed:%s\n' "$failed" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Phase 0.0 of the modernization work: make "the test suite passes" an actual
command before anything else in Phase 0 moves.

**This is PR A of three. Merge order: A → B → C.**

- A — this PR, tests only, base `working-1.6`
- B — [autoloader `FOG\` bridge], base `phase0-tests`
- C — [Composer], base `phase0-autoload-bridge`

## Why

`tests/` held four standalone scripts. Three regex over source text, one is a
UEFI shell test that self-skips without `efitools`. There was no runner, no
`.github/workflows/`, no PHPUnit, and `.githooks/pre-commit` never invoked
`tests/`. So "the tree is green after this commit" was satisfied by every
possible commit, including one that deletes the autoloader.

That is not hypothetical. **Two of the four existing tests were already failing
on `working-1.6`.** `facea052b` re-keyed the pxeMenu UPDATE and both BootMenu
filters from `pxeID` to `pxeName` — correctly, because `pxeMenu` is
user-writable with an `auto_increment` key, so ids 14/15 only belong to the
Secure Boot rows on a pristine install. The two tests were written against the
id form and were never updated with it. Nothing noticed, because nothing ran
them.

## What's here

**`16dc2f584` — fix the two failing Secure Boot tests.** Re-point both at the
`pxeName` form, and add a negative assertion to each so the id form cannot come
back silently. Verified they reject the old form by running them against
synthetic old-form source.

**`0bbba6575` — `tests/run-all.sh`.** Runs every `tests/*.test.php` and
`tests/*.test.sh`, prints one line per test, replays the output of anything that
failed, exits 1 if any did. Codifies the convention `docs/adr/0008` already
documents. Deliberately **not** wired into `pre-commit` — that hook already
rewrites the tree on every commit and a slow gate there is a different
conversation.

**`b6c3de90b` — `tests/autoload.test.php`.** The first test that boots PHP and
loads a FOG class. DB-free: it pre-defines `FOG_CACHE_DIR` / `FOG_LOG_DIR` /
`FOG_PLUGIN_DIR` into a temp dir, `require`s `commons/init.php`, does `new
Initiator()` (which registers the autoloader and nothing else) and asserts class
resolution. It does not call `startInit()`, which would need `System`, `Config`
and a database.

Four checks:

1. A representative class from each scan root resolves.
2. `CompressGzip` is unreachable until `Mysqldump` has loaded — pinning the
   fact that `lib/db/mysqldump.class.php` declares 13 types in one file, so a
   future PSR-4 enthusiasm breaks a test rather than a customer.
3. Every autoloadable file's basename stem resolves to a declared class of that
   name. This is the invariant all four discovery paths depend on —
   `EventManager::load()`, `FOGPageManager::loadPageClasses()`,
   `reportmanagement.page.php`, `PluginRunner` all derive the class name
   arithmetically from the filename. Done by static parse, not by loading.
4. The `FOG\` bridge is **absent** — which is the assertion PR B inverts, and
   is therefore the bridge's regression test.

**`19a3ecac6` — let the harness take a path.** `php tests/autoload.test.php` is
the source-tree/CI mode; `php tests/autoload.test.php /var/www/html/fog` points
it at a live server as a diagnostic, so it picks up that server's real
third-party plugins from `/opt/fog/plugins`.

`FOG_CACHE_DIR` is forced to a temp dir **always**, independent of the path
argument. The scan writes `filelist.*.json` under it (`init.php:195`), so
without that a diagnostic run would rebuild or clobber the live server's class
cache. Verified: after a live run, `/opt/fog/cache/filelist.*.json` still
carried its previous mtime.

Two other things the live mode needed:

- It does not pre-define `FOG_BASE_DIR`. The installer-generated
  `commons/fogpaths.php` is a bare unguarded `define()`, so pre-defining it
  produces a "already defined" warning on any real install.
- It guards on `method_exists('Initiator', 'classFileList')` and exits 1 with a
  clean FAIL when pointed at a 1.5 tree, rather than dying with an uncaught
  `Error`.

## Verification

```
sh tests/run-all.sh          # 5 tests, exit 0, at every commit in this PR
```

Green at each of the four commits individually.

## Risk

Additive only. No production file is touched by this PR. Revert restores the
tree exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
