### PR TITLE
Phase 0.2: teach the autoloader to answer to FOG\

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -68,16 +68,33 @@ The running example, `helloworld`, manages a trivial entity with a `name` and a
 - **Boot chain.** Every entry point loads `commons/base.inc.php` →
   `commons/init.php` → `LoadGlobals`, which sets the shared singletons
   (`FOGBase::$DB`, `$HookManager`, `$EventManager`, `$currentUser`).
-- **Autoloader.** `Initiator` scans `BASEPATH` recursively, adds every
-  directory containing a `*.{class,page,hook,event,report}.php` file to the PHP
-  `include_path`, then registers PHP's **default** `spl_autoload`. That default
-  autoloader **lowercases the class name** to find the file. So:
+- **Autoloader.** `Initiator` scans `BASEPATH` recursively, builds a
+  lowercased‑basename → path map of every `*.{class,page,hook,event,report,task}.php`
+  file, and registers that ahead of PHP's default `spl_autoload` (which stays
+  registered as a fallback). Lookup **lowercases the class name** to find the
+  file. So:
 
   > **The filename must be `strtolower(ClassName)` + the suffix.**
   > `class HelloWorldManagement` ⇒ `helloworldmanagement.page.php`.
   > `class AddHelloWorldJS` ⇒ `addhelloworldjs.hook.php`.
 
   (Class names in code are PascalCase; the files on disk are all‑lowercase.)
+
+  **Namespaced spellings work too.** `FOG\Host` resolves to the same class as
+  `Host` — the autoloader falls back to the short name and `class_alias`es the
+  result. One class entry under two names, so `instanceof`, `new`, Reflection
+  and `FOGBase::getClass()` all see a single type.
+
+  Nothing in FOG is namespaced yet; this exists so plugin code written today
+  survives the migration when it happens. Either spelling is correct for all of
+  1.6, and bare `Host` is the one to use if your plugin must also run on 1.6
+  betas before this landed. Two limits worth knowing: only the flat `FOG\<Name>`
+  form is bridged (`FOG\Model\Host` deliberately does not resolve), and your own
+  namespace is never touched — a `Vendor\Host` in your plugin stays yours and
+  will not silently become core's `Host`.
+
+  This does **not** change the filename rule above. `FOG\Host` is found by
+  looking up `host`, so the file is still `host.class.php`.
 - **Routing.** The whole UI is driven by `?node=<x>&sub=<y>&id=<n>`. `node` maps
   to a page class (`helloworld` → `HelloWorldManagement`, matched by its
   `public $node = 'helloworld'`), and `sub` maps to a method on it

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -162,6 +162,16 @@ class Initiator
     /** Seconds a persisted file-list cache is trusted before it is rebuilt. */
     private const FILELIST_TTL = 300;
 
+    /**
+     * The one namespace prefix the bridge in autoload() answers for.
+     *
+     * Deliberately a constant and not a setting. A bridge whose namespace
+     * varies per install is a bridge nobody can write documentation for, and
+     * one that answered for ANY prefix would make a plugin's `Vendor\Host`
+     * silently resolve to core's `Host`.
+     */
+    private const BRIDGE_NS = 'FOG\\';
+
     /** In-process memo of the class-source file list. */
     private static ?array $fileList = null;
 
@@ -249,6 +259,10 @@ class Initiator
      * differs per install. Keep colliding basenames out of the scan (see
      * _scanClassFiles) rather than relying on either rule.
      *
+     * A name that misses the map and carries the FOG\ prefix falls through to
+     * _bridgeNamespaced() below rather than to the built-in resolver, which
+     * cannot find it -- see that method.
+     *
      * @param string $class The class being autoloaded.
      *
      * @return void
@@ -283,6 +297,66 @@ class Initiator
             // a plugin shipping class/<name>manager.class.php declaring
             // something else.
             include_once self::$classMap[$key];
+            return;
+        }
+
+        self::_bridgeNamespaced($class);
+    }
+
+    /**
+     * Resolve a FOG\<Name> request to the still-global <Name> and alias it.
+     *
+     * Nothing in the tree is namespaced yet, so `FOG\User` currently misses
+     * everywhere and does so silently. autoload()'s map is keyed on a
+     * lowercased basename, and no basename can contain a backslash, so
+     * `fog\user` is never a key; the bare spl_autoload() registered behind it
+     * then converts the separator to a directory and probes for
+     * `fog/user.class.php`, which no include_path entry holds. No error, no
+     * log line, just a class-not-found at the call site.
+     *
+     * This makes the namespaced spelling work ahead of the files themselves
+     * moving, so call sites and plugin code can be written forward-compatibly
+     * now and the eventual migration is not also a flag day for every caller.
+     * class_alias produces one class entry under two names, so `instanceof`,
+     * `new`, Reflection and every getClass() consumer see a single type.
+     * (get_class() still reports the DECLARED name -- that asymmetry is why
+     * namespacing the models is a separate problem from bridging their names,
+     * and why this is safe while that is not.)
+     *
+     * Flat names only. A nested request such as FOG\Model\Host is the shape
+     * the real migration will use, and answering it here by guessing at the
+     * last segment would resolve two different future classes to one file.
+     *
+     * @param string $class The namespaced class being autoloaded.
+     *
+     * @return void
+     */
+    private static function _bridgeNamespaced(string $class): void
+    {
+        if (strncasecmp($class, self::BRIDGE_NS, strlen(self::BRIDGE_NS)) !== 0) {
+            return;
+        }
+        $short = substr($class, strlen(self::BRIDGE_NS));
+        if ($short === '' || strpos($short, '\\') !== false) {
+            return;
+        }
+        $key = strtolower($short);
+        if (!isset(self::$classMap[$key])) {
+            return;
+        }
+        include_once self::$classMap[$key];
+        // Checked with autoload OFF. With it on, a file whose declared class
+        // name does not match its basename would re-enter autoload() for the
+        // same short name and hit the "Cannot declare class X" fatal the
+        // include_once above exists to avoid. Aliasing a name that was never
+        // declared is itself a fatal, so both halves matter: only alias what
+        // the include actually produced, and let PHP raise its own
+        // catchable class-not-found for anything else.
+        if (class_exists($short, false)
+            || interface_exists($short, false)
+            || trait_exists($short, false)
+        ) {
+            class_alias($short, $class);
         }
     }
 

--- a/tests/autoload.test.php
+++ b/tests/autoload.test.php
@@ -65,7 +65,7 @@
  * This constant existing rather than the assertion simply being deleted is
  * the point: the flip is the bridge's regression test.
  */
-const EXPECT_BRIDGE = false;
+const EXPECT_BRIDGE = true;
 
 // An explicit path means "probe that tree", which is a different job from
 // "check this checkout" -- see the header. Compared by realpath so that


### PR DESCRIPTION
Phase 0.2 of the modernization work: teach `Initiator::autoload()` to answer to
`FOG\Foo` by resolving the still-global `Foo` and aliasing it. One method, one
new branch, purely additive.

**This is PR B of three. Merge order: A → B → C.** Based on
`phase0-tests` (#1046); the diff shown here is one commit once A merges.

## What is broken today

`Initiator::autoload()` keys its map on `strtolower(basename minus .<type>.php)`
and looks up `strtolower($class)`. For `FOG\User` that key is `fog\user` — a
string containing a backslash, which no basename can ever produce. Guaranteed
miss.

It then falls through to the bare `spl_autoload()` registered at `init.php:135`,
which converts `\` to a directory separator and probes `fog/user.class.php`
against `include_path`. That path list is built from the dirnames of class files
— 66 directories, and `packages/web/lib` is not among them (only `lib/index.php`
lives there, and it is not a class file). So there is no `…/fog/user.class.php`
to find. Silent miss, no error, no log line.

## Why now rather than in Phase 3

Phase 3 namespaces files one at a time. Every file it converts is a file whose
*callers* have to be able to say `FOG\Thing` — and callers get converted on a
different day. Shipping the bridge first means a namespaced spelling always
works, so the order files get converted in stops mattering.

## Behaviour

Verified by running, on both PHP 8.3.33 and 7.4.33:

| Request | Result |
|---|---|
| `FOG\Host` | resolves; `(new ReflectionClass('FOG\Host'))->getName()` is `Host` — same class entry |
| `fog\image` | resolves — `strncasecmp` matches PHP's own case-insensitivity |
| `FOG\FOGPagePost` | resolves as a **trait** — `class_alias` works on traits and interfaces |
| `FOG\NoSuchThing` | misses cleanly, no fatal, no warning |
| `FOG\Model\Host` | misses — nested names are refused, not guessed |
| `Vendor\Host` | untouched — a foreign namespace never enters the bridge |

Three design points, because the obvious alternatives are worse:

- **`class_exists($short, false)` — autoload off.** With autoload on, a miss
  re-enters `autoload()` for `$short`, and on a file whose declared name does
  not match its basename that recursion is the "Cannot declare class X" fatal
  already documented at `init.php:277-284`.
- **Alias only what actually got declared.** `class_alias` on a name that does
  not exist is a fatal, and a fatal here is a bodyless 500.
- **One prefix, not configurable.** A bridge that aliased any namespace would
  make every typo'd FQCN in a plugin resolve to a core class of the same short
  name.

The bridge sits at the end of `autoload()` rather than in its own
`spl_autoload_register` closure. A separate closure would register *behind* the
bare `spl_autoload()` at `:135`, so every namespaced miss would first cost a
full `include_path` probe across 66 directories — the exact stat storm the O(1)
map was introduced to kill.

## Also in this commit

An early `return` after the map-hit `include_once`, which the new branch
requires and which is a readability win regardless.

`docs/plugin-development.md` gains a "Namespaced spellings work too" block:
`FOG\Host` is the forward-compatible spelling, bare `Host` keeps working for all
of 1.6, the bridge is flat-only, and foreign namespaces are untouched. The
existing autoloader bullet in §2 is corrected while there — it described the
map as running behind PHP's built-in resolver, which has been the other way
round since the map was added.

## Verification

```
sh tests/run-all.sh          # exit 0
```

`tests/autoload.test.php`'s bridge assertion inverts in this commit — it
asserted the bridge was absent on PR A, asserts it is present here. That
inversion is the regression test.

## Risk

No name is removed. `Host` keeps working identically, which is what makes this
safe to ship ahead of any consumer. The bridge only executes after a map miss
on a `FOG\`-prefixed name, which no current code produces — so on today's tree
it is dead code that costs one `strncasecmp` per miss. Revert restores prior
behaviour exactly.

Nothing breaks for plugin authors. One thing becomes possible: a plugin may
write `FOG\Host` and it works on any 1.6 carrying this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
