### PR TITLE
Fix two callers that iterate listem()'s envelope instead of its rows

### DIFF
--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -147,7 +147,11 @@ class BootItem extends Hook
         $Menus = json_decode(
             Route::getData()
         );
-        foreach ($Menus as &$Menu) {
+        // ->data, not the envelope: listem() returns the paginated wrapper and
+        // the rows live under it. Iterating the wrapper walked its own scalar
+        // members (draw, recordsTotal, the page URLs...) instead, so $Menu->name
+        // was null every pass and the fog.local special-casing below never fired.
+        foreach ($Menus->data as $Menu) {
             if ($arguments['ipxe']['item-'.$Menu->name]
                 && $Menu->name == 'fog.local'
             ) {
@@ -167,7 +171,6 @@ class BootItem extends Hook
                     = $arguments['bootexittype']
                     . ' || goto MENU';
             }
-            unset($Menu);
         }
         // Default item is set to: 'ipxe' 'default'
         if ($arguments['ipxe']['default']) {

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -3021,9 +3021,13 @@ class Route extends FOGBase
                     $Tasks = json_decode(
                         Route::getData()
                     );
-                    foreach ($Tasks as &$Task) {
+                    // ->data, not the envelope: listem() returns the paginated
+                    // wrapper. Iterating the wrapper walked its own scalar
+                    // members, so $Task->id was null on every pass and this
+                    // cancelled nothing at all -- cancelling a group's tasks
+                    // reported success and left every task running.
+                    foreach ($Tasks->data as $Task) {
                         self::getClass('Task', $Task->id)->cancel();
-                        unset($Task);
                     }
                     break;
                 case 'host':

--- a/tests/listem-envelope.test.php
+++ b/tests/listem-envelope.test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Guards against iterating Route::listem()'s envelope instead of its rows.
+ *
+ * listem() puts a paginated wrapper in Route::$data -- draw, recordsTotal,
+ * recordsFiltered, truncated, data, _lang, recordsReturned and four page URLs
+ * -- so the rows are under ->data. Iterating the wrapper walks those eleven
+ * scalar members instead, which does not error: it warns "Attempt to read
+ * property X on int" and yields null for every field.
+ *
+ * That has bitten three times, in three repositories' worth of code, and each
+ * time it failed silently rather than loudly:
+ *   - ou plugin: ADOU never set on any client check-in
+ *   - bootitem.hook.php: the fog.local boot-to-disk label never applied
+ *   - route.class.php: cancelling a group's tasks cancelled nothing
+ *
+ * Static source check (no DB, no server) -- these call sites need the full FOG
+ * bootstrap to run, so this parses them instead.
+ *
+ * Usage: php tests/listem-envelope.test.php [path...]
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$roots = array_slice($argv, 1);
+if (count($roots) === 0) {
+    $roots = [dirname(__DIR__) . '/packages/web'];
+}
+
+$files = [];
+foreach ($roots as $root) {
+    if (is_file($root)) {
+        $files[] = $root;
+        continue;
+    }
+    if (!is_dir($root)) {
+        fwrite(STDERR, "FAIL: cannot read $root\n");
+        exit(1);
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $f) {
+        if ($f->getExtension() !== 'php') {
+            continue;
+        }
+        // Composer's tree is third-party and does not use Route at all.
+        if (strpos($f->getPathname(), DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) !== false) {
+            continue;
+        }
+        // lib/plugins is gitignored here -- it is fetched from FOGProject
+        // /fog-plugins by bin/fetch-plugins.sh (ADR 0009), so its contents
+        // vary per checkout and are not this repo's to assert on. That repo
+        // runs this same test against its own tree; point this one at it with
+        // an explicit path argument if you want to check both at once.
+        if (strpos($f->getPathname(), DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR) !== false) {
+            continue;
+        }
+        $files[] = $f->getPathname();
+    }
+}
+sort($files);
+
+$failures = [];
+
+foreach ($files as $file) {
+    $src = file_get_contents($file);
+
+    // $Foo = json_decode(Route::getData());  ... then how $Foo gets used.
+    if (!preg_match_all(
+        '/Route::listem\s*\(.{0,400}?\$(\w+)\s*=\s*json_decode\s*\(\s*Route::getData\(\)\s*\)\s*;(.{0,800})/s',
+        $src,
+        $matches,
+        PREG_SET_ORDER
+    )) {
+        continue;
+    }
+
+    foreach ($matches as $match) {
+        $var = $match[1];
+        $after = $match[2];
+
+        // Reading ->data is the correct shape; nothing more to check.
+        if (preg_match('/\$' . $var . '\s*->\s*data\b/', $after)) {
+            continue;
+        }
+        // foreach over the variable itself, or subscripting it, means the
+        // envelope is being treated as the row set.
+        if (preg_match(
+            '/foreach\s*\(\s*\$' . $var . '\s*(?!->)|\$' . $var . '\s*\[/',
+            $after
+        )) {
+            $line = substr_count(
+                substr($src, 0, strpos($src, $match[0])),
+                "\n"
+            ) + 1;
+            $failures[] = sprintf(
+                '%s:~%d: $%s holds listem()\'s envelope but is iterated '
+                . 'directly -- read $%s->data',
+                $file,
+                $line,
+                $var,
+                $var
+            );
+        }
+    }
+}
+
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        fwrite(STDERR, "FAIL: $f\n");
+    }
+    exit(1);
+}
+
+printf("listem-envelope: %d files scanned, no envelope iteration\n", count($files));
+echo "PASS\n";
+exit(0);


### PR DESCRIPTION
Two call sites iterated the object `Route::listem()` leaves in `Route::$data`
rather than its `->data` array, so the loop walked the envelope's own scalar
members instead of the rows.

The 1.6 envelope carries eleven of them — `draw`, `recordsTotal`,
`recordsFiltered`, `truncated`, `data`, `_lang`, `recordsReturned`, `firstUrl`,
`prevUrl`, `nextUrl`, `lastUrl` — so each pass yielded null for whatever field
the loop body asked for, plus a PHP warning.

Neither failed loudly. Both quietly did nothing.

## Verified on the 1.6 lab

| Site | Old | Fixed |
|---|---|---|
| `route.class.php` group task cancel | 11 iterations, **every id null** | 7 real task ids: 30, 31, 32, 33, 34, 17, 39 |
| `bootitem.hook.php` iPXE menu | 11 iterations, **every name null**, `fog.local` absent | 13 real menu entries, `fog.local` present |

**`route.class.php` is the one that matters.** Cancelling a group's tasks ran
`getClass('Task', null)->cancel()` eleven times — an invalid task, cancelled
repeatedly — while the group's seven real tasks kept running. The API reported
success. Tested against group 1 on the lab, which has those seven live tasks.

**`bootitem.hook.php`** meant `$Menu->name` never equalled `fog.local`, so the
"THIS BOOTS TO DISK" item label and the `bootexittype` choice were never
applied to the iPXE menu.

## Also

The by-reference iteration went with both. Nothing was written back through
either reference, and both `unset()` calls sat *inside* the loop, where they do
nothing, rather than after it.

## The guard

`tests/listem-envelope.test.php` covers the bug class rather than these two
instances. Static check, no DB: find a variable assigned from
`json_decode(Route::getData())` following a `listem()`, then fail if the body
iterates or subscripts that variable without going through `->data`.

Verified it rejects both old forms and passes on the fixed tree.

It skips `lib/plugins`, which is gitignored here and fetched from
`FOGProject/fog-plugins` per ADR 0009. **The same bug was in that repo's `ou`
plugin** — `ADOU` was never set on any client check-in, and it warned on every
one — fixed separately in FOGProject/fog-plugins#1. The test takes paths so it
can be pointed at that tree too; it passes there now.

That makes three instances of one root cause, in code that has been shipping
for years, none of which announced itself. Every caller currently has to know
the envelope's shape, and three of them didn't.

## Note on CI

The two `pxe-secureboot` tests fail on `working-1.6` today, before and after
this change alike — unrelated pre-existing breakage from `facea052b`, fixed in
#1046. This branch is based on `working-1.6` and does not include that fix, so
they will fail here.

There is also no `tests/run-all.sh` on `working-1.6` yet (it arrives with
#1046), so the new test is run directly:

```
php tests/listem-envelope.test.php
  listem-envelope: 296 files scanned, no envelope iteration
  PASS
```

## Risk

Two loops, one new test. No schema change. The behavior change is the intended
one: cancelling a group's tasks now cancels them, and the `fog.local` menu
label is now applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)