### PR TITLE
Route result wrappers: return values, raise instead of exiting

### DIFF
--- a/docs/adr/0011-route-result-wrappers.md
+++ b/docs/adr/0011-route-result-wrappers.md
@@ -1,0 +1,208 @@
+# Route hands results back as values, and raises instead of exiting
+
+## Status
+
+accepted
+
+## Context
+
+Nearly every backend use of the API router is three lines that do one thing:
+
+```php
+Route::listem('ouassociation', ['hostID' => $id]);
+$assocs = json_decode(Route::getData());
+foreach ($assocs->data as $assoc) { ... }
+```
+
+`getData()` JSON-encodes `Route::$data` purely so the caller can decode it back.
+There are **168 such sites in `packages/web` and 37 in `fog-plugins`**.
+
+The encode/decode is the least interesting part. Two hazards ride on this idiom,
+and both fail silently.
+
+### The envelope became caller knowledge
+
+`listem()` leaves a paginated wrapper in `Route::$data`, so the rows sit under
+`data`. On 1.6 that wrapper carries eleven members:
+
+```
+draw  recordsTotal  recordsFiltered  truncated  data
+_lang  recordsReturned  firstUrl  prevUrl  nextUrl  lastUrl
+```
+
+The envelope is the DataTables and pagination contract and has to keep
+existing. But a caller that iterates the envelope rather than `->data` walks
+those eleven scalars. It does not error. It warns `Attempt to read property X
+on int` and yields null for every field the loop body asks for.
+
+That mistake has shipped three times:
+
+| Site | Consequence |
+|---|---|
+| `ou` plugin's check-in hook | `ADOU` never set on any client check-in, one warning per check-in on a client endpoint |
+| `route.class.php` group task cancel | cancelling a group's tasks cancelled **nothing** — eleven nulls passed to `getClass('Task', null)->cancel()` while the real tasks kept running |
+| `bootitem.hook.php` | the iPXE menu never applied its `fog.local` boot-to-disk label |
+
+All three were verified against a live 1.6 database before being fixed. They are
+not near-misses; two of them were silently broken functionality in shipped
+releases.
+
+### The helpers end the process
+
+`listem()`, `indiv()` and `active()` report failure through
+`Route::sendResponse()`, which reaches `HTTPResponseCodes::breakHead()`, which
+ends in `exit`. At the HTTP boundary that is correct — the router is entitled
+to end the response.
+
+It is called from well below that boundary:
+
+| Where it runs | Sites | What `exit` means there |
+|---|---:|---|
+| page / model | 78 | a 406 — ugly, survivable |
+| **daemon / service** | **26** | **the daemon process dies**, after writing an HTTP status line to stdout |
+| reports / reg-task | 16 | response terminated mid-render |
+| router itself | 6 | correct — this *is* the boundary |
+| **client endpoint** | **3** | **non-2xx is invisible to the client** and reads as a transport failure |
+| hook | 1 | kills whatever request the hook fired inside |
+
+30 of 130 sites are in a context where terminating is the wrong answer.
+
+This is already known here. `multicasttask.class.php` carries a hand-rolled
+guard for exactly it (#907), and its comment describes the failure precisely:
+
+> `Route::indiv()` answers a missing row with `sendResponse(404)`, which ends in
+> `HTTPResponseCodes::breakHead()`'s exit. That is correct for a web request and
+> fatal here: it terminates the forked daemon child outright, with nothing
+> written to `multicast.log` and no exception for the service loop to catch, so
+> multicast stops dead until someone restarts the unit.
+
+That guard had to duplicate `indiv()`'s own validity test to avoid calling it.
+It is a workaround for one call site of a hazard that has thirty.
+
+### There is already a precedent for the fix
+
+`Route::getIds()` is this exact wrapper, and its docblock already names the
+problem — *"skips the json_encode/json_decode round-trip getData() incurs, for
+the common `Route::ids(...); json_decode(Route::getData())` idiom"*. It is used
+**232 times in core and 34 in plugins**. The wrapped form is already the
+majority idiom; nobody extended it to `listem()` and `indiv()`, which is where
+the remaining sites are.
+
+## Decision
+
+**Add `Route::getList()` and `Route::getItem()`, shaped after `getIds()`, and
+make `sendResponse()` raise instead of exiting while one of them is on the
+stack.**
+
+```php
+$assocs = Route::getList('ouassociation', ['hostID' => $id]);   // rows
+$ou     = Route::getItem('ou', $ouId);                           // one entity
+```
+
+Four properties, each chosen against a specific failure:
+
+**They return rows, so there is no envelope to hold wrongly.** `getList()`
+returns `[]` rather than null on an empty result, so a `foreach` is always
+safe. The static guard `tests/listem-envelope.test.php` stays as a backstop for
+sites that still use the raw form, but the wrapper removes the opportunity
+rather than catching the mistake.
+
+**They add no policy.** `listem()` and `indiv()` do the work, so every
+permission filter, hook, `expand` and `pluginItems` step runs exactly as before.
+
+**They hand back the object graph `json_decode()` would have produced**, via a
+recursive `objectify()` rather than a JSON round-trip: a list stays a list, an
+associative array becomes `stdClass`, scalars pass through. This is not
+cosmetic. Roughly 190 call sites read `$row->field`, and returning raw arrays
+would make migrating them a rewrite rather than a swap — and a `$row->id` left
+behind on an array reads null rather than erroring, which is the same silent
+shape as the bug being fixed. Equivalence is asserted against
+`json_decode(json_encode($x))` over fourteen shapes.
+
+**Failures raise, they do not exit.** A `private static $_rethrowDepth` counter
+is incremented by the wrappers; `sendResponse()` consults it and throws a
+`\RuntimeException` carrying the message and status code instead of calling
+`breakHead()`. When the counter is zero — every existing caller — behavior is
+byte-identical to today.
+
+The guard lives in `sendResponse()` rather than in the individual `catch`
+blocks because that is the single choke point: 44 call sites in the class
+funnel through it, and paths such as `getsearchbody()` end the response without
+ever reaching `listem()`'s own `catch`. Putting it in the three obvious catches
+was tried first and missed exactly that path.
+
+A counter rather than a boolean because `listem()` fires hooks that may
+re-enter `Route`, and the inner call must inherit the outer caller's context.
+`$expandDepth`, `$getterDepth` and `$_deleteDepth` are the existing precedent in
+this class.
+
+### `getItem()` establishes existence first
+
+`indiv()` answers a missing row with `sendResponse(404)`. Rather than make that
+ambiguous, `getItem()` asks a cheap id-only question first and returns null when
+there is no such row — or when the caller may not see it. One extra indexed
+query is the price of leaving `indiv()`'s HTTP behavior exactly as it is.
+
+### `inputoverride` is true
+
+Internal callers are not answering a DataTables POST. With the default,
+`listem()` reads pagination out of `php://input`, so a wrapper called inside a
+POST request could have its result silently paged by unrelated request data.
+This is a deliberate difference from the three-line idiom it replaces, and the
+only one.
+
+## Consequences
+
+Nothing changes for any existing caller. The wrappers are additive, the counter
+is zero unless one is on the stack, and `listem()`, `indiv()`, `active()` and
+`getData()` are untouched.
+
+Migration is a separate, ordered exercise and is explicitly not part of
+adopting this ADR:
+
+1. daemons and services — 26 sites, the only bucket that can kill a process
+2. client endpoints and hooks — 4 sites, invisible failures
+3. `fog-plugins` — 37 sites, gated on this shipping in a release
+4. pages, models, reports — 94 sites, mechanical, least urgent
+5. the router's own 6 sites — at the HTTP boundary, where `exit` is correct;
+   they may be right to leave alone, but that should be a decision rather than
+   an omission
+
+`multicasttask.class.php`'s hand-rolled guard can retire once step 1 reaches it.
+
+### What this does not fix
+
+`listem()` remains a single ~1,000-line method. Nothing here improves that, and
+the wrappers deliberately do not restructure it.
+
+The raised exception is a `\RuntimeException` carrying the message and code, not
+the original `PDOException` or `ReflectionException`. The message survives,
+which is what a daemon needs in order to log; the type does not. Preserving it
+would mean routing every one of the 44 call sites individually rather than
+guarding the choke point, and the choke point is what makes the guarantee
+total.
+
+## Alternatives considered
+
+**Change `getData()` to return decoded data.** Rejected — its output is echoed
+straight to the wire by the API's own routes, and it is public surface plugins
+call. The wrapper adds a name rather than redefining one.
+
+**Make `listem()` return rows and drop the envelope.** Rejected — the envelope
+is consumed by the browser and by scripted API clients. The question was only
+whether every *internal* caller should unwrap it by hand.
+
+**Fix the three bugs and stop.** This is the honest baseline, and it is already
+done. What the wrappers buy beyond it is removing the opportunity, and the
+`exit` hazard, which the bug fixes do not touch at all.
+
+**Return arrays rather than objects.** Rejected — see above; it converts a
+mechanical migration into a 190-site rewrite whose mistakes read as null rather
+than erroring.
+
+**Swallow errors and return `[]`.** Rejected — it turns a database error into
+"no rows", which is the same silent-failure shape this entire ADR is about.
+
+**Fold it into the Phase 0.1 backslash-prefix pass.** Rejected — that PR's
+safety argument is that it is mechanically a no-op, proven by token
+equivalence. A semantic change riding along would make that proof meaningless.

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -154,6 +154,17 @@ class Route extends FOGBase
      * @var int
      */
     private static $_deleteDepth = 0;
+    /**
+     * Nesting depth of the getX() result wrappers.
+     *
+     * Non-zero means a caller below the HTTP boundary is on the stack, so
+     * failed() rethrows instead of ending the response. A counter rather than
+     * a flag because listem() fires hooks that may re-enter Route, and the
+     * inner call must inherit the outer caller's context.
+     *
+     * @var int
+     */
+    private static $_rethrowDepth = 0;
     public static $sensitiveFields = [
         'host' => [
             'ADPass',
@@ -961,6 +972,33 @@ class Route extends FOGBase
      */
     public static function sendResponse($code, $msg = false)
     {
+        // The router is the HTTP boundary and is entitled to end the response:
+        // breakHead() sets the status and exits. That is still exactly what
+        // happens for every caller that reaches here normally.
+        //
+        // It is the wrong answer below that boundary, and this is called from
+        // well below it -- eleven classes under lib/service back the CLI
+        // daemons, where the exit ends the daemon process after writing an
+        // HTTP status line to stdout, and the client endpoints, where a
+        // non-2xx is invisible to the client and reads as a transport failure
+        // rather than an answer. multicasttask.class.php already carries a
+        // hand-rolled guard against exactly this (see #907); it had to
+        // duplicate indiv()'s own validity test to avoid calling it.
+        //
+        // So when a getX() result wrapper is on the stack, report the failure
+        // as an exception and let the caller decide. Those callers can catch
+        // and log; they cannot un-exit. See ADR 0011.
+        //
+        // The guard lives here rather than in the individual catch blocks
+        // because this is the single choke point -- 44 call sites in this
+        // class funnel through it, and paths like getsearchbody() end the
+        // response without ever reaching listem()'s own catch.
+        if (self::$_rethrowDepth > 0) {
+            throw new \RuntimeException(
+                is_string($msg) && $msg !== '' ? $msg : (string)$code,
+                (int)$code
+            );
+        }
         HTTPResponseCodes::breakHead(
             $code,
             $msg
@@ -4305,6 +4343,137 @@ class Route extends FOGBase
         $data = self::$data;
         self::$data = '';
         return is_array($data) ? $data : [];
+    }
+    /**
+     * Returns a list's rows directly as a PHP array.
+     *
+     * The listem() counterpart of getIds(), and the reason it exists is the
+     * same: `Route::listem(...); json_decode(Route::getData());` encodes the
+     * result to JSON only to decode it straight back, and leaves every caller
+     * holding the paginated envelope.
+     *
+     * That envelope is the DataTables and pagination contract and is not going
+     * anywhere -- but the rows live under its `data` key, and a caller that
+     * iterates the envelope instead walks its eleven scalar members (draw,
+     * recordsTotal, the page URLs...) and gets null for every field. It does
+     * not error, it warns. That mistake has shipped three times: the ou
+     * plugin never set ADOU on any client check-in, cancelling a group's tasks
+     * cancelled nothing, and the iPXE menu never applied its fog.local label.
+     *
+     * This returns the rows, so there is no envelope for a caller to hold
+     * wrongly. Every permission filter, hook, expand and pluginItems step
+     * still runs -- listem() does the work and this adds no policy.
+     *
+     * Failures rethrow rather than ending the response; see failed().
+     *
+     * @param string $class      The class to list.
+     * @param mixed  $whereItems The items to filter on.
+     * @param string $operator   The operator for the SQL. AND is default.
+     * @param string $orderby    How to order the returned rows.
+     *
+     * @throws \Exception When the underlying query fails.
+     *
+     * @return array The rows, or an empty array. Never null, so a foreach
+     *               over the result is always safe.
+     */
+    public static function getList(
+        $class,
+        $whereItems = false,
+        $operator = 'AND',
+        $orderby = 'name'
+    ) {
+        self::$_rethrowDepth++;
+        try {
+            // inputoverride stays true: an internal caller is not answering a
+            // DataTables POST, and without it listem() would read pagination
+            // out of php://input and silently page a result the caller asked
+            // for in full.
+            self::listem($class, $whereItems, true, $operator, $orderby);
+            $data = self::$data;
+            self::$data = '';
+        } finally {
+            self::$_rethrowDepth--;
+        }
+        if (is_array($data) && isset($data['data'])) {
+            $rows = is_array($data['data']) ? $data['data'] : [];
+        } else {
+            $rows = is_array($data) ? $data : [];
+        }
+        return self::objectify($rows);
+    }
+    /**
+     * Builds the object graph json_decode() would have produced, without the
+     * encode/decode round-trip.
+     *
+     * The idiom these wrappers replace ends in json_decode(), so its rows
+     * arrive as stdClass and every one of the ~190 call sites reads
+     * `$row->field`. Handing back raw arrays would make migrating them a
+     * rewrite rather than a swap, and a `$row->id` left behind on an array is
+     * a null read, not an error -- the same silent shape as the envelope bug
+     * this is meant to end.
+     *
+     * Mirrors json_decode()'s rule exactly: a list stays a list, an
+     * associative array becomes stdClass, scalars pass through untouched. An
+     * empty array stays an array, as json_decode('[]') does.
+     *
+     * @param mixed $value The value to convert.
+     *
+     * @return mixed
+     */
+    private static function objectify($value)
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+        // array_is_list() is PHP 8.1; the floor here is 7.4.
+        $isList = $value === []
+            || array_keys($value) === range(0, count($value) - 1);
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[$key] = self::objectify($item);
+        }
+        return $isList ? $out : (object)$out;
+    }
+    /**
+     * Returns one entity directly as a PHP object.
+     *
+     * The indiv() counterpart of getIds(). indiv()'s payload is flat -- there
+     * is no envelope on a single entity -- so this exists for the round-trip
+     * and for the not-found behaviour rather than for unwrapping.
+     *
+     * Existence is established first with an id-only query, deliberately.
+     * indiv() answers a row it cannot find with sendResponse(404), which
+     * reaches breakHead() and exits, and that is the right answer at the HTTP
+     * boundary. Rather than change it, this asks a cheap indexed question
+     * first so the wrapper can return null the way its callers need. One
+     * extra id-only query is the price of not making indiv() ambiguous.
+     *
+     * Failures rethrow rather than ending the response; see failed().
+     *
+     * @param string $class The class to fetch.
+     * @param mixed  $id    The id to fetch.
+     *
+     * @throws \Exception When the underlying query fails.
+     *
+     * @return object|null The entity, or null when no such row exists or the
+     *                     caller may not see it.
+     */
+    public static function getItem($class, $id)
+    {
+        self::$_rethrowDepth++;
+        try {
+            if (count(self::getIds($class, ['id' => $id])) === 0) {
+                return null;
+            }
+            self::indiv($class, $id);
+            $data = self::$data;
+            self::$data = '';
+        } finally {
+            self::$_rethrowDepth--;
+        }
+        // getter() builds an associative array; hand back the object graph so
+        // call sites read the same as the json_decode() form they replace.
+        return self::objectify($data);
     }
     /**
      * Delete items in mass.

--- a/tests/route-result-wrappers.test.php
+++ b/tests/route-result-wrappers.test.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Guards the two contracts Route's result wrappers rest on.
+ *
+ * 1. objectify() must produce exactly what json_decode(json_encode($x)) would.
+ *    The idiom getList()/getItem() replace ends in json_decode(), so its rows
+ *    arrive as stdClass and roughly 190 call sites read `$row->field`. If the
+ *    conversion ever drifts, a migrated caller reads null off an array rather
+ *    than erroring -- the same silent shape as the envelope bug the wrappers
+ *    exist to end.
+ *
+ * 2. sendResponse() must raise rather than exit while a wrapper is on the
+ *    stack. That is the whole reason a daemon may call one: eleven classes
+ *    under lib/service back the CLI daemons, where breakHead()'s exit ends the
+ *    process. See ADR 0011, and multicasttask.class.php's hand-rolled guard
+ *    against the same hazard (#907).
+ *
+ * DB-free: loads the autoloader and pokes the statics by reflection. It never
+ * calls listem() or indiv(), so no database is contacted.
+ *
+ * Usage: php tests/route-result-wrappers.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+$init = $web . '/commons/init.php';
+
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-route-wrappers-' . getmypid();
+foreach (['cache', 'log', 'plugins', 'sessions'] as $dir) {
+    if (!is_dir($tmp . '/' . $dir)) {
+        mkdir($tmp . '/' . $dir, 0777, true);
+    }
+}
+// Forced to a temp dir unconditionally: the class scan writes filelist.*.json
+// under FOG_CACHE_DIR, and a test must never rebuild a real server's cache.
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+ini_set('session.save_path', $tmp . '/sessions');
+
+require $init;
+new Initiator();
+
+$failures = [];
+
+/**
+ * Records a failed expectation.
+ *
+ * @param array  $failures Collected failures, by reference.
+ * @param string $label    What was being checked.
+ * @param mixed  $want     Expected value.
+ * @param mixed  $got      Actual value.
+ *
+ * @return void
+ */
+function expect(array &$failures, $label, $want, $got)
+{
+    if ($want !== $got) {
+        $failures[] = sprintf(
+            '%s: expected %s, got %s',
+            $label,
+            var_export($want, true),
+            var_export($got, true)
+        );
+    }
+}
+
+if (!class_exists('Route')) {
+    fwrite(STDERR, "FAIL: Route did not autoload\n");
+    exit(1);
+}
+
+$ref = new \ReflectionClass('Route');
+
+foreach (['getList', 'getItem', 'objectify'] as $method) {
+    if (!$ref->hasMethod($method)) {
+        $failures[] = "Route::$method() is missing";
+    }
+}
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        fwrite(STDERR, "FAIL: $f\n");
+    }
+    exit(1);
+}
+
+// ---- 1. objectify() matches the json round-trip -------------------------
+
+$objectify = $ref->getMethod('objectify');
+$objectify->setAccessible(true);
+
+$shapes = [
+    'empty array'            => [],
+    'list of scalars'        => [1, 2, 3],
+    'flat row'               => ['id' => '1', 'name' => 'fog.local'],
+    'list of rows'           => [['id' => '1'], ['id' => '2']],
+    'nested object'          => ['id' => '1', 'meta' => ['a' => 'b']],
+    'nested list'            => ['id' => '1', 'tags' => ['x', 'y']],
+    'list of nested rows'    => [['id' => '1', 'm' => ['k' => 'v']]],
+    'null value'             => ['id' => '1', 'desc' => null],
+    'bool and int'           => ['on' => true, 'n' => 7],
+    'scalar passthrough'     => 'plain',
+    'null passthrough'       => null,
+    'empty nested'           => ['rows' => [], 'meta' => []],
+    'numeric string keys'    => ['0' => 'a', '1' => 'b'],
+    'sparse keys'            => [3 => 'a', 7 => 'b'],
+];
+
+foreach ($shapes as $label => $input) {
+    $want = json_decode(json_encode($input));
+    $got = $objectify->invoke(null, $input);
+    if ($want != $got) {
+        $failures[] = sprintf(
+            'objectify(%s) diverged from json_decode(json_encode()): '
+            . 'expected %s, got %s',
+            $label,
+            json_encode($want),
+            json_encode($got)
+        );
+    }
+    // == compares structure and value; also pin the top-level PHP type, which
+    // is what decides whether a call site writes -> or [].
+    expect(
+        $failures,
+        "objectify($label) top-level type",
+        gettype($want),
+        gettype($got)
+    );
+}
+
+// ---- 2. the rethrow guard ------------------------------------------------
+
+$depth = $ref->getProperty('_rethrowDepth');
+$depth->setAccessible(true);
+expect($failures, 'rethrow depth starts at 0', 0, $depth->getValue());
+
+// Run the probe in a child process, deliberately. If the guard is ever
+// removed, sendResponse() reaches breakHead(), which echoes and calls exit --
+// and exit(0) in THIS process would end the test early with a success status
+// and no output, which the runner would read as a pass. A child lets the
+// absence of the marker be observed instead of ending the observer.
+$probe = <<<'PROBE'
+$tmp = sys_get_temp_dir() . '/fog-route-probe-' . getmypid();
+foreach (['cache', 'log', 'plugins'] as $d) { @mkdir($tmp . '/' . $d, 0777, true); }
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+ini_set('session.save_path', $tmp);
+require %s;
+new Initiator();
+$r = new ReflectionClass('Route');
+$d = $r->getProperty('_rethrowDepth');
+$d->setAccessible(true);
+$d->setValue(null, 1);
+try {
+    Route::sendResponse(406, 'probe');
+    echo 'MARKER:noraise';
+} catch (RuntimeException $e) {
+    echo 'MARKER:raised:' . $e->getMessage() . ':' . $e->getCode();
+} catch (Throwable $e) {
+    echo 'MARKER:wrongtype:' . get_class($e);
+}
+PROBE;
+
+$out = [];
+exec(
+    'php -r ' . escapeshellarg(sprintf($probe, var_export($init, true))) . ' 2>&1',
+    $out
+);
+$got = implode('', $out);
+
+if (strpos($got, 'MARKER:raised:probe:406') === false) {
+    if (strpos($got, 'MARKER:') === false) {
+        $failures[] = 'sendResponse() ended the process while a wrapper was '
+            . 'on the stack -- the guard is gone. Child produced: '
+            . var_export(substr($got, 0, 120), true);
+    } else {
+        $failures[] = 'sendResponse() did not raise as expected: '
+            . var_export(substr($got, 0, 120), true);
+    }
+}
+
+// A wrapper must leave the depth where it found it, including after a failure.
+expect($failures, 'rethrow depth restored', 0, $depth->getValue());
+
+// ---- report --------------------------------------------------------------
+
+@array_map('unlink', (array)glob($tmp . '/cache/*'));
+foreach (['cache', 'log', 'plugins', 'sessions'] as $dir) {
+    @rmdir($tmp . '/' . $dir);
+}
+@rmdir($tmp);
+
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        fwrite(STDERR, "FAIL: $f\n");
+    }
+    exit(1);
+}
+
+printf(
+    "route-result-wrappers: %d shapes match json_decode(), rethrow guard live\n",
+    count($shapes)
+);
+echo "PASS\n";
+exit(0);


### PR DESCRIPTION
Step 1 of the plan in ADR 0011: land the mechanism, migrate nothing.

169 lines added to `route.class.php`, **no existing line changed**. `listem()`,
`indiv()`, `active()` and `getData()` are untouched, and with the depth counter
at zero — every caller that exists today — behavior is byte-identical.

```php
$assocs = Route::getList('ouassociation', ['hostID' => $id]);   // rows
$ou     = Route::getItem('ou', $ouId);                           // one entity
```

## Why, beyond the round-trip

The `Route::listem(...); json_decode(Route::getData());` idiom appears **168
times in core and 37 in fog-plugins**. The encode/decode is the least
interesting part; two hazards ride on it, and both fail silently.

**The envelope became caller knowledge.** Rows sit under `->data`, and a caller
that iterates the envelope walks its eleven scalar members instead, reading
null for every field — with a warning, not an error. That has shipped three
times: `ADOU` never set on any client check-in, cancelling a group's tasks
cancelling **nothing**, and the iPXE menu never applying its `fog.local` label
(#1050, fog-plugins#1).

**The helpers end the process.** `sendResponse()` → `breakHead()` → `exit`.
Correct at the HTTP boundary; wrong in the **26 sites under `lib/service`** that
back the CLI daemons and the **3 client endpoints** where a non-2xx is invisible
to Zazzles.

That second one is already known here — `multicasttask.class.php` carries a
hand-rolled guard for it (#907):

> `Route::indiv()` answers a missing row with `sendResponse(404)` … That is
> correct for a web request and fatal here: it terminates the forked daemon
> child outright, with nothing written to `multicast.log` and no exception for
> the service loop to catch, so multicast stops dead until someone restarts the
> unit.

It had to duplicate `indiv()`'s own validity test to avoid calling it. That is a
workaround for one call site of a hazard with thirty.

## Not a new abstraction

`Route::getIds()` is this exact wrapper and its docblock already names the
problem. It is used **232 times in core, 34 in plugins**. The wrapped form is
already the majority idiom — nobody extended it to `listem()` and `indiv()`,
which is where the remaining sites are. This finishes it.

## Design notes worth reviewing

**The guard is in `sendResponse()`, not in the catch blocks.** I tried the three
obvious catches first and it missed `getsearchbody()`, which ends the response
without ever reaching `listem()`'s catch. `sendResponse()` is the single choke
point — 44 call sites funnel through it — so guarding it makes the guarantee
total rather than partial.

The cost, stated plainly: the raised `\RuntimeException` carries the message and
status code, not the original `PDOException`/`ReflectionException`. The message
is what a daemon needs to log; the type does not survive. Preserving it would
mean routing all 44 sites individually.

**A counter, not a boolean** — `listem()` fires hooks that may re-enter `Route`,
and the inner call must inherit the outer context. `$expandDepth`,
`$getterDepth`, `$_deleteDepth` are the existing precedent in this class.

**`objectify()` returns objects, not arrays.** Not cosmetic: ~190 call sites
read `$row->field`, and raw arrays would turn a mechanical migration into a
rewrite whose mistakes read as *null* rather than erroring — the same silent
shape as the bug being fixed.

**`getItem()` pre-checks existence** with a cheap id-only query so `indiv()`'s
404-then-exit stays exactly as it is for the HTTP callers it was written for.

**`inputoverride` is passed `true`** — the one deliberate behavioral difference.
An internal caller is not answering a DataTables POST, and the default lets
`listem()` read pagination out of `php://input`, so a wrapper called inside a
POST could have its result silently paged by unrelated request data.

## Verification

Against the live 1.6 lab, `getList()` is **deeply equal** to the idiom it
replaces across six real result sets:

```
host  86 rows   ou  1   ouassociation  1   image  29   snapin  3   task  53
   all identical to json_decode(getData())->data : YES
getItem('ou', 1) identical to json_decode(...)   : YES
getItem('ou', 999999)                            : null, and did not exit
depth after success and after failure            : 0
Route::getList('nosuchclass')  -> caught RuntimeException, process alive
```

`tests/route-result-wrappers.test.php` is DB-free and covers both contracts.
Both assertions were verified to fail against deliberately broken builds.

One note on that test: **the rethrow probe runs in a child process on purpose.**
The first version asserted in-process and reported PASS against a build with the
guard disabled — because `breakHead()` calls `exit(0)`, ending the test early
with a success status and no output. A child lets the missing marker be
observed instead of ending the observer.

## Migration is not in this PR

Ordered in ADR 0011: daemons (26) → client endpoints and hooks (4) →
fog-plugins (37) → pages/models/reports (94) → a deliberate decision about the
router's own 6, where `exit` is correct.

## CI note

The two `pxe-secureboot` tests fail on `working-1.6` today, before and after
this change alike — pre-existing breakage from `facea052b`, fixed in #1046.

🤖 Generated with [Claude Code](https://claude.com/claude-code)