### PR TITLE
Phase 0.1: qualify every reference to a PHP built-in class

### DIFF
--- a/bin/prefix-global-classes.php
+++ b/bin/prefix-global-classes.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Prefixes unqualified references to PHP's built-in classes with a backslash.
+ *
+ * Phase 0.1 of the namespace work. Inside `namespace FOG;` an unqualified
+ * `catch (Exception $e)` means `FOG\Exception`, a class that does not exist,
+ * so the catch silently stops matching -- it compiles, it lints, it passes
+ * every static check, and it fails only on the error path, only at runtime, on
+ * somebody's server. Writing `\Exception` now, while the whole tree is still
+ * in the global namespace and the two spellings are identical, turns that from
+ * a Phase 3 risk into a Phase 3 non-event.
+ *
+ * Membership of "built-in" is decided by ReflectionClass::isInternal() on the
+ * running PHP rather than by a list kept here, so a class nobody thought of is
+ * caught instead of missed. Run it on a PHP whose extension set matches the
+ * server's; a class from an extension you do not have loaded is invisible to
+ * this tool.
+ *
+ * Usage:
+ *   php bin/prefix-global-classes.php --check [path...]   list, exit 1 if any
+ *   php bin/prefix-global-classes.php --fix   [path...]   rewrite in place
+ *
+ * With no paths it walks every tracked PHP file. --fix is idempotent: an
+ * already-prefixed name lexes as T_NAME_FULLY_QUALIFIED, a different token,
+ * so a second run finds nothing to do.
+ *
+ * @category Tooling
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+/**
+ * Third-party source. Composer owns these files and rewrites them on every
+ * install, so a prefix here would be reverted and the diff would never settle
+ * -- the same reason psrfix() and the gettext sweep skip the directory.
+ */
+const SKIP_PREFIXES = [
+    'packages/web/vendor/',
+];
+
+/**
+ * Collects the files to consider.
+ *
+ * Selection is by content rather than by extension on purpose: the nine daemon
+ * entry points under packages/service/ have no extension and open with a
+ * shebang before their `<?php`, and a namespace declaration in one of those
+ * would break just as loudly as one anywhere else.
+ *
+ * @param string $root  Repository root.
+ * @param array  $paths Optional explicit paths.
+ *
+ * @return array
+ */
+function collectFiles($root, array $paths)
+{
+    $candidates = [];
+    if (count($paths) > 0) {
+        foreach ($paths as $p) {
+            if (is_dir($p)) {
+                $it = new RecursiveIteratorIterator(
+                    new RecursiveDirectoryIterator($p, FilesystemIterator::SKIP_DOTS)
+                );
+                foreach ($it as $f) {
+                    $candidates[] = $f->getPathname();
+                }
+                continue;
+            }
+            $candidates[] = $p;
+        }
+    } else {
+        $out = [];
+        exec('git -C ' . escapeshellarg($root) . ' ls-files', $out);
+        foreach ($out as $rel) {
+            $candidates[] = $root . DIRECTORY_SEPARATOR . $rel;
+        }
+    }
+
+    $files = [];
+    foreach ($candidates as $f) {
+        if (!is_file($f)) {
+            continue;
+        }
+        $rel = ltrim(str_replace($root, '', $f), DIRECTORY_SEPARATOR);
+        foreach (SKIP_PREFIXES as $skip) {
+            if (strpos($rel, $skip) === 0) {
+                continue 2;
+            }
+        }
+        $head = (string)@file_get_contents($f, false, null, 0, 512);
+        if (strpos($head, '<?php') === false) {
+            continue;
+        }
+        $files[] = $f;
+    }
+    sort($files);
+    return $files;
+}
+
+/**
+ * Finds the token offsets of bare built-in class references in one file.
+ *
+ * A T_STRING is a class reference when it sits in one of the positions PHP
+ * resolves as a class name: after `new`, before `::`, after `instanceof`,
+ * after `extends`, or inside a catch list. Method calls, declarations and
+ * already-qualified names are all excluded -- which is the whole reason this
+ * is a tokenizer and not a regex. "Exception" also appears in docblocks
+ * (@throws Exception), in translated strings, in method names and inside
+ * SlackException / UploadException / PushbulletException, and only the
+ * tokenizer knows the difference between a class-reference position and a
+ * substring.
+ *
+ * @param array $tokens token_get_all() output.
+ *
+ * @return array Token indices to prefix.
+ */
+function findRefs(array $tokens)
+{
+    $n = count($tokens);
+
+    // Index of the significant tokens, so "the previous token" means the
+    // previous real one rather than a run of whitespace.
+    $ix = [];
+    for ($i = 0; $i < $n; $i++) {
+        $t = $tokens[$i];
+        if (is_array($t)
+            && in_array($t[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $ix[] = $i;
+    }
+    $count = count($ix);
+
+    $hits = [];
+    for ($k = 0; $k < $count; $k++) {
+        $i = $ix[$k];
+        $t = $tokens[$i];
+        if (!is_array($t) || $t[0] !== T_STRING) {
+            continue;
+        }
+
+        $prev = $k > 0 ? $tokens[$ix[$k - 1]] : null;
+        $next = $k + 1 < $count ? $tokens[$ix[$k + 1]] : null;
+        $pv = is_array($prev) ? $prev[0] : $prev;
+        $nv = is_array($next) ? $next[0] : $next;
+
+        // Already qualified, or one segment of a longer name.
+        if ($pv === T_NS_SEPARATOR || $nv === T_NS_SEPARATOR) {
+            continue;
+        }
+        // A method call, a property fetch, or the name being declared.
+        if ($pv === T_OBJECT_OPERATOR
+            || $pv === T_NULLSAFE_OBJECT_OPERATOR
+            || $pv === T_FUNCTION
+            || $pv === T_CONST
+            || $pv === T_CLASS
+            || $pv === T_INTERFACE
+            || $pv === T_TRAIT
+        ) {
+            continue;
+        }
+
+        $isRef = ($pv === T_NEW)
+            || ($nv === T_DOUBLE_COLON)
+            || ($pv === T_INSTANCEOF)
+            || ($pv === T_EXTENDS);
+
+        // catch (X ... and catch (X | Y ...
+        if (!$isRef && ($pv === '(' || $pv === '|')) {
+            for ($b = $k - 1; $b >= 0 && $b > $k - 6; $b--) {
+                $bt = $tokens[$ix[$b]];
+                if (is_array($bt) && $bt[0] === T_CATCH) {
+                    $isRef = true;
+                    break;
+                }
+                if ($bt === ')' || $bt === ';' || $bt === '{') {
+                    break;
+                }
+            }
+        }
+        if (!$isRef) {
+            continue;
+        }
+
+        // The runtime decides, not a list kept here.
+        try {
+            $ref = new ReflectionClass($t[1]);
+        } catch (Throwable $e) {
+            continue;
+        }
+        if (!$ref->isInternal()) {
+            continue;
+        }
+        $hits[] = $i;
+    }
+    return $hits;
+}
+
+/**
+ * Rebuilds a file's source with the separator inserted.
+ *
+ * @param array $tokens token_get_all() output.
+ * @param array $hits   Token indices to prefix.
+ *
+ * @return string
+ */
+function applyPrefix(array $tokens, array $hits)
+{
+    $set = array_flip($hits);
+    $out = '';
+    foreach ($tokens as $i => $t) {
+        $text = is_array($t) ? $t[1] : $t;
+        $out .= isset($set[$i]) ? '\\' . $text : $text;
+    }
+    return $out;
+}
+
+// ---- main ----------------------------------------------------------------
+
+$root = dirname(__DIR__);
+$args = array_slice($argv, 1);
+$mode = null;
+$paths = [];
+foreach ($args as $a) {
+    if ($a === '--check' || $a === '--fix') {
+        $mode = $a;
+        continue;
+    }
+    $paths[] = $a;
+}
+
+if ($mode === null) {
+    fwrite(
+        STDERR,
+        "usage: php bin/prefix-global-classes.php --check|--fix [path...]\n"
+    );
+    exit(2);
+}
+
+$files = collectFiles($root, $paths);
+$totalSites = 0;
+$totalFiles = 0;
+
+foreach ($files as $file) {
+    $src = file_get_contents($file);
+    $tokens = token_get_all($src);
+    $hits = findRefs($tokens);
+    if (count($hits) === 0) {
+        continue;
+    }
+    $totalFiles++;
+    $totalSites += count($hits);
+    $rel = ltrim(str_replace($root, '', $file), DIRECTORY_SEPARATOR);
+
+    if ($mode === '--check') {
+        foreach ($hits as $i) {
+            printf("%s:%d: %s\n", $rel, $tokens[$i][2], $tokens[$i][1]);
+        }
+        continue;
+    }
+
+    file_put_contents($file, applyPrefix($tokens, $hits));
+    printf("%s: %d\n", $rel, count($hits));
+}
+
+printf(
+    "\n%s: %d sites in %d files (of %d scanned)\n",
+    $mode === '--check' ? 'unprefixed' : 'prefixed',
+    $totalSites,
+    $totalFiles,
+    count($files)
+);
+
+exit(($mode === '--check' && $totalSites > 0) ? 1 : 0);

--- a/bin/prefix-global-classes.php
+++ b/bin/prefix-global-classes.php
@@ -59,8 +59,8 @@ function collectFiles($root, array $paths)
     if (count($paths) > 0) {
         foreach ($paths as $p) {
             if (is_dir($p)) {
-                $it = new RecursiveIteratorIterator(
-                    new RecursiveDirectoryIterator($p, FilesystemIterator::SKIP_DOTS)
+                $it = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($p, \FilesystemIterator::SKIP_DOTS)
                 );
                 foreach ($it as $f) {
                     $candidates[] = $f->getPathname();
@@ -186,8 +186,8 @@ function findRefs(array $tokens)
 
         // The runtime decides, not a list kept here.
         try {
-            $ref = new ReflectionClass($t[1]);
-        } catch (Throwable $e) {
+            $ref = new \ReflectionClass($t[1]);
+        } catch (\Throwable $e) {
             continue;
         }
         if (!$ref->isInternal()) {

--- a/bin/schema-manifest.php
+++ b/bin/schema-manifest.php
@@ -65,7 +65,7 @@ function connect($root)
         fwrite(STDERR, "Could not read DATABASE_* from $config\n");
         exit(1);
     }
-    return new PDO(
+    return new \PDO(
         sprintf(
             'mysql:host=%s;dbname=%s',
             $vals['HOST'] ?: 'localhost',
@@ -73,7 +73,7 @@ function connect($root)
         ),
         $vals['USERNAME'],
         $vals['PASSWORD'],
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
     );
 }
 
@@ -138,7 +138,7 @@ if ($cmd === 'generate') {
     $live = $pdo->query(
         'SELECT TABLE_NAME FROM information_schema.TABLES'
         . ' WHERE TABLE_SCHEMA = DATABASE() ORDER BY TABLE_NAME'
-    )->fetchAll(PDO::FETCH_COLUMN);
+    )->fetchAll(\PDO::FETCH_COLUMN);
 
     $tables = [];
     foreach ($live as $table) {
@@ -147,7 +147,7 @@ if ($cmd === 'generate') {
         }
         $raw = $pdo->query(
             sprintf('SHOW CREATE TABLE `%s`', $table)
-        )->fetch(PDO::FETCH_NUM)[1];
+        )->fetch(\PDO::FETCH_NUM)[1];
         $create = $raw;
         // Reconciler only ever runs this when the table is absent, but
         // IF NOT EXISTS makes it harmless if the snapshot was stale.

--- a/bin/verify-token-equivalence.php
+++ b/bin/verify-token-equivalence.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Proves a revision changed nothing but class-name qualification.
+ *
+ * The reviewer's tool for Phase 0.1, and for the same pass in fog-plugins and
+ * in Phase 3. It tokenizes both revisions of every changed file, throws away
+ * whitespace and comments, folds a fully-qualified name back to its bare form,
+ * and asserts the two token streams are identical. Anything that is not purely
+ * a qualification change shows up as a difference.
+ *
+ * Usage:
+ *   php bin/verify-token-equivalence.php <ref>   compare the working tree to <ref>
+ *
+ * What it CANNOT prove, stated plainly because it matters: it cannot tell a
+ * backslash correctly added to a class from one wrongly added to a constant or
+ * a label, because after normalization both look the same. That gap is closed
+ * from the other side, by prefix-global-classes.php only ever touching a name
+ * that ReflectionClass::isInternal() confirms. Together the two cover the
+ * space; neither does on its own.
+ *
+ * @category Tooling
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+/**
+ * Reduces source to a comparable token stream.
+ *
+ * Trivia goes because reformatting is not a semantic change. The separator
+ * goes, and T_NAME_FULLY_QUALIFIED is folded back to T_STRING, because
+ * qualification is the change being verified -- normalizing it away is what
+ * lets everything else be compared exactly.
+ *
+ * @param string $src PHP source.
+ *
+ * @return array
+ */
+function normalize($src)
+{
+    $out = [];
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)) {
+            if (in_array(
+                $token[0],
+                [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                true
+            )) {
+                continue;
+            }
+            // PHP 8 lexes \Foo as a single token; PHP 7 lexes it as
+            // T_NS_SEPARATOR followed by T_STRING. Fold both to the bare name
+            // so this tool gives the same answer on either.
+            if (defined('T_NAME_FULLY_QUALIFIED')
+                && $token[0] === T_NAME_FULLY_QUALIFIED
+            ) {
+                $out[] = [T_STRING, ltrim($token[1], '\\')];
+                continue;
+            }
+            $out[] = [$token[0], $token[1]];
+            continue;
+        }
+        if ($token === '\\') {
+            continue;
+        }
+        $out[] = [null, $token];
+    }
+    return $out;
+}
+
+$ref = $argv[1] ?? null;
+if ($ref === null) {
+    fwrite(STDERR, "usage: php bin/verify-token-equivalence.php <ref>\n");
+    exit(2);
+}
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$changed = [];
+exec(
+    'git diff --name-only ' . escapeshellarg($ref) . ' -- 2>/dev/null',
+    $changed
+);
+
+$checked = 0;
+$prefixes = 0;
+$differ = [];
+$unreadable = [];
+
+foreach ($changed as $rel) {
+    if (!is_file($rel)) {
+        continue;
+    }
+    $new = (string)file_get_contents($rel);
+    if (strpos(substr($new, 0, 512), '<?php') === false) {
+        continue;
+    }
+
+    $old = shell_exec(
+        'git show ' . escapeshellarg($ref . ':' . $rel) . ' 2>/dev/null'
+    );
+    if ($old === null) {
+        $unreadable[] = $rel;
+        continue;
+    }
+
+    $checked++;
+    $a = normalize($old);
+    $b = normalize($new);
+
+    if ($a !== $b) {
+        $differ[] = $rel;
+        continue;
+    }
+
+    // Count the qualifications this file gained, which is the change we
+    // expect to be the only one.
+    $prefixes += substr_count($new, '\\') - substr_count($old, '\\');
+}
+
+printf("compared %d files against %s\n", $checked, $ref);
+printf("qualifications added : %d\n", $prefixes);
+printf("other differences    : %d\n", count($differ));
+
+foreach ($differ as $d) {
+    printf("  DIFFERS: %s\n", $d);
+}
+foreach ($unreadable as $u) {
+    printf("  NEW FILE (no counterpart in %s): %s\n", $ref, $u);
+}
+
+exit(count($differ) > 0 ? 1 : 0);

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -425,15 +425,15 @@ class Initiator
             $matches = array_merge(
                 $matches,
                 iterator_to_array(
-                    new RegexIterator(
-                        new RecursiveIteratorIterator(
-                            new RecursiveDirectoryIterator(
+                    new \RegexIterator(
+                        new \RecursiveIteratorIterator(
+                            new \RecursiveDirectoryIterator(
                                 $root,
-                                FileSystemIterator::SKIP_DOTS
+                                \FileSystemIterator::SKIP_DOTS
                             )
                         ),
                         $regext,
-                        RegexIterator::GET_MATCH
+                        \RegexIterator::GET_MATCH
                     ),
                     false
                 )
@@ -571,7 +571,7 @@ class Initiator
     private static function _verCheck(): void
     {
         if (version_compare(phpversion(), '7.4', '<')) {
-            throw new Exception('FOG Requires PHP v7.4 or higher. You have PHP v' . phpversion());
+            throw new \Exception('FOG Requires PHP v7.4 or higher. You have PHP v' . phpversion());
         }
     }
 
@@ -580,7 +580,7 @@ class Initiator
         $requiredExtensions = ['gettext', 'mysqli'];
         $loadedExtensions = get_loaded_extensions();
         if (count(array_intersect($requiredExtensions, $loadedExtensions)) < count($requiredExtensions)) {
-            throw new Exception(_('Missing one or more extensions.'));
+            throw new \Exception(_('Missing one or more extensions.'));
         }
     }
 

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4363,7 +4363,7 @@ $this->schema[] = [
             . "WHERE `TABLE_SCHEMA` = DATABASE() "
             . "AND `TABLE_NAME` = 'roleUserAssoc' "
             . "GROUP BY `INDEX_NAME`"
-        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $hasComposite = false;
         $lonely = [];
         foreach ((array)$indexes as $index) {
@@ -4455,7 +4455,7 @@ $this->schema[] = [
             . "SELECT 1 FROM `rolePermissions` `p` "
             . "WHERE `p`.`rpRoleID` = `r`.`rID`"
             . ")"
-        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $values = [];
         foreach ((array)$techIDs as $row) {
             $rID = (int)$row['rID'];
@@ -4554,7 +4554,7 @@ $this->schema[] = [
         ];
         $techIDs = self::$DB->query(
             "SELECT `rID` FROM `roles` WHERE `rName` = 'Technician'"
-        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $values = [];
         foreach ((array)$techIDs as $row) {
             $rID = (int)$row['rID'];

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -98,7 +98,7 @@ abstract class FOGClient extends FOGBase
             if (!(isset($globalInfo[$this->shortName])
                 && $globalInfo[$this->shortName])
             ) {
-                throw new Exception('#!ng');
+                throw new \Exception('#!ng');
             }
             $find = [
                 'id' => self::$Host->get('modules'),
@@ -113,7 +113,7 @@ abstract class FOGClient extends FOGBase
                 if (!self::$Host->isValid()
                     && false === $hostnotrequired
                 ) {
-                    throw new Exception('#!nh');
+                    throw new \Exception('#!nh');
                 }
             }
             $validClientBrowserFiles = [
@@ -127,7 +127,7 @@ abstract class FOGClient extends FOGBase
             $scriptCheck = basename(self::$scriptname);
             $new = (self::$json || self::$newService);
             if ($new && !in_array($scriptCheck, $validClientBrowserFiles)) {
-                throw new Exception(_('Not allowed here'));
+                throw new \Exception(_('Not allowed here'));
             }
             $jsonSub = (!isset($sub) || $sub !== 'requestClientInfo');
             if ($jsonSub && self::$json) {
@@ -135,7 +135,7 @@ abstract class FOGClient extends FOGBase
                 $script = trim($script);
                 $script = basename($script);
                 if ($script !== 'jobs.php') {
-                    throw new Exception(
+                    throw new \Exception(
                         json_encode(
                             $this->{$method}()
                         )
@@ -164,10 +164,10 @@ abstract class FOGClient extends FOGBase
             );
             $this->send = trim($this->send);
             if (in_array($lowclass, $nonJsonEncode)) {
-                throw new Exception($this->send);
+                throw new \Exception($this->send);
             }
             $this->sendData($this->send);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             global $json;
             global $newService;
             if (!$json && $newService) {

--- a/packages/web/lib/client/servicemodule.class.php
+++ b/packages/web/lib/client/servicemodule.class.php
@@ -51,7 +51,7 @@ class ServiceModule extends FOGClient
                 break;
         }
         if (!in_array($mod, $mods)) {
-            throw new Exception('#!um');
+            throw new \Exception('#!um');
         }
         $remArr = [
             'dircleanup',
@@ -108,7 +108,7 @@ class ServiceModule extends FOGClient
             )
         )
         ) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     "#!n%s\n",
                     in_array($mod, $globalDisabled) ?

--- a/packages/web/lib/client/snapinclient.class.php
+++ b/packages/web/lib/client/snapinclient.class.php
@@ -250,7 +250,7 @@ class SnapinClient extends FOGClient
             $tID = filter_input(INPUT_GET, 'taskid');
         }
         if (!is_numeric($tID)) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -268,7 +268,7 @@ class SnapinClient extends FOGClient
                 ]
             ))
         ) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -278,7 +278,7 @@ class SnapinClient extends FOGClient
         }
         $Snapin = $SnapinTask->getSnapin();
         if (!$Snapin->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -395,7 +395,7 @@ class SnapinClient extends FOGClient
             $tID = filter_input(INPUT_GET, 'taskid');
         }
         if (!is_numeric($tID)) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -405,7 +405,7 @@ class SnapinClient extends FOGClient
         }
         $SnapinTask = new SnapinTask($tID);
         if (!$SnapinTask->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -422,7 +422,7 @@ class SnapinClient extends FOGClient
         // Same message as the isValid() failure above, so this is not an oracle
         // for "exists but belongs to someone else".
         if ((int)$SnapinTask->get('jobID') !== (int)$SnapinJob->get('id')) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -432,7 +432,7 @@ class SnapinClient extends FOGClient
         }
         $Snapin = $SnapinTask->getSnapin();
         if (!$Snapin->isValid()) {
-            throw new Exception(_('Invalid Snapin'));
+            throw new \Exception(_('Invalid Snapin'));
         }
         $StorageGroup = $StorageNode = null;
         self::$HookManager->processEvent(
@@ -457,7 +457,7 @@ class SnapinClient extends FOGClient
         ) {
             $StorageGroup = $Snapin->getStorageGroup();
             if (!$StorageGroup->isValid()) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         '#!er',
@@ -473,7 +473,7 @@ class SnapinClient extends FOGClient
             if (!($StorageNode instanceof StorageNode
                 && $StorageNode->isValid())
             ) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         '#!er',
@@ -499,7 +499,7 @@ class SnapinClient extends FOGClient
         self::$FOGFTP->password = $pass;
         self::$FOGFTP->host = $host;
         if (!self::$FOGFTP->connect()) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',
@@ -539,7 +539,7 @@ class SnapinClient extends FOGClient
         header('Cache-Control: must-revalidate');
         header('Pragma: public');
         if (($fh = fopen($SnapinFile, 'rb')) === false) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     '#!er',

--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -276,7 +276,7 @@ class DatabaseManager extends FOGCore
             return [];
         }
         $cols = [];
-        $rows = $res->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get('COLUMN_NAME');
+        $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get('COLUMN_NAME');
         foreach ((array)$rows as $col) {
             if (is_string($col) && $col !== '') {
                 $cols[] = strtolower($col);
@@ -335,7 +335,7 @@ class DatabaseManager extends FOGCore
         );
         $convert = self::$DB
             ->query($sql)
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get('Q');
         if (false !== $sql_modes) {
             $sql_modes = sprintf(

--- a/packages/web/lib/db/mysqldump.class.php
+++ b/packages/web/lib/db/mysqldump.class.php
@@ -154,8 +154,8 @@ class Mysqldump
     );
 
     protected $pdoSettingsDefault = array(
-        PDO::ATTR_PERSISTENT => true,
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        \PDO::ATTR_PERSISTENT => true,
+        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
     );
 
     /**
@@ -188,7 +188,7 @@ class Mysqldump
 
         // This drops MYSQL dependency, only use the constant if it's defined.
         if ("mysql" === $this->dbType) {
-            $this->pdoSettingsDefault[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
+            $this->pdoSettingsDefault[\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
         }
 
         $this->pdoSettings = array_replace_recursive($this->pdoSettingsDefault, $pdoSettings);
@@ -201,12 +201,12 @@ class Mysqldump
 
         $diff = array_diff(array_keys($this->dumpSettings), array_keys($this->dumpSettingsDefault));
         if (count($diff) > 0) {
-            throw new Exception("Unexpected value in dumpSettings: (".implode(",", $diff).")");
+            throw new \Exception("Unexpected value in dumpSettings: (".implode(",", $diff).")");
         }
 
         if (!is_array($this->dumpSettings['include-tables']) ||
             !is_array($this->dumpSettings['exclude-tables'])) {
-            throw new Exception("Include-tables and exclude-tables should be arrays");
+            throw new \Exception("Include-tables and exclude-tables should be arrays");
         }
 
         // If no include-views is passed in, dump the same views as tables, mimic mysqldump behaviour.
@@ -290,13 +290,13 @@ class Mysqldump
     public function restore($path)
     {
         if(!$path || !is_file($path)) {
-            throw new Exception("File {$path} does not exist.");
+            throw new \Exception("File {$path} does not exist.");
         }
 
         $handle = fopen($path, 'rb');
 
         if(!$handle) {
-            throw new Exception("Failed reading file {$path}. Check access permissions.");
+            throw new \Exception("Failed reading file {$path}. Check access permissions.");
         }
 
         if(!$this->dbHandler) {
@@ -336,14 +336,14 @@ class Mysqldump
     private function parseDsn($dsn)
     {
         if (empty($dsn) || (false === ($pos = strpos($dsn, ":")))) {
-            throw new Exception("Empty DSN string");
+            throw new \Exception("Empty DSN string");
         }
 
         $this->dsn = $dsn;
         $this->dbType = strtolower(substr($dsn, 0, $pos)); // always returns a string
 
         if (empty($this->dbType)) {
-            throw new Exception("Missing database type from DSN string");
+            throw new \Exception("Missing database type from DSN string");
         }
 
         $dsn = substr($dsn, $pos + 1);
@@ -355,13 +355,13 @@ class Mysqldump
 
         if (empty($this->dsnArray['host']) &&
             empty($this->dsnArray['unix_socket'])) {
-            throw new Exception("Missing host from DSN string");
+            throw new \Exception("Missing host from DSN string");
         }
         $this->host = (!empty($this->dsnArray['host'])) ?
             $this->dsnArray['host'] : $this->dsnArray['unix_socket'];
 
         if (empty($this->dsnArray['dbname'])) {
-            throw new Exception("Missing database name from DSN string");
+            throw new \Exception("Missing database name from DSN string");
         }
 
         $this->dbName = $this->dsnArray['dbname'];
@@ -380,12 +380,12 @@ class Mysqldump
         try {
             switch ($this->dbType) {
                 case 'sqlite':
-                    $this->dbHandler = @new PDO("sqlite:".$this->dbName, null, null, $this->pdoSettings);
+                    $this->dbHandler = @new \PDO("sqlite:".$this->dbName, null, null, $this->pdoSettings);
                     break;
                 case 'mysql':
                 case 'pgsql':
                 case 'dblib':
-                    $this->dbHandler = @new PDO(
+                    $this->dbHandler = @new \PDO(
                         $this->dsn,
                         $this->user,
                         $this->pass,
@@ -396,23 +396,23 @@ class Mysqldump
                         $this->dbHandler->exec($stmt);
                     }
                     // Store server version
-                    $this->version = $this->dbHandler->getAttribute(PDO::ATTR_SERVER_VERSION);
+                    $this->version = $this->dbHandler->getAttribute(\PDO::ATTR_SERVER_VERSION);
                     break;
                 default:
-                    throw new Exception("Unsupported database type (".$this->dbType.")");
+                    throw new \Exception("Unsupported database type (".$this->dbType.")");
             }
-        } catch (PDOException $e) {
-            throw new Exception(
+        } catch (\PDOException $e) {
+            throw new \Exception(
                 "Connection to ".$this->dbType." failed with message: ".
                 $e->getMessage()
             );
         }
 
         if (is_null($this->dbHandler)) {
-            throw new Exception("Connection to ".$this->dbType."failed");
+            throw new \Exception("Connection to ".$this->dbType."failed");
         }
 
-        $this->dbHandler->setAttribute(PDO::ATTR_ORACLE_NULLS, PDO::NULL_NATURAL);
+        $this->dbHandler->setAttribute(\PDO::ATTR_ORACLE_NULLS, \PDO::NULL_NATURAL);
         $this->typeAdapter = TypeAdapterFactory::create($this->dbType, $this->dbHandler, $this->dumpSettings);
     }
 
@@ -482,7 +482,7 @@ class Mysqldump
         // This check will be removed once include-tables supports regexps.
         if (0 < count($this->dumpSettings['include-tables'])) {
             $name = implode(",", $this->dumpSettings['include-tables']);
-            throw new Exception("Table (".$name.") not found in database");
+            throw new \Exception("Table (".$name.") not found in database");
         }
 
         $this->exportTables();
@@ -856,7 +856,7 @@ class Mysqldump
         $columns = $this->dbHandler->query(
             $this->typeAdapter->show_columns($tableName)
         );
-        $columns->setFetchMode(PDO::FETCH_ASSOC);
+        $columns->setFetchMode(\PDO::FETCH_ASSOC);
 
         foreach ($columns as $key => $col) {
             $types = $this->typeAdapter->parseColumnType($col);
@@ -1176,7 +1176,7 @@ class Mysqldump
         }
 
         $resultSet = $this->dbHandler->query($stmt);
-        $resultSet->setFetchMode(PDO::FETCH_ASSOC);
+        $resultSet->setFetchMode(\PDO::FETCH_ASSOC);
 
         $ignore = $this->dumpSettings['insert-ignore'] ? '  IGNORE' : '';
 
@@ -1390,7 +1390,7 @@ abstract class CompressManagerFactory
     {
         $c = ucfirst(strtolower($c));
         if (!CompressMethod::isValid($c)) {
-            throw new Exception("Compression method ($c) is not defined yet");
+            throw new \Exception("Compression method ($c) is not defined yet");
         }
 
         $method = __NAMESPACE__."\\"."Compress".$c;
@@ -1406,7 +1406,7 @@ class CompressBzip2 extends CompressManagerFactory
     public function __construct()
     {
         if (!function_exists("bzopen")) {
-            throw new Exception("Compression is enabled, but bzip2 lib is not installed or configured properly");
+            throw new \Exception("Compression is enabled, but bzip2 lib is not installed or configured properly");
         }
     }
 
@@ -1417,7 +1417,7 @@ class CompressBzip2 extends CompressManagerFactory
     {
         $this->fileHandler = bzopen($filename, "w");
         if (false === $this->fileHandler) {
-            throw new Exception("Output file is not writable");
+            throw new \Exception("Output file is not writable");
         }
 
         return true;
@@ -1427,7 +1427,7 @@ class CompressBzip2 extends CompressManagerFactory
     {
         $bytesWritten = bzwrite($this->fileHandler, $str);
         if (false === $bytesWritten) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new \Exception("Writting to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1445,7 +1445,7 @@ class CompressGzip extends CompressManagerFactory
     public function __construct()
     {
         if (!function_exists("gzopen")) {
-            throw new Exception("Compression is enabled, but gzip lib is not installed or configured properly");
+            throw new \Exception("Compression is enabled, but gzip lib is not installed or configured properly");
         }
     }
 
@@ -1456,7 +1456,7 @@ class CompressGzip extends CompressManagerFactory
     {
         $this->fileHandler = gzopen($filename, "wb");
         if (false === $this->fileHandler) {
-            throw new Exception("Output file is not writable");
+            throw new \Exception("Output file is not writable");
         }
 
         return true;
@@ -1466,7 +1466,7 @@ class CompressGzip extends CompressManagerFactory
     {
         $bytesWritten = gzwrite($this->fileHandler, $str);
         if (false === $bytesWritten) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new \Exception("Writting to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1488,7 +1488,7 @@ class CompressNone extends CompressManagerFactory
     {
         $this->fileHandler = fopen($filename, "wb");
         if (false === $this->fileHandler) {
-            throw new Exception("Output file is not writable");
+            throw new \Exception("Output file is not writable");
         }
 
         return true;
@@ -1498,7 +1498,7 @@ class CompressNone extends CompressManagerFactory
     {
         $bytesWritten = fwrite($this->fileHandler, $str);
         if (false === $bytesWritten) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new \Exception("Writting to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1522,7 +1522,7 @@ class CompressGzipstream extends CompressManagerFactory
     {
         $this->fileHandler = fopen($filename, "wb");
         if (false === $this->fileHandler) {
-            throw new Exception("Output file is not writable");
+            throw new \Exception("Output file is not writable");
         }
 
         $this->compressContext = deflate_init(ZLIB_ENCODING_GZIP, array('level' => 9));
@@ -1534,7 +1534,7 @@ class CompressGzipstream extends CompressManagerFactory
 
         $bytesWritten = fwrite($this->fileHandler, deflate_add($this->compressContext, $str, ZLIB_NO_FLUSH));
         if (false === $bytesWritten) {
-            throw new Exception("Writting to file failed! Probably, there is no more free space left?");
+            throw new \Exception("Writting to file failed! Probably, there is no more free space left?");
         }
         return $bytesWritten;
     }
@@ -1584,7 +1584,7 @@ abstract class TypeAdapterFactory
     {
         $c = ucfirst(strtolower($c));
         if (!TypeAdapter::isValid($c)) {
-            throw new Exception("Database type support for ($c) not yet available");
+            throw new \Exception("Database type support for ($c) not yet available");
         }
         $method = __NAMESPACE__."\\"."TypeAdapter".$c;
         return new $method($dbHandler, $dumpSettings);
@@ -1924,7 +1924,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     public function create_table($row)
     {
         if (!isset($row['Create Table'])) {
-            throw new Exception("Error getting table code, unknown output");
+            throw new \Exception("Error getting table code, unknown output");
         }
 
         $createTable = $row['Create Table'];
@@ -1950,7 +1950,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $ret = "";
         if (!isset($row['Create View'])) {
-            throw new Exception("Error getting view structure, unknown output");
+            throw new \Exception("Error getting view structure, unknown output");
         }
 
         $viewStmt = $row['Create View'];
@@ -1975,7 +1975,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $ret = "";
         if (!isset($row['SQL Original Statement'])) {
-            throw new Exception("Error getting trigger code, unknown output");
+            throw new \Exception("Error getting trigger code, unknown output");
         }
 
         $triggerStmt = $row['SQL Original Statement'];
@@ -1999,7 +1999,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $ret = "";
         if (!isset($row['Create Procedure'])) {
-            throw new Exception("Error getting procedure code, unknown output. ".
+            throw new \Exception("Error getting procedure code, unknown output. ".
                 "Please check 'https://bugs.mysql.com/bug.php?id=14564'");
         }
         $procedureStmt = $row['Create Procedure'];
@@ -2030,7 +2030,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $ret = "";
         if (!isset($row['Create Function'])) {
-            throw new Exception("Error getting function code, unknown output. ".
+            throw new \Exception("Error getting function code, unknown output. ".
                 "Please check 'https://bugs.mysql.com/bug.php?id=14564'");
         }
         $functionStmt = $row['Create Function'];
@@ -2077,7 +2077,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $ret = "";
         if (!isset($row['Create Event'])) {
-            throw new Exception("Error getting event code, unknown output. ".
+            throw new \Exception("Error getting event code, unknown output. ".
                 "Please check 'http://stackoverflow.com/questions/10853826/mysql-5-5-create-event-gives-syntax-error'");
         }
         $eventName = $row['Event'];
@@ -2381,7 +2381,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     private function check_parameters($num_args, $expected_num_args, $method_name)
     {
         if ($num_args != $expected_num_args) {
-            throw new Exception("Unexpected parameter passed to $method_name");
+            throw new \Exception("Unexpected parameter passed to $method_name");
         }
         return;
     }

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -128,14 +128,14 @@ class PDODB extends DatabaseManager
      * @var array
      */
     private static $_options = [
-        PDO::ATTR_PERSISTENT => false,
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_EMULATE_PREPARES => false,
+        \PDO::ATTR_PERSISTENT => false,
+        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        \PDO::ATTR_EMULATE_PREPARES => false,
 
         // Keep unbuffered by default (what you had).
         // Cursor closing below prevents SQLSTATE[HY000] 2014 in most cases.
-        PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false
+        \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false
     ];
 
     /**
@@ -160,11 +160,11 @@ class PDODB extends DatabaseManager
             }
             self::$_dbName = DATABASE_NAME;
             if (!$this->_connect()) {
-                throw new PDOException(
+                throw new \PDOException(
                     _('Failed to connect')
                 );
             }
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             $msg = sprintf(
                 '%s %s: %s, %s: %s',
                 _('Failed to'),
@@ -191,10 +191,10 @@ class PDODB extends DatabaseManager
     {
         self::$_result = null;
 
-        if (self::$_queryResult instanceof PDOStatement) {
+        if (self::$_queryResult instanceof \PDOStatement) {
             try {
                 self::$_queryResult->closeCursor();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // ignore
             }
         }
@@ -281,7 +281,7 @@ class PDODB extends DatabaseManager
                     $host
                 );
             }
-            self::$_link = new PDO(
+            self::$_link = new \PDO(
                 $dsn,
                 $user,
                 $pass,
@@ -293,7 +293,7 @@ class PDODB extends DatabaseManager
                 }
             }
             self::query("SET SESSION sql_mode=''");
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             if ($dbexists) {
                 self::$_link = false;
                 $this->_connect(false);
@@ -331,7 +331,7 @@ class PDODB extends DatabaseManager
     {
         try {
             if (!self::$_link) {
-                throw new PDOException(
+                throw new \PDOException(
                     _('No link established to the database')
                 );
             }
@@ -346,7 +346,7 @@ class PDODB extends DatabaseManager
             if (false === $dbTest) {
                 self::$_dbName = false;
             }
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             $msg = sprintf(
                 '%s %s: %s: %s %s: %s',
                 _('Failed to'),
@@ -386,14 +386,14 @@ class PDODB extends DatabaseManager
 
         try {
             if (!self::$_link) {
-                throw new PDOException($this->sqlerror());
+                throw new \PDOException($this->sqlerror());
             }
 
             // Prevent "Cannot execute queries while other unbuffered queries are active"
-            if (self::$_queryResult instanceof PDOStatement) {
+            if (self::$_queryResult instanceof \PDOStatement) {
                 try {
                     self::$_queryResult->closeCursor();
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     // best effort
                 }
             }
@@ -406,7 +406,7 @@ class PDODB extends DatabaseManager
                 $sql = vsprintf($sql, $data);
             }
             if (!$sql) {
-                throw new PDOException(_('No query passed'));
+                throw new \PDOException(_('No query passed'));
             }
 
             self::$_query = $sql;
@@ -417,7 +417,7 @@ class PDODB extends DatabaseManager
             $ok = self::_execute($paramvals);
             if ($ok === false) {
                 // execute() can return false without throwing (driver-dependent edge cases)
-                $info = (self::$_queryResult instanceof PDOStatement)
+                $info = (self::$_queryResult instanceof \PDOStatement)
                     ? self::$_queryResult->errorInfo()
                     : array(null, null, _('Unknown DB error'));
 
@@ -434,11 +434,11 @@ class PDODB extends DatabaseManager
                     self::_debugDumpParams()
                 );
 
-                throw new PDOException($msg);
+                throw new \PDOException($msg);
             }
 
             // Capture affected rows while statement is alive
-            if (self::$_queryResult instanceof PDOStatement) {
+            if (self::$_queryResult instanceof \PDOStatement) {
                 self::$_lastAffectedRows = (int) self::$_queryResult->rowCount();
             }
 
@@ -446,15 +446,15 @@ class PDODB extends DatabaseManager
                 self::currentDb($this);
             }
             if (!self::$_dbName) {
-                throw new PDOException(
+                throw new \PDOException(
                     _('No database to work off')
                 );
             }
 
             $this->error = false;
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             // Capture PDO errorInfo if possible
-            if (self::$_queryResult instanceof PDOStatement) {
+            if (self::$_queryResult instanceof \PDOStatement) {
                 $this->lastErrorInfo = self::$_queryResult->errorInfo();
                 if (isset($this->lastErrorInfo[1])) {
                     $this->errorCode = $this->lastErrorInfo[1];
@@ -498,14 +498,14 @@ class PDODB extends DatabaseManager
      * @throws PDOException
      */
     public function fetch(
-        $type = PDO::FETCH_ASSOC,
+        $type = \PDO::FETCH_ASSOC,
         $fetchType = 'fetch_assoc',
         $params = false
     ) {
         try {
             self::$_result = [];
             if (empty($type)) {
-                $type = PDO::FETCH_ASSOC;
+                $type = \PDO::FETCH_ASSOC;
             }
             if (empty($fetchType)) {
                 $fetchType = 'fetch_assoc';
@@ -513,7 +513,7 @@ class PDODB extends DatabaseManager
             if (is_bool(self::$_queryResult)) {
                 self::$_result = self::$_queryResult;
             } elseif (empty(self::$_queryResult)) {
-                throw new PDOException(
+                throw new \PDOException(
                     _('No query result, use query() first')
                 );
             } else {
@@ -524,7 +524,7 @@ class PDODB extends DatabaseManager
                     self::_single($type);
                 }
             }
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             $msg = sprintf(
                 '%s %s: %s: %s %s: %s',
                 _('Failed to'),
@@ -542,10 +542,10 @@ class PDODB extends DatabaseManager
         }
 
         // Close cursor to avoid unbuffered-query issues later.
-        if (self::$_queryResult instanceof PDOStatement) {
+        if (self::$_queryResult instanceof \PDOStatement) {
             try {
                 self::$_queryResult->closeCursor();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // ignore
             }
         }
@@ -566,12 +566,12 @@ class PDODB extends DatabaseManager
     {
         try {
             if (!self::$_link) {
-                throw new Exception(
+                throw new \Exception(
                     _('No connection to the database')
                 );
             }
             if (self::$_result === false) {
-                throw new Exception(
+                throw new \Exception(
                     _('No data returned')
                 );
             }
@@ -595,7 +595,7 @@ class PDODB extends DatabaseManager
             if (count($result ?: [])) {
                 return $result;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $msg = sprintf(
                 '%s %s: %s: %s %s: %s',
                 _('Failed to'),
@@ -619,7 +619,7 @@ class PDODB extends DatabaseManager
         $msg = '';
         if (isset(self::$_link) && self::$_link) {
             if (isset(self::$_queryResult)
-                && self::$_queryResult instanceof PDOStatement
+                && self::$_queryResult instanceof \PDOStatement
                 && self::$_queryResult->errorCode()
             ) {
                 $errCode = self::$_queryResult->errorCode();
@@ -671,7 +671,7 @@ class PDODB extends DatabaseManager
      */
     public function fieldCount()
     {
-        if (self::$_queryResult instanceof PDOStatement) {
+        if (self::$_queryResult instanceof \PDOStatement) {
             return self::$_queryResult->columnCount();
         }
         return 0;
@@ -792,7 +792,7 @@ class PDODB extends DatabaseManager
             if (self::$_link) {
                 return self::$_link->query('SELECT 1') ? true : false;
             }
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             self::debug($e->getMessage());
             self::error($e->getMessage());
         }
@@ -817,7 +817,7 @@ class PDODB extends DatabaseManager
      */
     private static function _debugDumpParams()
     {
-        if (self::$_queryResult instanceof PDOStatement) {
+        if (self::$_queryResult instanceof \PDOStatement) {
             ob_start();
             self::$_queryResult->debugDumpParams();
             return ob_get_clean();
@@ -854,7 +854,7 @@ class PDODB extends DatabaseManager
      *
      * @return void
      */
-    private static function _all($type = PDO::FETCH_ASSOC)
+    private static function _all($type = \PDO::FETCH_ASSOC)
     {
         self::$_result = self::$_queryResult->fetchAll($type);
     }
@@ -866,7 +866,7 @@ class PDODB extends DatabaseManager
      *
      * @return void
      */
-    private static function _single($type = PDO::FETCH_ASSOC)
+    private static function _single($type = \PDO::FETCH_ASSOC)
     {
         self::$_result = self::$_queryResult->fetch($type);
     }
@@ -893,7 +893,7 @@ class PDODB extends DatabaseManager
     private static function _bind($param, $value, $type = null)
     {
         if (is_null($type)) {
-            $type = PDO::PARAM_STR;
+            $type = \PDO::PARAM_STR;
         }
         // bindValue() copies the value immediately; bindParam() would bind by
         // reference to a local variable that goes out of scope before execute().

--- a/packages/web/lib/fog/FOGPagePost.class.php
+++ b/packages/web/lib/fog/FOGPagePost.class.php
@@ -116,7 +116,7 @@ trait FOGPagePost
                     'title' => $successTitle
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -184,7 +184,7 @@ trait FOGPagePost
                 return $msg;
             }
             $payload['object'] = Route::stripSensitive($classname, $object);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $msg;
         }
         $encoded = json_encode($payload);
@@ -244,7 +244,7 @@ trait FOGPagePost
                     'title' => $successTitle
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -363,7 +363,7 @@ trait FOGPagePost
             unset($val);
         }
         if (!in_array($scheduleType, $scheduleTypes)) {
-            throw new Exception(_('Invalid scheduling type'));
+            throw new \Exception(_('Invalid scheduling type'));
         }
         $schedule = [
             'scheduleType' => $scheduleType,
@@ -381,7 +381,7 @@ trait FOGPagePost
                     filter_input(INPUT_POST, 'scheduleSingleTime')
                 );
                 if ($scheduleDeployTime < self::niceDate()) {
-                    throw new Exception(_('Scheduled time is in the past'));
+                    throw new \Exception(_('Scheduled time is in the past'));
                 }
                 $schedule['scheduleDeployTime'] = $scheduleDeployTime;
                 break;
@@ -407,19 +407,19 @@ trait FOGPagePost
                 $tmonth = FOGCron::checkMonthField($month);
                 $tdow = FOGCron::checkDOWField($dow);
                 if (!$tmin) {
-                    throw new Exception(_('Minutes field is invalid'));
+                    throw new \Exception(_('Minutes field is invalid'));
                 }
                 if (!$thour) {
-                    throw new Exception(_('Hours field is invalid'));
+                    throw new \Exception(_('Hours field is invalid'));
                 }
                 if (!$tdom) {
-                    throw new Exception(_('Day of Month field is invalid'));
+                    throw new \Exception(_('Day of Month field is invalid'));
                 }
                 if (!$tmonth) {
-                    throw new Exception(_('Month field is invalid'));
+                    throw new \Exception(_('Month field is invalid'));
                 }
                 if (!$tdow) {
-                    throw new Exception(_('Day of Week field is invalid'));
+                    throw new \Exception(_('Day of Week field is invalid'));
                 }
                 $schedule['min'] = $min;
                 $schedule['hour'] = $hour;

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -334,7 +334,7 @@ class Authorization extends FOGBase
                 [],
                 ['userid' => $userID, 'usergroupid' => $userID]
             )
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         if (!is_array($rows) || count($rows) < 1) {
             // Zero role assignments, direct or group-sourced, grants
@@ -808,7 +808,7 @@ class Authorization extends FOGBase
                 [],
                 ['perm' => (string)$permission]
             )
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         $roleIDs = [];
         foreach ((array)$rows as $row) {
@@ -889,7 +889,7 @@ class Authorization extends FOGBase
         $membership = [];
         $rows = self::$DB
             ->query('SELECT `ruaRoleID`, `ruaUserID` FROM `roleUserAssoc`')
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         foreach ((array)$rows as $row) {
             $membership[(int)$row['ruaRoleID']][] = (int)$row['ruaUserID'];
@@ -898,7 +898,7 @@ class Authorization extends FOGBase
         $groupMembers = [];
         $rows = self::$DB
             ->query('SELECT `ugmGroupID`, `ugmUserID` FROM `userGroupMembers`')
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         foreach ((array)$rows as $row) {
             $groupMembers[(int)$row['ugmGroupID']][] = (int)$row['ugmUserID'];
@@ -907,7 +907,7 @@ class Authorization extends FOGBase
         $groupRoles = [];
         $rows = self::$DB
             ->query('SELECT `rugGroupID`, `rugRoleID` FROM `roleUserGroupAssoc`')
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
         foreach ((array)$rows as $row) {
             $groupRoles[(int)$row['rugGroupID']][] = (int)$row['rugRoleID'];
@@ -1079,7 +1079,7 @@ class Authorization extends FOGBase
         if (self::adminExistsGiven($changes)) {
             return;
         }
-        throw new Exception(
+        throw new \Exception(
             _('This would leave no account able to administer FOG.')
         );
     }
@@ -1144,11 +1144,11 @@ class Authorization extends FOGBase
     {
         $permName = trim((string)$permName);
         if ('' === $permName) {
-            throw new Exception(_('A permission name is required.'));
+            throw new \Exception(_('A permission name is required.'));
         }
         if ('*' === $permName) {
             if (!self::can('*')) {
-                throw new Exception(
+                throw new \Exception(
                     _('Only an administrator may grant full access.')
                 );
             }
@@ -1163,7 +1163,7 @@ class Authorization extends FOGBase
             }
         }
         if (!in_array($permName, $valid, true)) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s',
                     _('Unknown permission'),

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1510,7 +1510,7 @@ class BootMenu extends FOGBase
                 $_REQUEST['username']
             );
             $this->_chainBoot(false, true);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $Send['fail'] = [
                 '#!ipxe',
                 sprintf('echo %s', $e->getMessage()),
@@ -1656,7 +1656,7 @@ class BootMenu extends FOGBase
                     if (!($StorageNode instanceof StorageNode
                         && $StorageNode->isValid())
                     ) {
-                        throw new Exception(_('No valid storage nodes found'));
+                        throw new \Exception(_('No valid storage nodes found'));
                     }
                     $storage = escapeshellcmd(
                         sprintf(

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -55,15 +55,15 @@ class EventManager extends FOGBase
     {
         try {
             if (!is_string($event)) {
-                throw new Exception(_('Event must be a string'));
+                throw new \Exception(_('Event must be a string'));
             }
             if (!is_array($listener) && !is_object($listener)) {
-                throw new Exception(_('Listener must be an array or an object'));
+                throw new \Exception(_('Listener must be an array or an object'));
             }
             switch (get_class($this)) {
                 case 'EventManager':
                     if (!($listener instanceof Event)) {
-                        throw new Exception(_('Class must extend event'));
+                        throw new \Exception(_('Class must extend event'));
                     }
                     if (!isset($this->data[$event])) {
                         $this->data[$event] = [];
@@ -72,12 +72,12 @@ class EventManager extends FOGBase
                     break;
                 case 'HookManager':
                     if (!is_array($listener) || count($listener ?: []) !== 2) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('Second paramater must be in [class,function]')
                         );
                     }
                     if (!($listener[0] instanceof Hook)) {
-                        throw new Exception(_('Class must extend hook'));
+                        throw new \Exception(_('Class must extend hook'));
                     }
                     if (!method_exists($listener[0], $listener[1])) {
                         $msg = sprintf(
@@ -86,16 +86,16 @@ class EventManager extends FOGBase
                             get_class($listener[0]),
                             $listener[1]
                         );
-                        throw new Exception($msg);
+                        throw new \Exception($msg);
                     }
                     $this->data[$event][] = $listener;
                     break;
                 default:
-                    throw new Exception(
+                    throw new \Exception(
                         _('Register must be managed from hooks or events')
                     );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $string = sprintf(
                 '%s: %s: %s, $s: %s, %s: %s',
                 _('Could not register'),
@@ -160,13 +160,13 @@ class EventManager extends FOGBase
         }
         try {
             if (!is_string($event)) {
-                throw new Exception(_('Event must be a string'));
+                throw new \Exception(_('Event must be a string'));
             }
             if (!is_array($eventData)) {
-                throw new Exception(_('Event Data must be an array'));
+                throw new \Exception(_('Event Data must be an array'));
             }
             if (!isset($this->data[$event])) {
-                throw new Exception(_('Event and data are not set'));
+                throw new \Exception(_('Event and data are not set'));
             }
             $runEvent = function ($element) use ($event, $eventData) {
                 if (!$element->active) {
@@ -178,7 +178,7 @@ class EventManager extends FOGBase
                 $runEvent($element);
                 unset($element);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $string = sprintf(
                 '%s: %s: %s, $s: %s',
                 _('Could not notify'),

--- a/packages/web/lib/fog/filedeletequeue.class.php
+++ b/packages/web/lib/fog/filedeletequeue.class.php
@@ -56,10 +56,10 @@ class FileDeleteQueue extends FOGController
     {
         $path = str_replace('\\', '/', trim((string)$path));
         if ($path === '' || strpos($path, "\0") !== false) {
-            throw new Exception(_('Invalid delete path'));
+            throw new \Exception(_('Invalid delete path'));
         }
         if (preg_match('#^(/|[A-Za-z]:/)#', $path) || preg_match('#(^|/)\\.\\.(/|$)#', $path)) {
-            throw new Exception(_('Path escapes storage root'));
+            throw new \Exception(_('Path escapes storage root'));
         }
         return ltrim($path, '/');
     }
@@ -68,7 +68,7 @@ class FileDeleteQueue extends FOGController
     {
         $type = strtolower(trim((string)$this->get('pathtype')));
         if (!in_array($type, ['image', 'snapin'], true)) {
-            throw new Exception(_('Invalid pathtype'));
+            throw new \Exception(_('Invalid pathtype'));
         }
         $this->set('pathtype', ucfirst($type));
         $this->set('path', $this->normalizeQueuePath($this->get('path')));

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -531,7 +531,7 @@ abstract class FOGBase
     public static function getClass($class, $data = '', $props = false)
     {
         if (!is_string($class)) {
-            throw new Exception(_('Class name must be a string'));
+            throw new \Exception(_('Class name must be a string'));
         }
         // Get all args, even unnamed args.
         $args = func_get_args();
@@ -543,7 +543,7 @@ abstract class FOGBase
         // Test what the class is and return if it is Reflection.
         $lClass = strtolower($class);
         if ($lClass === 'reflectionclass') {
-            return new ReflectionClass(count($args ?: []) === 1 ? $args[0] : $args);
+            return new \ReflectionClass(count($args ?: []) === 1 ? $args[0] : $args);
         }
 
         global $sub;
@@ -556,7 +556,7 @@ abstract class FOGBase
         }
 
         // Initiate Reflection item.
-        $obj = new ReflectionClass($class);
+        $obj = new \ReflectionClass($class);
 
         // If props is set to true return the properties of the class.
         if ($props === true) {
@@ -681,7 +681,7 @@ abstract class FOGBase
                     $mac
                 );
             }
-            throw new Exception($msg);
+            throw new \Exception($msg);
         }
 
         // If returnmacs parameter is true, return the macs as an array
@@ -703,7 +703,7 @@ abstract class FOGBase
                 } else {
                     $msg = _('Invalid Host');
                 }
-                throw new Exception($msg);
+                throw new \Exception($msg);
             }
         }
         return;
@@ -988,7 +988,7 @@ abstract class FOGBase
         $new_value
     ) {
         if (!is_string($key)) {
-            throw new Exception(_('Key must be a string or index'));
+            throw new \Exception(_('Key must be a string or index'));
         }
         $new = [];
         foreach ($array as $k => &$value) {
@@ -1018,7 +1018,7 @@ abstract class FOGBase
         $new_value
     ) {
         if (!is_string($key) && !is_numeric($key)) {
-            throw new Exception(_('Key must be a string or index'));
+            throw new \Exception(_('Key must be a string or index'));
         }
         $new = [];
         foreach ($array as $k => &$value) {
@@ -1042,7 +1042,7 @@ abstract class FOGBase
     protected static function arrayRemove($key, array &$array)
     {
         if (!(is_string($key) || is_array($key))) {
-            throw new Exception(_('Key must be an array of keys or a string.'));
+            throw new \Exception(_('Key must be an array of keys or a string.'));
         }
         if (is_array($key)) {
             foreach ($key as &$k) {
@@ -1298,19 +1298,19 @@ abstract class FOGBase
         //      $date = 'now';
         // }
         if ($utc || empty(self::$TimeZone)) {
-            $tz = new DateTimeZone('UTC');
+            $tz = new \DateTimeZone('UTC');
         } else {
             try {
-                $tz = new DateTimeZone(self::$TimeZone);
-            } catch (Exception $e) {
-                $tz = new DateTimeZone('UTC');
+                $tz = new \DateTimeZone(self::$TimeZone);
+            } catch (\Exception $e) {
+                $tz = new \DateTimeZone('UTC');
             }
         }
         //Added try catch to catch when an invalid date is being brought in
         try {
-            $niceDate = new DateTime($date, $tz);
-        } catch (Exception $e) {
-            throw new Exception("Given date of '$date' is invalid! Can't create nicedate!");
+            $niceDate = new \DateTime($date, $tz);
+        } catch (\Exception $e) {
+            throw new \Exception("Given date of '$date' is invalid! Can't create nicedate!");
             $niceDate = $date;
         }
         return $niceDate;
@@ -1327,7 +1327,7 @@ abstract class FOGBase
      */
     public static function formatTime($time, $format = false, $utc = false)
     {
-        if (!$time instanceof DateTime) {
+        if (!$time instanceof \DateTime) {
             $time = self::niceDate($time, $utc);
         }
         if ($format) {
@@ -1388,17 +1388,17 @@ abstract class FOGBase
     protected static function validDate($date, $format = '')
     {
         if ($format == 'N') {
-            if ($date instanceof DateTime) {
+            if ($date instanceof \DateTime) {
                 return $date->format('N') >= 0;
             } else {
                 return $date >= 0 && $date <= 7;
             }
         }
         try {
-            if (!$date instanceof DateTime) {
+            if (!$date instanceof \DateTime) {
                 $date = self::niceDate($date);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return false;
         }
         if (!$format) {
@@ -1407,9 +1407,9 @@ abstract class FOGBase
         if (empty(self::$TimeZone)) {
             self::$TimeZone = 'UTC';
         }
-        $tz = new DateTimeZone(self::$TimeZone);
+        $tz = new \DateTimeZone(self::$TimeZone);
 
-        return DateTime::createFromFormat(
+        return \DateTime::createFromFormat(
             $format,
             $date->format($format),
             $tz
@@ -1429,7 +1429,7 @@ abstract class FOGBase
     protected static function pluralize($count, $text, $space = false)
     {
         if (!is_bool($space)) {
-            throw new Exception(_('Space variable must be boolean'));
+            throw new \Exception(_('Space variable must be boolean'));
         }
 
         return sprintf(
@@ -1454,12 +1454,12 @@ abstract class FOGBase
     protected static function diff($start, $end, $ago = false)
     {
         if (!is_bool($ago)) {
-            throw new Exception(_('Ago must be boolean'));
+            throw new \Exception(_('Ago must be boolean'));
         }
-        if (!$start instanceof DateTime) {
+        if (!$start instanceof \DateTime) {
             $start = self::niceDate($start);
         }
-        if (!$end instanceof DateTime) {
+        if (!$end instanceof \DateTime) {
             $end = self::niceDate($end);
         }
         $Duration = $start->diff($end);
@@ -1547,10 +1547,10 @@ abstract class FOGBase
     protected static function humanify($diff, $unit)
     {
         if (!is_numeric($diff)) {
-            throw new Exception(_('Diff parameter must be numeric'));
+            throw new \Exception(_('Diff parameter must be numeric'));
         }
         if (!is_string($unit)) {
-            throw new Exception(_('Unit of time must be a string'));
+            throw new \Exception(_('Unit of time must be a string'));
         }
         $before = $after = '';
         if ($diff < 0) {
@@ -1585,10 +1585,10 @@ abstract class FOGBase
     protected static function arrayChangeKey(array &$array, $old_key, $new_key)
     {
         if (!is_string($old_key)) {
-            throw new Exception(_('Old key must be a string'));
+            throw new \Exception(_('Old key must be a string'));
         }
         if (!is_string($new_key)) {
-            throw new Exception(_('New key must be a string'));
+            throw new \Exception(_('New key must be a string'));
         }
         $array[$old_key] = (
             is_string($array[$old_key]) ?
@@ -1862,7 +1862,7 @@ abstract class FOGBase
             return '';
         }
         if (!self::productKeyIsValid($posted)) {
-            throw new Exception(_('Invalid Windows product key'));
+            throw new \Exception(_('Invalid Windows product key'));
         }
         return self::productKeyFormat($posted);
     }
@@ -1988,10 +1988,10 @@ abstract class FOGBase
     protected static function certEncrypt($data)
     {
         if (!self::$Host->isValid()) {
-            throw new Exception('#!ih');
+            throw new \Exception('#!ih');
         }
         if (!self::$Host->get('pub_key')) {
-            throw new Exception('#!ihc');
+            throw new \Exception('#!ihc');
         }
         return self::aesencrypt($data, self::$Host->get('pub_key'));
     }
@@ -2026,7 +2026,7 @@ abstract class FOGBase
             unset($path);
         }
         if (count($tmpssl ?: []) < 1) {
-            throw new Exception(_('Private key path not found'));
+            throw new \Exception(_('Private key path not found'));
         }
         $sslbase = str_replace(
             ['\\', '/'],
@@ -2051,15 +2051,15 @@ abstract class FOGBase
          */
         $sslfile = sprintf('%s%s.srvprivate.key', $sslbase, DS);
         if (!file_exists($sslfile)) {
-            throw new Exception(_('Private key not found'));
+            throw new \Exception(_('Private key not found'));
         }
         if (!is_readable($sslfile)) {
-            throw new Exception(_('Private key not readable'));
+            throw new \Exception(_('Private key not readable'));
         }
         $sslfilecontents = file_get_contents($sslfile);
         $priv_key = openssl_pkey_get_private($sslfilecontents);
         if (!$priv_key) {
-            throw new Exception(_('Private key failed'));
+            throw new \Exception(_('Private key failed'));
         }
         $a_key = openssl_pkey_get_details($priv_key);
         $chunkSize = ceil($a_key['bits'] / 8);
@@ -2078,7 +2078,7 @@ abstract class FOGBase
                     $padding
                 );
                 if (!$test) {
-                    throw new Exception(_('Failed to decrypt data on server'));
+                    throw new \Exception(_('Failed to decrypt data on server'));
                 }
                 $dataun .= $decrypt;
             }
@@ -2248,7 +2248,7 @@ abstract class FOGBase
         }
         try {
             if (!self::$Host->isValid()) {
-                throw new Exception('#!ih');
+                throw new \Exception('#!ih');
             }
             $datatosend = trim($datatosend);
             $curdate = self::niceDate();
@@ -2258,7 +2258,7 @@ abstract class FOGBase
                     ->set('pub_key', '')
                     ->save();
                 if (self::$newService || self::$json) {
-                    throw new Exception('#!ihc');
+                    throw new \Exception('#!ihc');
                 }
             }
             if (self::$newService) {
@@ -2271,7 +2271,7 @@ abstract class FOGBase
                 echo $datatosend;
                 exit;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (self::$json) {
                 //die($datatosend);
                 if ($e->getMessage() === '#!ihc') {
@@ -2288,7 +2288,7 @@ abstract class FOGBase
                     return $data;
                 }
             }
-            throw new Exception($e->getMessage());
+            throw new \Exception($e->getMessage());
         }
     }
     /**
@@ -2333,10 +2333,10 @@ abstract class FOGBase
         $level = 1
     ) {
         if (!is_string($txt)) {
-            throw new Exception(_('Txt must be a string'));
+            throw new \Exception(_('Txt must be a string'));
         }
         if (!is_int($level)) {
-            throw new Exception(_('Level must be an integer'));
+            throw new \Exception(_('Level must be an integer'));
         }
         if (self::$ajax) {
             return;
@@ -2364,7 +2364,7 @@ abstract class FOGBase
     protected static function logHistory($string)
     {
         if (!is_string($string)) {
-            throw new Exception(_('String must be a string'));
+            throw new \Exception(_('String must be a string'));
         }
         $string = sprintf(
             '[%s] %s',
@@ -2483,7 +2483,7 @@ abstract class FOGBase
         $repStr = "\n";
         $rows = self::$DB->query(
             "SELECT `settingKey`, `settingValue` FROM `globalSettings`"
-        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
 
         $data = [];
         foreach ((array) $rows as $row) {
@@ -2643,7 +2643,7 @@ abstract class FOGBase
     public static function getSetting($key)
     {
         if (!is_string($key) && !is_array($key)) {
-            throw new Exception(_('Key must be a string or array of strings'));
+            throw new \Exception(_('Key must be a string or array of strings'));
         }
         $findStr = '\r\n';
         $repStr = "\n";
@@ -2686,7 +2686,7 @@ abstract class FOGBase
                 . "')";
 
             $rows = self::$DB->query($sql)
-                ->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+                ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
 
             foreach ((array) $rows as $row) {
                 self::$_settingsCache[$row['settingKey']] = [
@@ -3249,10 +3249,10 @@ abstract class FOGBase
         $size = filesize($path);
         if (is_dir($path)) {
             $size = 0;
-            $di = new RecursiveDirectoryIterator($path);
-            $rii = new RecursiveIteratorIterator(
+            $di = new \RecursiveDirectoryIterator($path);
+            $rii = new \RecursiveIteratorIterator(
                 $di,
-                FilesystemIterator::SKIP_DOTS
+                \FilesystemIterator::SKIP_DOTS
             );
             foreach ($rii as $file) {
                 $size += filesize($file);

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -166,10 +166,10 @@ abstract class FOGController extends FOGBase
         $this->databaseFields = array_filter($this->databaseFields);
         try {
             if (!isset($this->databaseTable)) {
-                throw new Exception(_('Table not defined for this class'));
+                throw new \Exception(_('Table not defined for this class'));
             }
             if (!count($this->databaseFields ?: [])) {
-                throw new Exception(_('Fields not defined for this class'));
+                throw new \Exception(_('Fields not defined for this class'));
             }
             $this->databaseFieldsFlipped = array_flip($this->databaseFields);
             if (is_numeric($data) && $data > 0) {
@@ -179,7 +179,7 @@ abstract class FOGController extends FOGBase
             } elseif (is_array($data)) {
                 $this->setQuery($data);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s, %s: %s',
                 _('Record not found'),
@@ -294,11 +294,11 @@ abstract class FOGController extends FOGBase
         try {
             $key = $this->key($key);
             if (!$key) {
-                throw new Exception(_('No key being requested'));
+                throw new \Exception(_('No key being requested'));
             }
             $test = $this->_testFields($key);
             if (!$test) {
-                throw new Exception(_('Invalid key being set'));
+                throw new \Exception(_('Invalid key being set'));
             }
             if (!$this->isLoaded($key)) {
                 $this->loadItem($key);
@@ -313,7 +313,7 @@ abstract class FOGController extends FOGBase
             self::info($msg);
             $this->data[$key] = $value;
             $this->dirty[$key] = true;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
                 _('Set failed'),
@@ -342,11 +342,11 @@ abstract class FOGController extends FOGBase
         try {
             $key = $this->key($key);
             if (!$key) {
-                throw new Exception(_('No key being requested'));
+                throw new \Exception(_('No key being requested'));
             }
             $test = $this->_testFields($key);
             if (!$test) {
-                throw new Exception(_('Invalid key being added'));
+                throw new \Exception(_('Invalid key being added'));
             }
             if (!$this->isLoaded($key)) {
                 $this->loadItem($key);
@@ -364,7 +364,7 @@ abstract class FOGController extends FOGBase
             }
             $this->data[$key][] = $value;
             $this->dirty[$key] = true;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
                 _('Add failed'),
@@ -393,11 +393,11 @@ abstract class FOGController extends FOGBase
         try {
             $key = $this->key($key);
             if (!$key) {
-                throw new Exception(_('No key being requested'));
+                throw new \Exception(_('No key being requested'));
             }
             $test = $this->_testFields($key);
             if (!$test) {
-                throw new Exception(_('Invalid key being removed'));
+                throw new \Exception(_('Invalid key being removed'));
             }
             if (!$this->isLoaded($key)) {
                 $this->loadItem($key);
@@ -420,7 +420,7 @@ abstract class FOGController extends FOGBase
             }
             $this->data[$key] = array_values(array_filter($this->data[$key]));
             $this->dirty[$key] = true;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
                 _('Remove failed'),
@@ -490,7 +490,7 @@ abstract class FOGController extends FOGBase
                         // Required *id must be integer >= 1
                         $validated = filter_var($val, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
                         if ($validated === false) {
-                            throw new Exception(self::$foglang['RequiredDB'] . ": " . $key);
+                            throw new \Exception(self::$foglang['RequiredDB'] . ": " . $key);
                         }
                         $val = (int)$validated;
                     } else {
@@ -510,7 +510,7 @@ abstract class FOGController extends FOGBase
                     $isEmpty = ($val === null) || (is_string($val) && trim($val) === '');
                     if ($isEmpty) {
                         if ($isRequired) {
-                            throw new Exception(self::$foglang['RequiredDB'] . ": " . $key);
+                            throw new \Exception(self::$foglang['RequiredDB'] . ": " . $key);
                         }
                         $val = '';
                     }
@@ -585,7 +585,7 @@ abstract class FOGController extends FOGBase
                     $this->set('id', $newId);
                 } else {
                     // This prevents "Task ID: 0 ... successfully updated" lies.
-                    throw new Exception(_('Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment.'));
+                    throw new \Exception(_('Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment.'));
                 }
             }
 
@@ -611,7 +611,7 @@ abstract class FOGController extends FOGBase
                 }
                 self::logHistory($msg);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (!$this instanceof History) {
                 if ($this->get('name')) {
                     $msg = sprintf(
@@ -667,18 +667,18 @@ abstract class FOGController extends FOGBase
     {
         try {
             if (!is_string($key)) {
-                throw new Exception(_('Key field must be a string'));
+                throw new \Exception(_('Key field must be a string'));
             }
             if (!$key) {
-                throw new Exception(_('No key being requested'));
+                throw new \Exception(_('No key being requested'));
             }
             $test = $this->_testFields($key);
             if (!$test) {
-                throw new Exception(_('Invalid key being added'));
+                throw new \Exception(_('Invalid key being added'));
             }
             $val = $this->get($key);
             if (!$val) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         _('Operation field not set'),
@@ -728,7 +728,7 @@ abstract class FOGController extends FOGBase
             );
             $vals = self::$DB->fetch()->get();
             $this->setQuery($vals);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
                 _('Load failed'),
@@ -766,11 +766,11 @@ abstract class FOGController extends FOGBase
         $objects = [];
         try {
             if (!is_string($key) || !$key) {
-                throw new Exception(_('Key field must be a string'));
+                throw new \Exception(_('Key field must be a string'));
             }
             $key = $this->key($key);
             if (!$this->_testFields($key)) {
-                throw new Exception(_('Invalid key being requested'));
+                throw new \Exception(_('Invalid key being requested'));
             }
             $vals = array_values(
                 array_unique(
@@ -818,7 +818,7 @@ abstract class FOGController extends FOGBase
             );
             $rows = self::$DB
                 ->query($query, [], $queryArray)
-                ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+                ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
                 ->get();
             $classname = get_class($this);
             foreach ((array) $rows as &$row) {
@@ -834,7 +834,7 @@ abstract class FOGController extends FOGBase
                 }
                 unset($row);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf(
                 '%s: %s: %s, %s: %s',
                 _('Bulk load failed'),
@@ -895,15 +895,15 @@ abstract class FOGController extends FOGBase
             }
             $key = $this->key($key);
             if (!$key) {
-                throw new Exception(_('No key being requested'));
+                throw new \Exception(_('No key being requested'));
             }
             $test = $this->_testFields($key);
             if (!$test) {
-                throw new Exception(_('Invalid key being destroyed'));
+                throw new \Exception(_('Invalid key being destroyed'));
             }
             $val = $this->get($key);
             if (!is_numeric($val) && !$val) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         _('Operation field not set'),
@@ -966,7 +966,7 @@ abstract class FOGController extends FOGBase
                 }
                 self::logHistory($msg);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (!$this instanceof History) {
                 if ($this->get('name')) {
                     $msg = sprintf(
@@ -1037,7 +1037,7 @@ abstract class FOGController extends FOGBase
     {
         $key = $this->key($key);
         if (!$key) {
-            throw new Exception(_('No key being requested'));
+            throw new \Exception(_('No key being requested'));
         }
         $test = $this->_testFields($key);
         if (!$test) {
@@ -1150,14 +1150,14 @@ abstract class FOGController extends FOGBase
     {
         $key = $this->key($key);
         if (!$key) {
-            throw new Exception(_('No key being requested'));
+            throw new \Exception(_('No key being requested'));
         }
         $test = $this->_testFields($key);
         if (!$test) {
-            throw new Exception(_('Invalid key being requested'));
+            throw new \Exception(_('Invalid key being requested'));
         }
         if (!in_array($array_type, ['merge', 'diff'])) {
-            throw new Exception(
+            throw new \Exception(
                 _('Invalid type, merge to add, diff to remove')
             );
         }
@@ -1197,7 +1197,7 @@ abstract class FOGController extends FOGBase
                 // If key ends with ID (case-insensitive), require integer >= 1
                 if (strtolower(substr($key, -2)) === 'id') {
                     if (filter_var($val, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
-                        throw new Exception(self::$foglang['RequiredDB'] . ": " . $key);
+                        throw new \Exception(self::$foglang['RequiredDB'] . ": " . $key);
                     }
                     continue; // don't fall through to the generic empty-check
                 }
@@ -1205,20 +1205,20 @@ abstract class FOGController extends FOGBase
                 // Generic "required" check for non-ID fields:
                 // treat null / empty string as missing, but allow 0 / "0"
                 if ($val === null || (is_string($val) && trim($val) === '')) {
-                    throw new Exception(self::$foglang['RequiredDB'] . ": " . $key);
+                    throw new \Exception(self::$foglang['RequiredDB'] . ": " . $key);
                 }
             }
 
             // Validate the model's own 'id' field
             if (filter_var($this->get('id'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
-                throw new Exception(_('Invalid ID passed'));
+                throw new \Exception(_('Invalid ID passed'));
             }
 
             if (array_key_exists('name', $this->databaseFields)) {
                 $val = trim($this->get('name'));
             }
 
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $str = sprintf('%s: %s: %s', _('Failed'), _('Error'), $e->getMessage());
             self::debug($str);
             return false;

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -35,7 +35,7 @@ class FOGCron extends FOGBase
     {
         $value = trim((string)$value);
         if (!preg_match('/^[0-9\*\/\-\,]+$/', $value)) {
-            throw new Exception(
+            throw new \Exception(
                 _('Invalid cron field value. Only digits, *, /, -, and commas are allowed.')
             );
         }

--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -165,7 +165,7 @@ class FOGFTP
                 $this->pasv($this->passive);
             }
             $this->_lastConnectionHash = $this->_currentConnectionHash;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             FOGCore::error($e->getMessage());
             return false;
         }
@@ -225,7 +225,7 @@ class FOGFTP
     public function ftperror($data)
     {
         $error = error_get_last();
-        throw new Exception(
+        throw new \Exception(
             sprintf(
                 '%s: %s, %s: %s, %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Type'),
@@ -274,8 +274,8 @@ class FOGFTP
             if (ftp_login($this->_link, $username, $password) === false) {
                 $this->ftperror($this->data);
             }
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
         $this->_lastLoginHash = $this->_currentLoginHash;
         return $this;
@@ -429,8 +429,8 @@ class FOGFTP
                 $autologin,
                 'ftp_ssl_connect'
             );
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
         return $this;
     }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -497,7 +497,7 @@ abstract class FOGManagerController extends FOGBase
                     continue;
                 }
                 $columnSrch = $column['db'];
-                $binding = self::bind($bindings, '%'.$str.'%', PDO::PARAM_STR);
+                $binding = self::bind($bindings, '%'.$str.'%', \PDO::PARAM_STR);
                 $globalSearch[] = "`".$columnSrch."` LIKE ".$binding;
             }
         }
@@ -519,7 +519,7 @@ abstract class FOGManagerController extends FOGBase
                 $binding = self::bind(
                     $bindings,
                     '%' . $str . '%',
-                    PDO::PARAM_STR
+                    \PDO::PARAM_STR
                 );
                 $columnSearch[] = "`".$columnSrch."` LIKE ".$binding;
             }
@@ -749,11 +749,11 @@ abstract class FOGManagerController extends FOGBase
         // Execute
         try {
             $stmt->execute();
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             self::fatal(_("An SQL error occurred").": ".$e->getMessage() . "SQL: $sql");
         }
         // Return all
-        return $stmt->fetchAll(PDO::FETCH_BOTH);
+        return $stmt->fetchAll(\PDO::FETCH_BOTH);
     }
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      * Internal methods
@@ -852,10 +852,10 @@ abstract class FOGManagerController extends FOGBase
         $fieldlength = count($fields ?: []);
         $valuelength = count($values ?: []);
         if ($fieldlength < 1) {
-            throw new Exception(_('No fields passed'));
+            throw new \Exception(_('No fields passed'));
         }
         if ($valuelength < 1) {
-            throw new Exception(_('No values passed'));
+            throw new \Exception(_('No values passed'));
         }
         $keys = [];
         foreach ((array) $fields as &$key) {
@@ -893,7 +893,7 @@ abstract class FOGManagerController extends FOGBase
                 unset($value);
             }
             if (count($vals ?: []) < 1) {
-                throw new Exception(_('No data to insert'));
+                throw new \Exception(_('No data to insert'));
             }
             $query = sprintf(
                 $this->insertBatchTemplate,

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1563,7 +1563,7 @@ abstract class FOGPage extends FOGBase
                 }
             }
             echo '</table>';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $e->getMessage();
         }
         return ob_get_clean()
@@ -1790,7 +1790,7 @@ abstract class FOGPage extends FOGBase
                 ]
             );
             $code = HTTPResponseCodes::HTTP_SUCCESS;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $msg = json_encode(
                 [
                     'error' => $e->getMessage(),
@@ -2102,20 +2102,20 @@ abstract class FOGPage extends FOGBase
                 if ($msg == 'dl') {
                     $destFilename = $_SESSION['dest-kernel-file'];
                     if (preg_match('/\./', $destFilename)) {
-                        throw new Exception(_('Dot in Filename not allowed!'));
+                        throw new \Exception(_('Dot in Filename not allowed!'));
                     }
                     $dlUrl = $_SESSION['dl-kernel-file'];
                     if (!(0 === stripos($dlUrl, 'https://fogproject.org/') ||
                         0 === stripos($dlUrl, 'https://github.com/FOGProject/'))
                     ) {
-                        throw new Exception(_('Specified download URL not allowed!'));
+                        throw new \Exception(_('Specified download URL not allowed!'));
                     }
                     $fh = fopen(
                         $_SESSION['tmp-kernel-file'],
                         'wb'
                     );
                     if ($fh === false) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('Error: Failed to open temp file')
                         );
                     }
@@ -2141,7 +2141,7 @@ abstract class FOGPage extends FOGBase
                         $fh
                     );
                     if ($httpCode < 200 || $httpCode > 299) {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s (HTTP %d)',
                                 _('Error'),
@@ -2151,7 +2151,7 @@ abstract class FOGPage extends FOGBase
                         );
                     }
                     if (!file_exists($_SESSION['tmp-kernel-file'])) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('Error: Failed to download kernel')
                         );
                     }
@@ -2165,7 +2165,7 @@ abstract class FOGPage extends FOGBase
                     // shipped to the TFTP server. The sprintf was also one
                     // argument long, swallowing the size it meant to report.
                     if ($filesize < 1048576) {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s: %s - %s',
                                 _('Error'),
@@ -2186,7 +2186,7 @@ abstract class FOGPage extends FOGBase
                     // than to fail inside the signing helper, or to hand Secure
                     // Boot clients something that was never a kernel.
                     if (self::readMagic($_SESSION['tmp-kernel-file'], 2) !== 'MZ') {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s',
                                 _('Error'),
@@ -2241,7 +2241,7 @@ abstract class FOGPage extends FOGBase
                     self::$FOGSSH->password = $tftpPass;
                     self::$FOGSSH->host = $tftpHost;
                     if (!self::$FOGSSH->connect()) {
-                        throw new Exception(_('Unable to connect to ssh'));
+                        throw new \Exception(_('Unable to connect to ssh'));
                     }
                     if (!self::$FOGSSH->exists($backuppath)) {
                         self::$FOGSSH->sftp_mkdir($backuppath);
@@ -2292,7 +2292,7 @@ abstract class FOGPage extends FOGBase
                     ));
                 }
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->jsonSend(HTTPResponseCodes::HTTP_BAD_REQUEST, json_encode(
                 [
                     'error' => $e->getMessage(),
@@ -2410,7 +2410,7 @@ abstract class FOGPage extends FOGBase
             if ($lock !== false) {
                 fclose($lock);
             }
-            throw new Exception(
+            throw new \Exception(
                 _('Error: Could not lock the Secure Boot staging directory')
             );
         }
@@ -2419,7 +2419,7 @@ abstract class FOGPage extends FOGBase
             // Overwrites any leftover from a run that died mid-sign, which is
             // what we want: ours is the only kernel anyone is waiting on.
             if (!rename($tmpfile, $shared)) {
-                throw new Exception(
+                throw new \Exception(
                     _('Error: Could not stage the kernel for signing')
                 );
             }
@@ -2437,7 +2437,7 @@ abstract class FOGPage extends FOGBase
             );
             exec("sudo -n {$helper} 2>&1", $output, $retVal);
             if ($retVal !== 0) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         _('Error: Failed to sign the kernel for Secure Boot'),
@@ -2482,14 +2482,14 @@ abstract class FOGPage extends FOGBase
                     if (!(0 === stripos($dlUrl, 'https://fogproject.org/') ||
                         0 === stripos($dlUrl, 'https://github.com/FOGProject/'))
                     ) {
-                        throw new Exception(_('Specified download URL not allowed!'));
+                        throw new \Exception(_('Specified download URL not allowed!'));
                     }
                     $fh = fopen(
                         $_SESSION['tmp-initrd-file'],
                         'wb'
                     );
                     if ($fh === false) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('Error: Failed to open temp file')
                         );
                     }
@@ -2511,7 +2511,7 @@ abstract class FOGPage extends FOGBase
                         $fh
                     );
                     if ($httpCode < 200 || $httpCode > 299) {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s (HTTP %d)',
                                 _('Error'),
@@ -2521,7 +2521,7 @@ abstract class FOGPage extends FOGBase
                         );
                     }
                     if (!file_exists($_SESSION['tmp-initrd-file'])) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('Error: Failed to download initrd')
                         );
                     }
@@ -2535,7 +2535,7 @@ abstract class FOGPage extends FOGBase
                     // shipped to the TFTP server. The sprintf was also one
                     // argument long, swallowing the size it meant to report.
                     if ($filesize < 1048576) {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s: %s - %s',
                                 _('Error'),
@@ -2589,7 +2589,7 @@ abstract class FOGPage extends FOGBase
                     self::$FOGSSH->password = $tftpPass;
                     self::$FOGSSH->host = $tftpHost;
                     if (!self::$FOGSSH->connect()) {
-                        throw new Exception(_('Unable to connect to SSH'));
+                        throw new \Exception(_('Unable to connect to SSH'));
                     }
                     if (!self::$FOGSSH->exists($backuppath)) {
                         self::$FOGSSH->sftp_mkdir($backuppath);
@@ -2637,7 +2637,7 @@ abstract class FOGPage extends FOGBase
                     ));
                 }
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->jsonSend(HTTPResponseCodes::HTTP_BAD_REQUEST, json_encode(
                 [
                     'error' => $e->getMessage(),
@@ -2815,7 +2815,7 @@ abstract class FOGPage extends FOGBase
              * destructive write instead of before it.
              */
             if (strlen($key) !== 64) {
-                throw new Exception('#!ihc');
+                throw new \Exception('#!ihc');
             }
             $secTok = (string)self::$Host->get('sec_tok');
             $prevTok = (string)self::$Host->get('prev_sec_tok');
@@ -2856,7 +2856,7 @@ abstract class FOGPage extends FOGBase
                 && !$matchesCurrent
                 && !$matchesPrev
             ) {
-                throw new Exception('#!ist');
+                throw new \Exception('#!ist');
             }
             $expire = self::niceDate(self::$Host->get('sec_time'));
             if (self::niceDate() > $expire
@@ -2914,7 +2914,7 @@ abstract class FOGPage extends FOGBase
             }
             self::$Host->save();
             echo $response;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             /**
              * These must go out as HTTP 200 with the error in the BODY.
              *
@@ -3128,7 +3128,7 @@ abstract class FOGPage extends FOGBase
                 true,
                 $array
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
         exit;
@@ -3244,7 +3244,7 @@ abstract class FOGPage extends FOGBase
         $serverFault = false;
         try {
             if ($this->obj->get('protected')) {
-                throw new Exception(_('Unable to remove protected items'));
+                throw new \Exception(_('Unable to remove protected items'));
             }
             if ($this->obj instanceof Group) {
                 if (isset($_POST['andHosts'])) {
@@ -3259,20 +3259,20 @@ abstract class FOGPage extends FOGBase
                     );
                     if ($hcount) {
                         $serverFault = true;
-                        throw new Exception(_('Failed to remove hosts'));
+                        throw new \Exception(_('Failed to remove hosts'));
                     }
                 }
             }
             if ($this->obj instanceof Image || $this->obj instanceof Snapin) {
                 if (isset($_POST['andFile'])) {
                     if (!$this->obj->deleteFile()) {
-                        throw new Exception(_('Unable to delete file data'));
+                        throw new \Exception(_('Unable to delete file data'));
                     }
                 }
             }
             if (!$this->obj->destroy()) {
                 $serverFault = true;
-                throw new Exception(
+                throw new \Exception(
                     _('Failed to remove')
                     . ': '
                     . Initiator::e($this->obj->get('name'))
@@ -3288,7 +3288,7 @@ abstract class FOGPage extends FOGBase
                     'title' => _('Delete Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $hook = "{$ucnode}_DELETE_FAIL";
             $code = (
                 $serverFault ?
@@ -3933,7 +3933,7 @@ abstract class FOGPage extends FOGBase
                     $item->{$entry['apply']}($ids);
                 }
                 $applied = true;
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // Stay lenient: a failed association must not fail the row.
                 $warnings[] = sprintf(
                     _('Could not apply %s: %s'),
@@ -4250,7 +4250,7 @@ abstract class FOGPage extends FOGBase
             }
             if ($_FILES['file']['error'] > 0) {
                 $serverFault = true;
-                throw new Exception($_FILES['file']['error']);
+                throw new \Exception($_FILES['file']['error']);
             }
             $tmpf = pathinfo($_FILES['file']['tmp_name']);
             $file = sprintf(
@@ -4260,7 +4260,7 @@ abstract class FOGPage extends FOGBase
                 $tmpf['basename']
             );
             if (!file_exists($file)) {
-                throw new Exception(_('Could not find temp filename'));
+                throw new \Exception(_('Could not find temp filename'));
             }
             $numSuccess = $numFailed = $numAlreadExist = 0;
             $uploadErrors = '';
@@ -4332,7 +4332,7 @@ abstract class FOGPage extends FOGBase
                     }
                     foreach ($required as $req) {
                         if (!array_key_exists($req, $headerMap)) {
-                            throw new Exception(
+                            throw new \Exception(
                                 sprintf(
                                     _('Header is missing the required "%s" column'),
                                     $req
@@ -4361,7 +4361,7 @@ abstract class FOGPage extends FOGBase
                         $importCount > $maxCols
                     )
                 ) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Invalid data being parsed')
                     );
                 }
@@ -4399,7 +4399,7 @@ abstract class FOGPage extends FOGBase
                         self::getClass('HostManager')
                             ->getHostByMacAddresses($macs);
                         if (self::$Host->isValid()) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('One or more macs are associated with a host')
                             );
                         }
@@ -4422,7 +4422,7 @@ abstract class FOGPage extends FOGBase
                         }
                     }
                     if ($ItemMan->exists($rowVals['name'])) {
-                        throw new Exception(
+                        throw new \Exception(
                             _('This host already exists')
                         );
                     }
@@ -4557,7 +4557,7 @@ abstract class FOGPage extends FOGBase
                     } else {
                         $numFailed++;
                     }
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     $numFailed++;
                     $uploadErrors .= sprintf(
                         '%s #%s: %s<br/>',
@@ -4593,7 +4593,7 @@ abstract class FOGPage extends FOGBase
                     )
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $error = $e->getMessage();
             $code = (
                 $serverFault ?

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -205,7 +205,7 @@ class FOGPageManager extends FOGBase
             } else {
                 self::resetRequest();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->debug(
                 _('Failed to Render Page: Node: %s, Error: %s'),
                 [
@@ -243,10 +243,10 @@ class FOGPageManager extends FOGBase
         }
         try {
             if (!($class instanceof FOGPage)) {
-                throw new Exception(self::$foglang['NotExtended']);
+                throw new \Exception(self::$foglang['NotExtended']);
             }
             if (!$class->node) {
-                throw new Exception(_('No node associated'));
+                throw new \Exception(_('No node associated'));
             }
             self::info(
                 sprintf(
@@ -256,7 +256,7 @@ class FOGPageManager extends FOGBase
                 )
             );
             $this->_nodes[$class->node] = $class;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->debug(
                 _('Failed to add Page: Node: %s, Page Class: %s, Error: %s'),
                 [

--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -198,7 +198,7 @@ class FOGSSH
                 $this->login();
             }
             $this->_lastConnectionHash = $this->_currentConnectionHash;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             FOGCore::error($e->getMessage());
             return false;
         }
@@ -215,7 +215,7 @@ class FOGSSH
     public function ssherror($data)
     {
         $error = error_get_last();
-        throw new Exception(
+        throw new \Exception(
             sprintf(
                 '%s: %s, %s: %s, %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Type'),
@@ -264,8 +264,8 @@ class FOGSSH
             if ($this->auth_password($username, $password) === false) {
                 $this->ssherror($this->data);
             }
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
         $this->_lastLoginHash = $this->_currentLoginHash;
         return $this;
@@ -309,14 +309,14 @@ class FOGSSH
         $sftp = $this->_sftp;
         $stream = @fopen("ssh2.sftp://$sftp$remotefile", 'w');
         if (!$stream) {
-            throw new Exception(_("Could not open file"). ": $remotefile");
+            throw new \Exception(_("Could not open file"). ": $remotefile");
         }
         $data_to_send = @file_get_contents($localfile);
         if (false === $data_to_send) {
-            throw new Exception(_("Could not open local file"). ": $localfile");
+            throw new \Exception(_("Could not open local file"). ": $localfile");
         }
         if (false === @fwrite($stream, $data_to_send)) {
-            throw new Exception(_("Could not send data from file"). ": $localfile");
+            throw new \Exception(_("Could not send data from file"). ": $localfile");
         }
 
         @fclose($stream);

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -368,7 +368,7 @@ class FOGURLRequests extends FOGBase
         }
         $this->_windowSize = min(count($this->_requests), $this->_windowSize);
         if ($this->_windowSize < 2) {
-            throw new Exception(_('Window size must be greater than 1'));
+            throw new \Exception(_('Window size must be greater than 1'));
         }
         $timeout = $available
             ? $this->_aconntimeout / 1000

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -489,7 +489,7 @@ class Group extends FOGController
     {
         $Image = new Image($imageID);
         if (!$Image->isValid() && is_numeric($imageID)) {
-            throw new Exception(_('Select a valid image'));
+            throw new \Exception(_('Select a valid image'));
         }
         $states = self::fastmerge(
             self::getQueuedStates(),
@@ -503,7 +503,7 @@ class Group extends FOGController
             ]
         );
         if ($TaskCount > 0) {
-            throw new Exception(_('There is a host in a tasking'));
+            throw new \Exception(_('There is a host in a tasking'));
         }
         self::getClass('HostManager')
             ->update(
@@ -553,7 +553,7 @@ class Group extends FOGController
             . self::niceDate()->format('Y-m-d H:i:s');
         $hostCount = $this->getHostCount();
         if ($hostCount < 1) {
-            throw new Exception(_('No hosts to task'));
+            throw new \Exception(_('No hosts to task'));
         }
         $hostids = $this->get('hosts');
         $find = [
@@ -569,7 +569,7 @@ class Group extends FOGController
             Route::getIds('task', $find, 'hostID')
         );
         if (count($hostids ?: []) < 1) {
-            throw new Exception(_('No hosts available to task'));
+            throw new \Exception(_('No hosts available to task'));
         }
         $imagingTypes = $TaskType->isImagingTask;
         $now = $this->niceDate();
@@ -585,18 +585,18 @@ class Group extends FOGController
             $imageID = self::minId(Route::getIds('host', $find, 'imageID'));
             $Image = new Image($imageID);
             if (!$Image->isValid()) {
-                throw new Exception(self::$foglang['ImageNotValid']);
+                throw new \Exception(self::$foglang['ImageNotValid']);
             }
             if (!$Image->get('isEnabled')) {
-                throw new Exception(_('Image is not enabled'));
+                throw new \Exception(_('Image is not enabled'));
             }
             $StorageGroup = $Image->getStorageGroup();
             if (!$StorageGroup->isValid()) {
-                throw new Exception(self::$foglang['ImageGroupNotValid']);
+                throw new \Exception(self::$foglang['ImageGroupNotValid']);
             }
             $StorageNode = $StorageGroup->getMasterStorageNode();
             if (!$StorageNode->isValid()) {
-                throw new Exception(_('Unable to find master Storage Node'));
+                throw new \Exception(_('Unable to find master Storage Node'));
             }
             if ($TaskType->isMulticast) {
                 MulticastSession::assertCapacity();

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -89,7 +89,7 @@ class HookManager extends EventManager
         foreach ((array) $this->data[$event] as &$function) {
             $active = false;
             $className = get_class($function[0]);
-            $refClass = new ReflectionClass($className);
+            $refClass = new \ReflectionClass($className);
             $filename = $refClass->getFileName();
             if (!method_exists($function[0], $function[1])) {
                 continue;

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -237,7 +237,7 @@ class Host extends FOGController
     public function save()
     {
         if (!$this->isHostnameSafe()) {
-            throw new Exception(
+            throw new \Exception(
                 _('Invalid hostname; must be 1-15 of these characters: ')
                 . 'a-z 0-9 ! @ # $ % ^ ( ) - \' { } . ~ _'
             );
@@ -860,7 +860,7 @@ class Host extends FOGController
             if (-1 == $snapin) {
                 $snapins = $this->get('snapins');
                 if (count($snapins ?: []) <= 0) {
-                    throw new Exception(_('No snapins associated'));
+                    throw new \Exception(_('No snapins associated'));
                 }
             }
             $SnapinJob = $this->get('snapinjob');
@@ -875,7 +875,7 @@ class Host extends FOGController
                         ->format('Y-m-d H:i:s')
                     );
                 if (!$SnapinJob->save()) {
-                    throw new Exception(_('Failed to create Snapin Job'));
+                    throw new \Exception(_('Failed to create Snapin Job'));
                 }
             } elseif ((int)$SnapinJob->get('abortOnFail')
                 !== (int)(bool)$abortOnFailure
@@ -895,7 +895,7 @@ class Host extends FOGController
             // predate that guard still carry a snapinID of 0.
             $snapin = self::positiveIntIds((array)$snapin);
             if (count($snapin) < 1) {
-                throw new Exception(_('No snapins associated'));
+                throw new \Exception(_('No snapins associated'));
             }
             // The job id gets the same treatment as the snapin id above. A
             // task is only reachable through its job, so one inserted against
@@ -905,7 +905,7 @@ class Host extends FOGController
             // behind. See the matching guard in Group::createImagePackage().
             $snapinJobID = (int)$SnapinJob->get('id');
             if ($snapinJobID < 1) {
-                throw new Exception(_('Failed to create Snapin Job'));
+                throw new \Exception(_('Failed to create Snapin Job'));
             }
             $nextSequence = 1;
             // listem order is ASC by the requested field, so the last row has max sequence.
@@ -940,10 +940,10 @@ class Host extends FOGController
                         $insert_values
                     );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if ($error) {
                 $Task->cancel();
-                throw new Exception($e->getMessage());
+                throw new \Exception($e->getMessage());
             }
         }
         return $this;
@@ -991,7 +991,7 @@ class Host extends FOGController
         $serverFault = false;
         try {
             if (!$this->isValid()) {
-                throw new Exception(self::$foglang['HostNotValid']);
+                throw new \Exception(self::$foglang['HostNotValid']);
             }
             $Task = $this->get('task');
             // A non-imaging active task (e.g. a queued snapin task) must not
@@ -1007,7 +1007,7 @@ class Host extends FOGController
             }
             // Block only if the host is already in an imaging task.
             if ($Task->isValid() && $TaskType->isImagingTask) {
-                throw new Exception(self::$foglang['InTask']);
+                throw new \Exception(self::$foglang['InTask']);
             }
 
             // Snapin Tasking
@@ -1033,7 +1033,7 @@ class Host extends FOGController
                                 ->set('typeID', TaskType::ALL_SNAPINS);
                             if (!$Task->save()) {
                                 $serverFault = true;
-                                throw new Exception(_('Unable to update task'));
+                                throw new \Exception(_('Unable to update task'));
                             }
                         }
                         break;
@@ -1047,10 +1047,10 @@ class Host extends FOGController
             $isCapture = $TaskType->isCapture;
             if ($imagingTypes) {
                 if (!$Image->isValid()) {
-                    throw new Exception(self::$foglang['ImageNotValid']);
+                    throw new \Exception(self::$foglang['ImageNotValid']);
                 }
                 if (!$Image->get('isEnabled')) {
-                    throw new Exception(_('Image is not enabled'));
+                    throw new \Exception(_('Image is not enabled'));
                 }
                 // Let plugins pick the group/node before falling back to the
                 // image's primary group. Every other place that resolves a
@@ -1093,7 +1093,7 @@ class Host extends FOGController
                     $StorageGroup = $Image->getStorageGroup();
                 }
                 if (!$StorageGroup->isValid()) {
-                    throw new Exception(self::$foglang['ImageGroupNotValid']);
+                    throw new \Exception(self::$foglang['ImageGroupNotValid']);
                 }
                 // Only a hook-chosen group needs checking; the image's own
                 // group holds the image by definition. Without this the task
@@ -1111,7 +1111,7 @@ class Host extends FOGController
                         ]
                     );
                     if (count($inGroup ?: []) < 1) {
-                        throw new Exception(
+                        throw new \Exception(
                             sprintf(
                                 '%s: %s -> %s',
                                 _('Image is not replicated to this storage group'),
@@ -1136,7 +1136,7 @@ class Host extends FOGController
                         _('Could not find any'),
                         _('nodes containing this image')
                     );
-                    throw new Exception($msg);
+                    throw new \Exception($msg);
                 }
                 $imageTaskImgID = $this->get('imageID');
                 $hostsWithImgID = Route::getIds(
@@ -1156,7 +1156,7 @@ class Host extends FOGController
                     );
                     if (!$this->save()) {
                         $serverFault = true;
-                        throw new Exception(_('Could not update host'));
+                        throw new \Exception(_('Could not update host'));
                     }
                 }
                 $this->set('imageID', $imageTaskImgID);
@@ -1179,7 +1179,7 @@ class Host extends FOGController
                 $Task->set('imageID', $this->get('imageID'));
                 if (!$Task->save()) {
                     $serverFault = true;
-                    throw new Exception(self::$foglang['FailedTask']);
+                    throw new \Exception(self::$foglang['FailedTask']);
                 }
                 $this->set('task', $Task);
             }
@@ -1254,7 +1254,7 @@ class Host extends FOGController
                     // part of the session.
                     if (!$MulticastSession->isJoinable()) {
                         if ($sessionjoin) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('That session has already started')
                                 . '. '
                                 . _('It can no longer be joined')
@@ -1298,7 +1298,7 @@ class Host extends FOGController
                         ->set('shutdown', (int)$shutdown);
                     if (!$MulticastSession->save()) {
                         $serverFault = true;
-                        throw new Exception(_('Failed to create multicast task'));
+                        throw new \Exception(_('Failed to create multicast task'));
                     }
                     $assoc = true;
                 }
@@ -1309,7 +1309,7 @@ class Host extends FOGController
                         ->save();
                     if (!$stat) {
                         $serverFault = true;
-                        throw new Exception(_('Unable to create association'));
+                        throw new \Exception(_('Unable to create association'));
                     }
                 }
             }
@@ -1327,7 +1327,7 @@ class Host extends FOGController
                     ->set('stateID', self::getCompleteState())
                     ->save();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $errcode = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $message = $e->getMessage();
             $title = _('Create Task Fail');
@@ -1344,7 +1344,7 @@ class Host extends FOGController
                 $message
             ));
             if (preg_match('#/service/ipxe/boot.php#', self::$scriptname)) {
-                throw new Exception($message);
+                throw new \Exception($message);
             }
             http_response_code($errcode);
             echo json_encode(
@@ -1448,14 +1448,14 @@ class Host extends FOGController
         $mac = self::parseMacList($mac);
         $count = count($mac ?: []);
         if ($count < 1) {
-            throw new Exception(_('No viable macs to use'));
+            throw new \Exception(_('No viable macs to use'));
         }
         if (is_array($mac) && $count > 0) {
             $mac = array_shift($mac);
         }
         $host = $mac->getHost();
         if ($host instanceof Host && $host->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     "%s: %s => %s",
                     _('MAC address is already in use by another host'),
@@ -1549,7 +1549,7 @@ class Host extends FOGController
                     $limit == 1 ? '' : 's',
                     _('per host')
                 );
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s %d %s',
                         _('You are only allowed to assign'),

--- a/packages/web/lib/fog/hostmanager.class.php
+++ b/packages/web/lib/fog/hostmanager.class.php
@@ -207,7 +207,7 @@ class HostManager extends FOGManagerController
 
                 // Check if there is a tie for the most frequent host ID
                 if (count($mostFrequentHostIDs) > 1) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Unable to determine the suspected true host'). '.'
                         . ' ' . _('Most Frequent Host IDs') . ': '
                         . '[' . _('Host ID') . '] => ' . _('Count'). ': '

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -202,7 +202,7 @@ class Image extends FOGController
     public function deleteFile()
     {
         if ($this->get('protected')) {
-            throw new Exception(self::$foglang['ProtectedImage']);
+            throw new \Exception(self::$foglang['ProtectedImage']);
         }
         foreach ($this->get('storagegroups') as $storagegroupID) {
             self::getClass('filedeletequeue')
@@ -318,7 +318,7 @@ class Image extends FOGController
             $groupids = Route::getIds('storagegroup', false);
             $groupids = [self::minId($groupids)];
             if (count($groupids) < 1) {
-                throw new Exception(_('No viable storage groups found'));
+                throw new \Exception(_('No viable storage groups found'));
             }
         }
         $primaryGroup = [];

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -123,7 +123,7 @@ class MACAddress extends FOGBase
              * If the mac address is not valid throw Invalid MAC message.
              */
             if (!$this->isValid()) {
-                throw new Exception("#!im\n");
+                throw new \Exception("#!im\n");
             }
             /**
              * Split the normalized mac into an array using 2 characters
@@ -151,7 +151,7 @@ class MACAddress extends FOGBase
                 str_repeat(chr(255), 6),
                 str_repeat($hwAddr, 16)
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::$FOGCore->debug(
                 sprintf(
                     '%s MAC: %s',

--- a/packages/web/lib/fog/multicastsession.class.php
+++ b/packages/web/lib/fog/multicastsession.class.php
@@ -181,7 +181,7 @@ class MulticastSession extends FOGController
     {
         $max = (int)self::getSetting('FOG_MULTICAST_MAX_SESSIONS');
         if ($max > 0 && self::activeCount() >= $max) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     _('Server is only configured to run %d multicast tasks'),
                     $max
@@ -263,7 +263,7 @@ class MulticastSession extends FOGController
                 return $port;
             }
         }
-        throw new Exception(
+        throw new \Exception(
             _('Every configured multicast port is already in use')
         );
     }

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -301,9 +301,9 @@ class OpenAPI extends FOGBase
             if (is_array($vars) && isset($vars['databaseFields'])) {
                 $result = $vars;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $result = null;
-        } catch (Error $e) {
+        } catch (\Error $e) {
             // A plugin class naming a parent that is not loaded raises Error,
             // not Exception, and one broken plugin must not take the whole
             // document down with it.

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -521,8 +521,8 @@ class Plugin extends FOGController
         // PharData reads .tar.gz without shelling out and, crucially, lets the
         // entry list be inspected before anything is extracted.
         try {
-            $phar = new PharData($archive, 0, null, Phar::TAR | Phar::GZ);
-        } catch (Exception $e) {
+            $phar = new \PharData($archive, 0, null, \Phar::TAR | \Phar::GZ);
+        } catch (\Exception $e) {
             return $fail(
                 sprintf(
                     _('%s is not a readable .tar.gz archive.'),
@@ -535,9 +535,9 @@ class Plugin extends FOGController
         $hasManifest = false;
         $fileCount = 0;
         try {
-            $walk = new RecursiveIteratorIterator(
+            $walk = new \RecursiveIteratorIterator(
                 $phar,
-                RecursiveIteratorIterator::SELF_FIRST
+                \RecursiveIteratorIterator::SELF_FIRST
             );
             foreach ($walk as $entry) {
                 $rel = str_replace('\\', '/', $entry->getPathname());
@@ -575,7 +575,7 @@ class Plugin extends FOGController
                     $hasManifest = true;
                 }
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $fail(_('The archive could not be read.'));
         }
         if (count($tops) !== 1) {
@@ -614,7 +614,7 @@ class Plugin extends FOGController
         }
         try {
             $phar->extractTo($dir, null, true);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $fail(_('The archive could not be extracted.'));
         }
         $staged = $dir . $top;
@@ -1114,7 +1114,7 @@ class Plugin extends FOGController
         if (file_exists($managerFile)
             && strcasecmp(get_class($manager), $wanted) !== 0
         ) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     _('%s could not be loaded. Check that %s declares a class of that exact name.'),
                     $wanted,

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -202,7 +202,7 @@ class Schema extends FOGController
         $dump = self::getClass('Mysqldump');
         $dump->start($file);
         if (!file_exists($file) || !is_readable($file)) {
-            throw new Exception(_('Could not read tmp file.'));
+            throw new \Exception(_('Could not read tmp file.'));
         }
         if ($remove_file) {
             while (ob_get_level()) {
@@ -239,7 +239,7 @@ class Schema extends FOGController
         set_time_limit(0);
 
         if (false === ($fh = fopen($file, 'rb'))) {
-            throw new Exception(_('Error Opening DB File'));
+            throw new \Exception(_('Error Opening DB File'));
         }
 
         $error = '';
@@ -459,7 +459,7 @@ class Schema extends FOGController
         $exists
     ) {
         if (!is_bool($exists)) {
-            throw new Exception(_('Exists item must be boolean'));
+            throw new \Exception(_('Exists item must be boolean'));
         }
         $string = sprintf(
             'CREATE DATABASE %s`%s`',
@@ -504,12 +504,12 @@ class Schema extends FOGController
         $autoin = ''
     ) {
         if (empty($name)) {
-            throw new Exception(_('Must have a name to create the table'));
+            throw new \Exception(_('Must have a name to create the table'));
         }
         $fieldCount = count($fields);
         $typeCount = count($types);
         if ($fieldCount !== $typeCount) {
-            throw new Exception(_('Fields and types must have equal count'));
+            throw new \Exception(_('Fields and types must have equal count'));
         }
         if (empty($engine)) {
             $engine = 'InnoDB';
@@ -656,7 +656,7 @@ class Schema extends FOGController
     public static function dropTable($name)
     {
         if (empty($name)) {
-            throw new Exception(_('Need the table name to drop'));
+            throw new \Exception(_('Need the table name to drop'));
         }
         return sprintf(
             'DROP TABLE IF EXISTS `%s`',
@@ -766,7 +766,7 @@ class Schema extends FOGController
                     // an admin on the updater page for a probe that cannot run.
                     continue;
                 }
-                $row = $res->fetch(PDO::FETCH_ASSOC)->get();
+                $row = $res->fetch(\PDO::FETCH_ASSOC)->get();
                 if (is_array($row) && isset($row['cnt']) && (int)$row['cnt'] < 1) {
                     return true;
                 }
@@ -795,7 +795,7 @@ class Schema extends FOGController
                 if (false !== $res->error) {
                     return $res->error;
                 }
-                $row = $res->fetch(PDO::FETCH_ASSOC)->get();
+                $row = $res->fetch(\PDO::FETCH_ASSOC)->get();
                 // Unreadable count is not "absent" -- inserting on a failed
                 // probe is how you end up with duplicates. Skip instead.
                 if (!is_array($row) || !isset($row['cnt'])) {

--- a/packages/web/lib/fog/schemareconciler.class.php
+++ b/packages/web/lib/fog/schemareconciler.class.php
@@ -125,7 +125,7 @@ class SchemaReconciler extends FOGBase
         if (false !== $res->error) {
             return null;
         }
-        $rows = $res->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         if (!is_array($rows)) {
             return null;
         }

--- a/packages/web/lib/fog/snapin.class.php
+++ b/packages/web/lib/fog/snapin.class.php
@@ -163,7 +163,7 @@ class Snapin extends FOGController
     public function deleteFile()
     {
         if ($this->get('protected')) {
-            throw new Exception(self::$foglang['ProtectedSnapin']);
+            throw new \Exception(self::$foglang['ProtectedSnapin']);
         }
         foreach ($this->get('storagegroups') as $storagegroupID) {
             self::getClass('filedeletequeue')
@@ -283,7 +283,7 @@ class Snapin extends FOGController
             $groupids = Route::getIds('storagegroup', false);
             $groupids = [self::minId($groupids)];
             if (count($groupids) < 1) {
-                throw new Exception(_('No viable storage groups found'));
+                throw new \Exception(_('No viable storage groups found'));
             }
         }
         $primaryGroup = [];

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -302,7 +302,7 @@ class StorageGroup extends FOGController
             ]
         );
         if (empty($StorageNode) || !$StorageNode->isValid()) {
-            throw new Exception(_('No master nodes available'));
+            throw new \Exception(_('No master nodes available'));
         }
         return $StorageNode;
     }
@@ -355,7 +355,7 @@ class StorageGroup extends FOGController
             ]
         );
         if (empty($StorageNode) || !$StorageNode->isValid()) {
-            throw new Exception(_('No nodes available'));
+            throw new \Exception(_('No nodes available'));
         }
         return $StorageNode;
     }

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -200,7 +200,7 @@ class Task extends TaskType
              ->set('checkInTime', $curtime->format('Y-m-d H:i:s'))
              ->set('scheduledStartTime', '0000-00-00 00:00:00');
         if (!$this->save()) {
-            throw new Exception(_('Failed to update task'));
+            throw new \Exception(_('Failed to update task'));
         }
         return true;
     }
@@ -363,7 +363,7 @@ class Task extends TaskType
             $store_update = true;
         }
         if ($store_update && !$this->save()) {
-            throw new Exception(_('Failed to update task'));
+            throw new \Exception(_('Failed to update task'));
         }
     }
     /**

--- a/packages/web/lib/fog/uploadexception.class.php
+++ b/packages/web/lib/fog/uploadexception.class.php
@@ -19,7 +19,7 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
-class UploadException extends Exception
+class UploadException extends \Exception
 {
     /**
      * Initializes the upload exception.

--- a/packages/web/lib/fog/wakeonlan.class.php
+++ b/packages/web/lib/fog/wakeonlan.class.php
@@ -53,7 +53,7 @@ class WakeOnLan extends FOGBase
         if (self::$_arrMAC === false
             || count(self::$_arrMAC) < 0
         ) {
-            throw new Exception(self::$foglang['InvalidMAC']);
+            throw new \Exception(self::$foglang['InvalidMAC']);
         }
         $BroadCast = self::fastmerge(
             (array) '255.255.255.255',

--- a/packages/web/lib/pages/UserGroupManagement.page.php
+++ b/packages/web/lib/pages/UserGroupManagement.page.php
@@ -136,7 +136,7 @@ class UserGroupManagement extends FOGPage
                 $exists = self::getClass('UserGroupManager')
                     ->exists($usergroup);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A user group already exists with this name!')
                     );
                 }
@@ -145,7 +145,7 @@ class UserGroupManagement extends FOGPage
                     ->set('description', $description);
                 if (!$UserGroup->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add user group failed!'));
+                    throw new \Exception(_('Add user group failed!'));
                 }
                 return $UserGroup;
             }
@@ -241,7 +241,7 @@ class UserGroupManagement extends FOGPage
         if ($usergroup != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A user group with this name already exists!')
             );
         }
@@ -281,7 +281,7 @@ class UserGroupManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -318,7 +318,7 @@ class UserGroupManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -387,7 +387,7 @@ class UserGroupManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('User group update failed!'));
+                    throw new \Exception(_('User group update failed!'));
                 }
                 Authorization::resetCache();
             }

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -614,14 +614,14 @@ class DashboardPage extends FOGPage
                 ':start' => $start->format('Y-m-d H:i:s'),
                 ':end' => $end->format('Y-m-d H:i:s')
             ]
-        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $counts = [];
         foreach ((array)$rows as $row) {
             $counts[$row['d']] = (int)$row['c'];
         }
         // Emit a continuous, zero-filled series so every day has a point.
-        $int = new DateInterval('P1D');
-        $period = new DatePeriod($start, $int, $end);
+        $int = new \DateInterval('P1D');
+        $period = new \DatePeriod($start, $int, $end);
         $data = [];
         foreach ($period as $date) {
             $key = $date->format('Y-m-d');

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -877,10 +877,10 @@ class FOGConfigurationPage extends FOGPage
         $_SESSION['dl-' . $type . '-file'] = $file;
         try {
             if (empty($dstName)) {
-                throw new Exception(_('A filename is required!'));
+                throw new \Exception(_('A filename is required!'));
             }
             if (empty($file)) {
-                throw new Exception(
+                throw new \Exception(
                     _('No external data to download the file from')
                 );
             }
@@ -891,7 +891,7 @@ class FOGConfigurationPage extends FOGPage
                     'title' => _('Download Starting')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->_jsonExit(
                 HTTPResponseCodes::HTTP_BAD_REQUEST,
                 [
@@ -1153,7 +1153,7 @@ class FOGConfigurationPage extends FOGPage
                     $set = intval($set) < 1 ? 0 : 1;
                 } elseif (isset($needstobenumeric[$name])) {
                     if (isset($needstobenumeric[$name]) && !is_numeric($set)) {
-                        throw new Exception(
+                        throw new \Exception(
                             $name . ' ' . _('value must be numeric')
                         );
                     }
@@ -1172,7 +1172,7 @@ class FOGConfigurationPage extends FOGPage
                 ];
                 if (!$SettingMan->insertBatch($insert_fields, $items)) {
                     $serverFault = true;
-                    throw new Exception(_('Settings update failed!'));
+                    throw new \Exception(_('Settings update failed!'));
                 }
                 // Writes globalSettings directly rather than through
                 // setSetting(), so nothing invalidated the shared settings
@@ -1186,7 +1186,7 @@ class FOGConfigurationPage extends FOGPage
                     'title' => _('iPXE Config Update Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -1769,7 +1769,7 @@ class FOGConfigurationPage extends FOGPage
                 break;
             case 'FOG_TZ_INFO':
                 $dt = self::niceDate('now');
-                $tzIDs = DateTimeZone::listIdentifiers();
+                $tzIDs = \DateTimeZone::listIdentifiers();
                 ob_start();
                 echo '<select class="form-control" name="'
                     . $row['settingID']
@@ -2135,7 +2135,7 @@ class FOGConfigurationPage extends FOGPage
                         $set = 0;
                     }
                     if (!is_numeric($set)) {
-                        throw new Exception(
+                        throw new \Exception(
                             $name . ' ' . _('value must be numeric')
                         );
                     }
@@ -2146,14 +2146,14 @@ class FOGConfigurationPage extends FOGPage
                                 && $set >= $constraint['min']
                                 && $set <= $constraint['max']);
                         if (!$inRange) {
-                            throw new Exception(
+                            throw new \Exception(
                                 $name . ' ' . _('value is not in the required range')
                             );
                         }
                     }
                 } elseif (isset($needstobeip[$name])) {
                     if (!filter_var($set, FILTER_VALIDATE_IP) and $set != 0 and $set) {
-                        throw new Exception(
+                        throw new \Exception(
                             $name . ' ' . _('value must be a valid IP Address')
                         );
                     }
@@ -2171,7 +2171,7 @@ class FOGConfigurationPage extends FOGPage
                         break;
                     case 'FOG_MEMORY_LIMIT':
                         if ($set < 128) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('Memory limit cannot be less than 128')
                             );
                         }
@@ -2212,17 +2212,17 @@ class FOGConfigurationPage extends FOGPage
                         ];
                         $extensionCheck = strtolower(pathinfo($set, PATHINFO_EXTENSION));
                         if (!in_array($extensionCheck, $validExtensions)) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('Upload file extension must be, jpg, jpeg, or png')
                             );
                         }
                         if ($width != 650) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('Width must be 650 pixels.')
                             );
                         }
                         if ($height != 120) {
-                            throw new Exception(
+                            throw new \Exception(
                                 _('Height must be 120 pixels.')
                             );
                         }
@@ -2241,7 +2241,7 @@ class FOGConfigurationPage extends FOGPage
                         if (!move_uploaded_file($src, $dest)) {
                             self::setSetting('FOG_CLIENT_BANNER_SHA', '');
                             $set = '';
-                            throw new Exception(_('Failed to install logo file'));
+                            throw new \Exception(_('Failed to install logo file'));
                         } else {
                             self::setSetting('FOG_CLIENT_BANNER_SHA', $hash);
                         }
@@ -2258,7 +2258,7 @@ class FOGConfigurationPage extends FOGPage
                 ];
                 if (!$SettingMan->insertBatch($insert_fields, $items)) {
                     $serverFault = true;
-                    throw new Exception(_('Settings update failed!'));
+                    throw new \Exception(_('Settings update failed!'));
                 }
                 // This saver writes globalSettings directly (insertBatch /
                 // Setting->save()) rather than through setSetting(), so
@@ -2281,7 +2281,7 @@ class FOGConfigurationPage extends FOGPage
                     'title' => _('Settings Update Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -2314,7 +2314,7 @@ class FOGConfigurationPage extends FOGPage
                     'title' => _('Cache Flushed')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->_jsonExit(
                 HTTPResponseCodes::HTTP_BAD_REQUEST,
                 [
@@ -2345,7 +2345,7 @@ class FOGConfigurationPage extends FOGPage
                     'title' => _('Cache Refreshed')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->_jsonExit(
                 HTTPResponseCodes::HTTP_BAD_REQUEST,
                 [
@@ -2464,7 +2464,7 @@ class FOGConfigurationPage extends FOGPage
             . '`settingValue`, `settingCategory` FROM `' . $table . '` '
             . 'ORDER BY `settingCategory` ASC, `settingKey` ASC';
         $rows = self::$DB->query($sql)
-            ->fetch(PDO::FETCH_ASSOC, 'fetch_all')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
             ->get();
 
         $byCat = [];
@@ -2842,7 +2842,7 @@ class FOGConfigurationPage extends FOGPage
                 $files[$StorageNode->name] = array_filter(
                     (array)$files[$StorageNode->name]
                 );
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 $files[$StorageNode->name] = [
                     $e->getMessage() => null,
                 ];
@@ -3095,7 +3095,7 @@ class FOGConfigurationPage extends FOGPage
                 $data = '';
                 self::getClass('Mysqldump')->start($tmpfile);
                 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {
-                    throw new Exception(_('Could not read file from tmp folder.'));
+                    throw new \Exception(_('Could not read file from tmp folder.'));
                 }
                 $fh = fopen($tmpfile, 'rb');
                 while (!feof($fh)) {
@@ -3120,25 +3120,25 @@ class FOGConfigurationPage extends FOGPage
 
                 // Basic size sanity (e.g., 10 MB cap; adjust as you like)
                 if (!isset($_FILES['dbFile']['size']) || $_FILES['dbFile']['size'] > (10 * 1024 * 1024)) {
-                    throw new Exception(_('Uploaded file too large.'));
+                    throw new \Exception(_('Uploaded file too large.'));
                 }
 
                 // Must be an uploaded file
                 if (!is_uploaded_file($_FILES['dbFile']['tmp_name'])) {
-                    throw new Exception(_('Invalid upload.'));
+                    throw new \Exception(_('Invalid upload.'));
                 }
 
                 // Move to a safe temp file we control
                 $dest = sys_get_temp_dir() . DS . 'fog_import_' . bin2hex(random_bytes(8)) . '.sql';
                 if (!move_uploaded_file($_FILES['dbFile']['tmp_name'], $dest)) {
-                    throw new Exception(_('Failed to move uploaded file.'));
+                    throw new \Exception(_('Failed to move uploaded file.'));
                 }
 
                 // Quick sniff: must look like SQL dump (CREATE/INSERT or mysqldump header)
                 $head = file_get_contents($dest, false, null, 0, 4096);
                 if ($head === false || !preg_match('/(CREATE\s+TABLE|INSERT\s+INTO|mysqldump)/i', $head)) {
                     @unlink($dest);
-                    throw new Exception(_('Not a recognizable SQL dump.'));
+                    throw new \Exception(_('Not a recognizable SQL dump.'));
                 }
 
                 // Now import
@@ -3149,7 +3149,7 @@ class FOGConfigurationPage extends FOGPage
                 }
                 if (true !== $result) {
                     $serverFault = true;
-                    throw new Exception(_('Import failed!'));
+                    throw new \Exception(_('Import failed!'));
                 }
                 $code = HTTPResponseCodes::HTTP_ACCEPTED;
                 $hook = 'CONFIG_IMPORT_SUCCESS';
@@ -3160,7 +3160,7 @@ class FOGConfigurationPage extends FOGPage
                     ]
                 );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -217,7 +217,7 @@ class GroupManagement extends FOGPage
                 $exists = self::getClass('GroupManager')
                     ->exists($group);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A group already exists with this name!')
                     );
                 }
@@ -230,7 +230,7 @@ class GroupManagement extends FOGPage
                     ->set('init', $init);
                 if (!$Group->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add group failed!'));
+                    throw new \Exception(_('Add group failed!'));
                 }
                 return $Group;
             }
@@ -694,7 +694,7 @@ class GroupManagement extends FOGPage
             $productKey = $key;
         } else {
             if (!self::productKeyIsValid($key)) {
-                throw new Exception(_('Invalid Windows product key'));
+                throw new \Exception(_('Invalid Windows product key'));
             }
             $productKey = self::productKeyFormat($key);
         }
@@ -718,7 +718,7 @@ class GroupManagement extends FOGPage
         );
         if ($group != $this->obj->get('name')) {
             if ($this->obj->getManager()->exists($group)) {
-                throw new Exception(_('Please use another group name'));
+                throw new \Exception(_('Please use another group name'));
             }
         }
         // Set the group relative items.
@@ -1642,7 +1642,7 @@ class GroupManagement extends FOGPage
             $dow = trim((string)filter_input(INPUT_POST, 'scheduleCronDOW'));
             $action = filter_input(INPUT_POST, 'action');
             if (!$action) {
-                throw new Exception(_('You must select an action to perform'));
+                throw new \Exception(_('You must select an action to perform'));
             }
             $items = [];
             if ($onDemand && $action === 'wol') {
@@ -2597,7 +2597,7 @@ class GroupManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Group update failed!'));
+                    throw new \Exception(_('Group update failed!'));
                 }
             }
         );
@@ -3145,13 +3145,13 @@ class GroupManagement extends FOGPage
             $hosts = $this->obj->get('hosts');
 
             if (!$TaskType->isValid()) {
-                throw new Exception(_('Task type is invalid'));
+                throw new \Exception(_('Task type is invalid'));
             }
             if (count($hosts ?: []) < 1) {
-                throw new Exception(_('There are no hosts to task'));
+                throw new \Exception(_('There are no hosts to task'));
             }
             if ($iscapturetask) {
-                throw new Exception(_('Groups cannot create capture tasks'));
+                throw new \Exception(_('Groups cannot create capture tasks'));
             }
 
             $labelClass = 'col-sm-3 col-form-label';
@@ -3326,7 +3326,7 @@ class GroupManagement extends FOGPage
                 ]
             );
             $code = HTTPResponseCodes::HTTP_SUCCESS;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $msg = json_encode(
                 [
                     'error' => $e->getMessage(),
@@ -3365,7 +3365,7 @@ class GroupManagement extends FOGPage
                 $find
             );
             if (count($hosts ?: []) < 1) {
-                throw new Exception(_('No hosts available to be tasked'));
+                throw new \Exception(_('No hosts available to be tasked'));
             }
             $nhosts = [];
             $hostImages = [];
@@ -3385,7 +3385,7 @@ class GroupManagement extends FOGPage
                 unset($host);
             }
             if (count($nhosts ?: []) < 1) {
-                throw new Exception(_('No hosts are assigned an image'));
+                throw new \Exception(_('No hosts are assigned an image'));
             }
 
             // Multicast task requires all hosts in the group to have the same
@@ -3397,7 +3397,7 @@ class GroupManagement extends FOGPage
                     )
                 );
                 if (count($hostImages ?: []) != 1) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('All hosts must have the same image assigned')
                     );
                 }
@@ -3406,7 +3406,7 @@ class GroupManagement extends FOGPage
             // Task Type setup
             $TaskType = self::getClass('TaskType', $type);
             if (!$TaskType->isValid()) {
-                throw new Exception(_('Task Type is invalid'));
+                throw new \Exception(_('Task Type is invalid'));
             }
 
             // Password reset setup
@@ -3416,7 +3416,7 @@ class GroupManagement extends FOGPage
             if (TaskType::PASSWORD_RESET == $type
                 && !$passreset
             ) {
-                throw new Exception(_('Password reset requires a user account'));
+                throw new \Exception(_('Password reset requires a user account'));
             }
 
             // Snapin setup
@@ -3468,7 +3468,7 @@ class GroupManagement extends FOGPage
             // Task Type Imaging Checks
             if ($TaskType->isImagingTask()) {
                 if ($TaskType->isCapture()) {
-                    throw new Exception(_('Groups cannot create capture tasks'));
+                    throw new \Exception(_('Groups cannot create capture tasks'));
                 }
             }
 
@@ -3518,7 +3518,7 @@ class GroupManagement extends FOGPage
                 }
                 if (!$ScheduledTask->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Failed to create scheduled task'));
+                    throw new \Exception(_('Failed to create scheduled task'));
                 }
             }
             $code = HTTPResponseCodes::HTTP_CREATED;
@@ -3529,7 +3529,7 @@ class GroupManagement extends FOGPage
                     'title' => _('Create Task Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -453,7 +453,7 @@ class HostManagement extends FOGPage
                 );
                 $code = HTTPResponseCodes::HTTP_ACCEPTED;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -991,19 +991,19 @@ class HostManagement extends FOGPage
                 $exists = self::getClass('HostManager')
                     ->exists($host);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A host already exists with this name!')
                     );
                 }
                 $MAC = new MACAddress($mac);
                 if (!$MAC->isValid()) {
-                    throw new Exception(_('MAC Format is invalid'));
+                    throw new \Exception(_('MAC Format is invalid'));
                 }
                 self::getClass('HostManager')->getHostByMacAddresses(
                     $MAC->__toString()
                 );
                 if (self::$Host->isValid()) {
-                    throw new Exception(
+                    throw new \Exception(
                         sprintf(
                             '%s: %s',
                             _('A host with this mac already exists with name'),
@@ -1041,7 +1041,7 @@ class HostManagement extends FOGPage
                     );
                 if (!self::$Host->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add host failed!'));
+                    throw new \Exception(_('Add host failed!'));
                 }
                 return self::$Host;
             }
@@ -1332,17 +1332,17 @@ class HostManagement extends FOGPage
         $enforce = filter_has_var(INPUT_POST, 'enforce') ? 1 : 0;
         if (strtolower($host) != strtolower($this->obj->get('name'))) {
             if (!$this->obj->isHostnameSafe($host)) {
-                throw new Exception(_('Please enter a valid hostname'));
+                throw new \Exception(_('Please enter a valid hostname'));
             }
             if ($this->obj->getManager()->exists($host)) {
-                throw new Exception(_('Please use another hostname'));
+                throw new \Exception(_('Please use another hostname'));
             }
         }
         $Task = $this->obj->get('task');
         if ($Task->isValid()
             && $imageID != $this->obj->get('imageID')
         ) {
-            throw new Exception(_('Cannot change image when in tasking'));
+            throw new \Exception(_('Cannot change image when in tasking'));
         }
         $this->obj
             ->set('name', $host)
@@ -1545,12 +1545,12 @@ class HostManagement extends FOGPage
             );
             $mact = new MACAddress($mac);
             if (!$mact->isValid()) {
-                throw new Exception(_('MAC Address is invalid!'));
+                throw new \Exception(_('MAC Address is invalid!'));
             }
             $mace = self::getClass('MACAddressAssociationManager')
                 ->exists($mac, '', 'mac');
             if ($mace) {
-                throw new Exception(
+                throw new \Exception(
                     _('MAC Address already exists')
                 );
             }
@@ -1659,7 +1659,7 @@ class HostManagement extends FOGPage
             );
 
             if (count($hasPrimary ?: []) > 0) {
-                throw new Exception(
+                throw new \Exception(
                     _('Cannot delete the primary mac address, please reselect')
                 );
             }
@@ -1677,7 +1677,7 @@ class HostManagement extends FOGPage
             );
 
             if (count($toRemove ?: []) < 1) {
-                throw new Exception(
+                throw new \Exception(
                     _('No mac addresses to be removed')
                 );
             }
@@ -2494,7 +2494,7 @@ class HostManagement extends FOGPage
             );
             extract($items);
             if (!$action) {
-                throw new Exception(
+                throw new \Exception(
                     _('You must select an action to perform')
                 );
             }
@@ -3568,11 +3568,11 @@ class HostManagement extends FOGPage
                         break;
                 }
                 if (!$this->obj->isValid()) {
-                    throw new Exception(_('Host is not valid!'));
+                    throw new \Exception(_('Host is not valid!'));
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Host update failed!'));
+                    throw new \Exception(_('Host update failed!'));
                 }
             }
         );
@@ -3599,10 +3599,10 @@ class HostManagement extends FOGPage
         $groups_new = $items['groups_new'];
         try {
             if (!count($hosts ?: [])) {
-                throw new Exception(_('No hosts selected to be added'));
+                throw new \Exception(_('No hosts selected to be added'));
             }
             if (!count($groups ?: []) && !count($groups_new ?: [])) {
-                throw new Exception(_('No groups are being created or selected'));
+                throw new \Exception(_('No groups are being created or selected'));
             }
             if (count($groups ?: [])) {
                 foreach ($groups as &$group) {
@@ -3630,7 +3630,7 @@ class HostManagement extends FOGPage
                     'title' => _('Add Hosts to Groups Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $msg = json_encode(
                 [
@@ -4018,23 +4018,23 @@ class HostManagement extends FOGPage
             $image = $this->obj->getImage();
 
             if ($this->obj->get('pending') > 0) {
-                throw new Exception(_('Cannot task pending hosts'));
+                throw new \Exception(_('Cannot task pending hosts'));
             }
             if ($imagingTypes
                 && !$image->isValid()
             ) {
-                throw new Exception(_('Assigned image is invalid'));
+                throw new \Exception(_('Assigned image is invalid'));
             }
             if ($imagingTypes
                 && $image->get('isEnabled') < 1
             ) {
-                throw new Exception(_('Assigned image is not enabled'));
+                throw new \Exception(_('Assigned image is not enabled'));
             }
             if ($imagingTypes
                 && $iscapturetask
                 && $image->get('protected')
             ) {
-                throw new Exception(_('Assigned image is protected'));
+                throw new \Exception(_('Assigned image is protected'));
             }
             $labelClass = 'col-sm-3 col-form-label';
             $fields = [];
@@ -4230,7 +4230,7 @@ class HostManagement extends FOGPage
                 ]
             );
             $code = HTTPResponseCodes::HTTP_SUCCESS;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $msg = json_encode(
                 [
                     'error' => $e->getMessage(),
@@ -4263,7 +4263,7 @@ class HostManagement extends FOGPage
             $TaskType = json_decode(Route::getData());
             // Pending check.
             if ($this->obj->get('pending')) {
-                throw new Exception(_('Pending hosts cannot be tasked'));
+                throw new \Exception(_('Pending hosts cannot be tasked'));
             }
             // Password reset setup
             $passreset = trim(
@@ -4272,7 +4272,7 @@ class HostManagement extends FOGPage
             if (TaskType::PASSWORD_RESET == $TaskType->id
                 && !$passreset
             ) {
-                throw new Exception(_('Password reset requires a user account'));
+                throw new \Exception(_('Password reset requires a user account'));
             }
 
             // Snapin setup
@@ -4334,15 +4334,15 @@ class HostManagement extends FOGPage
             if ($TaskType->isImagingTask) {
                 $Image = $this->obj->getImage();
                 if (!$Image->isValid()) {
-                    throw new Exception(_('Image is invalid'));
+                    throw new \Exception(_('Image is invalid'));
                 }
                 if (!$Image->get('isEnabled')) {
-                    throw new Exception(_('Image is not enabled'));
+                    throw new \Exception(_('Image is not enabled'));
                 }
                 if ($TaskType->isCapture
                     && $Image->get('protected')
                 ) {
-                    throw new Exception(_('Image is protected'));
+                    throw new \Exception(_('Image is protected'));
                 }
             }
 
@@ -4391,7 +4391,7 @@ class HostManagement extends FOGPage
                 }
                 if (!$ScheduledTask->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Failed to create scheduled task'));
+                    throw new \Exception(_('Failed to create scheduled task'));
                 }
             }
 
@@ -4403,7 +4403,7 @@ class HostManagement extends FOGPage
                     'title' => _('Create Task Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -69,7 +69,7 @@ class ImageManagement extends FOGPage
     {
         try {
             return $StorageGroup->getMasterStorageNode();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $getter = count($StorageGroup->get('enablednodes')) > 0
                 ? 'enablednodes'
                 : 'allnodes';
@@ -437,19 +437,19 @@ class ImageManagement extends FOGPage
                 $exists = self::getClass('ImageManager')
                     ->exists($image);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('An image already exists with this name!')
                     );
                 }
                 if (in_array($path, ['postdownloadscripts','dev'])) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Please choose a different filename/path as this is reserved')
                     );
                 }
                 $exists = self::getClass('ImageManager')
                     ->exists($path, '', 'path');
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('The path requested is already in use by another image!')
                     );
                 }
@@ -467,7 +467,7 @@ class ImageManagement extends FOGPage
                     ->addGroup($storagegroup);
                 if (!$Image->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add image failed!'));
+                    throw new \Exception(_('Add image failed!'));
                 }
                 /**
                  * During image creation we only allow a single group anyway.
@@ -813,7 +813,7 @@ class ImageManagement extends FOGPage
             filter_input(INPUT_POST, 'compression')
         );
         if ($this->obj->get('name') != $image && $exists) {
-            throw new Exception(_('An image with this name already exists!'));
+            throw new \Exception(_('An image with this name already exists!'));
         }
         $imagemanage = (int)trim(
             filter_input(INPUT_POST, 'imagemanage')
@@ -1101,7 +1101,7 @@ class ImageManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Image update failed!'));
+                    throw new \Exception(_('Image update failed!'));
                 }
             }
         );
@@ -1355,16 +1355,16 @@ class ImageManagement extends FOGPage
         );
         $sessionshutdown = (int)isset($_POST['sessionshutdown']);
         if (!$image) {
-            throw new Exception(_('Please choose an image'));
+            throw new \Exception(_('Please choose an image'));
         }
         $Image = new Image($image);
         if (!$Image->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 _('Please select a valid image')
             );
         }
         if (self::getClass('MulticastSessionManager')->exists($sessionname)) {
-            throw new Exception(_('Session with that name already exists!'));
+            throw new \Exception(_('Session with that name already exists!'));
         }
         if ($sessioncount < 1) {
             $sessioncount = Route::getCount('host');
@@ -1441,7 +1441,7 @@ class ImageManagement extends FOGPage
                     $MulticastSession = $this->sessionCreate();
                     if (!$MulticastSession->save()) {
                         $serverFault = true;
-                        throw new Exception(_('Failed to create Session'));
+                        throw new \Exception(_('Failed to create Session'));
                     }
 
                     // The port was already chosen by
@@ -1467,7 +1467,7 @@ class ImageManagement extends FOGPage
             );
             $code = 201;
             $hook = 'IMAGE_MULTICAST_SESSION_SUCCESS';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = ($serverFault ? 500 : 400);
             $hook = 'IMAGE_MULTICAST_SESSION_FAIL';
             $msg = json_encode(

--- a/packages/web/lib/pages/ipxemanagement.page.php
+++ b/packages/web/lib/pages/ipxemanagement.page.php
@@ -260,7 +260,7 @@ class IpxeManagement extends FOGPage
                 $exists = self::getClass('PXEMenuOptionsManager')
                     ->exists($ipxe);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A menu entry already exists with this name!')
                     );
                 }
@@ -282,7 +282,7 @@ class IpxeManagement extends FOGPage
                 }
                 if (!$iPXE->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add menu failed!'));
+                    throw new \Exception(_('Add menu failed!'));
                 }
                 return $iPXE;
             }
@@ -489,7 +489,7 @@ class IpxeManagement extends FOGPage
         $exists = self::getClass('PXEMenuOptionsManager')
             ->exists($ipxe);
         if ($this->obj->get('name') != $ipxe && $exists) {
-            throw new Exception(
+            throw new \Exception(
                 _('A menu entry already exists with this name!')
             );
         }
@@ -549,7 +549,7 @@ class IpxeManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Menu update failed!'));
+                    throw new \Exception(_('Menu update failed!'));
                 }
             }
         );

--- a/packages/web/lib/pages/modulemanagement.page.php
+++ b/packages/web/lib/pages/modulemanagement.page.php
@@ -176,7 +176,7 @@ class ModuleManagement extends FOGPage
                 $exists = self::getClass('ModuleManager')
                     ->exists($module);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A module already exists with this name!')
                     );
                 }
@@ -187,7 +187,7 @@ class ModuleManagement extends FOGPage
                     ->set('isDefault', $isDefault);
                 if (!$Module->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add module failed!'));
+                    throw new \Exception(_('Add module failed!'));
                 }
                 return $Module;
             }
@@ -324,7 +324,7 @@ class ModuleManagement extends FOGPage
         $isDefault = (int)isset($_POST['isDefault']);
         if ($module != $this->obj->get('name')) {
             if ($this->obj->getManager()->exists($module)) {
-                throw new Exception(_('Please use another module name'));
+                throw new \Exception(_('Please use another module name'));
             }
         }
         // Set the module relative items.
@@ -417,7 +417,7 @@ class ModuleManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Module update failed!'));
+                    throw new \Exception(_('Module update failed!'));
                 }
             }
         );

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -349,15 +349,15 @@ class PluginManagement extends FOGPage
         try {
             $blocked = self::uploadsBlocked();
             if ('' !== $blocked) {
-                throw new Exception($blocked);
+                throw new \Exception($blocked);
             }
             if (!isset($_FILES['pluginarchive'])
                 || !is_uploaded_file((string)$_FILES['pluginarchive']['tmp_name'])
             ) {
-                throw new Exception(_('No archive was uploaded.'));
+                throw new \Exception(_('No archive was uploaded.'));
             }
             if ($_FILES['pluginarchive']['error'] > 0) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         _('The upload failed (error %s). It may be larger than post_max_size, currently %s.'),
                         $_FILES['pluginarchive']['error'],
@@ -370,12 +370,12 @@ class PluginManagement extends FOGPage
                 basename((string)$_FILES['pluginarchive']['name'])
             );
             if (isset($staged['error'])) {
-                throw new Exception($staged['error']);
+                throw new \Exception($staged['error']);
             }
             $code = HTTPResponseCodes::HTTP_SUCCESS;
             $hook = 'PLUGIN_ARCHIVE_STAGED';
             $msg = json_encode($staged);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -433,12 +433,12 @@ class PluginManagement extends FOGPage
         try {
             $blocked = self::uploadsBlocked();
             if ('' !== $blocked) {
-                throw new Exception($blocked);
+                throw new \Exception($blocked);
             }
             $token = (string)filter_input(INPUT_POST, 'token');
             $result = Plugin::commitStaged($token);
             if (isset($result['error'])) {
-                throw new Exception($result['error']);
+                throw new \Exception($result['error']);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'PLUGIN_ARCHIVE_SUCCESS';
@@ -453,7 +453,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Upload Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -502,7 +502,7 @@ class PluginManagement extends FOGPage
         foreach ($blockers as $name => $reason) {
             $reasons[] = sprintf('%s %s', $name, $reason);
         }
-        throw new Exception(implode('; ', $reasons));
+        throw new \Exception(implode('; ', $reasons));
     }
     /**
      * Just a place holder
@@ -540,7 +540,7 @@ class PluginManagement extends FOGPage
             $PluginManager = self::getClass('PluginManager');
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
-                throw new Exception(_('Activate plugins failed!'));
+                throw new \Exception(_('Activate plugins failed!'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'PLUGIN_ACTIVATE_SUCCESS';
@@ -554,7 +554,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Activate Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -616,7 +616,7 @@ class PluginManagement extends FOGPage
             $PluginManager = self::getClass('PluginManager');
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
-                throw new Exception(_('Activate plugins failed!'));
+                throw new \Exception(_('Activate plugins failed!'));
             }
             Route::listem(
                 'plugin',
@@ -631,7 +631,7 @@ class PluginManagement extends FOGPage
             foreach ($Plugins->data as &$Plugin) {
                 $pluginObj = self::getClass('Plugin', $Plugin->id);
                 if (!$pluginObj->installdb()) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Failed to install ')
                         . $Plugin->name
                     );
@@ -640,7 +640,7 @@ class PluginManagement extends FOGPage
             }
             if (!$PluginManager->update($ids, '', $install)) {
                 $serverFault = true;
-                throw new Exception(_('Install plugins failed!'));
+                throw new \Exception(_('Install plugins failed!'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'PLUGIN_INSTALL_SUCCESS';
@@ -654,7 +654,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Install Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -730,7 +730,7 @@ class PluginManagement extends FOGPage
             foreach ($Plugins->data as &$Plugin) {
                 $pluginObj = self::getClass('Plugin', $Plugin->id);
                 if (!$pluginObj->installdb()) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Failed to update ')
                         . $Plugin->name
                     );
@@ -749,7 +749,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Update Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -809,7 +809,7 @@ class PluginManagement extends FOGPage
             $PluginManager = self::getClass('PluginManager');
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
-                throw new Exception(_('Deactivate plugins failed!'));
+                throw new \Exception(_('Deactivate plugins failed!'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'PLUGIN_DEACTIVATE_SUCCESS';
@@ -819,7 +819,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Deactivate Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -888,7 +888,7 @@ class PluginManagement extends FOGPage
             $PluginManager = self::getClass('PluginManager');
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
-                throw new Exception(_('Deactivate plugins failed!'));
+                throw new \Exception(_('Deactivate plugins failed!'));
             }
             Route::listem(
                 'plugin',
@@ -907,13 +907,13 @@ class PluginManagement extends FOGPage
                 );
                 if (!method_exists($installPlugin, 'uninstall')) {
                     $serverFault = true;
-                    throw new Exception(
+                    throw new \Exception(
                         _('Unable to uninstall, no method exists for ')
                         . $Plugin->name
                     );
                 }
                 if (!$installPlugin->uninstall()) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Failed to uninstall ')
                         . $Plugin->name
                     );
@@ -924,7 +924,7 @@ class PluginManagement extends FOGPage
             }
             if (!$PluginManager->update($ids, '', $install)) {
                 $serverFault = true;
-                throw new Exception(_('Uninstall plugins failed!'));
+                throw new \Exception(_('Uninstall plugins failed!'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'PLUGIN_UNINSTALL_SUCCESS';
@@ -938,7 +938,7 @@ class PluginManagement extends FOGPage
                     'title' => _('Plugin Uninstall Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -1009,7 +1009,7 @@ class PluginManagement extends FOGPage
         $serverFault = false;
         try {
             if (!count($plugins)) {
-                throw new Exception(_('No plugins selected.'));
+                throw new \Exception(_('No plugins selected.'));
             }
             Route::listem('plugin', ['id' => $plugins], true);
             $rows = json_decode(Route::getData());
@@ -1023,7 +1023,7 @@ class PluginManagement extends FOGPage
                 $present[] = $row->name;
             }
             if (count($present)) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         _('These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead.'),
                         implode(', ', $present)
@@ -1034,7 +1034,7 @@ class PluginManagement extends FOGPage
                 $plugin = self::getClass('Plugin', $id);
                 if (!$plugin->destroy()) {
                     $serverFault = true;
-                    throw new Exception(_('Failed to forget ') . $name);
+                    throw new \Exception(_('Failed to forget ') . $name);
                 }
                 // Same cleanup uninstall does. A row can reach here still
                 // marked installed -- the admin deleted the directory by hand
@@ -1054,7 +1054,7 @@ class PluginManagement extends FOGPage
                     )
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/printermanagement.page.php
+++ b/packages/web/lib/pages/printermanagement.page.php
@@ -392,7 +392,7 @@ class PrinterManagement extends FOGPage
             case 'network':
                 return 'Network';
         }
-        throw new Exception(_('Please select a valid printer type.'));
+        throw new \Exception(_('Please select a valid printer type.'));
     }
     /**
      * Applies the default RAW port (9100) for port-based printer types when
@@ -520,21 +520,21 @@ class PrinterManagement extends FOGPage
                 );
 
                 if ($printer === '') {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Please enter a printer name.')
                     );
                 }
                 $exists = self::getClass('PrinterManager')
                     ->exists($printer);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A printer already exists with this name!')
                     );
                 }
                 $printertype = $this->_normalizePrinterType($config);
                 $port = $this->_defaultPrinterPort($printertype, $port);
                 if ($printertype === 'Local' && $ip === '') {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A TCP/IP port printer requires an IP address or hostname.')
                     );
                 }
@@ -549,7 +549,7 @@ class PrinterManagement extends FOGPage
                     ->set('ip', $ip);
                 if (!$Printer->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add printer failed!'));
+                    throw new \Exception(_('Add printer failed!'));
                 }
                 return $Printer;
             }
@@ -689,7 +689,7 @@ class PrinterManagement extends FOGPage
         );
 
         if ($printer === '') {
-            throw new Exception(
+            throw new \Exception(
                 _('Please enter a printer name.')
             );
         }
@@ -698,14 +698,14 @@ class PrinterManagement extends FOGPage
         if ($printer != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A printer already exists with this name!')
             );
         }
         $printertype = $this->_normalizePrinterType($config);
         $port = $this->_defaultPrinterPort($printertype, $port);
         if ($printertype === 'Local' && $ip === '') {
-            throw new Exception(
+            throw new \Exception(
                 _('A TCP/IP port printer requires an IP address or hostname.')
             );
         }
@@ -943,7 +943,7 @@ class PrinterManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Printer update failed!'));
+                    throw new \Exception(_('Printer update failed!'));
                 }
             }
         );

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -91,7 +91,7 @@ class ProcessLogin extends FOGPage
                 $rememberme
             );
             if (!self::$FOGUser->isValid()) {
-                throw new Exception(self::$foglang['InvalidLogin']);
+                throw new \Exception(self::$foglang['InvalidLogin']);
             }
             // Setup language stuff
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
@@ -122,7 +122,7 @@ class ProcessLogin extends FOGPage
                 BASEPATH . 'fog_login_accepted.log'
             );
             chmod(BASEPATH . 'fog_login_accepted.log', 0200);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_FORBIDDEN;
             $msg = json_encode(
                 [

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -177,7 +177,7 @@ class RoleManagement extends FOGPage
                 $exists = self::getClass('RoleManager')
                     ->exists($role);
                 if ($exists) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('A role already exists with this name!')
                     );
                 }
@@ -186,7 +186,7 @@ class RoleManagement extends FOGPage
                     ->set('description', $description);
                 if (!$Role->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Add role failed!'));
+                    throw new \Exception(_('Add role failed!'));
                 }
                 return $Role;
             }
@@ -282,7 +282,7 @@ class RoleManagement extends FOGPage
         if ($role != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A role with this name already exists!')
             );
         }
@@ -461,7 +461,7 @@ class RoleManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -499,7 +499,7 @@ class RoleManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -577,7 +577,7 @@ class RoleManagement extends FOGPage
             ['groupRoles' => $groupRoles]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -658,7 +658,7 @@ class RoleManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Role update failed!'));
+                    throw new \Exception(_('Role update failed!'));
                 }
                 Authorization::resetCache();
             }

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -288,7 +288,7 @@ class SchemaUpdaterPage extends FOGPage
         $serverFault = false;
         try {
             if (!DatabaseManager::getLink()) {
-                throw new Exception(_('Database connection unavailable.'));
+                throw new \Exception(_('Database connection unavailable.'));
             }
             // Whether there is any INDEXED work. There may be none and still
             // be work to do: the reconcile and the required-row seed below are
@@ -502,7 +502,7 @@ class SchemaUpdaterPage extends FOGPage
                 || count($errors) > 0
             ) {
                 $serverFault = true;
-                throw new Exception(_('Unable to update schema'));
+                throw new \Exception(_('Unable to update schema'));
             }
             // Reported only once everything above has actually run, so a
             // server with no indexed steps left still gets its reconcile and
@@ -524,7 +524,7 @@ class SchemaUpdaterPage extends FOGPage
                     'title' => _('Schema Update Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -274,10 +274,10 @@ class ServiceConfigurationPage extends FOGPage
                 $extra();
             }
             if (!$Service->save()) {
-                throw new Exception(_('Unable to update global setting'));
+                throw new \Exception(_('Unable to update global setting'));
             }
             if (!$Module->save()) {
-                throw new Exception(_('Unable to update module default setting'));
+                throw new \Exception(_('Unable to update module default setting'));
             }
         }
     }
@@ -742,7 +742,7 @@ class ServiceConfigurationPage extends FOGPage
                     'title' => _('Module Update Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'SERVICE_EDIT_FAIL';
             $msg = json_encode(

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -614,7 +614,7 @@ class SnapinManagement extends FOGPage
                     'title' => _('Snapin Create Fail')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             // Legacy UI behavior: SSH/SFTP RuntimeExceptions and
             // InvalidArgumentException both map to HTTP 400 here.
             // Route::createSnapinWithFile maps them differently.
@@ -1128,12 +1128,12 @@ class SnapinManagement extends FOGPage
         if ($snapin != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A snapin already exists with this name!')
             );
         }
         if (!$snapinfile) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s, %s, %s!',
                     _('A file'),
@@ -1189,7 +1189,7 @@ class SnapinManagement extends FOGPage
             self::$FOGSSH->password = $StorageNode->get('pass');
             self::$FOGSSH->host = $StorageNode->get('ip');
             if (!self::$FOGSSH->connect()) {
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s: %s.',
                         _('Storage Node'),
@@ -1202,7 +1202,7 @@ class SnapinManagement extends FOGPage
             $rdir = $StorageNode->get('snapinpath');
             if (!self::$FOGSSH->exists($rdir)) {
                 if (false === self::$FOGSSH->sftp_mkdir($rdir)) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Failed to add snapin')
                         . ' ' . $rdir . ' '
                         . _('does not exist and cannot be created')
@@ -1213,7 +1213,7 @@ class SnapinManagement extends FOGPage
                 // Non-recursive removal only; delete() would walk the
                 // directory when the unlink fails (035 / 2.3.1).
                 if (!self::$FOGSSH->unlinkFile($dest)) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Failed to delete existing snapin file')
                     );
                 }
@@ -1486,7 +1486,7 @@ class SnapinManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Snapin update failed!'));
+                    throw new \Exception(_('Snapin update failed!'));
                 }
             }
         );

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -152,7 +152,7 @@ class StorageGroupManagement extends FOGPage
             $exists = self::getClass('StorageGroupManager')
                 ->exists($storagegroup);
             if ($exists) {
-                throw new Exception(
+                throw new \Exception(
                     _('A storage group exists with this name!')
                 );
             }
@@ -162,7 +162,7 @@ class StorageGroupManagement extends FOGPage
                 ->set('trustedcidrs', $trustedcidrs);
             if (!$StorageGroup->save()) {
                 $serverFault = true;
-                throw new Exception(self::$foglang['DBupfailed']);
+                throw new \Exception(self::$foglang['DBupfailed']);
             }
             $code = HTTPResponseCodes::HTTP_CREATED;
             $hook = 'STORAGEGROUP_ADD_SUCCESS';
@@ -172,7 +172,7 @@ class StorageGroupManagement extends FOGPage
                     'title' => _('Storage Group Create Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -310,7 +310,7 @@ class StorageGroupManagement extends FOGPage
         if ($storagegroup != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A storage group already exists with this name!')
             );
         }
@@ -840,7 +840,7 @@ class StorageGroupManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('Storage Group Update Failed'));
+                    throw new \Exception(_('Storage Group Update Failed'));
                 }
             }
         );

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -494,13 +494,13 @@ class StorageNodeManagement extends FOGPage
             $exists = self::getClass('StorageNodeManager')
                 ->exists($storagenode);
             if ($exists) {
-                throw new Exception(
+                throw new \Exception(
                     _('A storage node already exists with this name!')
                 );
             }
             if (is_numeric($bandwidth)) {
                 if ($bandwidth < 0) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Bandwidth should be numeric and greater than 0')
                     );
                 }
@@ -530,7 +530,7 @@ class StorageNodeManagement extends FOGPage
                 ->set('graphcolor', $graphcolor);
             if (!$StorageNode->save()) {
                 $serverFault = true;
-                throw new Exception(_('Add storage node failed!'));
+                throw new \Exception(_('Add storage node failed!'));
             }
             if ($StorageNode->get('isMaster')) {
                 $find = [
@@ -577,7 +577,7 @@ class StorageNodeManagement extends FOGPage
             } else {
                 self::$FOGSSH->disconnect();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -1110,20 +1110,20 @@ class StorageNodeManagement extends FOGPage
             filter_input(INPUT_POST, 'helloInterval')
         );
         if (!$storagenode) {
-            throw new Exception(self::$foglang['StorageNameRequired']);
+            throw new \Exception(self::$foglang['StorageNameRequired']);
         }
         $exists = self::getClass('StorageNodeManager')
             ->exists($storagenode, $this->obj->get('id'));
         if ($storagenode != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A storage node already exists with this name!')
             );
         }
         if (is_numeric($bandwidth)) {
             if ($bandwidth < 0) {
-                throw new Exception(
+                throw new \Exception(
                     _('Bandwidth should be numeric and greater than 0')
                 );
             }
@@ -1274,7 +1274,7 @@ class StorageNodeManagement extends FOGPage
             }
             if (!$this->obj->save()) {
                 $serverFault = true;
-                throw new Exception(_('Storage Node Update Failed'));
+                throw new \Exception(_('Storage Node Update Failed'));
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'STORAGENODE_EDIT_SUCCESS';
@@ -1295,7 +1295,7 @@ class StorageNodeManagement extends FOGPage
                     ]
                 );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -1014,7 +1014,7 @@ class TaskManagement extends FOGPage
                     'title' => _('Task Cancel Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'TASK_CANCEL_FAIL';
             $msg = json_encode(
@@ -1076,7 +1076,7 @@ class TaskManagement extends FOGPage
                     'title' => _('Task Cancel Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'TASK_CANCEL_FAIL';
             $msg = json_encode(
@@ -1130,7 +1130,7 @@ class TaskManagement extends FOGPage
                     'title' => _('Task Cancel Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'TASK_CANCEL_FAIL';
             $msg = json_encode(
@@ -1184,7 +1184,7 @@ class TaskManagement extends FOGPage
                     'title' => _('Task Cancel Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'TASK_CANCEL_FAIL';
             $msg = json_encode(
@@ -1238,7 +1238,7 @@ class TaskManagement extends FOGPage
                     'title' => _('Queue Deletion Cancel Success')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             $hook = 'QUEUED_DELETION_CANCEL_FAIL';
             $msg = json_encode(

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -243,12 +243,12 @@ class UserManagement extends FOGPage
         $serverFault = false;
         try {
             if (!preg_match($userPat, $user)) {
-                throw new Exception($userErr);
+                throw new \Exception($userErr);
             }
             $exists = self::getClass('UserManager')
                 ->exists($user);
             if ($exists) {
-                throw new Exception(
+                throw new \Exception(
                     _('A username already exists with this name!')
                 );
             }
@@ -261,7 +261,7 @@ class UserManagement extends FOGPage
                 ->set('token', $token);
             if (!$User->save()) {
                 $serverFault = true;
-                throw new Exception(_('Add user failed!'));
+                throw new \Exception(_('Add user failed!'));
             }
             $code = HTTPResponseCodes::HTTP_CREATED;
             $hook = 'USER_ADD_SUCCESS';
@@ -272,7 +272,7 @@ class UserManagement extends FOGPage
                     'id' => $User->get('id')
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $code = (
                 $serverFault ?
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR :
@@ -409,14 +409,14 @@ class UserManagement extends FOGPage
             filter_input(INPUT_POST, 'display')
         );
         if (!preg_match($userPat, $user)) {
-            throw new Exception($userErr);
+            throw new \Exception($userErr);
         }
         $exists = self::getClass('UserManager')
             ->exists($user);
         if ($user != $this->obj->get('name')
             && $exists
         ) {
-            throw new Exception(
+            throw new \Exception(
                 _('A user already exists with this name')
             );
         }
@@ -687,7 +687,7 @@ class UserManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -724,7 +724,7 @@ class UserManagement extends FOGPage
             ]
         );
         if (!$adminRemains) {
-            throw new Exception(
+            throw new \Exception(
                 _('This change would leave no user with administrator access.')
             );
         }
@@ -817,7 +817,7 @@ class UserManagement extends FOGPage
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
-                    throw new Exception(_('User update failed!'));
+                    throw new \Exception(_('User update failed!'));
                 }
                 if ('user-role' === $tab || 'user-group' === $tab) {
                     Authorization::resetCache();

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -73,7 +73,7 @@ class Registration extends FOGBase
             );
             $this->PriMAC = array_shift($this->MACs);
             if ($this->regExists($check)) {
-                throw new Exception();
+                throw new \Exception();
             }
             $this->macsimple = strtolower(
                 str_replace(
@@ -97,7 +97,7 @@ class Registration extends FOGBase
             } else {
                 $this->_quickRegAuto();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             die($e->getMessage());
         }
     }
@@ -113,7 +113,7 @@ class Registration extends FOGBase
         try {
             self::getClass('HostManager')->getHostByMacAddresses($this->PriMAC);
             if (self::$Host->isValid()) {
-                throw new Exception(
+                throw new \Exception(
                     _(
                         'This machine already registered as '
                         . self::$Host->get('name')
@@ -122,19 +122,19 @@ class Registration extends FOGBase
             }
             self::getClass('HostManager')->getHostByMacAddresses($this->MACs);
             if (self::$Host->isValid()) {
-                throw new Exception(
+                throw new \Exception(
                     _(
                         'This machine already registered as '
                         . self::$Host->get('name')
                     )
                 );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
             return true;
         }
         if ($check === true) {
-            throw new Exception('#!ok');
+            throw new \Exception('#!ok');
         }
         return false;
     }
@@ -149,12 +149,12 @@ class Registration extends FOGBase
             $stripped = self::stripAndDecode($_POST);
             $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
             if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
-                throw new Exception(_('Invalid product key supplied'));
+                throw new \Exception(_('Invalid product key supplied'));
             }
             $host = filter_var($stripped['host'] ?? '');
             $hostnameSafe = self::getClass('Host')->isHostnameSafe($host);
             if (!$hostnameSafe) {
-                throw new Exception(
+                throw new \Exception(
                     _(
                         'Unsafe hostname entered, please try again: '
                         . $host
@@ -163,7 +163,7 @@ class Registration extends FOGBase
             }
             $hostnameExists = self::getClass('HostManager')->exists($host);
             if ($hostnameExists) {
-                throw new Exception(
+                throw new \Exception(
                     _(
                         'Hostname already used, please try again'
                     )
@@ -246,7 +246,7 @@ class Registration extends FOGBase
                     $productKey
                 );
             if (!self::$Host->save()) {
-                throw new Exception(
+                throw new \Exception(
                     _('Failed to create Host!')
                 );
             }
@@ -257,12 +257,12 @@ class Registration extends FOGBase
             );
             try {
                 if (!$doimage) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Done, without imaging!')
                     );
                 }
                 self::_deployHost();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 echo $e->getMessage();
             }
             self::getClass('Inventory')
@@ -271,7 +271,7 @@ class Registration extends FOGBase
                 ->set('other1', $other1)
                 ->set('other2', $other2)
                 ->save();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
     }
@@ -291,7 +291,7 @@ class Registration extends FOGBase
         $password = filter_var($stripped['password'] ?? '');
         $userTest = self::getClass('User')->passwordValidate($username, $password);
         if (!$userTest && !$quickReg) {
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging: Invalid Login.')
             );
         }
@@ -305,17 +305,17 @@ class Registration extends FOGBase
         $username = ($username ?: 'fog');
         $Image = self::$Host->getImage();
         if (!$Image->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging! No image assigned.')
             );
         }
         if (!$Image->get('isEnabled')) {
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging! Image is not enabled.')
             );
         }
         if (!$Image->getStorageGroup()->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging! Image not in storage group.')
             );
         }
@@ -331,11 +331,11 @@ class Registration extends FOGBase
             $username
         );
         if (!$task) {
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging! Failed to create tasking.')
             );
         }
-        throw new Exception(_('Done, with imaging'));
+        throw new \Exception(_('Done, with imaging'));
     }
     /**
      * Quick registration handler.
@@ -435,12 +435,12 @@ class Registration extends FOGBase
             if ($prodkeyget > 0) {
                 $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
-                    throw new Exception(_('Invalid product key supplied'));
+                    throw new \Exception(_('Invalid product key supplied'));
                 }
                 self::$Host->set('productKey', $productKey);
             }
             if (!self::$Host->save()) {
-                throw new Exception(
+                throw new \Exception(
                     _('Failed to create Host!')
                 );
             }
@@ -451,15 +451,15 @@ class Registration extends FOGBase
             );
             try {
                 if (!$performimg) {
-                    throw new Exception(
+                    throw new \Exception(
                         _('Done, without imaging!')
                     );
                 }
                 self::_deployHost(true);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 echo $e->getMessage();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
     }
@@ -482,12 +482,12 @@ class Registration extends FOGBase
             if ($prodkeyget > 0) {
                 $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
-                    throw new Exception(_('Invalid product key supplied'));
+                    throw new \Exception(_('Invalid product key supplied'));
                 }
                 self::$Host->set('productKey', $productKey);
             }
             if (!self::$Host->save()) {
-                throw new Exception(
+                throw new \Exception(
                     _('Failed to create Host!')
                 );
             }
@@ -496,10 +496,10 @@ class Registration extends FOGBase
                 'HOST_REGISTER',
                 ['Host' => &self::$Host]
             );
-            throw new Exception(
+            throw new \Exception(
                 _('Done, without imaging!')
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
     }

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -144,7 +144,7 @@ abstract class TaskingElement extends FOGBase
                         ->getMasterStorageNode();
                 }
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo Initiator::e($e->getMessage());
             exit;
         }
@@ -166,7 +166,7 @@ abstract class TaskingElement extends FOGBase
         $mac
     ) {
         if (!$Task->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s (%s)',
                     _('No Active Task found for Host'),
@@ -188,7 +188,7 @@ abstract class TaskingElement extends FOGBase
             Route::names($classname);
             $names = json_decode(Route::getData());
             if (count($names ?: []) <= 0) {
-                throw new Exception(
+                throw new \Exception(
                     _('There are no ' . $classname . 's on this server')
                 );
             }
@@ -199,7 +199,7 @@ abstract class TaskingElement extends FOGBase
                     $item->name
                 );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
         exit;
@@ -216,7 +216,7 @@ abstract class TaskingElement extends FOGBase
     protected static function checkStorageGroup(&$StorageGroup)
     {
         if (!$StorageGroup->isValid()) {
-            throw new Exception(
+            throw new \Exception(
                 _('Invalid Storage Group')
             );
         }
@@ -237,7 +237,7 @@ abstract class TaskingElement extends FOGBase
             $getter = 'allnodes';
         }
         if (!count($StorageGroup->get($getter) ?: [])) {
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s, %s?',
                     _('Could not find a Storage Node in this group'),

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -56,7 +56,7 @@ class TaskQueue extends TaskingElement
         }
         try {
             self::getHostItem(false);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return;
         }
         if (!self::$Host->isValid()) {
@@ -98,7 +98,7 @@ class TaskQueue extends TaskingElement
         try {
             $elapsed = self::niceDate()->getTimestamp()
                 - self::niceDate($checkin)->getTimestamp();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return;
         }
         // Bound to one day so a stale prior task of the same type can't be
@@ -133,7 +133,7 @@ class TaskQueue extends TaskingElement
                         $msID
                     );
                     if (!$MulticastSession->isValid()) {
-                        throw new Exception(_('Invalid Multicast Session'));
+                        throw new \Exception(_('Invalid Multicast Session'));
                     }
                     if ($MulticastSession->get('clients') < 0) {
                         $clients = 1;
@@ -144,10 +144,10 @@ class TaskQueue extends TaskingElement
                         ->set('clients', $clients)
                         ->set('stateID', self::getProgressState());
                     if (!$MulticastSession->save()) {
-                        throw new Exception(_('Failed to update Session'));
+                        throw new \Exception(_('Failed to update Session'));
                     }
                     if (!self::$Host->isValid()) {
-                        throw new Exception('##@GO');
+                        throw new \Exception('##@GO');
                     }
                     self::$Host->set(
                         'imageID',
@@ -193,7 +193,7 @@ class TaskQueue extends TaskingElement
                             _('On reboot we will try to find a new node'),
                             _('automatically')
                         );
-                        throw new Exception($msg);
+                        throw new \Exception($msg);
                     }
                     $totalSlots = $this->StorageNode->get('maxClients');
                     $usedSlots = $this->StorageNode->getUsedSlotCount();
@@ -216,7 +216,7 @@ class TaskQueue extends TaskingElement
                             _('Got in line at'),
                             $MyLineTime->format('Y-m-d H:i:s')
                         );
-                        throw new Exception($msg);
+                        throw new \Exception($msg);
                     }
                     
                     if ($groupOpenSlots <= $inFront) {
@@ -229,30 +229,30 @@ class TaskQueue extends TaskingElement
                             _('Got in line at'),
                             $MyLineTime->format('Y-m-d H:i:s')
                         );
-                        throw new Exception($msg);
+                        throw new \Exception($msg);
                     }
                 }
                 $this->Task
                     ->set('storagenodeID', $this->StorageNode->get('id'));
                 if (!$this->imageLog(true)) {
-                    throw new Exception(_('Failed to update/create image log'));
+                    throw new \Exception(_('Failed to update/create image log'));
                 }
             }
             $this->Task
                 ->set('stateID', self::getProgressState())
                 ->set('checkInTime', self::niceDate()->format('Y-m-d H:i:s'));
             if (!$this->Task->save()) {
-                throw new Exception(_('Failed to update Task'));
+                throw new \Exception(_('Failed to update Task'));
             }
             if (!$this->taskLog()) {
-                throw new Exception(_('Failed to update/create task log'));
+                throw new \Exception(_('Failed to update/create task log'));
             }
             self::$EventManager->notify(
                 'HOST_CHECKIN',
                 ['Host' => &self::$Host]
             );
             echo '##@GO';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo Initiator::e($e->getMessage());
         }
     }
@@ -451,7 +451,7 @@ class TaskQueue extends TaskingElement
         self::$FOGSSH->password = $this->StorageNode->get('pass');
         self::$FOGSSH->host = $this->StorageNode->get('ip');
         if (!self::$FOGSSH->connect()) {
-            throw new Exception(_('Unable to connect to ssh during move upload'));
+            throw new \Exception(_('Unable to connect to ssh during move upload'));
         }
         // Move any existing image aside instead of deleting it up front. If the
         // rename below fails we can put it back, rather than having destroyed
@@ -462,7 +462,7 @@ class TaskQueue extends TaskingElement
             self::$FOGSSH->delete($backup);
             if (!self::$FOGSSH->sftp_rename($dest, $backup)) {
                 self::$FOGSSH->disconnect();
-                throw new Exception(
+                throw new \Exception(
                     sprintf(
                         '%s: %s',
                         _('Unable to move the existing image aside'),
@@ -477,7 +477,7 @@ class TaskQueue extends TaskingElement
                 self::$FOGSSH->sftp_rename($backup, $dest);
             }
             self::$FOGSSH->disconnect();
-            throw new Exception(
+            throw new \Exception(
                 sprintf(
                     '%s: %s -> %s. %s',
                     _('Unable to move the captured image into place'),
@@ -561,7 +561,7 @@ class TaskQueue extends TaskingElement
                 ->set('percent', 100)
                 ->set('stateID', self::getCompleteState());
             if (!self::$Host->isValid()) {
-                throw new Exception('##');
+                throw new \Exception('##');
             }
             $updatedHost = self::getClass('HostManager')->update(
                 ['id' => self::$Host->get('id')],
@@ -569,10 +569,10 @@ class TaskQueue extends TaskingElement
                 $updateFields
             );
             if (!$updatedHost) {
-                throw new Exception(_('Failed to update host'));
+                throw new \Exception(_('Failed to update host'));
             }
             if (!$this->Task->save()) {
-                throw new Exception(_('Failed to update Task'));
+                throw new \Exception(_('Failed to update Task'));
             }
             self::$HookManager->processEvent(
                 'HOST_TASKING_COMPLETE',
@@ -582,11 +582,11 @@ class TaskQueue extends TaskingElement
                 ]
             );
             if (!$this->taskLog()) {
-                throw new Exception(_('Failed to update task log'));
+                throw new \Exception(_('Failed to update task log'));
             }
             if ($this->imagingTask) {
                 if (!$this->imageLog(false)) {
-                    throw new Exception(_('Failed to update imaging log'));
+                    throw new \Exception(_('Failed to update imaging log'));
                 }
             }
             self::$EventManager->notify(
@@ -594,7 +594,7 @@ class TaskQueue extends TaskingElement
                 ['HostName' => self::$Host->get('name')]
             );
             echo '##';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
     }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1947,7 +1947,7 @@ class Route extends FOGBase
                         'formatter' => function ($d, $row) use (&$StorageGroup) {
                             try {
                                 $sn = $StorageGroup->getMasterStorageNode();
-                            } catch (Exception $e) {
+                            } catch (\Exception $e) {
                                 $sn = new StorageNode();
                             }
                             return self::getter('storagenode', $sn);
@@ -2133,7 +2133,7 @@ class Route extends FOGBase
                 self::$data = $listData;
             }
             self::paginate(isset($pass_vars) ? $pass_vars : []);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2250,7 +2250,7 @@ class Route extends FOGBase
                 self::$countOnly = false;
             }
             self::$data = ['total' => self::$data['recordsFiltered']];
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2367,7 +2367,7 @@ class Route extends FOGBase
                     [],
                     $params
                 )->fetch(
-                    PDO::FETCH_ASSOC,
+                    \PDO::FETCH_ASSOC,
                     'fetch_all'
                 )->get();
                 foreach ($vals as $val) {
@@ -2403,7 +2403,7 @@ class Route extends FOGBase
                 ['data' => &$data]
             );
             self::$data = $data;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2443,7 +2443,7 @@ class Route extends FOGBase
                     'classman' => &$classman
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2495,7 +2495,7 @@ class Route extends FOGBase
                     'class' => &$class
                 ]
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2748,7 +2748,7 @@ class Route extends FOGBase
                 );
             }
             self::indiv($classname, $id);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -2972,7 +2972,7 @@ class Route extends FOGBase
                 );
             }
             self::indiv($classname, $id);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -3145,7 +3145,7 @@ class Route extends FOGBase
                         }
                     }
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -3184,7 +3184,7 @@ class Route extends FOGBase
             // here (they used to be expanded down in _buildSql, which also
             // caught internally-built filters -- see expandSearchWildcards).
             return self::expandSearchWildcards($find);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -3221,7 +3221,7 @@ class Route extends FOGBase
                     $find = ['stateID' => $states];
             }
             self::listem($class, $find);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -3259,7 +3259,7 @@ class Route extends FOGBase
             // runs the same removeItems map and fires DELETEMASS_API for plugins,
             // instead of a bare row delete that orphaned every association.
             return self::deletemass($class, $whereItems);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -3717,7 +3717,7 @@ class Route extends FOGBase
                 ]
             );
             return $data;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -4205,7 +4205,7 @@ class Route extends FOGBase
                 $orderby
             );
 
-            $vals = self::$DB->query($sqlResult['sql'], [], $sqlResult['params'])->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+            $vals = self::$DB->query($sqlResult['sql'], [], $sqlResult['params'])->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
             foreach ($vals as &$val) {
                 if (is_array($getField)) {
                     $row = [];
@@ -4219,7 +4219,7 @@ class Route extends FOGBase
                 unset($val);
             }
             self::$data = $data;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -4742,7 +4742,7 @@ class Route extends FOGBase
             );
 
             return self::$DB->query($sqlResult['sql'], [], $sqlResult['params']);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -4918,7 +4918,7 @@ class Route extends FOGBase
                 . '` ASC';
 
             return ['sql' => $sql, 'params' => $params];
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -4978,7 +4978,7 @@ class Route extends FOGBase
                 $operator,
                 $orderby
             );
-            $vals = self::$DB->query($sqlResult['sql'], [], $sqlResult['params'])->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+            $vals = self::$DB->query($sqlResult['sql'], [], $sqlResult['params'])->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
             foreach ($vals as &$val) {
                 $data[] = [
                     'id' => $val[$classVars['databaseFields']['id']],
@@ -4988,7 +4988,7 @@ class Route extends FOGBase
             }
 
             self::$data = $data;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()
@@ -5172,7 +5172,7 @@ class Route extends FOGBase
                     $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
             }
             self::sendResponse($code);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
                 $e->getMessage()

--- a/packages/web/lib/service/filedeleter.class.php
+++ b/packages/web/lib/service/filedeleter.class.php
@@ -88,10 +88,10 @@ class FileDeleter extends FOGService
     private static function humanifyRun($diff, $unit)
     {
         if (!is_numeric($diff)) {
-            throw new Exception(_('Diff parameter must be numeric'));
+            throw new \Exception(_('Diff parameter must be numeric'));
         }
         if (!is_string($unit)) {
-            throw new Exception(_('Unit of time must be a string'));
+            throw new \Exception(_('Unit of time must be a string'));
         }
         $before = $after = '';
         if ($diff < 0) {
@@ -115,7 +115,7 @@ class FileDeleter extends FOGService
     }
     private static function formatRunTime($time)
     {
-        if (!$time instanceof DateTime) {
+        if (!$time instanceof \DateTime) {
             $time = self::niceDate($time);
         }
         $now = self::niceDate('now');
@@ -152,7 +152,7 @@ class FileDeleter extends FOGService
         try {
             self::$_schedOn = self::getSetting('FILEDELETEQUEUEGLOBALENABLED');
             if (self::$_schedOn < 1) {
-                throw new Exception(_(' * File delete queue is globally disabled'));
+                throw new \Exception(_(' * File delete queue is globally disabled'));
             }
             Route::active('filedeletequeue');
             $filedeletes = json_decode(Route::getData());
@@ -306,7 +306,7 @@ class FileDeleter extends FOGService
                     ->set('stateID', self::getCompleteState())
                     ->save();
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall($e->getMessage());
         }
     }

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -147,7 +147,7 @@ abstract class FOGService extends FOGBase
         if (count($StorageNodes) > 0) {
             return $StorageNodes;
         }
-        throw new Exception(
+        throw new \Exception(
             _(' | This is not the master node')
         );
     }
@@ -391,10 +391,10 @@ abstract class FOGService extends FOGBase
         Route::indiv('storagenode', $myStorageNodeID);
         $myStorageNode = json_decode(Route::getData());
         if (!$myStorageNode->isMaster) {
-            throw new Exception(_('This is not the master for this group'));
+            throw new \Exception(_('This is not the master for this group'));
         }
         if (!$myStorageNode->online) {
-            throw new Exception(_('This node does not appear to be online'));
+            throw new \Exception(_('This node does not appear to be online'));
         }
         Route::listem('storagenode', $find);
         $StorageNodes = json_decode(Route::getData());

--- a/packages/web/lib/service/imagereplicator.class.php
+++ b/packages/web/lib/service/imagereplicator.class.php
@@ -91,7 +91,7 @@ class ImageReplicator extends FOGService
             // Check of status changed.
             self::$_repOn = self::getSetting('IMAGEREPLICATORGLOBALENABLED');
             if (self::$_repOn < 1) {
-                throw new Exception(_(' * Image replication is globally disabled'));
+                throw new \Exception(_(' * Image replication is globally disabled'));
             }
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $skip = false;
@@ -291,7 +291,7 @@ class ImageReplicator extends FOGService
                 }
                 unset($Images);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall(
                 sprintf(
                     ' * %s',

--- a/packages/web/lib/service/imagesize.class.php
+++ b/packages/web/lib/service/imagesize.class.php
@@ -91,7 +91,7 @@ class ImageSize extends FOGService
             self::$_sizeOn = self::getSetting('IMAGESIZEGLOBALENABLED');
             self::$_sizeOn = self::getSetting('IMAGESIZEGLOBALENABLED');
             if (self::$_sizeOn < 1) {
-                throw new Exception(_(' * Image size is globally disabled'));
+                throw new \Exception(_(' * Image size is globally disabled'));
             }
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $myStorageGroupID = $StorageNode->storagegroupID;
@@ -244,7 +244,7 @@ class ImageSize extends FOGService
                 )
             );
             unset($StorageNodes);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall(
                 sprintf(
                     ' * %s',

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -322,7 +322,7 @@ class MulticastManager extends FOGService
 
                 // If disabled, state and restart loop.
                 if (self::$_mcOn < 1) {
-                    throw new Exception(
+                    throw new \Exception(
                         _(' * Multicast service is globally disabled')
                     );
                 }
@@ -799,7 +799,7 @@ class MulticastManager extends FOGService
                     );
                     $Task->clearSenderRef();
                 }
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 self::outall($e->getMessage());
             }
             if ($first) {

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -878,7 +878,7 @@ class MulticastTask extends FOGService
                         } else {
                             $lvmscan = true;
                             $filename = 'd1p%d.%s';
-                            $iterator = new DirectoryIterator(
+                            $iterator = new \DirectoryIterator(
                                 $this->getImagePath()
                             );
                             foreach ($iterator as $fileInfo) {
@@ -906,7 +906,7 @@ class MulticastTask extends FOGService
                     default:
                         $lvmscan = true;
                         $filename = 'd1p%d.%s';
-                        $iterator = new DirectoryIterator(
+                        $iterator = new \DirectoryIterator(
                             $this->getImagePath()
                         );
                         foreach ($iterator as $fileInfo) {
@@ -933,7 +933,7 @@ class MulticastTask extends FOGService
             case 2:
                 $lvmscan = true;
                 $filename = 'd1p%d.%s';
-                $iterator = new DirectoryIterator(
+                $iterator = new \DirectoryIterator(
                     $this->getImagePath()
                 );
                 foreach ($iterator as $fileInfo) {
@@ -959,7 +959,7 @@ class MulticastTask extends FOGService
             case 3:
                 $lvmscan = true;
                 $filename = 'd%dp%d.%s';
-                $iterator = new DirectoryIterator(
+                $iterator = new \DirectoryIterator(
                     $this->getImagePath()
                 );
                 foreach ($iterator as $fileInfo) {
@@ -984,7 +984,7 @@ class MulticastTask extends FOGService
                 unset($iterator);
                 break;
             case 4:
-                $iterator = new DirectoryIterator(
+                $iterator = new \DirectoryIterator(
                     $this->getImagePath()
                 );
                 foreach ($iterator as $fileInfo) {
@@ -1003,7 +1003,7 @@ class MulticastTask extends FOGService
              * the send loop below expands it into the sidecar's LV image
              * files in line order — the order the FOS client restores in.
              */
-            $iterator = new DirectoryIterator(
+            $iterator = new \DirectoryIterator(
                 $this->getImagePath()
             );
             foreach ($iterator as $fileInfo) {

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -101,7 +101,7 @@ class PingHosts extends FOGService
         try {
             self::$_pingOn = self::getSetting('PINGHOSTGLOBALENABLED');
             if (self::$_pingOn < 1) {
-                throw new Exception(_(' * Ping hosts is globally disabled'));
+                throw new \Exception(_(' * Ping hosts is globally disabled'));
             }
             $webServerIP = self::resolveHostName(
                 self::$_fogWeb
@@ -111,7 +111,7 @@ class PingHosts extends FOGService
             );
             self::getIPAddress();
             if (!in_array($webServerIP, self::$ips)) {
-                throw new Exception(
+                throw new \Exception(
                     _('I am not the fog web server')
                 );
             }
@@ -179,7 +179,7 @@ class PingHosts extends FOGService
                     );
             }
             self::outall(' * All hosts updated');
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall($e->getMessage());
         }
     }

--- a/packages/web/lib/service/pluginrunner.class.php
+++ b/packages/web/lib/service/pluginrunner.class.php
@@ -283,7 +283,7 @@ class PluginRunner extends FOGService
                     microtime(true) - $started
                 )
             );
-        } catch (Throwable $e) {
+        } catch (\Throwable $e) {
             // Throwable, not Exception: an Error walks past a catch on
             // Exception and would kill the child, which the supervisor then
             // re-forks straight back into the same failure (#815). A plugin
@@ -311,12 +311,12 @@ class PluginRunner extends FOGService
         try {
             self::$_runnerOn = self::getSetting('PLUGINRUNNERGLOBALENABLED');
             if (self::$_runnerOn < 1) {
-                throw new Exception(
+                throw new \Exception(
                     _('Plugin runner is globally disabled')
                 );
             }
             if (!self::getSetting('FOG_PLUGINSYS_ENABLED')) {
-                throw new Exception(_('The plugin system is disabled'));
+                throw new \Exception(_('The plugin system is disabled'));
             }
             // Every other daemon gates on this, and plugin tasks need it for
             // the same reason: without it each node in a group runs every
@@ -333,7 +333,7 @@ class PluginRunner extends FOGService
             $this->checkIfNodeMaster();
             $tasks = $this->_discoverTasks();
             if (!count($tasks)) {
-                throw new Exception(_('No plugin tasks to run'));
+                throw new \Exception(_('No plugin tasks to run'));
             }
             // Reached work, so the next idle spell is a state change and gets
             // logged immediately rather than waiting out IDLE_REPEAT. The
@@ -367,7 +367,7 @@ class PluginRunner extends FOGService
                 $this->_nextRun[$key] = self::niceDate()->getTimestamp()
                     + $interval;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->_logIdle($e->getMessage());
         }
     }

--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -90,7 +90,7 @@ class SnapinHash extends FOGService
         try {
             self::$_hashOn = self::getSetting('SNAPINHASHGLOBALENABLED');
             if (self::$_hashOn < 1) {
-                throw new Exception(_(' * Snapin hash is globally disabled'));
+                throw new \Exception(_(' * Snapin hash is globally disabled'));
             }
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $myStorageGroupID = $StorageNode->storagegroupID;
@@ -231,7 +231,7 @@ class SnapinHash extends FOGService
                     _('Completed')
                 )
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall(
                 sprintf(
                     ' * %s',

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -90,7 +90,7 @@ class SnapinReplicator extends FOGService
         try {
             self::$_repOn = self::getSetting('SNAPINREPLICATORGLOBALENABLED');
             if (self::$_repOn < 1) {
-                throw new Exception(_(' * Snapin replication is globally disabled'));
+                throw new \Exception(_(' * Snapin replication is globally disabled'));
             }
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $skip = false;
@@ -281,7 +281,7 @@ class SnapinReplicator extends FOGService
                 }
                 unset($Snapins);
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall(
                 sprintf(
                     ' * %s',

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -85,7 +85,7 @@ class TaskScheduler extends FOGService
         try {
             self::$_schedOn = self::getSetting('SCHEDULERGLOBALENABLED');
             if (self::$_schedOn < 1) {
-                throw new Exception(_(' * Task Scheduler is globally disabled'));
+                throw new \Exception(_(' * Task Scheduler is globally disabled'));
             }
             $findWhere = [
                 'stateID' => self::getQueuedStates(),
@@ -138,7 +138,7 @@ class TaskScheduler extends FOGService
             $ptaskcount = $PMTasks->recordsFiltered;
             $taskCount = $staskcount + $ptaskcount;
             if ($taskCount <= 0) {
-                throw new Exception(' * No tasks found!');
+                throw new \Exception(' * No tasks found!');
             }
             self::outall(
                 sprintf(
@@ -292,7 +292,7 @@ class TaskScheduler extends FOGService
                     )
                 );
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             self::outall($e->getMessage());
         }
     }

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -40,7 +40,7 @@ $tmpfile = '/tmp/' . $backup_name;
 $data = '';
 FOGCore::getClass('Mysqldump')->start($tmpfile);
 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {
-    throw new Exception(_('Could not read file from tmp folder.'));
+    throw new \Exception(_('Could not read file from tmp folder.'));
 }
 $fh = fopen($tmpfile, 'rb');
 while (!feof($fh)) {

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -105,24 +105,24 @@ try {
     $username = $readParam('username');
     $username = base64_decode($username, true);
     if (!is_string($username)) {
-        throw new Exception('#!il');
+        throw new \Exception('#!il');
     }
     $username = trim($username);
     $password = $readParam('password');
     $password = base64_decode($password, true);
     if (!is_string($password)) {
-        throw new Exception('#!il');
+        throw new \Exception('#!il');
     }
     $password = trim($password);
     $userTest = FOGCore::getClass('User')
         ->passwordValidate($username, $password);
     if (!$userTest) {
         $recordBadAttempt();
-        throw new Exception('#!il');
+        throw new \Exception('#!il');
     }
     $clearAttempts();
     echo '#!ok';
-} catch (Exception $e) {
+} catch (\Exception $e) {
     if ($e->getMessage() !== '#!il') {
         $recordBadAttempt();
     }

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -26,7 +26,7 @@ try {
         Route::getData()
     );
     if (count($groupnames ?: []) < 1) {
-        throw new Exception(
+        throw new \Exception(
             _('There are no groups on this server')
         );
     }
@@ -38,7 +38,7 @@ try {
         );
         unset($group);
     }
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo $e->getMessage();
 }
 exit;

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -28,20 +28,20 @@ try {
     //    throw new Exception(_('Cannot view from browser'));
     //}
     if (!$Task->isValid()) {
-        throw new Exception(_('Invalid tasking!'));
+        throw new \Exception(_('Invalid tasking!'));
     }
     $hosttoken = filter_input(INPUT_POST, 'hosttoken');
     if (!$hosttoken) {
         $hosttoken = filter_input(INPUT_GET, 'hosttoken');
     }
     if (!$hosttoken) {
-        throw new Exception(_('No token passed to authenticate this host'));
+        throw new \Exception(_('No token passed to authenticate this host'));
     }
     if (!FOGCore::$Host->get('tokenlock')) {
-        throw new Exception(_('Have not locked the host for access'));
+        throw new \Exception(_('Have not locked the host for access'));
     }
     if ($hosttoken != FOGCore::$Host->get('token')) {
-        throw new Exception(_('Invalid token passed for host'));
+        throw new \Exception(_('Invalid token passed for host'));
     }
     $TaskType = $Task->getTaskType();
     $Image = $Task->getImage();
@@ -64,7 +64,7 @@ try {
                 FOGCore::maxId($msIDs)
             );
             if (!$MulticastSession->isValid()) {
-                throw new Exception(_('Invalid Multicast Session'));
+                throw new \Exception(_('Invalid Multicast Session'));
             }
             $taskImgID = $Task->get('imageID');
             $mcImgID = $MulticastSession->get('image');
@@ -290,7 +290,7 @@ try {
             'tokenlock' => false
         ]
     );
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo Initiator::e($e->getMessage());
     exit(1);
 }

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -37,10 +37,10 @@ try {
             _('The primary mac associated is'),
             $Host->get('mac')->__toString()
         );
-        throw new Exception($msg);
+        throw new \Exception($msg);
     }
     $msg = '#!ok';
-} catch (Exception $e) {
+} catch (\Exception $e) {
     $msg = $e->getMessage();
 }
 echo $msg;

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -33,7 +33,7 @@ try {
     // host.
     FOGCore::getHostItem(false);
     if (!FOGCore::$Host->isValid()) {
-        throw new Exception(_('Invalid Host'));
+        throw new \Exception(_('Invalid Host'));
     }
     $Inventory = FOGCore::$Host->get('inventory');
     if (!$Inventory instanceof Inventory
@@ -127,12 +127,12 @@ try {
             ->set('hdserial', $hdserial);
     }
     if (!$Inventory->save()) {
-        throw new Exception(
+        throw new \Exception(
             _('Failed to create inventory for this host')
         );
     }
     echo _('Done');
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo Initiator::e($e->getMessage());
 }
 exit;

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -26,14 +26,14 @@ try {
         Route::getData()
     );
     if (count($printernames ?: []) < 1) {
-        throw new Exception("#!np\n");
+        throw new \Exception("#!np\n");
     }
     echo "#!ok\n";
     foreach ((array)$printernames as $index => $printer) {
         echo "#printer{$index}={$printer->name}\n";
         unset($printer);
     }
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo $e->getMessage();
 }
 exit;

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -25,7 +25,7 @@ try {
     $Task = FOGCore::$Host->get('task');
     $TaskType = new TaskType($Task->get('typeID'));
     if (!$Task->isValid()) {
-        throw new Exception(
+        throw new \Exception(
             sprintf(
                 '%s: %s (%s)',
                 _('No Active Task found for Host'),
@@ -36,7 +36,7 @@ try {
     }
     $Image = $Task->getImage();
     if (!$Image->isValid()) {
-        throw new Exception(_('Invalid image'));
+        throw new \Exception(_('Invalid image'));
     }
     $statusRaw = base64_decode(
         (string)
@@ -48,7 +48,7 @@ try {
         true
     );
     if (false === $statusRaw) {
-        throw new Exception(_('Invalid status payload'));
+        throw new \Exception(_('Invalid status payload'));
     }
     $imagingTasks = $TaskType->isImagingTask();
     if ($imagingTasks) {
@@ -91,7 +91,7 @@ try {
             )
         )->save();
     }
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo Initiator::e($e->getMessage());
 }
 exit;

--- a/packages/web/service/snapcheck.php
+++ b/packages/web/service/snapcheck.php
@@ -23,11 +23,11 @@ require '../commons/base.inc.php';
 try {
     FOGCore::getHostItem(false);
     if (!FOGCore::$Host->isValid()) {
-        throw new Exception('#!ih');
+        throw new \Exception('#!ih');
     }
     $SnapinJob = FOGCore::$Host->get('snapinjob');
     if (!$SnapinJob->isValid()) {
-        throw new Exception(0);
+        throw new \Exception(0);
     }
     $find = [
         'stateID' => $FOGCore->getQueuedStates(),
@@ -57,7 +57,7 @@ try {
         $snapinnames = [count($snapins ?: []) ? 1 : 0];
     }
     echo implode(' ', $snapinnames);
-} catch (Exception $e) {
+} catch (\Exception $e) {
     // Aisle 021: escape the error text at the sink. Today the reflected MAC is
     // already neutralised upstream by stripAndDecodeItem(), so this is inert --
     // but that makes the safety of this echo an accident of a shared helper.

--- a/packages/web/status/bandwidth.php
+++ b/packages/web/status/bandwidth.php
@@ -44,7 +44,7 @@ function read_return_int($filename)
  */
 $getBytes = function ($dev) {
     if (!is_string($dev)) {
-        throw new Exception(_('Device must be a string'));
+        throw new \Exception(_('Device must be a string'));
     }
     $txpath = "/sys/class/net/$dev/statistics/tx_bytes";
     $rxpath = "/sys/class/net/$dev/statistics/rx_bytes";

--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -24,13 +24,13 @@ header('Content-Type: text/plain');
 try {
     FOGCore::getHostItem(false, true);
     if (!FOGCore::$Host->isValid()) {
-        throw new Exception(_('Host Invalid'));
+        throw new \Exception(_('Host Invalid'));
     }
     #if (FOGCore::$useragent) {
     #    throw new Exception(_('Accessed inappropriately'));
     #}
     if (!FOGCore::$Host->get('task')->isValid()) {
-        throw new Exception(_('Invalid Tasking'));
+        throw new \Exception(_('Invalid Tasking'));
     }
     /**
      * Aisle 016: this endpoint is unauthenticated and MAC-resolved, and the
@@ -48,10 +48,10 @@ try {
      * sees a message it already handles.
      */
     if (!FOGCore::hostKeySourceAllowed(filter_input(INPUT_SERVER, 'REMOTE_ADDR'))) {
-        throw new Exception(_('Invalid Tasking'));
+        throw new \Exception(_('Invalid Tasking'));
     }
     if (FOGCore::$Host->get('token') && FOGCore::$Host->get('tokenlock')) {
-        throw new Exception(_('Host token is currently in use'));
+        throw new \Exception(_('Host token is currently in use'));
     }
     if (!FOGCore::$Host->get('token')) {
         FOGCore::getClass('HostManager')->update(
@@ -62,7 +62,7 @@ try {
                 'tokenlock' => true
             ]
         );
-        throw new Exception(FOGCore::$Host->get('token'));
+        throw new \Exception(FOGCore::$Host->get('token'));
     }
     if (FOGCore::$Host->isValid() && !FOGCore::$Host->get('tokenlock')) {
         FOGCore::getClass('HostManager')->update(
@@ -70,9 +70,9 @@ try {
             '',
             ['tokenlock' => true]
         );
-        throw new Exception(FOGCore::$Host->get('token'));
+        throw new \Exception(FOGCore::$Host->get('token'));
     }
-} catch (Exception $e) {
+} catch (\Exception $e) {
     echo $e->getMessage();
     exit(1);
 }

--- a/tests/autoload.test.php
+++ b/tests/autoload.test.php
@@ -93,9 +93,9 @@ register_shutdown_function(
         if (!is_dir($tmp)) {
             return;
         }
-        $it = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($tmp, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
         );
         foreach ($it as $f) {
             $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
@@ -261,8 +261,8 @@ if ($bridged) {
     // every getClass()/Reflection consumer see one type. get_class() still
     // reports the declared name -- that asymmetry is why namespacing the
     // models is a separate problem from bridging their names.
-    $refFqcn = new ReflectionClass('FOG\Host');
-    $refShort = new ReflectionClass('Host');
+    $refFqcn = new \ReflectionClass('FOG\Host');
+    $refShort = new \ReflectionClass('Host');
     if ($refFqcn->getName() !== $refShort->getName()) {
         $failures[] = 'FOG\Host resolves to a different class entry than '
             . 'Host (' . $refFqcn->getName() . ' vs ' . $refShort->getName()

--- a/tests/global-class-prefix.test.php
+++ b/tests/global-class-prefix.test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Guards the Phase 0.1 invariant: no bare references to PHP's built-in
+ * classes remain in tracked PHP.
+ *
+ * Inside `namespace FOG;` an unqualified `catch (Exception $e)` means
+ * FOG\Exception, which does not exist, so the catch stops matching -- silently,
+ * at runtime, on the error path only. Phase 3 is safe from that only for as
+ * long as every such reference stays qualified, so this test exists to fail
+ * when a new bare one is written.
+ *
+ * Wraps bin/prefix-global-classes.php --check, which does the actual work.
+ *
+ * Usage: php tests/global-class-prefix.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+// The count this tree is expected to carry. Non-zero here on purpose: the
+// checker is landing one commit ahead of the rewrite, so this asserts that it
+// SEES the problem before the next commit asserts that it sees the fix. A
+// test that only ever asserted zero could be broken and green and nobody
+// would know. 729 = the 722 this pass originally found, plus 2 in
+// openapi.class.php from #1045, plus the 5 in the checker itself.
+const EXPECT_SITES = 729;
+
+$tool = dirname(__DIR__) . '/bin/prefix-global-classes.php';
+
+if (!is_readable($tool)) {
+    fwrite(STDERR, "FAIL: cannot read $tool\n");
+    exit(1);
+}
+
+exec('php ' . escapeshellarg($tool) . ' --check 2>&1', $out, $rc);
+
+$summary = array_pop($out);
+while ($summary !== null && trim($summary) === '') {
+    $summary = array_pop($out);
+}
+
+if (!preg_match('/^unprefixed: (\d+) sites in (\d+) files/', (string)$summary, $m)) {
+    fwrite(STDERR, "FAIL: could not read the checker's summary line\n");
+    fwrite(STDERR, "  got: " . var_export($summary, true) . "\n");
+    exit(1);
+}
+
+$sites = (int)$m[1];
+
+if ($sites !== EXPECT_SITES) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: %d bare built-in class references, expected %d\n",
+            $sites,
+            EXPECT_SITES
+        )
+    );
+    // Show a sample rather than all of them.
+    foreach (array_slice($out, 0, 20) as $line) {
+        fwrite(STDERR, "  $line\n");
+    }
+    if (count($out) > 20) {
+        fwrite(STDERR, '  ... and ' . (count($out) - 20) . " more\n");
+    }
+    exit(1);
+}
+
+printf("global-class-prefix: %d sites (expected %d)\n", $sites, EXPECT_SITES);
+echo "PASS\n";
+exit(0);

--- a/tests/global-class-prefix.test.php
+++ b/tests/global-class-prefix.test.php
@@ -15,13 +15,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
-// The count this tree is expected to carry. Non-zero here on purpose: the
-// checker is landing one commit ahead of the rewrite, so this asserts that it
-// SEES the problem before the next commit asserts that it sees the fix. A
-// test that only ever asserted zero could be broken and green and nobody
-// would know. 729 = the 722 this pass originally found, plus 2 in
-// openapi.class.php from #1045, plus the 5 in the checker itself.
-const EXPECT_SITES = 729;
+// Zero, and it stays zero. The previous commit set this to 729 and passed,
+// which is how we know the assertion has teeth rather than being green
+// because the checker is broken.
+const EXPECT_SITES = 0;
 
 $tool = dirname(__DIR__) . '/bin/prefix-global-classes.php';
 

--- a/tests/route-filter-fields.test.php
+++ b/tests/route-filter-fields.test.php
@@ -34,8 +34,8 @@ if (!is_dir($root)) {
 }
 
 $files = [];
-$rii = new RecursiveIteratorIterator(
-    new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS)
+$rii = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($root, \RecursiveDirectoryIterator::SKIP_DOTS)
 );
 foreach ($rii as $f) {
     if (!$f->isDir() && substr($f->getFilename(), -4) === '.php') {


### PR DESCRIPTION
729 single-character insertions across 87 files, produced by a tokenizer and
nothing else. No line was edited by hand.

Replaces #1049, which was auto-closed when its base branch was deleted during
the stacked merge. Regenerated against the current `working-1.6` rather than
rebased — the rewrite is a script's output, so re-running it is both cheaper
and more trustworthy than resolving conflicts across 87 files.

## Why

Inside `namespace FOG;` an unqualified `catch (Exception $e)` means
`FOG\Exception` — a class that does not exist — so the catch stops matching. It
compiles, it lints, it passes every static check, and it fails only on the error
path, only at runtime, only on somebody's server. There are 132
`catch (Exception` sites and 8 `catch (PDOException`; each is a `try`/`catch`
that would quietly stop catching.

Doing it now, standalone, while the whole tree is still in the global namespace
and the two spellings resolve to the identical class entry, turns that from a
Phase 3 risk into a Phase 3 non-event.

## Regenerating found something a hand inventory missed

The count moved from 727 to 729, and the two new sites are the argument for the
tool's design. `openapi.class.php` (from #1045) contains:

```php
} catch (Error $e) {
    // A plugin class naming a parent that is not loaded raises Error,
    // not Exception, and one broken plugin must not take the whole
    // document down with it.
```

`Error` was not in the original hand-compiled inventory at all. The tool caught
it because membership comes from `ReflectionClass::isInternal()` on the running
PHP rather than from a list in the script — which is exactly the failure mode
that design exists to prevent.

## The safety argument, checked from two sides

Neither is sufficient alone.

**Side one — the diff really is only qualification.**

```
php bin/verify-token-equivalence.php HEAD~1
  compared 88 files
  qualifications added : 729
  other differences    : 1   <- tests/global-class-prefix.test.php
```

That one difference is the test's own constant flipping 729 → 0 in the same
commit — intended, not an artifact. The tool tokenizes both revisions, drops
whitespace and comments, folds `T_NAME_FULLY_QUALIFIED` back to the bare name,
and compares exactly. Controls: `\Exception ≡ Exception` equal,
`Exception ≡ Throwable` different. Every changed file lints clean; a second
`--fix` is a no-op.

**Side two — the names touched really are classes.**

The check above deliberately *cannot* tell a backslash correctly added to a
class from one wrongly added to a constant, since normalizing qualification away
is what erases the difference. `php -l` will not catch it either —
`\SOME_CONSTANT` is valid syntax and fails only at runtime.

So the rewriter only touches names `isInternal()` confirms. Verified against the
lab's PHP, whose extension set matches the server's:

| Check | Result |
|---|---|
| `isInternal()` | all names yes |
| also a defined **constant** | none |
| also a defined **function** | none |
| **shadowed by a FOG class** | none |

The last row is the one that would hurt: a FOG class of the same name would mean
the prefix changed *which* class resolves rather than nothing. Negative control
confirms the check works — it finds `Host` and `FOGBase`, and nothing for
`Exception`/`DateTime`. The only FOG class extending a built-in is
`UploadException extends \Exception`.

## Commits

1. **`acf99fbfc`** — both tools. Rewrites nothing, wired to no gate.
2. **`f394dc295`** — the test, asserting the baseline of **729**, not zero, so
   the assertion is proven to have teeth before it is proven to hold.
3. **`7e4d740e2`** — the mechanical rewrite; constant flips to zero.

## Deliberately not done

- **`packages/web/vendor/`** excluded — Composer rewrites those files on every
  install, so a prefix there would never settle.
- **Casing not normalized.** `FileSystemIterator` and `FilesystemIterator` are
  the same class spelled two ways; both prefixed as spelled. Normalizing is a
  real change, however invisible, and contaminates the "purely mechanical" claim
  this PR's value rests on. It belongs to Phase 3's casing sweep.
- **Global *functions* not prefixed** — fallback to global scope is automatic
  inside a namespace, so it is a micro-optimization, and it would bury 729
  meaningful edits under tens of thousands of meaningless ones.

## Verification

```
sh tests/run-all.sh
8 passed, 0 failed
```

Including `route-result-wrappers.test.php` and `listem-envelope.test.php`, so
the wrappers merged in #1051 still behave identically after the rewrite.

## Companion

`fog-plugins` carries its own 127 sites — FOGProject/fog-plugins#2, no ordering
dependency in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)