### PR TITLE
Migrate the daemons off the Route listem/getData idiom (ADR 0011 step 1)

### DIFF
--- a/docs/adr/0011-route-result-wrappers.md
+++ b/docs/adr/0011-route-result-wrappers.md
@@ -99,6 +99,9 @@ $assocs = Route::getList('ouassociation', ['hostID' => $id]);   // rows
 $ou     = Route::getItem('ou', $ouId);                           // one entity
 ```
 
+Plus `Route::asValue(callable)` for the callers those two do not fit — see
+below. All three raise rather than exit.
+
 Four properties, each chosen against a specific failure:
 
 **They return rows, so there is no envelope to hold wrongly.** `getList()`
@@ -143,6 +146,34 @@ ambiguous, `getItem()` asks a cheap id-only question first and returns null when
 there is no such row — or when the caller may not see it. One extra indexed
 query is the price of leaving `indiv()`'s HTTP behavior exactly as it is.
 
+### `asValue()` covers what the other two do not
+
+`getList()` and `getItem()` unwrap, and unwrapping is the wrong answer for two
+kinds of caller:
+
+- **Callers that genuinely want the envelope.** `taskscheduler.class.php:133`
+  reads `->recordsFiltered` off `active()` for its task count and then iterates
+  `->data`; `filedeleter.class.php:160` does the same. Earlier drafts of this
+  document claimed essentially no caller needed the metadata. That was wrong,
+  and it was found by migrating the daemons.
+- **Helpers with no wrapper.** `active()`, `names()`, `availablekernels()`,
+  `logfiles()`. `pinghosts.class.php` calls `names('host')`, whose payload is a
+  bare list with no envelope to unwrap at all.
+
+```php
+$tasks = Route::asValue(function () { Route::active('scheduledtask'); });
+$tasks->recordsFiltered;   // reads exactly as before
+```
+
+It returns exactly what `json_decode(Route::getData())` returned, so adopting it
+is a swap with no semantic change. What it adds is the half those callers still
+need: inside the callable, a failure raises instead of ending the process.
+
+It is deliberately the third choice. `getList()`/`getItem()` say what the caller
+wants and remove the envelope that has now caused three silent bugs; `asValue()`
+preserves the envelope, and with it the opportunity. Reach for it only when
+neither of the other two fits.
+
 ### `inputoverride` is true
 
 Internal callers are not answering a DataTables POST. With the default,
@@ -160,7 +191,8 @@ is zero unless one is on the stack, and `listem()`, `indiv()`, `active()` and
 Migration is a separate, ordered exercise and is explicitly not part of
 adopting this ADR:
 
-1. daemons and services — 26 sites, the only bucket that can kill a process
+1. ~~daemons and services — 26 sites, the only bucket that can kill a process~~
+   **done**; 11 files, verified against a live 1.6 install
 2. client endpoints and hooks — 4 sites, invisible failures
 3. `fog-plugins` — 37 sites, gated on this shipping in a release
 4. pages, models, reports — 94 sites, mechanical, least urgent
@@ -168,7 +200,25 @@ adopting this ADR:
    they may be right to leave alone, but that should be a decision rather than
    an omission
 
-`multicasttask.class.php`'s hand-rolled guard can retire once step 1 reaches it.
+### `multicasttask.class.php`'s hand-rolled guard stays
+
+This document originally said the guard could retire once step 1 reached it.
+Step 1 has now reached it, and it cannot — the guard was doing two jobs and the
+wrappers only take over one.
+
+`getItem()` establishes **existence**. `indiv()` gates on **`isValid()`**. So a
+deleted image now answers null, which is the half that killed the daemon; but an
+image that is present and does not validate — `osID` of 0, a blank name or path
+— still reaches `indiv()` and still fails. It raises rather than exiting now, so
+the daemon survives, but the exception unwinds the entire session-collection
+pass and takes every other queued session with it. The guard keeps that failure
+scoped to the one session it belongs to, which is a smaller claim than the one
+it originally made and still worth the four lines.
+
+Making `getItem()` gate on validity instead was considered and rejected: the
+existence check runs through `getIds()`, so it also answers null for a row the
+caller may not *see*, and constructing the entity to test `isValid()` directly
+would bypass that filtering. Refs #907.
 
 ### What this does not fix
 

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -4480,6 +4480,48 @@ class Route extends FOGBase
         return self::objectify($data);
     }
     /**
+     * Runs any router call as a value rather than as a response.
+     *
+     * getList() and getItem() cover listem() and indiv(), which is most of the
+     * tree, and they drop the envelope because their callers only ever wanted
+     * the rows. Some callers want the envelope: taskscheduler reads
+     * `->recordsFiltered` off active() for its task count and then iterates
+     * `->data`, so unwrapping would change what it does.
+     *
+     * This is the escape hatch for those, and for the helpers no wrapper
+     * covers -- active(), names(), availablekernels(), logfiles(). It returns
+     * exactly what `json_decode(Route::getData())` returned, envelope and all,
+     * so adopting it is a swap with no semantic change at all. What it adds is
+     * the part the daemons need: inside the callable, a failure raises instead
+     * of ending the process.
+     *
+     *     $tasks = Route::asValue(function () { Route::active('scheduledtask'); });
+     *     $tasks->recordsFiltered;   // reads exactly as before
+     *
+     * Prefer getList()/getItem() where they fit; they say more about intent
+     * and they remove the envelope that has now caused three silent bugs.
+     *
+     * @param callable $call Makes the router call. Its return value is
+     *                       ignored; the result is read from Route::$data,
+     *                       which is how every helper reports.
+     *
+     * @throws \Exception Whatever the call raised, rather than exiting.
+     *
+     * @return mixed
+     */
+    public static function asValue(callable $call)
+    {
+        self::$_rethrowDepth++;
+        try {
+            $call();
+            $data = self::$data;
+            self::$data = '';
+        } finally {
+            self::$_rethrowDepth--;
+        }
+        return self::objectify($data);
+    }
+    /**
      * Delete items in mass.
      *
      * @param string $class      The class we're to remove items.

--- a/packages/web/lib/service/filedeleter.class.php
+++ b/packages/web/lib/service/filedeleter.class.php
@@ -154,8 +154,14 @@ class FileDeleter extends FOGService
             if (self::$_schedOn < 1) {
                 throw new \Exception(_(' * File delete queue is globally disabled'));
             }
-            Route::active('filedeletequeue');
-            $filedeletes = json_decode(Route::getData());
+            // asValue(), not getList(): the count below comes off the
+            // envelope, so the envelope has to survive. What this buys is the
+            // other half -- a failure raises instead of ending the daemon.
+            $filedeletes = Route::asValue(
+                function () {
+                    Route::active('filedeletequeue');
+                }
+            );
 
             $taskCount = $filedeletes->recordsFiltered;
 
@@ -206,15 +212,14 @@ class FileDeleter extends FOGService
                 $Task = self::getClass('filedeletequeue', $filedelete->id)
                     ->set('stateID', self::getProgressState())
                     ->save();
-                Route::listem(
+                $StorageNodes = Route::getList(
                     'storagenode',
                     [
                         'storagegroupID' => $filedelete->storagegroupID,
                         'isEnabled' => 1
                     ]
                 );
-                $StorageNodes = json_decode(Route::getData());
-                foreach ($StorageNodes->data as $StorageNode) {
+                foreach ($StorageNodes as $StorageNode) {
                     switch ($filedelete->pathtype) {
                         case 'Image':
                         case 'image':

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -100,7 +100,7 @@ abstract class FOGService extends FOGBase
     protected function checkIfNodeMaster()
     {
         self::getIPAddress();
-        Route::listem(
+        $StorageNodesFound = Route::getList(
             'storagenode',
             [
                 'isMaster' => 1,
@@ -117,13 +117,11 @@ abstract class FOGService extends FOGBase
         // was re-forked straight back into it. That is every non-master node
         // running the multicast daemon with the Location plugin on (#815).
         $MasterIDs = [];
-        $StorageNodesFound = json_decode(
-            Route::getData()
-        );
-        foreach ($StorageNodesFound->data as &$StorageNode) {
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
-            if (!$StorageNode->online) {
+        foreach ($StorageNodesFound as &$StorageNode) {
+            // getItem(), not indiv(): a node that vanished between the list
+            // and the fetch used to exit the daemon child here. Refs #907.
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode || !$StorageNode->online) {
                 continue;
             }
             $ip = self::resolveHostname(
@@ -388,18 +386,22 @@ abstract class FOGService extends FOGBase
             $groupID = $Obj->get('storagegroups');
             $find['isMaster'] = [1];
         }
-        Route::indiv('storagenode', $myStorageNodeID);
-        $myStorageNode = json_decode(Route::getData());
+        // getItem(), not indiv(): the two throws below are what this method
+        // already uses to report "cannot sync from here", and a node that has
+        // been deleted belongs with them rather than exiting. Refs #907.
+        $myStorageNode = Route::getItem('storagenode', $myStorageNodeID);
+        if (!$myStorageNode) {
+            throw new \Exception(_('This node could not be found'));
+        }
         if (!$myStorageNode->isMaster) {
             throw new \Exception(_('This is not the master for this group'));
         }
         if (!$myStorageNode->online) {
             throw new \Exception(_('This node does not appear to be online'));
         }
-        Route::listem('storagenode', $find);
-        $StorageNodes = json_decode(Route::getData());
+        $StorageNodes = Route::getList('storagenode', $find);
         $objType = get_class($Obj);
-        $groupOrNodeCount = count($StorageNodes->data ?: []);
+        $groupOrNodeCount = count($StorageNodes);
         $counttest = 2;
         if (!$master) {
             $groupOrNodeCount--;
@@ -442,12 +444,16 @@ abstract class FOGService extends FOGBase
         $myFile = ($fileOverride ?: $Obj->get($fileField));
         $myAdd = "{$myDir}{$myFile}";
         $myAddItem = false;
-        foreach ($StorageNodes->data as $i => &$StorageNode) {
+        foreach ($StorageNodes as $i => &$StorageNode) {
             if ($StorageNode->id == $myStorageNodeID) {
                 continue;
             }
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
+            // getItem(), not indiv(): a node that vanished between the list
+            // and the fetch used to exit the daemon child here. Refs #907.
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode) {
+                continue;
+            }
             if ($master && $StorageNode->storagegroupID == $myStorageGroupID) {
                 continue;
             }

--- a/packages/web/lib/service/imagereplicator.class.php
+++ b/packages/web/lib/service/imagereplicator.class.php
@@ -104,13 +104,22 @@ class ImageReplicator extends FOGService
                 );
                 $myStorageGroupID = $StorageNode->storagegroupID;
                 $myStorageNodeID = $StorageNode->id;
-                Route::indiv(
+                // getItem(), not indiv(): a miss answers with null here
+                // rather than exiting the daemon child outright. Refs #907.
+                $StorageGroup = Route::getItem(
                     'storagegroup',
                     $myStorageGroupID
                 );
-                $StorageGroup = json_decode(
-                    Route::getData()
-                );
+                if (!$StorageGroup) {
+                    self::outall(
+                        sprintf(
+                            ' * %s: %d',
+                            _('Skipping, no such storage group'),
+                            $myStorageGroupID
+                        )
+                    );
+                    continue;
+                }
                 self::outall(
                     sprintf(
                         ' * %s.',
@@ -205,12 +214,9 @@ class ImageReplicator extends FOGService
                     $find,
                     'imageID'
                 );
-                Route::listem(
+                $Images = Route::getList(
                     'image',
                     ['id' => $imageIDs]
-                );
-                $Images = json_decode(
-                    Route::getData()
                 );
                 /**
                  * Handles replicating of our dev/postinitscripts
@@ -242,7 +248,7 @@ class ImageReplicator extends FOGService
                         $scripts
                     );
                 }
-                foreach ($Images->data as $Image) {
+                foreach ($Images as $Image) {
                     if (!Image::getPrimaryGroup($myStorageGroupID, $Image->id)) {
                         self::outall(
                             sprintf(
@@ -280,7 +286,7 @@ class ImageReplicator extends FOGService
                         _('image replication')
                     )
                 );
-                foreach ($Images->data as $Image) {
+                foreach ($Images as $Image) {
                     $I = new Image($Image->id);
                     $this->replicateItems(
                         $myStorageGroupID,

--- a/packages/web/lib/service/imagesize.class.php
+++ b/packages/web/lib/service/imagesize.class.php
@@ -96,13 +96,22 @@ class ImageSize extends FOGService
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $myStorageGroupID = $StorageNode->storagegroupID;
                 $myStorageNodeID = $StorageNode->id;
-                Route::indiv(
+                // getItem(), not indiv(): a miss answers with null here
+                // rather than exiting the daemon child outright. Refs #907.
+                $StorageGroup = Route::getItem(
                     'storagegroup',
                     $myStorageGroupID
                 );
-                $StorageGroup = json_decode(
-                    Route::getData()
-                );
+                if (!$StorageGroup) {
+                    self::outall(
+                        sprintf(
+                            ' * %s: %d',
+                            _('Skipping, no such storage group'),
+                            $myStorageGroupID
+                        )
+                    );
+                    continue;
+                }
                 self::outall(
                     sprintf(
                         ' * %s.',
@@ -175,14 +184,11 @@ class ImageSize extends FOGService
                         _('to update size values as needed')
                     )
                 );
-                Route::listem(
+                $Images = Route::getList(
                     'image',
                     ['id' => $imageIDs]
                 );
-                $Images = json_decode(
-                    Route::getData()
-                );
-                foreach ($Images->data as $Image) {
+                foreach ($Images as $Image) {
                     self::outall(
                         sprintf(
                             ' * %s: %s, %s: %d',

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -214,14 +214,11 @@ class MulticastManager extends FOGService
     private function _reconcileOrphanedSenders()
     {
         foreach ($this->checkIfNodeMaster() as $StorageNode) {
-            Route::listem(
+            $Sessions = Route::getList(
                 'multicastsession',
                 ['sendernode' => $StorageNode->id]
             );
-            $Sessions = json_decode(
-                Route::getData()
-            );
-            foreach ($Sessions->data as $Session) {
+            foreach ($Sessions as $Session) {
                 $pid = (int)$Session->senderpid;
                 if ($pid < 1) {
                     continue;

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -35,13 +35,15 @@ class MulticastTask extends FOGService
         $myStorageNodeID,
         $queuedStates
     ) {
-        Route::indiv(
+        // getItem(), not indiv(): a miss answers with null here rather than
+        // exiting the forked daemon child outright. Refs #907.
+        $StorageNode = Route::getItem(
             'storagenode',
             $myStorageNodeID
         );
-        $StorageNode = json_decode(
-            Route::getData()
-        );
+        if (!$StorageNode) {
+            return;
+        }
         self::$HookManager->processEvent(
             'CHECK_NODE_MASTER',
             [
@@ -109,18 +111,15 @@ class MulticastTask extends FOGService
         // master evaluated every session and the only thing standing between
         // two groups and two udp-senders on one session was whether both
         // happened to hold the image file -- which replication makes likely.
-        Route::listem(
+        $Tasks = Route::getList(
             'multicastsession',
             [
                 'stateID' => $queuedStates,
                 'storagegroupID' => $myStorageGroupID
             ]
         );
-        $Tasks = json_decode(
-            Route::getData()
-        );
         $NewTasks = [];
-        foreach ($Tasks->data as $Task) {
+        foreach ($Tasks as $Task) {
             $find = ['msID' => $Task->id];
             $taskIDs = Route::getIds(
                 'multicastsessionassociation',
@@ -154,23 +153,19 @@ class MulticastTask extends FOGService
                 );
                 continue;
             }
-            // Route::indiv() answers a missing row with sendResponse(404),
-            // which ends in HTTPResponseCodes::breakHead()'s exit. That is
-            // correct for a web request and fatal here: it terminates the
-            // forked daemon child outright, with nothing written to
-            // multicast.log and no exception for the service loop to catch,
-            // so multicast stops dead until someone restarts the unit. All
-            // it takes is deleting an image while a session for it is still
-            // queued. Ask the same question indiv() is about to ask and skip
-            // the session instead -- the REST API's exit is load-bearing
-            // everywhere else, so the router is left alone.
+            // This guard stays, and it is narrower than it was. getItem()
+            // below ends the half of #907 that killed the daemon: a deleted
+            // image now answers null instead of reaching indiv()'s
+            // sendResponse(404) and breakHead()'s exit.
             //
-            // isValid(), not an existence check: indiv() gates on isValid()
-            // rather than on the row being present, so an image that exists
-            // but fails validation -- osID of 0, a blank name or path --
-            // takes the daemon down exactly as a deleted one does. Testing
-            // for existence alone would leave that half of the bug open.
-            // Refs #907.
+            // It does not end the other half. getItem() establishes
+            // *existence*, while indiv() gates on isValid(), so an image that
+            // is present but does not validate -- osID of 0, a blank name or
+            // path -- still reaches indiv() and still fails. It raises rather
+            // than exiting now, so the daemon survives, but the exception
+            // unwinds the whole collection pass and takes every other queued
+            // session with it. Testing validity here keeps the failure scoped
+            // to the one session it belongs to. Refs #907, ADR 0011.
             if (!self::getClass('Image', $Task->image)->isValid()) {
                 self::outall(
                     sprintf(
@@ -181,12 +176,9 @@ class MulticastTask extends FOGService
                 );
                 continue;
             }
-            Route::indiv(
+            $Image = Route::getItem(
                 'image',
                 $Task->image
-            );
-            $Image = json_decode(
-                Route::getData()
             );
             $fullPath = sprintf('%s/%s', $root, $Task->logpath);
             if (!file_exists($fullPath)) {
@@ -528,11 +520,17 @@ class MulticastTask extends FOGService
      */
     public function getPartitions()
     {
-        Route::indiv(
+        // getItem(), not indiv(): a session whose image was deleted while it
+        // was running used to exit the daemon child here. 0 is the same
+        // answer a whole-disk image gives -- send every file -- which is the
+        // conservative one when the partition cannot be determined. Refs #907.
+        $Image = Route::getItem(
             'image',
             $this->_MultiSess->get('image')
         );
-        $Image = json_decode(Route::getData());
+        if (!$Image) {
+            return 0;
+        }
         return (int)$Image->imagepartitiontype->type;
     }
     /**
@@ -1041,10 +1039,8 @@ class MulticastTask extends FOGService
         // every other one on this class, and self:: binds statically to
         // MulticastTask, so any subclass override is silently ignored. No
         // subclass ships today, but it makes the method untestable in
-        // isolation -- an override is skipped, the real one runs
-        // Route::indiv() on whatever session is loaded, and a miss exits the
-        // process outright (the #907 path), which reads as the harness dying
-        // for no reason. Behaviour in the daemon is unchanged.
+        // isolation -- an override is skipped and the real one queries
+        // whatever session is loaded. Behaviour in the daemon is unchanged.
         $partid = $this->getPartitions();
         if ($partid < 1) {
             $filelist = array_values((array)$filelist);

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -126,8 +126,15 @@ class PingHosts extends FOGService
                 }
                 self::outall(" |\t$ip");
             }
-            Route::names('host');
-            $hosts = json_decode(Route::getData());
+            // asValue(): names() has no wrapper of its own -- its payload is
+            // a bare list, not a paginated envelope, so there is nothing to
+            // unwrap. This is here for the other half, so a failure raises
+            // rather than ending the daemon.
+            $hosts = Route::asValue(
+                function () {
+                    Route::names('host');
+                }
+            );
             $hostCount = count($hosts);
             self::outall(
                 sprintf(

--- a/packages/web/lib/service/pluginrunner.class.php
+++ b/packages/web/lib/service/pluginrunner.class.php
@@ -190,20 +190,17 @@ class PluginRunner extends FOGService
     private function _discoverTasks()
     {
         $tasks = [];
-        // inputoverride = true, for the same reason Plugin::getPlugins() sets
-        // it: without it listem() parses php://input for DataTables paging.
-        // There is no request behind a daemon, but the argument is cheap and
-        // leaving it off would make this depend on that staying true.
-        Route::listem(
+        // getList() always sets inputoverride, which is why the explicit
+        // argument is gone: without it listem() parses php://input for
+        // DataTables paging, and there is no request behind a daemon.
+        $plugins = Route::getList(
             'plugin',
             [
                 'installed' => 1,
                 'state' => 1
-            ],
-            true
+            ]
         );
-        $plugins = json_decode(Route::getData());
-        foreach ((array)($plugins->data ?? []) as $plugin) {
+        foreach ($plugins as $plugin) {
             $name = strtolower(trim((string)$plugin->name));
             $location = trim((string)$plugin->location);
             // A row whose code is not on disk. Plugin::isMissing() does not

--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -95,13 +95,22 @@ class SnapinHash extends FOGService
             foreach ($this->checkIfNodeMaster() as $StorageNode) {
                 $myStorageGroupID = $StorageNode->storagegroupID;
                 $myStorageNodeID = $StorageNode->id;
-                Route::indiv(
+                // getItem(), not indiv(): a miss answers with null here
+                // rather than exiting the daemon child outright. Refs #907.
+                $StorageGroup = Route::getItem(
                     'storagegroup',
                     $myStorageGroupID
                 );
-                $StorageGroup = json_decode(
-                    Route::getData()
-                );
+                if (!$StorageGroup) {
+                    self::outall(
+                        sprintf(
+                            ' * %s: %d',
+                            _('Skipping, no such storage group'),
+                            $myStorageGroupID
+                        )
+                    );
+                    continue;
+                }
                 self::outall(
                     sprintf(
                         ' * %s.',
@@ -174,14 +183,11 @@ class SnapinHash extends FOGService
                         _('to update hash values as needed')
                     )
                 );
-                Route::listem(
+                $Snapins = Route::getList(
                     'snapin',
                     ['id' => $snapinIDs]
                 );
-                $Snapins = json_decode(
-                    Route::getData()
-                );
-                foreach ($Snapins->data as $Snapin) {
+                foreach ($Snapins as $Snapin) {
                     self::outall(
                         sprintf(
                             ' * %s: %s, %s: %d',

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -103,13 +103,22 @@ class SnapinReplicator extends FOGService
                 );
                 $myStorageGroupID = $StorageNode->storagegroupID;
                 $myStorageNodeID = $StorageNode->id;
-                Route::indiv(
+                // getItem(), not indiv(): a miss answers with null here
+                // rather than exiting the daemon child outright. Refs #907.
+                $StorageGroup = Route::getItem(
                     'storagegroup',
                     $myStorageGroupID
                 );
-                $StorageGroup = json_decode(
-                    Route::getData()
-                );
+                if (!$StorageGroup) {
+                    self::outall(
+                        sprintf(
+                            ' * %s: %d',
+                            _('Skipping, no such storage group'),
+                            $myStorageGroupID
+                        )
+                    );
+                    continue;
+                }
                 self::outall(
                     sprintf(
                         ' * %s.',
@@ -203,12 +212,9 @@ class SnapinReplicator extends FOGService
                     $find,
                     'snapinID'
                 );
-                Route::listem(
+                $Snapins = Route::getList(
                     'snapin',
                     ['id' => $snapinIDs]
-                );
-                $Snapins = json_decode(
-                    Route::getData()
                 );
                 /**
                  * Handles replicating of our ssl folder and contents.
@@ -232,7 +238,7 @@ class SnapinReplicator extends FOGService
                         $ssl
                     );
                 }
-                foreach ($Snapins->data as $Snapin) {
+                foreach ($Snapins as $Snapin) {
                     if (!Snapin::getPrimaryGroup($myStorageGroupID, $Snapin->id)) {
                         self::outall(
                             sprintf(
@@ -270,7 +276,7 @@ class SnapinReplicator extends FOGService
                         _('snapin replication')
                     )
                 );
-                foreach ($Snapins->data as $Snapin) {
+                foreach ($Snapins as $Snapin) {
                     $S = new Snapin($Snapin->id);
                     $this->replicateItems(
                         $myStorageGroupID,

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -127,14 +127,23 @@ class TaskScheduler extends FOGService
                     self::wakeUp($hostMACs);
                 }
             }
+            // asValue(), not getList(): both counts below come off the
+            // envelope, so the envelope has to survive. What this buys is the
+            // other half -- a failure raises instead of ending the daemon.
             // Scheduled Task Information
-            Route::active('scheduledtask');
-            $ScheduledTasks = json_decode(Route::getData());
+            $ScheduledTasks = Route::asValue(
+                function () {
+                    Route::active('scheduledtask');
+                }
+            );
             $staskcount = $ScheduledTasks->recordsFiltered;
 
             // Powermanagement Task Information
-            Route::active('powermanagement');
-            $PMTasks = json_decode(Route::getData());
+            $PMTasks = Route::asValue(
+                function () {
+                    Route::active('powermanagement');
+                }
+            );
             $ptaskcount = $PMTasks->recordsFiltered;
             $taskCount = $staskcount + $ptaskcount;
             if ($taskCount <= 0) {
@@ -162,9 +171,8 @@ class TaskScheduler extends FOGService
                 'stateID' => self::getCheckedInState(),
                 'typeID' => $used
             ];
-            Route::listem('task', $find);
-            $Tasks = json_decode(Route::getData());
-            foreach ($Tasks->data as $Task) {
+            $Tasks = Route::getList('task', $find);
+            foreach ($Tasks as $Task) {
                 if(self::getClass('Task', $Task->id)->expireTaskCheckin()) {
                     self::outall(
                         ' * '
@@ -232,8 +240,20 @@ class TaskScheduler extends FOGService
                         $Item->get('name')
                     )
                 );
-                Route::indiv('tasktype', $Task->get('taskTypeID'));
-                $tasktype = json_decode(Route::getData());
+                // getItem(), not indiv(): a scheduled task pointing at a task
+                // type that has since been deleted used to exit the daemon
+                // here rather than skip the one task. Refs #907.
+                $tasktype = Route::getItem('tasktype', $Task->get('taskTypeID'));
+                if (!$tasktype) {
+                    self::outall(
+                        sprintf(
+                            "\t\t - %s: %s",
+                            _('Skipping, no such task type'),
+                            $Task->get('taskTypeID')
+                        )
+                    );
+                    continue;
+                }
                 $Item->createImagePackage(
                     $tasktype,
                     $Task->get('name'),

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6592,6 +6592,13 @@ msgstr "Es gibt nichts zu replizieren"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Snapins einer Speichergruppe zu"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7671,6 +7678,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Bereits registriert als"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6592,6 +6592,13 @@ msgstr "There is nothing to replicate"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Snapin Storage Group"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7668,6 +7675,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Already registered as"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Could not read temp file"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6747,6 +6747,13 @@ msgstr ""
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Grupo de almacenamiento primaria"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7857,6 +7864,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Impresora ya existe"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "No se pudo leer el archivo temporal"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6593,6 +6593,13 @@ msgstr "Es gibt nichts zu replizieren"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Snapins einer Speichergruppe zu"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7672,6 +7679,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Bereits registriert als"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6594,6 +6594,13 @@ msgstr "Il n'y a rien à répliquer"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Storage Group Snapin"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7670,6 +7677,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Déjà inscrit comme"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Impossible de lire le fichier temporaire"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6352,6 +6352,13 @@ msgstr "Non c'è nulla da replicare"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Snap in un gruppo di archiviazione"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7374,6 +7381,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Già registrato come"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Impossibile leggere il file temporaneo"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6286,6 +6286,13 @@ msgstr "レプリケーションする項目はありません"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "スナップインをストレージグループへ"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7299,6 +7306,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "既に次の名前で登録されています:"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "強制終了できませんでした"
 
 msgid "This node does not appear to be online"
 msgstr "このノードはオンラインではないようです"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5574,6 +5574,12 @@ msgstr ""
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+msgid "Skipping, no such storage group"
+msgstr ""
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -6488,6 +6494,9 @@ msgid "This is what MokManager's own View key screen shows after enrolling from 
 msgstr ""
 
 msgid "This machine already registered as "
+msgstr ""
+
+msgid "This node could not be found"
 msgstr ""
 
 msgid "This node does not appear to be online"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6593,6 +6593,13 @@ msgstr "Não há nada para replicar"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "Snapin grupo de armazenamento"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7669,6 +7676,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "Já está registado como"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "Não foi possível ler arquivo temporário"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6593,6 +6593,13 @@ msgstr "没有什么可以复制"
 msgid "Skipping unsafe queued delete path"
 msgstr ""
 
+#, fuzzy
+msgid "Skipping, no such storage group"
+msgstr "管理单元存储组"
+
+msgid "Skipping, no such task type"
+msgstr ""
+
 msgid "Skipping, not a PluginTask"
 msgstr ""
 
@@ -7669,6 +7676,10 @@ msgstr ""
 #, fuzzy
 msgid "This machine already registered as "
 msgstr "已注册为"
+
+#, fuzzy
+msgid "This node could not be found"
+msgstr "无法读取临时文件"
 
 msgid "This node does not appear to be online"
 msgstr ""

--- a/tests/route-result-wrappers.test.php
+++ b/tests/route-result-wrappers.test.php
@@ -77,7 +77,7 @@ if (!class_exists('Route')) {
 
 $ref = new \ReflectionClass('Route');
 
-foreach (['getList', 'getItem', 'objectify'] as $method) {
+foreach (['getList', 'getItem', 'asValue', 'objectify'] as $method) {
     if (!$ref->hasMethod($method)) {
         $failures[] = "Route::$method() is missing";
     }
@@ -133,6 +133,48 @@ foreach ($shapes as $label => $input) {
     );
 }
 
+// ---- 1b. asValue() hands back the whole payload, envelope included -------
+
+// getList() drops the envelope on purpose; asValue() must not, because
+// taskscheduler and filedeleter read recordsFiltered off it. DB-free: the
+// callable writes Route::$data the way active()/names() do.
+$dataProp = $ref->getProperty('data');
+$dataProp->setAccessible(true);
+
+$envelope = [
+    'draw' => 0,
+    'recordsTotal' => 2,
+    'recordsFiltered' => 2,
+    'data' => [['id' => '1'], ['id' => '2']],
+];
+$got = Route::asValue(
+    function () use ($dataProp, $envelope) {
+        $dataProp->setValue(null, $envelope);
+    }
+);
+expect($failures, 'asValue keeps recordsFiltered', 2, $got->recordsFiltered ?? null);
+expect($failures, 'asValue keeps data as a list', 2, count($got->data ?? []));
+expect($failures, 'asValue rows are objects', '1', $got->data[0]->id ?? null);
+expect(
+    $failures,
+    'asValue matches the json round-trip it replaces',
+    json_encode(json_decode(json_encode($envelope))),
+    json_encode($got)
+);
+
+// A bare list payload -- names() reports this shape -- stays a list, so the
+// count() in pinghosts reads the same.
+$got = Route::asValue(
+    function () use ($dataProp) {
+        $dataProp->setValue(null, ['a', 'b', 'c']);
+    }
+);
+expect($failures, 'asValue passes a bare list through', 'array', gettype($got));
+expect($failures, 'asValue bare list count', 3, count($got));
+
+// Route::$data must be cleared, or the next caller inherits this result.
+expect($failures, 'asValue clears Route::$data', '', $dataProp->getValue());
+
 // ---- 2. the rethrow guard ------------------------------------------------
 
 $depth = $ref->getProperty('_rethrowDepth');
@@ -165,6 +207,18 @@ try {
 } catch (Throwable $e) {
     echo 'MARKER:wrongtype:' . get_class($e);
 }
+// Same question, but with asValue() raising the depth rather than the test.
+// Eleven daemon sites now go through it, so it has to carry the guard itself.
+$d->setValue(null, 0);
+try {
+    Route::asValue(function () { Route::sendResponse(406, 'inner'); });
+    echo ' MARKER2:noraise';
+} catch (RuntimeException $e) {
+    echo ' MARKER2:raised:' . $e->getMessage();
+} catch (Throwable $e) {
+    echo ' MARKER2:wrongtype:' . get_class($e);
+}
+echo ' DEPTH:' . $d->getValue();
 PROBE;
 
 $out = [];
@@ -183,6 +237,15 @@ if (strpos($got, 'MARKER:raised:probe:406') === false) {
         $failures[] = 'sendResponse() did not raise as expected: '
             . var_export(substr($got, 0, 120), true);
     }
+}
+
+if (strpos($got, 'MARKER2:raised:inner') === false) {
+    $failures[] = 'asValue() did not raise its callable\'s failure: '
+        . var_export(substr($got, 0, 200), true);
+}
+if (strpos($got, 'DEPTH:0') === false) {
+    $failures[] = 'asValue() left the rethrow depth raised after a failure: '
+        . var_export(substr($got, 0, 200), true);
 }
 
 // A wrapper must leave the depth where it found it, including after a failure.


### PR DESCRIPTION
All 26 `Route::listem` / `indiv` / `active` / `names` sites under
`packages/web/lib/service`, across 11 files. This is the bucket
[ADR 0011](docs/adr/0011-route-result-wrappers.md) ordered first, because it
is the only one where the current behaviour can kill a process.

## Why this bucket first

`listem()`, `indiv()` and `active()` report failure through
`Route::sendResponse()`, which reaches `HTTPResponseCodes::breakHead()`, which
ends in `exit`. At the HTTP boundary that is correct. Under a CLI daemon it
terminates the forked child outright — nothing written to the log, no exception
for the service loop to catch, and the systemd unit still reading `active`
while doing nothing.

This is not theoretical. `multicasttask.class.php` has carried a hand-rolled
guard against exactly it since #907.

## Which wrapper, and why

| Wrapper | Sites | When |
|---|---:|---|
| `getList()` | 16 | the caller only ever wanted the rows |
| `getItem()` | 6 | one entity; a miss now answers `null` |
| `asValue()` | 4 | the caller reads the envelope, or the helper has no wrapper |

The `getItem()` sites are the ones that needed thought rather than a swap,
because `indiv()` used to exit on a miss and `null` is a value a caller has to
handle. Each got the answer belonging to its context:

- skip the storage group and carry on — `imagesize`, `snapinhash`, both replicators
- skip the node — `fogservice`'s master loop and its replicate loop
- skip the scheduled task — `taskscheduler`'s `tasktype` lookup
- return "not master" — `multicasttask::getAllMulticastTasks()`
- throw, alongside the two throws already there for "cannot sync from here" — `fogservice::replicateItems()`
- return `0` — `getPartitions()`, the same answer a whole-disk image gives, and the conservative one when the partition cannot be determined

## `Route::asValue()`

ADR 0011 claimed essentially no internal caller needed the envelope metadata.
Migrating the daemons proved that wrong twice — `taskscheduler.class.php:133`
and `filedeleter.class.php:160` both read `->recordsFiltered` off `active()`
and then iterate `->data`. There is a second gap: `active()`, `names()`,
`availablekernels()` and `logfiles()` have no wrapper at all, and `names()`'s
payload is a bare list with nothing to unwrap.

`asValue(callable)` runs the call with the rethrow depth raised and hands back
exactly what `json_decode(Route::getData())` returned. Adopting it is a swap
with no semantic change; what it adds is the half those callers still need.

It is deliberately the third choice, and the docblock says so.

## The #907 guard stays, and the ADR is corrected

ADR 0011 said `multicasttask`'s hand-rolled guard could retire once step 1
reached it. Step 1 reached it and it cannot — the guard was doing two jobs and
the wrappers take over one.

`getItem()` establishes **existence**; `indiv()` gates on **`isValid()`**. A
deleted image now answers `null`, which is the half that killed the daemon. An
image that is present but does not validate (`osID` of 0, blank name or path)
still reaches `indiv()` and still fails — it raises rather than exiting now, so
the daemon survives, but the exception would unwind the entire
session-collection pass instead of skipping the one session. The guard keeps
that scoped, and its comment now says so.

Making `getItem()` gate on validity was considered and rejected: its existence
check runs through `getIds()`, so it also answers `null` for a row the caller
may not *see*, and constructing the entity to test `isValid()` directly would
bypass that filtering.

## Verification

Against the live 1.6 lab at `10.255.20.1`:

- **27 assertions** comparing the old idiom against the new wrapper on every
  migrated query — all byte-identical under `json_encode()`, top-level type
  included.
- `getItem()` on a nonexistent row returns `null` for all four classes used,
  and the script keeps running — `indiv()` would have exited.
- `asValue()` results identical to `json_decode(getData())` for
  `active('scheduledtask')`, `active('powermanagement')`,
  `active('filedeletequeue')` and `names('host')`, with `->recordsFiltered` and
  `->data` intact.
- Then the real methods, not just their queries:
  `FOGService::checkIfNodeMaster()` (the by-reference loop),
  `PluginRunner::_discoverTasks()` (compared old vs new tree — both `[]`), and
  `MulticastTask::getAllMulticastTasks()` — the last against a storage node id
  that does not exist, which returned `null` where it previously would have
  killed the daemon child.
- `sh tests/run-all.sh` → 8 passed, 0 failed.

New test coverage for `asValue()`: the envelope survives, a bare list stays a
list, `Route::$data` is cleared, and the child-process probe now also asserts
`asValue()` raises its callable's failure rather than exiting. Verified the
probe **fails** when the depth increment is removed.

## Not in this PR

Steps 2–5 of ADR 0011's migration order: client endpoints and hooks (4 sites),
`fog-plugins` (37), pages/models/reports (94), and a deliberate decision about
the router's own 6 sites.