### PR TITLE
Migrate the client endpoints and hooks to the Route wrappers (ADR 0011 step 2)

### DIFF
--- a/packages/web/lib/client/pm.class.php
+++ b/packages/web/lib/client/pm.class.php
@@ -62,18 +62,15 @@ class PM extends FOGClient
             'onDemand' => [0, ''],
             'action' => ['shutdown', 'reboot']
         ];
-        Route::listem(
+        $PMTasks = Route::getList(
             'powermanagement',
             $PMFind
-        );
-        $PMTasks = json_decode(
-            Route::getData()
         );
         $data = [
             'onDemand' => $action,
             'tasks' => [],
         ];
-        foreach ($PMTasks->data as $PMTask) {
+        foreach ($PMTasks as $PMTask) {
             $min = trim($PMTask->min);
             $hour = trim($PMTask->hour);
             $dom = trim($PMTask->dom);

--- a/packages/web/lib/client/printerclient.class.php
+++ b/packages/web/lib/client/printerclient.class.php
@@ -91,12 +91,9 @@ class PrinterClient extends FOGClient
         } else {
             $default = array_shift($defaultName);
         }
-        Route::listem('printer');
-        $Printers = json_decode(
-            Route::getData()
-        );
+        $Printers = Route::getList('printer');
         $printers = [];
-        foreach ((array)$Printers->data as $Printer) {
+        foreach ($Printers as $Printer) {
             if (!in_array($Printer->id, $printerIDs)) {
                 continue;
             }

--- a/packages/web/lib/client/snapinclient.class.php
+++ b/packages/web/lib/client/snapinclient.class.php
@@ -101,16 +101,19 @@ class SnapinClient extends FOGClient
                     ),
                     'jobID' => $SnapinJob->get('id')
                 ];
-                Route::listem(
+                // getList() sets inputoverride, which the old call left off.
+                // That is the one behaviour change here and it is deliberate:
+                // this runs inside the client's POST, so without it listem()
+                // parses php://input -- and folds in ?length/?start -- and a
+                // request carrying either would silently truncate the snapin
+                // list the client is about to run.
+                $SnapinTasks = Route::getList(
                     'snapintask',
                     $find,
-                    false,
                     'AND',
                     'sequence'
                 );
-                $SnapinTasks = json_decode(Route::getData());
-                $SnapinTasks = isset($SnapinTasks->data) ? $SnapinTasks->data : [];
-                if (count($SnapinTasks ?: []) < 1) {
+                if (count($SnapinTasks) < 1) {
                     $SnapinJob
                         ->set('stateID', self::getCancelledState())
                         ->save();

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -143,15 +143,13 @@ class BootItem extends Hook
          * inside the item label is an arrayed item of value [0] containing
          * the label so to tweak:
          */
-        Route::listem('pxemenuoptions');
-        $Menus = json_decode(
-            Route::getData()
-        );
-        // ->data, not the envelope: listem() returns the paginated wrapper and
-        // the rows live under it. Iterating the wrapper walked its own scalar
-        // members (draw, recordsTotal, the page URLs...) instead, so $Menu->name
-        // was null every pass and the fog.local special-casing below never fired.
-        foreach ($Menus->data as $Menu) {
+        // getList(), not listem(): this loop used to iterate the paginated
+        // envelope instead of the rows beneath it, so $Menu->name was null
+        // every pass and the fog.local special-casing below never fired. The
+        // wrapper returns the rows, so there is no envelope left to hold
+        // wrongly. See ADR 0011.
+        $Menus = Route::getList('pxemenuoptions');
+        foreach ($Menus as $Menu) {
             if ($arguments['ipxe']['item-'.$Menu->name]
                 && $Menu->name == 'fog.local'
             ) {

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -21,11 +21,16 @@
  */
 require '../commons/base.inc.php';
 try {
-    Route::names('group');
-    $groupnames = json_decode(
-        Route::getData()
+    // asValue(): names() has no wrapper, and its payload is a bare list with
+    // no envelope to unwrap. What this buys is that a router failure raises
+    // into the catch below rather than reaching breakHead()'s exit. See
+    // ADR 0011.
+    $groupnames = Route::asValue(
+        function () {
+            Route::names('group');
+        }
     );
-    if (count($groupnames ?: []) < 1) {
+    if (count((array)$groupnames) < 1) {
         throw new \Exception(
             _('There are no groups on this server')
         );

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -47,15 +47,12 @@ try {
     $Image = $Task->getImage();
     if ($TaskType->isInitNeededTasking()) {
         if ($TaskType->isMulticast()) {
-            Route::listem(
+            $ids = Route::getList(
                 'multicastsessionassociation',
                 ['taskID' => $Task->get('id')]
             );
-            $ids = json_decode(
-                Route::getData()
-            );
             $msIDs = [];
-            foreach ($ids->data as $id) {
+            foreach ($ids as $id) {
                 $msIDs[] = $id->msID;
             }
 

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -21,11 +21,17 @@
  */
 require '../commons/base.inc.php';
 try {
-    Route::names('printer');
-    $printernames = json_decode(
-        Route::getData()
+    // asValue(): names() has no wrapper, and its payload is a bare list with
+    // no envelope to unwrap. What this buys is that a router failure raises
+    // into the catch below and the client gets "#!np" -- rather than reaching
+    // breakHead()'s exit, which sends a non-2xx the client reads as a
+    // transport failure. See ADR 0011.
+    $printernames = Route::asValue(
+        function () {
+            Route::names('printer');
+        }
     );
-    if (count($printernames ?: []) < 1) {
+    if (count((array)$printernames) < 1) {
         throw new \Exception("#!np\n");
     }
     echo "#!ok\n";


### PR DESCRIPTION
Seven sites — not the four [ADR 0011](docs/adr/0011-route-result-wrappers.md)
counted. It bucketed `packages/web/service/` elsewhere, but `hostinfo.php`,
`printerlisting.php` and `grouplisting.php` are client endpoints too and belong
in this pass.

## How this bucket fails

Nothing dies here. The response just ends with a non-2xx — and a non-2xx is
invisible to the fog-client. It reads as a *transport* failure rather than as
an answer, so the client retries against a server that is working fine.

`printerlisting.php` and `grouplisting.php` make the shape obvious: both
already wrap their work in a `try`/`catch` that prints something the client can
read, and `breakHead()`'s `exit` was walking straight past it. `asValue()` lets
the raise reach that catch.

| Wrapper | Sites |
|---|---|
| `getList()` | `pm`, `printerclient`, `snapinclient`, `bootitem.hook`, `hostinfo.php` |
| `asValue()` | `printerlisting.php`, `grouplisting.php` — `names()` has no wrapper and its payload is a bare list, so there is nothing to unwrap |

`bootitem.hook.php` keeps its comment, reworded. That loop is one of the three
places the envelope bug actually shipped; the wrapper removes the opportunity,
which is worth more than the note explaining it.

## One deliberate behaviour change

`snapinclient` passed `inputoverride = false`; `getList()` always sets it. That
call runs inside the client's own POST, so `listem()` was parsing `php://input`
and folding in `?length` / `?start` — a request carrying either would silently
truncate the snapin list the client is about to run. Commented at the site.

## Noted, not changed

`grouplisting.php`'s `printf` uses a single-quoted format string, so it emits
literal `\t` and `\n` rather than tabs and newlines. Pre-existing, it is the
endpoint's wire format today, and whatever still consumes it may be parsing
exactly that. Out of scope for this PR.

## Verification

Against the live 1.6 lab at `10.255.20.1`:

- Every migrated query compared old idiom against new wrapper — byte-identical
  under `json_encode()`, including `snapintask`'s 22KB result with its
  non-default `orderby => sequence`.
- `printerlisting.php` and `grouplisting.php` produce **byte-identical output**
  when run against the deployed (old) tree and against the new one.
- `PrinterClient::json()` and `PM::json()` likewise, on a live host.
- `sh tests/run-all.sh` → 8 passed, 0 failed.

## Remaining

ADR 0011 steps 3–5: `fog-plugins` (37 sites), pages/models/reports (94), and a
deliberate decision about the router's own 6 sites, where `exit` is correct.