### PR TITLE
Migrate the boot menu to the Route wrappers, and drop a dead menu query

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -327,16 +327,22 @@ class BootMenu extends FOGBase
                     ['sysuuid' => $sysuuid]
                 );
             }
-            Route::indiv('host', self::$Host->get('id'));
-            $host = json_decode(Route::getData());
-            $host_items = self::generateIpxeItems($host);
-            foreach ($host_items as $item) {
-                $Send['hostinfo'][] = $item;
+            // getItem(), not indiv(): a miss answers null rather than
+            // reaching breakHead()'s exit, which on a boot request means the
+            // machine gets a truncated iPXE script instead of a menu.
+            $host = Route::getItem('host', self::$Host->get('id'));
+            if ($host) {
+                $host_items = self::generateIpxeItems($host);
+                foreach ($host_items as $item) {
+                    $Send['hostinfo'][] = $item;
+                }
             }
-            Route::listem('inventory', ['hostID' => self::$Host->get('id')]);
-            $inventory = json_decode(Route::getData());
-            if (!empty($inventory->data)) {
-                $inventory_items = self::generateIpxeItems($inventory->data[0]);
+            $inventory = Route::getList(
+                'inventory',
+                ['hostID' => self::$Host->get('id')]
+            );
+            if (!empty($inventory)) {
+                $inventory_items = self::generateIpxeItems($inventory[0]);
                 foreach ($inventory_items as $item) {
                     $Send['inventoryinfo'][] = $item;
                 }
@@ -463,19 +469,13 @@ class BootMenu extends FOGBase
             . "://{$webserver}/fog/service";
         $this->_memdisk = "kernel $memdisk initrd=$memtest";
         $this->_memtest = "initrd $memtest";
-        Route::listem(
+        $StorageNodes = Route::getList(
             'storagenode',
             ['ip' => [$webserver, self::resolveHostname($webserver)]]
         );
-        $StorageNodes = json_decode(
-            Route::getData()
-        );
-        if (count($StorageNodes->data ?: []) < 1) {
-            Route::listem('storagenode');
-            $StorageNodes = json_decode(
-                Route::getData()
-            );
-            foreach ($StorageNodes->data as &$StorageNode) {
+        if (count($StorageNodes) < 1) {
+            $StorageNodes = Route::getList('storagenode');
+            foreach ($StorageNodes as &$StorageNode) {
                 $hostname = self::resolveHostname($StorageNode->ip);
                 if ($hostname == $webserver
                     || $hostname == self::resolveHostname($webserver)
@@ -496,7 +496,7 @@ class BootMenu extends FOGBase
                 $StorageNode = new StorageNode(self::minId($storageNodeIDs));
             }
         } else {
-            $first = array_shift($StorageNodes->data);
+            $first = array_shift($StorageNodes);
             $StorageNode = new StorageNode($first->id);
         }
         if ($StorageNode->isValid()) {
@@ -806,15 +806,12 @@ class BootMenu extends FOGBase
                 (array)self::getProgressState()
             ),
         ];
-        Route::listem(
+        $Sessions = Route::getList(
             'multicastsession',
             $findWhere
         );
-        $Sessions = json_decode(
-            Route::getData()
-        );
         $MulticastSessionID = 0;
-        foreach ($Sessions->data as &$MulticastSession) {
+        foreach ($Sessions as &$MulticastSession) {
             if ($MulticastSession->sessclients < 1) {
                 $MulticastSessionID = 0;
                 unset($MulticastSession);
@@ -927,6 +924,34 @@ class BootMenu extends FOGBase
      *
      * @return void
      */
+    /**
+     * Tells the operator a seeded task type is missing, on screen.
+     *
+     * The three createImagePackage() callers below fetch a task type by its
+     * seeded id. getItem() answers null when the row is gone, where indiv()
+     * used to reach breakHead()'s exit -- which on a boot request truncates
+     * the iPXE script mid-stream, so the machine drops to a bare prompt with
+     * nothing said about why. See ADR 0011.
+     *
+     * @param int $id The task type id that could not be loaded.
+     *
+     * @return void
+     */
+    private function _noTaskType($id)
+    {
+        $this->_parseMe(
+            [
+                'fail' => [
+                    '#!ipxe',
+                    sprintf(
+                        'echo Task type %d is missing from this server.',
+                        $id
+                    ),
+                    'sleep 5',
+                ],
+            ]
+        );
+    }
     public function sesscreate()
     {
         $sessname = trim($_REQUEST['sessname']);
@@ -955,8 +980,11 @@ class BootMenu extends FOGBase
             '#isdebug=yes|mode=debug|mode=onlydebug#i',
             $extraargs
         );
-        Route::indiv('tasktype', TaskType::MULTICAST);
-        $tasktype = json_decode(Route::getData());
+        $tasktype = Route::getItem('tasktype', TaskType::MULTICAST);
+        if (!$tasktype) {
+            $this->_noTaskType(TaskType::MULTICAST);
+            return;
+        }
         self::$Host->createImagePackage(
             $tasktype,
             $sessname,
@@ -1129,14 +1157,10 @@ class BootMenu extends FOGBase
         if ($imgFind === false) {
             $Images = false;
         } else {
-            Route::listem(
+            $Images = Route::getList(
                 'image',
                 $imgFind
             );
-            $Images = json_decode(
-                Route::getData()
-            );
-            $Images = $Images->data;
         }
         if (!$Images) {
             $Send['NoImages'] = [
@@ -1260,8 +1284,11 @@ class BootMenu extends FOGBase
             $extraargs
         );
         if (self::$Host->isValid() && !self::$Host->get('pending')) {
-            Route::indiv('tasktype', TaskType::MULTICAST);
-            $tasktype = json_decode(Route::getData());
+            $tasktype = Route::getItem('tasktype', TaskType::MULTICAST);
+            if (!$tasktype) {
+                $this->_noTaskType(TaskType::MULTICAST);
+                return;
+            }
             self::$Host->createImagePackage(
                 $tasktype,
                 $MultiSess->get('name'),
@@ -1498,8 +1525,18 @@ class BootMenu extends FOGBase
             return;
         }
         try {
-            Route::indiv('tasktype', TaskType::DEPLOY);
-            $tasktype = json_decode(Route::getData());
+            $tasktype = Route::getItem('tasktype', TaskType::DEPLOY);
+            if (!$tasktype) {
+                // Thrown rather than handed to _noTaskType(): the catch below
+                // already renders a message from the exception, and this is
+                // the one of the three sites that has one.
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        TaskType::DEPLOY
+                    )
+                );
+            }
             self::$Host->createImagePackage(
                 $tasktype,
                 'AutoRegTask',
@@ -2110,16 +2147,6 @@ class BootMenu extends FOGBase
             return;
         }
 
-        Route::listem(
-            'pxemenuoptions',
-            false,
-            false,
-            'AND',
-            'id'
-        );
-        $Menus = json_decode(
-            Route::getData()
-        );
         $ipxeGrabs = [
             'FOG_ADVANCED_MENU_LOGIN',
             'FOG_IPXE_BG_FILE',
@@ -2212,15 +2239,11 @@ class BootMenu extends FOGBase
                 4
             );
         }
-        Route::listem(
+        $Menus = Route::getList(
             'pxemenuoptions',
             ['regMenu' => $RegArrayOfStuff],
-            false,
             'AND',
             'id'
-        );
-        $Menus = json_decode(
-            Route::getData()
         );
         // pxeID 14 ("Enroll Secure Boot Key (MOK attended setup)") and
         // pxeID 15 ("Enroll Secure Boot Key (Unattended...)") are both
@@ -2251,9 +2274,9 @@ class BootMenu extends FOGBase
         if (isset($_REQUEST['platform'])
             && $_REQUEST['platform'] != 'efi'
         ) {
-            $Menus->data = array_values(
+            $Menus = array_values(
                 array_filter(
-                    $Menus->data,
+                    $Menus,
                     // By pxeName, not pxeID -- see _menuOpt(). Keyed by id,
                     // a BIOS client would have had an unrelated custom menu
                     // entry sitting at 14 or 15 hidden from it instead.
@@ -2289,9 +2312,9 @@ class BootMenu extends FOGBase
             || !file_exists($authDir . 'KEK.auth')
             || !file_exists($authDir . 'db.auth')
         ) {
-            $Menus->data = array_values(
+            $Menus = array_values(
                 array_filter(
-                    $Menus->data,
+                    $Menus,
                     function ($Menu) {
                         return 'fog.enrollsecurebootunattended' !== $Menu->name;
                     }
@@ -2309,7 +2332,7 @@ class BootMenu extends FOGBase
                     $desc
                 );
             },
-            $Menus->data
+            $Menus
         );
         $Send['default'] = [$this->_defaultChoice];
         array_map(
@@ -2319,7 +2342,7 @@ class BootMenu extends FOGBase
                     trim($Menu->args)
                 );
             },
-            $Menus->data
+            $Menus
         );
         $Send['bootme'] = [
             ':bootme',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7369,6 +7369,10 @@ msgstr "Task-Typ hinzugefügt"
 msgid "Task state update failed!"
 msgstr "Aktualisierung des Task Status fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "Es gibt keine Snapins auf diesem Server."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "Task-Typ ist nicht gültig"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7367,6 +7367,10 @@ msgstr "Task State added, editing"
 msgid "Task state update failed!"
 msgstr "User created"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "There are no snapins on this server."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "Task type is not valid"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7554,6 +7554,10 @@ msgstr "Nombre de la tarea"
 msgid "Task state update failed!"
 msgstr "creado por el usuario"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "No hay grupos en este servidor."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "tipo de tarea no es válida"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7370,6 +7370,10 @@ msgstr "Task-Typ hinzugefügt"
 msgid "Task state update failed!"
 msgstr "Aktualisierung des Task Status fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "Es gibt keine Snapins auf diesem Server."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "Task-Typ ist nicht gültig"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7369,6 +7369,10 @@ msgstr "État Tâche ajouté, édition"
 msgid "Task state update failed!"
 msgstr "utilisateur créé"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "Il n'y a pas snapins sur ce serveur."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "Type de tâche n'est pas valide"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -7081,6 +7081,10 @@ msgstr "Aggiunta tipo attività riuscita!"
 msgid "Task state update failed!"
 msgstr "Aggiunta stato attività fallito"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "Non ci sono snapins su questo server"
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "Tipo di attività non è valido"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -7006,6 +7006,10 @@ msgstr "タスク状態を追加しました！"
 msgid "Task state update failed!"
 msgstr "タスク状態の更新に失敗しました"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "このサーバーにはスナップインがありません"
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "タスクタイプが無効です"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6220,6 +6220,10 @@ msgstr ""
 msgid "Task state update failed!"
 msgstr ""
 
+#, php-format
+msgid "Task type %d is missing from this server."
+msgstr ""
+
 msgid "Task type is invalid"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7368,6 +7368,10 @@ msgstr "Estado tarefa adicional, a edição"
 msgid "Task state update failed!"
 msgstr "usuário criado"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "Não há snapins neste servidor."
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "tipo de tarefa não é válido"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7368,6 +7368,10 @@ msgstr "任务状态添加，编辑"
 msgid "Task state update failed!"
 msgstr "用户创建"
 
+#, fuzzy, php-format
+msgid "Task type %d is missing from this server."
+msgstr "有此服务器上没有snapins。"
+
 #, fuzzy
 msgid "Task type is invalid"
 msgstr "任务类型无效"


### PR DESCRIPTION
Eleven `Route::listem`/`indiv` sites in `bootmenu.class.php`. Pulled out of
[ADR 0011](docs/adr/0011-route-result-wrappers.md)'s step 4 and done on its own
because it is the last bucket where a failure has an operational consequence
rather than a cosmetic one: this code builds the iPXE script, and
`breakHead()`'s `exit` truncates that script mid-stream. The machine drops to a
bare prompt with nothing said about why.

| Wrapper | Sites |
|---|---:|
| `getList()` | 7 |
| `getItem()` | 4 — `host`, and the three seeded task types |

## The four `getItem()` sites each needed an answer for null

`indiv()` never had to have one, because it exited instead.

- **`host`** — skip the `hostinfo` block, keep building the menu.
- **the three `tasktype` fetches** — say so on screen. `sesscreate()` and
  `multijoin()` call a new `_noTaskType()`, which renders through the same
  `_parseMe()` path every other in-band boot message uses. The autoreg site
  throws instead, because it already sits inside a `try`/`catch` that renders
  the message.

## Dead query removed

`printDefault()` fetched the **whole `pxemenuoptions` table** at the top of the
method and never read the result — `$Menus` is overwritten sixty lines later by
the `regMenu`-filtered fetch the rest of the method actually uses. Nothing
between the two assignments touches the variable.

That was a full `listem()`, with its hooks, permission filtering and getter
machinery, **on every PXE boot**, for nothing.

## `inputoverride`

Two `listem()` calls passed `inputoverride = false`; `getList()` always sets
it. `boot.php` is a POST from iPXE, so `listem()` was parsing `php://input` and
folding in `?length` / `?start` on a menu query. Pagination on a boot menu is
not a thing anyone wants.

## Verification

Served the edited tree alongside the running lab server at `10.255.20.1` and
diffed real `boot.php` responses. **Byte-identical on all twelve request shapes
tried:**

| Shape | Response |
|---|---|
| registered host | 5082 B |
| unknown MAC / empty MAC | 4263 B |
| `platform=efi` | 4198 B |
| `platform=bios` | 3098 B |
| `qihost` image list | 11054 B |
| `sessjoin` | 1582 B |
| `sesscheck` (named session) | 1789 B |
| `menuaccess` | 1464 B |
| `keyreg` | 1484 B |
| `advLogin` | 5082 B |
| `debugAccess` | 1442 B |
| bad login | 1520 B |

The registered-host response carries all 51 `set hostname` / `set sysman` /
`set mbman` lines, so both migrated `generateIpxeItems()` blocks — the one fed
by `getItem('host')` and the one fed by `getList('inventory')` — are inside
what was compared.

`sh tests/run-all.sh` → 8 passed, 0 failed.