### PR TITLE
Migrate the model layer to the Route wrappers (ADR 0011 step 4a)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -741,19 +741,16 @@ abstract class FOGBase
             'taskID' => self::$Host->get('task')->get('id'),
             'hostID' => self::$Host->get('id'),
         ];
-        Route::listem(
+        $NodeFails = Route::getList(
             'nodefailure',
             $find
-        );
-        $NodeFails = json_decode(
-            Route::getData()
         );
         $nodeRet = array_values(
             array_unique(
                 array_filter(
                     array_map(
                         $nodeFail,
-                        $NodeFails->data
+                        $NodeFails
                     )
                 )
             )
@@ -3317,17 +3314,15 @@ abstract class FOGBase
         if ($macCount < 1) {
             return;
         }
-        Route::listem(
+        $StorageNodes = Route::getList(
             'storagenode',
             ['isEnabled' => 1]
         );
-        $StorageNodes = json_decode(
-            Route::getData()
-        );
-        foreach ($StorageNodes->data as &$StorageNode) {
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
-            if (!$StorageNode->online) {
+        foreach ($StorageNodes as &$StorageNode) {
+            // getItem(), not indiv(): a node deleted between the list and the
+            // fetch answers null here rather than ending the response.
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode || !$StorageNode->online) {
                 continue;
             }
             $nodeURLs[] = sprintf(

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1120,18 +1120,14 @@ abstract class FOGManagerController extends FOGBase
         );
         if ($filter) {
             $find = ['id' => $filter];
-            Route::listem(
+            $Items = Route::getList(
                 $this->childClass,
-                $find,
-                true
+                $find
             );
         } else {
-            Route::listem($this->childClass, false, true);
+            $Items = Route::getList($this->childClass);
         }
-        $Items = json_decode(
-            Route::getData()
-        );
-        foreach ($Items->data as &$Item) {
+        foreach ($Items as &$Item) {
             if (isset($Item->isEnabled) && !$Item->isEnabled) {
                 continue;
             }

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1752,12 +1752,11 @@ abstract class FOGPage extends FOGBase
                     'storagegroupID'
                 ];
                 $insert_values = [];
-                Route::listem(
+                $items = Route::getList(
                     $this->childClass,
                     $where
                 );
-                $items = json_decode(Route::getData());
-                foreach ($items->data as $item) {
+                foreach ($items as $item) {
                     $storagegroups[$item->$pathKey] = Route::getIds(
                         $groupassoc,
                         [strtolower($this->childClass).'ID' => $item->id],
@@ -3671,9 +3670,7 @@ abstract class FOGPage extends FOGBase
         $idSet = [];
         $nameToId = [];
         $idToName = [];
-        Route::listem($class, false, true);
-        $items = json_decode(Route::getData());
-        $items = isset($items->data) ? $items->data : [];
+        $items = Route::getList($class);
         foreach ($items as &$it) {
             if (!isset($it->id)) {
                 continue;
@@ -4067,13 +4064,10 @@ abstract class FOGPage extends FOGBase
             ) {
                 continue;
             }
-            Route::listem(
+            $rows = Route::getList(
                 $entry['bulkclass'],
-                [$entry['parentkey'] => $ids],
-                true
+                [$entry['parentkey'] => $ids]
             );
-            $rows = json_decode(Route::getData());
-            $rows = isset($rows->data) ? $rows->data : [];
             $orderkey = isset($entry['orderkey']) ? $entry['orderkey'] : '';
             $byParent = [];
             foreach ($rows as $r) {

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -700,13 +700,12 @@ class Group extends FOGController
             } elseif ($TaskType->isDeploy) {
                 $hostIDs = array_values($hostids);
                 $hostCount = count($hostIDs);
-                Route::listem(
+                $Hosts = Route::getList(
                     'host',
                     ['id' => $hostIDs]
                 );
-                $Hosts = json_decode(Route::getData());
                 $imageMap = [];
-                foreach ($Hosts->data as $Host) {
+                foreach ($Hosts as $Host) {
                     $imageMap[$Host->id] = $Host->imageID;
                 }
                 $batchFields = [

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -909,19 +909,14 @@ class Host extends FOGController
             }
             $nextSequence = 1;
             // listem order is ASC by the requested field, so the last row has max sequence.
-            Route::listem(
+            $existingTasks = Route::getList(
                 'snapintask',
                 ['jobID' => $snapinJobID],
-                false,
                 'AND',
                 'sequence'
             );
-            $existingTasks = json_decode(Route::getData());
-            if (isset($existingTasks->data)
-                && count((array)$existingTasks->data) > 0
-            ) {
-                $dataArray = (array)$existingTasks->data;
-                $lastTask = end($dataArray);
+            if (count($existingTasks) > 0) {
+                $lastTask = end($existingTasks);
                 $nextSequence = max(1, (int)$lastTask->sequence + 1);
             }
             foreach ((array)$snapin as &$snapinID) {
@@ -1214,7 +1209,7 @@ class Host extends FOGController
                 // port, own local sender.
                 $mcGroupID = $StorageNode->get('storagegroupID');
                 if ($sessionjoin) {
-                    Route::listem(
+                    $MCSessions = Route::getList(
                         'multicastsession',
                         [
                             'name' => $taskName,
@@ -1222,13 +1217,9 @@ class Host extends FOGController
                             'storagegroupID' => $mcGroupID
                         ]
                     );
-                    $MCSessions = json_decode(
-                        Route::getData()
-                    );
-                    $MCSessions = $MCSessions->data;
                     $assoc = true;
                 } else {
-                    Route::listem(
+                    $MCSessions = Route::getList(
                         'multicastsession',
                         [
                             'image' => $Image->get('id'),
@@ -1236,10 +1227,6 @@ class Host extends FOGController
                             'storagegroupID' => $mcGroupID
                         ]
                     );
-                    $MCSessions = json_decode(
-                        Route::getData()
-                    );
-                    $MCSessions = $MCSessions->data;
                 }
                 $MultiSessJoin = array_values(
                     array_filter(
@@ -1605,15 +1592,12 @@ class Host extends FOGController
         if ($hostID < 1) {
             return;
         }
-        Route::listem(
+        $associations = Route::getList(
             'snapinassociation',
             ['hostID' => $hostID],
-            false,
             'AND',
             'sequence'
         );
-        $associations = json_decode(Route::getData());
-        $associations = isset($associations->data) ? $associations->data : [];
         $maxSequence = 0;
         $unsequenced = [];
         foreach ($associations as $association) {

--- a/packages/web/lib/fog/hostmanager.class.php
+++ b/packages/web/lib/fog/hostmanager.class.php
@@ -83,9 +83,7 @@ class HostManager extends FOGManagerController
         if (empty($filter)) {
             return;
         }
-        Route::listem('inventory', $filter, false, 'OR');
-        $Inventories = json_decode(Route::getData());
-        $Inventories = $Inventories->data;
+        $Inventories = Route::getList('inventory', $filter, 'OR');
         if (count($Inventories ?: []) < 1) {
             return;
         }

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -870,11 +870,10 @@ class Plugin extends FOGController
         // against. Paginating it would under-report both. Safe today only
         // because the POST body carries plugins[] and no DataTables length --
         // which is not a property worth relying on. See getPlugins().
-        Route::listem('plugin', false, true);
-        $rows = json_decode(Route::getData());
+        $rows = Route::getList('plugin');
         $batch = [];
         $active = [];
-        foreach ((array)($rows->data ?? []) as $row) {
+        foreach ($rows as $row) {
             $name = strtolower((string)$row->name);
             if (in_array((int)$row->id, $ids, true)) {
                 $batch[$name] = $row;
@@ -948,9 +947,8 @@ class Plugin extends FOGController
         // page size below the plugin count returned a short list -- and every
         // plugin past it looked new (see the id lookup below for what that
         // then did). Discovery wants every row, always.
-        Route::listem('plugin', false, true);
-        $rows = json_decode(Route::getData());
-        foreach ((array)($rows->data ?? []) as $row) {
+        $rows = Route::getList('plugin');
+        foreach ($rows as $row) {
             $existing[strtolower((string)$row->name)] = $row;
         }
         foreach ((array) $this->_getDirs() as $file) {

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -37,9 +37,8 @@ class PluginManager extends FOGManagerController
         // truncate this list -- see Plugin::getPlugins(). Read-only here, so
         // the worst case was a missing "needs update" badge rather than a
         // damaged row, but it is the same mistake.
-        Route::listem('plugin', ['installed' => 1], true);
-        $plugins = json_decode(Route::getData());
-        foreach ((array)$plugins->data as $row) {
+        $plugins = Route::getList('plugin', ['installed' => 1]);
+        foreach ($plugins as $row) {
             $plugin = self::getClass('Plugin', $row->id);
             if ($plugin->needsSchemaUpdate()) {
                 $needing[] = $plugin;

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -177,14 +177,11 @@ class StorageGroup extends FOGController
         ];
         $nodeids = [];
         $testurls = [];
-        Route::listem(
+        $StorageNodes = Route::getList(
             'storagenode',
             $find
         );
-        $StorageNodes = json_decode(
-            Route::getData()
-        );
-        foreach ($StorageNodes->data as &$StorageNode) {
+        foreach ($StorageNodes as &$StorageNode) {
             if ($StorageNode->maxClients < 1) {
                 continue;
             }
@@ -280,10 +277,14 @@ class StorageGroup extends FOGController
         $StorageNodes = json_decode(
             Route::getData()
         );
+        // $StorageNodes stays the paginated envelope on purpose: it is handed
+        // to MASTER_STORAGE_NODE below by reference, so its shape is surface a
+        // third-party plugin may already read. Only the per-row fetch moves --
+        // getItem() answers null for a node deleted between the list and the
+        // fetch, where indiv() ended the response outright. Refs ADR 0011.
         foreach ($StorageNodes->data as $StorageNode) {
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
-            if (!$StorageNode->online) {
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode || !$StorageNode->online) {
                 continue;
             }
             if ($masternode == null) {
@@ -325,10 +326,11 @@ class StorageGroup extends FOGController
         $StorageNodes = json_decode(
             Route::getData()
         );
+        // Envelope kept, per the note in getMasterStorageNode(): this one is
+        // handed to OPTIMAL_STORAGE_NODE by reference.
         foreach ($StorageNodes->data as &$StorageNode) {
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
-            if (!$StorageNode->online) {
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode || !$StorageNode->online) {
                 continue;
             }
             if (!$StorageNode->isEnabled) {

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -236,17 +236,14 @@ class StorageNode extends FOGController
      */
     public function getNodeFailure($Host)
     {
-        Route::listem(
+        $Failures = Route::getList(
             'nodefailure',
             [
                 'hostID' => $Host,
                 'storagenodeID' => $this->get('id')
             ]
         );
-        $Failures = json_decode(
-            Route::getData()
-        );
-        foreach ($Failures->data as &$Failed) {
+        foreach ($Failures as &$Failed) {
             $curr = self::niceDate();
             $prev = self::niceDate($Failed->failureTime);
             if ($curr < $prev) {

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -226,10 +226,9 @@ class Task extends TaskType
             'storagegroupID' => $this->get('storagegroupID'),
             'storagenodeID' => $this->get('storagenodeID')
         ];
-        Route::listem(__CLASS__, $find);
-        $Tasks = json_decode(Route::getData());
+        $Tasks = Route::getList(__CLASS__, $find);
 
-        foreach ($Tasks->data as $Task) {
+        foreach ($Tasks as $Task) {
             $tid = (int) $Task->id;
             if ($tid === $myTaskID) {
                 continue;

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -319,8 +319,18 @@ class Registration extends FOGBase
                 _('Done, without imaging! Image not in storage group.')
             );
         }
-        Route::indiv('tasktype', TaskType::DEPLOY);
-        $tasktype = json_decode(Route::getData());
+        // getItem(), not indiv(): a missing task type answers null rather
+        // than ending the registration response with a 404 the client cannot
+        // see. Refs #907, ADR 0011.
+        $tasktype = Route::getItem('tasktype', TaskType::DEPLOY);
+        if (!$tasktype) {
+            throw new \Exception(
+                sprintf(
+                    _('Task type %d is missing from this server.'),
+                    TaskType::DEPLOY
+                )
+            );
+        }
         $task = self::$Host->createImagePackage(
             $tasktype,
             'AutoRegTask',

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -122,14 +122,11 @@ abstract class TaskingElement extends FOGBase
                 if (!count($this->StorageGroup->get($getter) ?: [])) {
                     $getter = 'allnodes';
                 }
-                Route::listem(
+                $StorageNodes = Route::getList(
                     'storagenode',
                     ['id' => $this->StorageGroup->get($getter)]
                 );
-                $StorageNodes = json_decode(
-                    Route::getData()
-                );
-                foreach ($StorageNodes->data as &$StorageNode) {
+                foreach ($StorageNodes as &$StorageNode) {
                     $this->StorageNodes[] = self::getClass(
                         'StorageNode',
                         $StorageNode->id
@@ -185,8 +182,14 @@ abstract class TaskingElement extends FOGBase
     public static function getlisting($classname)
     {
         try {
-            Route::names($classname);
-            $names = json_decode(Route::getData());
+            // asValue(): names() has no wrapper of its own, and its payload
+            // is a bare list with no envelope to unwrap. This is here so a
+            // failure raises into the caller rather than ending the response.
+            $names = Route::asValue(
+                function () use ($classname) {
+                    Route::names($classname);
+                }
+            );
             if (count($names ?: []) <= 0) {
                 throw new \Exception(
                     _('There are no ' . $classname . 's on this server')

--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -127,14 +127,11 @@ if (isset($_POST['newNode'])) {
 } elseif (isset($_POST['nodePass'])) {
     // $ip, $user, $pass are already base64_decoded via the $stripped loop above.
     // Do NOT call base64_decode() again here.
-    Route::listem(
+    $StorageNodes = Route::getList(
         'storagenode',
         ['ip' => $ip]
     );
-    $StorageNodes = json_decode(
-        Route::getData()
-    );
-    foreach ($StorageNodes->data as &$StorageNode) {
+    foreach ($StorageNodes as &$StorageNode) {
         if ($StorageNode->user === trim($user)
             && $StorageNode->pass === trim($pass)
         ) {


### PR DESCRIPTION
31 sites across `lib/fog`, `lib/reg-task` and `maintenance/` — everything the
pages call into, so it lands before the pages themselves.

| Wrapper | Sites |
|---|---|
| `getList()` | 28 |
| `getItem()` | 3 — `storagegroup` ×2, `registration`'s tasktype |
| `asValue()` | 1 — `taskingelement`'s `names()`, which no wrapper covers |

## Six sites deliberately NOT migrated — the part worth reviewing

**Three are the HTTP boundary.** `FOGPageRender`'s two `echo
Route::getData(); exit;` endpoints, and `fogpage.class.php:958`, which hands
the raw JSON string to `AJAX_DATA_DISPLAY_CHANGE` by reference and then echoes
it. The envelope *is* the response and DataTables consumes it.

**Two are plugin-facing surface.** `StorageGroup::getMasterStorageNode()` and
`::getOptimalStorageNode()` pass their `listem()` result to
`MASTER_STORAGE_NODE` / `OPTIMAL_STORAGE_NODE` **by reference**. Nothing in
core or in `fog-plugins` registers for either event — but `/opt/fog/plugins`
can't be enumerated, so changing what a third-party listener receives isn't
mine to do silently.

Only the `indiv()` inside each loop moved. That's a loop local, and it's where
the exit hazard actually lived, so the fix lands without touching the contract.
Commented at both sites.

**One isn't a call at all** — `image.class.php`'s hit is a comment.

Worth noting for the next PR: `lib/reports`' nine sites are the same
`echo`/`exit` boundary shape and stay for the same reason. So step 4 is ~72
real sites, not the 81 a grep suggests.

## Two deliberate behaviour changes

`getList()` always sets `inputoverride`. `host.class.php`'s `snapintask` and
`snapinassociation` lookups and `hostmanager`'s inventory search passed
`false`, so `listem()` was parsing `php://input` and folding in
`?length`/`?start`. All three run inside POSTs.

## Verification

Two trees whose only difference is this commit, against the live 1.6 lab at
`10.255.20.1`:

- **`StorageGroup`'s three methods across all three groups** — real results
  (`1:DefaultMember`, `3:debian`, `"No master nodes available"`), with the
  migrated `getItem()` loops firing.
- **`buildSelectBox()`** for Host/Image/StorageGroup/Snapin — real `<select>`
  HTML.
- `associationMaps()`, `primeAssociationExport()`, `activationBlockers()`,
  `getInFrontOfHostCount()` across all six of the host's tasks,
  `getHostByUuidAndSerial()`, `getNodeFailure()` on all four nodes.
- **`Host::appendSnapinSequence()`** → `1:seq=1 2:seq=2 3:seq=3`, the ordered
  loop genuinely iterating. `snapinassociation` and `nfsFailures` were empty on
  the lab, so temporary fixture rows were created for host 154 (pre-flighted as
  having none) and removed afterwards — both tables verified back at 0.
- The `nodefailure` queries compared old idiom vs wrapper **with rows present**.
- **`boot.php` over HTTP**, byte-identical on three request shapes including
  the 11KB image list, which drives `getOptimalStorageNode` and the node URLs.

`management/index.php` differs only in its CSP nonce, CSRF token and
memory-peak comment — the same tree requested twice differs the same way, which
is the control I ran to confirm it.

`sh tests/run-all.sh` → 8 passed, 0 failed.

## Remaining

`lib/pages` — 40 sites, the last bucket.