### PR TITLE
Move the management pages onto the Route result wrappers

### DIFF
--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -90,11 +90,8 @@ class DashboardPage extends FOGPage
         if (self::$ajax) {
             return;
         }
-        Route::listem('storagenode');
-        $Nodes = json_decode(
-            Route::getData()
-        );
-        foreach ($Nodes->data as &$StorageNode) {
+        $Nodes = Route::getList('storagenode');
+        foreach ($Nodes as &$StorageNode) {
             if (!($StorageNode->isEnabled && $StorageNode->isGraphEnabled)) {
                 continue;
             }
@@ -129,12 +126,8 @@ class DashboardPage extends FOGPage
             self::$_nodeColors[] = $StorageNode->graphcolor;
             unset($StorageNode);
         }
-        Route::listem('storagegroup');
-        $Groups = json_decode(
-            Route::getData()
-        );
-        $Groups = $Groups->data;
-        foreach ((array)$Groups as &$StorageGroup) {
+        $Groups = Route::getList('storagegroup');
+        foreach ($Groups as &$StorageGroup) {
             self::$_groupOpts .= sprintf(
                 '<option value="%s">%s</option>',
                 Initiator::e($StorageGroup->id),
@@ -749,13 +742,10 @@ class DashboardPage extends FOGPage
     public function nodeversions()
     {
         header('Content-type: application/json');
-        Route::listem('storagenode');
-        $Nodes = json_decode(
-            Route::getData()
-        );
+        $Nodes = Route::getList('storagenode');
         $ids = [];
         $urls = [];
-        foreach ($Nodes->data as &$StorageNode) {
+        foreach ($Nodes as &$StorageNode) {
             if (!($StorageNode->isEnabled && $StorageNode->isGraphEnabled)) {
                 continue;
             }

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -134,15 +134,15 @@ class FOGConfigurationPage extends FOGPage
         $this->title = _('FOG Version Information');
 
         // Get our storage node urls.
-        Route::listem('storagenode');
-        $StorageNodes = json_decode(
-            Route::getData()
-        );
-        $StorageNodes = $StorageNodes->data;
+        $StorageNodes = Route::getList('storagenode');
         ob_start();
         foreach ($StorageNodes as &$StorageNode) {
-            Route::indiv('storagenode', $StorageNode->id);
-            $StorageNode = json_decode(Route::getData());
+            // getItem(), not indiv(): a node deleted between the list and the
+            // fetch answers null rather than ending the page mid-render.
+            $StorageNode = Route::getItem('storagenode', $StorageNode->id);
+            if (!$StorageNode) {
+                continue;
+            }
             $id = str_replace(' ', '_', $StorageNode->name);
             $url = filter_var(
                 sprintf(
@@ -1139,11 +1139,11 @@ class FOGConfigurationPage extends FOGPage
             $items = [];
             foreach ($vars as $key => &$val) {
                 $id = self::_settingIdFor($key);
-                Route::indiv('setting', $id);
+                $Service = Route::getItem('setting', $id);
                 $set = trim($val);
-                $Service = json_decode(
-                    Route::getData()
-                );
+                if (!$Service) {
+                    continue;
+                }
                 $name = trim($Service->name);
                 $val = trim($Service->value);
                 if ($val == $set) {
@@ -2110,13 +2110,13 @@ class FOGConfigurationPage extends FOGPage
                 // because the $_FILES lookup below is keyed by what the form
                 // actually sent.
                 $id = self::_settingIdFor($key);
-                Route::indiv('setting', $id);
+                $Setting = Route::getItem('setting', $id);
                 if (!isset($_FILES[$key]) || !$_FILES[$key]) {
                     $set = trim(filter_var($val));
                 }
-                $Setting = json_decode(
-                    Route::getData()
-                );
+                if (!$Setting) {
+                    continue;
+                }
                 $name = trim($Setting->name);
                 $val = trim($Setting->value);
                 if ($val && $val == ($set ?? '')) {
@@ -2584,10 +2584,7 @@ class FOGConfigurationPage extends FOGPage
      */
     public function logviewer()
     {
-        Route::listem('storagegroup');
-        $StorageGroups = json_decode(
-            Route::getData()
-        );
+        $StorageGroups = Route::getList('storagegroup');
 
         // Log selector.
         $logtype = _('error');
@@ -2616,7 +2613,7 @@ class FOGConfigurationPage extends FOGPage
             );
             $files[$StorageNode->name][_($str)] = $log;
         };
-        foreach ($StorageGroups->data as &$StorageGroup) {
+        foreach ($StorageGroups as &$StorageGroup) {
             if (count($StorageGroup->enablednodes ?: []) < 1) {
                 continue;
             }

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -1699,14 +1699,12 @@ class GroupManagement extends FOGPage
     public function groupInventory()
     {
         // Get this group's Host Inventory items.
-        Route::listem(
+        $inventories = Route::getList(
             'inventory',
             ['hostID' => $this->obj->get('hosts')],
-            false,
             'AND',
             'hostID'
         );
-        $inventories = json_decode(Route::getData());
 
         // Get the host names
         $hostnames = Route::getIds(
@@ -1734,7 +1732,7 @@ class GroupManagement extends FOGPage
             return;
         }
         // Loop and print the inventory data broken out by host names.
-        foreach ($inventories->data as $i => &$inventory) {
+        foreach ($inventories as $i => &$inventory) {
             if (!isset($hostnames[$i])) {
                 continue;
             }
@@ -2639,16 +2637,14 @@ class GroupManagement extends FOGPage
             ]
         ];
         // The items we're getting.
-        Route::listem(
+        $items = Route::getList(
             'tasktype',
             $key,
-            false,
             'AND',
             'id'
         );
-        $items = json_decode(Route::getData());
         // Loop 1, the basic non-advanced tasks.
-        foreach ($items->data as &$TaskType) {
+        foreach ($items as &$TaskType) {
             $taskTypeIterator($TaskType, 0);
             unset($TaskType);
         }
@@ -2661,7 +2657,7 @@ class GroupManagement extends FOGPage
         $data = [];
         $advanced = 1;
         // Loop 2, the advanced tasks.
-        foreach ($items->data as &$TaskType) {
+        foreach ($items as &$TaskType) {
             $taskTypeIterator($TaskType, 1);
             unset($TaskType);
         }
@@ -2810,8 +2806,14 @@ class GroupManagement extends FOGPage
                 ]
             ));
         }
-        Route::names('printer');
-        $printerNames = json_decode(Route::getData());
+        // asValue(): names() has no wrapper -- its payload is a bare list
+        // with no envelope to unwrap -- so this is here for the other half,
+        // a failure raising rather than ending the page.
+        $printerNames = Route::asValue(
+            function () {
+                Route::names('printer');
+            }
+        );
         foreach ($printerNames as &$printer) {
             $printers[$printer->id] = $printer->name;
             unset($printer);
@@ -2948,15 +2950,12 @@ class GroupManagement extends FOGPage
         $hostCount = count($hostIDs);
         $data = [];
         if ($hostCount > 0) {
-            Route::listem(
+            $assocs = Route::getList(
                 'snapinassociation',
                 ['hostID' => $hostIDs],
-                false,
                 'AND',
                 'sequence'
             );
-            $assocs = json_decode(Route::getData());
-            $assocs = isset($assocs->data) ? $assocs->data : [];
             $counts = [];
             $minSeq = [];
             foreach ($assocs as $assoc) {
@@ -2982,9 +2981,7 @@ class GroupManagement extends FOGPage
                 }
             );
             if (count($shared) > 0) {
-                Route::listem('snapin', ['id' => $shared]);
-                $Snapins = json_decode(Route::getData());
-                $Snapins = isset($Snapins->data) ? $Snapins->data : [];
+                $Snapins = Route::getList('snapin', ['id' => $shared]);
                 $names = [];
                 foreach ($Snapins as $Snapin) {
                     $names[(int)$Snapin->id] = $Snapin->name;
@@ -3080,9 +3077,7 @@ class GroupManagement extends FOGPage
         $names = [];
         $order = [];
         if (count($hostIDs) > 0) {
-            Route::listem('host', ['id' => $hostIDs]);
-            $hosts = json_decode(Route::getData());
-            $hosts = isset($hosts->data) ? $hosts->data : [];
+            $hosts = Route::getList('host', ['id' => $hostIDs]);
             foreach ($hosts as $host) {
                 $names[(int)$host->id] = $host->name;
                 $order[] = (int)$host->id;
@@ -3369,14 +3364,11 @@ class GroupManagement extends FOGPage
             }
             $nhosts = [];
             $hostImages = [];
-            Route::listem(
+            $Hosts = Route::getList(
                 'host',
                 ['id' => $hosts]
             );
-            $Hosts = json_decode(
-                Route::getData()
-            );
-            foreach ($Hosts->data as &$host) {
+            foreach ($Hosts as &$host) {
                 if (!$host->imageID) {
                     continue;
                 }
@@ -3474,8 +3466,17 @@ class GroupManagement extends FOGPage
 
             // Actually create tasking
             if ($scheduleType == 'instant') {
-                Route::indiv('tasktype', $type);
-                $tasktype = json_decode(Route::getData());
+                // getItem(), not indiv(): a deleted task type used to end the
+                // response with a 404 rather than report it. Refs ADR 0011.
+                $tasktype = Route::getItem('tasktype', $type);
+                if (!$tasktype) {
+                    throw new \Exception(
+                        sprintf(
+                            _('Task type %d is missing from this server.'),
+                            $type
+                        )
+                    );
+                }
                 $this->obj->createImagePackage(
                     $tasktype,
                     $taskName,

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -2103,9 +2103,7 @@ class HostManagement extends FOGPage
         $snapinIDs = (array)$this->obj->get('snapins');
         $names = [];
         if (count($snapinIDs) > 0) {
-            Route::listem('snapin', ['id' => $snapinIDs]);
-            $Snapins = json_decode(Route::getData());
-            $Snapins = isset($Snapins->data) ? $Snapins->data : [];
+            $Snapins = Route::getList('snapin', ['id' => $snapinIDs]);
             foreach ($Snapins as $Snapin) {
                 $names[$Snapin->id] = $Snapin->name;
             }
@@ -3875,16 +3873,14 @@ class HostManagement extends FOGPage
             ]
         ];
         // The items we're getting.
-        Route::listem(
+        $items = Route::getList(
             'tasktype',
             $key,
-            false,
             'AND',
             'id'
         );
-        $items = json_decode(Route::getData());
         // Loop 1, the basic non-advanced tasks.
-        foreach ($items->data as &$TaskType) {
+        foreach ($items as &$TaskType) {
             $taskTypeIterator($TaskType, 0);
             unset($TaskType);
         }
@@ -3897,7 +3893,7 @@ class HostManagement extends FOGPage
         $data = [];
         $advanced = 1;
         // Loop 2, the advanced tasks.
-        foreach ($items->data as &$TaskType) {
+        foreach ($items as &$TaskType) {
             $taskTypeIterator($TaskType, 1);
             unset($TaskType);
         }
@@ -3998,8 +3994,17 @@ class HostManagement extends FOGPage
             if (!is_numeric($type) || $type < 1) {
                 $type = 1;
             }
-            Route::indiv('tasktype', $type);
-            $TaskType = json_decode(Route::getData());
+            // getItem(), not indiv(): a deleted task type used to end the
+            // response with a 404 rather than report it. Refs ADR 0011.
+            $TaskType = Route::getItem('tasktype', $type);
+            if (!$TaskType) {
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        $type
+                    )
+                );
+            }
 
             $this->title = $TaskType->name
                 . ' '
@@ -4259,8 +4264,17 @@ class HostManagement extends FOGPage
                 $type = 1;
             }
 
-            Route::indiv('tasktype', $type);
-            $TaskType = json_decode(Route::getData());
+            // getItem(), not indiv(): a deleted task type used to end the
+            // response with a 404 rather than report it. Refs ADR 0011.
+            $TaskType = Route::getItem('tasktype', $type);
+            if (!$TaskType) {
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        $type
+                    )
+                );
+            }
             // Pending check.
             if ($this->obj->get('pending')) {
                 throw new \Exception(_('Pending hosts cannot be tasked'));
@@ -4519,11 +4533,16 @@ class HostManagement extends FOGPage
                 ]
             ));
         }
-        Route::names(
-            'printer',
-            ['id' => $printersAssigned]
+        // asValue(): names() has no wrapper of its own, and its payload is a
+        // bare list with nothing to unwrap.
+        $printerNames = Route::asValue(
+            function () use ($printersAssigned) {
+                Route::names(
+                    'printer',
+                    ['id' => $printersAssigned]
+                );
+            }
         );
-        $printerNames = json_decode(Route::getData());
         foreach ($printerNames as $printer) {
             $printers[$printer->id] = $printer->name;
         }

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1609,11 +1609,16 @@ class ImageManagement extends FOGPage
                 ]
             ));
         }
-        Route::names(
-            'storagegroup',
-            ['id' => $storagegroupsAssigned]
+        // asValue(): names() has no wrapper of its own, and its payload is
+        // a bare list with nothing to unwrap.
+        $storagegroupNames = Route::asValue(
+            function () use ($storagegroupsAssigned) {
+                Route::names(
+                    'storagegroup',
+                    ['id' => $storagegroupsAssigned]
+                );
+            }
         );
-        $storagegroupNames = json_decode(Route::getData());
         foreach ($storagegroupNames as &$storagegroup) {
             $storagegroups[$storagegroup->id] = $storagegroup->name;
             unset($storagegroup);

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -618,17 +618,14 @@ class PluginManagement extends FOGPage
                 $serverFault = true;
                 throw new \Exception(_('Activate plugins failed!'));
             }
-            Route::listem(
+            $Plugins = Route::getList(
                 'plugin',
                 [
                     'id' => $plugins,
                     'installed' => ['',0,'0']
                 ]
             );
-            $Plugins = json_decode(
-                Route::getData()
-            );
-            foreach ($Plugins->data as &$Plugin) {
+            foreach ($Plugins as &$Plugin) {
                 $pluginObj = self::getClass('Plugin', $Plugin->id);
                 if (!$pluginObj->installdb()) {
                     throw new \Exception(
@@ -717,17 +714,14 @@ class PluginManagement extends FOGPage
             // Only update plugins that are actually installed (the reverse of
             // the install filter): updating a not-installed plugin is a no-op
             // for the admin's intent.
-            Route::listem(
+            $Plugins = Route::getList(
                 'plugin',
                 [
                     'id' => $plugins,
                     'installed' => 1
                 ]
             );
-            $Plugins = json_decode(
-                Route::getData()
-            );
-            foreach ($Plugins->data as &$Plugin) {
+            foreach ($Plugins as &$Plugin) {
                 $pluginObj = self::getClass('Plugin', $Plugin->id);
                 if (!$pluginObj->installdb()) {
                     throw new \Exception(
@@ -890,17 +884,14 @@ class PluginManagement extends FOGPage
                 $serverFault = true;
                 throw new \Exception(_('Deactivate plugins failed!'));
             }
-            Route::listem(
+            $Plugins = Route::getList(
                 'plugin',
                 [
                     'id' => $plugins,
                     'installed' => 1
                 ]
             );
-            $Plugins = json_decode(
-                Route::getData()
-            );
-            foreach ($Plugins->data as &$Plugin) {
+            foreach ($Plugins as &$Plugin) {
                 $installPlugin = self::getClass(
                     $Plugin->name
                     . 'Manager'
@@ -1011,11 +1002,10 @@ class PluginManagement extends FOGPage
             if (!count($plugins)) {
                 throw new \Exception(_('No plugins selected.'));
             }
-            Route::listem('plugin', ['id' => $plugins], true);
-            $rows = json_decode(Route::getData());
+            $rows = Route::getList('plugin', ['id' => $plugins]);
             $present = [];
             $forget = [];
-            foreach ((array)($rows->data ?? []) as $row) {
+            foreach ($rows as $row) {
                 if (Plugin::isMissing((string)$row->location)) {
                     $forget[(int)$row->id] = (string)$row->name;
                     continue;

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -169,8 +169,13 @@ class ProcessLogin extends FOGPage
                 }
                 $selector = filter_input(INPUT_COOKIE, 'foguserauthsel');
                 $password = filter_input(INPUT_COOKIE, 'foguserauthpass');
-                Route::indiv('userauth', $id);
-                $userauth = json_decode(Route::getData());
+                // getItem(), not indiv(): a userauth row that vanished mid
+                // login used to end the response with a 404 instead of
+                // falling through to the normal "not authenticated" path.
+                $userauth = Route::getItem('userauth', $id);
+                if (!$userauth) {
+                    return self::mainLoginForm();
+                }
                 $current_date = self::niceDate()->format('Y-m-d H:i:s');
                 $expireTime = self::niceDate($userauth->expire)->format('Y-m-d H:i:s');
                 $isExpired = (bool)(

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -73,14 +73,10 @@ class ServiceConfigurationPage extends FOGPage
             $notWhere
         );
 
-        Route::listem(
+        self::$_modules = Route::getList(
             'module',
             ['shortName' => $where]
         );
-        $Modules = json_decode(
-            Route::getData()
-        );
-        self::$_modules = $Modules->data;
     }
     /**
      * Presents the home for this page.

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -1224,15 +1224,12 @@ class SnapinManagement extends FOGPage
                 // * At least here we can queue it
                 // * So it could be stopped before
                 // * Its actually deleted.
-                Route::listem(
+                $othersnapins = Route::getList(
                     'snapin',
                     ['file' => $this->obj->get('file')]
                 );
-                $othersnapins = json_decode(
-                    Route::getData()
-                );
                 $otherfiles = [];
-                foreach ($othersnapins->data as $osnapin) {
+                foreach ($othersnapins as $osnapin) {
                     if ($osnapin->id == $this->obj->get('id')) {
                         continue;
                     }
@@ -1572,11 +1569,16 @@ class SnapinManagement extends FOGPage
                 ]
             ));
         }
-        Route::names(
-            'storagegroup',
-            ['id' => $storagegroupsAssigned]
+        // asValue(): names() has no wrapper of its own, and its payload is
+        // a bare list with nothing to unwrap.
+        $storagegroupNames = Route::asValue(
+            function () use ($storagegroupsAssigned) {
+                Route::names(
+                    'storagegroup',
+                    ['id' => $storagegroupsAssigned]
+                );
+            }
         );
-        $storagegroupNames = json_decode(Route::getData());
         foreach ($storagegroupNames as &$storagegroup) {
             $storagegroups[$storagegroup->id] = $storagegroup->name;
             unset($storagegroup);

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -967,11 +967,16 @@ class StorageGroupManagement extends FOGPage
                 ]
             ));
         }
-        Route::names(
-            'storagenode',
-            ['id' => $storagenodesAssigned]
+        // asValue(): names() has no wrapper of its own, and its payload is
+        // a bare list with nothing to unwrap.
+        $storagenodeNames = Route::asValue(
+            function () use ($storagenodesAssigned) {
+                Route::names(
+                    'storagenode',
+                    ['id' => $storagenodesAssigned]
+                );
+            }
         );
-        $storagenodeNames = json_decode(Route::getData());
         foreach ($storagenodeNames as &$storagenode) {
             $storagenodes[$storagenode->id] = $storagenode->name;
             unset($storagenode);


### PR DESCRIPTION
Last core bucket for [ADR 0011](docs/adr/0011-route-result-wrappers.md). 33 sites across 10 page classes drop `Route::listem(...); json_decode(Route::getData())` for `getList()` / `getItem()` / `asValue()`.

### What it buys, beyond the noise reduction

- **A router failure mid-render no longer reaches `breakHead()`'s `exit`.** It raises instead, so the page finishes or fails as a page rather than as a 406 with half a document already flushed.
- **`getList()` sets `inputoverride`; most of these call sites did not.** Any of them reached from a POST was parsing `php://input` and folding in `?length`/`?start` — silently paginating a list the page had asked for whole.
- **`processlogin` no longer ends the response when a `userauth` row vanishes mid-login.** `getItem()` answers null and the code falls through to the normal "not authenticated" path, which is what it always meant.

The five `Route::names()` sites use `asValue()`: `names()` has no wrapper of its own, and its payload is a bare list with no envelope to unwrap.

### Deliberately not migrated

The seven HTTP-boundary sites — `hostmanagement` ×4, `taskmanagement` ×2, and `pluginmanagement`'s `jsonSend`, which mutates the envelope on purpose. There the envelope *is* the response and the `exit` is correct. Commented where it isn't obvious.

### Verification

Crawled 56 authenticated management pages against two trees differing only by this commit, using a pre-seeded session file rather than the login form.

- **54 byte-identical** after normalizing the CSP nonce and the `Memory Peak` comment.
- The 2 that differ also differ on a **control run of the old tree against itself**: `service/configure` randomizes `#sleep=`, and `storagenode/edit` renders the node's live CPU speed.

That crawl caught one real regression before it shipped: `groupmanagement`'s host-inventory loop still said `$inventories->data` after the list had been unwrapped, which is a fatal on any group edit page. Fixed here. The remaining `->data` in the diff is `pluginmanagement`'s boundary site and is correct.

`sh tests/run-all.sh` — 8 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR