### PR TITLE
Never purge permissions for a node core owns

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -261,7 +261,26 @@ class Authorization extends FOGBase
         if (null !== self::$_registry) {
             return self::$_registry;
         }
-        $registry = [
+        $registry = self::coreRegistry();
+        self::$HookManager->processEvent(
+            'PERMISSION_REGISTRY_DATA',
+            ['registry' => &$registry]
+        );
+        return self::$_registry = $registry;
+    }
+    /**
+     * The nodes core itself owns, before any plugin has contributed.
+     *
+     * Split out of registry() so purgePermissions() has something to test
+     * against that a plugin cannot influence. Deliberately NOT the
+     * post-hook result: a plugin that registered a node must not thereby
+     * be able to make that node unpurgeable, which is exactly backwards.
+     *
+     * @return array node => list of valid actions
+     */
+    public static function coreRegistry()
+    {
+        return [
             'host' => ['view', 'create', 'edit', 'delete', 'task'],
             'group' => ['view', 'create', 'edit', 'delete', 'task'],
             'image' => ['view', 'create', 'edit', 'delete', 'task'],
@@ -280,11 +299,21 @@ class Authorization extends FOGBase
             'report' => ['view', 'create'],
             'plugin' => ['view', 'edit', 'install']
         ];
-        self::$HookManager->processEvent(
-            'PERMISSION_REGISTRY_DATA',
-            ['registry' => &$registry]
-        );
-        return self::$_registry = $registry;
+    }
+    /**
+     * Is this registry node owned by core rather than by a plugin?
+     *
+     * @param string $node the registry node (e.g. 'host')
+     *
+     * @return bool
+     */
+    public static function isCoreOwnedNode($node)
+    {
+        $node = strtolower(trim((string)$node));
+        if ('' === $node) {
+            return false;
+        }
+        return array_key_exists($node, self::coreRegistry());
     }
     /**
      * Get the union of a user's permissions across all assigned roles.
@@ -1193,6 +1222,14 @@ class Authorization extends FOGBase
      * 'site', 'site.*', 'site.view', ... but never a sibling like
      * 'siteother' (the dot boundary is required).
      *
+     * A node core owns is never purged, whatever plugin name was passed.
+     * The two callers derive the prefix from `plugins.pName`, so a plugin
+     * sharing its name with a core node -- which is precisely what happens
+     * while a capability is being moved out of a plugin and into core --
+     * would otherwise delete live grants belonging to core on uninstall.
+     * The grants outlive the plugin on purpose in that case; the node has
+     * not left the registry, it changed owner.
+     *
      * @param string $nodePrefix the registry node (e.g. 'site')
      *
      * @return void
@@ -1201,6 +1238,9 @@ class Authorization extends FOGBase
     {
         $nodePrefix = strtolower(trim((string)$nodePrefix));
         if ('' === $nodePrefix) {
+            return;
+        }
+        if (self::isCoreOwnedNode($nodePrefix)) {
             return;
         }
         $names = array_values(

--- a/tests/permission-purge-guard.test.php
+++ b/tests/permission-purge-guard.test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Guards the one path that can silently revoke live access.
+ *
+ * Authorization::purgePermissions() deletes every rolePermissions row in a
+ * node namespace. Both callers derive the namespace from `plugins.pName`
+ * (pluginmanagement.page.php:914 on uninstall, :1033 on forget), so the
+ * string it acts on is a PLUGIN name being used as a REGISTRY node name.
+ *
+ * Those two are the same thing right up until a capability moves out of a
+ * plugin and into core -- at which point the node stays in the registry,
+ * owned by core, while a plugin of that name is still installed. Uninstalling
+ * the leftover then deletes grants that core is still honouring, and nothing
+ * anywhere says so: no error, no log line, just users who quietly lost
+ * access. That is the failure this test exists to make impossible.
+ *
+ * DB-free, so it runs in tests/run-all.sh. Possible because the guard is
+ * pure: coreRegistry() is a literal and isCoreOwnedNode() is an array
+ * lookup. The behavioural half of the test leans on that deliberately --
+ * with no database configured, purgePermissions() can only return without
+ * throwing if it bailed out BEFORE reaching Route::getIds(). If the guard
+ * is ever removed, this stops passing rather than silently doing nothing.
+ *
+ * Usage: php tests/permission-purge-guard.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-purge-guard-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+// Same reasoning as autoload.test.php: the constructor only registers the
+// autoloader, so the cache dir must be redirected somewhere throwaway and
+// startInit() must not be called -- that is what would need MySQL.
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+if (!class_exists('Authorization', true)) {
+    fwrite(STDERR, "FAIL: Authorization did not resolve\n");
+    exit(1);
+}
+
+/*
+ * 1. Every node in the core literal reports as core-owned.
+ */
+$core = Authorization::coreRegistry();
+check(
+    'coreRegistry() returned a non-empty array',
+    is_array($core) && count($core) > 0,
+    $failures,
+    $checks
+);
+foreach (array_keys($core) as $node) {
+    check(
+        "isCoreOwnedNode('$node') is true",
+        Authorization::isCoreOwnedNode($node) === true,
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 2. A name that is not a core node is not protected. Without this the guard
+ *    could be a blanket "never purge anything", which would leave a real
+ *    plugin's permissions orphaned in every role's matrix after uninstall --
+ *    the problem purgePermissions was written to solve.
+ */
+foreach (['capone', 'ldap', 'wolbroadcast', 'definitelynotanode', ''] as $node) {
+    check(
+        "isCoreOwnedNode('$node') is false",
+        Authorization::isCoreOwnedNode($node) === false,
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 3. Case and whitespace are normalised. The callers pass strtolower() of a
+ *    database value, but the guard must not depend on its callers being
+ *    careful -- it is the last thing standing between a stray uninstall and
+ *    a silent revocation.
+ */
+check(
+    "isCoreOwnedNode('  HOST  ') is true",
+    Authorization::isCoreOwnedNode('  HOST  ') === true,
+    $failures,
+    $checks
+);
+
+/*
+ * 4. The behavioural half: with no database configured, purgePermissions()
+ *    on a core node must return without throwing, which it can only do by
+ *    returning before it reaches Route::getIds().
+ */
+try {
+    Authorization::purgePermissions('host');
+    check('purgePermissions("host") returned without touching the DB', true, $failures, $checks);
+} catch (\Throwable $e) {
+    check(
+        'purgePermissions("host") returned without touching the DB'
+        . ' (threw ' . get_class($e) . ': ' . $e->getMessage() . ')',
+        false,
+        $failures,
+        $checks
+    );
+}
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL (" . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Phase 1 commit 1 of 14. Lands first and alone because it is worth having regardless of whether the rest of the phase proceeds.

### The problem

`Authorization::purgePermissions()` deletes every `rolePermissions` row in a node namespace, and both callers derive that namespace from `plugins.pName` — a **plugin** name used as a **registry node** name:

- `pluginmanagement.page.php:914` — on uninstall
- `pluginmanagement.page.php:1033` — on forget

Those are the same thing right up until a capability moves out of a plugin and into core. Then the node stays in the registry *owned by core*, while a plugin of that name is still installed on upgraded servers. Uninstalling the leftover deletes grants core is still honouring — no error, no log line, just users who quietly lost access.

That is exactly what happens when the site plugin becomes core code, but it is not specific to site: any future core node sharing a name with an installed plugin has the same exposure today.

### The change

A node in core's own registry literal is never purged, whatever plugin name was passed.

The check is against the **hardcoded literal**, not against `registry()`'s post-hook result. A plugin that registered a node must not thereby be able to make its own node unpurgeable — that is exactly backwards. Splitting the literal into `coreRegistry()` is what makes the distinction expressible; `registry()` is unchanged in behaviour and still fires `PERMISSION_REGISTRY_DATA` over a copy of it.

**A real plugin's permissions are still purged on uninstall.** That was the point of the function and it keeps working. The test asserts both directions, because a blanket "never purge" would leave orphaned entries in every role's permission matrix — the problem `purgePermissions()` was written to solve.

### Verification

`tests/permission-purge-guard.test.php`, DB-free so it runs in `tests/run-all.sh`. 25 checks: every core node protected, five non-core names unprotected, case and whitespace normalised, plus a behavioural check.

The behavioural half is the useful one. With no database configured, `purgePermissions('host')` can only return without throwing if it bailed out **before** reaching `Route::getIds()`. Removing the guard and re-running gives:

```
FAIL (1 of 25):
  - purgePermissions("host") returned without touching the DB (threw Error: Call to a member function query() on null)
```

So the test fails on removal rather than passing silently. `sh tests/run-all.sh` — 9 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR