### PR TITLE
Add core's own site schema, and stop steps stranding above FOG_SCHEMA

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -619,6 +619,51 @@ return [
                 'vValue' => 'int(11) NOT NULL',
             ],
         ],
+        'siteGroupMembers' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteGroupMembers` ( `sgmID` int(11) NOT NULL AUTO_INCREMENT, `sgmName` varchar(60) NOT NULL DEFAULT \'\', `sgmSiteID` int(11) NOT NULL, `sgmGroupID` int(11) NOT NULL, PRIMARY KEY (`sgmID`), UNIQUE KEY `sgmSiteGroup` (`sgmSiteID`,`sgmGroupID`), KEY `sgmGroupID` (`sgmGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sgmID' => 'int(11) NOT NULL',
+                'sgmName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'sgmSiteID' => 'int(11) NOT NULL',
+                'sgmGroupID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'siteHostMembers' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteHostMembers` ( `shmID` int(11) NOT NULL AUTO_INCREMENT, `shmName` varchar(60) NOT NULL DEFAULT \'\', `shmSiteID` int(11) NOT NULL, `shmHostID` int(11) NOT NULL, PRIMARY KEY (`shmID`), UNIQUE KEY `shmSiteHost` (`shmSiteID`,`shmHostID`), KEY `shmHostID` (`shmHostID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'shmID' => 'int(11) NOT NULL',
+                'shmName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'shmSiteID' => 'int(11) NOT NULL',
+                'shmHostID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'sites' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `sites` ( `siteID` int(11) NOT NULL AUTO_INCREMENT, `siteName` varchar(255) NOT NULL, `siteDesc` longtext NOT NULL, `siteCatchAll` tinyint(1) unsigned DEFAULT NULL, PRIMARY KEY (`siteID`), UNIQUE KEY `siteName` (`siteName`), UNIQUE KEY `siteCatchAll` (`siteCatchAll`), CONSTRAINT `siteCatchAllIsOneOrNull` CHECK (`siteCatchAll` = 1) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'siteID' => 'int(11) NOT NULL',
+                'siteName' => 'varchar(255) NOT NULL',
+                'siteDesc' => 'longtext NOT NULL',
+                'siteCatchAll' => 'tinyint(1) unsigned DEFAULT NULL',
+            ],
+        ],
+        'siteUserGroupMembers' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteUserGroupMembers` ( `sugmID` int(11) NOT NULL AUTO_INCREMENT, `sugmName` varchar(60) NOT NULL DEFAULT \'\', `sugmSiteID` int(11) NOT NULL, `sugmUserGroupID` int(11) NOT NULL, PRIMARY KEY (`sugmID`), UNIQUE KEY `sugmSiteUserGroup` (`sugmSiteID`,`sugmUserGroupID`), KEY `sugmUserGroupID` (`sugmUserGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sugmID' => 'int(11) NOT NULL',
+                'sugmName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'sugmSiteID' => 'int(11) NOT NULL',
+                'sugmUserGroupID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'siteUserMembers' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteUserMembers` ( `sumID` int(11) NOT NULL AUTO_INCREMENT, `sumName` varchar(60) NOT NULL DEFAULT \'\', `sumSiteID` int(11) NOT NULL, `sumUserID` int(11) NOT NULL, PRIMARY KEY (`sumID`), UNIQUE KEY `sumSiteUser` (`sumSiteID`,`sumUserID`), KEY `sumUserID` (`sumUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sumID' => 'int(11) NOT NULL',
+                'sumName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'sumSiteID' => 'int(11) NOT NULL',
+                'sumUserID' => 'int(11) NOT NULL',
+            ],
+        ],
         'snapinAssoc' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `snapinAssoc` ( `saID` int(11) NOT NULL AUTO_INCREMENT, `saHostID` int(11) NOT NULL, `saSnapinID` int(11) NOT NULL, `saSequence` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`saID`), UNIQUE KEY `saHostID` (`saHostID`,`saSnapinID`), UNIQUE KEY `saSnapinID` (`saSnapinID`,`saHostID`), KEY `new_index` (`saHostID`), KEY `new_index1` (`saSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5145,3 +5145,110 @@ $this->schema[] = [
     . "fleet use -- schedule against a single test host only.','shield','',"
     . "'mode=enrollsbforce','fog','1','both')",
 ];
+// 331
+$this->schema[] = [
+    // Sites, moving out of the site plugin and into core (Phase 1).
+    //
+    // Deliberately NOT the plugin's DDL adopted in place, which is how
+    // roles came across at step 302. That worked because accesscontrol's
+    // roles table was already the shape core wanted. site's is not: its
+    // four association tables carry no unique key, so the same host can be
+    // in the same site twice, and their Name columns have no default,
+    // which breaks assocSetter's batch inserts under strict SQL mode -- the
+    // exact two problems steps 303 and 309 had to write repair closures
+    // for. Reconstructing (step 332) costs one migration and lets core
+    // start from the shape it would choose today.
+    //
+    // New table names throughout, because the plugin's tables have to stay
+    // readable until the reconstruct has run and been checked. `sites` vs
+    // `site` is not a typo.
+    //
+    // Empty and unread at this step. Nothing queries these until scope
+    // resolution moves into core, so this is inert on any server.
+    "CREATE TABLE IF NOT EXISTS `sites` ("
+    . "`siteID` INT NOT NULL AUTO_INCREMENT,"
+    . "`siteName` VARCHAR(255) NOT NULL,"
+    . "`siteDesc` LONGTEXT NOT NULL,"
+    // The catch-all marker, and the reason it is NULL rather than 0.
+    //
+    // A catch-all site means "no restriction": its members are in scope
+    // for everything. Two of them would be meaningless, and worse than
+    // meaningless -- a second one is indistinguishable from the first at
+    // the point of use, so a stray insert would silently widen what a
+    // whole set of users can see. That is a boundary invariant, so the
+    // engine holds it rather than the application: InnoDB allows any
+    // number of NULLs in a UNIQUE index but only one of a given value,
+    // so at most one row can ever carry the marker.
+    //
+    // Consequence a writer MUST honour: a site that is not the catch-all
+    // stores NULL, never 0. 0 is a value like any other, so the second
+    // site to store it collides -- and under FOGController::save() that
+    // collision is NOT an error. save() builds INSERT ... ON DUPLICATE KEY
+    // UPDATE (fogcontroller.class.php:557-562), so creating a second site
+    // with siteCatchAll = 0 would UPDATE the first one's row instead of
+    // inserting: a create that silently overwrites an unrelated site. That
+    // is the bug class three other tables here were repaired for.
+    //
+    // NULL avoids it structurally rather than by care. save() drops any
+    // field whose value is null before building the column list (:545),
+    // so a null marker is never in the INSERT at all, never participates
+    // in a key collision, and takes the column default -- which is NULL.
+    //
+    // The CHECK is the belt: it makes storing 0 a hard error rather than a
+    // silent overwrite, on every server new enough to enforce it (MariaDB
+    // 10.2+, MySQL 8.0.16+). Older servers parse CHECK and ignore it, so
+    // it cannot break the CREATE anywhere -- it just does not protect
+    // there, which is why the NULL convention above is the real rule and
+    // this is only the backstop.
+    . "`siteCatchAll` TINYINT(1) UNSIGNED NULL DEFAULT NULL,"
+    . "PRIMARY KEY (`siteID`),"
+    . "UNIQUE KEY `siteName` (`siteName`),"
+    . "UNIQUE KEY `siteCatchAll` (`siteCatchAll`),"
+    . "CONSTRAINT `siteCatchAllIsOneOrNull` CHECK (`siteCatchAll` = 1)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
+    // The four membership tables. Same shape as userGroupMembers (step
+    // 309): composite unique so a thing is in a site at most once, and a
+    // defaulted Name column so assocSetter's batch inserts survive strict
+    // SQL mode.
+    //
+    // Each also carries a plain index on the object column. Scope
+    // resolution asks both directions -- "which sites is this user in"
+    // when a request starts, and "is this host in any of them" per object
+    // -- and the composite unique only serves the site-leading half.
+    "CREATE TABLE IF NOT EXISTS `siteHostMembers` ("
+    . "`shmID` INT NOT NULL AUTO_INCREMENT,"
+    . "`shmName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`shmSiteID` INT NOT NULL,"
+    . "`shmHostID` INT NOT NULL,"
+    . "PRIMARY KEY (`shmID`),"
+    . "UNIQUE KEY `shmSiteHost` (`shmSiteID`,`shmHostID`),"
+    . "KEY `shmHostID` (`shmHostID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `siteUserMembers` ("
+    . "`sumID` INT NOT NULL AUTO_INCREMENT,"
+    . "`sumName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`sumSiteID` INT NOT NULL,"
+    . "`sumUserID` INT NOT NULL,"
+    . "PRIMARY KEY (`sumID`),"
+    . "UNIQUE KEY `sumSiteUser` (`sumSiteID`,`sumUserID`),"
+    . "KEY `sumUserID` (`sumUserID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `siteGroupMembers` ("
+    . "`sgmID` INT NOT NULL AUTO_INCREMENT,"
+    . "`sgmName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`sgmSiteID` INT NOT NULL,"
+    . "`sgmGroupID` INT NOT NULL,"
+    . "PRIMARY KEY (`sgmID`),"
+    . "UNIQUE KEY `sgmSiteGroup` (`sgmSiteID`,`sgmGroupID`),"
+    . "KEY `sgmGroupID` (`sgmGroupID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `siteUserGroupMembers` ("
+    . "`sugmID` INT NOT NULL AUTO_INCREMENT,"
+    . "`sugmName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`sugmSiteID` INT NOT NULL,"
+    . "`sugmUserGroupID` INT NOT NULL,"
+    . "PRIMARY KEY (`sugmID`),"
+    . "UNIQUE KEY `sugmSiteUserGroup` (`sugmSiteID`,`sugmUserGroupID`),"
+    . "KEY `sugmUserGroupID` (`sugmUserGroupID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,23 +62,36 @@ class System
         define('FOG_VERSION', '1.6.0-beta.3409');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
-        // commons/schema.php. It is NOT the element count -- it has drifted
-        // well above it (289 elements at the time of writing) -- and nothing
-        // requires the two to agree. What it must never do is fall BELOW the
-        // element count: DatabaseManager::init() and schemaNeedsDeploy() test
+        // commons/schema.php, and it must never fall BELOW that element
+        // count. DatabaseManager::init() and schemaNeedsDeploy() test
         // `mySchema < FOG_SCHEMA` to decide whether to send the admin (or the
         // installer's token bootstrap) to the schema updater, and the updater
         // then does the real work with `count($this->schema) <= mySchema`. So
-        // this is the coarse gate and the count is the precise one; keeping the
-        // gate comfortably above the count is what makes a genuinely behind
-        // server get there at all.
+        // this is the coarse gate and the count is the precise one -- and a
+        // gate below the count means the admin is never sent to the updater
+        // at all, so the precise check never gets to run and the step sits
+        // there applying to nobody.
+        //
+        // That is not hypothetical: 18edea94f appended the element labelled
+        // 330 without touching this constant, leaving it at 329, and task
+        // type 26 reached no install until this bump. An earlier revision of
+        // this comment said the constant had "drifted well above" the count
+        // (289 at the time) and that nothing required the two to agree, which
+        // read as licence not to bump. They do have to agree, so tests/
+        // schema-gate.test.php now fails the build when they do not.
+        //
+        // The invariant the test pins, and the one to keep when appending:
+        // the highest `// N` label in commons/schema.php equals
+        // count($this->schema) equals this constant. The labels are not
+        // array indexes -- index 79 is written by a foreach over
+        // $keySequences, so the numbers only line up as counts.
         //
         // Corollary worth knowing before chasing a step that "did not run": a
         // database storing a vValue ABOVE the element count -- which is what a
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 329);
+        define('FOG_SCHEMA', 331);
         define('FOG_BCACHE_VER', 277);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * FOG_SCHEMA must not sit below the last step in commons/schema.php.
+ *
+ * The schema updater has two gates. The coarse one is
+ * `mySchema < FOG_SCHEMA` (DatabaseManager::init(), FOGBase::
+ * schemaNeedsDeploy()); it decides whether the admin -- or the installer's
+ * token bootstrap -- is sent to the updater page at all. The precise one is
+ * `count($this->schema) > mySchema` inside SchemaUpdaterPage::update(); it
+ * decides which elements actually run.
+ *
+ * Leave the coarse gate behind and the precise one never gets to speak. The
+ * server reports itself up to date, the updater is never opened, and the
+ * appended step applies to nobody. Nothing errors and nothing logs -- the
+ * only symptom is a table or a row that is missing on every install in the
+ * world, which is a thing you find out about months later from a bug report.
+ *
+ * This is not a hypothetical failure. 18edea94f appended the element
+ * labelled 330 (task type 26) and left FOG_SCHEMA at 329, so that step
+ * reached no install until the bump alongside this test. The comment on the
+ * constant at the time said it had "drifted well above" the element count
+ * and that nothing required the two to agree, which is exactly the kind of
+ * thing a contributor reads as "no bump needed".
+ *
+ * WHAT IS COMPARED, and why it is the label rather than a real count.
+ * Counting the array needs a database: commons/schema.php calls
+ * self::$DB->query() at file scope. So the test compares FOG_SCHEMA against
+ * the highest `// N` comment in that file, which the file has maintained
+ * beside every element for its whole history -- 18edea94f wrote its `// 330`
+ * correctly and only missed the constant, which is the shape of mistake this
+ * catches.
+ *
+ * Those labels are NOT array indexes. Index 79 is written by a foreach over
+ * $keySequences that appends 35 elements from a single line of source, so
+ * the labels only line up as COUNTS: the element under `// N` is the Nth,
+ * sitting at index N-1. Verified against a live 1.6 database at vValue 329,
+ * where the element under `// 329` was applied and the one under `// 330`
+ * was not.
+ *
+ * Deliberately an inequality, not an equality. The constant is documented as
+ * a coarse gate and is allowed to run ahead of the count; only falling
+ * behind breaks anything.
+ *
+ * Usage: php tests/schema-gate.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__) . '/packages/web';
+$schemaFile = $root . '/commons/schema.php';
+$systemFile = $root . '/lib/fog/system.class.php';
+
+foreach ([$schemaFile, $systemFile] as $path) {
+    if (!is_readable($path)) {
+        fwrite(STDERR, "FAIL: cannot read $path\n");
+        exit(1);
+    }
+}
+
+/*
+ * Highest step label. Anchored to the start of the line so a number
+ * mentioned inside a step's own explanatory comment -- which is indented --
+ * cannot be mistaken for a label.
+ */
+$labels = [];
+preg_match_all(
+    '/^\/\/ (\d+)$/m',
+    file_get_contents($schemaFile),
+    $labels
+);
+if (!count($labels[1])) {
+    fwrite(STDERR, "FAIL: found no `// N` step labels in $schemaFile\n");
+    exit(1);
+}
+$highest = max(array_map('intval', $labels[1]));
+
+$const = [];
+if (!preg_match(
+    "/define\(\s*'FOG_SCHEMA'\s*,\s*(\d+)\s*\)/",
+    file_get_contents($systemFile),
+    $const
+)) {
+    fwrite(STDERR, "FAIL: no FOG_SCHEMA definition in $systemFile\n");
+    exit(1);
+}
+$schema = (int)$const[1];
+
+if ($schema < $highest) {
+    fwrite(
+        STDERR,
+        "FAIL: FOG_SCHEMA is $schema but commons/schema.php goes to "
+        . "$highest.\n"
+        . "  Every step after $schema applies to nobody: the coarse gate\n"
+        . "  (mySchema < FOG_SCHEMA) never sends anyone to the schema\n"
+        . "  updater, so the updater's own count check never runs. There is\n"
+        . "  no error and no log line -- the step is simply never applied.\n"
+        . "  Set FOG_SCHEMA to $highest in packages/web/lib/fog/"
+        . "system.class.php.\n"
+    );
+    exit(1);
+}
+
+echo "ok  FOG_SCHEMA $schema covers schema.php's highest step ($highest)\n";
+exit(0);


### PR DESCRIPTION
Phase 1, commit 3 of moving sites out of the `site` plugin and into core. Creates tables only — nothing reads them until scope resolution moves over, so this is inert on every server.

## The schema

Five new tables, deliberately **not** the plugin's DDL adopted in place:

| Core | Replaces |
|---|---|
| `sites` | `site` |
| `siteHostMembers` | `siteHostAssoc` |
| `siteUserMembers` | `siteUserAssoc` |
| `siteGroupMembers` | `siteGroupAssoc` |
| `siteUserGroupMembers` | `siteUserGroupAssoc` |

Roles came across by adoption at step 302 because accesscontrol's table was already the shape core wanted. `site`'s is not: its four association tables carry **no unique key**, so the same host can sit in the same site twice, and their `*Name` columns have **no default**, which breaks `assocSetter`'s batch inserts under strict SQL mode. Those are exactly the two defects steps 303 and 309 had to write repair closures for. The plugin's tables keep their names and stay readable until the reconstruct (commit 5) has run and its row counts checked.

## The catch-all marker

`siteCatchAll TINYINT(1) UNSIGNED NULL DEFAULT NULL`, `UNIQUE`, plus a `CHECK (siteCatchAll = 1)`.

"At most one catch-all" is a boundary invariant, not a nicety — a catch-all site means *no restriction*, so a second one silently widens what a whole set of users can see. InnoDB permits unlimited NULLs in a UNIQUE index but only one of a given value, so the engine holds it rather than the application hoping.

**NULL rather than 0, and this part is load-bearing.** `FOGController::save()` builds `INSERT ... ON DUPLICATE KEY UPDATE` (`fogcontroller.class.php:557-562`), so a second site storing `0` would *UPDATE the first one's row* instead of inserting — a create that silently overwrites an unrelated site, the same bug class three other tables here have already been repaired for. `save()` drops null-valued fields before building the column list (`:545`), so a null marker never enters the INSERT and cannot collide at all. The CHECK backs this up on MariaDB 10.2+ / MySQL 8.0.16+; older servers parse and ignore CHECK, so it cannot break the CREATE anywhere — which is why the NULL convention is the rule and the CHECK is only the backstop.

Verified against MariaDB 11.8:

| Case | Result |
|---|---|
| Two non-catch-all sites (NULL) + one catch-all | accepted |
| A second catch-all | `ERROR 1062` duplicate entry |
| Storing `0` instead of NULL | `ERROR 4025` CHECK failed |
| The silent-overwrite shape (`ON DUPLICATE KEY UPDATE` with `0`) | `ERROR 4025` — rejected, not clobbered |
| Omitting the column, as `save()` does for null | accepted |

## A stranded step this bump would otherwise have hidden

`FOG_SCHEMA` was **329** while `commons/schema.php` already went to **330**. The coarse gate `mySchema < FOG_SCHEMA` is what sends an admin to the schema updater at all, so with the constant behind the file the updater's own count check never got to run: **task type 26, added in 18edea94f, reached no install.** No error, no log line.

Confirmed against the lab database at `vValue = 329` — the element under `// 329` (the PLUGINRUNNER settings) was applied, the one under `// 330` (task type 26) was not.

The comment on the constant said it had "drifted well above" the element count and that nothing required the two to agree, which reads as licence not to bump. It now says the opposite, and `tests/schema-gate.test.php` fails the build when the constant falls behind the file. The invariant it pins: the highest `// N` label in `commons/schema.php` equals `count($this->schema)` equals `FOG_SCHEMA`. Those labels are *not* array indexes — index 79 is written by a `foreach` over `$keySequences` that appends 35 elements from one line of source, so the numbers only line up as counts.

**This bump also un-strands task type 26.** It is a schedule-only diagnostic behind the Advanced toggle, but it will now appear on installs rather than nowhere — flagging it rather than deciding it.

## Manifest

`commons/schema-expected.php` regenerated with `bin/schema-manifest.php` so `SchemaReconciler` can create these tables on a database that skipped the indexed step — the 1.5-carried-count case it exists for. Purely additive: five tables added, six renames preserved, nothing removed or changed. Verified by dropping the tables and recreating them from the manifest alone, CHECK constraint intact.

## Verification

```
sh tests/run-all.sh          # 10 passed, 0 failed
php tests/schema-gate.test.php   # ok, and fails as intended when FOG_SCHEMA is reverted to 329
```

The pre-commit schema check reports `manifest covers all 65 tables schema.php builds. 0 difference(s).`