### PR TITLE
Refuse an unlabelled schema append, not just a lagging FOG_SCHEMA

### DIFF
--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -41,6 +41,19 @@
  * a coarse gate and is allowed to run ahead of the count; only falling
  * behind breaks anything.
  *
+ * The label would be a leaky proxy on its own -- an element appended with no
+ * label at all would not raise the highest label, so the gate would still
+ * look covered while the element stranded. So the second check below refuses
+ * an unlabelled append. Together they close it: you cannot append without
+ * labelling, and you cannot label above FOG_SCHEMA.
+ *
+ * Counting the array for real was tried and rejected. commons/schema.php can
+ * be included against a stubbed $this and a fake DB, but it also wants ~35
+ * config constants and a couple of core classes, and every one of those is a
+ * thing an unrelated schema commit could add. A guard that fails for reasons
+ * unconnected to what it guards is a guard people learn to ignore, and these
+ * two textual checks are exact for every shape the file actually uses.
+ *
  * Usage: php tests/schema-gate.test.php
  * Exit status 0 = pass, 1 = fail.
  */
@@ -56,15 +69,18 @@ foreach ([$schemaFile, $systemFile] as $path) {
     }
 }
 
+$schemaSrc = file_get_contents($schemaFile);
+
 /*
  * Highest step label. Anchored to the start of the line so a number
  * mentioned inside a step's own explanatory comment -- which is indented --
- * cannot be mistaken for a label.
+ * cannot be mistaken for a label. Trailing prose is allowed: the file writes
+ * both `// 320` and `// 278 is #268 in 1.5.8`.
  */
 $labels = [];
 preg_match_all(
-    '/^\/\/ (\d+)$/m',
-    file_get_contents($schemaFile),
+    '/^\/\/ (\d+)(?:\D.*)?$/m',
+    $schemaSrc,
     $labels
 );
 if (!count($labels[1])) {
@@ -72,6 +88,59 @@ if (!count($labels[1])) {
     exit(1);
 }
 $highest = max(array_map('intval', $labels[1]));
+
+/*
+ * No unlabelled appends. Every top-level `$this->schema[] =` must have a
+ * `// N` line somewhere between it and the append before it -- true of all
+ * 296 of them today, and the thing that lets the highest label stand in for
+ * the element count.
+ *
+ * Deliberately "somewhere between" rather than "on the line directly above".
+ * Thirteen steps read a column out of information_schema first and branch on
+ * it (`$this->schema[] = count($column ?: []) ? [] : [...]`), so the label,
+ * the lookup and the append are three separate statements. Requiring
+ * adjacency would fail all thirteen and teach the next person that this test
+ * is noise.
+ *
+ * Only column-zero appends are checked. The one indented append is inside
+ * the foreach over $keySequences, which writes 35 elements (indexes 45-79)
+ * from a single line of source; it is covered by the `// 45 - 79 setup`
+ * label above the loop and cannot be counted from the text at all, which is
+ * the specific reason the labels rather than a static count are authoritative
+ * here.
+ */
+$lines = preg_split('/\r?\n/', $schemaSrc);
+$unlabelled = [];
+$seenLabel = false;
+foreach ($lines as $i => $line) {
+    if (preg_match('/^\/\/ \d+(?:\D.*)?$/', $line)) {
+        $seenLabel = true;
+        continue;
+    }
+    if (!preg_match('/^\$this->schema\[\] *=/', $line)) {
+        continue;
+    }
+    if (!$seenLabel) {
+        // Reported 1-indexed, to match what an editor shows.
+        $unlabelled[] = $i + 1;
+    }
+    $seenLabel = false;
+}
+
+if (count($unlabelled)) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($unlabelled) . " append(s) in commons/schema.php\n"
+        . "  carry no `// N` step label, at line(s) "
+        . implode(', ', $unlabelled) . ".\n"
+        . "  An unlabelled element does not raise the highest label, so the\n"
+        . "  FOG_SCHEMA check below would still pass while that element sat\n"
+        . "  above the gate and applied to nobody. Put the step's number on\n"
+        . "  a line of its own above the append, as every other step does,\n"
+        . "  and raise FOG_SCHEMA to match.\n"
+    );
+    exit(1);
+}
 
 $const = [];
 if (!preg_match(


### PR DESCRIPTION
Follow-up to #1060, closing a hole in the guard that PR shipped.

## The hole

`tests/schema-gate.test.php` compared `FOG_SCHEMA` against the highest `// N` label in `commons/schema.php`. That is a proxy for the element count, and it leaks in one direction: **an element appended with no label does not raise the highest label**, so the comparison still passes while the new element sits above the gate and applies to nobody — the exact failure the test exists for, reached by a slightly different route.

## The fix

The test now also refuses an append with no label between it and the append before it. Together the two are closed:

- you cannot append without labelling, and
- you cannot label above `FOG_SCHEMA`.

**"Between", not "directly above".** Thirteen steps read a column out of `information_schema` and branch on it (`$this->schema[] = count($column ?: []) ? [] : [...]`), so the label, the lookup and the append are three separate statements. Requiring adjacency fails all thirteen and teaches the next person that this test is noise.

Verified against the file as it stands: **296 top-level appends, all 296 labelled.** 296 + the 35 elements the `$keySequences` loop writes from one line of source = 331 = `FOG_SCHEMA`. Everything reconciles exactly.

## What was tried first, and why it lost

Counting the array for real. `commons/schema.php` *can* be included against a stubbed `$this` and a fake DB — I got it running — but it also wants ~35 config constants (`TFTP_HOST`, `STORAGE_DATADIR`, `PXE_KERNEL`, …) and a couple of core classes, and every one of those is a thing an unrelated schema commit could add. A guard that fails for reasons unconnected to what it guards is a guard people learn to ignore.

The two textual checks are exact for every shape the file actually uses, including the `foreach` over `$keySequences` that writes 35 elements from a single line and cannot be counted from the text at all — which is precisely why the labels, not a static count, are authoritative here.

## Verification

Both halves proven by making them fail, then restoring:

```
# unlabelled append appended to schema.php
FAIL: 1 append(s) in commons/schema.php
  carry no `// N` step label, at line(s) 5255.

# labelled step 332 with FOG_SCHEMA left at 331
FAIL: FOG_SCHEMA is 331 but commons/schema.php goes to 332.
  Set FOG_SCHEMA to 332 in packages/web/lib/fog/system.class.php.
```

`sh tests/run-all.sh` → 10 passed, 0 failed. Test-only change; no production file touched.