### PR TITLE
Stop the API reference rendering all 716 operations on load

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -79,7 +79,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 329);
-        define('FOG_BCACHE_VER', 277);
+        define('FOG_BCACHE_VER', 278);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
@@ -78,8 +78,25 @@
             // invites pointing this at some other server's document. There is
             // one spec worth reading here and it is this server's.
             layout: 'BaseLayout',
-            docExpansion: 'list',
-            defaultModelsExpandDepth: 1,
+            // 'none', not 'list'. 'list' expands every tag group on load, and
+            // this document is generated: 69 tags x the ten generic routes each
+            // class gets (list, create, get, update, delete, search, count,
+            // names, ids, join) is 716 operations, which Swagger UI renders as
+            // 17,400 DOM nodes before the page is usable. 'none' renders the 69
+            // tag headers only -- 1,672 nodes -- and expands on demand. Measured
+            // on the 1.6 lab: settled render 4.3s -> 2.5s, and every subsequent
+            // interaction stops reconciling a 17k-node tree.
+            //
+            // A hand-written spec would never hit this; one generated from the
+            // class list grows an operation block every time a class or a plugin
+            // is added, so the default that suits a 20-operation API is the wrong
+            // one here by construction.
+            docExpansion: 'none',
+            // Collapsed groups need a way in other than scrolling 69 headers.
+            filter: true,
+            // Depth 1 still walks all 70 schemas at startup. The models section
+            // is reference material read on purpose, not on arrival.
+            defaultModelsExpandDepth: 0,
             // Same-origin, so the browser sends the session cookie and try-it
             // works against this very server.
             withCredentials: true


### PR DESCRIPTION
## Problem

The API Documentation page took seconds to appear and stayed sluggish afterwards — every operation expand paused on a spinner.

The server was never the cause:

| | measured |
|---|---|
| `OpenAPI::document()` generation | 36ms, 622KB |
| spec fetch + `JSON.parse` | 30ms + 4ms |
| `swagger-ui-bundle.js` warm re-exec | 35ms |
| **Swagger UI rendering the spec** | **4.18s, 17,439 DOM nodes** |

## Cause

`docExpansion: 'list'` expands every tag group on load. That's the right default for a hand-written spec with twenty or thirty operations.

This document is *generated* from `Route::$validClasses`, and every class contributes the same ten generic routes — list, create, get, update, delete, search, count, names, ids, join. A stock 1.6 install with plugins is **69 tags / 512 paths / 716 operations**, which Swagger UI commits as 17,439 DOM nodes before the page is usable, then reconciles again on every expand.

It also gets worse over time: each new class or plugin adds another ten operation blocks.

## Fix

Three option values in `fog.apidocs.list.js`:

- `docExpansion: 'none'` — render the 69 tag headers, expand on demand
- `filter: true` — a search box, since collapsed groups need a way in other than scrolling
- `defaultModelsExpandDepth: 0` — don't walk all 70 schemas at startup

Deep links still resolve; Swagger UI expands the targeted operation regardless of `docExpansion`.

## Measured (1.6 lab, AJAX nav from the dashboard)

| | before | after |
|---|---|---|
| DOM nodes | 17,439 | 1,675 |
| settled render | 4.18s | 2.61s |
| tag expand | 896ms | 710ms |

## Behavior change

The page now opens as 69 collapsed resource groups plus a filter box, instead of 716 listed operations. That is the change that makes it fast.

## Not fixed here

Heap grows ~150MB per visit to the page — `doPageLoad()` does `ajaxPageWrapper.empty().html(data)`, tearing the DOM out from under React without unmounting, and the bundle exposes no unmount API. This PR shrinks the leaked tree ~10x, which is most of the practical relief, but the leak itself is still there.

Includes a `FOG_BCACHE_VER` bump so browsers pick up the changed JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)