### PR TITLE
Stop a plugin shadowing a core class, and add the site membership models

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -270,6 +270,35 @@ class Initiator
     }
 
     /**
+     * Is this path plugin code rather than core code?
+     *
+     * Two roots count: BASEPATH/lib/plugins, where the bundled plugins are
+     * unpacked by bin/fetch-plugins.sh, and FOG_PLUGIN_DIR, where an admin's
+     * own plugins live (ADR 0009). Everything else under BASEPATH is core.
+     *
+     * Used only to break a name collision in autoload(), so it answers the
+     * one question that matters there -- may this file shadow a core class --
+     * and nothing else.
+     *
+     * @param string $path An absolute path from the class-file scan.
+     *
+     * @return bool
+     */
+    private static function _isPluginPath(string $path): bool
+    {
+        $roots = [rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins' . DS];
+        if (defined('FOG_PLUGIN_DIR') && FOG_PLUGIN_DIR) {
+            $roots[] = rtrim(FOG_PLUGIN_DIR, DS) . DS;
+        }
+        foreach ($roots as $root) {
+            if (strncmp($path, $root, strlen($root)) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Resolve a class to its source file via an O(1) name => path map.
      *
      * The built-in spl_autoload() probes every include_path directory by every
@@ -281,13 +310,33 @@ class Initiator
      * suffix — exactly what the built-in resolver matches. A miss falls through
      * to the still-registered built-in autoloader.
      *
-     * Where two files claim one key the first one walked wins, and that is NOT
-     * what the built-in does: spl_autoload() loops the registered extensions on
-     * the outside and the include_path on the inside, so a .class.php always
-     * beats a .report.php of the same name however the directories are ordered.
-     * This map has no such precedence — the winner is readdir order, which
-     * differs per install. Keep colliding basenames out of the scan (see
-     * _scanClassFiles) rather than relying on either rule.
+     * Where two files claim one key, CORE WINS and the collision is logged.
+     * Keeping colliding basenames out of the scan is still the rule (see
+     * _scanClassFiles) -- this is what happens when that rule is broken.
+     *
+     * It used to be "first one walked wins", which is readdir order and so
+     * differs per install: the same code resolving to a different file on two
+     * servers, silently. That is the usertracking failure documented in
+     * _scanClassFiles, and it had a second edge nobody had cause to look at
+     * yet -- external plugins under FOG_PLUGIN_DIR already lost to core,
+     * because _scanRoots() puts BASEPATH first and first-wins does the rest,
+     * but BUNDLED plugins live *inside* BASEPATH at lib/plugins, so they
+     * shared one directory walk with lib/fog and the winner was a coin flip.
+     * A bundled plugin shipping class/authorization.class.php could therefore
+     * replace core's Authorization on some installs and not others.
+     *
+     * Core winning makes the two plugin roots behave the same way, which is
+     * the behaviour the external-plugin case already had, and it is the only
+     * safe direction: a plugin must never be able to shadow a core class by
+     * naming a file after it. Verified against the shipped tree at the time
+     * of writing -- 396 scanned files, zero colliding basenames -- so this
+     * changes no resolution that exists today.
+     *
+     * Note this is still NOT what the built-in does: spl_autoload() loops the
+     * registered extensions on the outside and the include_path on the inside,
+     * so a .class.php always beats a .report.php of the same name however the
+     * directories are ordered. Two core files colliding remain unordered, and
+     * are reported rather than resolved.
      *
      * A name that misses the map and carries the FOG\ prefix falls through to
      * _bridgeNamespaced() below rather than to the built-in resolver, which
@@ -311,7 +360,28 @@ class Initiator
                 );
                 if (!isset($map[$base])) {
                     $map[$base] = $path;
+                    continue;
                 }
+                // Collision. Let a core file displace a plugin one, and say so
+                // either way -- a shadowed class is otherwise completely
+                // silent, and the symptom (a method that does not exist, or
+                // one that reads the wrong table) surfaces nowhere near here.
+                $held = $map[$base];
+                if (self::_isPluginPath($held) && !self::_isPluginPath($path)) {
+                    $map[$base] = $path;
+                }
+                $loser = ($map[$base] === $held) ? $path : $held;
+                error_log(
+                    sprintf(
+                        'FOG autoloader: two files claim the class name "%s"; '
+                        . 'using %s and ignoring %s. Rename one -- a shadowed '
+                        . 'class resolves to whichever file this rule picks, '
+                        . 'not to the one the caller meant.',
+                        $base,
+                        $map[$base],
+                        $loser
+                    )
+                );
             }
             self::$classMap = $map;
         }

--- a/packages/web/lib/fog/sitegroupmember.class.php
+++ b/packages/web/lib/fog/sitegroupmember.class.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Membership association between site -> host group links.
+ *
+ * PHP version 5
+ *
+ * @category SiteGroupMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Membership association between site -> host group links.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives membership through this association
+ * the same way UserGroup drives UserGroupMember.
+ *
+ * @category SiteGroupMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteGroupMember extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteGroupMembers';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'sgmID',
+        'name' => 'sgmName',
+        'siteID' => 'sgmSiteID',
+        'groupID' => 'sgmGroupID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'groupID'
+    ];
+}

--- a/packages/web/lib/fog/sitegroupmembermanager.class.php
+++ b/packages/web/lib/fog/sitegroupmembermanager.class.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SiteGroupMember manager class.
+ *
+ * PHP version 5
+ *
+ * @category SiteGroupMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * SiteGroupMember manager class.
+ *
+ * @category SiteGroupMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteGroupMemberManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteGroupMembers';
+}

--- a/packages/web/lib/fog/sitehostmember.class.php
+++ b/packages/web/lib/fog/sitehostmember.class.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Membership association between site -> host links.
+ *
+ * PHP version 5
+ *
+ * @category SiteHostMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Membership association between site -> host links.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives membership through this association
+ * the same way UserGroup drives UserGroupMember.
+ *
+ * @category SiteHostMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteHostMember extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteHostMembers';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'shmID',
+        'name' => 'shmName',
+        'siteID' => 'shmSiteID',
+        'hostID' => 'shmHostID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'hostID'
+    ];
+}

--- a/packages/web/lib/fog/sitehostmembermanager.class.php
+++ b/packages/web/lib/fog/sitehostmembermanager.class.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SiteHostMember manager class.
+ *
+ * PHP version 5
+ *
+ * @category SiteHostMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * SiteHostMember manager class.
+ *
+ * @category SiteHostMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteHostMemberManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteHostMembers';
+}

--- a/packages/web/lib/fog/siteusergroupmember.class.php
+++ b/packages/web/lib/fog/siteusergroupmember.class.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Membership association between site -> user group links.
+ *
+ * PHP version 5
+ *
+ * @category SiteUserGroupMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Membership association between site -> user group links.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives membership through this association
+ * the same way UserGroup drives UserGroupMember.
+ *
+ * @category SiteUserGroupMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserGroupMember extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteUserGroupMembers';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'sugmID',
+        'name' => 'sugmName',
+        'siteID' => 'sugmSiteID',
+        'usergroupID' => 'sugmUserGroupID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'usergroupID'
+    ];
+}

--- a/packages/web/lib/fog/siteusergroupmembermanager.class.php
+++ b/packages/web/lib/fog/siteusergroupmembermanager.class.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SiteUserGroupMember manager class.
+ *
+ * PHP version 5
+ *
+ * @category SiteUserGroupMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * SiteUserGroupMember manager class.
+ *
+ * @category SiteUserGroupMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserGroupMemberManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteUserGroupMembers';
+}

--- a/packages/web/lib/fog/siteusermember.class.php
+++ b/packages/web/lib/fog/siteusermember.class.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Membership association between site -> user links.
+ *
+ * PHP version 5
+ *
+ * @category SiteUserMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Membership association between site -> user links.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives membership through this association
+ * the same way UserGroup drives UserGroupMember.
+ *
+ * @category SiteUserMember
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserMember extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteUserMembers';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'sumID',
+        'name' => 'sumName',
+        'siteID' => 'sumSiteID',
+        'userID' => 'sumUserID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'userID'
+    ];
+}

--- a/packages/web/lib/fog/siteusermembermanager.class.php
+++ b/packages/web/lib/fog/siteusermembermanager.class.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SiteUserMember manager class.
+ *
+ * PHP version 5
+ *
+ * @category SiteUserMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * SiteUserMember manager class.
+ *
+ * @category SiteUserMemberManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserMemberManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteUserMembers';
+}

--- a/tests/autoload-core-wins.test.php
+++ b/tests/autoload-core-wins.test.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * A plugin file may not shadow a core class of the same name.
+ *
+ * Initiator::autoload() maps a lowercased basename to a path. Two files
+ * claiming one key used to be resolved by whichever the directory walk
+ * reached first -- readdir order, which differs per install, so the same
+ * code resolves to a different file on two servers with nothing to say so.
+ * That is the usertracking failure recorded in _scanClassFiles(), and it had
+ * a second edge: external plugins under FOG_PLUGIN_DIR already lost to core
+ * (BASEPATH is scanned first and first-wins did the rest), but the BUNDLED
+ * plugins live inside BASEPATH at lib/plugins, so they shared one directory
+ * walk with lib/fog and the winner was a coin flip. A bundled plugin
+ * shipping class/authorization.class.php could replace core's Authorization
+ * on some installs and not others.
+ *
+ * autoload() now prefers the core file and logs the collision. This test
+ * pins that, because the rule is invisible until it matters and its failure
+ * mode is a class that silently is not the class the caller meant.
+ *
+ * It matters right now for a specific reason. Sites are moving out of the
+ * site plugin and into core, and core's Site cannot be declared while the
+ * plugin's site/class/site.class.php is still on disk without exactly this
+ * collision. Core winning is what makes the changeover a decision rather
+ * than a coin flip -- and it is why core's Site lands in the same commit as
+ * the FOG_PLUGINS_VERSION bump that removes the plugin's copy, not before.
+ *
+ * DB-free, same shape as autoload.test.php: the Initiator constructor only
+ * registers the autoloader, so the cache dir is redirected somewhere
+ * throwaway and startInit() -- the part that needs MySQL -- is never called.
+ *
+ * Usage: php tests/autoload-core-wins.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__) . '/packages/web';
+$init = $root . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-core-wins-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+// An external plugin root, so both plugin shapes are exercised.
+@mkdir($tmp . '/extplugins', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/extplugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/*
+ * 1. The rule itself. _isPluginPath() is private, so it is reached through
+ *    Reflection rather than being made public for a test -- the classifier
+ *    is an autoloader implementation detail and should stay one.
+ */
+$m = new \ReflectionMethod('Initiator', '_isPluginPath');
+$m->setAccessible(true);
+$isPlugin = function ($path) use ($m) {
+    return $m->invoke(null, $path);
+};
+
+$base = rtrim(BASEPATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+$cases = [
+    // path                                          => is it plugin code?
+    $base . 'lib/fog/host.class.php'                 => false,
+    $base . 'lib/fog/site.class.php'                 => false,
+    $base . 'lib/router/route.class.php'             => false,
+    $base . 'lib/pages/hostmanagement.page.php'      => false,
+    $base . 'lib/plugins/site/class/site.class.php'  => true,
+    $base . 'lib/plugins/x/class/authorization.class.php' => true,
+    FOG_PLUGIN_DIR . '/mine/class/host.class.php'    => true,
+];
+foreach ($cases as $path => $expected) {
+    check(
+        '_isPluginPath(' . str_replace($base, '', $path) . ') is '
+        . ($expected ? 'true' : 'false'),
+        $isPlugin($path) === $expected,
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 2. A path that merely CONTAINS the word plugins is not plugin code. The
+ *    classifier decides whether a file may shadow a core class, so a
+ *    substring match here would hand that right to any core file whose name
+ *    happened to mention plugins -- lib/fog/pluginmanager.class.php, for one.
+ */
+check(
+    'lib/fog/pluginmanager.class.php is core, not plugin',
+    $isPlugin($base . 'lib/fog/pluginmanager.class.php') === false,
+    $failures,
+    $checks
+);
+check(
+    'lib/pages/pluginmanagement.page.php is core, not plugin',
+    $isPlugin($base . 'lib/pages/pluginmanagement.page.php') === false,
+    $failures,
+    $checks
+);
+
+/*
+ * 3. The rule as autoload() actually applies it, driven with a synthetic
+ *    file list so BOTH branches are reached deterministically. Walk order is
+ *    the whole problem here, and it is exactly the thing a test cannot
+ *    control by putting real files on disk -- hence Reflection on the two
+ *    memoised statics rather than a fixture directory.
+ *
+ *    error_log output is redirected for the duration: the collisions below
+ *    are deliberate, and a passing test should not leave four alarming lines
+ *    in the tester's PHP log.
+ */
+$fileList = new \ReflectionProperty('Initiator', 'fileList');
+$fileList->setAccessible(true);
+$classMap = new \ReflectionProperty('Initiator', 'classMap');
+$classMap->setAccessible(true);
+$heldList = $fileList->getValue();
+
+$errLog = ini_get('error_log');
+$quiet = $tmp . '/collisions.log';
+ini_set('error_log', $quiet);
+
+$build = function (array $list) use ($fileList, $classMap) {
+    $fileList->setValue(null, $list);
+    $classMap->setValue(null, null);
+    // Any name will do -- the map is built before the lookup.
+    Initiator::autoload('__does_not_exist__');
+    return $classMap->getValue();
+};
+
+$corePath = $base . 'lib/fog/site.class.php';
+$bundled = $base . 'lib/plugins/site/class/site.class.php';
+$external = FOG_PLUGIN_DIR . '/mine/class/site.class.php';
+
+$order = [
+    'bundled plugin walked first' => [$bundled, $corePath],
+    'core walked first' => [$corePath, $bundled],
+    'external plugin walked first' => [$external, $corePath],
+];
+foreach ($order as $label => $list) {
+    $map = $build($list);
+    check(
+        "core wins when the $label",
+        ($map['site'] ?? null) === $corePath,
+        $failures,
+        $checks
+    );
+}
+
+// Two core files stay first-wins. Deliberately NOT ordered: there is no
+// honest basis to prefer one core file over another, and pretending there is
+// would hide the rename that actually fixes it.
+$map = $build([$base . 'lib/fog/dup.class.php', $base . 'lib/pages/dup.page.php']);
+check(
+    'two core files keep first-wins',
+    ($map['dup'] ?? null) === $base . 'lib/fog/dup.class.php',
+    $failures,
+    $checks
+);
+
+// Every collision above must have been reported. A silent shadow is the
+// failure this whole mechanism exists to prevent, so an unlogged one is a
+// bug even when the resolution is right.
+$logged = is_readable($quiet) ? file_get_contents($quiet) : '';
+check(
+    'each collision was logged',
+    substr_count($logged, 'two files claim the class name') === 4,
+    $failures,
+    $checks
+);
+
+ini_set('error_log', (string)$errLog);
+$fileList->setValue(null, $heldList);
+$classMap->setValue(null, null);
+
+/*
+ * 4. The shipped tree still has no colliding basenames. This is the rule the
+ *    precedence above is a backstop for, not a replacement of: two CORE files
+ *    colliding are still unordered, and the only fix for those is a rename.
+ */
+$seen = [];
+$collisions = [];
+foreach (Initiator::classFileList() as $path) {
+    $key = strtolower(
+        preg_replace(
+            '#\.(report|event|class|hook|page|task)\.php$#',
+            '',
+            basename($path)
+        )
+    );
+    if (isset($seen[$key])) {
+        $collisions[$key] = [$seen[$key], $path];
+        continue;
+    }
+    $seen[$key] = $path;
+}
+check(
+    'no colliding basenames in the scanned tree'
+    . (count($collisions)
+        ? ' (found: ' . implode(', ', array_keys($collisions)) . ')'
+        : ''),
+    count($collisions) === 0,
+    $failures,
+    $checks
+);
+
+/*
+ * 5. The four site membership models resolve and are wired to the tables
+ *    schema step 331 creates. Cheap, and it catches the two mistakes that
+ *    would otherwise surface as an empty result set rather than an error:
+ *    a class name that does not match its filename, and a databaseFields
+ *    key that does not match what assocSetter derives from Site.
+ */
+$models = [
+    'SiteHostMember' => ['siteHostMembers', 'hostID'],
+    'SiteUserMember' => ['siteUserMembers', 'userID'],
+    'SiteGroupMember' => ['siteGroupMembers', 'groupID'],
+    'SiteUserGroupMember' => ['siteUserGroupMembers', 'usergroupID'],
+];
+foreach ($models as $class => $spec) {
+    if (!class_exists($class, true)) {
+        check("$class resolves", false, $failures, $checks);
+        continue;
+    }
+    check("$class resolves", true, $failures, $checks);
+
+    $ref = new \ReflectionClass($class);
+    check(
+        "$class extends FOGController",
+        $ref->isSubclassOf('FOGController'),
+        $failures,
+        $checks
+    );
+
+    $table = $ref->getProperty('databaseTable');
+    $table->setAccessible(true);
+    check(
+        "$class maps to `{$spec[0]}`",
+        $table->getValue($ref->newInstanceWithoutConstructor()) === $spec[0],
+        $failures,
+        $checks
+    );
+
+    $fields = $ref->getProperty('databaseFields');
+    $fields->setAccessible(true);
+    $keys = array_keys(
+        $fields->getValue($ref->newInstanceWithoutConstructor())
+    );
+    // siteID is the half assocSetter derives from the Site class name; the
+    // object key is the half the scope queries filter on. Both are load
+    // bearing and neither is checked anywhere else.
+    check(
+        "$class has a siteID field",
+        in_array('siteID', $keys, true),
+        $failures,
+        $checks
+    );
+    check(
+        "$class has a {$spec[1]} field",
+        in_array($spec[1], $keys, true),
+        $failures,
+        $checks
+    );
+
+    $mgr = $class . 'Manager';
+    check(
+        "$mgr resolves",
+        class_exists($mgr, true),
+        $failures,
+        $checks
+    );
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Phase 1, commit 4 — but **not the commit the plan described**, and the reason is the point of the PR.

## The plan was wrong about this one

It said commit 4 would be "`Site` and its managers as core classes … inert on its own — nothing calls these yet and the plugin still drives enforcement." Checking that before writing it, it is not inert and cannot be:

- `Initiator::autoload()` keys an O(1) map on the lowercased basename. Core's `lib/fog/site.class.php` and the plugin's `lib/plugins/site/class/site.class.php` both produce the key `site`.
- Resolution was **first-walked-wins**. External plugins under `FOG_PLUGIN_DIR` already lost to core, because `_scanRoots()` puts `BASEPATH` first and first-wins does the rest — but the **bundled** plugins live *inside* `BASEPATH` at `lib/plugins`, so they share one directory walk with `lib/fog` and the winner is readdir order. Measured on this box: core's file at walk position 48, the plugin's at 313. Core wins *here*. On another filesystem it need not.
- The plugin's `SiteScopeCheck` hook calls `Site::inScope()`. Where core's `Site` wins, that call hits core's **empty `sites` table**, every membership lookup returns empty, and `inScope()` denies on an empty set.

So the plan's commit 4 ships a **coin-flip lockout**: every non-`*` user denied every host, on some installs and not others.

Neither side can move first — the plugin can't drop `Site` before core has one, and core can't add one while the plugin has it. The answer is that core's `Site` lands **in the same commit as the `FOG_PLUGINS_VERSION` bump** that removes the plugin's copy, which `bin/fetch-plugins.sh` makes atomic.

## What is in here, then

Everything that is genuinely safe to land alone.

**The four membership models** for schema step 331's tables — `SiteHostMember`, `SiteUserMember`, `SiteGroupMember`, `SiteUserGroupMember`, plus managers. Names collide with nothing (the plugin's are `SiteHostAssociation` etc.). Shaped on `UserGroupMember`: the friendly `siteID` key is what `assocSetter` derives from the `Site` class name.

**The precedence rule.** Core now wins a basename collision and both files are named in the log. Same outcome external plugins already had, applied to bundled ones, and the only safe direction — a plugin must never be able to replace a core class by naming a file after it. A bundled plugin shipping `class/authorization.class.php` could do exactly that today.

Verified against the shipped tree: **396 files scanned, zero colliding basenames**, so no resolution that exists today changes.

Two *core* files colliding stay first-wins and are only reported. There is no honest basis to order them, and pretending there is would hide the rename that actually fixes it.

## Deliberately not included

`Route::$validClasses` is untouched. Adding the four would create REST endpoints `Authorization::API_CLASS_ENTITIES` does not map — which is admin-only plus a log line per call, so correct, but nothing consumes them yet. They go in with the entity mapping.

## Verification

`tests/autoload-core-wins.test.php` drives the map build through Reflection with a synthetic file list, because walk order is the whole problem and is the one thing a fixture directory cannot control.

| Case | Result |
|---|---|
| bundled plugin walked first | core wins |
| core walked first | core wins |
| external plugin walked first | core wins |
| two core files | first-wins, reported only |
| all four collisions | logged |

Removing just the precedence branch (helper kept) fails exactly two named checks:

```
FAIL (2 of 39):
  - core wins when the bundled plugin walked first
  - core wins when the external plugin walked first
```

`sh tests/run-all.sh` → 11 passed, 0 failed.