### PR TITLE
Create the catch-all site so an upgrade is not a fleet-wide lockout

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5326,30 +5326,59 @@ $this->schema[] = [
         // tables carry no unique key, so the same host can be in the same
         // site twice; core's tables do, so the duplicate would be ignored
         // and the raw row counts would disagree on a database that is
-        // actually fine. Rows pointing at a site that no longer exists are
-        // excluded here and counted separately below -- they are already
-        // unusable, and letting them block the drop would strand the
-        // tables on exactly the servers that need tidying most.
+        // actually fine.
+        //
+        // Rows are carried across only when BOTH ends still exist. The
+        // plugin never cleaned up after a delete, so its tables hold links
+        // to sites, hosts and users that are long gone -- verified on a
+        // real install, where siteUserAssoc still granted a site to user 6,
+        // deleted at some point in the past.
+        //
+        // A dangling link is not merely untidy. users.uId is
+        // AUTO_INCREMENT, and InnoDB recomputes that counter as MAX(id)+1
+        // on restart, so an id CAN come round again once every row above it
+        // has also gone. A leftover row would then hand a brand new account
+        // the deleted one's site without anybody granting it. Remote, but
+        // this is the one moment the contents of a security boundary are
+        // being chosen, and carrying known-dead rows into it is a decision
+        // rather than an oversight.
+        //
+        // They are counted and logged, not treated as loss: excluded from
+        // the expected count as well as the insert, so they cannot block
+        // the drop and strand the tables on the servers that need tidying
+        // most.
         $members = [
-            // core table => [core site col, core obj col,
-            //                plugin table, plugin site col, plugin obj col]
+            // core table => [core site col, core obj col, plugin table,
+            //                plugin site col, plugin obj col,
+            //                object's own table, object's own key]
             'siteHostMembers' => [
                 'shmSiteID', 'shmHostID',
                 'siteHostAssoc', 'shaSiteID', 'shaHostID',
+                'hosts', 'hostID',
             ],
             'siteUserMembers' => [
                 'sumSiteID', 'sumUserID',
                 'siteUserAssoc', 'suaSiteID', 'suaUserID',
+                'users', 'uId',
             ],
             'siteGroupMembers' => [
                 'sgmSiteID', 'sgmGroupID',
                 'siteGroupAssoc', 'sgaSiteID', 'sgaGroupID',
+                'groups', 'groupID',
             ],
             'siteUserGroupMembers' => [
                 'sugmSiteID', 'sugmUserGroupID',
                 'siteUserGroupAssoc', 'sugaSiteID', 'sugaUserGroupID',
+                'userGroups', 'ugID',
             ],
         ];
+        // One WHERE for the insert, the expected count and the orphan
+        // count, so the three can never drift apart.
+        $live = function ($map) {
+            list(, , , $sSite, $sObj, $oTable, $oKey) = $map;
+            return "`$sSite` IN (SELECT `siteID` FROM `sites`) "
+                . "AND `$sObj` IN (SELECT `$oKey` FROM `$oTable`)";
+        };
         foreach ($members as $dest => $map) {
             list($dSite, $dObj, $src, $sSite, $sObj) = $map;
             if (!in_array($src, $present, true)) {
@@ -5358,7 +5387,7 @@ $this->schema[] = [
             self::$DB->query(
                 "INSERT IGNORE INTO `$dest` (`$dSite`, `$dObj`) "
                 . "SELECT DISTINCT `$sSite`, `$sObj` FROM `$src` "
-                . "WHERE `$sSite` IN (SELECT `siteID` FROM `sites`)"
+                . "WHERE " . $live($map)
             );
         }
 
@@ -5389,8 +5418,8 @@ $this->schema[] = [
                 continue;
             }
             $expected = $count(
-                "SELECT COUNT(DISTINCT `$sSite`, `$sObj`) AS `cnt` FROM `$src` "
-                . "WHERE `$sSite` IN (SELECT `siteID` FROM `sites`)"
+                "SELECT COUNT(DISTINCT `$sSite`, `$sObj`) AS `cnt` "
+                . "FROM `$src` WHERE " . $live($map)
             );
             $actual = $count(
                 "SELECT COUNT(*) AS `cnt` FROM `$dest` "
@@ -5401,16 +5430,17 @@ $this->schema[] = [
             }
             $orphans += $count(
                 "SELECT COUNT(*) AS `cnt` FROM `$src` "
-                . "WHERE `$sSite` NOT IN (SELECT `siteID` FROM `sites`)"
+                . "WHERE NOT (" . $live($map) . ")"
             );
         }
 
         if ($orphans > 0) {
             error_log(
                 sprintf(
-                    'FOG site migration: %d association row(s) referenced a '
-                    . 'site that does not exist and were not carried across. '
-                    . 'They were already unreachable.',
+                    'FOG site migration: %d association row(s) pointed at a '
+                    . 'site, host, user or group that no longer exists and '
+                    . 'were not carried across. They were already '
+                    . 'unreachable.',
                     $orphans
                 )
             );
@@ -5438,6 +5468,108 @@ $this->schema[] = [
                 self::$DB->query("DROP TABLE IF EXISTS `$table`");
             }
         }
+        return true;
+    },
+];
+// 333
+$this->schema[] = [
+    // The catch-all site, and every user who is in no site joins it.
+    //
+    // This is what stops the changeover being a fleet-wide lockout. Sites
+    // become unconditional here: before, installing the plugin WAS the
+    // opt-in, and Site::inScope() denies a user with no sites (deny-all is
+    // the correct posture and is not changing). Make the boundary
+    // unconditional without this and every non-'*' user on every upgraded
+    // server is denied every host the moment they log in.
+    //
+    // Runs after the reconstruct, so a user the plugin had genuinely
+    // scoped keeps exactly the scope they had and is not touched here.
+    //
+    // A user who had the plugin installed but was never assigned to a site
+    // DOES join, which widens what they can see. That is deliberate. "No
+    // site" today means the plugin denies them every host, user and group
+    // in the system -- an account that cannot do anything is almost never
+    // what an admin intended, and far more likely a site they never got
+    // round to filling in. The alternative is upgrading a server into a
+    // state where working accounts silently stop working, which is the
+    // failure this whole step exists to prevent.
+    //
+    // Nothing is written to the host, group or usergroup tables. The
+    // catch-all means "no restriction", not "these particular objects" --
+    // it is a flag that scope resolution short circuits on. An enumerated
+    // membership list would look identical on the day of the upgrade and
+    // then quietly rot: the first host registered afterwards would belong
+    // to no site and so be invisible to everyone, which is a migration
+    // that appears to work and fails on day two, during the most common
+    // operation FOG performs.
+    function () {
+        $held = self::$DB->query(
+            "SELECT `siteID` AS `cnt` FROM `sites` "
+            . "WHERE `siteCatchAll` IS NOT NULL LIMIT 1"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        if (is_array($held) && isset($held['cnt'])) {
+            // Already present. Only reachable on a re-run, and a re-run
+            // must not re-add users an admin has since taken out.
+            return true;
+        }
+
+        // siteName is UNIQUE and a migrated site may already be called
+        // Everything, so take the first free spelling rather than letting
+        // the insert be ignored and the catch-all silently not exist.
+        $exists = function ($name) {
+            $row = self::$DB->query(
+                sprintf(
+                    "SELECT COUNT(*) AS `cnt` FROM `sites` "
+                    . "WHERE `siteName` = %s",
+                    self::$DB->escape($name)
+                )
+            )->fetch(\PDO::FETCH_ASSOC)->get();
+            return is_array($row) && isset($row['cnt']) && (int)$row['cnt'];
+        };
+        $name = 'Everything';
+        for ($n = 2; $exists($name); $n++) {
+            $name = "Everything ($n)";
+        }
+
+        self::$DB->query(
+            sprintf(
+                "INSERT INTO `sites` (`siteName`, `siteDesc`, `siteCatchAll`) "
+                . "VALUES (%s, %s, 1)",
+                self::$DB->escape($name),
+                self::$DB->escape(
+                    'Members of this site are not restricted to any site: '
+                    . 'they see every host, user and group, which is how FOG '
+                    . 'behaved before sites were built in. Created during the '
+                    . 'upgrade so existing accounts kept working. Safe to '
+                    . 'rename; remove members from it to start scoping them.'
+                )
+            )
+        );
+
+        // Read the id back rather than relying on a last-insert-id API.
+        // siteCatchAll is UNIQUE, so this identifies the row exactly, and
+        // it doubles as confirmation that the insert actually landed.
+        $row = self::$DB->query(
+            "SELECT `siteID` AS `cnt` FROM `sites` "
+            . "WHERE `siteCatchAll` IS NOT NULL LIMIT 1"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        if (!is_array($row) || !isset($row['cnt'])) {
+            return _('Could not create the catch-all site');
+        }
+        $siteID = (int)$row['cnt'];
+
+        // Users only, and only those in no site at all. `uId` is spelled
+        // with a capital I in this table -- see the CREATE in step 0.
+        self::$DB->query(
+            sprintf(
+                "INSERT IGNORE INTO `siteUserMembers` "
+                . "(`sumSiteID`, `sumUserID`) "
+                . "SELECT %d, `u`.`uId` FROM `users` `u` "
+                . "WHERE `u`.`uId` NOT IN "
+                . "(SELECT `sumUserID` FROM `siteUserMembers`)",
+                $siteID
+            )
+        );
         return true;
     },
 ];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -91,7 +91,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 332);
+        define('FOG_SCHEMA', 333);
         define('FOG_BCACHE_VER', 278);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1403,6 +1403,10 @@ msgid "Could not apply %s: %s"
 msgstr "Aktualisieren des Hosts fehlgeschlagen"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1406,6 +1406,10 @@ msgid "Could not apply %s: %s"
 msgstr "Failed to update"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Failed to create Snapin Job"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Failed to create Snapin Job"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1427,6 +1427,10 @@ msgid "Could not apply %s: %s"
 msgstr "No se ha podido destruir"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "No se pudo crear Complemento de empleo"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "No se pudo crear Complemento de empleo"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1403,6 +1403,10 @@ msgid "Could not apply %s: %s"
 msgstr "Aktualisieren des Hosts fehlgeschlagen"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1408,6 +1408,10 @@ msgid "Could not apply %s: %s"
 msgstr "Impossible de mettre à jour"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Échec de la création d'emploi Snapin"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Échec de la création d'emploi Snapin"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1353,6 +1353,10 @@ msgid "Could not apply %s: %s"
 msgstr "Impossibile aggiornare l'host"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Impossibile creare Snapin lavoro"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Impossibile creare Snapin lavoro"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1334,6 +1334,10 @@ msgid "Could not apply %s: %s"
 msgstr "見つかりませんでした"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "スナップインジョブの作成に失敗しました"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "スナップインジョブの作成に失敗しました"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1189,6 +1189,9 @@ msgstr ""
 msgid "Could not apply %s: %s"
 msgstr ""
 
+msgid "Could not create the catch-all site"
+msgstr ""
+
 msgid "Could not create the staging directory."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1407,6 +1407,10 @@ msgid "Could not apply %s: %s"
 msgstr "Falha ao atualizar"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "Falha ao criar Snapin Job"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Falha ao criar Snapin Job"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1407,6 +1407,10 @@ msgid "Could not apply %s: %s"
 msgstr "无法更新"
 
 #, fuzzy
+msgid "Could not create the catch-all site"
+msgstr "无法创建管理单元工作"
+
+#, fuzzy
 msgid "Could not create the staging directory."
 msgstr "无法创建管理单元工作"
 


### PR DESCRIPTION
Phase 1, commit 6. Schema step 333 creates one catch-all site and joins every user who is in no site to it.

## Why this step exists

Installing the plugin used to **be** the opt-in, and `Site::inScope()` denies a user who has no sites — deny-all is the right posture and is not changing. Without this step, making the boundary unconditional denies **every non-`*` user every host on every upgraded server** the moment they log in.

It runs after the reconstruct, so a user the plugin had genuinely scoped keeps exactly the scope they had.

**A user who had the plugin but was never assigned to a site does join, which widens what they can see.** Deliberate, and worth being explicit about: "no site" today means the plugin denies them every host, user and group in the system. An account that can do nothing at all is far more likely a site nobody got round to filling in than a considered decision — and the alternative is upgrading a server into a state where working accounts silently stop working.

**Nothing is written to the host, group or usergroup tables.** The catch-all means "no restriction", not "these particular objects" — it is a flag that scope resolution short circuits on. An enumerated membership list would look identical on upgrade day and then quietly rot: the first host registered afterwards would belong to no site and so be invisible to everyone. A migration that appears to work and fails on day two, during the most common operation FOG performs.

## It also tightens step 332, because the testing found a live case

Membership rows are now carried across only when **both ends still exist**.

The plugin never cleaned up after a delete, and the lab database proved it: `siteUserAssoc` still granted a site to **user 6, deleted at some point in the past**, and the migration was faithfully copying that row into a fresh security-boundary table.

That is not merely untidy. `users.uId` is `AUTO_INCREMENT`, and InnoDB recomputes that counter as `MAX(id)+1` on restart — so an id *can* come round again once every row above it has also gone, and a leftover row would hand a brand new account the deleted one's site with nobody having granted it. Remote, but this is the one moment the contents of a boundary are being chosen, and carrying known-dead rows into it should be a decision rather than an oversight.

Dead rows are counted and logged, and excluded from the **expected** count as well as the insert, so they cannot block the drop and strand the tables on the servers that most need tidying. One WHERE builder feeds the insert, the expected count and the orphan count, so the three cannot drift apart.

## Verification

Lab database, dumped beforehand and restored to **byte-identical checksums** afterwards.

| Case | Result |
|---|---|
| Real data | user 7 keeps `site1`; the other 9 users join the catch-all; dead user 6 excluded and logged; **0 users left without a site** |
| A migrated site already called `Everything` | catch-all takes `Everything (3)`, skipping `Everything` and `Everything (2)` |
| Re-run | one catch-all still, 10 memberships still, nobody re-added |
| Fresh install, no plugin tables | catch-all created, all 10 users placed, none unassigned |
| Catch-all's host/group/usergroup rows | 0 |

The orphan log, verbatim:

```
FOG site migration: 1 association row(s) pointed at a site, host, user or
group that no longer exists and were not carried across. They were already
unreachable.
```

`FOG_SCHEMA` → 333. `sh tests/run-all.sh` → 11 passed, 0 failed. Lab DB left in its pristine pre-migration state.

## Known gap, for a later commit

A user created **after** this runs has no site and will be denied everything once enforcement goes live. That is the same day-two shape the catch-all flag fixes for hosts, and it needs an answer on the user create path — not in a schema step. Flagging it here so it is not discovered as a surprise.