### PR TITLE
Describe the API as OpenAPI 3.0.3, not 3.1.0

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -69,8 +69,33 @@ class OpenAPI extends FOGBase
 {
     /**
      * The OpenAPI specification version this document conforms to.
+     *
+     * 3.0.3 rather than 3.1.0, and the reason is that declaring 3.1 costs a
+     * second of blocking main thread every time an operation is expanded in
+     * the reference UI. Swagger UI resolves a 3.1 document through its
+     * JSON-Schema-2020-12 resolver, which re-resolves the WHOLE document each
+     * time a subtree is requested; the 3.0 path resolves the subtree alone.
+     * The difference is not subtle and it scales with the document, which
+     * this one does -- measured on the 1.6 lab, opening GET /availablekernels
+     * (a two-line operation with no parameters):
+     *
+     *   openapi: 3.1.0   1798ms, of which 1760ms is one blocking task
+     *   openapi: 3.0.3    156ms, of which  119ms is one blocking task
+     *
+     * Nothing is given up by saying 3.0.3. An audit of the generated document
+     * found exactly one 3.1-only construct in it -- the type-array spelling,
+     * in 70 places -- and no const, $schema, webhooks, prefixItems,
+     * unevaluatedProperties, schema-level examples or numeric
+     * exclusiveMinimum. Those 70 are re-spelled below as 3.0's `nullable`
+     * (for the null unions) and `oneOf` (for the genuine unions), which say
+     * the same thing to a client and are understood by considerably more
+     * tooling than 3.1 is.
+     *
+     * The one real cost: `nullable` is deprecated in 3.1, so if this document
+     * ever needs actual JSON Schema features, this decision has to be
+     * revisited rather than extended.
      */
-    const OAS_VERSION = '3.1.0';
+    const OAS_VERSION = '3.0.3';
     /**
      * Cache of the decoded schema manifest, so a 50-class walk reads and
      * parses commons/schema-expected.php once rather than once per class.
@@ -392,8 +417,9 @@ class OpenAPI extends FOGBase
             }
         }
         if ($nullable) {
-            // 3.1 spelling: null joins the type rather than a nullable flag.
-            $schema['type'] = [$schema['type'], 'null'];
+            // 3.0 spelling: a flag beside the type, rather than 3.1's null
+            // joining the type. See OAS_VERSION for why this document is 3.0.
+            $schema['nullable'] = true;
         }
         return $schema;
     }
@@ -616,13 +642,14 @@ class OpenAPI extends FOGBase
                 ],
                 '_lang' => ['type' => 'string'],
                 'data' => ['type' => 'array', 'items' => ['type' => 'object']],
-                'firstUrl' => ['type' => ['string', 'null']],
-                'prevUrl' => ['type' => ['string', 'null']],
+                'firstUrl' => ['type' => 'string', 'nullable' => true],
+                'prevUrl' => ['type' => 'string', 'nullable' => true],
                 'nextUrl' => [
-                    'type' => ['string', 'null'],
+                    'type' => 'string',
+                    'nullable' => true,
                     'description' => _('Null when this is the last page.')
                 ],
-                'lastUrl' => ['type' => ['string', 'null']]
+                'lastUrl' => ['type' => 'string', 'nullable' => true]
             ]
         ];
     }
@@ -838,14 +865,14 @@ class OpenAPI extends FOGBase
                                 'schema' => [
                                     'type' => 'object',
                                     'properties' => [
-                                        'taskTypeID' => ['type' => ['string', 'integer']],
+                                        'taskTypeID' => self::_oneOfTypes(['string', 'integer']),
                                         'taskName' => ['type' => 'string'],
-                                        'shutdown' => ['type' => ['string', 'boolean']],
-                                        'debug' => ['type' => ['string', 'boolean']],
-                                        'deploySnapins' => ['type' => ['string', 'integer', 'boolean']],
+                                        'shutdown' => self::_oneOfTypes(['string', 'boolean']),
+                                        'debug' => self::_oneOfTypes(['string', 'boolean']),
+                                        'deploySnapins' => self::_oneOfTypes(['string', 'integer', 'boolean']),
                                         'passreset' => ['type' => 'string'],
-                                        'sessionjoin' => ['type' => ['string', 'boolean']],
-                                        'wol' => ['type' => ['string', 'boolean']]
+                                        'sessionjoin' => self::_oneOfTypes(['string', 'boolean']),
+                                        'wol' => self::_oneOfTypes(['string', 'boolean'])
                                     ]
                                 ]
                             ]
@@ -932,6 +959,35 @@ class OpenAPI extends FOGBase
         }
         $permission = Authorization::resolveApiPermission($routeName, $class);
         return ('' === $permission || null === $permission) ? null : $permission;
+    }
+
+    /**
+     * A property that genuinely accepts more than one scalar type.
+     *
+     * 3.1 would spell this `type: [a, b]`. 3.0 has no type array, so it is
+     * oneOf -- and oneOf rather than anyOf because a JSON scalar is exactly
+     * one of these, never several at once. See OAS_VERSION for why this
+     * document is 3.0.
+     *
+     * These unions are real, not an artifact of the spelling: the task route
+     * reads its body through PHP's loose comparison, so shutdown accepts
+     * true and "1" alike, and documenting only one of them would understate
+     * what the server takes.
+     *
+     * @param array $types The accepted JSON types.
+     *
+     * @return array
+     */
+    private static function _oneOfTypes(array $types)
+    {
+        return [
+            'oneOf' => array_map(
+                function ($t) {
+                    return ['type' => $t];
+                },
+                $types
+            )
+        ];
     }
 
     /**


### PR DESCRIPTION
Follow-up to #1062. That PR fixed how long the API reference took to *load*; this one fixes how long it takes to *open something*, which turned out to be a separate and larger problem.

## Problem

Expanding any operation blocked the main thread for ~2 seconds — and the cost had nothing to do with the operation expanded. `GET /availablekernels` (two lines, no parameters) cost the same as anything else, because the work is proportional to the document, not to the thing clicked.

Swagger UI resolves a **3.1** document through its JSON-Schema-2020-12 resolver, which re-resolves the *whole* document each time a subtree is requested. The **3.0** path resolves the requested subtree alone. At 512 paths / 716 operations that difference is the entire interaction cost.

Measured on the 1.6 lab, opening `GET /availablekernels`:

| spec declares | ms to open | blocking task |
|---|---|---|
| `openapi: 3.1.0` | 1798ms | 1760ms |
| `openapi: 3.0.3` | **156ms** | 119ms |

## Nothing is given up

Audited the generated document for 3.1-only constructs. Found exactly one — the type-array spelling, in 70 places. No `const`, `$schema`, `webhooks`, `prefixItems`, `unevaluatedProperties`, schema-level `examples`, or numeric `exclusiveMinimum`.

Those 70 are re-spelled:

- **22 null unions** → `nullable: true` (`_columnSchema()` and the list envelope's four url fields)
- **48 genuine unions** on the task body → `oneOf`. These are real, not an artifact of the spelling — the task route compares loosely, so `shutdown` takes `true` and `"1"` alike — so they're documented rather than narrowed to one type.

3.0.3 also has considerably wider tooling support than 3.1 for client generators and Postman, so this is a gain for consumers rather than only for us.

**The one real cost:** `nullable` is deprecated in 3.1, so this is a decision to revisit rather than extend if the document ever needs real JSON Schema features. Called out in the `OAS_VERSION` docblock.

## Verified on the 1.6 lab

- `redocly lint` reports the document **valid**. The 16 `no-ambiguous-paths` warnings are the pre-existing `/{class}/search/{item}` vs `/{class}/{id}/task` template overlap already discussed in the class docblock.
- `$ref` resolution still renders: `GET /host` (`allOf` across two `$ref`s) opens in 244ms with its example generated from the resolved envelope.
- Try-it still executes — returned 86 hosts, zero console errors.
- Zero type arrays remain in the generated document; 22 `nullable`, 48 `oneOf`, 512 paths and 70 schemas unchanged.

## Combined effect with #1062

| | before both | after both |
|---|---|---|
| initial DOM nodes | 17,439 | 907 |
| open one operation | ~1,900ms | ~210ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)