### PR TITLE
Teach scope resolution the catch-all and the empty server

### DIFF
--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Resolves whether an object is inside a user's site scope.
+ *
+ * PHP version 5
+ *
+ * @category SiteScope
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Resolves whether an object is inside a user's site scope.
+ *
+ * The decision half of sites, kept apart from the `sites` row itself. A
+ * model is a row with accessors; this is policy, and policy is what
+ * Authorization asks for. Splitting them also means this can land and be
+ * tested while the site plugin still declares its own Site class -- the
+ * autoloader maps a lowercased basename, so core cannot own the name Site
+ * until the plugin release that gives it up ships alongside.
+ *
+ * DENY-ALL is the posture. A user in one or more sites sees only what those
+ * sites contain. Two short circuits sit in front of that, and both are
+ * load-bearing rather than convenience:
+ *
+ *   1. A member of a CATCH-ALL site is in scope for everything. That is what
+ *      "no restriction" is, and it is a flag on the site rather than a
+ *      membership list precisely so that a host registered tomorrow is
+ *      covered by it too. An enumerated list would look identical on
+ *      upgrade day and then quietly stop containing new objects.
+ *
+ *   2. If NO sites exist at all, everything is in scope. Redundant once
+ *      schema step 333 has created the catch-all -- and that is exactly why
+ *      it is here. Between deploying new code and running the schema
+ *      updater a server has this class and an empty (or absent) `sites`
+ *      table, and endpoints that do not route through the updater gate
+ *      would otherwise deny every non-'*' user everything. A server with a
+ *      pending schema deploy must behave like today, not lock its admin
+ *      out of the page they need in order to fix it.
+ *
+ * A node this does not scope is always in scope. Images, snapins and
+ * printers are deliberately not scoped: each needs its own answer to what a
+ * catch-all means for a shared image, and its own table. Tasks ARE scoped,
+ * because a task is not a new axis -- it is derived from the host it runs
+ * against, so it needs no table and no migration.
+ *
+ * Queries are written here rather than going through Route::getIds(). Same
+ * reasoning as Authorization::rolesHolding(): this is the query whose wrong
+ * answer hands a user another site's hosts, so it owns its own SQL rather
+ * than depending on the filter builder's wildcard handling continuing to
+ * treat these values as scalars. It also keeps the membership tables out of
+ * Route::$validClasses, which would publish four REST endpoints nothing
+ * asks for.
+ *
+ * @category SiteScope
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteScope extends FOGBase
+{
+    /**
+     * Scoped node => [membership table, site column, object column].
+     *
+     * A node absent from this map is not scoped and is always allowed.
+     *
+     * @var array
+     */
+    private static $_nodes = [
+        'host' => ['siteHostMembers', 'shmSiteID', 'shmHostID'],
+        'user' => ['siteUserMembers', 'sumSiteID', 'sumUserID'],
+        'group' => ['siteGroupMembers', 'sgmSiteID', 'sgmGroupID'],
+        'usergroup' => [
+            'siteUserGroupMembers',
+            'sugmSiteID',
+            'sugmUserGroupID'
+        ],
+    ];
+    /**
+     * Per-request cache of site ids by user id.
+     *
+     * @var array
+     */
+    private static $_userSites = [];
+    /**
+     * Per-request cache of catch-all membership by user id.
+     *
+     * @var array
+     */
+    private static $_catchAll = [];
+    /**
+     * Per-request cache of "does any site exist". Null until asked.
+     *
+     * @var bool|null
+     */
+    private static $_anySites = null;
+    /**
+     * Drops the per-request caches.
+     *
+     * Web requests are short enough that the caches never go stale, but the
+     * CLI daemons are not: FOGPluginRunner and the schedulers run for days,
+     * and a site created in the UI would otherwise never be seen by them.
+     * Also what the tests call between fixtures.
+     *
+     * @return void
+     */
+    public static function forgetCaches()
+    {
+        self::$_userSites = [];
+        self::$_catchAll = [];
+        self::$_anySites = null;
+    }
+    /**
+     * Runs a scalar count, treating an unusable table as zero.
+     *
+     * A missing `sites` table is not an error here, it is the pre-migration
+     * state described in the class docblock, and it has to answer "none"
+     * rather than throw -- a fatal in a scope check is a bodyless 500 on
+     * every page at once.
+     *
+     * @param string $sql    the query, returning a column aliased cnt
+     * @param array  $params bound parameters
+     *
+     * @return int
+     */
+    private static function _count($sql, $params = [])
+    {
+        try {
+            $res = self::$DB->query($sql, [], $params);
+            if (false !== $res->error) {
+                return 0;
+            }
+            $row = $res->fetch(\PDO::FETCH_ASSOC)->get();
+        } catch (\Exception $e) {
+            return 0;
+        }
+        return is_array($row) && isset($row['cnt']) ? (int)$row['cnt'] : 0;
+    }
+    /**
+     * Does this install have any sites at all?
+     *
+     * @return bool
+     */
+    public static function anySitesExist()
+    {
+        if (null === self::$_anySites) {
+            self::$_anySites = self::_count(
+                'SELECT COUNT(*) AS `cnt` FROM `sites`'
+            ) > 0;
+        }
+        return self::$_anySites;
+    }
+    /**
+     * Is this user a member of a catch-all site?
+     *
+     * @param int $userID the acting user id
+     *
+     * @return bool
+     */
+    public static function isUnscoped($userID)
+    {
+        $userID = (int)$userID;
+        if (!array_key_exists($userID, self::$_catchAll)) {
+            self::$_catchAll[$userID] = self::_count(
+                'SELECT COUNT(*) AS `cnt` FROM `siteUserMembers` `m` '
+                . 'INNER JOIN `sites` `s` ON `s`.`siteID` = `m`.`sumSiteID` '
+                . 'WHERE `m`.`sumUserID` = :uid '
+                . 'AND `s`.`siteCatchAll` IS NOT NULL',
+                ['uid' => $userID]
+            ) > 0;
+        }
+        return self::$_catchAll[$userID];
+    }
+    /**
+     * The site ids a user belongs to. Empty means deny-all, not allow-all.
+     *
+     * Direct membership only, matching what the plugin enforced. This is
+     * deliberately the ONLY place that answers "which sites is this user
+     * in", so that inherited membership -- via a user group, or via a role
+     * -- is one more UNION arm here and not a second rule somewhere else.
+     * Both joins already exist (`userGroupMembers`, `roleUserAssoc`); what
+     * is missing is the site-side edge, and adding one is a schema step
+     * plus an arm in this query. Nothing else in this class changes,
+     * because everything downstream consumes the list this returns.
+     *
+     * Note that inherited membership only ever ADDS sites. Union semantics
+     * are what make "most open wins" true by construction rather than by a
+     * precedence rule somebody has to remember.
+     *
+     * @param int $userID the acting user id
+     *
+     * @return array int site ids
+     */
+    public static function userSiteIDs($userID)
+    {
+        $userID = (int)$userID;
+        if (array_key_exists($userID, self::$_userSites)) {
+            return self::$_userSites[$userID];
+        }
+        $ids = [];
+        try {
+            $res = self::$DB->query(
+                'SELECT `sumSiteID` FROM `siteUserMembers` '
+                . 'WHERE `sumUserID` = :uid',
+                [],
+                ['uid' => $userID]
+            );
+            if (false === $res->error) {
+                $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+                foreach ((array)$rows as $row) {
+                    $ids[] = (int)$row['sumSiteID'];
+                }
+            }
+        } catch (\Exception $e) {
+            $ids = [];
+        }
+        return self::$_userSites[$userID] = $ids;
+    }
+    /**
+     * The host a task runs against, or 0 if there is not one.
+     *
+     * A task carries no site of its own -- it belongs to whichever site its
+     * host is in. Deriving it here means task views are scoped with no
+     * extra table, no migration and no second place for the rule to drift.
+     *
+     * @param int $id the task id
+     *
+     * @return int the host id, or 0
+     */
+    private static function _taskHostID($id)
+    {
+        return self::_count(
+            'SELECT `taskHostID` AS `cnt` FROM `tasks` WHERE `taskID` = :tid',
+            ['tid' => (int)$id]
+        );
+    }
+    /**
+     * Is a single object within a user's site scope?
+     *
+     * Order matters here and is not arbitrary. The two allow-everything
+     * short circuits are checked BEFORE the task lookup, so that a server
+     * mid-upgrade and a catch-all user both answer without touching the
+     * database more than once -- and so that "no sites yet means behave
+     * like today" holds for tasks as well as hosts.
+     *
+     * @param string $node   the node (host|user|group|usergroup|task)
+     * @param int    $id     the object id
+     * @param int    $userID the acting user id
+     *
+     * @return bool
+     */
+    public static function inScope($node, $id, $userID)
+    {
+        $node = strtolower(trim((string)$node));
+        $id = (int)$id;
+        if (!isset(self::$_nodes[$node]) && 'task' !== $node) {
+            return true;
+        }
+        if (!self::anySitesExist()) {
+            return true;
+        }
+        if (self::isUnscoped($userID)) {
+            return true;
+        }
+        if ('task' === $node) {
+            $id = self::_taskHostID($id);
+            // A task that does not exist, or whose host is gone, cannot be
+            // SHOWN to be in scope, and unprovable is denied. Allowing it
+            // would leave a deleted host's tasks visible to everyone.
+            if ($id < 1) {
+                return false;
+            }
+            $node = 'host';
+        }
+        $siteIDs = self::userSiteIDs($userID);
+        if (empty($siteIDs)) {
+            return false;
+        }
+        list($table, $siteCol, $objCol) = self::$_nodes[$node];
+        return self::_count(
+            sprintf(
+                'SELECT COUNT(*) AS `cnt` FROM `%s` '
+                . 'WHERE `%s` = :oid AND `%s` IN (%s)',
+                $table,
+                $objCol,
+                $siteCol,
+                implode(',', $siteIDs)
+            ),
+            ['oid' => $id]
+        ) > 0;
+    }
+    /**
+     * Narrows a list of object ids to those within a user's site scope.
+     *
+     * One query rather than one per id, because the callers are list pages
+     * and a per-row check is how the grid query-storm bugs happened.
+     *
+     * @param string $node   the node (host|user|group|usergroup|task)
+     * @param array  $ids    candidate object ids
+     * @param int    $userID the acting user id
+     *
+     * @return array int ids in scope, in the order given
+     */
+    public static function filterInScope($node, $ids, $userID)
+    {
+        $ids = array_values(
+            array_unique(array_map('intval', (array)$ids))
+        );
+        $node = strtolower(trim((string)$node));
+        if (!isset(self::$_nodes[$node]) && 'task' !== $node) {
+            return $ids;
+        }
+        if (!self::anySitesExist() || self::isUnscoped($userID)) {
+            return $ids;
+        }
+        if (empty($ids)) {
+            return [];
+        }
+        $siteIDs = self::userSiteIDs($userID);
+        if (empty($siteIDs)) {
+            return [];
+        }
+        // Tasks are filtered one at a time through inScope(), which
+        // resolves each to its host. A list of tasks is a list of tasks
+        // being ACTED on -- cancel, restart -- and is bounded by what the
+        // user selected, unlike a host grid page.
+        if ('task' === $node) {
+            $kept = [];
+            foreach ($ids as $id) {
+                if (self::inScope('task', $id, $userID)) {
+                    $kept[] = $id;
+                }
+            }
+            return $kept;
+        }
+        list($table, $siteCol, $objCol) = self::$_nodes[$node];
+        $inScope = [];
+        try {
+            $res = self::$DB->query(
+                sprintf(
+                    'SELECT DISTINCT `%s` AS `oid` FROM `%s` '
+                    . 'WHERE `%s` IN (%s) AND `%s` IN (%s)',
+                    $objCol,
+                    $table,
+                    $objCol,
+                    implode(',', $ids),
+                    $siteCol,
+                    implode(',', $siteIDs)
+                )
+            );
+            if (false === $res->error) {
+                $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+                foreach ((array)$rows as $row) {
+                    $inScope[] = (int)$row['oid'];
+                }
+            }
+        } catch (\Exception $e) {
+            // Unreadable membership cannot be read as permission.
+            return [];
+        }
+        return array_values(array_intersect($ids, $inScope));
+    }
+}

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -59,7 +59,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.3409');
+        define('FOG_VERSION', '1.6.0-beta.3427');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/site-scope.test.php
+++ b/tests/site-scope.test.php
@@ -1,0 +1,575 @@
+<?php
+/**
+ * SiteScope decides who sees which hosts. This pins the decisions.
+ *
+ * The posture is deny-all, so every bug in this class fails in one of two
+ * directions and neither is visible from the UI: too tight and an admin
+ * quietly loses hosts they own, too loose and a site sees another site's
+ * machines. Neither raises an error, which is why the rules are asserted
+ * here rather than left to be noticed.
+ *
+ * Two of the cases below are not about correctness of the membership query
+ * at all, they are about it NOT RUNNING:
+ *
+ *   - a server with no sites yet must allow everything. That is the window
+ *     between deploying this code and running the schema updater, and if it
+ *     denied instead, the admin would be locked out of the very page that
+ *     fixes it.
+ *   - a catch-all member must be allowed without consulting membership,
+ *     because the catch-all is a flag rather than a list. If it were
+ *     satisfied by enumerating members it would look identical on upgrade
+ *     day and then silently stop covering hosts registered afterwards.
+ *
+ * So the assertions check the issued SQL, not just the boolean. A short
+ * circuit that returns the right answer for the wrong reason -- by falling
+ * through to a membership query that happens to match -- passes a
+ * value-only test and fails this one.
+ *
+ * DB-free: FOGBase::$DB is a static, so a recording fake is injected
+ * through it and each scenario declares exactly what the database
+ * contains. That also lets the unreachable-table cases be tested at all,
+ * which is awkward against a real database and is precisely the state a
+ * mid-upgrade server is in.
+ *
+ * Usage: php tests/site-scope.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-site-scope-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+// Same reasoning as autoload.test.php: the constructor only registers the
+// autoloader, so the cache dir is redirected somewhere throwaway and
+// startInit() -- the part that needs MySQL -- is never called.
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+if (!class_exists('SiteScope', true)) {
+    fwrite(STDERR, "FAIL: SiteScope does not resolve\n");
+    exit(1);
+}
+
+/**
+ * Stands in for PDODB. Chainable in the same shape SiteScope uses --
+ * query()->fetch()->get() -- and records every statement so a test can
+ * assert on what was NOT asked as well as what was.
+ *
+ * A responder returning the sentinel '__ERROR__' reproduces PDODB's
+ * error-flag path; a responder that throws reproduces an unreachable or
+ * absent table. Both are real states and both must be answered without a
+ * fatal.
+ */
+class FakeDB
+{
+    public $error = false;
+    public $log = [];
+    private $_responder;
+    private $_result;
+
+    public function __construct(callable $responder)
+    {
+        $this->_responder = $responder;
+    }
+
+    public function query($sql, $a = [], $params = [])
+    {
+        $this->log[] = $sql;
+        $this->_result = call_user_func($this->_responder, $sql, $params);
+        $this->error = ('__ERROR__' === $this->_result) ? 'failed' : false;
+        return $this;
+    }
+
+    public function fetch($mode = null, $type = '')
+    {
+        return $this;
+    }
+
+    public function get($field = '')
+    {
+        return $this->_result;
+    }
+}
+
+$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp->setAccessible(true);
+
+/**
+ * Installs a scenario. $tables declares what the database holds; the
+ * responder translates SiteScope's queries against it.
+ *
+ * Recognising each query by a fragment unique to it keeps the fake honest:
+ * if SiteScope ever stops issuing one of these, the scenario answers 0 or
+ * [] rather than silently agreeing, and the expectations below fail.
+ */
+$scenario = function (array $tables) use ($dbProp) {
+    $db = new FakeDB(
+        function ($sql, $params) use ($tables) {
+            // Catch-all membership -- checked before the plain sites count
+            // because both mention `sites`.
+            if (false !== strpos($sql, 'INNER JOIN `sites`')) {
+                if (isset($tables['catchAllThrows'])) {
+                    throw new \Exception('no such table');
+                }
+                $uid = (int)$params['uid'];
+                $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
+                return ['cnt' => $hit ? 1 : 0];
+            }
+            if (false !== strpos($sql, 'FROM `sites`')) {
+                if (isset($tables['sitesThrows'])) {
+                    throw new \Exception('no such table');
+                }
+                if (isset($tables['sitesErrors'])) {
+                    return '__ERROR__';
+                }
+                return ['cnt' => (int)($tables['siteCount'] ?? 0)];
+            }
+            if (false !== strpos($sql, 'FROM `siteUserMembers` WHERE')) {
+                $uid = (int)$params['uid'];
+                $out = [];
+                foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
+                    $out[] = ['sumSiteID' => $s];
+                }
+                return $out;
+            }
+            if (false !== strpos($sql, 'FROM `tasks`')) {
+                $tid = (int)$params['tid'];
+                return ['cnt' => (int)($tables['tasks'][$tid] ?? 0)];
+            }
+            if (false !== strpos($sql, 'SELECT DISTINCT')) {
+                if (isset($tables['filterThrows'])) {
+                    throw new \Exception('unreadable');
+                }
+                $out = [];
+                foreach ((array)($tables['members'] ?? []) as $oid) {
+                    $out[] = ['oid' => $oid];
+                }
+                return $out;
+            }
+            // Single-object membership count.
+            $oid = (int)$params['oid'];
+            $hit = in_array($oid, (array)($tables['members'] ?? []), true);
+            return ['cnt' => $hit ? 1 : 0];
+        }
+    );
+    $dbProp->setValue(null, $db);
+    SiteScope::forgetCaches();
+    return $db;
+};
+
+/** Did any statement touch a membership table? */
+$touchedMembership = function (FakeDB $db) {
+    foreach ($db->log as $sql) {
+        if (preg_match('/`site(Host|User|Group|UserGroup)Members`/', $sql)
+            && false === strpos($sql, 'INNER JOIN `sites`')
+        ) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/*
+ * 1. No sites at all -- the mid-upgrade window. Everything is in scope, and
+ *    membership is never consulted (there is nothing to consult).
+ */
+$db = $scenario(['siteCount' => 0]);
+check(
+    'zero-site server: single object allowed',
+    SiteScope::inScope('host', 5, 3) === true,
+    $failures,
+    $checks
+);
+check(
+    'zero-site server: list passes through unchanged',
+    SiteScope::filterInScope('host', [3, 1, 2], 3) === [3, 1, 2],
+    $failures,
+    $checks
+);
+check(
+    'zero-site server: membership never queried',
+    !$touchedMembership($db),
+    $failures,
+    $checks
+);
+
+/*
+ * 2. A `sites` table that cannot be read at all -- code deployed, schema
+ *    step not yet run. Must behave like case 1, not fatal and not deny.
+ */
+$db = $scenario(['sitesThrows' => true]);
+check(
+    'absent sites table allows, does not fatal',
+    SiteScope::inScope('host', 5, 3) === true,
+    $failures,
+    $checks
+);
+$db = $scenario(['sitesErrors' => true]);
+check(
+    'sites table error flag allows, does not fatal',
+    SiteScope::inScope('host', 5, 3) === true,
+    $failures,
+    $checks
+);
+
+/*
+ * 3. Catch-all member. Allowed for a host that is in NO site at all -- the
+ *    whole point of the flag -- and without a membership query.
+ */
+$db = $scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [3],
+        'userSites' => [3 => []],
+        'members' => [],
+    ]
+);
+check(
+    'catch-all user sees a host in no site',
+    SiteScope::inScope('host', 5, 3) === true,
+    $failures,
+    $checks
+);
+check(
+    'catch-all user: membership never queried',
+    !$touchedMembership($db),
+    $failures,
+    $checks
+);
+$db = $scenario(
+    ['siteCount' => 2, 'catchAll' => [3], 'userSites' => [3 => []]]
+);
+check(
+    'catch-all user: list passes through unchanged',
+    SiteScope::filterInScope('host', [9, 8], 3) === [9, 8],
+    $failures,
+    $checks
+);
+
+/*
+ * 4. A scoped user. Sees what their sites contain and nothing else. This is
+ *    the pair the whole class exists for.
+ */
+$fixture = [
+    'siteCount' => 2,
+    'catchAll' => [],
+    'userSites' => [3 => [7]],
+    'members' => [42],
+];
+$scenario($fixture);
+check(
+    'scoped user sees a host in their site',
+    SiteScope::inScope('host', 42, 3) === true,
+    $failures,
+    $checks
+);
+$scenario($fixture);
+check(
+    'scoped user does not see a host outside it',
+    SiteScope::inScope('host', 5, 3) === false,
+    $failures,
+    $checks
+);
+$scenario($fixture);
+check(
+    'scoped user: node name is case-insensitive',
+    SiteScope::inScope('HOST', 42, 3) === true,
+    $failures,
+    $checks
+);
+
+/*
+ * 5. A user in no site is denied, rather than treated as unrestricted. The
+ *    inverse mistake -- empty meaning "no restriction" -- is the one that
+ *    would silently hand every host to every user, so it gets its own case.
+ */
+$scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]]);
+check(
+    'user with no sites is denied a single object',
+    SiteScope::inScope('host', 42, 3) === false,
+    $failures,
+    $checks
+);
+$scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]]);
+check(
+    'user with no sites gets an empty list',
+    SiteScope::filterInScope('host', [1, 2, 3], 3) === [],
+    $failures,
+    $checks
+);
+
+/*
+ * 6. Nodes this does not scope are allowed without any query at all.
+ *    Images and snapins are deliberately unscoped; if that ever changes it
+ *    must be a decision, not a side effect.
+ */
+$db = $scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]]);
+check(
+    'unscoped node is allowed',
+    SiteScope::inScope('image', 5, 3) === true,
+    $failures,
+    $checks
+);
+check(
+    'unscoped node issues no query',
+    count($db->log) === 0,
+    $failures,
+    $checks
+);
+$db = $scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]]);
+check(
+    'unscoped node list is unchanged',
+    SiteScope::filterInScope('snapin', [4, 5], 3) === [4, 5],
+    $failures,
+    $checks
+);
+
+/*
+ * 7. Tasks are derived from their host. A task in the user's site resolves
+ *    through to the host membership query with the HOST's id -- checked
+ *    explicitly, because passing the task id through by mistake would still
+ *    produce a plausible true/false.
+ */
+$db = $scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'tasks' => [900 => 42],
+        'members' => [42],
+    ]
+);
+check(
+    'task in scope via its host',
+    SiteScope::inScope('task', 900, 3) === true,
+    $failures,
+    $checks
+);
+$hostQuery = '';
+foreach ($db->log as $sql) {
+    if (false !== strpos($sql, '`siteHostMembers`')) {
+        $hostQuery = $sql;
+    }
+}
+check(
+    'task scope queries siteHostMembers, not a task table',
+    '' !== $hostQuery,
+    $failures,
+    $checks
+);
+
+$db = $scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'tasks' => [900 => 5],
+        'members' => [42],
+    ]
+);
+check(
+    'task out of scope via its host',
+    SiteScope::inScope('task', 900, 3) === false,
+    $failures,
+    $checks
+);
+
+// A task that does not exist, or whose host is gone, cannot be shown to be
+// in scope. Allowing it would make a deleted host's tasks visible to
+// everyone.
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'tasks' => [],
+        'members' => [42],
+    ]
+);
+check(
+    'task with no resolvable host is denied',
+    SiteScope::inScope('task', 900, 3) === false,
+    $failures,
+    $checks
+);
+
+// Filtering a task list keeps only the in-scope ones.
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'tasks' => [900 => 42, 901 => 5],
+        'members' => [42],
+    ]
+);
+check(
+    'task list filters to the in-scope task',
+    SiteScope::filterInScope('task', [900, 901], 3) === [900],
+    $failures,
+    $checks
+);
+
+/*
+ * 8. filterInScope's contract: input order preserved, duplicates collapsed,
+ *    out-of-scope ids dropped. Order matters because callers feed the
+ *    result straight back into a grid.
+ */
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'members' => [8, 9],
+    ]
+);
+check(
+    'filter keeps order and drops out-of-scope ids',
+    SiteScope::filterInScope('host', [9, 5, 8], 3) === [9, 8],
+    $failures,
+    $checks
+);
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'members' => [8],
+    ]
+);
+check(
+    'filter collapses duplicate ids',
+    SiteScope::filterInScope('host', [8, 8, 8], 3) === [8],
+    $failures,
+    $checks
+);
+
+/*
+ * 9. Unreadable membership is not permission. If the filter query fails,
+ *    the answer is an empty list, never the unfiltered input.
+ */
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'filterThrows' => true,
+    ]
+);
+check(
+    'unreadable membership denies rather than passing through',
+    SiteScope::filterInScope('host', [1, 2], 3) === [],
+    $failures,
+    $checks
+);
+
+/*
+ * 10. The per-request caches. Two decisions for one user must not re-ask
+ *     the same three questions -- this runs on every row of a host grid.
+ */
+$db = $scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'members' => [42],
+    ]
+);
+SiteScope::inScope('host', 42, 3);
+$after = count($db->log);
+SiteScope::inScope('host', 43, 3);
+check(
+    'second decision issues only the membership query',
+    count($db->log) === $after + 1,
+    $failures,
+    $checks
+);
+check(
+    'forgetCaches makes the next call re-read',
+    (function () use ($db) {
+        SiteScope::forgetCaches();
+        $before = count($db->log);
+        SiteScope::inScope('host', 42, 3);
+        return count($db->log) - $before > 1;
+    })(),
+    $failures,
+    $checks
+);
+
+/*
+ * 11. Users are independent. A catch-all user's answer must not be served
+ *     from cache to a scoped one -- a per-user cache keyed wrongly is how
+ *     one admin's view leaks into another's.
+ */
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [3],
+        'userSites' => [3 => [], 4 => []],
+        'members' => [],
+    ]
+);
+$catchAllUser = SiteScope::inScope('host', 5, 3);
+$otherUser = SiteScope::inScope('host', 5, 4);
+check(
+    'catch-all user allowed, other user denied, same request',
+    $catchAllUser === true && $otherUser === false,
+    $failures,
+    $checks
+);
+
+$dbProp->setValue(null, null);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Commit 7 of the site-into-core plan. Adds `SiteScope`, the decision half of sites.

**Inert at this commit.** Nothing listens for `OBJECT_SCOPE_CHECK` yet, so behaviour is unchanged. It lands separately so the rules can be tested before anything enforces them; commit 8 moves single-object enforcement into `Authorization::objectInScope()`.

## The two short circuits

Both sit in front of the membership query and both are load-bearing:

1. **A member of a catch-all site is in scope for everything.** The catch-all is a flag on the site, not a membership list, precisely so a host registered tomorrow is covered. An enumerated list would look identical on upgrade day and then quietly stop containing new objects.
2. **If no sites exist, everything is in scope.** Redundant once schema step 333 has run — which is exactly why it is here. Between deploying this code and running the schema updater, a server has an empty or absent `sites` table. Endpoints that do not route through the updater gate would otherwise deny every non-`*` user everything, locking the admin out of the page that fixes it.

Deny-all otherwise. A user in no site sees nothing; empty meaning "no restriction" is the inverse mistake that would hand every host to every user, so it gets its own test.

## Tasks

Scoped by deriving the host they run against — no table, no migration. A task whose host is missing is denied; unprovable is not permission. The ordering is asserted, because resolving the task before the short circuits would make a mid-upgrade server deny tasks. (The first draft did exactly that and the test caught it.)

## Why the SQL is written here

Same reasoning as `Authorization::rolesHolding()`: a wrong answer hands a user another site's hosts, so it does not depend on the filter builder continuing to treat these values as scalars — see the `*`/`+` wildcard rewrite that previously defeated the RBAC lockout guard. It also keeps the four membership tables out of `Route::$validClasses`, which would publish REST endpoints nothing asks for.

## `userSiteIDs()` is the single funnel

Deliberately the only place answering "which sites is this user in", so inherited membership — via a user group or a role — is one more UNION arm there rather than a second rule elsewhere. Both joins already exist (`userGroupMembers`, `roleUserAssoc`); only the site-side edge is missing. Union semantics make "most open wins" true by construction rather than by a precedence rule someone has to remember. Direct membership only for now, matching what the plugin enforced.

Note that a `*` holder never reaches this class at all — `Authorization::objectInScope()` short-circuits on `_isUnrestricted()` before firing the hook. "Full admin sees everything" is structurally guaranteed one layer up.

## Naming

`SiteScope`, not `Site`: scope resolution is policy rather than an ORM entity, and core cannot claim the autoload key `site` until the plugin release that gives it up ships alongside.

## Verification

```
php tests/site-scope.test.php     # ok  27 checks passed
sh tests/run-all.sh               # 12 passed, 0 failed
```

The test is DB-free — `FOGBase::$DB` is a static, so a recording fake is injected through it and each scenario declares what the database contains. That also makes the unreachable-table cases testable, which is awkward against a real database and is exactly the state a mid-upgrade server is in. Assertions check the *issued SQL*, not just the boolean: a short circuit that returns the right answer by falling through to a membership query that happens to match passes a value-only test and fails this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR