### PR TITLE
Reuse the API console across visits instead of leaking one per visit

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -92,7 +92,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 333);
-        define('FOG_BCACHE_VER', 278);
+        define('FOG_BCACHE_VER', 279);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
@@ -67,10 +67,13 @@
             });
     }
 
-    function render(specUrl) {
+    function render(specUrl, mount) {
         SwaggerUIBundle({
             url: specUrl,
-            dom_id: '#apidocs-container',
+            // domNode rather than dom_id, because the node this renders into
+            // is one we own and keep (see boot()), not the server-rendered
+            // container, which is thrown away on every page navigation.
+            domNode: mount,
             deepLinking: true,
             presets: [SwaggerUIBundle.presets.apis],
             // BaseLayout deliberately, not StandaloneLayout. The latter adds
@@ -119,10 +122,52 @@
         }
         container.setAttribute('data-apidocs-booted', '1');
 
+        /**
+         * Reuse the console this session already built, rather than building
+         * a second one.
+         *
+         * Every visit to this page used to construct a fresh SwaggerUIBundle,
+         * and the previous one was never taken down: FOG's AJAX navigation
+         * replaces the page with ajaxPageWrapper.empty().html(data), which
+         * tears the DOM out from under React without unmounting it, and the
+         * bundle exposes no unmount API to call even if there were somewhere
+         * to call it from. Measured on the 1.6 lab with forced GC, bouncing
+         * between the dashboard and this page: 10MB, 32, 52, 70, 90 -- a flat
+         * ~20MB per visit that collection never reclaimed.
+         *
+         * The retainer lives inside the bundle and is tied to deepLinking
+         * (with it off, an instance is fully collectable; with it on, ~5MB
+         * survives per instance, and more once the re-executed bundle is held
+         * alive too). Rather than hunt a reference we cannot reach from here,
+         * this stops creating the second instance at all: the rendered node is
+         * kept and moved into each new container. One instance per session, so
+         * nothing accumulates, and coming back to the page is now a DOM move
+         * rather than a full re-render.
+         *
+         * Kept on window deliberately, not in this closure. renderPage() in
+         * fog.common.js re-adds every node script on each navigation, so this
+         * file is re-executed each visit and a closure variable would be a
+         * fresh, empty one every time.
+         */
+        var cached = window.fogApidocsConsole;
+        if (cached && cached.getAttribute('data-spec-url') === specUrl) {
+            container.appendChild(cached);
+            return;
+        }
+
+        // Our own node inside the server-rendered container. The container is
+        // replaced on every navigation; this is what survives.
+        var mount = document.createElement('div');
+        mount.setAttribute('data-spec-url', specUrl);
+        container.appendChild(mount);
+
         var tries = 0;
         (function waitForBundle() {
             if (typeof SwaggerUIBundle !== 'undefined') {
-                render(specUrl);
+                render(specUrl, mount);
+                // Only cache once it has actually rendered, so a failed load
+                // is retried on the next visit instead of being remembered.
+                window.fogApidocsConsole = mount;
                 return;
             }
             tries += 1;


### PR DESCRIPTION
Third and last of the API Documentation performance fixes, after #1062 (load) and #1066 (expand). This one is the memory leak.

## Problem

Every visit to the page built a fresh `SwaggerUIBundle` and the previous one was never taken down. FOG's AJAX navigation replaces the page with `ajaxPageWrapper.empty().html(data)`, which tears the DOM out from under React without unmounting it — and the bundle exposes no unmount API to call even if there were a teardown hook to call it from.

Measured on the 1.6 lab with **forced GC** (CDP `HeapProfiler.collectGarbage`), bouncing between the dashboard and this page:

| | baseline | v1 | v2 | v3 | v4 |
|---|---|---|---|---|---|
| before | 10MB | 32 | 52 | 70 | 90 |
| after | 11MB | 31 | 36 | 40 | 45 |

~20MB per visit that collection never reclaimed → ~5MB.

## Why reuse rather than cleanup

The retainer is inside the bundle and is tied to `deepLinking` — with it off an instance is fully collectable (0MB retained), with it on ~5MB survives per instance:

| | retained per instance, after forced GC |
|---|---|
| `deepLinking: true` | 5.3MB |
| `deepLinking: false` | 0MB |

It is **not** the hashchange listener: `window.addEventListener` is never called during render (verified by wrapping it across the async mount), and `window.onhashchange` is not a function. Rather than keep hunting a reference unreachable from our side, this stops creating the second instance at all.

The rendered node is now ours, kept on `window`, and moved into each new container. One instance per session, so nothing accumulates.

**Second win:** returning to the page becomes a DOM move rather than a re-render — revisit render went **326ms → ~100ms**.

`window` and not the closure, deliberately: `renderPage()` re-adds every node script on each navigation, so this file is re-executed each visit and a closure variable would be a fresh empty one every time.

## What's left

The residual ~5MB/visit is that same unconditional script re-add handing the page a new copy of the bundle's module graph each time. Fixing it means changing script handling for **every** page, not just this one, so it's deliberately left alone here.

## Verified on the 1.6 lab

- Exactly **one** `.swagger-ui` instance in the DOM after repeated round trips (reuse, not duplication)
- 69 tag groups, filter box, operations open, try-it executes and returns live data
- Deep links resolve on a genuine cold load *and* on reload — checked with real cross-document navigation, since a hash-only change is same-document and proves nothing
- No console errors or warnings

Bumps `FOG_BCACHE_VER` so browsers pick up the changed JS.

## Cumulative effect of the three PRs

| | before | after |
|---|---|---|
| initial DOM nodes | 17,439 | 907 |
| open one operation | ~1,900ms | ~210ms |
| heap per visit | ~150MB | ~5MB |
| revisit render | ~1,400ms | ~100ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)