### PR TITLE
Load libraries once per session instead of on every navigation

### DIFF
--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -125,6 +125,36 @@ class Page extends FOGBase
         'css/fog-default-ui.min.css'
     ];
     /**
+     * Scripts that must be executed at most once per browser session.
+     *
+     * renderPage() in fog.common.js re-adds every script a page declares on
+     * each AJAX navigation, and that is deliberate: FOG's page scripts are
+     * IIFEs that wire the new DOM the moment they run, so a page revisited
+     * without re-executing its script would render buttons that do nothing.
+     *
+     * A library is the opposite case. swagger-ui-bundle.js defines a global
+     * and touches nothing until it is called, so re-running it only builds a
+     * second copy of a 1.5MB module graph -- measured on the 1.6 lab with
+     * forced GC, and creating no Swagger instances at all, each re-execution
+     * kept ~3.5MB that collection never returned (10MB, 14, 18, 21, 24).
+     *
+     * Naming a script here means: never remove it on navigation, and add it
+     * only if it is not already loaded.
+     *
+     * The bar for this list is that the script has NO side effects at
+     * execution time. jscolor.js deliberately is NOT here despite looking
+     * similar: it scans the DOM for .jscolor inputs when it runs, so loading
+     * it once would leave the storage node edit page with no colour pickers
+     * the second time it is opened. If in doubt, leave a script out -- the
+     * cost of being wrong is silent, and it is missing behaviour rather than
+     * a visible error.
+     *
+     * @var array
+     */
+    protected static $onceJavascripts = [
+        'js/swagger-ui-bundle.js'
+    ];
+    /**
      * Javascripts that are common to every page.
      * Currently, the contents of this array is added to $javascripts for output.
      *
@@ -485,6 +515,12 @@ class Page extends FOGBase
                             'X-FOG-Common-JavaScripts: '
                             . json_encode(
                                 self::$commonJavascripts
+                            )
+                        );
+                        header(
+                            'X-FOG-Once-JavaScripts: '
+                            . json_encode(
+                                self::$onceJavascripts
                             )
                         );
                         header(

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -92,7 +92,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 333);
-        define('FOG_BCACHE_VER', 279);
+        define('FOG_BCACHE_VER', 280);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3377,6 +3377,11 @@ function clearAllIntervals(){
     /** UPDATE SCRIPTS **/
     var scripts = JSON.parse(req.getResponseHeader('X-FOG-JavaScripts'));
     var commonScripts = JSON.parse(req.getResponseHeader('X-FOG-Common-JavaScripts'));
+    // Libraries that must execute at most once per session. Defaults to empty
+    // so a response from an older server (or any handler that does not send
+    // the header) keeps exactly the previous behaviour.
+    var onceHeader = req.getResponseHeader('X-FOG-Once-JavaScripts');
+    var onceScripts = onceHeader ? JSON.parse(onceHeader) : [];
 
     scripts.forEach(function(value, index){
       if(scripts[index] == null) { delete scripts[index]; return; }
@@ -3388,6 +3393,13 @@ function clearAllIntervals(){
       commonScripts[index] = commonScripts[index] + (commonScripts[index].indexOf("?v") === -1 ? "?ver=" + assetVersion : "");
     });
 
+    // Same version suffix as the other two lists, so the comparisons below are
+    // against the src actually sitting in the DOM.
+    onceScripts.forEach(function(value, index){
+      if(onceScripts[index] == null) { delete onceScripts[index]; return; }
+      onceScripts[index] = onceScripts[index] + (onceScripts[index].indexOf("?v") === -1 ? "?ver=" + assetVersion : "");
+    });
+
     // Determine the currently loaded scripts.
     var loadedScripts = [];
     $("#scripts").find("script").each(function(index, element){
@@ -3396,14 +3408,24 @@ function clearAllIntervals(){
 
     // Calculate the script delta:
     var scriptDelta = {};
-    // -> If a script is loaded and it isn't a script common to every page, remove it.
+    // -> If a script is loaded and it is neither common to every page nor a
+    //    load-once library, remove it.
     for(var scriptIndex in loadedScripts){
       var script = loadedScripts[scriptIndex];
-      if (commonScripts.indexOf(script) === -1) scriptDelta[script] = -1;
+      if (commonScripts.indexOf(script) === -1 && onceScripts.indexOf(script) === -1) scriptDelta[script] = -1;
     }
-    // -> Reload all scripts this page needs.
+    // -> Reload all scripts this page needs. Re-executing them is the point:
+    //    FOG's page scripts are IIFEs that wire up the DOM when they run, and
+    //    the DOM they wired has just been replaced, so skipping this would
+    //    leave a revisited page with controls that do nothing.
+    //
+    //    A load-once library is the exception. It has no side effects at
+    //    execution time, so a second copy buys nothing and costs a retained
+    //    module graph -- ~3.5MB per re-execution for swagger-ui-bundle.js,
+    //    measured with forced GC. Add it only if it is not already there.
     for(var scriptIndex in scripts){
       var script = scripts[scriptIndex];
+      if (onceScripts.indexOf(script) !== -1 && loadedScripts.indexOf(script) !== -1) continue;
       scriptDelta[script] = 1;
     }
 


### PR DESCRIPTION
Last of the API Documentation performance work, after #1062, #1066 and #1068. This one closes the residual leak — and unlike the others it touches a code path every page uses, so the design is the important part of the review.

## Why the re-add exists and has to stay

`renderPage()` re-adds every script a page declares on each AJAX navigation. That is **deliberate**. FOG's page scripts are IIFEs that wire the new DOM the moment they run:

```js
(function($) {
    var addToGroup = $('#addSelectedToGroup'), ...
    disableButtons(true);
```

The DOM they wired has just been replaced, so a page revisited *without* re-executing its script renders controls that do nothing. A blanket "skip if already loaded" would silently break every page in the product.

## The distinction that actually matters

A library is the opposite case. `swagger-ui-bundle.js` defines a global and touches nothing until it's called, so re-running it only builds a second copy of a 1.5MB module graph.

Measured on the 1.6 lab with forced GC, **creating no Swagger instances at all** — just re-executing the script as `renderPage()` does:

```
10MB → 14 → 18 → 21 → 24     (~3.5MB retained per re-execution)
```

So scripts are split by whether *executing* them does anything. A new `$onceJavascripts` list is sent as `X-FOG-Once-JavaScripts`; `renderPage()` never removes those on navigation and adds them only when absent.

**Everything not named there behaves exactly as before**, and a response without the header (older server, or any handler that doesn't send it) also behaves exactly as before.

## The trap, and why jscolor is not on the list

The bar is **no side effects at execution time**. `jscolor.js` is deliberately excluded despite looking like a library: it scans the DOM for `.jscolor` inputs when it runs, so loading it once would leave the storage-node edit page with no colour pickers the second time it's opened.

The failure mode for getting this wrong is *silent missing behaviour*, not an error — so the docblock on the list says to leave a script out when in doubt.

## Measured (1.6 lab, dashboard ↔ API reference, forced GC)

| | baseline | v1 | v2 | v3 | v4 |
|---|---|---|---|---|---|
| before | 11MB | 31 | 36 | 40 | 45 |
| after | 11MB | 31 | 33 | 34 | 36 |

~5MB → ~1.5MB per visit. Revisit render also drops **100ms → ~70ms**, since the bundle is no longer refetched and re-parsed.

## Regression checked on pages that depend on re-execution

- **Host list**, three consecutive visits: its IIFE's `disableButtons(true)` still fires (`addSelectedToGroup` disabled), three DataTables still initialise, its script tag still re-added each time
- **Storage node** page: jscolor still loads
- Exactly one `swagger-ui-bundle.js` tag, surviving navigation away as intended
- No page errors

Bumps `FOG_BCACHE_VER` so browsers pick up the changed JS.

## Cumulative across all four PRs

| | before | after |
|---|---|---|
| initial DOM nodes | 17,439 | 907 |
| open one operation | ~1,900ms | ~120ms |
| heap per visit | ~150MB | ~1.5MB |
| revisit render | ~1,400ms | ~70ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)