### PR TITLE
Enforce the site boundary on lists and clean up on delete

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -764,6 +764,53 @@ class Authorization extends FOGBase
         return (bool)$allowed;
     }
     /**
+     * The object ids a user may see for a listed node, or null when the
+     * list needs no narrowing at all.
+     *
+     * The list counterpart of objectInScope(), and the distinction the
+     * return type carries is the whole point: null means "no boundary
+     * applies -- leave the list alone", while an ARRAY narrows the list,
+     * and an EMPTY array is a real answer meaning the user may see
+     * nothing. Collapsing those two onto "empty" is the mistake that
+     * silently shows every host to a user with no site.
+     *
+     * null is returned for an unrestricted '*' holder, a node that is not
+     * site-scoped, an install with no sites configured, and a member of a
+     * catch-all site -- the same short circuits objectInScope() applies,
+     * so single objects and lists cannot disagree about who is scoped.
+     *
+     * @param string   $node   the node being listed
+     * @param int|null $userID acting user (defaults to current user)
+     *
+     * @return array|null ids to narrow to, or null for no restriction
+     */
+    public static function scopedObjectIDs($node, $userID = null)
+    {
+        if (self::_isUnrestricted($userID)) {
+            return null;
+        }
+        if (null === $userID) {
+            $userID = (
+                self::$FOGUser && self::$FOGUser->isValid() ?
+                (int)self::$FOGUser->get('id') :
+                0
+            );
+        }
+        $userID = (int)$userID;
+        $node = strtolower(trim((string)$node));
+        if (!SiteScope::isScopedNode($node)) {
+            return null;
+        }
+        // Same two short circuits as the single-object path: a server with
+        // no sites behaves as it always did, and a catch-all member is not
+        // narrowed to an enumerated list (which would stop covering
+        // objects created after the catch-all was made).
+        if (!SiteScope::anySitesExist() || SiteScope::isUnscoped($userID)) {
+            return null;
+        }
+        return SiteScope::allInScopeIDs($node, $userID);
+    }
+    /**
      * Enforce object scope for a management page request. Allowed →
      * returns silently. Denied → 403 JSON (AJAX) or a flash message plus
      * redirect home (full page), then exits. Mirrors the denial UX of

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -966,6 +966,21 @@ abstract class FOGPage extends FOGBase
                         'delNeeded' => &$delNeeded
                     ]
                 );
+                // Core's site boundary for the listed page. Re-lists with
+                // the in-scope ids rather than dropping rows from the
+                // payload above, so the row counts describe what the user
+                // can actually see -- a filtered payload with the unscoped
+                // totals still tells them how much exists outside their
+                // scope. null means no boundary applies; an empty array is
+                // a real deny-all and must still narrow the list.
+                $scopeIDs = Authorization::scopedObjectIDs($this->node);
+                if (null !== $scopeIDs) {
+                    Route::listem(
+                        $this->childClass,
+                        ['id' => $scopeIDs ?: [0]]
+                    );
+                    $data = Route::getData();
+                }
                 echo $data;
                 exit;
             }

--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -237,6 +237,85 @@ class SiteScope extends FOGBase
         );
     }
     /**
+     * Is this node subject to a site boundary at all?
+     *
+     * Public so the single-object and list paths can agree on the answer
+     * rather than each keeping a copy of the node list.
+     *
+     * @param string $node the node
+     *
+     * @return bool
+     */
+    public static function isScopedNode($node)
+    {
+        $node = strtolower(trim((string)$node));
+        return isset(self::$_nodes[$node]) || 'task' === $node;
+    }
+    /**
+     * Every object id of a node that lies in the user's sites.
+     *
+     * The list counterpart of inScope(). Callers use it to push the
+     * boundary into the query that builds a list, rather than fetching a
+     * page and discarding rows afterwards -- discarding rows leaves the
+     * row COUNTS describing objects the user cannot see, which both looks
+     * broken and tells them how much exists outside their scope.
+     *
+     * Returns [] for a user with no sites, which is deny-all and must be
+     * passed on as such rather than read as "no filter".
+     *
+     * @param string $node   the node (host|user|group|usergroup)
+     * @param int    $userID the acting user id
+     *
+     * @return array int object ids
+     */
+    public static function allInScopeIDs($node, $userID)
+    {
+        $node = strtolower(trim((string)$node));
+        if (!self::isScopedNode($node)) {
+            return [];
+        }
+        $siteIDs = self::userSiteIDs($userID);
+        if (empty($siteIDs)) {
+            return [];
+        }
+        if ('task' === $node) {
+            // Tasks have no membership table of their own; they inherit
+            // the site of the host they run against. Done as one join
+            // rather than by resolving each task, because this feeds a
+            // list and a per-row lookup here is the grid query storm.
+            $sql = sprintf(
+                'SELECT DISTINCT `taskID` AS `oid` FROM `tasks` '
+                . 'WHERE `taskHostID` IN ('
+                . 'SELECT `shmHostID` FROM `siteHostMembers` '
+                . 'WHERE `shmSiteID` IN (%s))',
+                implode(',', $siteIDs)
+            );
+        } else {
+            list($table, $siteCol, $objCol) = self::$_nodes[$node];
+            $sql = sprintf(
+                'SELECT DISTINCT `%s` AS `oid` FROM `%s` WHERE `%s` IN (%s)',
+                $objCol,
+                $table,
+                $siteCol,
+                implode(',', $siteIDs)
+            );
+        }
+        $ids = [];
+        try {
+            $res = self::$DB->query($sql);
+            if (false === $res->error) {
+                $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+                foreach ((array)$rows as $row) {
+                    $ids[] = (int)$row['oid'];
+                }
+            }
+        } catch (\Exception $e) {
+            // Unreadable membership cannot be read as permission.
+            return [];
+        }
+        return $ids;
+    }
+    /**
      * Is a single object within a user's site scope?
      *
      * Order matters here and is not arbitrary. The two allow-everything

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2090,6 +2090,7 @@ class Route extends FOGBase
                     'classman' => &$classman
                 ]
             );
+            self::_applySiteScope($classname);
             self::$data['_lang'] = $classname;
             if (self::$getterDepth === 0
                 && self::expandRequested()
@@ -2443,6 +2444,7 @@ class Route extends FOGBase
                     'classman' => &$classman
                 ]
             );
+            self::_applySiteScope($classname);
         } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_ACCEPTABLE,
@@ -4754,6 +4756,27 @@ class Route extends FOGBase
                 $whereItems = self::getsearchbody($classname);
             }
 
+            // Core site membership cleanup. Added after the switch rather
+            // than repeated across four of its cases, and before
+            // DELETEMASS_API so a listener still sees the full map.
+            //
+            // A leftover membership row is not merely untidy. InnoDB
+            // recomputes AUTO_INCREMENT as MAX(id)+1 on restart, so ids
+            // are reused -- a row left behind by a deleted host can later
+            // put an unrelated NEW host into the site the old one was in,
+            // granting access nobody asked for.
+            $siteMemberTables = [
+                'host' => 'sitehostmember',
+                'user' => 'siteusermember',
+                'group' => 'sitegroupmember',
+                'usergroup' => 'siteusergroupmember'
+            ];
+            if (isset($siteMemberTables[$classname])) {
+                $removeItems[$siteMemberTables[$classname]] = [
+                    $classname . 'ID' => $itemIDs
+                ];
+            }
+
             self::$HookManager->processEvent(
                 'DELETEMASS_API',
                 [
@@ -4810,6 +4833,72 @@ class Route extends FOGBase
      * @param string $orderby    How to order the returned values.
      *
      * @return string|array
+     */
+    /**
+     * Narrows a REST list/search payload to the acting user's site scope.
+     *
+     * The web UI path re-lists with the in-scope ids, which keeps the row
+     * counts honest. This path cannot: the payload has already been built
+     * by FOGManagerController::complex() from a SQL statement assembled
+     * from the request, so the boundary is applied to the rows that came
+     * back. The counts are rewritten to what survived, because leaving the
+     * unscoped totals in place would tell a site-restricted user how many
+     * objects exist outside their scope.
+     *
+     * On a payload capped by MAX_ROWS (flagged `truncated`) the rows are
+     * one page of the result set, so the rewritten count is a FLOOR on the
+     * in-scope total rather than the total. The flag rides along and says
+     * which of the two the consumer is holding. A true scoped count needs
+     * the boundary pushed into the query's WHERE clause, which is a larger
+     * change than this.
+     *
+     * @param string $classname the class being listed
+     *
+     * @return void
+     */
+    private static function _applySiteScope($classname)
+    {
+        $node = strtolower((string)$classname);
+        if (!SiteScope::isScopedNode($node)) {
+            return;
+        }
+        $scopeIDs = Authorization::scopedObjectIDs($node);
+        if (null === $scopeIDs) {
+            return;
+        }
+        // Snapshot by value rather than working through self::$data. The
+        // scope lookups issue their own queries, and anything that touches
+        // self::$data mid-method would otherwise blank out the payload
+        // being filtered.
+        $payload = self::$data;
+        if (empty($payload['data']) || !is_array($payload['data'])) {
+            return;
+        }
+        $allowed = array_flip(array_map('intval', $scopeIDs));
+        $kept = [];
+        foreach ($payload['data'] as $row) {
+            $id = (int)(
+                is_array($row) ?
+                ($row['id'] ?? 0) :
+                ($row->id ?? 0)
+            );
+            if (isset($allowed[$id])) {
+                $kept[] = $row;
+            }
+        }
+        if (count($kept) === count($payload['data'])) {
+            self::$data = $payload;
+            return;
+        }
+        $payload['data'] = array_values($kept);
+        $payload['recordsFiltered'] = count($kept);
+        $payload['recordsTotal'] = count($kept);
+        self::$data = $payload;
+    }
+    /**
+     * Builds the sql statement.
+     *
+     * @return array
      */
     private static function _buildSql(
         $sql,

--- a/tests/site-scope-lists.test.php
+++ b/tests/site-scope-lists.test.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * The list half of the site boundary.
+ *
+ * A single-object check that holds while the LIST is unfiltered is not a
+ * boundary -- the user is denied the host edit page and shown every host
+ * on the way to it, names, MACs and all. This pins the list side, which
+ * moved into core alongside the single-object side.
+ *
+ * The assertion this file exists for is the difference between NULL and an
+ * EMPTY ARRAY:
+ *
+ *   null  = no boundary applies, leave the list exactly as it is
+ *   []    = the user may see nothing
+ *
+ * Both are falsy. Collapsing them -- `if (!$ids) { return; }` -- silently
+ * shows every host to a user with no site, which is the precise failure the
+ * whole feature is meant to prevent, and it produces no error and no log
+ * line. So each caller of scopedObjectIDs() must distinguish them, and the
+ * cases below check both sides for every short circuit.
+ *
+ * DB-free by the same means as site-scope.test.php.
+ *
+ * Usage: php tests/site-scope-lists.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-site-lists-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/** Minimal stand-in for PDODB; see site-scope.test.php for rationale. */
+class FakeDB
+{
+    public $error = false;
+    public $log = [];
+    private $_responder;
+    private $_result;
+
+    public function __construct(callable $responder)
+    {
+        $this->_responder = $responder;
+    }
+
+    public function query($sql, $a = [], $params = [])
+    {
+        $this->log[] = $sql;
+        $this->_result = call_user_func($this->_responder, $sql, $params);
+        return $this;
+    }
+
+    public function fetch($mode = null, $type = '')
+    {
+        return $this;
+    }
+
+    public function get($field = '')
+    {
+        return $this->_result;
+    }
+}
+
+$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp->setAccessible(true);
+$permProp = new \ReflectionProperty('Authorization', '_permCache');
+$permProp->setAccessible(true);
+
+$scenario = function (array $tables, array $perms) use ($dbProp, $permProp) {
+    $db = new FakeDB(
+        function ($sql, $params) use ($tables) {
+            if (false !== strpos($sql, 'INNER JOIN `sites`')) {
+                $uid = (int)$params['uid'];
+                $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
+                return ['cnt' => $hit ? 1 : 0];
+            }
+            if (false !== strpos($sql, 'FROM `sites`')) {
+                return ['cnt' => (int)($tables['siteCount'] ?? 0)];
+            }
+            if (false !== strpos($sql, 'FROM `siteUserMembers` WHERE')) {
+                $uid = (int)$params['uid'];
+                $out = [];
+                foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
+                    $out[] = ['sumSiteID' => $s];
+                }
+                return $out;
+            }
+            // allInScopeIDs, for either a membership table or the task join.
+            $key = (false !== strpos($sql, 'FROM `tasks`'))
+                ? 'taskMembers'
+                : 'members';
+            $out = [];
+            foreach ((array)($tables[$key] ?? []) as $oid) {
+                $out[] = ['oid' => $oid];
+            }
+            return $out;
+        }
+    );
+    $dbProp->setValue(null, $db);
+    $permProp->setValue(null, $perms);
+    SiteScope::forgetCaches();
+    return $db;
+};
+
+/*
+ * 1. Every short circuit returns null -- "leave the list alone" -- and is
+ *    checked with an identity comparison, because == would accept [].
+ */
+$scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]], [3 => ['*']]);
+check(
+    'global * holder: null (no restriction), not an empty list',
+    Authorization::scopedObjectIDs('host', 3) === null,
+    $failures,
+    $checks
+);
+
+$scenario(['siteCount' => 0], [3 => ['host.view']]);
+check(
+    'no sites configured: null, not an empty list',
+    Authorization::scopedObjectIDs('host', 3) === null,
+    $failures,
+    $checks
+);
+
+$scenario(
+    ['siteCount' => 2, 'catchAll' => [3], 'userSites' => [3 => []]],
+    [3 => ['host.view']]
+);
+check(
+    'catch-all member: null, not an enumerated list',
+    Authorization::scopedObjectIDs('host', 3) === null,
+    $failures,
+    $checks
+);
+
+$scenario(
+    ['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => [7]]],
+    [3 => ['image.view']]
+);
+check(
+    'unscoped node: null',
+    Authorization::scopedObjectIDs('image', 3) === null,
+    $failures,
+    $checks
+);
+
+/*
+ * 2. A user with no sites gets [], NOT null. This is the case that a
+ *    falsy check would turn into "show everything".
+ */
+$scenario(
+    ['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]],
+    [3 => ['host.view']]
+);
+$noSites = Authorization::scopedObjectIDs('host', 3);
+check(
+    'user with no sites: empty array, and NOT null',
+    $noSites === [],
+    $failures,
+    $checks
+);
+check(
+    'user with no sites: null identity check would be wrong',
+    $noSites !== null,
+    $failures,
+    $checks
+);
+
+/*
+ * 3. A scoped user gets exactly their sites' objects.
+ */
+$scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'members' => [42, 43],
+    ],
+    [3 => ['host.view']]
+);
+check(
+    'scoped user gets their sites objects',
+    Authorization::scopedObjectIDs('host', 3) === [42, 43],
+    $failures,
+    $checks
+);
+
+/*
+ * 4. Tasks are scoped through their hosts on the list path too. They have
+ *    no membership table, so this resolves as a join rather than by asking
+ *    per task -- a per-row lookup on a list is the grid query storm.
+ */
+$db = $scenario(
+    [
+        'siteCount' => 2,
+        'catchAll' => [],
+        'userSites' => [3 => [7]],
+        'taskMembers' => [900],
+    ],
+    [3 => ['task.view']]
+);
+check(
+    'task list scopes via the host join',
+    Authorization::scopedObjectIDs('task', 3) === [900],
+    $failures,
+    $checks
+);
+$joined = false;
+foreach ($db->log as $sql) {
+    if (false !== strpos($sql, 'FROM `tasks`')
+        && false !== strpos($sql, '`siteHostMembers`')
+    ) {
+        $joined = true;
+    }
+}
+check(
+    'task scope is one join, not a lookup per task',
+    $joined,
+    $failures,
+    $checks
+);
+
+/*
+ * 5. allInScopeIDs is deny-all on its own terms: a user with no sites gets
+ *    nothing, and an unreadable table is not read as permission.
+ */
+$scenario(
+    ['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => []]],
+    [3 => ['host.view']]
+);
+check(
+    'allInScopeIDs is empty for a user with no sites',
+    SiteScope::allInScopeIDs('host', 3) === [],
+    $failures,
+    $checks
+);
+$scenario(
+    ['siteCount' => 2, 'catchAll' => [], 'userSites' => [3 => [7]]],
+    [3 => ['host.view']]
+);
+check(
+    'allInScopeIDs is empty for a node that is not scoped',
+    SiteScope::allInScopeIDs('image', 3) === [],
+    $failures,
+    $checks
+);
+
+/*
+ * 6. isScopedNode agrees with the single-object path. If these ever
+ *    diverge, a node is filtered in lists but not on edit, or the reverse.
+ */
+$nodes = [
+    'host' => true,
+    'user' => true,
+    'group' => true,
+    'usergroup' => true,
+    'task' => true,
+    'image' => false,
+    'snapin' => false,
+    'printer' => false,
+];
+foreach ($nodes as $node => $expected) {
+    check(
+        "isScopedNode($node) is " . ($expected ? 'true' : 'false'),
+        SiteScope::isScopedNode($node) === $expected,
+        $failures,
+        $checks
+    );
+    check(
+        "isScopedNode($node) is case-insensitive",
+        SiteScope::isScopedNode(strtoupper($node)) === $expected,
+        $failures,
+        $checks
+    );
+}
+
+$dbProp->setValue(null, null);
+$permProp->setValue(null, []);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
The other half of the boundary. A check that holds on the edit page while the **list** is unfiltered is not a boundary — the user is denied the host and shown every host's name and MAC on the way to it.

**This is the prerequisite for removing the site plugin's enforcement hooks** (the lockout flagged in #1069). Those hooks cover three surfaces; core only had one of them until now.

## Three surfaces

| Surface | Plugin hook | Core now |
|---|---|---|
| Web UI list | `AJAX_DATA_DISPLAY_CHANGE` | re-lists with in-scope ids |
| REST list + search | `API_MASSDATA_MAPPING` | filters rows, rewrites counts |
| Delete cascade | `DELETEMASS_API` | clears site membership |

The web path re-lists rather than dropping rows from the payload, so the row counts describe what the user can actually see — a filtered payload carrying the unscoped totals still tells a restricted user how much exists outside their scope. The REST path can't do that (the payload is already built from a statement assembled out of the request), so it filters rows and rewrites the counts; on a payload capped by `MAX_ROWS` the count is a floor rather than a total, and the existing `truncated` flag says which the consumer holds.

Delete cleanup is not tidiness. InnoDB recomputes `AUTO_INCREMENT` as `MAX(id)+1` on restart, so ids get reused — a row left behind by a deleted host can later put an unrelated **new** host into the site the old one was in.

## The distinction this PR is really about

`Authorization::scopedObjectIDs()` returns:

- `null` — no boundary applies, leave the list alone
- `[]` — a real answer: the user may see nothing
- `[ids]` — narrow to these

Both `null` and `[]` are falsy. Collapsing them (`if (!$ids) return;`) silently shows **every host to a user with no site** — no error, no log line. Every short circuit is asserted with identity comparisons on both sides for exactly that reason.

Task lists scope through their host as a single join, not a lookup per task; a per-row check on a list is how the grid query storms happened.

One incidental improvement over the plugin: core's `SiteScope` uses direct SQL rather than `Route::getIds()`, so it cannot clobber `Route::$data` mid-filter — the bug the plugin's hook had to snapshot around.

## Verification

```
php tests/site-scope-lists.test.php   # ok  27 checks passed
sh tests/run-all.sh                   # 14 passed, 0 failed
```

`isScopedNode()` is asserted to agree across the single-object and list paths, so a node cannot end up filtered in lists but not on edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR