### PR TITLE
Pin plugins to v1.6.5, which retires the site plugin

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -105,7 +105,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.4');
+        define('FOG_PLUGINS_VERSION', 'v1.6.5');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Pairs with [fog-plugins v1.6.5](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.5), which removes the site plugin. Core now owns sites end to end: schema steps 331–333 build and populate the tables, `SiteScope` resolves the boundary, and `Authorization` enforces it for single objects (#1069) and lists (#1071).

**The bump and the release are two halves of one change.** Without the bump, `fetch-plugins.sh` keeps pulling v1.6.4 — and that tree's four enforcement hooks read the tables schema step 332 drops. `Route::getIds()` answers `[]` rather than raising on a missing table, so they conclude the user has no sites and deny every host, user, group and usergroup to every non-`*` user, silently.

## The upgrade ordering is safe

`downloadplugins()` runs during install, before the admin ever reaches the schema updater — so the old plugin is gone before its tables are. In the window between them, core sees an empty `sites` table, `SiteScope`'s no-sites short circuit allows everything, and the server behaves exactly as it did before. There is no point in the sequence where both the old enforcement and the dropped tables coexist.

## Known gap

Site management has no UI in core yet. Until it lands, an install has sites enforced correctly and no page to administer them from. Visible, and taken deliberately over an invisible lockout — that is the next piece of work.

## Verification

```
bin/fetch-plugins.sh --version    # v1.6.5
sh tests/run-all.sh               # 14 passed, 0 failed
```

Release asset built with the repo's own `make-release.sh` (git archive → explicit 644/755 → deterministic tar), and the tarball confirmed to contain no `site/` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR