### PR TITLE
Stop the dashboard charts polling after you leave the dashboard

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -92,7 +92,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 333);
-        define('FOG_BCACHE_VER', 280);
+        define('FOG_BCACHE_VER', 281);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/js/fog/dashboard/fog.dashboard.js
+++ b/packages/web/management/js/fog/dashboard/fog.dashboard.js
@@ -110,6 +110,39 @@
     return POLL_SLOW - ((new Date().getTime() - startTime) % POLL_SLOW);
   }
 
+  /**
+   * Is this widget still on the page?
+   *
+   * Every chart below polls by rescheduling itself with setTimeout from its
+   * own complete handler, and nothing ever stopped those chains. FOG's AJAX
+   * navigation replaces the page body and cancels intervals -- fog.common.js
+   * wraps window.setInterval and calls clearAllIntervals() in doPageLoad --
+   * but it does not and cannot generically cancel timeouts, which are also
+   * used for debounces and for deferring work by a tick. So a setTimeout
+   * chain outlived the page that started it, and every visit to the dashboard
+   * left another one running for the life of the tab.
+   *
+   * Measured on the 1.6 lab: one dashboard visit, then five and a half
+   * minutes sitting on Host Management, produced 122 requests with nothing to
+   * draw into. The bandwidth chain is the expensive one -- POLL_BW is 2.5s,
+   * so roughly 24 requests a minute, per dashboard visit, indefinitely. It
+   * answers 200, which is why it was never noticed; the only visible symptom
+   * was the disk usage chain's 400 once every five minutes, because
+   * $('.nodeid') is not on the page either and the endpoint reports a missing
+   * node id as "Node is unavailable".
+   *
+   * Checked per widget rather than by tracking timers centrally, which keeps
+   * it local and self-healing: a chain ends the first time it wakes up on a
+   * page that no longer has its chart.
+   *
+   * @param {string} sel The widget's container selector.
+   *
+   * @return {boolean}
+   */
+  function alive(sel) {
+    return !!document.querySelector(sel);
+  }
+
   // Humanize a byte count using binary units.
   function humanBytes(v) {
     var units = [' iB', ' KiB', ' MiB', ' GiB', ' TiB', ' PiB', ' EiB', ' ZiB', ' YiB'];
@@ -248,6 +281,9 @@
     };
 
     function poll() {
+      if (!alive(SEL)) {
+        return;
+      }
       boxLoad(SEL, true);
       Pace.ignore(function () {
         $.ajax({
@@ -373,6 +409,9 @@
     };
 
     function poll() {
+      if (!alive(SEL)) {
+        return;
+      }
       boxLoad(SEL, true);
       Pace.ignore(function () {
         $.ajax({
@@ -462,6 +501,9 @@
     };
 
     function poll() {
+      if (!alive(SEL)) {
+        return;
+      }
       boxLoad(SEL, true);
       Pace.ignore(function () {
         $.ajax({
@@ -600,6 +642,9 @@
     }
 
     function fetchData() {
+      if (!alive(SEL)) {
+        return;
+      }
       ajax = $.ajax({
         url: BASE + '&sub=bandwidth',
         type: 'post',


### PR DESCRIPTION
Started as "why does the dashboard log a 400 for `sub=diskusage`". The 400 turned out to be the small, visible symptom of something much larger.

## Problem

Each of the four dashboard charts polls by rescheduling itself with `setTimeout` from its own `complete` handler, and **nothing ever stopped those chains**. FOG's AJAX navigation replaces the page body and cancels *intervals* — `fog.common.js` wraps `window.setInterval` and calls `clearAllIntervals()` from `doPageLoad()` — but it does not cancel timeouts, and generically cancelling them isn't an option, because `setTimeout` is also how debounces and next-tick deferrals are written.

So a chain outlives the page that started it, and **every visit to the dashboard leaves another one running for the life of the tab.**

Measured on the 1.6 lab — one dashboard visit, then 5½ minutes sitting on Host Management:

| | |
|---|---|
| requests while on the dashboard | 4 |
| requests **after leaving** it | **122** |
| cadence | `sub=bandwidth` every ~2.5s (`POLL_BW`), forever |

Roughly **24 requests a minute, per dashboard visit, indefinitely**, against a page that isn't the dashboard and has nothing to draw into.

## Why nobody noticed

The bandwidth poll answers `200`. The only visible symptom was the disk-usage chain's `400` once every five minutes: `$('.nodeid')` isn't on the page either, jQuery drops the resulting `undefined` id, and the endpoint reports a **missing node id** as `"Node is unavailable"` — so the console blamed an offline storage node for what was really a poll that should never have been running.

(Verified separately: the endpoint returns 400 for an absent, empty, `"undefined"` or `"null"` id, and storage nodes 1/2/3 all return 200 with real data. Node 7 `fognode1.lan` *is* genuinely offline, but it isn't in the dashboard's selector, so it was never the source.)

## Fix

Each poll returns early when its own chart is no longer in the document. That both suppresses the request and ends the chain, since the reschedule lives in the `complete` handler that then never runs.

Checked per widget rather than by tracking timers centrally — it stays local to this file, and it's self-healing: a chain ends the first time it wakes up on a page that no longer has its chart.

All four are guarded: activity (`clientcount`), disk usage (`diskusage`), imaging history (`get30day`), bandwidth (`bandwidth`).

## Verified on the 1.6 lab

- Leaving the dashboard and waiting **75 seconds — 30× the bandwidth cadence: 0 requests**, against ~30 before
- Returning to the dashboard **restarts** the chains rather than leaving them dead — 4 bandwidth polls in the 10s after coming back
- All four charts draw on both the first and the second visit
- No page errors

Bumps `FOG_BCACHE_VER` so browsers pick up the changed JS.

## Not changed

The endpoint still answers a missing `id` with `"Node is unavailable"`, which is misleading — but with this fix the dashboard no longer sends idless requests, so that path is only reachable by a genuinely offline node (where the message is correct) or a hand-crafted request. Left alone rather than widened into an API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)