### PR TITLE
Describe the paging bounds on system/info, not just return them

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -176,6 +176,53 @@ class OpenAPI extends FOGBase
     }
 
     /**
+     * The shape of what pagingLimits() returns.
+     *
+     * Kept next to the producer so the two are read together. Publishing the
+     * bounds on system/info only helps a client that was generated from this
+     * document if the document says the key is there -- a generator builds
+     * its model from this property list, so an undescribed key is a key the
+     * generated client cannot see, which would defeat the point of putting
+     * the bounds on the cheap endpoint in the first place.
+     *
+     * Both integers are nullable because pagingLimits() reports null rather
+     * than a guess when reflection cannot find the constant.
+     *
+     * @return array
+     */
+    private static function _pagingSchema()
+    {
+        return [
+            'type' => 'object',
+            'description' => _('Server paging bounds. Also published as '
+                . 'x-fog-paging at the root of this document.'),
+            'properties' => [
+                'maxRows' => [
+                    'type' => 'integer',
+                    'nullable' => true,
+                    'description' => _('Row cap applied to a list request '
+                        . 'that omits start, asks for length=-1, or sends a '
+                        . 'negative length. An explicit non-negative start '
+                        . 'with a positive length is served verbatim.')
+                ],
+                'expandMaxItems' => [
+                    'type' => 'integer',
+                    'nullable' => true,
+                    'description' => _('Page size cap applied to an expand '
+                        . 'request even when a larger length was asked for, '
+                        . 'so a page can be smaller than requested. Advance '
+                        . 'by the rows returned, not the length requested.')
+                ],
+                'description' => [
+                    'type' => 'string',
+                    'description' => _('The same rules in prose, for a client '
+                        . 'reading this at runtime.')
+                ]
+            ]
+        ];
+    }
+
+    /**
      * Document metadata.
      *
      * @return array
@@ -1169,17 +1216,21 @@ class OpenAPI extends FOGBase
                 'get' => self::_op(
                     '',
                     'status',
-                    _('Server version'),
-                    _('Unauthenticated. Also reachable as /system/status.'),
+                    _('Server version and paging bounds'),
+                    _('Unauthenticated. Also reachable as /system/status. The '
+                        . 'cheap way to read the paging bounds -- the same '
+                        . 'values appear as x-fog-paging on this document, '
+                        . 'which is several hundred kilobytes larger.'),
                     $json(
                         [
                             'type' => 'object',
                             'properties' => [
                                 'version' => ['type' => 'string'],
+                                'paging' => self::_pagingSchema(),
                                 'msg' => ['type' => 'string']
                             ]
                         ],
-                        _('Version information.')
+                        _('Version information and paging bounds.')
                     )
                 )
             ],


### PR DESCRIPTION
Targets `api-paging-limits`, not `working-1.6` — it is a one-commit follow-on to that branch, meant to go in before it is opened for merge.

## What is wrong

`Route::status()` on this branch returns `paging`, which is right. But `/system/info` is one of the hand-written paths in `OpenAPI::_fixedPaths()`, and it still declares only two properties:

```php
'properties' => [
    'version' => ['type' => 'string'],
    'msg'     => ['type' => 'string']   // no 'paging'
]
```

So the endpoint returns three keys and the document promises two.

## Why it is worth fixing rather than leaving

Nothing misbehaves at runtime — the response is correct and try-it shows the real thing. The cost lands on generated clients. `openapi-generator` builds its model of this response from that property list, so `paging` is dropped from the generated type. The stated reason for putting the bounds on `system/info` is that it is the endpoint a client can afford to call, as against a several-hundred-kilobyte document; a client generated from the document cannot see the key there, which is the one case the feature exists to serve. Swagger UI's rendered example for the operation omits it too.

## The change

Adds a `_pagingSchema()` helper next to `pagingLimits()`, so the shape and its producer are read together, and references it from the `/system/info` response. Both integers are described `nullable` because `pagingLimits()` reports null rather than a guess when reflection cannot find a constant. The operation's summary and description now mention the bounds and point at `x-fog-paging` as the same values on the document root.

## One deliberate choice worth a look

The nullable fields are spelled 3.0's `nullable: true`, not 3.1's type array, even though this branch still declares `OAS_VERSION = '3.1.0'` — it predates #1066. The destination is 3.0.3, where a type array would be invalid, whereas `nullable` under 3.1 is merely an ignored keyword. Merging `working-1.6` into this branch resolves the mismatch in the other direction and would also make the branch testable standalone without the 1.7s-per-expansion UI cost. I did not do that here to keep the diff to the one concern.

## Verification

`php -l` clean. Not exercised against a running server — the generator needs a live install, so the emitted document has not been re-linted here. Worth a look at `/system/info` in the reference UI when this is next deployed to the 1.6 lab.

## Note

`api-paging-limits` still merges cleanly onto current `working-1.6` (`e59fe486a`) with this commit on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27)_