### PR TITLE
Add core's Site model, manager and registrations

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -205,6 +205,7 @@ class Authorization extends FOGBase
         'roleuserassociation' => 'role',
         'scheduledtask' => 'task',
         'setting' => 'settings',
+        'site' => 'site',
         'snapin' => 'snapin',
         'snapinassociation' => 'snapin',
         'snapingroupassociation' => 'snapin',
@@ -290,6 +291,11 @@ class Authorization extends FOGBase
             'user' => ['view', 'create', 'edit', 'delete'],
             'usergroup' => ['view', 'create', 'edit', 'delete'],
             'role' => ['view', 'create', 'edit', 'delete'],
+            // Sites came in from the site plugin. The node keeps the name
+            // the plugin registered so grants written against it survive
+            // the move -- a rename here would silently drop every existing
+            // site.* permission on upgrade.
+            'site' => ['view', 'create', 'edit', 'delete'],
             'storagenode' => ['view', 'create', 'edit', 'delete'],
             'storagegroup' => ['view', 'create', 'edit', 'delete'],
             'ipxe' => ['view', 'create', 'edit', 'delete'],

--- a/packages/web/lib/fog/site.class.php
+++ b/packages/web/lib/fog/site.class.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * A site: a named group of hosts, users, groups and user groups.
+ *
+ * PHP version 5
+ *
+ * @category Site
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * A site: a named group of hosts, users, groups and user groups.
+ *
+ * The row. SiteScope is the policy that reads it -- kept apart because a
+ * model is a row with accessors and a boundary decision is not, and
+ * because SiteScope must answer during a request that never builds one of
+ * these.
+ *
+ * Originally the Site Control plugin by Fernando Gietz; moved into core so
+ * the boundary it enforces is owned by the same code that owns the
+ * permission check it sits behind.
+ *
+ * @category Site
+ * @package  FOGProject
+ * @author   Fernando Gietz <fernando.gietz@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class Site extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'sites';
+    /**
+     * The table fields.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'siteID',
+        'name' => 'siteName',
+        'description' => 'siteDesc',
+        'catchall' => 'siteCatchAll'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'name'
+    ];
+    /**
+     * Additional fields.
+     *
+     * @var array
+     */
+    protected $additionalFields = [
+        'users',
+        'hosts',
+        'groups',
+        'usergroups'
+    ];
+    /**
+     * The list query.
+     *
+     * COUNT(DISTINCT ...) because the four LEFT OUTER JOINs multiply each
+     * other's rows -- a site with 3 hosts and 2 users produces 6 rows, and
+     * a plain COUNT would report 6 of each.
+     *
+     * @var string
+     */
+    protected $sqlQueryStr = "SELECT
+        COUNT(DISTINCT `shmHostID`) `shmMembers`,
+        COUNT(DISTINCT `sumUserID`) `sumMembers`,
+        COUNT(DISTINCT `sgmGroupID`) `sgmMembers`,
+        COUNT(DISTINCT `sugmUserGroupID`) `sugmMembers`, `%s`
+        FROM `%s`
+        LEFT OUTER JOIN `siteHostMembers`
+        ON `sites`.`siteID` = `siteHostMembers`.`shmSiteID`
+        LEFT OUTER JOIN `siteUserMembers`
+        ON `sites`.`siteID` = `siteUserMembers`.`sumSiteID`
+        LEFT OUTER JOIN `siteGroupMembers`
+        ON `sites`.`siteID` = `siteGroupMembers`.`sgmSiteID`
+        LEFT OUTER JOIN `siteUserGroupMembers`
+        ON `sites`.`siteID` = `siteUserGroupMembers`.`sugmSiteID`
+        %s
+        GROUP BY `siteID`
+        %s
+        %s";
+    /**
+     * The filter query.
+     *
+     * @var string
+     */
+    protected $sqlFilterStr = "SELECT COUNT(`%s`)
+        FROM `%s`
+        %s";
+    /**
+     * The total query.
+     *
+     * @var string
+     */
+    protected $sqlTotalStr = "SELECT COUNT(`%s`)
+        FROM `%s`";
+    /**
+     * Add user to site.
+     *
+     * @param array $addArray The users to add.
+     *
+     * @return object
+     */
+    public function addUser($addArray)
+    {
+        return $this->addRemItem('users', (array)$addArray, 'merge');
+    }
+    /**
+     * Remove user from site.
+     *
+     * @param array $removeArray The users to remove.
+     *
+     * @return object
+     */
+    public function removeUser($removeArray)
+    {
+        return $this->addRemItem('users', (array)$removeArray, 'diff');
+    }
+    /**
+     * Add host to site.
+     *
+     * @param array $addArray The hosts to add.
+     *
+     * @return object
+     */
+    public function addHost($addArray)
+    {
+        return $this->addRemItem('hosts', (array)$addArray, 'merge');
+    }
+    /**
+     * Remove host from site.
+     *
+     * @param array $removeArray The hosts to remove.
+     *
+     * @return object
+     */
+    public function removeHost($removeArray)
+    {
+        return $this->addRemItem('hosts', (array)$removeArray, 'diff');
+    }
+    /**
+     * Add group to site.
+     *
+     * @param array $addArray The groups to add.
+     *
+     * @return object
+     */
+    public function addGroup($addArray)
+    {
+        return $this->addRemItem('groups', (array)$addArray, 'merge');
+    }
+    /**
+     * Remove group from site.
+     *
+     * @param array $removeArray The groups to remove.
+     *
+     * @return object
+     */
+    public function removeGroup($removeArray)
+    {
+        return $this->addRemItem('groups', (array)$removeArray, 'diff');
+    }
+    /**
+     * Add user group to site.
+     *
+     * @param array $addArray The user groups to add.
+     *
+     * @return object
+     */
+    public function addUserGroup($addArray)
+    {
+        return $this->addRemItem('usergroups', (array)$addArray, 'merge');
+    }
+    /**
+     * Remove user group from site.
+     *
+     * @param array $removeArray The user groups to remove.
+     *
+     * @return object
+     */
+    public function removeUserGroup($removeArray)
+    {
+        return $this->addRemItem('usergroups', (array)$removeArray, 'diff');
+    }
+    /**
+     * Stores/updates the site.
+     *
+     * @return object
+     */
+    public function save()
+    {
+        // `siteDesc` is LONGTEXT NOT NULL with no default -- a TEXT column
+        // cannot carry one before MySQL 8.0.13, so the empty case has to be
+        // filled in here. save() drops null-valued fields before building
+        // the column list, so leaving it unset omits the column entirely
+        // and strict mode rejects the INSERT.
+        if (!$this->isPopulated('description')
+            || null === $this->get('description')
+        ) {
+            $this->set('description', '');
+        }
+        parent::save();
+        return $this
+            ->assocSetter('SiteUserMember', 'user', true)
+            ->assocSetter('SiteHostMember', 'host', true)
+            ->assocSetter('SiteGroupMember', 'group', true)
+            ->assocSetter('SiteUserGroupMember', 'usergroup', true)
+            ->load();
+    }
+    /**
+     * Is this the catch-all site?
+     *
+     * @return bool
+     */
+    public function isCatchAll()
+    {
+        return null !== $this->get('catchall')
+            && '' !== $this->get('catchall');
+    }
+    /**
+     * Makes this site the catch-all, or stops it being one.
+     *
+     * Not done through save(), and both halves are the reason:
+     *
+     * `siteCatchAll` is NULL or 1 and nothing else -- a UNIQUE index makes
+     * "at most one" a property of the table rather than of this code, and a
+     * CHECK constraint rejects 0. So turning the flag OFF means writing
+     * NULL, and save() DROPS null-valued fields before building its column
+     * list, which would silently leave the site as the catch-all while
+     * reporting success.
+     *
+     * Turning it ON has to clear the incumbent first or the UNIQUE index
+     * rejects the write. Done as two statements in one transaction so a
+     * failure cannot leave the install with no catch-all at all, which
+     * would quietly narrow every unassigned user's view to nothing.
+     *
+     * @param bool $on true to make this the catch-all
+     *
+     * @return object
+     */
+    public function makeCatchAll($on = true)
+    {
+        $id = (int)$this->get('id');
+        if ($id < 1) {
+            throw new \Exception(_('Save the site before setting catch-all'));
+        }
+        if (!$on) {
+            self::$DB->query(
+                'UPDATE `sites` SET `siteCatchAll` = NULL '
+                . 'WHERE `siteID` = :id',
+                [],
+                ['id' => $id]
+            );
+            return $this->set('catchall', null);
+        }
+        self::$DB->query('START TRANSACTION');
+        try {
+            self::$DB->query(
+                'UPDATE `sites` SET `siteCatchAll` = NULL '
+                . 'WHERE `siteCatchAll` IS NOT NULL AND `siteID` != :id',
+                [],
+                ['id' => $id]
+            );
+            self::$DB->query(
+                'UPDATE `sites` SET `siteCatchAll` = 1 WHERE `siteID` = :id',
+                [],
+                ['id' => $id]
+            );
+            self::$DB->query('COMMIT');
+        } catch (\Exception $e) {
+            self::$DB->query('ROLLBACK');
+            throw $e;
+        }
+        return $this->set('catchall', 1);
+    }
+    /**
+     * Load users.
+     *
+     * @return void
+     */
+    protected function loadUsers()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'users',
+            (array)Route::getIds('siteusermember', $find, 'userID')
+        );
+    }
+    /**
+     * Load groups.
+     *
+     * @return void
+     */
+    protected function loadGroups()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'groups',
+            (array)Route::getIds('sitegroupmember', $find, 'groupID')
+        );
+    }
+    /**
+     * Load user groups.
+     *
+     * @return void
+     */
+    protected function loadUsergroups()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'usergroups',
+            (array)Route::getIds('siteusergroupmember', $find, 'usergroupID')
+        );
+    }
+    /**
+     * Load hosts.
+     *
+     * @return void
+     */
+    protected function loadHosts()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'hosts',
+            (array)Route::getIds('sitehostmember', $find, 'hostID')
+        );
+    }
+    /**
+     * Destroy this particular object.
+     *
+     * @param string $key the key to destroy for match
+     *
+     * @return bool
+     */
+    public function destroy($key = 'id')
+    {
+        // Funnel through the single cascade authority so a single-site
+        // delete clears the same membership tables the REST delete does,
+        // instead of keeping a second copy of the map here.
+        Route::deletemass('site', ['id' => $this->get('id')]);
+        return parent::destroy($key);
+    }
+}

--- a/packages/web/lib/fog/sitemanager.class.php
+++ b/packages/web/lib/fog/sitemanager.class.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Site manager.
+ *
+ * PHP version 5
+ *
+ * @category SiteManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Site manager.
+ *
+ * No schema()/install()/uninstall() here, unlike the plugin manager this
+ * replaces. Core tables are created by commons/schema.php (step 331) and
+ * migrated by step 332; a manager that could also create them would be a
+ * second, divergent definition of the same tables.
+ *
+ * @category SiteManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteManager extends FOGManagerController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    public $tablename = 'sites';
+    /**
+     * The catch-all site, or null when there is not one.
+     *
+     * Read by id from the flag rather than by name: the name is whatever
+     * was free when schema step 333 ran ('Everything', or 'Everything (2)'
+     * if that was taken), and an admin may rename it afterwards. The flag
+     * is the identity.
+     *
+     * @return Site|null
+     */
+    public function catchAll()
+    {
+        $ids = Route::getIds('site', ['catchall' => 1]);
+        if (empty($ids)) {
+            return null;
+        }
+        return self::getClass('Site', (int)array_shift($ids));
+    }
+}

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -291,6 +291,7 @@ class Route extends FOGBase
         'roleusergroupassociation',
         'scheduledtask',
         'setting',
+        'site',
         'snapin',
         'snapinassociation',
         'snapingroupassociation',
@@ -4745,6 +4746,22 @@ class Route extends FOGBase
                     $removeItems = [
                         'usergroupmember' => $findWhere,
                         'roleusergroupassociation' => $findWhere
+                    ];
+                    break;
+                case 'site':
+                    // Deleting a site clears its four membership lists.
+                    // Nothing stops the CATCH-ALL site being deleted here:
+                    // it is an ordinary site carrying a flag, and refusing
+                    // would be a rule the admin cannot see or undo. What it
+                    // costs is real though -- every user who relied on it
+                    // for blanket access falls back to their own sites, and
+                    // a user with none then sees nothing.
+                    $findWhere = ['siteID' => $itemIDs];
+                    $removeItems = [
+                        'sitehostmember' => $findWhere,
+                        'siteusermember' => $findWhere,
+                        'sitegroupmember' => $findWhere,
+                        'siteusergroupmember' => $findWhere
                     ];
                     break;
                 default:

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -291,10 +291,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 
@@ -566,10 +562,6 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1582,10 +1574,6 @@ msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Neuen Drucker erstellen"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Neues Snapin erstellen"
 
@@ -2184,10 +2172,6 @@ msgid "Export OUs"
 msgstr "Benutzer exportieren"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "Sites exportieren"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Gruppen exportieren"
 
@@ -2713,19 +2697,11 @@ msgid "Group"
 msgstr "Gruppe"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "Gruppen-Snapins"
 
 #, fuzzy
@@ -2852,18 +2828,6 @@ msgid "Group Search DN"
 msgstr "Gruppensuche DN"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "Gruppe aktualisiert"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "Host Snapinverlauf"
 
@@ -2881,10 +2845,6 @@ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
@@ -3045,10 +3005,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Host-EFI-Exit-Typ"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "Host Init"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Host erstellen fehlgeschlagen"
 
@@ -3168,18 +3124,6 @@ msgid "Host Registration"
 msgstr "Host-Registrierung"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Hostliste"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Site aktualisiert!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "zugeordneter Host"
 
@@ -3197,10 +3141,6 @@ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3634,10 +3574,6 @@ msgstr "Berichte importieren"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Berichte importieren"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "Sites importieren"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6158,6 +6094,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Speichern von Daten für %s Objekt"
@@ -6508,74 +6447,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "Sites"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "Drucker erstellen fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Drucker hinzufügen erfolgreich."
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Site Beschreibung"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "zugeordneter Host"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Speicherverwaltung"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Sitename"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Drucker aktualisiert!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "Sites"
 
 #, fuzzy
 msgid "Size"
@@ -8206,10 +8077,6 @@ msgid "User Cleanup"
 msgstr "Benutzer-Bereinigung"
 
 #, fuzzy
-msgid "User Count"
-msgstr "CPU-Anzahl"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "Benutzer erstellen fehlgeschlagen"
 
@@ -8234,10 +8101,6 @@ msgid "User Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Gruppe erstellen fehlgeschlagen"
 
@@ -8260,22 +8123,6 @@ msgstr "Gruppen-Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Regel Zuordnung"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8305,22 +8152,6 @@ msgstr "Benutzername Attribut"
 
 msgid "User Password"
 msgstr "Benutzerpasswort"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Neue Site"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Benutzeraktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Site aktualisiert!"
 
 msgid "User Tracker"
 msgstr "Benutzer-Tracker"
@@ -9414,6 +9245,10 @@ msgstr ""
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
@@ -9517,6 +9352,10 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Admingruppe"
 
@@ -9556,6 +9395,10 @@ msgstr ""
 #~ msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Neuen Drucker erstellen"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "Kein Knoten verknüpft"
 
@@ -9588,6 +9431,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Import erfolgreich"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "Sites exportieren"
 
 #~ msgid "Export Snapins"
 #~ msgstr "Snapins exportieren"
@@ -9622,11 +9469,35 @@ msgstr ""
 #~ msgstr "Neustarten"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
 
 #~ msgid "Group Search DN did not return any results"
 #~ msgstr "Gruppensuche DN gab keine Ergebnisse zurück"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9635,6 +9506,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "zugeordneter Host"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9653,8 +9528,24 @@ msgstr ""
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Hostliste"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Site aktualisiert!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9709,6 +9600,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Berichte importieren"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "Sites importieren"
 
 #~ msgid "Import Snapins"
 #~ msgstr "Snapins importieren"
@@ -9851,6 +9746,74 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "Sites"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "Drucker erstellen fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Site Beschreibung"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "zugeordneter Host"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Speicherverwaltung"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Sitename"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Drucker hinzugefügt"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Drucker aktualisiert!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "Sites"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin erstellt"
 
@@ -9913,6 +9876,30 @@ msgstr ""
 #~ msgstr "Drucker Aktualisieren/Entfernen"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "CPU-Anzahl"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "Benutzer-Bereinigung"
 
@@ -9923,6 +9910,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Benutzeraktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Neue Site"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Benutzeraktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -296,10 +296,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "An image already exists with this name!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "An image already exists with this name!"
 
@@ -570,10 +566,6 @@ msgstr "Remove selected printers"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Remove selected snapins"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Add snapin failed!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1585,10 +1577,6 @@ msgid "Create New Scheduled"
 msgstr "Create New %s"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Create New %s"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Create New %s"
 
@@ -2186,10 +2174,6 @@ msgid "Export OUs"
 msgstr "Export Users"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "Export Printers"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Export Groups"
 
@@ -2715,19 +2699,11 @@ msgid "Group"
 msgstr "Group"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Storage Node Created"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Storage Node Created"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "Export Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "Export Snapins"
 
 #, fuzzy
@@ -2855,18 +2831,6 @@ msgid "Group Search DN"
 msgstr "Host Search"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "Export Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "User created"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "Group added"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "Snapin History"
 
@@ -2884,10 +2848,6 @@ msgstr "Group create failed"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Group create failed"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Group create failed"
 
 #, fuzzy
@@ -3047,10 +3007,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Host EFI Exit Type"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "Host List"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Host create failed"
 
@@ -3170,18 +3126,6 @@ msgid "Host Registration"
 msgstr "Host Registration"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Host List"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Service Updated!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "No node associated"
 
@@ -3199,10 +3143,6 @@ msgstr "Host Update Failed"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Host Update Failed"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Host Update Failed"
 
 #, fuzzy
@@ -3636,10 +3576,6 @@ msgstr "Import Hosts"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Import Hosts"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "Import Printers"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6158,6 +6094,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Saving data for %s object"
@@ -6508,74 +6447,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "minutes"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Image Association"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "Printer update failed!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Printer already exists"
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Printer Description"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Storage Node Created"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "No node associated"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Storage Management"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Printer Name"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "Printer update failed!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Image Association"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Storage Node Created"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Printer Name"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "Printer update failed!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Printer updated!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "minutes"
 
 #, fuzzy
 msgid "Size"
@@ -8204,10 +8075,6 @@ msgid "User Cleanup"
 msgstr "User Cleanup"
 
 #, fuzzy
-msgid "User Count"
-msgstr "CPU Count"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "User created"
 
@@ -8232,10 +8099,6 @@ msgid "User Group Associations"
 msgstr "Storage Node Created"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "Export Snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Group create failed"
 
@@ -8258,22 +8121,6 @@ msgstr "Export Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Image Association"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "Export Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Group create failed"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "User created"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "Group added"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8303,22 +8150,6 @@ msgstr "User Name"
 
 msgid "User Password"
 msgstr "User Password"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Add New Snapin"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "Printer update failed!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Service Updated!"
 
 msgid "User Tracker"
 msgstr "User Tracker"
@@ -9408,6 +9239,10 @@ msgstr ""
 #~ msgstr "An image already exists with this name!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "An image already exists with this name!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "An image already exists with this name!"
 
@@ -9508,6 +9343,10 @@ msgstr ""
 #~ msgstr "Add snapin failed!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Add snapin failed!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Modify Group"
 
@@ -9547,6 +9386,10 @@ msgstr ""
 #~ msgstr "Create New %s"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Create New %s"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "No node associated"
 
@@ -9579,6 +9422,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Successful"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "Export Printers"
 
 #~ msgid "Export Snapins"
 #~ msgstr "Export Snapins"
@@ -9613,8 +9460,32 @@ msgstr ""
 #~ msgstr "Reboot"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Storage Node Created"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "User created"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "Group added"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Group create failed"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9623,6 +9494,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No node associated"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Host List"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9641,8 +9516,24 @@ msgstr ""
 #~ msgstr "User update failed"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Host List"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Service Updated!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Snapin History"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Host Update Failed"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"
@@ -9693,6 +9584,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Import Hosts"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "Import Printers"
 
 #~ msgid "Import Snapins"
 #~ msgstr "Import Snapins"
@@ -9831,6 +9726,74 @@ msgstr ""
 #~ msgstr "Printer update failed!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "minutes"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Image Association"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "Printer update failed!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Printer already exists"
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Printer Description"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Storage Node Created"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "No node associated"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Storage Management"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Printer Name"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "Printer update failed!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Image Association"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Storage Node Created"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Printer Name"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "Printer update failed!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Printer updated!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "minutes"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin updated"
 
@@ -9893,6 +9856,30 @@ msgstr ""
 #~ msgstr "Update Printer"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "CPU Count"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Group create failed"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "User created"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "Group added"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "User Cleanup"
 
@@ -9903,6 +9890,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Add New Snapin"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "Printer update failed!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Service Updated!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -293,10 +293,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Una imagen ya existe con este nombre!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
@@ -580,10 +576,6 @@ msgstr "Impresora"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Impresora"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1605,10 +1597,6 @@ msgid "Create New Scheduled"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Crear nuevo grupo"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Crear nuevo grupo"
 
@@ -2226,10 +2214,6 @@ msgid "Export OUs"
 msgstr "Exportar"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "impresora iPrint"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Exportar"
 
@@ -2771,19 +2755,11 @@ msgid "Group"
 msgstr "Grupo"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "nodo de almacenamiento"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "nodo de almacenamiento"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "snapins"
 
 #, fuzzy
@@ -2912,18 +2888,6 @@ msgid "Group Search DN"
 msgstr "Disco de grupo primario"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "creado por el usuario"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "grupo añadió"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "Camino snapin"
 
@@ -2941,10 +2905,6 @@ msgstr "Grupo Error de creación"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Grupo Error de creación"
 
 #, fuzzy
@@ -3106,10 +3066,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Grupo EFI Tipo de salida"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "ID de host"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Grupo Error de creación"
 
@@ -3241,18 +3197,6 @@ msgid "Host Registration"
 msgstr "Lista de host"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Hospedadores"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Servicio de Actualización!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "No nodo asociado"
 
@@ -3270,10 +3214,6 @@ msgstr "actualización Valoración falló"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "actualización Valoración falló"
 
 #, fuzzy
@@ -3720,10 +3660,6 @@ msgstr "Importar"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Importar"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "Impresora TCP / IP Port"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6310,6 +6246,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Guardar los datos de %s objeto"
@@ -6664,74 +6603,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "minutos"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Asociación para la imagen"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Impresora ya existe"
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Descripción de la impresora"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "nodo de almacenamiento"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "No nodo asociado"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Gestión de usuarios"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Nombre de la impresora"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Asociación para la imagen"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "nodo de almacenamiento"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Nombre de la impresora"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Impresora actualiza!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "minutos"
 
 #, fuzzy
 msgid "Size"
@@ -8389,10 +8260,6 @@ msgid "User Cleanup"
 msgstr ""
 
 #, fuzzy
-msgid "User Count"
-msgstr "Contador de la CPU"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "creado por el usuario"
 
@@ -8417,10 +8284,6 @@ msgid "User Group Associations"
 msgstr "nodo de almacenamiento"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Grupo Error de creación"
 
@@ -8443,22 +8306,6 @@ msgstr "snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Asociación para la imagen"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "creado por el usuario"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "grupo añadió"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8488,22 +8335,6 @@ msgstr "Nombre de usuario"
 
 msgid "User Password"
 msgstr "Contraseña de usuario"
-
-#, fuzzy
-msgid "User Site"
-msgstr "snapin"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Actualizar impresora"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Servicio de Actualización!"
 
 #, fuzzy
 msgid "User Tracker"
@@ -9594,6 +9425,10 @@ msgstr ""
 #~ msgstr "Una imagen ya existe con este nombre!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Una imagen ya existe con este nombre!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Una imagen ya existe con este nombre!"
 
@@ -9694,6 +9529,10 @@ msgstr ""
 #~ msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Añadir fallidos SNAPin!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "modificar Grupo"
 
@@ -9734,6 +9573,10 @@ msgstr ""
 #~ msgstr "Crear nuevo grupo"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Crear nuevo grupo"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "No nodo asociado"
 
@@ -9770,6 +9613,10 @@ msgstr ""
 #~ msgstr "Exitoso"
 
 #, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "impresora iPrint"
+
+#, fuzzy
 #~ msgid "Export Snapins"
 #~ msgstr "snapins"
 
@@ -9802,8 +9649,32 @@ msgstr ""
 #~ msgstr "Reiniciar"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "creado por el usuario"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "grupo añadió"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Grupo Error de creación"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9812,6 +9683,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No nodo asociado"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "ID de host"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9830,8 +9705,24 @@ msgstr ""
 #~ msgstr "actualización Valoración falló"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Hospedadores"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "actualización Valoración falló"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Servicio de Actualización!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Camino snapin"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9888,6 +9779,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Importar"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "Impresora TCP / IP Port"
 
 #, fuzzy
 #~ msgid "Import Snapins"
@@ -10015,6 +9910,74 @@ msgstr ""
 #~ msgstr "actualización de la impresora ha fallado!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "minutos"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Impresora ya existe"
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Descripción de la impresora"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "No nodo asociado"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Gestión de usuarios"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Nombre de la impresora"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "actualización Valoración falló"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Nombre de la impresora"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Impresora actualiza!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "minutos"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Nombre snapin"
 
@@ -10077,6 +10040,30 @@ msgstr ""
 #~ msgstr "Eliminar todos los elementos seleccionados"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "Contador de la CPU"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Grupo Error de creación"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "creado por el usuario"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "grupo añadió"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "snapin"
 
@@ -10087,6 +10074,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Actualizar impresora"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "snapin"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Actualizar impresora"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Servicio de Actualización!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -291,10 +291,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 
@@ -566,10 +562,6 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1582,10 +1574,6 @@ msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Neuen Drucker erstellen"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Neues Snapin erstellen"
 
@@ -2184,10 +2172,6 @@ msgid "Export OUs"
 msgstr "Benutzer exportieren"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "Sites exportieren"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Gruppen exportieren"
 
@@ -2713,19 +2697,11 @@ msgid "Group"
 msgstr "Gruppe"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "Gruppen-Snapins"
 
 #, fuzzy
@@ -2852,18 +2828,6 @@ msgid "Group Search DN"
 msgstr "Gruppensuche DN"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "Gruppe aktualisiert"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "Host Snapinverlauf"
 
@@ -2881,10 +2845,6 @@ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
@@ -3045,10 +3005,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Host-EFI-Exit-Typ"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "Host Init"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Host erstellen fehlgeschlagen"
 
@@ -3168,18 +3124,6 @@ msgid "Host Registration"
 msgstr "Host-Registrierung"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Hostliste"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Site aktualisiert!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "zugeordneter Host"
 
@@ -3197,10 +3141,6 @@ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3634,10 +3574,6 @@ msgstr "Berichte importieren"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Berichte importieren"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "Sites importieren"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6159,6 +6095,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Speichern von Daten für %s Objekt"
@@ -6509,74 +6448,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "Sites"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "Drucker erstellen fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Drucker hinzufügen erfolgreich."
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Site Beschreibung"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "zugeordneter Host"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Speicherverwaltung"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Sitename"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Drucker aktualisiert!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "Sites"
 
 #, fuzzy
 msgid "Size"
@@ -8207,10 +8078,6 @@ msgid "User Cleanup"
 msgstr "Benutzer-Bereinigung"
 
 #, fuzzy
-msgid "User Count"
-msgstr "CPU-Anzahl"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "Benutzer erstellen fehlgeschlagen"
 
@@ -8235,10 +8102,6 @@ msgid "User Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Gruppe erstellen fehlgeschlagen"
 
@@ -8261,22 +8124,6 @@ msgstr "Gruppen-Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Regel Zuordnung"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "Gruppen-Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8306,22 +8153,6 @@ msgstr "Benutzername Attribut"
 
 msgid "User Password"
 msgstr "Benutzerpasswort"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Neue Site"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Benutzeraktualisierung erfolgreich!"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Site aktualisiert!"
 
 msgid "User Tracker"
 msgstr "Benutzer-Tracker"
@@ -9415,6 +9246,10 @@ msgstr ""
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
@@ -9518,6 +9353,10 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Admingruppe"
 
@@ -9557,6 +9396,10 @@ msgstr ""
 #~ msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Neuen Drucker erstellen"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "Kein Knoten verknüpft"
 
@@ -9589,6 +9432,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Import erfolgreich"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "Sites exportieren"
 
 #~ msgid "Export Snapins"
 #~ msgstr "Snapins exportieren"
@@ -9623,11 +9470,35 @@ msgstr ""
 #~ msgstr "Neustarten"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
 
 #~ msgid "Group Search DN did not return any results"
 #~ msgstr "Gruppensuche DN gab keine Ergebnisse zurück"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9636,6 +9507,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "zugeordneter Host"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9654,8 +9529,24 @@ msgstr ""
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Hostliste"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Site aktualisiert!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9710,6 +9601,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Berichte importieren"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "Sites importieren"
 
 #~ msgid "Import Snapins"
 #~ msgstr "Snapins importieren"
@@ -9852,6 +9747,74 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "Sites"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "Drucker erstellen fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Site Beschreibung"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "zugeordneter Host"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Speicherverwaltung"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Sitename"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Drucker hinzugefügt"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Drucker aktualisiert!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "Sites"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin erstellt"
 
@@ -9914,6 +9877,30 @@ msgstr ""
 #~ msgstr "Drucker Aktualisieren/Entfernen"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "CPU-Anzahl"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "Gruppen-Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "Benutzer-Bereinigung"
 
@@ -9924,6 +9911,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Benutzeraktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Neue Site"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Benutzeraktualisierung erfolgreich!"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -297,10 +297,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Une image existe déjà avec ce nom!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
@@ -571,10 +567,6 @@ msgstr "Imprimante"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Imprimante"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1587,10 +1579,6 @@ msgid "Create New Scheduled"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Créer un nouveau %s"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Créer un nouveau %s"
 
@@ -2188,10 +2176,6 @@ msgid "Export OUs"
 msgstr "Les utilisateurs d'exportation"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "Imprimantes Export"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Groupes d'exportation"
 
@@ -2717,19 +2701,11 @@ msgid "Group"
 msgstr "Groupe"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Nœud de stockage Créé"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Nœud de stockage Créé"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "Export SnapIns"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "Export SnapIns"
 
 #, fuzzy
@@ -2857,18 +2833,6 @@ msgid "Group Search DN"
 msgstr "Recherche d'hôte"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "Export SnapIns"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "utilisateur créé"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "Groupe ajouté"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "snapin Histoire"
 
@@ -2886,10 +2850,6 @@ msgstr "Groupe create a échoué"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Groupe create a échoué"
 
 #, fuzzy
@@ -3049,10 +3009,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Hôte EFI Type de sortie"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "Liste des hôtes"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Hôte créer échoué"
 
@@ -3172,18 +3128,6 @@ msgid "Host Registration"
 msgstr "Enregistrement de l'hôte"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Liste des hôtes"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Service de mise à jour!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "Aucun noeud associé"
 
@@ -3201,10 +3145,6 @@ msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Mise à jour de l'hôte a échoué"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
@@ -3638,10 +3578,6 @@ msgstr "Hôtes d'importation"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Hôtes d'importation"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "Imprimantes d'importation"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6160,6 +6096,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Enregistrement des données pour %s l'objet"
@@ -6510,74 +6449,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "minutes"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Association Image"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Imprimante existe déjà"
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Printer description"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Nœud de stockage Créé"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "Aucun noeud associé"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Gestion du stockage"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Nom de l'imprimante"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Association Image"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Nœud de stockage Créé"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Nom de l'imprimante"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Imprimante mis à jour!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "minutes"
 
 #, fuzzy
 msgid "Size"
@@ -8206,10 +8077,6 @@ msgid "User Cleanup"
 msgstr "Nettoyage de l'utilisateur"
 
 #, fuzzy
-msgid "User Count"
-msgstr "Nombre de CPU"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "utilisateur créé"
 
@@ -8234,10 +8101,6 @@ msgid "User Group Associations"
 msgstr "Nœud de stockage Créé"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "Export SnapIns"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Groupe create a échoué"
 
@@ -8260,22 +8123,6 @@ msgstr "Export SnapIns"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Association Image"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "Export SnapIns"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "utilisateur créé"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "Groupe ajouté"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8305,22 +8152,6 @@ msgstr "Nom d'utilisateur"
 
 msgid "User Password"
 msgstr "Mot de passe de l'utilisateur"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Ajouter New Snapin"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Service de mise à jour!"
 
 msgid "User Tracker"
 msgstr "Tracker utilisateur"
@@ -9410,6 +9241,10 @@ msgstr ""
 #~ msgstr "Une image existe déjà avec ce nom!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Une image existe déjà avec ce nom!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Une image existe déjà avec ce nom!"
 
@@ -9510,6 +9345,10 @@ msgstr ""
 #~ msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Ajouter SnapIn a échoué!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Modifier Groupe"
 
@@ -9549,6 +9388,10 @@ msgstr ""
 #~ msgstr "Créer un nouveau %s"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Créer un nouveau %s"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "Aucun noeud associé"
 
@@ -9581,6 +9424,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Réussi"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "Imprimantes Export"
 
 #~ msgid "Export Snapins"
 #~ msgstr "Export SnapIns"
@@ -9615,8 +9462,32 @@ msgstr ""
 #~ msgstr "Réinitialiser"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "utilisateur créé"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "Groupe ajouté"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Groupe create a échoué"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9625,6 +9496,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "Aucun noeud associé"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Liste des hôtes"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9643,8 +9518,24 @@ msgstr ""
 #~ msgstr "mise à jour de l'utilisateur a échoué"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Liste des hôtes"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Service de mise à jour!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "snapin Histoire"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9699,6 +9590,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Hôtes d'importation"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "Imprimantes d'importation"
 
 #~ msgid "Import Snapins"
 #~ msgstr "Importer SnapIns"
@@ -9837,6 +9732,74 @@ msgstr ""
 #~ msgstr "mise à jour de l'imprimante a échoué!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "minutes"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Association Image"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Imprimante existe déjà"
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Printer description"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "Aucun noeud associé"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Gestion du stockage"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Nom de l'imprimante"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Association Image"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Nom de l'imprimante"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Imprimante mis à jour!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "minutes"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "snapin mise à jour"
 
@@ -9899,6 +9862,30 @@ msgstr ""
 #~ msgstr "Supprimer les imprimantes sélectionnées"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "Nombre de CPU"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Groupe create a échoué"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "utilisateur créé"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "Groupe ajouté"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "Nettoyage de l'utilisateur"
 
@@ -9909,6 +9896,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Ajouter New Snapin"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Service de mise à jour!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -286,10 +286,6 @@ msgstr "non è più in esecuzione"
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
-#, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Un host già esiste con questo nome!"
-
 msgid "A snapin already exists with this name!"
 msgstr "Esiste già un snapin con questo nome!"
 
@@ -548,10 +544,6 @@ msgstr "Aggiungi stampanti selezionate"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Aggiungi gruppo di archiviazione selezionato"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Aggiunta host non riuscita!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1525,10 +1517,6 @@ msgid "Create New Scheduled"
 msgstr "Crea nuovo %s"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Crea nuova stampante"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Crea nuovo snapin"
 
@@ -2115,9 +2103,6 @@ msgstr "Esporta luoghi"
 msgid "Export OUs"
 msgstr "Esporta utenti"
 
-msgid "Export Sites"
-msgstr "Esporta Siti"
-
 #, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Gruppi Export"
@@ -2627,19 +2612,11 @@ msgid "Group"
 msgstr "Gruppo"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Storage Node Creato"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Storage Node Creato"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "Gruppo Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "Gruppo Snapins"
 
 msgid "Group Create Fail"
@@ -2763,18 +2740,6 @@ msgid "Group Search DN"
 msgstr "Ricerca gruppo DN"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "Gruppo Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "Aggiornamento del gruppo completato"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "Gruppo aggiornato!"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "Storia Snapin Host"
 
@@ -2791,10 +2756,6 @@ msgstr "Aggiornamento gruppo non riuscito"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
 msgid "Group Update Success"
@@ -2949,10 +2910,6 @@ msgstr "Host associato"
 msgid "Host BIOS Exit Type"
 msgstr "Host EFI Tipo Exit"
 
-#, fuzzy
-msgid "Host Count"
-msgstr "Host Init"
-
 msgid "Host Create Fail"
 msgstr "Creazione Host fallita"
 
@@ -3069,18 +3026,6 @@ msgid "Host Registration"
 msgstr "registrazione Host"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Lista Host"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Aggiornamento host completato!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Sito aggiornato!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "Host associato"
 
@@ -3096,10 +3041,6 @@ msgstr "Aggiornamento Host completato"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Aggiornamento Host completato"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Aggiornamento Host completato"
 
 msgid "Host Update Success"
@@ -3513,9 +3454,6 @@ msgstr "Importa Report"
 
 msgid "Import Reports"
 msgstr "Importa Report"
-
-msgid "Import Sites"
-msgstr "importa Siti"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -5934,6 +5872,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 msgid "Saving data for"
 msgstr "Salvataggio dei dati per"
 
@@ -6273,70 +6214,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "Siti"
-
-msgid "Site Association"
-msgstr "Associazione Sito"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "Creazione stampante fallita"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Creazione stampante riuscita"
-
-msgid "Site Description"
-msgstr "Descrizione Sito"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Storage Node Creato"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "Host associato"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Storage Management"
-
-msgid "Site Name"
-msgstr "Nome sito"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "Aggiornamento della stampante non riuscito"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Aggiornamento host completato!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Associazione Sito"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Storage Node Creato"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Stampante aggiunta"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "Aggiornamento della stampante non è riuscito!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "aggiornato stampante!"
-
-msgid "Sites"
-msgstr "Siti"
 
 msgid "Size"
 msgstr "Dimensione"
@@ -7896,10 +7773,6 @@ msgstr "Associazione Sito"
 msgid "User Cleanup"
 msgstr "Cleanup utente"
 
-#, fuzzy
-msgid "User Count"
-msgstr "Conte CPU"
-
 msgid "User Create Fail"
 msgstr "Creazione utente fallita"
 
@@ -7920,10 +7793,6 @@ msgstr "Storage Node Creato"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Storage Node Creato"
-
-#, fuzzy
-msgid "User Group Count"
-msgstr "Gruppo Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -7948,22 +7817,6 @@ msgstr "Gruppo Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Regole di associazione"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "Gruppo Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "Aggiornamento del gruppo completato"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "Gruppo aggiornato!"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -7992,22 +7845,6 @@ msgstr "Attributo nome utente"
 
 msgid "User Password"
 msgstr "Password utente"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Nuovo Sito"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "Aggiornamento della stampante non riuscito"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Utente aggiornato con successo"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Sito aggiornato!"
 
 msgid "User Tracker"
 msgstr "Tracker utente"
@@ -9033,6 +8870,10 @@ msgstr ""
 #~ msgstr "Esiste già un ruolo con questo nome!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Un host già esiste con questo nome!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Esiste già un ruolo con questo nome!"
 
@@ -9132,6 +8973,10 @@ msgstr ""
 #~ msgid "Add rule failed!"
 #~ msgstr "Aggiunta utente fallita!"
 
+#, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Aggiunta host non riuscita!"
+
 #~ msgid "Admin Group"
 #~ msgstr "Gruppo amministrativo"
 
@@ -9171,6 +9016,10 @@ msgstr ""
 #~ msgstr "Crea nuovo %s"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Crea nuova stampante"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "Nessun nodo associato"
 
@@ -9203,6 +9052,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Importazione riuscita"
+
+#~ msgid "Export Sites"
+#~ msgstr "Esporta Siti"
 
 #~ msgid "Export Snapins"
 #~ msgstr "Export Snapins"
@@ -9237,17 +9089,45 @@ msgstr ""
 #~ msgstr "Riavvio"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Storage Node Creato"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "Gruppo Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Luoghi"
 
 #~ msgid "Group Search DN did not return any results"
 #~ msgstr "Ricerca nel gruppo DN non ha restituito alcun risultato"
 
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "Gruppo Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "Aggiornamento del gruppo completato"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "Gruppo aggiornato!"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
+
 #~ msgid "Group module settings"
 #~ msgstr "Impostazioni modulo del gruppo"
 
 #~ msgid "Host Associated"
 #~ msgstr "Host associato"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9266,8 +9146,24 @@ msgstr ""
 #~ msgstr "Aggiornamento ruolo non riuscito"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Lista Host"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Aggiornamento host completato!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Sito aggiornato!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Storia Snapin Host"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Aggiornamento Host completato"
 
 #~ msgid "Host module settings"
 #~ msgstr "Impostazioni del modulo host"
@@ -9321,6 +9217,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Importa Report"
+
+#~ msgid "Import Sites"
+#~ msgstr "importa Siti"
 
 #~ msgid "Import Snapins"
 #~ msgstr "Importa Snapins"
@@ -9455,6 +9354,70 @@ msgstr ""
 #~ msgid "Rule update failed!"
 #~ msgstr "Aggiornamento della stampante non è riuscito!"
 
+#, fuzzy
+#~ msgid "Site"
+#~ msgstr "Siti"
+
+#~ msgid "Site Association"
+#~ msgstr "Associazione Sito"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "Creazione stampante fallita"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Creazione stampante riuscita"
+
+#~ msgid "Site Description"
+#~ msgstr "Descrizione Sito"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Storage Node Creato"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "Host associato"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Storage Management"
+
+#~ msgid "Site Name"
+#~ msgstr "Nome sito"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "Aggiornamento della stampante non riuscito"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Aggiornamento host completato!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Associazione Sito"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Storage Node Creato"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Stampante aggiunta"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "Aggiornamento della stampante non è riuscito!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "aggiornato stampante!"
+
+#~ msgid "Sites"
+#~ msgstr "Siti"
+
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin creato"
 
@@ -9512,6 +9475,30 @@ msgstr ""
 #~ msgstr "Aggiorna/Rimuovi stampanti"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "Conte CPU"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "Gruppo Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "Gruppo Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "Aggiornamento del gruppo completato"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "Gruppo aggiornato!"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "Cleanup utente"
 
@@ -9522,6 +9509,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Utente aggiornato con successo"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Nuovo Sito"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "Aggiornamento della stampante non riuscito"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Utente aggiornato con successo"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Sito aggiornato!"
 
 #~ msgid "You have version"
 #~ msgstr "Hai l'ultima versione"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -274,9 +274,6 @@ msgstr "選択したプリンターを追加"
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
-msgid "A site already exists with this name!"
-msgstr "この名前のサイトは既に存在します！"
-
 msgid "A snapin already exists with this name!"
 msgstr "この名前のスナップインは既に存在します！"
 
@@ -532,9 +529,6 @@ msgstr "選択したホストを追加"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "選択したストレージグループを追加"
-
-msgid "Add site failed!"
-msgstr "サイトの追加に失敗しました！"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1504,10 +1498,6 @@ msgstr "新しいキーを作成"
 msgid "Create New Scheduled"
 msgstr "新しい電源管理スケジュールを作成"
 
-#, fuzzy
-msgid "Create New Site"
-msgstr "新しいプリンターを作成"
-
 msgid "Create New Snapin"
 msgstr "新しいスナップインを作成"
 
@@ -2095,9 +2085,6 @@ msgstr "ロケーションをエクスポート"
 msgid "Export OUs"
 msgstr "ユーザーをエクスポート"
 
-msgid "Export Sites"
-msgstr "サイトをエクスポート"
-
 #, fuzzy
 msgid "Export Subnet Groups"
 msgstr "サブネットグループをエクスポート"
@@ -2597,20 +2584,12 @@ msgstr "Green FOG"
 msgid "Group"
 msgstr "グループ"
 
-#, fuzzy
-msgid "Group Association"
-msgstr "グループの関連付け"
-
 msgid "Group Associations"
 msgstr "グループの関連付け"
 
 #, fuzzy
 msgid "Group BIOS Exit"
 msgstr "グループ EFI 終了方法"
-
-#, fuzzy
-msgid "Group Count"
-msgstr "グループ自動ログアウト"
 
 msgid "Group Create Fail"
 msgstr "グループの作成に失敗しました"
@@ -2733,18 +2712,6 @@ msgid "Group Search DN"
 msgstr "グループ検索 DN"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "グループイメージ"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "グループの更新に成功しました"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "サイトを更新しました！"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "グループ スナップイン"
 
@@ -2761,10 +2728,6 @@ msgstr "グループの更新に失敗しました"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "グループの更新に失敗しました"
 
 msgid "Group Update Success"
@@ -2918,10 +2881,6 @@ msgstr "関連付けられたホスト"
 msgid "Host BIOS Exit Type"
 msgstr "ホスト EFI 終了方法"
 
-#, fuzzy
-msgid "Host Count"
-msgstr "ホスト Init"
-
 msgid "Host Create Fail"
 msgstr "ホストの作成に失敗しました"
 
@@ -3035,17 +2994,6 @@ msgstr "ホスト プロダクトキー"
 msgid "Host Registration"
 msgstr "ホスト登録"
 
-msgid "Host Site"
-msgstr "ホスト サイト"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "サイトを更新しました"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "サイトを更新しました！"
-
 #, fuzzy
 msgid "Host Snapin Associations"
 msgstr "スナップインロケーション"
@@ -3062,10 +3010,6 @@ msgstr "ホストの更新に失敗しました"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "ホストの更新に失敗しました"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "ホストの更新に失敗しました"
 
 msgid "Host Update Success"
@@ -3475,9 +3419,6 @@ msgstr "レポートをインポートしますか？"
 
 msgid "Import Reports"
 msgstr "レポートをインポート"
-
-msgid "Import Sites"
-msgstr "サイトをインポート"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -5876,6 +5817,9 @@ msgstr "保存は完了しましたが、有効な ID が割り当てられま�
 msgid "Save order"
 msgstr "Initrd を保存"
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 msgid "Saving data for"
 msgstr "次のデータを保存しています:"
 
@@ -6214,63 +6158,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-msgid "Site"
-msgstr "サイト"
-
-msgid "Site Association"
-msgstr "サイトの関連付け"
-
-msgid "Site Create Fail"
-msgstr "サイトの作成に失敗しました"
-
-msgid "Site Create Success"
-msgstr "サイトを作成しました"
-
-msgid "Site Description"
-msgstr "サイトの説明"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "サイトの関連付け"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "ストレージ管理"
-
-msgid "Site Name"
-msgstr "サイト名"
-
-msgid "Site Update Fail"
-msgstr "サイトの更新に失敗しました"
-
-msgid "Site Update Success"
-msgstr "サイトを更新しました"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "サイトの関連付け"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "グループの関連付け"
-
-msgid "Site added!"
-msgstr "サイトを追加しました！"
-
-msgid "Site update failed!"
-msgstr "サイトの更新に失敗しました！"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "サイトを更新しました！"
-
-msgid "Sites"
-msgstr "サイト"
 
 msgid "Size"
 msgstr "サイズ"
@@ -7822,10 +7709,6 @@ msgstr "ルールの関連付け"
 msgid "User Cleanup"
 msgstr "ユーザークリーンアップ"
 
-#, fuzzy
-msgid "User Count"
-msgstr "CPU 数"
-
 msgid "User Create Fail"
 msgstr "ユーザーの作成に失敗しました"
 
@@ -7846,10 +7729,6 @@ msgstr "グループの関連付け"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "User Group Count"
-msgstr "グループ自動ログアウト"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -7874,22 +7753,6 @@ msgstr "グループ名"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "ユーザーを更新しました！"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "グループの更新に成功しました"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "サイトを更新しました！"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -7918,22 +7781,6 @@ msgstr "ユーザー名属性"
 
 msgid "User Password"
 msgstr "ユーザーパスワード"
-
-#, fuzzy
-msgid "User Site"
-msgstr "ユーザーフィルター"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "サイトの更新に失敗しました"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "サイトを更新しました"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "サイトを更新しました！"
 
 msgid "User Tracker"
 msgstr "ユーザートラッカー"
@@ -8983,6 +8830,9 @@ msgstr ""
 #~ msgid "A rule already exists with this name"
 #~ msgstr "この名前のルールは既に存在します"
 
+#~ msgid "A site already exists with this name!"
+#~ msgstr "この名前のサイトは既に存在します！"
+
 #~ msgid "A snapin name is required!"
 #~ msgstr "スナップイン名は必須です！"
 
@@ -9084,6 +8934,9 @@ msgstr ""
 
 #~ msgid "Add selected users"
 #~ msgstr "選択したユーザーを追加"
+
+#~ msgid "Add site failed!"
+#~ msgstr "サイトの追加に失敗しました！"
 
 #~ msgid "Additional MACs"
 #~ msgstr "追加の MAC アドレス"
@@ -9262,6 +9115,10 @@ msgstr ""
 
 #~ msgid "Create New Access Control Role"
 #~ msgstr "新しいアクセス制御ロールを作成"
+
+#, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "新しいプリンターを作成"
 
 #~ msgid "Create New iPXE Menu Entry"
 #~ msgstr "新しい iPXE メニューエントリを作成"
@@ -9465,6 +9322,9 @@ msgstr ""
 #~ msgid "Export Printers"
 #~ msgstr "プリンターをエクスポート"
 
+#~ msgid "Export Sites"
+#~ msgstr "サイトをエクスポート"
+
 #~ msgid "Extension"
 #~ msgstr "拡張子"
 
@@ -9605,8 +9465,16 @@ msgstr ""
 #~ msgid "Goto task list"
 #~ msgstr "タスク一覧へ移動"
 
+#, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "グループの関連付け"
+
 #~ msgid "Group Bios Exit Type"
 #~ msgstr "グループ BIOS 終了方法"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "グループ自動ログアウト"
 
 #~ msgid "Group FOG Client Module configuration"
 #~ msgstr "グループ FOG クライアントモジュール設定"
@@ -9626,6 +9494,22 @@ msgstr ""
 
 #~ msgid "Group Search DN did not return any results"
 #~ msgstr "グループ検索 DN は結果を返しませんでした"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "グループイメージ"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "グループの更新に成功しました"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "サイトを更新しました！"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "グループの更新に失敗しました"
 
 #~ msgid "Group general"
 #~ msgstr "グループ全般"
@@ -9681,6 +9565,10 @@ msgstr ""
 #~ msgid "Host Bios Exit Type"
 #~ msgstr "ホスト BIOS 終了方法"
 
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "ホスト Init"
+
 #~ msgid "Host Desc"
 #~ msgstr "ホスト説明"
 
@@ -9711,6 +9599,17 @@ msgstr ""
 #~ msgid "Host Screen Resolution"
 #~ msgstr "ホスト画面解像度"
 
+#~ msgid "Host Site"
+#~ msgstr "ホスト サイト"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "サイトを更新しました"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "サイトを更新しました！"
+
 #~ msgid "Host Snapins"
 #~ msgstr "ホスト スナップイン"
 
@@ -9722,6 +9621,10 @@ msgstr ""
 
 #~ msgid "Host Unassociated Snapins"
 #~ msgstr "ホストに関連付けられていないスナップイン"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "ホストの更新に失敗しました"
 
 #~ msgid "Host Virus History"
 #~ msgstr "ホスト ウイルス 履歴"
@@ -9833,6 +9736,9 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "プリンターをインポート"
+
+#~ msgid "Import Sites"
+#~ msgstr "サイトをインポート"
 
 #~ msgid "Included Items"
 #~ msgstr "含まれる項目"
@@ -10590,11 +10496,68 @@ msgstr ""
 #~ msgid "Shutdown after install"
 #~ msgstr "インストール後にシャットダウン"
 
+#~ msgid "Site"
+#~ msgstr "サイト"
+
+#~ msgid "Site Association"
+#~ msgstr "サイトの関連付け"
+
 #~ msgid "Site Control Management"
 #~ msgstr "サイト制御管理"
 
+#~ msgid "Site Create Fail"
+#~ msgstr "サイトの作成に失敗しました"
+
+#~ msgid "Site Create Success"
+#~ msgstr "サイトを作成しました"
+
+#~ msgid "Site Description"
+#~ msgstr "サイトの説明"
+
 #~ msgid "Site General"
 #~ msgstr "サイト全般"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "グループの関連付け"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "サイトの関連付け"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "ストレージ管理"
+
+#~ msgid "Site Name"
+#~ msgstr "サイト名"
+
+#~ msgid "Site Update Fail"
+#~ msgstr "サイトの更新に失敗しました"
+
+#~ msgid "Site Update Success"
+#~ msgstr "サイトを更新しました"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "サイトの関連付け"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "グループの関連付け"
+
+#~ msgid "Site added!"
+#~ msgstr "サイトを追加しました！"
+
+#~ msgid "Site update failed!"
+#~ msgstr "サイトの更新に失敗しました！"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "サイトを更新しました！"
+
+#~ msgid "Sites"
+#~ msgstr "サイト"
 
 #~ msgid "Snapin Args"
 #~ msgstr "スナップイン引数"
@@ -10920,11 +10883,51 @@ msgstr ""
 #~ msgid "User Change Password"
 #~ msgstr "ユーザーパスワードを変更"
 
+#, fuzzy
+#~ msgid "User Count"
+#~ msgstr "CPU 数"
+
 #~ msgid "User General"
 #~ msgstr "ユーザー全般"
 
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "グループ自動ログアウト"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "ユーザーを更新しました！"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "グループの更新に失敗しました"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "グループの更新に成功しました"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "サイトを更新しました！"
+
 #~ msgid "User Password (confirm)"
 #~ msgstr "ユーザーパスワード（確認）"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "ユーザーフィルター"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "サイトの更新に失敗しました"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "サイトを更新しました"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "サイトを更新しました！"
 
 #~ msgid "User Tracking"
 #~ msgstr "ユーザー追跡"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -244,9 +244,6 @@ msgstr ""
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
-msgid "A site already exists with this name!"
-msgstr ""
-
 msgid "A snapin already exists with this name!"
 msgstr ""
 
@@ -472,9 +469,6 @@ msgid "Add selected"
 msgstr ""
 
 msgid "Add selected to group"
-msgstr ""
-
-msgid "Add site failed!"
 msgstr ""
 
 msgid "Add slack account failed!"
@@ -1331,9 +1325,6 @@ msgstr ""
 msgid "Create New Scheduled"
 msgstr ""
 
-msgid "Create New Site"
-msgstr ""
-
 msgid "Create New Snapin"
 msgstr ""
 
@@ -1850,9 +1841,6 @@ msgstr ""
 msgid "Export OUs"
 msgstr ""
 
-msgid "Export Sites"
-msgstr ""
-
 msgid "Export Subnet Groups"
 msgstr ""
 
@@ -2307,16 +2295,10 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
-msgid "Group Association"
-msgstr ""
-
 msgid "Group Associations"
 msgstr ""
 
 msgid "Group BIOS Exit"
-msgstr ""
-
-msgid "Group Count"
 msgstr ""
 
 msgid "Group Create Fail"
@@ -2418,15 +2400,6 @@ msgstr ""
 msgid "Group Search DN"
 msgstr ""
 
-msgid "Group Site"
-msgstr ""
-
-msgid "Group Site Update Success"
-msgstr ""
-
-msgid "Group Site Updated!"
-msgstr ""
-
 msgid "Group Snapin Assignment"
 msgstr ""
 
@@ -2440,9 +2413,6 @@ msgid "Group Update Location Fail"
 msgstr ""
 
 msgid "Group Update OU Fail"
-msgstr ""
-
-msgid "Group Update Site Fail"
 msgstr ""
 
 msgid "Group Update Success"
@@ -2572,9 +2542,6 @@ msgstr ""
 msgid "Host BIOS Exit Type"
 msgstr ""
 
-msgid "Host Count"
-msgstr ""
-
 msgid "Host Create Fail"
 msgstr ""
 
@@ -2674,15 +2641,6 @@ msgstr ""
 msgid "Host Registration"
 msgstr ""
 
-msgid "Host Site"
-msgstr ""
-
-msgid "Host Site Update Success"
-msgstr ""
-
-msgid "Host Site Updated!"
-msgstr ""
-
 msgid "Host Snapin Associations"
 msgstr ""
 
@@ -2696,9 +2654,6 @@ msgid "Host Update Location Fail"
 msgstr ""
 
 msgid "Host Update OU Fail"
-msgstr ""
-
-msgid "Host Update Site Fail"
 msgstr ""
 
 msgid "Host Update Success"
@@ -3064,9 +3019,6 @@ msgid "Import Report"
 msgstr ""
 
 msgid "Import Reports"
-msgstr ""
-
-msgid "Import Sites"
 msgstr ""
 
 msgid "Import Subnet Groups"
@@ -5214,6 +5166,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 msgid "Saving data for"
 msgstr ""
 
@@ -5507,57 +5462,6 @@ msgid "Signed in as %s."
 msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
-msgstr ""
-
-msgid "Site"
-msgstr ""
-
-msgid "Site Association"
-msgstr ""
-
-msgid "Site Create Fail"
-msgstr ""
-
-msgid "Site Create Success"
-msgstr ""
-
-msgid "Site Description"
-msgstr ""
-
-msgid "Site Group Associations"
-msgstr ""
-
-msgid "Site Host Associations"
-msgstr ""
-
-msgid "Site Management"
-msgstr ""
-
-msgid "Site Name"
-msgstr ""
-
-msgid "Site Update Fail"
-msgstr ""
-
-msgid "Site Update Success"
-msgstr ""
-
-msgid "Site User Associations"
-msgstr ""
-
-msgid "Site User Group Associations"
-msgstr ""
-
-msgid "Site added!"
-msgstr ""
-
-msgid "Site update failed!"
-msgstr ""
-
-msgid "Site updated!"
-msgstr ""
-
-msgid "Sites"
 msgstr ""
 
 msgid "Size"
@@ -6953,9 +6857,6 @@ msgstr ""
 msgid "User Cleanup"
 msgstr ""
 
-msgid "User Count"
-msgstr ""
-
 msgid "User Create Fail"
 msgstr ""
 
@@ -6974,9 +6875,6 @@ msgstr ""
 msgid "User Group Associations"
 msgstr ""
 
-msgid "User Group Count"
-msgstr ""
-
 msgid "User Group Create Fail"
 msgstr ""
 
@@ -6993,18 +6891,6 @@ msgid "User Group Name"
 msgstr ""
 
 msgid "User Group Role Associations"
-msgstr ""
-
-msgid "User Group Site"
-msgstr ""
-
-msgid "User Group Site Update Fail"
-msgstr ""
-
-msgid "User Group Site Update Success"
-msgstr ""
-
-msgid "User Group Site Updated!"
 msgstr ""
 
 msgid "User Group Update Fail"
@@ -7029,18 +6915,6 @@ msgid "User Name Attribute"
 msgstr ""
 
 msgid "User Password"
-msgstr ""
-
-msgid "User Site"
-msgstr ""
-
-msgid "User Site Update Fail"
-msgstr ""
-
-msgid "User Site Update Success"
-msgstr ""
-
-msgid "User Site Updated!"
 msgstr ""
 
 msgid "User Tracker"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -296,10 +296,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "Uma imagem já existe com este nome!"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
@@ -570,10 +566,6 @@ msgstr "Impressora"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Impressora"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1586,10 +1578,6 @@ msgid "Create New Scheduled"
 msgstr "Criar novo %s"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "Criar novo %s"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "Criar novo %s"
 
@@ -2187,10 +2175,6 @@ msgid "Export OUs"
 msgstr "Usuários de exportação"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "Impressoras de exportação"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "Grupos de exportação"
 
@@ -2716,19 +2700,11 @@ msgid "Group"
 msgstr "Grupo"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "Nó de Armazenamento Criado"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "exportação Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "exportação Snapins"
 
 #, fuzzy
@@ -2856,18 +2832,6 @@ msgid "Group Search DN"
 msgstr "anfitrião Pesquisa"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "exportação Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "usuário criado"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "grupo adicionado"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "História Snapin"
 
@@ -2885,10 +2849,6 @@ msgstr "Grupo Criar falhou"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "Grupo Criar falhou"
 
 #, fuzzy
@@ -3048,10 +3008,6 @@ msgid "Host BIOS Exit Type"
 msgstr "Hospedar EFI Tipo Exit"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "Lista de Host"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "Hospedar criar falha"
 
@@ -3171,18 +3127,6 @@ msgid "Host Registration"
 msgstr "Registro de acolhimento"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "Lista de Host"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "Serviço Atualizado!"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "No nó associado"
 
@@ -3200,10 +3144,6 @@ msgstr "Anfitrião Update Failed"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "Anfitrião Update Failed"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "Anfitrião Update Failed"
 
 #, fuzzy
@@ -3637,10 +3577,6 @@ msgstr "Hosts de importação"
 #, fuzzy
 msgid "Import Reports"
 msgstr "Hosts de importação"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "importação Impressoras"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6159,6 +6095,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Salvando dados para %s objeto"
@@ -6509,74 +6448,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "minutos"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "Associação imagem"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "Impressora já existe"
-
-#, fuzzy
-msgid "Site Description"
-msgstr "Descrição Printer"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "No nó associado"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "Gerenciamento de armazenamento"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "Nome da impressora"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "Associação imagem"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "Nome da impressora"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "Impressora atualizado!"
-
-#, fuzzy
-msgid "Sites"
-msgstr "minutos"
 
 #, fuzzy
 msgid "Size"
@@ -8205,10 +8076,6 @@ msgid "User Cleanup"
 msgstr "Limpeza de usuário"
 
 #, fuzzy
-msgid "User Count"
-msgstr "Contagem de CPU"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "usuário criado"
 
@@ -8233,10 +8100,6 @@ msgid "User Group Associations"
 msgstr "Nó de Armazenamento Criado"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "exportação Snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "Grupo Criar falhou"
 
@@ -8259,22 +8122,6 @@ msgstr "exportação Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "Associação imagem"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "exportação Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "usuário criado"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "grupo adicionado"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8304,22 +8151,6 @@ msgstr "Nome de usuário"
 
 msgid "User Password"
 msgstr "Senha do usuário"
-
-#, fuzzy
-msgid "User Site"
-msgstr "Adicionar novo Snapin"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "Serviço Atualizado!"
 
 msgid "User Tracker"
 msgstr "User tracker"
@@ -9409,6 +9240,10 @@ msgstr ""
 #~ msgstr "Uma imagem já existe com este nome!"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "Uma imagem já existe com este nome!"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Uma imagem já existe com este nome!"
 
@@ -9509,6 +9344,10 @@ msgstr ""
 #~ msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "Adicionar snap-in falhou!"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "modificar Grupo"
 
@@ -9548,6 +9387,10 @@ msgstr ""
 #~ msgstr "Criar novo %s"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "Criar novo %s"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "No nó associado"
 
@@ -9580,6 +9423,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "Bem sucedido"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "Impressoras de exportação"
 
 #~ msgid "Export Snapins"
 #~ msgstr "exportação Snapins"
@@ -9614,8 +9461,32 @@ msgstr ""
 #~ msgstr "reinicialização"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "usuário criado"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "grupo adicionado"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "Grupo Criar falhou"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9624,6 +9495,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No nó associado"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "Lista de Host"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9642,8 +9517,24 @@ msgstr ""
 #~ msgstr "atualização do utilizador falhou"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "Lista de Host"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "Serviço Atualizado!"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "História Snapin"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "Anfitrião Update Failed"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9698,6 +9589,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "Hosts de importação"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "importação Impressoras"
 
 #~ msgid "Import Snapins"
 #~ msgstr "importação Snapins"
@@ -9836,6 +9731,74 @@ msgstr ""
 #~ msgstr "atualização da impressora falhou!"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "minutos"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "Impressora já existe"
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "Descrição Printer"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "No nó associado"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "Gerenciamento de armazenamento"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "Nome da impressora"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "Nome da impressora"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "Impressora atualizado!"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "minutos"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin atualizada"
 
@@ -9898,6 +9861,30 @@ msgstr ""
 #~ msgstr "Remover impressoras selecionadas"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "Contagem de CPU"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "Grupo Criar falhou"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "usuário criado"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "grupo adicionado"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "Limpeza de usuário"
 
@@ -9908,6 +9895,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "Adicionar novo Snapin"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "Serviço Atualizado!"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -296,10 +296,6 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
-msgid "A site already exists with this name!"
-msgstr "图像已经存在具有此名称！"
-
-#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
@@ -570,10 +566,6 @@ msgstr "打印机"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "打印机"
-
-#, fuzzy
-msgid "Add site failed!"
-msgstr "添加管理单元失败！"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1586,10 +1578,6 @@ msgid "Create New Scheduled"
 msgstr "新建%s"
 
 #, fuzzy
-msgid "Create New Site"
-msgstr "新建%s"
-
-#, fuzzy
 msgid "Create New Snapin"
 msgstr "新建%s"
 
@@ -2187,10 +2175,6 @@ msgid "Export OUs"
 msgstr "导出用户"
 
 #, fuzzy
-msgid "Export Sites"
-msgstr "出口打印机"
-
-#, fuzzy
 msgid "Export Subnet Groups"
 msgstr "出口组"
 
@@ -2716,19 +2700,11 @@ msgid "Group"
 msgstr "组"
 
 #, fuzzy
-msgid "Group Association"
-msgstr "存储节点创建"
-
-#, fuzzy
 msgid "Group Associations"
 msgstr "存储节点创建"
 
 #, fuzzy
 msgid "Group BIOS Exit"
-msgstr "出口Snapins"
-
-#, fuzzy
-msgid "Group Count"
 msgstr "出口Snapins"
 
 #, fuzzy
@@ -2856,18 +2832,6 @@ msgid "Group Search DN"
 msgstr "主机搜索"
 
 #, fuzzy
-msgid "Group Site"
-msgstr "出口Snapins"
-
-#, fuzzy
-msgid "Group Site Update Success"
-msgstr "用户创建"
-
-#, fuzzy
-msgid "Group Site Updated!"
-msgstr "集团补充"
-
-#, fuzzy
 msgid "Group Snapin Assignment"
 msgstr "历史管理单元"
 
@@ -2885,10 +2849,6 @@ msgstr "集团创建失败"
 
 #, fuzzy
 msgid "Group Update OU Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
-msgid "Group Update Site Fail"
 msgstr "集团创建失败"
 
 #, fuzzy
@@ -3048,10 +3008,6 @@ msgid "Host BIOS Exit Type"
 msgstr "主持人EFI退出类型"
 
 #, fuzzy
-msgid "Host Count"
-msgstr "主机列表"
-
-#, fuzzy
 msgid "Host Create Fail"
 msgstr "主机创建失败"
 
@@ -3171,18 +3127,6 @@ msgid "Host Registration"
 msgstr "主机注册"
 
 #, fuzzy
-msgid "Host Site"
-msgstr "主机列表"
-
-#, fuzzy
-msgid "Host Site Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Host Site Updated!"
-msgstr "服务更新！"
-
-#, fuzzy
 msgid "Host Snapin Associations"
 msgstr "无关联的节点"
 
@@ -3200,10 +3144,6 @@ msgstr "主机更新失败"
 
 #, fuzzy
 msgid "Host Update OU Fail"
-msgstr "主机更新失败"
-
-#, fuzzy
-msgid "Host Update Site Fail"
 msgstr "主机更新失败"
 
 #, fuzzy
@@ -3637,10 +3577,6 @@ msgstr "进口主机"
 #, fuzzy
 msgid "Import Reports"
 msgstr "进口主机"
-
-#, fuzzy
-msgid "Import Sites"
-msgstr "进口打印机"
 
 #, fuzzy
 msgid "Import Subnet Groups"
@@ -6159,6 +6095,9 @@ msgstr ""
 msgid "Save order"
 msgstr ""
 
+msgid "Save the site before setting catch-all"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "保存数据%s对象"
@@ -6509,74 +6448,6 @@ msgstr ""
 
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
-
-#, fuzzy
-msgid "Site"
-msgstr "分钟"
-
-#, fuzzy
-msgid "Site Association"
-msgstr "图像协会"
-
-#, fuzzy
-msgid "Site Create Fail"
-msgstr "打印机更新失败！"
-
-#, fuzzy
-msgid "Site Create Success"
-msgstr "打印机已经存在"
-
-#, fuzzy
-msgid "Site Description"
-msgstr "打印机说明"
-
-#, fuzzy
-msgid "Site Group Associations"
-msgstr "存储节点创建"
-
-#, fuzzy
-msgid "Site Host Associations"
-msgstr "无关联的节点"
-
-#, fuzzy
-msgid "Site Management"
-msgstr "存储管理"
-
-#, fuzzy
-msgid "Site Name"
-msgstr "打印机名称"
-
-#, fuzzy
-msgid "Site Update Fail"
-msgstr "打印机更新失败！"
-
-#, fuzzy
-msgid "Site Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Site User Associations"
-msgstr "图像协会"
-
-#, fuzzy
-msgid "Site User Group Associations"
-msgstr "存储节点创建"
-
-#, fuzzy
-msgid "Site added!"
-msgstr "打印机名称"
-
-#, fuzzy
-msgid "Site update failed!"
-msgstr "打印机更新失败！"
-
-#, fuzzy
-msgid "Site updated!"
-msgstr "打印机更新！"
-
-#, fuzzy
-msgid "Sites"
-msgstr "分钟"
 
 #, fuzzy
 msgid "Size"
@@ -8205,10 +8076,6 @@ msgid "User Cleanup"
 msgstr "用户清理"
 
 #, fuzzy
-msgid "User Count"
-msgstr "CPU计数"
-
-#, fuzzy
 msgid "User Create Fail"
 msgstr "用户创建"
 
@@ -8233,10 +8100,6 @@ msgid "User Group Associations"
 msgstr "存储节点创建"
 
 #, fuzzy
-msgid "User Group Count"
-msgstr "出口Snapins"
-
-#, fuzzy
 msgid "User Group Create Fail"
 msgstr "集团创建失败"
 
@@ -8259,22 +8122,6 @@ msgstr "出口Snapins"
 #, fuzzy
 msgid "User Group Role Associations"
 msgstr "图像协会"
-
-#, fuzzy
-msgid "User Group Site"
-msgstr "出口Snapins"
-
-#, fuzzy
-msgid "User Group Site Update Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
-msgid "User Group Site Update Success"
-msgstr "用户创建"
-
-#, fuzzy
-msgid "User Group Site Updated!"
-msgstr "集团补充"
 
 #, fuzzy
 msgid "User Group Update Fail"
@@ -8304,22 +8151,6 @@ msgstr "用户名"
 
 msgid "User Password"
 msgstr "用户密码"
-
-#, fuzzy
-msgid "User Site"
-msgstr "添加新的管理单元"
-
-#, fuzzy
-msgid "User Site Update Fail"
-msgstr "打印机更新失败！"
-
-#, fuzzy
-msgid "User Site Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "User Site Updated!"
-msgstr "服务更新！"
 
 msgid "User Tracker"
 msgstr "用户跟踪"
@@ -9409,6 +9240,10 @@ msgstr ""
 #~ msgstr "图像已经存在具有此名称！"
 
 #, fuzzy
+#~ msgid "A site already exists with this name!"
+#~ msgstr "图像已经存在具有此名称！"
+
+#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "图像已经存在具有此名称！"
 
@@ -9509,6 +9344,10 @@ msgstr ""
 #~ msgstr "添加管理单元失败！"
 
 #, fuzzy
+#~ msgid "Add site failed!"
+#~ msgstr "添加管理单元失败！"
+
+#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "修改组"
 
@@ -9548,6 +9387,10 @@ msgstr ""
 #~ msgstr "新建%s"
 
 #, fuzzy
+#~ msgid "Create New Site"
+#~ msgstr "新建%s"
+
+#, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "无关联的节点"
 
@@ -9580,6 +9423,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export Rules"
 #~ msgstr "成功"
+
+#, fuzzy
+#~ msgid "Export Sites"
+#~ msgstr "出口打印机"
 
 #~ msgid "Export Snapins"
 #~ msgstr "出口Snapins"
@@ -9614,8 +9461,32 @@ msgstr ""
 #~ msgstr "重启"
 
 #, fuzzy
+#~ msgid "Group Association"
+#~ msgstr "存储节点创建"
+
+#, fuzzy
+#~ msgid "Group Count"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Group Site"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
+#~ msgid "Group Site Update Success"
+#~ msgstr "用户创建"
+
+#, fuzzy
+#~ msgid "Group Site Updated!"
+#~ msgstr "集团补充"
+
+#, fuzzy
+#~ msgid "Group Update Site Fail"
+#~ msgstr "集团创建失败"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -9624,6 +9495,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "无关联的节点"
+
+#, fuzzy
+#~ msgid "Host Count"
+#~ msgstr "主机列表"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9642,8 +9517,24 @@ msgstr ""
 #~ msgstr "用户更新失败"
 
 #, fuzzy
+#~ msgid "Host Site"
+#~ msgstr "主机列表"
+
+#, fuzzy
+#~ msgid "Host Site Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Host Site Updated!"
+#~ msgstr "服务更新！"
+
+#, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "历史管理单元"
+
+#, fuzzy
+#~ msgid "Host Update Site Fail"
+#~ msgstr "主机更新失败"
 
 #, fuzzy
 #~ msgid "Host module settings"
@@ -9698,6 +9589,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Rules"
 #~ msgstr "进口主机"
+
+#, fuzzy
+#~ msgid "Import Sites"
+#~ msgstr "进口打印机"
 
 #~ msgid "Import Snapins"
 #~ msgstr "进口Snapins"
@@ -9836,6 +9731,74 @@ msgstr ""
 #~ msgstr "打印机更新失败！"
 
 #, fuzzy
+#~ msgid "Site"
+#~ msgstr "分钟"
+
+#, fuzzy
+#~ msgid "Site Association"
+#~ msgstr "图像协会"
+
+#, fuzzy
+#~ msgid "Site Create Fail"
+#~ msgstr "打印机更新失败！"
+
+#, fuzzy
+#~ msgid "Site Create Success"
+#~ msgstr "打印机已经存在"
+
+#, fuzzy
+#~ msgid "Site Description"
+#~ msgstr "打印机说明"
+
+#, fuzzy
+#~ msgid "Site Group Associations"
+#~ msgstr "存储节点创建"
+
+#, fuzzy
+#~ msgid "Site Host Associations"
+#~ msgstr "无关联的节点"
+
+#, fuzzy
+#~ msgid "Site Management"
+#~ msgstr "存储管理"
+
+#, fuzzy
+#~ msgid "Site Name"
+#~ msgstr "打印机名称"
+
+#, fuzzy
+#~ msgid "Site Update Fail"
+#~ msgstr "打印机更新失败！"
+
+#, fuzzy
+#~ msgid "Site Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Site User Associations"
+#~ msgstr "图像协会"
+
+#, fuzzy
+#~ msgid "Site User Group Associations"
+#~ msgstr "存储节点创建"
+
+#, fuzzy
+#~ msgid "Site added!"
+#~ msgstr "打印机名称"
+
+#, fuzzy
+#~ msgid "Site update failed!"
+#~ msgstr "打印机更新失败！"
+
+#, fuzzy
+#~ msgid "Site updated!"
+#~ msgstr "打印机更新！"
+
+#, fuzzy
+#~ msgid "Sites"
+#~ msgstr "分钟"
+
+#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "更新管理单元"
 
@@ -9898,6 +9861,30 @@ msgstr ""
 #~ msgstr "删除选定的打印机"
 
 #, fuzzy
+#~ msgid "User Count"
+#~ msgstr "CPU计数"
+
+#, fuzzy
+#~ msgid "User Group Count"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
+#~ msgid "User Group Site Update Fail"
+#~ msgstr "集团创建失败"
+
+#, fuzzy
+#~ msgid "User Group Site Update Success"
+#~ msgstr "用户创建"
+
+#, fuzzy
+#~ msgid "User Group Site Updated!"
+#~ msgstr "集团补充"
+
+#, fuzzy
 #~ msgid "User Role"
 #~ msgstr "用户清理"
 
@@ -9908,6 +9895,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "User Role Update Success"
 #~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "User Site"
+#~ msgstr "添加新的管理单元"
+
+#, fuzzy
+#~ msgid "User Site Update Fail"
+#~ msgstr "打印机更新失败！"
+
+#, fuzzy
+#~ msgid "User Site Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "User Site Updated!"
+#~ msgstr "服务更新！"
 
 #, fuzzy
 #~ msgid "You have version"

--- a/tests/site-model.test.php
+++ b/tests/site-model.test.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Core's Site model, and the three registrations that make it reachable.
+ *
+ * Sites came in from the site plugin, and the move is only finished if the
+ * name, the node and the permissions all land where the plugin had them.
+ * Each of these is silent when wrong:
+ *
+ *   - a field map that does not match schema step 331 produces an empty
+ *     result set, not an error;
+ *   - a missing Route::$validClasses entry means the REST routes for
+ *     /fog/site are simply never registered, so the endpoint 404s with
+ *     nothing to say why;
+ *   - a missing API_CLASS_ENTITIES entry falls through to
+ *     'unmapped.site', which only a '*' holder passes -- so the API works
+ *     perfectly for the administrator testing it and for nobody else;
+ *   - a registry node spelled differently from the plugin's would drop
+ *     every existing site.* grant on upgrade, without a word.
+ *
+ * DB-free: every assertion is a class property or a constant.
+ *
+ * Usage: php tests/site-model.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-site-model-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/*
+ * 1. The model resolves, and to CORE. The site plugin declared a class of
+ *    the same name for years; if a stale copy is still on disk the
+ *    autoloader prefers core, but this pins which file actually won so a
+ *    lingering plugin cannot quietly supply the model.
+ */
+if (!class_exists('Site', true)) {
+    fwrite(STDERR, "FAIL: Site does not resolve\n");
+    exit(1);
+}
+$ref = new \ReflectionClass('Site');
+check(
+    'Site extends FOGController',
+    $ref->isSubclassOf('FOGController'),
+    $failures,
+    $checks
+);
+check(
+    'Site resolves to core, not to a plugin copy',
+    false === strpos($ref->getFileName(), DIRECTORY_SEPARATOR . 'plugins'),
+    $failures,
+    $checks
+);
+
+$instance = $ref->newInstanceWithoutConstructor();
+$prop = function ($name) use ($ref, $instance) {
+    $p = $ref->getProperty($name);
+    $p->setAccessible(true);
+    return $p->getValue($instance);
+};
+
+/*
+ * 2. The field map matches schema step 331 exactly. `sites`, not the
+ *    plugin's `site` -- pointing at the dropped table is the single
+ *    likeliest way for this move to go wrong, and it reads as "no sites
+ *    exist", which SiteScope then treats as "allow everything".
+ */
+check(
+    'Site maps to `sites`, not the plugin\'s dropped `site`',
+    $prop('databaseTable') === 'sites',
+    $failures,
+    $checks
+);
+$fields = $prop('databaseFields');
+$expected = [
+    'id' => 'siteID',
+    'name' => 'siteName',
+    'description' => 'siteDesc',
+    'catchall' => 'siteCatchAll'
+];
+foreach ($expected as $friendly => $column) {
+    check(
+        "Site maps $friendly => $column",
+        ($fields[$friendly] ?? null) === $column,
+        $failures,
+        $checks
+    );
+}
+check(
+    'Site requires a name',
+    in_array('name', $prop('databaseFieldsRequired'), true),
+    $failures,
+    $checks
+);
+foreach (['users', 'hosts', 'groups', 'usergroups'] as $assoc) {
+    check(
+        "Site carries the $assoc association",
+        in_array($assoc, $prop('additionalFields'), true),
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 3. The list query counts members with COUNT(DISTINCT ...). Four LEFT
+ *    OUTER JOINs multiply each other's rows -- 3 hosts and 2 users produce
+ *    6 rows -- so a plain COUNT reports 6 of each and the site list shows
+ *    numbers that are simply wrong.
+ */
+$sql = $prop('sqlQueryStr');
+check(
+    'member counts are COUNT(DISTINCT ...)',
+    substr_count($sql, 'COUNT(DISTINCT') === 4,
+    $failures,
+    $checks
+);
+foreach (
+    [
+        'siteHostMembers',
+        'siteUserMembers',
+        'siteGroupMembers',
+        'siteUserGroupMembers'
+    ] as $table
+) {
+    check(
+        "list query joins $table",
+        false !== strpos($sql, $table),
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 4. The manager.
+ */
+check(
+    'SiteManager resolves',
+    class_exists('SiteManager', true),
+    $failures,
+    $checks
+);
+if (class_exists('SiteManager', true)) {
+    $mref = new \ReflectionClass('SiteManager');
+    check(
+        'SiteManager resolves to core, not to a plugin copy',
+        false === strpos($mref->getFileName(), DIRECTORY_SEPARATOR . 'plugins'),
+        $failures,
+        $checks
+    );
+    check(
+        'SiteManager targets `sites`',
+        $mref->newInstanceWithoutConstructor()->tablename === 'sites',
+        $failures,
+        $checks
+    );
+    // Core tables are built by commons/schema.php. A manager that could
+    // also create them would be a second, divergent definition of the same
+    // tables -- which is how the plugin's schema and core's drifted apart
+    // in the first place.
+    check(
+        'SiteManager does not redeclare the schema',
+        !$mref->hasMethod('schema') || $mref->getMethod('schema')
+            ->getDeclaringClass()->getName() !== 'SiteManager',
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 5. The three registrations.
+ */
+check(
+    'site is a valid API class',
+    in_array('site', Route::$validClasses, true),
+    $failures,
+    $checks
+);
+check(
+    'site maps to its own registry node in API_CLASS_ENTITIES',
+    (Authorization::API_CLASS_ENTITIES['site'] ?? null) === 'site',
+    $failures,
+    $checks
+);
+$registry = Authorization::coreRegistry();
+check(
+    'site is a core-owned registry node',
+    isset($registry['site']),
+    $failures,
+    $checks
+);
+foreach (['view', 'create', 'edit', 'delete'] as $action) {
+    check(
+        "site.$action is a registered permission",
+        in_array($action, (array)($registry['site'] ?? []), true),
+        $failures,
+        $checks
+    );
+}
+// Core-owned matters beyond tidiness: purgePermissions() refuses to wipe a
+// core node's grants, so an admin who "forgets" a leftover site plugin
+// cannot take every site.* grant with it.
+check(
+    'site is protected from plugin-uninstall permission purges',
+    Authorization::isCoreOwnedNode('site'),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Commit 10. Core can finally declare `Site` — fog-plugins v1.6.5 gave up the name, so the autoload key is free. `SiteScope` stays separate: a model is a row with accessors, a boundary decision is not, and `SiteScope` has to answer during requests that never build one of these.

## Three registrations, each silent when missing

| Registration | What its absence looks like |
|---|---|
| `Route::$validClasses` | the `/fog/site` routes are never registered; endpoint 404s with nothing to say why |
| `API_CLASS_ENTITIES` | falls through to `unmapped.site`, which only a `*` holder passes — so the API works for the admin testing it and for nobody else |
| `coreRegistry` | `site.view/create/edit/delete`, spelled as the plugin spelled them so existing grants survive the move |

The registry node also has to be **core-owned**: `purgePermissions()` refuses to wipe a core node's grants, so an admin who forgets a leftover site plugin can't take every `site.*` grant with it.

## Two column traps handled in the model

**`siteDesc`** is `LONGTEXT NOT NULL` with no default — TEXT can't carry one before MySQL 8.0.13 — and `save()` drops null-valued fields before building its column list. An unset description omits the column and strict mode rejects the INSERT. `save()` fills it.

**`siteCatchAll`** is `NULL` or `1` and nothing else: a UNIQUE index makes "at most one" a property of the table, and a CHECK rejects `0`. So turning the flag *off* means writing NULL — which `save()` would drop, reporting success while leaving the site as the catch-all. `makeCatchAll()` does both directions in SQL, and clears the incumbent inside a transaction so a failure can't leave an install with **no** catch-all, which would quietly narrow every unassigned user's view to nothing.

`deletemass()` grows a `site` case clearing the four membership tables, so `Site::destroy()` and the REST delete share one cascade map. Deleting the catch-all is deliberately allowed — it's an ordinary site carrying a flag, and refusing would be a rule the admin can neither see nor undo.

## Verification

```
php tests/site-model.test.php   # ok  29 checks passed
sh tests/run-all.sh             # 15 passed, 0 failed
```

Worth noting how those tests behaved *before* I re-fetched plugins: against a stale v1.6.4 tree, `autoload-core-wins` reported the `site`/`sitemanager` collisions and `route-filter-fields` resolved `catchall` against the **plugin's** field map and flagged it. Re-running `bin/fetch-plugins.sh` pulled v1.6.5, removed the stale tree, and both went green — end-to-end proof that the pin, the release and the commit-4 autoloader precedence rule all agree. The precedence rule also did exactly its job in the meantime: core won both collisions rather than coin-flipping.

Next: the `SiteManagement` page (commit 11), then the association tabs (commit 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR