### PR TITLE
Add the core site management page

### DIFF
--- a/packages/web/lib/fog/FOGPageRender.class.php
+++ b/packages/web/lib/fog/FOGPageRender.class.php
@@ -43,6 +43,12 @@ trait FOGPageRender
      * @param string $createNode optional node owning a create form (e.g. 'group').
      *                          When given, the tab grows a "Create New X" button
      *                          and the modal it opens. See renderAssocCreate().
+     * @param string $noun     optional display noun for that button, for the
+     *                          nodes where ucfirst() reads badly -- 'usergroup'
+     *                          becomes "Usergroup", 'ou' becomes "Ou". Forwarded
+     *                          to renderAssocCreate(), which has always taken
+     *                          one; without this pass-through a tab could only
+     *                          reach it by calling that helper itself.
      *
      * @return void
      */
@@ -53,7 +59,8 @@ trait FOGPageRender
         $delItem,
         $sendClass = 'btn btn-primary float-end',
         $helpBlock = '',
-        $createNode = ''
+        $createNode = '',
+        $noun = ''
     ) {
         $this->headerData = [
             $colHeader,
@@ -89,7 +96,8 @@ trait FOGPageRender
                 $tabSlug,
                 $createNode,
                 $buttons,
-                $this->obj->get('id')
+                $this->obj->get('id'),
+                $noun
             );
         }
 

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -486,6 +486,13 @@ abstract class FOGPage extends FOGBase
                 _('Roles'),
                 'fa fa-key'
             ],
+            // Beside roles rather than beside hosts: a site says which
+            // objects a user may reach, which is the same kind of answer a
+            // role gives about which actions.
+            'site' => [
+                _('Sites'),
+                'fa fa-map-marker'
+            ],
             'ipxe' => [
                 _('iPXE Menu'),
                 'fa fa-bars'

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -1,0 +1,623 @@
+<?php
+/**
+ * Site management page.
+ *
+ * PHP version 5
+ *
+ * @category SiteManagement
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Site management page.
+ *
+ * Originally the Site Control plugin's page by Fernando Gietz. Moved into
+ * core with sites themselves, and pointed at the core tables schema step
+ * 331 creates rather than the plugin tables step 332 drops.
+ *
+ * @category SiteManagement
+ * @package  FOGProject
+ * @author   Fernando Gietz <fernando.gietz@gmail.com>
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteManagement extends FOGPage
+{
+    /**
+     * The node this page works with.
+     *
+     * @var string
+     */
+    public $node = 'site';
+    /**
+     * Constructor.
+     *
+     * @param string $name The name for the page.
+     *
+     * @return void
+     */
+    public function __construct($name = '')
+    {
+        $this->name = _('Site Management');
+        parent::__construct($this->name);
+        $this->headerData = [
+            _('Name'),
+            _('Host Count'),
+            _('User Count'),
+            _('Group Count'),
+            _('User Group Count')
+        ];
+        $this->attributes = [
+            [],
+            ['width' => 5],
+            ['width' => 5],
+            ['width' => 5],
+            ['width' => 5]
+        ];
+    }
+    /**
+     * Builds the create-form fields (shared by add() and addModal()).
+     *
+     * @return array
+     */
+    protected function _addFields()
+    {
+        $site = filter_input(INPUT_POST, 'site');
+        $description = filter_input(INPUT_POST, 'description');
+
+        $labelClass = 'col-sm-3 col-form-label';
+
+        return [
+            self::makeLabel(
+                $labelClass,
+                'site',
+                _('Site Name')
+            ) => self::makeInput(
+                'form-control sitename-input',
+                'site',
+                _('Site Name'),
+                'text',
+                'site',
+                $site,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'description',
+                _('Site Description')
+            ) => self::makeTextarea(
+                'form-control sitedescription-input',
+                'description',
+                _('Site Description'),
+                'description',
+                $description
+            )
+        ];
+    }
+    /**
+     * Creates new item.
+     *
+     * @return void
+     */
+    public function add()
+    {
+        $this->renderAddForm(
+            'site',
+            _('Create New Site'),
+            'SITE_ADD_FIELDS',
+            'Site'
+        );
+    }
+    /**
+     * Creates new item, as a modal for create-and-associate.
+     *
+     * @return void
+     */
+    public function addModal()
+    {
+        $this->renderAddModalForm(
+            'site',
+            'SITE_ADD_FIELDS',
+            'Site'
+        );
+    }
+    /**
+     * Add post.
+     *
+     * @return void
+     */
+    public function addPost()
+    {
+        $this->handleAddPost(
+            'Site',
+            'SITE_ADD',
+            _('Site added!'),
+            _('Site Create Success'),
+            _('Site Create Fail'),
+            function (&$serverFault) {
+                $site = trim(
+                    filter_input(INPUT_POST, 'site')
+                );
+                $description = trim(
+                    filter_input(INPUT_POST, 'description')
+                );
+                // `sites`.`siteName` is UNIQUE, and save() builds an
+                // INSERT ... ON DUPLICATE KEY UPDATE -- so without this
+                // check creating a site with an existing name silently
+                // OVERWRITES that site instead of failing.
+                $exists = self::getClass('SiteManager')
+                    ->exists($site);
+                if ($exists) {
+                    throw new \Exception(
+                        _('A site already exists with this name!')
+                    );
+                }
+                $Site = self::getClass('Site')
+                    ->set('name', $site)
+                    ->set('description', $description);
+                if (!$Site->save()) {
+                    $serverFault = true;
+                    throw new \Exception(_('Add site failed!'));
+                }
+                return $Site;
+            }
+        );
+    }
+    /**
+     * Displays the site general tab.
+     *
+     * @return void
+     */
+    public function siteGeneral()
+    {
+        $site = (
+            filter_input(INPUT_POST, 'site') ?:
+            $this->obj->get('name')
+        );
+        $description = (
+            filter_input(INPUT_POST, 'description') ?:
+            $this->obj->get('description')
+        );
+
+        $labelClass = 'col-sm-3 col-form-label';
+
+        $fields = [
+            self::makeLabel(
+                $labelClass,
+                'site',
+                _('Site Name')
+            ) => self::makeInput(
+                'form-control sitename-input',
+                'site',
+                _('Site Name'),
+                'text',
+                'site',
+                $site,
+                true
+            ),
+            self::makeLabel(
+                $labelClass,
+                'description',
+                _('Site Description')
+            ) => self::makeTextarea(
+                'form-control sitedescription-input',
+                'description',
+                _('Site Description'),
+                'description',
+                $description
+            ),
+            // A checkbox rather than a button, because the flag has two
+            // directions and a button only has one. Safe here despite
+            // save() dropping null-valued fields -- makeCatchAll() writes
+            // the column in SQL and never goes through save().
+            self::makeLabel(
+                $labelClass,
+                'catchall',
+                _('Catch-All Site')
+            ) => self::makeInput(
+                'catchall-input',
+                'catchall',
+                '',
+                'checkbox',
+                'catchall',
+                '',
+                false,
+                false,
+                -1,
+                -1,
+                $this->obj->isCatchAll() ? 'checked' : ''
+            )
+        ];
+
+        $buttons = self::makeButton(
+            'general-send',
+            _('Update'),
+            'btn btn-primary float-end'
+        );
+        $buttons .= self::makeButton(
+            'general-delete',
+            _('Delete'),
+            'btn btn-danger float-start'
+        );
+
+        self::$HookManager->processEvent(
+            'SITE_GENERAL_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'Site' => &$this->obj
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            '',
+            'site-general-form',
+            self::makeTabUpdateURL(
+                'site-general',
+                $this->obj->get('id')
+            ),
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="card">';
+        echo '<div class="card-body">';
+        if ($this->obj->isCatchAll()) {
+            // Said plainly, because the consequence is invisible from the
+            // member lists: this site's members are not what grants access,
+            // the flag is.
+            echo '<div class="alert alert-info">'
+                . _(
+                    'This is the catch-all site. Its members are in scope '
+                    . 'for everything, including hosts registered after '
+                    . 'they joined.'
+                )
+                . '</div>';
+        }
+        echo $rendered;
+        echo '</div>';
+        echo '<div class="card-footer">';
+        echo $buttons;
+        echo $this->deleteModal();
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+    }
+    /**
+     * Site general post element.
+     *
+     * @return void
+     */
+    public function siteGeneralPost()
+    {
+        self::checkAuthAndCSRF();
+        $site = trim(
+            filter_input(INPUT_POST, 'site')
+        );
+        $description = trim(
+            filter_input(INPUT_POST, 'description')
+        );
+
+        // Same silent-overwrite guard as addPost(); a rename onto an
+        // existing name would take that site's row with it.
+        $exists = self::getClass('SiteManager')
+            ->exists($site);
+        if ($site != $this->obj->get('name')
+            && $exists
+        ) {
+            throw new \Exception(_('A site already exists with this name!'));
+        }
+
+        $this->obj
+            ->set('name', $site)
+            ->set('description', $description);
+
+        // Set through the model, which clears the incumbent in the same
+        // transaction. Applied here rather than left to the save() below
+        // because save() drops null-valued fields -- unticking the box
+        // would otherwise report success and change nothing.
+        //
+        // Only written when it actually changed: makeCatchAll(true) on the
+        // site that already holds the flag would clear every OTHER site's
+        // and rewrite its own for no reason, and an unticked box on a site
+        // that was never the catch-all would run an UPDATE per save.
+        $wanted = (bool)filter_input(INPUT_POST, 'catchall');
+        if ($wanted !== $this->obj->isCatchAll()) {
+            $this->obj->makeCatchAll($wanted);
+        }
+    }
+    /**
+     * Presents the hosts list.
+     *
+     * @return void
+     */
+    public function siteHosts()
+    {
+        $this->renderAssocTab(
+            'site-host',
+            _('Site Host Associations'),
+            _('Host Name'),
+            'host',
+            'btn btn-primary float-end',
+            '',
+            'host'
+        );
+    }
+    /**
+     * Updates site hosts.
+     *
+     * @return void
+     */
+    public function siteHostPost()
+    {
+        $this->assocPost('addHost', 'removeHost');
+    }
+    /**
+     * Presents the users list.
+     *
+     * @return void
+     */
+    public function siteUsers()
+    {
+        $this->renderAssocTab(
+            'site-user',
+            _('Site User Associations'),
+            _('User Name'),
+            'user',
+            'btn btn-primary float-end',
+            '',
+            'user'
+        );
+    }
+    /**
+     * Updates site users.
+     *
+     * @return void
+     */
+    public function siteUserPost()
+    {
+        $this->assocPost('addUser', 'removeUser');
+    }
+    /**
+     * Presents the groups list.
+     *
+     * @return void
+     */
+    public function siteGroups()
+    {
+        $this->renderAssocTab(
+            'site-group',
+            _('Site Group Associations'),
+            _('Group Name'),
+            'group',
+            'btn btn-primary float-end',
+            '',
+            'group'
+        );
+    }
+    /**
+     * Updates site groups.
+     *
+     * @return void
+     */
+    public function siteGroupPost()
+    {
+        $this->assocPost('addGroup', 'removeGroup');
+    }
+    /**
+     * Presents the user groups list.
+     *
+     * @return void
+     */
+    public function siteUserGroups()
+    {
+        $this->renderAssocTab(
+            'site-usergroup',
+            _('Site User Group Associations'),
+            _('User Group Name'),
+            'usergroup',
+            'btn btn-primary float-end',
+            '',
+            'usergroup',
+            _('User Group')
+        );
+    }
+    /**
+     * Updates site user groups.
+     *
+     * @return void
+     */
+    public function siteUserGroupPost()
+    {
+        $this->assocPost('addUserGroup', 'removeUserGroup');
+    }
+    /**
+     * Edit existing item.
+     *
+     * @return void
+     */
+    public function edit()
+    {
+        $tabData = [];
+
+        $tabData[] = [
+            'name' => _('General'),
+            'id' => 'site-general',
+            'generator' => function () {
+                $this->siteGeneral();
+            }
+        ];
+
+        $tabData[] = [
+            'tabs' => [
+                'name' => _('Associations'),
+                'tabData' => [
+                    [
+                        'name' => _('Host Association'),
+                        'id' => 'site-host',
+                        'generator' => function () {
+                            $this->siteHosts();
+                        }
+                    ],
+                    [
+                        'name' => _('User Association'),
+                        'id' => 'site-user',
+                        'generator' => function () {
+                            $this->siteUsers();
+                        }
+                    ],
+                    [
+                        'name' => _('Group Association'),
+                        'id' => 'site-group',
+                        'generator' => function () {
+                            $this->siteGroups();
+                        }
+                    ],
+                    [
+                        'name' => _('User Group Association'),
+                        'id' => 'site-usergroup',
+                        'generator' => function () {
+                            $this->siteUserGroups();
+                        }
+                    ]
+                ]
+            ]
+        ];
+        $this->renderEditTabs($tabData, $this->obj);
+    }
+    /**
+     * Edit post.
+     *
+     * @return void
+     */
+    public function editPost()
+    {
+        $this->handleEditPost(
+            'Site',
+            'SITE_EDIT',
+            _('Site updated!'),
+            _('Site Update Success'),
+            _('Site Update Fail'),
+            function (&$serverFault) {
+                global $tab;
+                switch ($tab) {
+                    case 'site-general':
+                        $this->siteGeneralPost();
+                        break;
+                    case 'site-host':
+                        $this->siteHostPost();
+                        break;
+                    case 'site-user':
+                        $this->siteUserPost();
+                        break;
+                    case 'site-group':
+                        $this->siteGroupPost();
+                        break;
+                    case 'site-usergroup':
+                        $this->siteUserGroupPost();
+                }
+                if (!$this->obj->save()) {
+                    $serverFault = true;
+                    throw new \Exception(_('Site update failed!'));
+                }
+            }
+        );
+    }
+    /**
+     * Gets the host list.
+     *
+     * @return void
+     */
+    public function getHostsList()
+    {
+        return $this->assocItemsList(
+            'host',
+            'sitehostmember',
+            'siteHostMembers',
+            '`hosts`.`hostID`',
+            '`siteHostMembers`.`shmHostID`',
+            '`siteHostMembers`.`shmSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+    /**
+     * Gets the user list.
+     *
+     * @return void
+     */
+    public function getUsersList()
+    {
+        return $this->assocItemsList(
+            'user',
+            'siteusermember',
+            'siteUserMembers',
+            '`users`.`uID`',
+            '`siteUserMembers`.`sumUserID`',
+            '`siteUserMembers`.`sumSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+    /**
+     * Gets the group list.
+     *
+     * @return void
+     */
+    public function getGroupsList()
+    {
+        return $this->assocItemsList(
+            'group',
+            'sitegroupmember',
+            'siteGroupMembers',
+            '`groups`.`groupID`',
+            '`siteGroupMembers`.`sgmGroupID`',
+            '`siteGroupMembers`.`sgmSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+    /**
+     * Gets the user group list.
+     *
+     * @return void
+     */
+    public function getUserGroupsList()
+    {
+        return $this->assocItemsList(
+            'usergroup',
+            'siteusergroupmember',
+            'siteUserGroupMembers',
+            '`userGroups`.`ugID`',
+            '`siteUserGroupMembers`.`sugmUserGroupID`',
+            '`siteUserGroupMembers`.`sugmSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+}

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1631,6 +1631,37 @@ class Route extends FOGBase
                         'removeFromQuery' => true
                     ];
                     break;
+                case 'site':
+                    // The four member counts Site::$sqlQueryStr computes.
+                    // removeFromQuery because they are aggregates of the
+                    // JOINs, not columns of `sites` -- selecting them again
+                    // by name would be an unknown-column error.
+                    //
+                    // The dt names are the plugin's, unchanged: they are
+                    // the DataTables field names fog.site.list.js binds to,
+                    // and a tidier spelling here would leave every column
+                    // rendering empty with nothing to say why.
+                    $columns[] = [
+                        'db' => 'shmMembers',
+                        'dt' => 'hostcount',
+                        'removeFromQuery' => true
+                    ];
+                    $columns[] = [
+                        'db' => 'sumMembers',
+                        'dt' => 'usercount',
+                        'removeFromQuery' => true
+                    ];
+                    $columns[] = [
+                        'db' => 'sgmMembers',
+                        'dt' => 'groupcount',
+                        'removeFromQuery' => true
+                    ];
+                    $columns[] = [
+                        'db' => 'sugmMembers',
+                        'dt' => 'usergroupcount',
+                        'removeFromQuery' => true
+                    ];
+                    break;
                 case 'inventory':
                     $columns[] = ['db' => 'hostName', 'dt' => 'hostname'];
                     $columns[] = [

--- a/packages/web/management/js/fog/site/fog.site.add.js
+++ b/packages/web/management/js/fog/site/fog.site.add.js
@@ -1,0 +1,3 @@
+(function($) {
+    $('#site-create-form').wireCreateForm();
+})(jQuery);

--- a/packages/web/management/js/fog/site/fog.site.edit.js
+++ b/packages/web/management/js/fog/site/fog.site.edit.js
@@ -1,0 +1,56 @@
+$(function() {
+    // ---------------------------------------------------------------
+    // GENERAL TAB
+    $.registerGeneralTab({
+        nameInputSel: '#site',
+        formSel: '#site-general-form'
+    });
+    // ---------------------------------------------------------------
+    // HOST ASSOCIATION TAB
+    var siteHostsTable = $.registerAssociationTab({
+        slug: 'site-host',
+        item: 'host',
+        sub: 'getHostsList'
+    });
+
+    // ---------------------------------------------------------------
+    // USER ASSOCIATION TAB
+    var siteUsersTable = $.registerAssociationTab({
+        slug: 'site-user',
+        item: 'user',
+        sub: 'getUsersList'
+    });
+
+    // ---------------------------------------------------------------
+    // GROUP ASSOCIATION TAB
+    var siteGroupsTable = $.registerAssociationTab({
+        slug: 'site-group',
+        item: 'group',
+        sub: 'getGroupsList'
+    });
+
+    // ---------------------------------------------------------------
+    // USER GROUP ASSOCIATION TAB
+    var siteUserGroupsTable = $.registerAssociationTab({
+        slug: 'site-usergroup',
+        item: 'usergroup',
+        sub: 'getUserGroupsList'
+    });
+
+    // ---------------------------------------------------------------
+    // CREATE AND ASSOCIATE
+    // Each association tab can create the thing it associates without
+    // leaving the page. These are grid tabs, so the modal posts additems[]
+    // straight back through the tab's own table.
+    $.registerCreateAndAssociate('site-host', siteHostsTable);
+    $.registerCreateAndAssociate('site-user', siteUsersTable);
+    $.registerCreateAndAssociate('site-group', siteGroupsTable);
+    $.registerCreateAndAssociate('site-usergroup', siteUserGroupsTable);
+
+    if (Common.search && Common.search.length > 0) {
+        siteHostsTable.search(Common.search).draw();
+        siteUsersTable.search(Common.search).draw();
+        siteGroupsTable.search(Common.search).draw();
+        siteUserGroupsTable.search(Common.search).draw();
+    }
+});

--- a/packages/web/management/js/fog/site/fog.site.list.js
+++ b/packages/web/management/js/fog/site/fog.site.list.js
@@ -1,0 +1,37 @@
+(function($) {
+    $.registerListPage({
+        order: [
+            [0, 'asc']
+        ],
+        columns: [
+            {data: 'mainlink'},
+            {data: 'hostcount'},
+            {data: 'usercount'},
+            {data: 'groupcount'},
+            {data: 'usergroupcount'}
+        ],
+        rowId: 'id',
+        columnDefs: [
+            {
+                responsivePriority: -1,
+                targets: 0
+            },
+            {
+                responsivePriority: 0,
+                targets: 1
+            },
+            {
+                responsivePriority: 0,
+                targets: 2
+            },
+            {
+                responsivePriority: 0,
+                targets: 3
+            },
+            {
+                responsivePriority: 0,
+                targets: 4
+            }
+        ]
+    });
+})(jQuery);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -291,6 +291,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 
@@ -562,6 +566,10 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Ausgewählte Speichergruppen hinzufügen"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1199,6 +1207,9 @@ msgstr "Seriennummer"
 msgid "Case Version"
 msgstr "Neueste Version"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1572,6 +1583,10 @@ msgstr "Neuen Schlüssel erstellen"
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
+
+#, fuzzy
+msgid "Create New Site"
+msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
 msgid "Create New Snapin"
@@ -2697,11 +2712,19 @@ msgid "Group"
 msgstr "Gruppe"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "Gruppen-Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "Gruppen-Snapins"
 
 #, fuzzy
@@ -3003,6 +3026,10 @@ msgstr "zugeordneter Host"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Host-EFI-Exit-Typ"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Host Init"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6449,6 +6476,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "Drucker erstellen fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Site Beschreibung"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "zugeordneter Host"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Speicherverwaltung"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Sitename"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Drucker hinzugefügt"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "Sites"
+
+#, fuzzy
 msgid "Size"
 msgstr "Größe"
 
@@ -7548,6 +7635,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8077,6 +8167,10 @@ msgid "User Cleanup"
 msgstr "Benutzer-Bereinigung"
 
 #, fuzzy
+msgid "User Count"
+msgstr "CPU-Anzahl"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "Benutzer erstellen fehlgeschlagen"
 
@@ -8099,6 +8193,10 @@ msgstr "Speicherknoten erstellt"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "Gruppen-Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9245,10 +9343,6 @@ msgstr ""
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
@@ -9352,10 +9446,6 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Admingruppe"
 
@@ -9393,10 +9483,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Create New Rule"
 #~ msgstr "Neuen Schlüssel erstellen"
-
-#, fuzzy
-#~ msgid "Create New Site"
-#~ msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
 #~ msgid "Create and associate"
@@ -9469,14 +9555,6 @@ msgstr ""
 #~ msgstr "Neustarten"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "Gruppen-Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
 
@@ -9506,10 +9584,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "zugeordneter Host"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9754,66 +9828,6 @@ msgstr ""
 #~ msgstr "Site Zugehörigkeit"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "Drucker erstellen fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Drucker hinzufügen erfolgreich."
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Site Beschreibung"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "zugeordneter Host"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Speicherverwaltung"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Sitename"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Drucker aktualisiert!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "Sites"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin erstellt"
 
@@ -9874,14 +9888,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "CPU-Anzahl"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "Gruppen-Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -296,6 +296,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "An image already exists with this name!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "An image already exists with this name!"
 
@@ -566,6 +570,10 @@ msgstr "Remove selected printers"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Remove selected snapins"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Add snapin failed!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1203,6 +1211,9 @@ msgstr "System Serial"
 msgid "Case Version"
 msgstr "Latest Version"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1574,6 +1585,10 @@ msgstr "Create New %s"
 
 #, fuzzy
 msgid "Create New Scheduled"
+msgstr "Create New %s"
+
+#, fuzzy
+msgid "Create New Site"
 msgstr "Create New %s"
 
 #, fuzzy
@@ -2699,11 +2714,19 @@ msgid "Group"
 msgstr "Group"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Storage Node Created"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Storage Node Created"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "Export Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "Export Snapins"
 
 #, fuzzy
@@ -3005,6 +3028,10 @@ msgstr "No node associated"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Host EFI Exit Type"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Host List"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6449,6 +6476,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "Printer update failed!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Printer already exists"
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Printer Description"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Storage Node Created"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "No node associated"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Storage Management"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Printer Name"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "Printer update failed!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Install / Update Successful!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Image Association"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Storage Node Created"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Printer Name"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "Printer update failed!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Printer updated!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "minutes"
+
+#, fuzzy
 msgid "Size"
 msgstr "Max Size"
 
@@ -7545,6 +7632,9 @@ msgstr " | This is not the primary group"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8075,6 +8165,10 @@ msgid "User Cleanup"
 msgstr "User Cleanup"
 
 #, fuzzy
+msgid "User Count"
+msgstr "CPU Count"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "User created"
 
@@ -8097,6 +8191,10 @@ msgstr "Storage Node Created"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Storage Node Created"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "Export Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9239,10 +9337,6 @@ msgstr ""
 #~ msgstr "An image already exists with this name!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "An image already exists with this name!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "An image already exists with this name!"
 
@@ -9343,10 +9437,6 @@ msgstr ""
 #~ msgstr "Add snapin failed!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Add snapin failed!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Modify Group"
 
@@ -9383,10 +9473,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Create New Rule"
-#~ msgstr "Create New %s"
-
-#, fuzzy
-#~ msgid "Create New Site"
 #~ msgstr "Create New %s"
 
 #, fuzzy
@@ -9460,14 +9546,6 @@ msgstr ""
 #~ msgstr "Reboot"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Storage Node Created"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "Export Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Location"
 
@@ -9494,10 +9572,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No node associated"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Host List"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9734,66 +9808,6 @@ msgstr ""
 #~ msgstr "Image Association"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "Printer update failed!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Printer already exists"
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Printer Description"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Storage Node Created"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "No node associated"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Storage Management"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Printer Name"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "Printer update failed!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Install / Update Successful!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Image Association"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Storage Node Created"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Printer Name"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "Printer update failed!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Printer updated!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "minutes"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin updated"
 
@@ -9854,14 +9868,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Update Printer"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "CPU Count"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "Export Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -293,6 +293,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Una imagen ya existe con este nombre!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
@@ -576,6 +580,10 @@ msgstr "Impresora"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Impresora"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1219,6 +1227,9 @@ msgstr "sistema de serie"
 msgid "Case Version"
 msgstr "Versión del sistema"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1594,6 +1605,10 @@ msgstr "Crear nuevo grupo"
 
 #, fuzzy
 msgid "Create New Scheduled"
+msgstr "Crear nuevo grupo"
+
+#, fuzzy
+msgid "Create New Site"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
@@ -2755,11 +2770,19 @@ msgid "Group"
 msgstr "Grupo"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "nodo de almacenamiento"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "nodo de almacenamiento"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "snapins"
 
 #, fuzzy
@@ -3064,6 +3087,10 @@ msgstr "No nodo asociado"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Grupo EFI Tipo de salida"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "ID de host"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6605,6 +6632,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Impresora ya existe"
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Descripción de la impresora"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "nodo de almacenamiento"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "No nodo asociado"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Gestión de usuarios"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Nombre de la impresora"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Asociación para la imagen"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "nodo de almacenamiento"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Nombre de la impresora"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Impresora actualiza!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "minutos"
+
+#, fuzzy
 msgid "Size"
 msgstr "Tamaño máximo:"
 
@@ -7734,6 +7821,9 @@ msgstr ""
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8260,6 +8350,10 @@ msgid "User Cleanup"
 msgstr ""
 
 #, fuzzy
+msgid "User Count"
+msgstr "Contador de la CPU"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "creado por el usuario"
 
@@ -8282,6 +8376,10 @@ msgstr "nodo de almacenamiento"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "nodo de almacenamiento"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9425,10 +9523,6 @@ msgstr ""
 #~ msgstr "Una imagen ya existe con este nombre!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Una imagen ya existe con este nombre!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Una imagen ya existe con este nombre!"
 
@@ -9529,10 +9623,6 @@ msgstr ""
 #~ msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Añadir fallidos SNAPin!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "modificar Grupo"
 
@@ -9570,10 +9660,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Create New Rule"
-#~ msgstr "Crear nuevo grupo"
-
-#, fuzzy
-#~ msgid "Create New Site"
 #~ msgstr "Crear nuevo grupo"
 
 #, fuzzy
@@ -9649,14 +9735,6 @@ msgstr ""
 #~ msgstr "Reiniciar"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "nodo de almacenamiento"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Lista de host"
 
@@ -9683,10 +9761,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No nodo asociado"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "ID de host"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9918,66 +9992,6 @@ msgstr ""
 #~ msgstr "Asociación para la imagen"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Impresora ya existe"
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Descripción de la impresora"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "nodo de almacenamiento"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "No nodo asociado"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Gestión de usuarios"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Nombre de la impresora"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "actualización Valoración falló"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Asociación para la imagen"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "nodo de almacenamiento"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Nombre de la impresora"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Impresora actualiza!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "minutos"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Nombre snapin"
 
@@ -10038,14 +10052,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Eliminar todos los elementos seleccionados"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "Contador de la CPU"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -291,6 +291,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 
@@ -562,6 +566,10 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Ausgewählte Speichergruppen hinzufügen"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1199,6 +1207,9 @@ msgstr "Seriennummer"
 msgid "Case Version"
 msgstr "Neueste Version"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1572,6 +1583,10 @@ msgstr "Neuen Schlüssel erstellen"
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
+
+#, fuzzy
+msgid "Create New Site"
+msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
 msgid "Create New Snapin"
@@ -2697,11 +2712,19 @@ msgid "Group"
 msgstr "Gruppe"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Speicherknoten erstellt"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "Gruppen-Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "Gruppen-Snapins"
 
 #, fuzzy
@@ -3003,6 +3026,10 @@ msgstr "zugeordneter Host"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Host-EFI-Exit-Typ"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Host Init"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6450,6 +6477,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "Drucker erstellen fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Site Beschreibung"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "zugeordneter Host"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Speicherverwaltung"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Sitename"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Drucker hinzugefügt"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Drucker aktualisiert!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "Sites"
+
+#, fuzzy
 msgid "Size"
 msgstr "Größe"
 
@@ -7549,6 +7636,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8078,6 +8168,10 @@ msgid "User Cleanup"
 msgstr "Benutzer-Bereinigung"
 
 #, fuzzy
+msgid "User Count"
+msgstr "CPU-Anzahl"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "Benutzer erstellen fehlgeschlagen"
 
@@ -8100,6 +8194,10 @@ msgstr "Speicherknoten erstellt"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "Gruppen-Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9246,10 +9344,6 @@ msgstr ""
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
@@ -9353,10 +9447,6 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Admingruppe"
 
@@ -9394,10 +9484,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Create New Rule"
 #~ msgstr "Neuen Schlüssel erstellen"
-
-#, fuzzy
-#~ msgid "Create New Site"
-#~ msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
 #~ msgid "Create and associate"
@@ -9470,14 +9556,6 @@ msgstr ""
 #~ msgstr "Neustarten"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "Gruppen-Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
 
@@ -9507,10 +9585,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "zugeordneter Host"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9755,66 +9829,6 @@ msgstr ""
 #~ msgstr "Site Zugehörigkeit"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "Drucker erstellen fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Drucker hinzufügen erfolgreich."
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Site Beschreibung"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "zugeordneter Host"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Speicherverwaltung"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Sitename"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Site Zugehörigkeit"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Speicherknoten erstellt"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Drucker hinzugefügt"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Drucker aktualisiert!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "Sites"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin erstellt"
 
@@ -9875,14 +9889,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "CPU-Anzahl"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "Gruppen-Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -297,6 +297,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Une image existe déjà avec ce nom!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
@@ -567,6 +571,10 @@ msgstr "Imprimante"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Imprimante"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1204,6 +1212,9 @@ msgstr "Serial System"
 msgid "Case Version"
 msgstr "Dernière version"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1576,6 +1587,10 @@ msgstr "Créer un nouveau %s"
 
 #, fuzzy
 msgid "Create New Scheduled"
+msgstr "Créer un nouveau %s"
+
+#, fuzzy
+msgid "Create New Site"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
@@ -2701,11 +2716,19 @@ msgid "Group"
 msgstr "Groupe"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Nœud de stockage Créé"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Nœud de stockage Créé"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "Export SnapIns"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "Export SnapIns"
 
 #, fuzzy
@@ -3007,6 +3030,10 @@ msgstr "Aucun noeud associé"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Hôte EFI Type de sortie"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Liste des hôtes"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6451,6 +6478,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Imprimante existe déjà"
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Printer description"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "Aucun noeud associé"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Gestion du stockage"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Nom de l'imprimante"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Association Image"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Nom de l'imprimante"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Imprimante mis à jour!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "minutes"
+
+#, fuzzy
 msgid "Size"
 msgstr "Max Taille"
 
@@ -7547,6 +7634,9 @@ msgstr " | Cela ne veut pas le groupe principal"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8077,6 +8167,10 @@ msgid "User Cleanup"
 msgstr "Nettoyage de l'utilisateur"
 
 #, fuzzy
+msgid "User Count"
+msgstr "Nombre de CPU"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "utilisateur créé"
 
@@ -8099,6 +8193,10 @@ msgstr "Nœud de stockage Créé"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "Export SnapIns"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9241,10 +9339,6 @@ msgstr ""
 #~ msgstr "Une image existe déjà avec ce nom!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Une image existe déjà avec ce nom!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Une image existe déjà avec ce nom!"
 
@@ -9345,10 +9439,6 @@ msgstr ""
 #~ msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Ajouter SnapIn a échoué!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "Modifier Groupe"
 
@@ -9385,10 +9475,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Create New Rule"
-#~ msgstr "Créer un nouveau %s"
-
-#, fuzzy
-#~ msgid "Create New Site"
 #~ msgstr "Créer un nouveau %s"
 
 #, fuzzy
@@ -9462,14 +9548,6 @@ msgstr ""
 #~ msgstr "Réinitialiser"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Nœud de stockage Créé"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "Export SnapIns"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "hôte Lieu"
 
@@ -9496,10 +9574,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "Aucun noeud associé"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Liste des hôtes"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9740,66 +9814,6 @@ msgstr ""
 #~ msgstr "Association Image"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Imprimante existe déjà"
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Printer description"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Nœud de stockage Créé"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "Aucun noeud associé"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Gestion du stockage"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Nom de l'imprimante"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Association Image"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Nœud de stockage Créé"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Nom de l'imprimante"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Imprimante mis à jour!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "minutes"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "snapin mise à jour"
 
@@ -9860,14 +9874,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Supprimer les imprimantes sélectionnées"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "Nombre de CPU"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "Export SnapIns"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -286,6 +286,10 @@ msgstr "non è più in esecuzione"
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
+#, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Un host già esiste con questo nome!"
+
 msgid "A snapin already exists with this name!"
 msgstr "Esiste già un snapin con questo nome!"
 
@@ -544,6 +548,10 @@ msgstr "Aggiungi stampanti selezionate"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Aggiungi gruppo di archiviazione selezionato"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Aggiunta host non riuscita!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1159,6 +1167,9 @@ msgstr "Sistema seriale"
 msgid "Case Version"
 msgstr "Ultima versione"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1515,6 +1526,10 @@ msgstr "Crea nuovo %s"
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Crea nuovo %s"
+
+#, fuzzy
+msgid "Create New Site"
+msgstr "Crea nuova stampante"
 
 #, fuzzy
 msgid "Create New Snapin"
@@ -2612,11 +2627,19 @@ msgid "Group"
 msgstr "Gruppo"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Storage Node Creato"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Storage Node Creato"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "Gruppo Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "Gruppo Snapins"
 
 msgid "Group Create Fail"
@@ -2909,6 +2932,10 @@ msgstr "Host associato"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Host EFI Tipo Exit"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Host Init"
 
 msgid "Host Create Fail"
 msgstr "Creazione Host fallita"
@@ -6215,6 +6242,63 @@ msgstr ""
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
+#, fuzzy
+msgid "Site Create Fail"
+msgstr "Creazione stampante fallita"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Creazione stampante riuscita"
+
+msgid "Site Description"
+msgstr "Descrizione Sito"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Storage Node Creato"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "Host associato"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Storage Management"
+
+msgid "Site Name"
+msgstr "Nome sito"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "Aggiornamento della stampante non riuscito"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Aggiornamento host completato!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Associazione Sito"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Storage Node Creato"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Stampante aggiunta"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "Aggiornamento della stampante non è riuscito!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "aggiornato stampante!"
+
+msgid "Sites"
+msgstr "Siti"
+
 msgid "Size"
 msgstr "Dimensione"
 
@@ -7257,6 +7341,9 @@ msgstr "Questo non è il gruppo primario"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -7773,6 +7860,10 @@ msgstr "Associazione Sito"
 msgid "User Cleanup"
 msgstr "Cleanup utente"
 
+#, fuzzy
+msgid "User Count"
+msgstr "Conte CPU"
+
 msgid "User Create Fail"
 msgstr "Creazione utente fallita"
 
@@ -7793,6 +7884,10 @@ msgstr "Storage Node Creato"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Storage Node Creato"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "Gruppo Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -8870,10 +8965,6 @@ msgstr ""
 #~ msgstr "Esiste già un ruolo con questo nome!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Un host già esiste con questo nome!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Esiste già un ruolo con questo nome!"
 
@@ -8973,10 +9064,6 @@ msgstr ""
 #~ msgid "Add rule failed!"
 #~ msgstr "Aggiunta utente fallita!"
 
-#, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Aggiunta host non riuscita!"
-
 #~ msgid "Admin Group"
 #~ msgstr "Gruppo amministrativo"
 
@@ -9014,10 +9101,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Create New Rule"
 #~ msgstr "Crea nuovo %s"
-
-#, fuzzy
-#~ msgid "Create New Site"
-#~ msgstr "Crea nuova stampante"
 
 #, fuzzy
 #~ msgid "Create and associate"
@@ -9089,14 +9172,6 @@ msgstr ""
 #~ msgstr "Riavvio"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Storage Node Creato"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "Gruppo Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Luoghi"
 
@@ -9124,10 +9199,6 @@ msgstr ""
 
 #~ msgid "Host Associated"
 #~ msgstr "Host associato"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Host Init"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9361,63 +9432,6 @@ msgstr ""
 #~ msgid "Site Association"
 #~ msgstr "Associazione Sito"
 
-#, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "Creazione stampante fallita"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Creazione stampante riuscita"
-
-#~ msgid "Site Description"
-#~ msgstr "Descrizione Sito"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Storage Node Creato"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "Host associato"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Storage Management"
-
-#~ msgid "Site Name"
-#~ msgstr "Nome sito"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "Aggiornamento della stampante non riuscito"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Aggiornamento host completato!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Associazione Sito"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Storage Node Creato"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Stampante aggiunta"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "Aggiornamento della stampante non è riuscito!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "aggiornato stampante!"
-
-#~ msgid "Sites"
-#~ msgstr "Siti"
-
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin creato"
 
@@ -9473,14 +9487,6 @@ msgstr ""
 
 #~ msgid "Update/Remove printers"
 #~ msgstr "Aggiorna/Rimuovi stampanti"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "Conte CPU"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "Gruppo Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -274,6 +274,9 @@ msgstr "選択したプリンターを追加"
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
+msgid "A site already exists with this name!"
+msgstr "この名前のサイトは既に存在します！"
+
 msgid "A snapin already exists with this name!"
 msgstr "この名前のスナップインは既に存在します！"
 
@@ -529,6 +532,9 @@ msgstr "選択したホストを追加"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "選択したストレージグループを追加"
+
+msgid "Add site failed!"
+msgstr "サイトの追加に失敗しました！"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1142,6 +1148,10 @@ msgstr "シャーシシリアル"
 msgid "Case Version"
 msgstr "シャーシバージョン"
 
+#, fuzzy
+msgid "Catch-All Site"
+msgstr "サイトを作成"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1497,6 +1507,10 @@ msgstr "新しいキーを作成"
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "新しい電源管理スケジュールを作成"
+
+#, fuzzy
+msgid "Create New Site"
+msgstr "新しいプリンターを作成"
 
 msgid "Create New Snapin"
 msgstr "新しいスナップインを作成"
@@ -2584,12 +2598,20 @@ msgstr "Green FOG"
 msgid "Group"
 msgstr "グループ"
 
+#, fuzzy
+msgid "Group Association"
+msgstr "グループの関連付け"
+
 msgid "Group Associations"
 msgstr "グループの関連付け"
 
 #, fuzzy
 msgid "Group BIOS Exit"
 msgstr "グループ EFI 終了方法"
+
+#, fuzzy
+msgid "Group Count"
+msgstr "グループ自動ログアウト"
 
 msgid "Group Create Fail"
 msgstr "グループの作成に失敗しました"
@@ -2880,6 +2902,10 @@ msgstr "関連付けられたホスト"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "ホスト EFI 終了方法"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "ホスト Init"
 
 msgid "Host Create Fail"
 msgstr "ホストの作成に失敗しました"
@@ -6159,6 +6185,57 @@ msgstr ""
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
+msgid "Site Create Fail"
+msgstr "サイトの作成に失敗しました"
+
+msgid "Site Create Success"
+msgstr "サイトを作成しました"
+
+msgid "Site Description"
+msgstr "サイトの説明"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "グループの関連付け"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "サイトの関連付け"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "ストレージ管理"
+
+msgid "Site Name"
+msgstr "サイト名"
+
+msgid "Site Update Fail"
+msgstr "サイトの更新に失敗しました"
+
+msgid "Site Update Success"
+msgstr "サイトを更新しました"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "サイトの関連付け"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "グループの関連付け"
+
+msgid "Site added!"
+msgstr "サイトを追加しました！"
+
+msgid "Site update failed!"
+msgstr "サイトの更新に失敗しました！"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "サイトを更新しました！"
+
+msgid "Sites"
+msgstr "サイト"
+
 msgid "Size"
 msgstr "サイズ"
 
@@ -7192,6 +7269,9 @@ msgstr "これはプライマリグループではありません"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -7709,6 +7789,10 @@ msgstr "ルールの関連付け"
 msgid "User Cleanup"
 msgstr "ユーザークリーンアップ"
 
+#, fuzzy
+msgid "User Count"
+msgstr "CPU 数"
+
 msgid "User Create Fail"
 msgstr "ユーザーの作成に失敗しました"
 
@@ -7729,6 +7813,10 @@ msgstr "グループの関連付け"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "グループの関連付け"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "グループ自動ログアウト"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -8830,9 +8918,6 @@ msgstr ""
 #~ msgid "A rule already exists with this name"
 #~ msgstr "この名前のルールは既に存在します"
 
-#~ msgid "A site already exists with this name!"
-#~ msgstr "この名前のサイトは既に存在します！"
-
 #~ msgid "A snapin name is required!"
 #~ msgstr "スナップイン名は必須です！"
 
@@ -8934,9 +9019,6 @@ msgstr ""
 
 #~ msgid "Add selected users"
 #~ msgstr "選択したユーザーを追加"
-
-#~ msgid "Add site failed!"
-#~ msgstr "サイトの追加に失敗しました！"
 
 #~ msgid "Additional MACs"
 #~ msgstr "追加の MAC アドレス"
@@ -9116,10 +9198,6 @@ msgstr ""
 #~ msgid "Create New Access Control Role"
 #~ msgstr "新しいアクセス制御ロールを作成"
 
-#, fuzzy
-#~ msgid "Create New Site"
-#~ msgstr "新しいプリンターを作成"
-
 #~ msgid "Create New iPXE Menu Entry"
 #~ msgstr "新しい iPXE メニューエントリを作成"
 
@@ -9128,9 +9206,6 @@ msgstr ""
 
 #~ msgid "Create Rule?"
 #~ msgstr "ルールを作成しますか？"
-
-#~ msgid "Create Site"
-#~ msgstr "サイトを作成"
 
 #, fuzzy
 #~ msgid "Create and associate"
@@ -9465,16 +9540,8 @@ msgstr ""
 #~ msgid "Goto task list"
 #~ msgstr "タスク一覧へ移動"
 
-#, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "グループの関連付け"
-
 #~ msgid "Group Bios Exit Type"
 #~ msgstr "グループ BIOS 終了方法"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "グループ自動ログアウト"
 
 #~ msgid "Group FOG Client Module configuration"
 #~ msgstr "グループ FOG クライアントモジュール設定"
@@ -9564,10 +9631,6 @@ msgstr ""
 
 #~ msgid "Host Bios Exit Type"
 #~ msgstr "ホスト BIOS 終了方法"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "ホスト Init"
 
 #~ msgid "Host Desc"
 #~ msgstr "ホスト説明"
@@ -10505,59 +10568,8 @@ msgstr ""
 #~ msgid "Site Control Management"
 #~ msgstr "サイト制御管理"
 
-#~ msgid "Site Create Fail"
-#~ msgstr "サイトの作成に失敗しました"
-
-#~ msgid "Site Create Success"
-#~ msgstr "サイトを作成しました"
-
-#~ msgid "Site Description"
-#~ msgstr "サイトの説明"
-
 #~ msgid "Site General"
 #~ msgstr "サイト全般"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "グループの関連付け"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "サイトの関連付け"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "ストレージ管理"
-
-#~ msgid "Site Name"
-#~ msgstr "サイト名"
-
-#~ msgid "Site Update Fail"
-#~ msgstr "サイトの更新に失敗しました"
-
-#~ msgid "Site Update Success"
-#~ msgstr "サイトを更新しました"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "サイトの関連付け"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "グループの関連付け"
-
-#~ msgid "Site added!"
-#~ msgstr "サイトを追加しました！"
-
-#~ msgid "Site update failed!"
-#~ msgstr "サイトの更新に失敗しました！"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "サイトを更新しました！"
-
-#~ msgid "Sites"
-#~ msgstr "サイト"
 
 #~ msgid "Snapin Args"
 #~ msgstr "スナップイン引数"
@@ -10883,16 +10895,8 @@ msgstr ""
 #~ msgid "User Change Password"
 #~ msgstr "ユーザーパスワードを変更"
 
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "CPU 数"
-
 #~ msgid "User General"
 #~ msgstr "ユーザー全般"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "グループ自動ログアウト"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -244,6 +244,9 @@ msgstr ""
 msgid "A server URL and topic endpoint are required"
 msgstr ""
 
+msgid "A site already exists with this name!"
+msgstr ""
+
 msgid "A snapin already exists with this name!"
 msgstr ""
 
@@ -469,6 +472,9 @@ msgid "Add selected"
 msgstr ""
 
 msgid "Add selected to group"
+msgstr ""
+
+msgid "Add site failed!"
 msgstr ""
 
 msgid "Add slack account failed!"
@@ -1010,6 +1016,9 @@ msgstr ""
 msgid "Case Version"
 msgstr ""
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1323,6 +1332,9 @@ msgid "Create New Role"
 msgstr ""
 
 msgid "Create New Scheduled"
+msgstr ""
+
+msgid "Create New Site"
 msgstr ""
 
 msgid "Create New Snapin"
@@ -2295,10 +2307,16 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
+msgid "Group Association"
+msgstr ""
+
 msgid "Group Associations"
 msgstr ""
 
 msgid "Group BIOS Exit"
+msgstr ""
+
+msgid "Group Count"
 msgstr ""
 
 msgid "Group Create Fail"
@@ -2540,6 +2558,9 @@ msgid "Host Associations"
 msgstr ""
 
 msgid "Host BIOS Exit Type"
+msgstr ""
+
+msgid "Host Count"
 msgstr ""
 
 msgid "Host Create Fail"
@@ -5464,6 +5485,51 @@ msgstr ""
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
+msgid "Site Create Fail"
+msgstr ""
+
+msgid "Site Create Success"
+msgstr ""
+
+msgid "Site Description"
+msgstr ""
+
+msgid "Site Group Associations"
+msgstr ""
+
+msgid "Site Host Associations"
+msgstr ""
+
+msgid "Site Management"
+msgstr ""
+
+msgid "Site Name"
+msgstr ""
+
+msgid "Site Update Fail"
+msgstr ""
+
+msgid "Site Update Success"
+msgstr ""
+
+msgid "Site User Associations"
+msgstr ""
+
+msgid "Site User Group Associations"
+msgstr ""
+
+msgid "Site added!"
+msgstr ""
+
+msgid "Site update failed!"
+msgstr ""
+
+msgid "Site updated!"
+msgstr ""
+
+msgid "Sites"
+msgstr ""
+
 msgid "Size"
 msgstr ""
 
@@ -6398,6 +6464,9 @@ msgstr ""
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -6857,6 +6926,9 @@ msgstr ""
 msgid "User Cleanup"
 msgstr ""
 
+msgid "User Count"
+msgstr ""
+
 msgid "User Create Fail"
 msgstr ""
 
@@ -6873,6 +6945,9 @@ msgid "User Group Association"
 msgstr ""
 
 msgid "User Group Associations"
+msgstr ""
+
+msgid "User Group Count"
 msgstr ""
 
 msgid "User Group Create Fail"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -296,6 +296,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "Uma imagem já existe com este nome!"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
@@ -566,6 +570,10 @@ msgstr "Impressora"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "Impressora"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1203,6 +1211,9 @@ msgstr "Serial sistema"
 msgid "Case Version"
 msgstr "Última versão"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1575,6 +1586,10 @@ msgstr "Criar novo %s"
 
 #, fuzzy
 msgid "Create New Scheduled"
+msgstr "Criar novo %s"
+
+#, fuzzy
+msgid "Create New Site"
 msgstr "Criar novo %s"
 
 #, fuzzy
@@ -2700,11 +2715,19 @@ msgid "Group"
 msgstr "Grupo"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "Nó de Armazenamento Criado"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "exportação Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "exportação Snapins"
 
 #, fuzzy
@@ -3006,6 +3029,10 @@ msgstr "No nó associado"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "Hospedar EFI Tipo Exit"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "Lista de Host"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6450,6 +6477,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "Impressora já existe"
+
+#, fuzzy
+msgid "Site Description"
+msgstr "Descrição Printer"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "No nó associado"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "Gerenciamento de armazenamento"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "Nome da impressora"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "Associação imagem"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "Nome da impressora"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "Impressora atualizado!"
+
+#, fuzzy
+msgid "Sites"
+msgstr "minutos"
+
+#, fuzzy
 msgid "Size"
 msgstr "Max Size"
 
@@ -7546,6 +7633,9 @@ msgstr " | Este não é o grupo primário"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8076,6 +8166,10 @@ msgid "User Cleanup"
 msgstr "Limpeza de usuário"
 
 #, fuzzy
+msgid "User Count"
+msgstr "Contagem de CPU"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "usuário criado"
 
@@ -8098,6 +8192,10 @@ msgstr "Nó de Armazenamento Criado"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "exportação Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9240,10 +9338,6 @@ msgstr ""
 #~ msgstr "Uma imagem já existe com este nome!"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "Uma imagem já existe com este nome!"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "Uma imagem já existe com este nome!"
 
@@ -9344,10 +9438,6 @@ msgstr ""
 #~ msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "Adicionar snap-in falhou!"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "modificar Grupo"
 
@@ -9384,10 +9474,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Create New Rule"
-#~ msgstr "Criar novo %s"
-
-#, fuzzy
-#~ msgid "Create New Site"
 #~ msgstr "Criar novo %s"
 
 #, fuzzy
@@ -9461,14 +9547,6 @@ msgstr ""
 #~ msgstr "reinicialização"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "exportação Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "anfitrião Localização"
 
@@ -9495,10 +9573,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "No nó associado"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "Lista de Host"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9739,66 +9813,6 @@ msgstr ""
 #~ msgstr "Associação imagem"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "Impressora já existe"
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "Descrição Printer"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "No nó associado"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "Gerenciamento de armazenamento"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "Nome da impressora"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "Associação imagem"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "Nó de Armazenamento Criado"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "Nome da impressora"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "Impressora atualizado!"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "minutos"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin atualizada"
 
@@ -9859,14 +9873,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Remover impressoras selecionadas"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "Contagem de CPU"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "exportação Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -296,6 +296,10 @@ msgid "A server URL and topic endpoint are required"
 msgstr ""
 
 #, fuzzy
+msgid "A site already exists with this name!"
+msgstr "图像已经存在具有此名称！"
+
+#, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
@@ -566,6 +570,10 @@ msgstr "打印机"
 #, fuzzy
 msgid "Add selected to group"
 msgstr "打印机"
+
+#, fuzzy
+msgid "Add site failed!"
+msgstr "添加管理单元失败！"
 
 #, fuzzy
 msgid "Add slack account failed!"
@@ -1203,6 +1211,9 @@ msgstr "系统序列"
 msgid "Case Version"
 msgstr "最新版本"
 
+msgid "Catch-All Site"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1575,6 +1586,10 @@ msgstr "新建%s"
 
 #, fuzzy
 msgid "Create New Scheduled"
+msgstr "新建%s"
+
+#, fuzzy
+msgid "Create New Site"
 msgstr "新建%s"
 
 #, fuzzy
@@ -2700,11 +2715,19 @@ msgid "Group"
 msgstr "组"
 
 #, fuzzy
+msgid "Group Association"
+msgstr "存储节点创建"
+
+#, fuzzy
 msgid "Group Associations"
 msgstr "存储节点创建"
 
 #, fuzzy
 msgid "Group BIOS Exit"
+msgstr "出口Snapins"
+
+#, fuzzy
+msgid "Group Count"
 msgstr "出口Snapins"
 
 #, fuzzy
@@ -3006,6 +3029,10 @@ msgstr "无关联的节点"
 #, fuzzy
 msgid "Host BIOS Exit Type"
 msgstr "主持人EFI退出类型"
+
+#, fuzzy
+msgid "Host Count"
+msgstr "主机列表"
 
 #, fuzzy
 msgid "Host Create Fail"
@@ -6450,6 +6477,66 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site Create Fail"
+msgstr "打印机更新失败！"
+
+#, fuzzy
+msgid "Site Create Success"
+msgstr "打印机已经存在"
+
+#, fuzzy
+msgid "Site Description"
+msgstr "打印机说明"
+
+#, fuzzy
+msgid "Site Group Associations"
+msgstr "存储节点创建"
+
+#, fuzzy
+msgid "Site Host Associations"
+msgstr "无关联的节点"
+
+#, fuzzy
+msgid "Site Management"
+msgstr "存储管理"
+
+#, fuzzy
+msgid "Site Name"
+msgstr "打印机名称"
+
+#, fuzzy
+msgid "Site Update Fail"
+msgstr "打印机更新失败！"
+
+#, fuzzy
+msgid "Site Update Success"
+msgstr "安装/升级成功！"
+
+#, fuzzy
+msgid "Site User Associations"
+msgstr "图像协会"
+
+#, fuzzy
+msgid "Site User Group Associations"
+msgstr "存储节点创建"
+
+#, fuzzy
+msgid "Site added!"
+msgstr "打印机名称"
+
+#, fuzzy
+msgid "Site update failed!"
+msgstr "打印机更新失败！"
+
+#, fuzzy
+msgid "Site updated!"
+msgstr "打印机更新！"
+
+#, fuzzy
+msgid "Sites"
+msgstr "分钟"
+
+#, fuzzy
 msgid "Size"
 msgstr "最大尺寸"
 
@@ -7546,6 +7633,9 @@ msgstr "|这不是主要组"
 msgid "This is the amount of physical disk space"
 msgstr ""
 
+msgid "This is the catch-all site. Its members are in scope for everything, including hosts registered after they joined."
+msgstr ""
+
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
@@ -8076,6 +8166,10 @@ msgid "User Cleanup"
 msgstr "用户清理"
 
 #, fuzzy
+msgid "User Count"
+msgstr "CPU计数"
+
+#, fuzzy
 msgid "User Create Fail"
 msgstr "用户创建"
 
@@ -8098,6 +8192,10 @@ msgstr "存储节点创建"
 #, fuzzy
 msgid "User Group Associations"
 msgstr "存储节点创建"
+
+#, fuzzy
+msgid "User Group Count"
+msgstr "出口Snapins"
 
 #, fuzzy
 msgid "User Group Create Fail"
@@ -9240,10 +9338,6 @@ msgstr ""
 #~ msgstr "图像已经存在具有此名称！"
 
 #, fuzzy
-#~ msgid "A site already exists with this name!"
-#~ msgstr "图像已经存在具有此名称！"
-
-#, fuzzy
 #~ msgid "A value already exists with this content!"
 #~ msgstr "图像已经存在具有此名称！"
 
@@ -9344,10 +9438,6 @@ msgstr ""
 #~ msgstr "添加管理单元失败！"
 
 #, fuzzy
-#~ msgid "Add site failed!"
-#~ msgstr "添加管理单元失败！"
-
-#, fuzzy
 #~ msgid "Admin Group"
 #~ msgstr "修改组"
 
@@ -9384,10 +9474,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Create New Rule"
-#~ msgstr "新建%s"
-
-#, fuzzy
-#~ msgid "Create New Site"
 #~ msgstr "新建%s"
 
 #, fuzzy
@@ -9461,14 +9547,6 @@ msgstr ""
 #~ msgstr "重启"
 
 #, fuzzy
-#~ msgid "Group Association"
-#~ msgstr "存储节点创建"
-
-#, fuzzy
-#~ msgid "Group Count"
-#~ msgstr "出口Snapins"
-
-#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "主机位置"
 
@@ -9495,10 +9573,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Associated"
 #~ msgstr "无关联的节点"
-
-#, fuzzy
-#~ msgid "Host Count"
-#~ msgstr "主机列表"
 
 #, fuzzy
 #~ msgid "Host Ext"
@@ -9739,66 +9813,6 @@ msgstr ""
 #~ msgstr "图像协会"
 
 #, fuzzy
-#~ msgid "Site Create Fail"
-#~ msgstr "打印机更新失败！"
-
-#, fuzzy
-#~ msgid "Site Create Success"
-#~ msgstr "打印机已经存在"
-
-#, fuzzy
-#~ msgid "Site Description"
-#~ msgstr "打印机说明"
-
-#, fuzzy
-#~ msgid "Site Group Associations"
-#~ msgstr "存储节点创建"
-
-#, fuzzy
-#~ msgid "Site Host Associations"
-#~ msgstr "无关联的节点"
-
-#, fuzzy
-#~ msgid "Site Management"
-#~ msgstr "存储管理"
-
-#, fuzzy
-#~ msgid "Site Name"
-#~ msgstr "打印机名称"
-
-#, fuzzy
-#~ msgid "Site Update Fail"
-#~ msgstr "打印机更新失败！"
-
-#, fuzzy
-#~ msgid "Site Update Success"
-#~ msgstr "安装/升级成功！"
-
-#, fuzzy
-#~ msgid "Site User Associations"
-#~ msgstr "图像协会"
-
-#, fuzzy
-#~ msgid "Site User Group Associations"
-#~ msgstr "存储节点创建"
-
-#, fuzzy
-#~ msgid "Site added!"
-#~ msgstr "打印机名称"
-
-#, fuzzy
-#~ msgid "Site update failed!"
-#~ msgstr "打印机更新失败！"
-
-#, fuzzy
-#~ msgid "Site updated!"
-#~ msgstr "打印机更新！"
-
-#, fuzzy
-#~ msgid "Sites"
-#~ msgstr "分钟"
-
-#, fuzzy
 #~ msgid "Snapin Created"
 #~ msgstr "更新管理单元"
 
@@ -9859,14 +9873,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "删除选定的打印机"
-
-#, fuzzy
-#~ msgid "User Count"
-#~ msgstr "CPU计数"
-
-#, fuzzy
-#~ msgid "User Group Count"
-#~ msgstr "出口Snapins"
 
 #, fuzzy
 #~ msgid "User Group Site"

--- a/tests/site-model.test.php
+++ b/tests/site-model.test.php
@@ -251,6 +251,109 @@ check(
     $checks
 );
 
+/*
+ * 6. The page, and the one cross-file contract in it that breaks quietly.
+ *
+ * fog.site.list.js binds DataTables columns by name to the `dt` names
+ * Route declares for the site class. They live in different files, in
+ * different languages, and a mismatch renders an empty column with no
+ * error anywhere -- so it is asserted rather than trusted.
+ */
+check(
+    'SiteManagement page resolves',
+    class_exists('SiteManagement', true),
+    $failures,
+    $checks
+);
+if (class_exists('SiteManagement', true)) {
+    $pref = new \ReflectionClass('SiteManagement');
+    check(
+        'SiteManagement page resolves to core, not to a plugin copy',
+        false === strpos($pref->getFileName(), DIRECTORY_SEPARATOR . 'plugins'),
+        $failures,
+        $checks
+    );
+    $pvars = $pref->getDefaultProperties();
+    check(
+        'SiteManagement drives the site node',
+        ($pvars['node'] ?? null) === 'site',
+        $failures,
+        $checks
+    );
+    // The association lists must read the CORE membership tables. Pointing
+    // at the plugin's dropped ones would show every tab as empty.
+    $pageSrc = file_get_contents($pref->getFileName());
+    foreach (
+        [
+            'sitehostmember',
+            'siteusermember',
+            'sitegroupmember',
+            'siteusergroupmember'
+        ] as $assoc
+    ) {
+        check(
+            "association lists use $assoc",
+            false !== strpos($pageSrc, "'$assoc'"),
+            $failures,
+            $checks
+        );
+    }
+    // The dropped tables and the plugin's association classes, by name.
+    // Not a blanket search for 'Assoc': `siteAssoc` is the join alias
+    // getItemsList() derives as strtolower(get_class($this)).'Assoc', and
+    // renderAssocTab is a helper -- both are correct and both contain it.
+    foreach (
+        [
+            'siteHostAssoc',
+            'siteUserAssoc',
+            'siteGroupAssoc',
+            'siteUserGroupAssoc',
+            'sitehostassociation',
+            'siteuserassociation',
+            'sitegroupassociation',
+            'siteusergroupassociation'
+        ] as $dropped
+    ) {
+        check(
+            "the page does not reference the dropped $dropped",
+            false === strpos($pageSrc, $dropped),
+            $failures,
+            $checks
+        );
+    }
+}
+
+$listJs = $webroot . '/management/js/fog/site/fog.site.list.js';
+$routeSrc = file_get_contents($webroot . '/lib/router/route.class.php');
+check(
+    'the site list JS exists',
+    is_readable($listJs),
+    $failures,
+    $checks
+);
+if (is_readable($listJs)) {
+    preg_match_all(
+        "/data:\s*'([a-z]+)'/",
+        file_get_contents($listJs),
+        $bound
+    );
+    $columns = array_diff($bound[1], ['mainlink']);
+    check(
+        'the list JS binds the four member counts',
+        count($columns) === 4,
+        $failures,
+        $checks
+    );
+    foreach ($columns as $col) {
+        check(
+            "Route declares a dt name for the JS column '$col'",
+            false !== strpos($routeSrc, "'dt' => '$col'"),
+            $failures,
+            $checks
+        );
+    }
+}
+
 if (count($failures)) {
     fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Commit 11. Closes the gap fog-plugins v1.6.5 opened — sites were enforced with no page to administer them from. This is the plugin's page, pointed at the core tables step 331 creates rather than the ones step 332 drops.

List, add, edit, delete, and the four association tabs. The menu entry sits beside **Roles** rather than Hosts: a site says which objects a user may reach, which is the same kind of answer a role gives about which actions.

## Catch-all is a checkbox, not a button

The flag has two directions and a button only has one. Safe despite `save()` dropping null-valued fields, because `makeCatchAll()` writes the column in SQL and never goes through `save()`.

It's only written when it actually **changed** — re-asserting it on the site that already holds it would clear every other site's flag and rewrite its own for nothing. The tab also states plainly what the flag means, because the consequence is invisible from the member lists: it's the flag that grants scope, not the membership.

## Silent-overwrite guards on both name paths

`siteName` is UNIQUE and `save()` builds `INSERT ... ON DUPLICATE KEY UPDATE`, so creating *or renaming* onto an existing name would take that site's row with it rather than failing. Both paths check first.

## Two shared-file changes worth calling out

**`Route` grows the four member-count columns** for the site list. The `dt` names are the plugin's, unchanged — they're what `fog.site.list.js` binds to, and a tidier spelling here would leave every count column rendering empty with nothing anywhere to say why. That cross-file contract is now asserted by a test that reads the JS and checks each bound column against Route's declarations.

**`renderAssocTab()` gains a `$noun` pass-through** to `renderAssocCreate()`, which has always accepted one. Additive with a default, so no existing caller changes. Without it a tab could only reach that argument by calling the helper itself, and `usergroup` rendered as "Create New Usergroup". Flagging it because it's a shared helper, though the change is a defaulted parameter and a forward.

All four association tabs are wired for create-and-associate, per the convention in CLAUDE.md.

## Verification

```
php tests/site-model.test.php   # ok  50 checks passed
sh tests/run-all.sh             # 15 passed, 0 failed
php -l / node --check           # clean on everything touched
```

The test also asserts the page names none of the eight dropped plugin identifiers — deliberately by name rather than a blanket search for `Assoc`, since `siteAssoc` is the join alias `getItemsList()` derives as `strtolower(get_class($this)).'Assoc'` and is correct.

No `FOG_BCACHE_VER` bump: every asset here is new, so there's no cached copy for a browser to prefer.

Next: association tabs on the host / user / group / usergroup edit pages (commit 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR