### PR TITLE
Add the Site tab to host, user, group and usergroup edit

### DIFF
--- a/packages/web/lib/fog/FOGPagePost.class.php
+++ b/packages/web/lib/fog/FOGPagePost.class.php
@@ -429,4 +429,66 @@ trait FOGPagePost
         }
         return $schedule;
     }
+
+    /**
+     * Saves the Site tab shared by the host, user, group and usergroup
+     * edit pages.
+     *
+     * Replaces whatever memberships the object had with the one selected,
+     * which is what a single dropdown can express. renderSiteTab() warns
+     * first when that would drop more than one, so the replacement is
+     * never silent.
+     *
+     * Selecting the blank option removes the object from every site. That
+     * is a real choice and not an error -- but for a USER it means they
+     * fall back to whatever the catch-all grants, and if there is no
+     * catch-all they see nothing.
+     *
+     * @param string $node the owning node (host|user|group|usergroup)
+     * @param object $obj  the owning object
+     *
+     * @return void
+     */
+    protected function siteTabPost($node, $obj)
+    {
+        self::checkAuthAndCSRF();
+        if (!isset(self::$siteTabMap[$node])) {
+            return;
+        }
+        list($route, $field, $manager) = self::$siteTabMap[$node];
+        $objectID = (int)$obj->get('id');
+        if ($objectID < 1) {
+            return;
+        }
+        $siteID = (int)filter_input(INPUT_POST, 'site');
+        $current = self::siteIDsFor($node, $objectID);
+
+        // Nothing to do. Worth the check rather than delete-then-insert
+        // anyway: this runs on every save of the tab, and rewriting an
+        // unchanged row churns the id sequence for no reason.
+        if ($siteID > 0 && $current === [$siteID]) {
+            return;
+        }
+        if ($siteID < 1 && empty($current)) {
+            return;
+        }
+
+        Route::deletemass($route, [$field => $objectID]);
+        if ($siteID < 1) {
+            return;
+        }
+        // Guard against pointing at a site that no longer exists: the
+        // membership tables carry no foreign keys, and a stale row would
+        // otherwise sit there granting scope for an id that could later be
+        // reused by a different site.
+        $site = self::getClass('Site', $siteID);
+        if (!$site->isValid()) {
+            throw new \Exception(_('The selected site no longer exists'));
+        }
+        self::getClass($manager)
+            ->insertBatch(
+                [$field, 'siteID'],
+                [[$objectID, $siteID]]
+            );
+    }
 }

--- a/packages/web/lib/fog/FOGPageRender.class.php
+++ b/packages/web/lib/fog/FOGPageRender.class.php
@@ -735,4 +735,165 @@ trait FOGPageRender
         }
         return $fields;
     }
+
+    /**
+     * Site membership map for the per-object Site tab.
+     *
+     * node => [member route, object id field, manager class]. The
+     * manager is spelled out rather than derived: ucfirst() on the route
+     * yields Sitehostmember, not SiteHostMember, and getClass() would fail
+     * to resolve it only at the moment somebody saves the tab.
+     *
+     * Kept here rather than read
+     * from SiteScope: that map is table and column names for the boundary
+     * queries, this one is route names for the ORM, and collapsing them
+     * would tie a security lookup to a presentation detail.
+     *
+     * @var array
+     */
+    protected static $siteTabMap = [
+        'host' => ['sitehostmember', 'hostID', 'SiteHostMemberManager'],
+        'user' => ['siteusermember', 'userID', 'SiteUserMemberManager'],
+        'group' => ['sitegroupmember', 'groupID', 'SiteGroupMemberManager'],
+        'usergroup' => [
+            'siteusergroupmember',
+            'usergroupID',
+            'SiteUserGroupMemberManager'
+        ]
+    ];
+    /**
+     * The site ids an object currently belongs to.
+     *
+     * @param string $node     the owning node
+     * @param int    $objectID the object id
+     *
+     * @return array int site ids
+     */
+    protected static function siteIDsFor($node, $objectID)
+    {
+        if (!isset(self::$siteTabMap[$node]) || (int)$objectID < 1) {
+            return [];
+        }
+        list($route, $field) = self::$siteTabMap[$node];
+        return array_map(
+            'intval',
+            (array)Route::getIds(
+                $route,
+                [$field => (int)$objectID],
+                'siteID'
+            )
+        );
+    }
+    /**
+     * Renders the Site tab shared by the host, user, group and usergroup
+     * edit pages.
+     *
+     * A single dropdown, as the site plugin had it: an object sits at one
+     * site, and that is the shape admins already know.
+     *
+     * The membership tables are many-to-many though, and the site page's
+     * association grids can genuinely put one object in several sites --
+     * at which point saving this tab replaces all of them with the one
+     * selected. That is the plugin's behaviour and it is kept, but it is
+     * no longer SILENT: when an object is in more than one site the tab
+     * says so and names them, so the replacement is a choice rather than a
+     * surprise. Losing a membership with no message is the failure worth
+     * spending markup on.
+     *
+     * @param string $node the owning node (host|user|group|usergroup)
+     * @param object $obj  the owning object
+     *
+     * @return void
+     */
+    protected function renderSiteTab($node, $obj)
+    {
+        $objectID = (int)$obj->get('id');
+        $current = self::siteIDsFor($node, $objectID);
+        $siteID = (
+            (int)filter_input(INPUT_POST, 'site') ?:
+            (int)reset($current)
+        );
+
+        $fields = [
+            self::makeLabel(
+                'col-sm-3 col-form-label',
+                'site',
+                _('Site')
+            ) => self::getClass('SiteManager')->buildSelectBox($siteID, 'site')
+        ];
+
+        $buttons = self::makeButton(
+            'site-send',
+            _('Update'),
+            'btn btn-primary float-end'
+        );
+        // Create-and-associate, same button and modal the grid tabs get.
+        // Added before the *_FIELDS event so a listener still sees it, and
+        // right after Update so Update stays the rightmost (primary) one.
+        $createModal = self::renderAssocCreate(
+            $node . '-site',
+            'site',
+            $buttons,
+            $objectID
+        );
+
+        self::$HookManager->processEvent(
+            strtoupper($node) . '_SITE_FIELDS',
+            [
+                'fields' => &$fields,
+                'buttons' => &$buttons,
+                'obj' => &$obj
+            ]
+        );
+        $rendered = self::formFields($fields);
+        unset($fields);
+
+        echo self::makeFormTag(
+            '',
+            $node . '-site-form',
+            self::makeTabUpdateURL($node . '-site', $objectID),
+            'post',
+            'application/x-www-form-urlencoded',
+            true
+        );
+        echo '<div class="card">';
+        echo '<div class="card-header">';
+        echo '<h4 class="card-title">';
+        echo _('Site');
+        echo '</h4>';
+        echo '</div>';
+        echo '<div class="card-body">';
+        if (count($current) > 1) {
+            $names = [];
+            foreach ($current as $sid) {
+                $site = self::getClass('Site', $sid);
+                if ($site->isValid()) {
+                    $names[] = $site->get('name');
+                }
+            }
+            echo '<div class="alert alert-warning">'
+                . sprintf(
+                    _(
+                        'This is currently in %d sites (%s). Saving here '
+                        . 'replaces them all with the single site selected '
+                        . 'below. Use the site\'s own page to keep more '
+                        . 'than one.'
+                    ),
+                    count($current),
+                    Initiator::e(implode(', ', $names))
+                )
+                . '</div>';
+        }
+        echo $rendered;
+        echo '</div>';
+        echo '<div class="card-footer">';
+        echo $buttons;
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
+        // Outside the form, deliberately: the modal holds a fetched create
+        // form, and a <form> inside another <form> is invalid markup -- the
+        // browser drops the inner one and the create posts nothing.
+        echo $createModal;
+    }
 }

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -92,7 +92,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 333);
-        define('FOG_BCACHE_VER', 281);
+        define('FOG_BCACHE_VER', 282);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/UserGroupManagement.page.php
+++ b/packages/web/lib/pages/UserGroupManagement.page.php
@@ -358,6 +358,15 @@ class UserGroupManagement extends FOGPage
                 $this->usergroupRoles();
             }
         ];
+        // Site
+        $tabData[] = [
+            'name' => _('Site'),
+            'id' => 'usergroup-site',
+            'generator' => function () {
+                $this->usergroupSite();
+            }
+        ];
+
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -376,6 +385,9 @@ class UserGroupManagement extends FOGPage
             function (&$serverFault) {
                 global $tab;
                 switch ($tab) {
+                    case 'usergroup-site':
+                        $this->usergroupSitePost();
+                        break;
                     case 'usergroup-general':
                         $this->usergroupGeneralPost();
                         break;
@@ -499,5 +511,24 @@ class UserGroupManagement extends FOGPage
                 ]
             ]
         );
+    }
+
+    /**
+     * Presents the site tab.
+     *
+     * @return void
+     */
+    public function usergroupSite()
+    {
+        $this->renderSiteTab('usergroup', $this->obj);
+    }
+    /**
+     * Updates the site.
+     *
+     * @return void
+     */
+    public function usergroupSitePost()
+    {
+        $this->siteTabPost('usergroup', $this->obj);
     }
 }

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -2550,6 +2550,15 @@ class GroupManagement extends FOGPage
                 ]
             ]
         ];
+        // Site
+        $tabData[] = [
+            'name' => _('Site'),
+            'id' => 'group-site',
+            'generator' => function () {
+                $this->groupSite();
+            }
+        ];
+
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -2568,6 +2577,9 @@ class GroupManagement extends FOGPage
             function (&$serverFault) {
                 global $tab;
                 switch ($tab) {
+                    case 'group-site':
+                        $this->groupSitePost();
+                        break;
                     case 'group-general':
                         $this->groupGeneralPost();
                         break;
@@ -3582,5 +3594,24 @@ class GroupManagement extends FOGPage
     public function getSnapinHist()
     {
         $this->renderSnapinHistoryData($this->obj->get('hosts'));
+    }
+
+    /**
+     * Presents the site tab.
+     *
+     * @return void
+     */
+    public function groupSite()
+    {
+        $this->renderSiteTab('group', $this->obj);
+    }
+    /**
+     * Updates the site.
+     *
+     * @return void
+     */
+    public function groupSitePost()
+    {
+        $this->siteTabPost('group', $this->obj);
     }
 }

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -3519,6 +3519,15 @@ class HostManagement extends FOGPage
                 ]
             ]
         ];
+        // Site
+        $tabData[] = [
+            'name' => _('Site'),
+            'id' => 'host-site',
+            'generator' => function () {
+                $this->hostSite();
+            }
+        ];
+
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -3537,6 +3546,9 @@ class HostManagement extends FOGPage
             function (&$serverFault) {
                 global $tab;
                 switch ($tab) {
+                    case 'host-site':
+                        $this->hostSitePost();
+                        break;
                     case 'host-general':
                         $this->hostGeneralPost();
                         break;
@@ -4570,5 +4582,24 @@ class HostManagement extends FOGPage
                 'disablebtn' => false
             ]
         ));
+    }
+
+    /**
+     * Presents the site tab.
+     *
+     * @return void
+     */
+    public function hostSite()
+    {
+        $this->renderSiteTab('host', $this->obj);
+    }
+    /**
+     * Updates the site.
+     *
+     * @return void
+     */
+    public function hostSitePost()
+    {
+        $this->siteTabPost('host', $this->obj);
     }
 }

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -782,6 +782,15 @@ class UserManagement extends FOGPage
                 $this->userGroup();
             }
         ];
+        // Site
+        $tabData[] = [
+            'name' => _('Site'),
+            'id' => 'user-site',
+            'generator' => function () {
+                $this->userSite();
+            }
+        ];
+
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -800,6 +809,9 @@ class UserManagement extends FOGPage
             function (&$serverFault) {
                 global $tab;
                 switch ($tab) {
+                    case 'user-site':
+                        $this->userSitePost();
+                        break;
                     case 'user-general':
                         $this->userGeneralPost();
                         break;
@@ -870,5 +882,24 @@ class UserManagement extends FOGPage
                 ]
             ]
         );
+    }
+
+    /**
+     * Presents the site tab.
+     *
+     * @return void
+     */
+    public function userSite()
+    {
+        $this->renderSiteTab('user', $this->obj);
+    }
+    /**
+     * Updates the site.
+     *
+     * @return void
+     */
+    public function userSitePost()
+    {
+        $this->siteTabPost('user', $this->obj);
     }
 }

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -1003,4 +1003,15 @@
         groupHistoryImageTable.search(Common.search).draw();
         groupHistorySnapinTable.search(Common.search).draw();
     }
+
+    // ---------------------------------------------------------------
+    // SITE TAB
+    // Single dropdown, so registerSelectTab rather than the grid wiring.
+    // node:'site' adds the create-and-select button when the user holds
+    // site.create; without it the tab is just the select and Update.
+    $.registerSelectTab({
+        slug: 'group-site',
+        send: 'site-send',
+        node: 'site'
+    });
 })(jQuery)

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -1307,4 +1307,15 @@
         hostHistoryImageTable.search(Common.search).draw();
         hostHistorySnapinTable.search(Common.search).draw();
     }
+
+    // ---------------------------------------------------------------
+    // SITE TAB
+    // Single dropdown, so registerSelectTab rather than the grid wiring.
+    // node:'site' adds the create-and-select button when the user holds
+    // site.create; without it the tab is just the select and Update.
+    $.registerSelectTab({
+        slug: 'host-site',
+        send: 'site-send',
+        node: 'site'
+    });
 })(jQuery);

--- a/packages/web/management/js/fog/user/fog.user.edit.js
+++ b/packages/web/management/js/fog/user/fog.user.edit.js
@@ -99,4 +99,15 @@
         item: 'usergroup',
         sub: 'getGroupsList'
     });
+
+    // ---------------------------------------------------------------
+    // SITE TAB
+    // Single dropdown, so registerSelectTab rather than the grid wiring.
+    // node:'site' adds the create-and-select button when the user holds
+    // site.create; without it the tab is just the select and Update.
+    $.registerSelectTab({
+        slug: 'user-site',
+        send: 'site-send',
+        node: 'site'
+    });
 })(jQuery);

--- a/packages/web/management/js/fog/usergroup/fog.usergroup.edit.js
+++ b/packages/web/management/js/fog/usergroup/fog.usergroup.edit.js
@@ -25,4 +25,15 @@ $(function() {
     if (Common.search && Common.search.length > 0) {
         membersTable.search(Common.search).draw();
     }
+
+    // ---------------------------------------------------------------
+    // SITE TAB
+    // Single dropdown, so registerSelectTab rather than the grid wiring.
+    // node:'site' adds the create-and-select button when the user holds
+    // site.create; without it the tab is just the select and Update.
+    $.registerSelectTab({
+        slug: 'usergroup-site',
+        send: 'site-send',
+        node: 'site'
+    });
 });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6476,6 +6476,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "Sites"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "Drucker erstellen fehlgeschlagen!"
 
@@ -7506,6 +7510,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr "läuft nicht mehr"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
 
@@ -7619,6 +7627,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9818,10 +9830,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "Sites"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6476,6 +6476,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "minutes"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "Printer update failed!"
 
@@ -7504,6 +7508,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr " no longer exists"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -7616,6 +7624,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9798,10 +9810,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "Printer update failed!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "minutes"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6632,6 +6632,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "minutos"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "actualización de la impresora ha fallado!"
 
@@ -7693,6 +7697,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Error, es una imagen asociada con este anfitrión"
 
+msgid "The selected site no longer exists"
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -7807,6 +7814,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9982,10 +9993,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "actualización de la impresora ha fallado!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "minutos"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6477,6 +6477,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "Sites"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "Drucker erstellen fehlgeschlagen!"
 
@@ -7507,6 +7511,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr "läuft nicht mehr"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
 
@@ -7620,6 +7628,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9819,10 +9831,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "Drucker-Update fehlgeschlagen!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "Sites"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6478,6 +6478,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "minutes"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "mise à jour de l'imprimante a échoué!"
 
@@ -7506,6 +7510,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr " n'existe plus"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -7618,6 +7626,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9804,10 +9816,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "mise à jour de l'imprimante a échoué!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "minutes"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6243,6 +6243,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "Siti"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "Creazione stampante fallita"
 
@@ -7218,6 +7222,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "Il MAC primario associato è"
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr "non è più in esecuzione"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Le impostazioni tendono ad essere le impostazioni globali che influenzano tutti gli host"
 
@@ -7326,6 +7334,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9424,10 +9436,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "Aggiornamento della stampante non è riuscito!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "Siti"
 
 #~ msgid "Site Association"
 #~ msgstr "Associazione Sito"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6185,6 +6185,9 @@ msgstr ""
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
+msgid "Site"
+msgstr "サイト"
+
 msgid "Site Create Fail"
 msgstr "サイトの作成に失敗しました"
 
@@ -7146,6 +7149,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr "関連付けられたプライマリ MAC アドレス:"
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr "選択したプリンターを追加"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr "これらの設定は通常グローバル設定であり、すべてのホストに影響します。"
 
@@ -7256,6 +7263,10 @@ msgstr "これは一度だけ実行されるタスクであり、現在は実行
 
 msgid "This is a single run task that should run now."
 msgstr "これは一度だけ実行されるタスクであり、現在実行される予定です。"
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
+msgstr ""
 
 msgid "This is especially useful if you have multiple"
 msgstr "複数ある場合に特に便利です"
@@ -10558,9 +10569,6 @@ msgstr ""
 
 #~ msgid "Shutdown after install"
 #~ msgstr "インストール後にシャットダウン"
-
-#~ msgid "Site"
-#~ msgstr "サイト"
 
 #~ msgid "Site Association"
 #~ msgstr "サイトの関連付け"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5485,6 +5485,9 @@ msgstr ""
 msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
+msgid "Site"
+msgstr ""
+
 msgid "Site Create Fail"
 msgstr ""
 
@@ -6348,6 +6351,9 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+msgid "The selected site no longer exists"
+msgstr ""
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -6450,6 +6456,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6477,6 +6477,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "minutos"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "atualização da impressora falhou!"
 
@@ -7505,6 +7509,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr " não existe mais"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -7617,6 +7625,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9803,10 +9815,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "atualização da impressora falhou!"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "minutos"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6477,6 +6477,10 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 #, fuzzy
+msgid "Site"
+msgstr "分钟"
+
+#, fuzzy
 msgid "Site Create Fail"
 msgstr "打印机更新失败！"
 
@@ -7505,6 +7509,10 @@ msgstr ""
 msgid "The primary mac associated is"
 msgstr ""
 
+#, fuzzy
+msgid "The selected site no longer exists"
+msgstr "不复存在"
+
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""
 
@@ -7617,6 +7625,10 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+#, php-format
+msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
 msgid "This is especially useful if you have multiple"
@@ -9803,10 +9815,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Rule update failed!"
 #~ msgstr "打印机更新失败！"
-
-#, fuzzy
-#~ msgid "Site"
-#~ msgstr "分钟"
 
 #, fuzzy
 #~ msgid "Site Association"


### PR DESCRIPTION
Commit 12. The reverse direction of the site page's association grids: assign an object to a site from the object rather than from the site.

## Written once, shared

All four tabs render the same card — one select, one Update — so `renderSiteTab()` / `siteTabPost()` live in the `FOGPageRender` and `FOGPagePost` traits. Each page contributes a two-line method pair, a `tabData` entry, and a case in its `editPost` switch. The plugin shipped four near-identical hooks to do this; the traits exist to stop exactly that.

## The many-to-many problem, made visible

A single dropdown, as the plugin had it — an object sits at one site and that's the shape admins know. But the membership tables are many-to-many, and the site page's grids can genuinely put one object in several sites. Saving this tab then replaces all of them with the one selected.

**That behaviour is kept and is no longer silent.** When an object is in more than one site, the tab says so and names them, so the replacement is a choice rather than something noticed later by its absence. Losing a membership with no message is the failure worth spending markup on.

I considered making these grids instead, for full symmetry with the site page. Rejected: it changes a UX admins already know, and needs a `sites` association added to all four models — more surface for the same outcome, when the actual defect was the silence rather than the shape.

## Two guards beyond the plugin's version

- The post **skips the write when nothing changed**, instead of delete-then-insert on every save of the tab.
- It **refuses a site id that no longer exists**. These tables carry no foreign keys, so a stale row would sit there granting scope for an id that could later be reused by a different site.

Membership is also read per object (`Route::getIds` by the object's own id) rather than by listing every association and looping to find the match, which is what the plugin did on each host edit render.

## Cache

`FOG_BCACHE_VER` 281 → 282. Four **existing** edit JS files changed, so without the bump a browser serves its cached copy and the tab renders with a dead Update button. (Commit 11 needed no bump — every asset there was new.)

## Verification

```
sh tests/run-all.sh    # 15 passed, 0 failed
php -l / node --check  # clean on all eleven touched files
```

A live smoke test of the site page is running separately; I'll report it and fix anything it turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR