### PR TITLE
Fix the three ways the core Site pages were half-wired

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -292,6 +292,13 @@ abstract class FOGBase
         'printer',
         'role',
         'setting',
+        // Sites came in from the site plugin, which added itself here from
+        // its menu hook (`$arguments['searchPages'][] = $this->node`). Core
+        // pages are listed statically instead, and missing from this list a
+        // page renders "Index page of: SiteManagement" rather than its grid
+        // -- FOGPage::index() only takes the list branch for a node it finds
+        // here. No error, just the wrong half of an if.
+        'site',
         'snapin',
         'storagegroup',
         'storagenode',

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -110,6 +110,7 @@ abstract class FOGPage extends FOGBase
         'printer',
         'task',
         'role',
+        'site',
         'usergroup'
     ];
     /**

--- a/packages/web/lib/fog/site.class.php
+++ b/packages/web/lib/fog/site.class.php
@@ -45,8 +45,7 @@ class Site extends FOGController
     protected $databaseFields = [
         'id' => 'siteID',
         'name' => 'siteName',
-        'description' => 'siteDesc',
-        'catchall' => 'siteCatchAll'
+        'description' => 'siteDesc'
     ];
     /**
      * The required fields.
@@ -59,13 +58,26 @@ class Site extends FOGController
     /**
      * Additional fields.
      *
+     * `catchall` is here rather than in $databaseFields, and that placement
+     * is load bearing. FOGController::save() can only omit a column -- and
+     * so store SQL NULL -- when the FRIENDLY key ends in "id"; for every
+     * other key an unset value is coerced to '' and written. `siteCatchAll`
+     * is TINYINT UNSIGNED with a CHECK of exactly 1, so '' is rejected
+     * outright (MySQL 1366) and the whole INSERT fails.
+     *
+     * That is not theoretical: with it declared as a database field, every
+     * "create site" failed while the page reported success. So the column
+     * is not save()-managed at all. makeCatchAll() writes it in SQL, and
+     * loadCatchall() reads it.
+     *
      * @var array
      */
     protected $additionalFields = [
         'users',
         'hosts',
         'groups',
-        'usergroups'
+        'usergroups',
+        'catchall'
     ];
     /**
      * The list query.
@@ -204,17 +216,14 @@ class Site extends FOGController
      */
     public function save()
     {
-        // `siteDesc` is LONGTEXT NOT NULL with no default -- a TEXT column
-        // cannot carry one before MySQL 8.0.13, so the empty case has to be
-        // filled in here. save() drops null-valued fields before building
-        // the column list, so leaving it unset omits the column entirely
-        // and strict mode rejects the INSERT.
-        if (!$this->isPopulated('description')
-            || null === $this->get('description')
-        ) {
-            $this->set('description', '');
+        // Propagated, not discarded. parent::save() returns false on
+        // failure, and an override that returns $this regardless makes
+        // every caller's `if (!$obj->save())` unreachable -- the create
+        // page then reports "Site added!" over a row that was never
+        // written, with the real error only in the history table.
+        if (!parent::save()) {
+            return false;
         }
-        parent::save();
         return $this
             ->assocSetter('SiteUserMember', 'user', true)
             ->assocSetter('SiteHostMember', 'host', true)
@@ -239,10 +248,11 @@ class Site extends FOGController
      *
      * `siteCatchAll` is NULL or 1 and nothing else -- a UNIQUE index makes
      * "at most one" a property of the table rather than of this code, and a
-     * CHECK constraint rejects 0. So turning the flag OFF means writing
-     * NULL, and save() DROPS null-valued fields before building its column
-     * list, which would silently leave the site as the catch-all while
-     * reporting success.
+     * CHECK constraint rejects 0. save() cannot write either state: it
+     * coerces an empty non-"id" field to '' rather than NULL (see the
+     * $additionalFields docblock), so turning the flag OFF through it
+     * fails the CHECK, and so does creating a site that was never meant to
+     * be the catch-all at all.
      *
      * Turning it ON has to clear the incumbent first or the UNIQUE index
      * rejects the write. Done as two statements in one transaction so a
@@ -326,6 +336,35 @@ class Site extends FOGController
             'usergroups',
             (array)Route::getIds('siteusergroupmember', $find, 'usergroupID')
         );
+    }
+    /**
+     * Load the catch-all flag.
+     *
+     * Read in SQL because `catchall` is not a database field -- see the
+     * $additionalFields docblock for why it cannot be one -- so load()
+     * would otherwise never populate it and isCatchAll() would answer
+     * "no" for the catch-all site itself.
+     *
+     * @return void
+     */
+    protected function loadCatchall()
+    {
+        $id = (int)$this->get('id');
+        if ($id < 1) {
+            $this->set('catchall', null);
+            return;
+        }
+        $row = self::$DB
+            ->query(
+                'SELECT `siteCatchAll` AS `flag` FROM `sites` '
+                . 'WHERE `siteID` = :id',
+                [],
+                ['id' => $id]
+            )
+            ->fetch(\PDO::FETCH_ASSOC)
+            ->get();
+        $flag = is_array($row) && isset($row['flag']) ? $row['flag'] : null;
+        $this->set('catchall', ('' === $flag ? null : $flag));
     }
     /**
      * Load hosts.

--- a/packages/web/lib/fog/sitemanager.class.php
+++ b/packages/web/lib/fog/sitemanager.class.php
@@ -40,14 +40,25 @@ class SiteManager extends FOGManagerController
      * if that was taken), and an admin may rename it afterwards. The flag
      * is the identity.
      *
+     * Direct SQL rather than Route::getIds(): `catchall` is not one of
+     * Site's database fields (it cannot be -- see Site::$additionalFields),
+     * so there is no column for a filter to name. It is also NULL-or-1, and
+     * a filter builder that emits `= :val` has no way to ask for NOT NULL.
+     *
      * @return Site|null
      */
     public function catchAll()
     {
-        $ids = Route::getIds('site', ['catchall' => 1]);
-        if (empty($ids)) {
+        $row = self::$DB
+            ->query(
+                'SELECT `siteID` AS `id` FROM `sites` '
+                . 'WHERE `siteCatchAll` IS NOT NULL LIMIT 1'
+            )
+            ->fetch(\PDO::FETCH_ASSOC)
+            ->get();
+        if (!is_array($row) || empty($row['id'])) {
             return null;
         }
-        return self::getClass('Site', (int)array_shift($ids));
+        return self::getClass('Site', (int)$row['id']);
     }
 }

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -210,9 +210,9 @@ class SiteManagement extends FOGPage
                 $description
             ),
             // A checkbox rather than a button, because the flag has two
-            // directions and a button only has one. Safe here despite
-            // save() dropping null-valued fields -- makeCatchAll() writes
-            // the column in SQL and never goes through save().
+            // directions and a button only has one. The value never reaches
+            // save() either way -- makeCatchAll() writes the column in SQL,
+            // for the reasons in Site::$additionalFields.
             self::makeLabel(
                 $labelClass,
                 'catchall',

--- a/tests/list-pages-registered.test.php
+++ b/tests/list-pages-registered.test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * A node whose JS registers a DataTables list must be a search page.
+ *
+ * FOGPage::index() has two branches. For a node in FOGBase::$searchPages it
+ * renders the grid and serves the AJAX payload the list JS asks for; for
+ * any other node it falls through to a stub that prints
+ * "Index page of: <PageClass>" and nothing else.
+ *
+ * Missing from that list, a page therefore looks half-built rather than
+ * broken: the menu entry works, the page loads, the title is right, and the
+ * grid is simply absent. No error, no log line, no failing request -- it is
+ * the wrong half of an if, and nothing else in the tree says so.
+ *
+ * That is not hypothetical. Sites moved out of the site plugin into core,
+ * and the plugin had been adding itself to $searchPages from its menu hook
+ * (`$arguments['searchPages'][] = $this->node`). Core pages are listed
+ * statically instead, the static list was not updated, and Site Management
+ * shipped rendering "Index page of: SiteManagement".
+ *
+ * The tell is the grid registration itself. Two exist -- $.registerListPage
+ * and $.registerTable -- and a fog.<node>.list.js calling either is asking
+ * for a grid the server can only supply from the list branch. Two nodes ship
+ * a list JS that calls NEITHER (apidocs, service): those are page scripts
+ * that happen to follow the naming convention, and they are correctly absent
+ * from $searchPages. So the rule keys on the call, not on the filename.
+ *
+ * DB-free: reads the JS files and the static property.
+ *
+ * Usage: php tests/list-pages-registered.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$jsRoot = $webroot . '/management/js/fog';
+$baseFile = $webroot . '/lib/fog/fogbase.class.php';
+
+foreach ([$jsRoot, $baseFile] as $needed) {
+    if (!file_exists($needed)) {
+        fwrite(STDERR, "FAIL: cannot read $needed\n");
+        exit(1);
+    }
+}
+
+// Read $searchPages out of the source rather than booting FOG: the property
+// is protected, and a harness that instantiated FOGBase would need a
+// database it has no reason to want.
+$src = file_get_contents($baseFile);
+if (!preg_match(
+    '/protected static \$searchPages = \[(.*?)\];/s',
+    $src,
+    $m
+)) {
+    fwrite(STDERR, "FAIL: could not locate \$searchPages in fogbase\n");
+    exit(1);
+}
+preg_match_all("/'([a-z]+)'/", $m[1], $found);
+$searchPages = $found[1];
+
+$failures = [];
+$checks = 0;
+
+if (count($searchPages) < 10) {
+    fwrite(
+        STDERR,
+        'FAIL: parsed only ' . count($searchPages) . " search pages; the "
+        . "property's shape must have changed\n"
+    );
+    exit(1);
+}
+
+foreach (glob($jsRoot . '/*', GLOB_ONLYDIR) as $dir) {
+    $node = basename($dir);
+    $listJs = $dir . '/fog.' . $node . '.list.js';
+    if (!is_readable($listJs)) {
+        continue;
+    }
+    $js = file_get_contents($listJs);
+    // registerReloadToggle does not count and does not collide: it contains
+    // neither of these substrings.
+    if (false === strpos($js, 'registerListPage')
+        && false === strpos($js, 'registerTable')
+    ) {
+        // A list JS that registers no grid needs no list branch.
+        continue;
+    }
+    $checks++;
+    if (!in_array($node, $searchPages, true)) {
+        $failures[] = "$node registers a list page but is not in "
+            . '$searchPages, so its page renders "Index page of: ..." '
+            . 'instead of the grid';
+    }
+}
+
+if (0 === $checks) {
+    fwrite(STDERR, "FAIL: found no list pages to check; layout changed?\n");
+    exit(1);
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks list pages registered\n";
+exit(0);

--- a/tests/page-objects-registered.test.php
+++ b/tests/page-objects-registered.test.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * A page that reads $this->obj must be in FOGPage::$PagesWithObjects.
+ *
+ * FOGPage's constructor only populates $this->obj -- the model instance the
+ * edit and delete tabs are rendered from -- for a node it finds in
+ * $PagesWithObjects. A page missing from that list gets null, and the first
+ * `$this->obj->get(...)` is a fatal on null, which FOG serves as a bodyless
+ * 500: no page, no message, nothing in the UI to read.
+ *
+ * That shipped. Sites moved out of the site plugin into core; the plugin had
+ * been injecting itself into the list from a hook, core pages are listed
+ * statically, and the static list was not updated. `?node=site&sub=edit`
+ * fataled in renderEditTabs() for every site, while the list page it was
+ * reached from worked fine.
+ *
+ * The rule keys on assignment, not on the read. Three pages -- the dashboard
+ * and the server-info page -- read $this->obj too, but assign it themselves
+ * first (a StorageNode chosen from a request parameter, not the page's own
+ * node), so they neither need nor want the constructor's help. A page that
+ * only ever READS it is the one depending on the list.
+ *
+ * Sibling of tests/list-pages-registered.test.php: same shape of bug, the
+ * other half of the page wiring. Missing from $searchPages a page renders a
+ * stub instead of its grid; missing from $PagesWithObjects it 500s on edit.
+ *
+ * DB-free: reads the page sources and the property.
+ *
+ * Usage: php tests/page-objects-registered.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$pageDir = $webroot . '/lib/pages';
+$pageBase = $webroot . '/lib/fog/fogpage.class.php';
+
+foreach ([$pageDir, $pageBase] as $needed) {
+    if (!file_exists($needed)) {
+        fwrite(STDERR, "FAIL: cannot read $needed\n");
+        exit(1);
+    }
+}
+
+// Read the property out of the source rather than booting FOG -- the
+// harness has no reason to want a database.
+$src = file_get_contents($pageBase);
+if (!preg_match(
+    '/public \$PagesWithObjects = \[(.*?)\];/s',
+    $src,
+    $m
+)) {
+    fwrite(STDERR, "FAIL: could not locate \$PagesWithObjects in fogpage\n");
+    exit(1);
+}
+preg_match_all("/'([a-z]+)'/", $m[1], $found);
+$pagesWithObjects = $found[1];
+
+if (count($pagesWithObjects) < 10) {
+    fwrite(
+        STDERR,
+        'FAIL: parsed only ' . count($pagesWithObjects) . " entries; the "
+        . "property's shape must have changed\n"
+    );
+    exit(1);
+}
+
+$failures = [];
+$checks = 0;
+
+foreach (glob($pageDir . '/*.page.php') as $file) {
+    $pageSrc = file_get_contents($file);
+    if (false === strpos($pageSrc, '$this->obj->')) {
+        continue;
+    }
+    // Assigns its own -- see the docblock. Not the constructor's business.
+    if (preg_match('/\$this->obj\s*=/', $pageSrc)) {
+        continue;
+    }
+    if (!preg_match("/public \\\$node\s*=\s*'([a-z]+)'/", $pageSrc, $n)) {
+        $failures[] = basename($file)
+            . ' reads $this->obj but declares no $node';
+        $checks++;
+        continue;
+    }
+    $checks++;
+    if (!in_array($n[1], $pagesWithObjects, true)) {
+        $failures[] = basename($file) . " (node '{$n[1]}') reads \$this->obj "
+            . 'but is not in $PagesWithObjects, so sub=edit and sub=delete '
+            . 'fatal on null and serve a bodyless 500';
+    }
+}
+
+if (0 === $checks) {
+    fwrite(STDERR, "FAIL: found no pages to check; layout changed?\n");
+    exit(1);
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks object pages registered\n";
+exit(0);

--- a/tests/site-model.test.php
+++ b/tests/site-model.test.php
@@ -120,8 +120,7 @@ $fields = $prop('databaseFields');
 $expected = [
     'id' => 'siteID',
     'name' => 'siteName',
-    'description' => 'siteDesc',
-    'catchall' => 'siteCatchAll'
+    'description' => 'siteDesc'
 ];
 foreach ($expected as $friendly => $column) {
     check(
@@ -145,6 +144,56 @@ foreach (['users', 'hosts', 'groups', 'usergroups'] as $assoc) {
         $checks
     );
 }
+
+/*
+ * 2b. `catchall` must NOT be a database field, and the reason is not
+ *     stylistic. FOGController::save() only omits a column -- and so stores
+ *     SQL NULL -- when the FRIENDLY key ends in "id"; for every other key an
+ *     unset value is coerced to '' and written (fogcontroller.class.php:515).
+ *     `siteCatchAll` is TINYINT UNSIGNED with `CHECK (siteCatchAll = 1)`, so
+ *     '' is rejected with MySQL 1366 and the ENTIRE insert fails.
+ *
+ *     That shipped: every "create site" failed while the page reported
+ *     "Site added!" with HTTP 201, because the error only surfaced in the
+ *     history table. So the column is written by makeCatchAll() in SQL and
+ *     read by loadCatchall(), and declaring it a database field re-breaks
+ *     creation completely.
+ */
+check(
+    'catchall is NOT a database field (save() would write \'\' and fail '
+    . 'the CHECK constraint)',
+    !array_key_exists('catchall', $fields),
+    $failures,
+    $checks
+);
+check(
+    'catchall is an additional field',
+    in_array('catchall', $prop('additionalFields'), true),
+    $failures,
+    $checks
+);
+check(
+    'Site::loadCatchall() exists, so load() still populates the flag',
+    method_exists('Site', 'loadCatchall'),
+    $failures,
+    $checks
+);
+/*
+ * 2c. save() must propagate parent::save()'s failure. An override that
+ *     returns $this unconditionally makes every `if (!$obj->save())` in the
+ *     page dead code -- which is exactly how the create failure above got
+ *     reported as a success.
+ */
+$saveSrc = file_get_contents($ref->getFileName());
+check(
+    'Site::save() returns false when parent::save() fails',
+    (bool)preg_match(
+        '/if\s*\(\s*!\s*parent::save\(\)\s*\)\s*\{\s*return false;/',
+        $saveSrc
+    ),
+    $failures,
+    $checks
+);
 
 /*
  * 3. The list query counts members with COUNT(DISTINCT ...). Four LEFT


### PR DESCRIPTION
Three bugs found on the deployed commit 11/12 tree, all the same family: sites moved from the plugin into core, and each of the three registrations the plugin used to make for itself from a hook had to become an explicit core one. Two were missed.

## 1. The list page rendered a stub

Site Management showed **"Index page of: SiteManagement"** with no grid.

`FOGPage::index()` has two branches. A node in `FOGBase::$searchPages` gets the list and the AJAX payload its JS asks for; anything else falls through to a stub that prints that line and stops. `site` was missing, so the page took the wrong half of an `if` — menu entry fine, page loads, title right, grid simply absent, no error anywhere to say why.

The plugin had been adding itself from its menu hook (`$arguments['searchPages'][] = $this->node`).

## 2. Every edit and delete was a bodyless 500

`FOGPage`'s constructor only populates `$this->obj` for a node in `$PagesWithObjects`, and `site` was missing there too. `?node=site&sub=edit` fataled on null in `renderEditTabs()`:

```
PHP Fatal error: Uncaught Error: Call to a member function get() on null
  in .../FOGPageRender.class.php:397
#0 .../sitemanagement.page.php(491): FOGPage->renderEditTabs()
```

## 3. Creating a site reported success and wrote nothing

`{"msg":"Site added!"}`, HTTP 201, no row. Two faults compounding:

- **`catchall` was declared a database field.** `FOGController::save()` only omits a column — and so stores SQL NULL — when the *friendly* key ends in `id`; every other key with an empty value is coerced to `''` and written (`fogcontroller.class.php:515`). `siteCatchAll` is `TINYINT UNSIGNED` with `CHECK (siteCatchAll = 1)`, so `''` fails with MySQL 1366 and takes the whole INSERT with it. The column is now not `save()`-managed at all: `makeCatchAll()` already wrote it in SQL, and `loadCatchall()` now reads it back, which `load()` would otherwise never do. `SiteManager::catchAll()` moves off a `catchall` filter for the same reason.
- **`Site::save()` returned `$this` unconditionally**, so `addPost()`'s `if (!\$Site->save())` was dead code and the real error only reached the `history` table.

Also dropped `save()`'s description fill-in — it was justified by the same wrong belief that `save()` drops null-valued fields, and the coercion at `:515` already writes `''` for it. Three comments repeating that claim are corrected rather than deleted; the rule is genuinely surprising and the next person to add a `Site` field needs it.

## Guards

Two invariant tests, each verified to fail on the unfixed tree:

- **`tests/list-pages-registered.test.php`** — a `fog.<node>.list.js` calling `\$.registerListPage` or `\$.registerTable` is asking for a grid only the list branch can serve, so its node must be in `\$searchPages`. Keyed on the registration **call**, not the filename: `apidocs` and `service` both ship a `fog.<node>.list.js` that registers no grid and are correctly absent. Covers all 15 grid pages.
- **`tests/page-objects-registered.test.php`** — a page that *reads* `\$this->obj` without assigning its own must be in `\$PagesWithObjects`. Keying on assignment is what lets the dashboard and server-info pages, which pick a `StorageNode` from a request parameter, sit outside the list legitimately. Covers 13 pages.

## Verification

```
sh tests/run-all.sh    # 17 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR