### PR TITLE
Say in CLAUDE.md which route changes the OpenAPI document covers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,48 @@ Everything is driven by `?node=host&sub=list&id=42`:
 - `node` → maps to a page class (e.g., `host` → `HostManagement`)
 - `sub` → maps to a method on that class (e.g., `list` → `HostManagement::index()`)
 
+### REST API routes and the OpenAPI document
+
+The REST API is routed separately from the `?node=` UI above: `Route::defineRoutes()`
+(`lib/router/route.class.php`) maps the URIs, and `OpenAPI::document()`
+(`lib/fog/openapi.class.php`) describes them, served at `system/openapi` and `swagger.json`
+and rendered by the API Documentation page. The document is generated per request, but only
+*partly* from the router — so **a route change can change behaviour without changing the
+document**. Treat the spec as part of the route commit, not as follow-up.
+
+Updates itself, nothing to do:
+
+| Changed | Covered by |
+|---|---|
+| `Route::$validClasses` | `_paths()` — emits the ten generic operations, a schema and a tag per class, plugin classes included |
+| `$validTaskingClasses` / `$validActiveTasks` | adds `/{id}/task` and `/{id}/cancel`, or `/current` |
+| a model's `$databaseFields` / `$databaseFieldsRequired` / `$databaseFieldsToIgnore` | `_entitySchema()` reflects them; column types come from `commons/schema-expected.php`, so regenerate the manifest or the field is typed `string` |
+| the permission a route requires | `_op()` calls the same `Authorization::resolveApiPermission()` the router does |
+
+Hand-edit `openapi.class.php` in the same commit:
+
+| Changed | Also edit |
+|---|---|
+| added a route that is not the generic CRUD shape | `_classPaths()` for a per-class route, `_fixedPaths()` for a `system/*` or other fixed one |
+| changed a hand-built response body (e.g. `Route::status()` feeding `/system/info`) | that path's literal schema in `_fixedPaths()` |
+| added or renamed a route alias, or an optional trailing segment | the prose on the affected operation — aliases are collapsed to one documented path deliberately |
+| added a field to a special request body (e.g. the task body) | the literal property list in `_classPaths()` |
+
+Two standing rules:
+
+- If a commit touches `route.class.php` and not `openapi.class.php`, say in the message why no
+  spec change was needed. "It is generated" is not the answer for a non-CRUD route.
+- The document is **OAS 3.0.3, not 3.1** — nullable is `nullable: true` and a genuine union is
+  `_oneOfTypes()`, never `type: [x, 'null']`. The `OAS_VERSION` docblock explains why; that is a
+  decision to revisit, not to quietly extend.
+
+**Downstream consumers of the class list.** FogApi (`darksidemilk/FogApi`, the PowerShell module)
+keeps its *own* hardcoded copy of the 1.6 class list in `Private/Get-DynmicParam.ps1` for
+`-coreObject` tab completion — it does not read `system/openapi`. A class added here is missing
+there until someone syncs it by hand, and that list has already drifted. So when a change adds or
+removes a route class, call it out in the PR body under a "Downstream" note naming FogApi, so the
+sync is visible rather than discovered later.
+
 ### Settings
 
 All app config lives in the `globalSettings` MySQL table:
@@ -338,6 +380,7 @@ badly — `ou` and `windowskey` become "Ou" and "Windowskey" without it.
 - Do not use raw `$_GET`/`$_POST` — use `filter_input()` or the already-sanitized values
 - Do not echo user data without `Initiator::e()`
 - Do not remove hooks, events, or plugin integration points without explicit confirmation
+- Do not add or change a REST route without checking whether `OpenAPI::document()` still describes it
 - Do not touch `config.class.php` — it's generated and excluded from git
 - Do not change existing `$databaseFields` key names without understanding the ORM impact
 


### PR DESCRIPTION
Documentation only — `CLAUDE.md`, +43 lines, no code.

## Why

"The document is generated per request" reads as "it keeps itself current", and that is only half true. Class lists, model field metadata and permissions are read live. The *shape* of every operation is hand-written PHP. So a route that is not the generic CRUD shape is served and undescribed unless someone edits `openapi.class.php` in the same breath — and nothing catches it, because there is no test tying the router to the document.

That is not hypothetical. Three cases exist today:

- `POST /snapin/createwithfile` and `POST /storagegroup/{id}/uploadsnapinfiles` are routed and absent from the document.
- `/system/info` grew a `paging` key in #1074's branch while the documented response still promised two properties. That one is fixed in #1080, and it is the first row of the table this PR adds — which is a fair test of whether the table earns its place.

## What it adds

Under *PHP Architecture*, next to `### URL Routing`, since the `?node=` routing and the REST routing are the pair people conflate. Two lookup tables so the answer is a lookup rather than a reading of the generator:

- **Free**: `Route::$validClasses`, `$validTaskingClasses` / `$validActiveTasks`, a model's `$databaseFields` / `$databaseFieldsRequired` / `$databaseFieldsToIgnore`, and the permission a route requires.
- **Hand-edit in the same commit**: a non-CRUD route, a hand-built response body, alias and trailing-segment prose, and special request bodies like the task body.

Plus two standing rules — a commit touching `route.class.php` but not `openapi.class.php` should say why, and the document is 3.0.3, so `nullable: true` and `_oneOfTypes()` rather than `type: [x, 'null']` — and one line in *What NOT to Do*.

## The FogApi note

The last paragraph names a downstream consumer that is easy to forget. `darksidemilk/FogApi` keeps its **own** hardcoded copy of the 1.6 class list in `Private/Get-DynmicParam.ps1` for `-coreObject` tab completion; it does not read `system/openapi`. A class added here goes missing there silently, and that copy has already drifted — comparing it against `Route::$validClasses` today:

- **missing 7** the router serves: `filedeletequeue`, `role`, `rolepermission`, `roleuserassociation`, `roleusergroupassociation`, `usergroup`, `usergroupmember`
- **lists 3** that are not route classes: `site`, `siteassociation` (plugin-provided today) and `unisearch` (a route, not a class)

So the section asks for a "Downstream" line in the PR body when a change adds or removes a route class. That makes the sync visible rather than discovered later; the structural fix would be FogApi reading the document's tags instead of hardcoding, which is a change for that repo.

## Notes

- Scoped to the 1.6 line on purpose. `dev-branch`'s `CLAUDE.md` says nothing about OpenAPI and should not — there is no `openapi.class.php` there, so this guidance would describe code a 1.5 agent cannot find.
- `working-1.6` merged in, since `CLAUDE.md` itself changed above this branch's base in `8208f0bbf`. Clean merge; the net diff against `working-1.6` is exactly the 43 added lines, and the poll-guard section from that commit is intact.
- `tests/run-all.sh`: 14 passed, 1 failed — `secureboot-authvars.test.sh`, which fails identically on a clean `working-1.6` in this container (missing `packages/secureboot/fog-build-sb-authvars`, and it needs bash rather than sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27)_