### PR TITLE
Schema 334: delete the site plugin's orphaned `plugins` row

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5573,3 +5573,62 @@ $this->schema[] = [
         return true;
     },
 ];
+// 334
+$this->schema[] = [
+    // Retire the site plugin's `plugins` row.
+    //
+    // The plugin's code is gone as of fog-plugins v1.6.5 -- sites are core
+    // now -- but deleting the directory does not delete the row that
+    // described it. Discovery only ever walks directories that exist, so
+    // nothing else will ever touch it, and Plugin Management goes on
+    // listing `site` as installed and active with no code behind it.
+    //
+    // Inert rather than dangerous: hooks are loaded from disk, so none of
+    // the plugin's four enforcement hooks can fire, and activationBlockers()
+    // already refuses to re-activate anything with "no code on disk". This
+    // is tidying a ghost, not closing a hole.
+    //
+    // A closure because the row must only go if it really is the bundled
+    // plugin we deleted. Three conditions, and each one is load bearing:
+    //
+    //   name = 'site'          the only plugin this release retired
+    //   location under the     an admin's own `site` plugin in
+    //     bundled root         FOG_PLUGIN_DIR is not ours to delete
+    //   directory absent       the code really is gone
+    //
+    // The last one is the reason isMissing()'s docblock warns against
+    // acting on absence generally: an unmounted external root makes every
+    // plugin look absent at once. Pinning to the bundled root -- which is
+    // inside the web tree the installer just re-laid -- takes that failure
+    // mode off the table, because if THAT is missing the server has bigger
+    // problems than a stale row.
+    function () {
+        $row = self::$DB->query(
+            "SELECT `pID` AS `id`, `pLocation` AS `loc` FROM `plugins` "
+            . "WHERE LOWER(`pName`) = 'site' LIMIT 1"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        if (!is_array($row) || empty($row['id'])) {
+            return true;
+        }
+        $loc = trim((string)($row['loc'] ?? ''));
+        $bundled = rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins' . DS;
+        if ('' === $loc || 0 !== strncmp($loc, $bundled, strlen($bundled))) {
+            return true;
+        }
+        if (is_dir($loc)) {
+            // Code still there, so the row is describing something real and
+            // this is not the state the step was written for -- someone put
+            // the plugin back deliberately, or an install ran the updater
+            // over an older web tree. A step runs once, so nothing revisits
+            // this; leaving a live plugin's row alone is the right way to
+            // spend that one chance.
+            return true;
+        }
+        self::$DB->query(
+            "DELETE FROM `plugins` WHERE `pID` = :id",
+            [],
+            ['id' => (int)$row['id']]
+        );
+        return true;
+    },
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -91,7 +91,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 333);
+        define('FOG_SCHEMA', 334);
         define('FOG_BCACHE_VER', 283);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
Follow-up to the site-into-core work. fog-plugins v1.6.5 deleted the `site` plugin, but deleting a plugin's directory does not delete the row that described it.

## What you see

Confirmed on the 1.6 lab: `plugins` row id 7, `pInstalled=1`, `pState=1`, `pSchema=7`, `pLocation` pointing into `lib/plugins/site/` — a directory that no longer ships. Plugin Management lists it as an installed, active plugin with no code behind it.

Nothing else will ever clear it: `Plugin::getPlugins()` only walks directories that exist, so a row whose directory is gone is never revisited.

## Why it is a tidy-up and not a fix

Inert. Hooks are loaded from disk, so none of the plugin's four (now-removed) enforcement hooks can fire, and `Plugin::activationBlockers()` already refuses to re-activate anything with "has no code on disk". Nothing is exposed by the row's presence — it just looks wrong.

## Why a closure and not a one-line DELETE

The row only goes if it really is the bundled plugin this release removed. Three conditions, each load bearing:

| Condition | Why |
|---|---|
| `LOWER(pName) = 'site'` | the only plugin this release retired |
| `pLocation` under the bundled root | an admin's own `site` plugin in `FOG_PLUGIN_DIR` is not ours to delete |
| directory genuinely absent | the code really is gone |

The third is the one `Plugin::isMissing()`'s own docblock warns against acting on in general — an unmounted external root makes *every* plugin look absent at once, which is why discovery deliberately never deactivates on absence. Pinning to the bundled root, which lives inside the web tree `configureHttpd()` has just re-laid, takes that failure mode off the table: if *that* is missing, a stale row is the least of the server's problems.

Idempotent, and a no-op on every install that never had the plugin.

## Schema bump

`FOG_SCHEMA` 333 → 334. `tests/schema-gate.test.php` is what caught the mismatch — without the bump the step applies to nobody, silently.

334 is free: checked every remote branch, none claims it (the `secureboot-enrollment-task` branch that caused the 322 collision is gone).

## Verification

```
sh tests/run-all.sh    # 17 passed, 0 failed
php -l packages/web/commons/schema.php
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR