### PR TITLE
Fix the plugin runner log line running into the SELinux line

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1355,8 +1355,14 @@ installFOGServices() {
     dots "Creating FOG plugin runner log directory"
     mkdir -p $servicelogs/plugins >>$error_log 2>&1
     chown ${apacheuser}:${apacheuser} $servicelogs/plugins >>$error_log 2>&1
-    setSELinuxContext "$servicelogs/plugins" httpd_sys_rw_content_t
     errorStat $?
+    # Outside the dots/errorStat pair, like every other caller: setSELinuxContext
+    # prints its own "Setting SELinux context" line, so calling it between them
+    # ran that line into ours ("...directory.... * Setting SELinux context...OK"
+    # with our OK stranded on the next line) AND left errorStat reporting the
+    # labelling result instead of whether the directory was created -- a failed
+    # mkdir or chown here would have printed OK.
+    setSELinuxContext "$servicelogs/plugins" httpd_sys_rw_content_t
     # servicemaster.log is where service_lib.php writes every daemon's start,
     # stop and fatal lines, and where PHP's own error_log is pointed. The
     # runner has to be able to append to it or its supervisor lines silently


### PR DESCRIPTION
Reported from an install:

```
 * Creating FOG plugin runner log directory.................... * Setting SELinux context.....................................OK
OK
```

## Cause

`setSELinuxContext()` prints its own `dots()`/OK pair. `installFOGServices()` called it *between* the block's `dots` and its `errorStat`, so the whole second line landed inside the first and our OK was stranded on the next.

## The half you cannot see

`errorStat $?` reports the exit status of the last command — which was `setSELinuxContext`, not the work the line is about. So a failed `mkdir -p $servicelogs/plugins` or a failed `chown` printed **OK**. The plugin runner would then start with nowhere to write and nothing in the install output saying so.

## Fix

Label after `errorStat`, like every other caller. This is not a new discovery: the cache block eight lines below already carries a comment saying exactly this, and the node-certificate helper at `:3511` carries another. This one block was missed.

Swept `lib/common/functions.sh` for the pattern (`dots` → `setSELinuxContext` → `errorStat`) — it was the only remaining instance.

## Not a port candidate

`dev-branch` has no plugin runner log block; `FOGPluginRunner` is 1.6-only (ADR 0010). Verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR