### PR TITLE
Drop SiteManager::catchAll(), which nothing ever called

### DIFF
--- a/packages/web/lib/fog/sitemanager.class.php
+++ b/packages/web/lib/fog/sitemanager.class.php
@@ -32,33 +32,4 @@ class SiteManager extends FOGManagerController
      * @var string
      */
     public $tablename = 'sites';
-    /**
-     * The catch-all site, or null when there is not one.
-     *
-     * Read by id from the flag rather than by name: the name is whatever
-     * was free when schema step 333 ran ('Everything', or 'Everything (2)'
-     * if that was taken), and an admin may rename it afterwards. The flag
-     * is the identity.
-     *
-     * Direct SQL rather than Route::getIds(): `catchall` is not one of
-     * Site's database fields (it cannot be -- see Site::$additionalFields),
-     * so there is no column for a filter to name. It is also NULL-or-1, and
-     * a filter builder that emits `= :val` has no way to ask for NOT NULL.
-     *
-     * @return Site|null
-     */
-    public function catchAll()
-    {
-        $row = self::$DB
-            ->query(
-                'SELECT `siteID` AS `id` FROM `sites` '
-                . 'WHERE `siteCatchAll` IS NOT NULL LIMIT 1'
-            )
-            ->fetch(\PDO::FETCH_ASSOC)
-            ->get();
-        if (!is_array($row) || empty($row['id'])) {
-            return null;
-        }
-        return self::getClass('Site', (int)$row['id']);
-    }
 }


### PR DESCRIPTION
Found by the lab smoke test of the site pages: to exercise this method at all, the test had to call it directly — there is no live path that reaches it.

Confirmed by grep across `packages/web`, `packages/service`, `tests/` and the entire `fog-plugins` tree. The only occurrence of the name is its own definition.

## Why remove rather than leave

Unused is tolerable. **Untested code that returns a real `Site` object** is the shape that invites a future caller to trust a path nobody has ever run — and this one only became correct two commits ago, when `catchall` stopped being a database field and the `Route::getIds('site', ['catchall' => 1])` filter it originally used became invalid.

The two questions it asks are already answered, in the places that own them:

| Question | Answered by |
|---|---|
| Is *this* site the catch-all? | `Site::isCatchAll()` |
| Is *this user* in a catch-all site? | `SiteScope::isUnscoped()` |

The second is the only one the scope boundary actually needs, and it is a genuinely different query — a join from `siteUserMembers` to `sites` — not this one with a filter bolted on. So there is no duplication to consolidate; there is one method too many.

## What is not lost

The docblock's reasoning — that the *flag* identifies the catch-all, not the name, because schema step 333 picks whatever name was free and an admin may rename it afterwards — already lives on `Site::makeCatchAll()`, which is where the flag is written.

## Verification

```
sh tests/run-all.sh    # 18 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR