### PR TITLE
Fix four PHP warnings on every universal search

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2352,11 +2352,6 @@ class Route extends FOGBase
                 ) {
                     continue;
                 }
-                $data['_lang'][$search] = (
-                    $search != 'setting' ?
-                    _($search) :
-                    _('settings')
-                );
                 $searchfor = $search;
                 if ($search === 'ipxe') {
                     $searchfor = 'pxemenuoptions';
@@ -2365,6 +2360,28 @@ class Route extends FOGBase
                     $searchfor,
                     '',
                     true
+                );
+                // An entity with no `name` field has nothing for a universal
+                // search to match on or to label a result with. Skipped
+                // rather than special-cased, because this list is not ours
+                // alone: SEARCH_PAGES hands $searchPages to plugins BY
+                // REFERENCE and they append to it, so no amount of reading
+                // the core list can tell you what arrives here. The live
+                // example is the ntfy plugin, whose model is id/serverURL/
+                // topicEndpoint/credentials -- every unisearch emitted two
+                // "Undefined array key: name" warnings, built a SELECT with
+                // an empty backtick pair, got false back, and then
+                // foreach()ed over the false.
+                //
+                // Before the _lang stamp, so a skipped entity does not leave
+                // a heading behind for results it will never contribute.
+                if (!isset($classVars['databaseFields']['name'])) {
+                    continue;
+                }
+                $data['_lang'][$search] = (
+                    $search != 'setting' ?
+                    _($search) :
+                    _('settings')
                 );
                 $j = $w = $g = '';
                 $params = ['item1' => $like, 'item2' => $like];
@@ -3425,7 +3442,21 @@ class Route extends FOGBase
         if (!is_array($data)) {
             return $data;
         }
-        $classname = isset($data['_lang'])
+        // is_scalar, because '_lang' is not always the classname stamp this
+        // was written for. unisearch() builds it as an ARRAY -- a heading per
+        // entity plus 'AllResults' -- so the cast produced the literal string
+        // "Array", a PHP "Array to string conversion" warning on every
+        // universal search, and a classname of "array" that matches nothing
+        // in the sensitive map. Stripping therefore did nothing at all on
+        // that path while appearing to run.
+        //
+        // Falling through to $emitClassname is right for it: a multi-entity
+        // payload has no single classname, and guessing one would strip the
+        // wrong entity's fields. What keeps that safe is upstream -- the
+        // unisearch query selects exactly two columns and each row is rebuilt
+        // as ['id' => ..., 'name' => ...], so no secret can reach here. If
+        // that ever selects more, this needs a per-entity pass, not a cast.
+        $classname = isset($data['_lang']) && is_scalar($data['_lang'])
             ? strtolower((string)$data['_lang'])
             : self::$emitClassname;
         if ('' === $classname) {


### PR DESCRIPTION
Found while smoke-testing the site pages on the 1.6 lab. Every `POST /fog/unisearch` emits four warnings. **None is caused by sites** — all four are pre-existing and live in `Route`.

## Three from an entity with no `name` field

```
PHP Warning: Undefined array key "name"   route.class.php:2388
PHP Warning: Undefined array key "name"   route.class.php:2392
PHP Warning: foreach() argument must be of type array|object, false given   route.class.php:2406
```

The SELECT is built as ``` `id`,`` FROM ... ```, MySQL rejects it, `query()` returns `false`, and the `foreach` runs over the `false`.

**The entity is `ntfy`**, whose model is `id/serverURL/topicEndpoint/credentials`. It is not in the core `$searchPages` list, and no amount of reading that list would find it: `SEARCH_PAGES` hands the array to plugins **by reference** and the plugin appends itself (`ntfy/hooks/addntfymenuitem.hook.php:97`). Instrumenting the deployed tree put the warnings strictly between `ntfy` and `ou`; the live array holds 22 entries, 6 of them plugin-added.

So the fix is a general property — skip an entity with nothing to match on — rather than naming `ntfy` anywhere. Any plugin can do this, and the next one will.

`ipxe` looks like the culprit and is not: `unisearch()` remaps it to `pxemenuoptions` at `:2361`, which does have a `name`.

## The fourth is unrelated to the other three

```
PHP Warning: Array to string conversion   route.class.php:3429
```

`stripSensitivePayload()` reads `$data['_lang']` as the classname stamp, but `unisearch()` builds `_lang` as an **array** of per-entity headings. The cast yielded the literal `"Array"`, so the classname was `"array"` — which matches nothing in the sensitive map. **Stripping ran and did nothing** on that path, while appearing to work.

Now guarded with `is_scalar` and falling through to `$emitClassname`, which is empty for a unisearch request, so the payload is returned untouched. That is the right answer for a payload with no single classname: guessing one would strip the wrong entity's fields.

### Not a disclosure — verified, not assumed

The unisearch query selects exactly two columns and each row is rebuilt as `['id' => ..., 'name' => ...]`, so no secret can reach the emitter. Checked against live responses for host, ipxe, module, setting, storagenode, user, plugin, role and ldap — every row came back with exactly those two keys, no `ADPass`, no `password`, no `bindPwd`, no node pass. The new comment states what would have to change for that to stop being true.

## Visible effect

`ntfy` no longer appears in universal search results. It never contributed any — its query has always failed — so this makes the behavior honest rather than changing it. Worth a follow-up in `fog-plugins`: a plugin that registers a search page should have something to search.

## Verification

```
sh tests/run-all.sh    # 18 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR