### PR TITLE
Match settings by key only in universal search

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2394,8 +2394,25 @@ class Route extends FOGBase
                         $g = "GROUP BY `hosts`.`hostName`";
                         break;
                     case 'setting':
-                        $w = " OR `settingValue` LIKE :item3";
-                        $params['item3'] = $like;
+                        // Deliberately no `settingValue` clause, and this
+                        // empty case is here to say so rather than leave a
+                        // gap that reads like an oversight.
+                        //
+                        // A setting is found by its key, the way every other
+                        // entity is found by its name. Matching the value
+                        // made the result count carry information about a
+                        // field the response never contains -- and
+                        // globalSettings is where FOG keeps its credentials,
+                        // which is why maskSensitiveSetting() strips `value`
+                        // from this same user's API reads. A search that
+                        // answers questions about a field the API will not
+                        // show gives back what the masking withholds.
+                        //
+                        // Excluding only the credential keys was the other
+                        // option and is worse: it needs a second copy of
+                        // isSensitiveSetting()'s rule living beside the
+                        // query, and the day the two drift nothing fails --
+                        // the values just quietly become findable again.
                         break;
                     case 'storagenode':
                         $w = " OR `ngmHostname` LIKE :item3";

--- a/tests/search-no-value-match.test.php
+++ b/tests/search-no-value-match.test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Universal search must not match a globalSettings value.
+ *
+ * `Route::unisearch()` returns only an id and a name per row, so a setting's
+ * value never appears in a response. It used to be matched anyway, with
+ * `OR settingValue LIKE :item3`, and that is a different thing from
+ * returning it: the number of results answers "does this value contain that
+ * substring", which is exactly the question `maskSensitiveSetting()` exists
+ * to refuse. globalSettings is where FOG keeps its credentials, so the
+ * answer is worth having.
+ *
+ * Restoring the clause looks like a small usability improvement -- "let
+ * admins find a setting by its value" -- and nothing about the code says
+ * otherwise, which is why this test exists rather than a comment alone.
+ * The empty `case 'setting':` in that switch carries the reasoning.
+ *
+ * Scoped to the query builder, not the whole file: `settingValue` is a real
+ * column and legitimately appears in reads elsewhere. What must not come
+ * back is matching it in a search.
+ *
+ * DB-free: reads the source.
+ *
+ * Usage: php tests/search-no-value-match.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$routeFile = dirname(__DIR__)
+    . '/packages/web/lib/router/route.class.php';
+
+if (!is_readable($routeFile)) {
+    fwrite(STDERR, "FAIL: cannot read $routeFile\n");
+    exit(1);
+}
+
+$src = file_get_contents($routeFile);
+
+// The body of unisearch(), from its signature to the next method.
+$start = strpos($src, 'public static function unisearch(');
+if (false === $start) {
+    fwrite(STDERR, "FAIL: could not locate unisearch() in route\n");
+    exit(1);
+}
+$end = strpos($src, 'public static function search(', $start);
+if (false === $end) {
+    fwrite(STDERR, "FAIL: could not find the end of unisearch()\n");
+    exit(1);
+}
+$body = substr($src, $start, $end - $start);
+
+$failures = [];
+$checks = 0;
+
+// Comments explain the absence, so they must not count as the thing itself.
+$code = preg_replace('#//[^\n]*#', '', $body);
+
+$checks++;
+if (preg_match('/settingValue/i', $code)) {
+    $failures[] = 'unisearch() references settingValue. The universal '
+        . 'search must match a setting by its KEY only -- matching the '
+        . 'value turns the result count into an oracle for credential '
+        . 'settings whose value the API deliberately masks.';
+}
+
+// The marker case is what makes the omission legible in the source. Losing
+// it is not a vulnerability, but it is how the next person re-adds the
+// clause without knowing there was a reason.
+$checks++;
+if (false === strpos($body, "case 'setting':")) {
+    $failures[] = "the explicit `case 'setting':` marker in unisearch()'s "
+        . 'switch is gone; it is what records that the missing value clause '
+        . 'is deliberate';
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks search value-match checks\n";
+exit(0);


### PR DESCRIPTION
Universal search returns an id and a name per row and nothing else, so a setting's **value** never appears in a response. It was still matched, via `OR settingValue LIKE :item3` — and that is not the same thing as not returning it. Whether a row comes back is itself an answer about the value.

`globalSettings` is where FOG keeps its credentials. `Route::maskSensitiveSetting()` strips `value` from API reads for exactly that reason, and it applies to the same users this loop is gated on — `Authorization::can('list', 'setting')`. A search that answers questions about the field hands back what the masking is there to withhold.

## The change

Settings are found by **key**, the way every other entity is found by its name. The `case 'setting':` arm stays as an empty marker rather than being deleted: the missing clause has a reason, and an unexplained gap invites the next person to fill it in as a usability improvement.

## Why not exclude only the credential keys

That was the alternative, and it is worse. It needs a second copy of `isSensitiveSetting()`'s rule living beside the query — pattern, include list and exempt list, in SQL rather than PHP. The day the two drift, nothing fails: values simply become matchable again, silently. One rule in one place is the property worth keeping, and "find a setting by its value" is not worth buying a second one.

## Guard

`tests/search-no-value-match.test.php` — asserts `unisearch()` makes no reference to `settingValue` (comments stripped first, so the explanation doesn't count as the thing it explains) and that the marker case survives. Checked against a tree with the clause restored: it fails.

## Not a port candidate

`dev-branch`'s `route.class.php` has no `unisearch()` and no `settingValue` reference at all. Verified, not assumed.

## Verification

```
sh tests/run-all.sh    # 19 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR