### PR TITLE
Restore setting-value search, minus the credential rows

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2394,25 +2394,29 @@ class Route extends FOGBase
                         $g = "GROUP BY `hosts`.`hostName`";
                         break;
                     case 'setting':
-                        // Deliberately no `settingValue` clause, and this
-                        // empty case is here to say so rather than leave a
-                        // gap that reads like an oversight.
+                        // The value IS matched -- searching "bzImage" to find
+                        // FOG_TFTP_PXE_KERNEL is the point of searching
+                        // settings at all, and a key-only search can never
+                        // do it.
                         //
-                        // A setting is found by its key, the way every other
-                        // entity is found by its name. Matching the value
-                        // made the result count carry information about a
-                        // field the response never contains -- and
-                        // globalSettings is where FOG keeps its credentials,
-                        // which is why maskSensitiveSetting() strips `value`
-                        // from this same user's API reads. A search that
-                        // answers questions about a field the API will not
-                        // show gives back what the masking withholds.
+                        // What must not happen is confirming a CREDENTIAL
+                        // value. globalSettings is also where FOG keeps its
+                        // passwords, maskSensitiveSetting() strips their
+                        // value from this same user's API reads, and a hit
+                        // here would answer the question that masking
+                        // refuses -- repeatedly, a few characters at a time.
+                        // So a credential row that matched ONLY on its value
+                        // is dropped below, after the query.
                         //
-                        // Excluding only the credential keys was the other
-                        // option and is worse: it needs a second copy of
-                        // isSensitiveSetting()'s rule living beside the
-                        // query, and the day the two drift nothing fails --
-                        // the values just quietly become findable again.
+                        // Dropped after rather than excluded in the WHERE on
+                        // purpose: an SQL-side exclusion needs a second copy
+                        // of isSensitiveSetting()'s rule (pattern, include
+                        // list, exempt list) written in a different dialect,
+                        // and the day the two drift nothing fails -- the
+                        // values just quietly become findable again. Calling
+                        // the real predicate keeps one rule in one place.
+                        $w = " OR `settingValue` LIKE :item3";
+                        $params['item3'] = $like;
                         break;
                     case 'storagenode':
                         $w = " OR `ngmHostname` LIKE :item3";
@@ -2451,6 +2455,27 @@ class Route extends FOGBase
                             '_api'
                         );
                         if (false !== $api) {
+                            continue;
+                        }
+                    }
+                    // A credential setting that matched only on its VALUE is
+                    // dropped: returning it would confirm a substring of a
+                    // value maskSensitiveSetting() refuses to show. Matching
+                    // its key still returns it -- searching "PASSWORD" should
+                    // find FOG_TFTP_FTP_PASSWORD, that is not a secret.
+                    //
+                    // Recomputed here rather than asked of the query, because
+                    // SQL cannot say which OR arm matched. stripos is the
+                    // same substring test the bound '%term%' performs. Where
+                    // the two can disagree -- a term containing % or _, which
+                    // LIKE treats as a wildcard and stripos does not -- the
+                    // disagreement drops the row, which is the safe direction.
+                    if ('setting' === $search) {
+                        $sid = (string)$val[$classVars['databaseFields']['id']];
+                        $skey = (string)$val[$classVars['databaseFields']['name']];
+                        $visible = false !== stripos($sid, $item)
+                            || false !== stripos($skey, $item);
+                        if (!$visible && self::isSensitiveSetting($skey)) {
                             continue;
                         }
                     }

--- a/tests/search-no-value-match.test.php
+++ b/tests/search-no-value-match.test.php
@@ -1,23 +1,32 @@
 <?php
 /**
- * Universal search must not match a globalSettings value.
+ * Universal search may match a setting's value, but must not confirm a
+ * credential one.
  *
- * `Route::unisearch()` returns only an id and a name per row, so a setting's
- * value never appears in a response. It used to be matched anyway, with
- * `OR settingValue LIKE :item3`, and that is a different thing from
- * returning it: the number of results answers "does this value contain that
- * substring", which is exactly the question `maskSensitiveSetting()` exists
- * to refuse. globalSettings is where FOG keeps its credentials, so the
- * answer is worth having.
+ * Searching settings by VALUE is the point of searching settings: "bzImage"
+ * finds FOG_TFTP_PXE_KERNEL, and no key-only search ever can. So the value
+ * clause stays.
  *
- * Restoring the clause looks like a small usability improvement -- "let
- * admins find a setting by its value" -- and nothing about the code says
- * otherwise, which is why this test exists rather than a comment alone.
- * The empty `case 'setting':` in that switch carries the reasoning.
+ * globalSettings is also where FOG keeps its passwords, and
+ * Route::maskSensitiveSetting() strips their value from API reads. A hit on
+ * the value would answer the question that masking refuses -- and answer it
+ * repeatedly, a few characters at a time -- even though the value itself
+ * never appears in the response. So unisearch() drops a credential row that
+ * matched ONLY on its value, using Route::isSensitiveSetting() itself.
  *
- * Scoped to the query builder, not the whole file: `settingValue` is a real
- * column and legitimately appears in reads elsewhere. What must not come
- * back is matching it in a search.
+ * The invariant is the PAIR, which is why this test is conditional rather
+ * than a ban on either half:
+ *
+ *   matching settingValue  =>  calling isSensitiveSetting()
+ *
+ * Removing the drop while keeping the match is the regression that matters,
+ * and it is an easy one to make -- the drop lives thirty lines below the
+ * clause it guards, in the result loop, because SQL cannot report which OR
+ * arm matched. Removing both is merely a feature regression, and the second
+ * check names it so nobody re-adds the clause without the guard.
+ *
+ * Scoped to unisearch(), not the whole file: settingValue is a real column
+ * and legitimately appears in reads elsewhere.
  *
  * DB-free: reads the source.
  *
@@ -48,28 +57,30 @@ if (false === $end) {
 }
 $body = substr($src, $start, $end - $start);
 
+// Comments explain both halves, so they must not count as either half.
+$code = preg_replace('#//[^\n]*#', '', $body);
+
 $failures = [];
 $checks = 0;
 
-// Comments explain the absence, so they must not count as the thing itself.
-$code = preg_replace('#//[^\n]*#', '', $body);
+$matchesValue = (bool)preg_match('/settingValue/i', $code);
+$guards = (bool)preg_match('/isSensitiveSetting\s*\(/', $code);
 
 $checks++;
-if (preg_match('/settingValue/i', $code)) {
-    $failures[] = 'unisearch() references settingValue. The universal '
-        . 'search must match a setting by its KEY only -- matching the '
-        . 'value turns the result count into an oracle for credential '
-        . 'settings whose value the API deliberately masks.';
+if ($matchesValue && !$guards) {
+    $failures[] = 'unisearch() matches settingValue without calling '
+        . 'isSensitiveSetting(). Matching the value of a credential setting '
+        . 'confirms a substring of a value the API deliberately masks, so '
+        . 'the value clause may only ship alongside the drop that follows it '
+        . 'in the result loop.';
 }
 
-// The marker case is what makes the omission legible in the source. Losing
-// it is not a vulnerability, but it is how the next person re-adds the
-// clause without knowing there was a reason.
 $checks++;
-if (false === strpos($body, "case 'setting':")) {
-    $failures[] = "the explicit `case 'setting':` marker in unisearch()'s "
-        . 'switch is gone; it is what records that the missing value clause '
-        . 'is deliberate';
+if (!$matchesValue) {
+    $failures[] = 'unisearch() no longer matches settingValue, so a setting '
+        . 'can only be found by its key -- "bzImage" stops finding '
+        . 'FOG_TFTP_PXE_KERNEL. If that is deliberate, delete this check and '
+        . 'say why; do not just let it fail.';
 }
 
 if (count($failures)) {
@@ -80,5 +91,5 @@ if (count($failures)) {
     exit(1);
 }
 
-echo "ok  $checks search value-match checks\n";
+echo "ok  $checks setting value-match checks\n";
 exit(0);


### PR DESCRIPTION
Fixes a regression I introduced in #1086.

That PR removed the `settingValue` clause from `unisearch()` outright, which also removed the reason people search settings at all: **`bzImage` no longer finds `FOG_TFTP_PXE_KERNEL`**, and no key-only search ever can. Reported within the hour.

## What was actually worth protecting

Narrower than what #1086 removed. A hit on a **credential** setting's value confirms a substring of a value `maskSensitiveSetting()` refuses to show — and confirms it repeatedly, a few characters at a time. Every *other* setting's value is ordinary configuration that admins have always been able to read on the settings page.

So the clause is back, and a credential row that matched **only** on its value is dropped in the result loop. A credential row that matched on its key or id is kept: searching `PASSWORD` should still find `FOG_TFTP_FTP_PASSWORD`. The key was never the secret.

## The part #1086 got wrong

Its commit message argued that excluding credential keys needs a second copy of `isSensitiveSetting()`'s rule — pattern, include list, exempt list — rewritten in SQL, and that the two would drift apart silently. That is true of an **SQL-side** exclusion. It is not true of calling the predicate itself on the rows that came back. One rule, one place, no extra query.

SQL cannot report which `OR` arm matched, so visibility is recomputed with `stripos` — the same substring test the bound `'%term%'` performs. The two can disagree only on a term containing `%` or `_`, which `LIKE` treats as a wildcard and `stripos` does not; there the row is dropped, which is the safe direction.

## Test

`tests/search-no-value-match.test.php` now pins the **pair** instead of banning the clause:

> matching `settingValue` ⇒ calling `isSensitiveSetting()`

That is the invariant worth holding, because the dangerous regression is keeping the clause and losing the drop — and the drop sits thirty lines below the clause it guards, in the result loop. Verified the test fails on exactly that tree. A second check fails if the clause disappears again, so the `bzImage` regression can't come back silently either.

## Verification

```
sh tests/run-all.sh    # 19 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR