### PR TITLE
Don't let a request filter or search a field the emitter strips

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -510,6 +510,15 @@ abstract class FOGManagerController extends FOGBase
      * word by word on any field. It's possible to do here performance on large
      * databases would be very poor
      *
+     * Two column flags suppress a column here, and they mean different
+     * things. 'removeFromQuery' says the column is not a real column of the
+     * table -- an aggregate or a formatter's invention -- so naming it in
+     * SQL is an error. 'nosearch' says the column IS real and IS selected,
+     * but must never be matched against: Route::listem() sets it on every
+     * field the emitter strips, so a caller cannot use match/no-match to
+     * learn a value the response refuses to contain. The searchable flag in
+     * the request cannot serve for this -- the client sends it.
+     *
      * @param array $request  Data sent to server by DataTables
      * @param array $columns  Column information array
      * @param array $bindings Array of values for PDO bindings, used in the
@@ -537,6 +546,7 @@ abstract class FOGManagerController extends FOGBase
                     || $requestColumn['searchable'] != 'true'
                     || !isset($column['db'])
                     || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
+                    || (isset($column['nosearch']) && $column['nosearch'])
                 ) {
                     continue;
                 }
@@ -556,6 +566,7 @@ abstract class FOGManagerController extends FOGBase
                     || $str == ''
                     || !isset($column['db'])
                     || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
+                    || (isset($column['nosearch']) && $column['nosearch'])
                 ) {
                     continue;
                 }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -573,8 +573,18 @@ class Route extends FOGBase
         if (count($whereItems ?: []) < 1) {
             return;
         }
+        self::_assertNoSensitiveFilter($whereItems, $class);
         $classVars = self::getClass($class, '', true);
-        $valid = array_keys((array)$classVars['databaseFields']);
+        // Blocked fields are dropped from the advertised list as well as
+        // refused above -- an error that names them as valid alternatives
+        // would be telling the caller to retry with the one thing this
+        // refuses.
+        $valid = array_values(
+            array_diff(
+                array_keys((array)$classVars['databaseFields']),
+                self::unfilterableFields($class)
+            )
+        );
         $unknown = array_diff(array_keys($whereItems), $valid);
         if (count($unknown) < 1) {
             return;
@@ -589,6 +599,80 @@ class Route extends FOGBase
                         implode(', ', $unknown)
                     ),
                     'valid' => $valid
+                ]
+            )
+        );
+    }
+    /**
+     * Fields a REQUEST may never filter or search on.
+     *
+     * The same list the emitter strips, read from the same place, because
+     * two lists that must agree are two lists that will not. Plugin secrets
+     * declared through API_SENSITIVE_FIELDS are included by construction --
+     * sensitiveFieldMap() fires that event -- so a plugin gets this
+     * protection without knowing the rule exists.
+     *
+     * Both tiers, deliberately. 'always' is never returned at all; 'fields'
+     * is returned on a direct single-entity GET and stripped everywhere
+     * else. Filtering is neither: it is a question asked of every row at
+     * once, which is exactly the shape a single-GET exemption is not meant
+     * to cover.
+     *
+     * NOT the place for globalSettings values. A setting's value is
+     * ordinary configuration for all but a handful of keys, so it is
+     * filtered per ROW against isSensitiveSetting() rather than blocked
+     * per FIELD -- blocking the field would take "which setting holds
+     * bzImage" away to protect four passwords.
+     *
+     * @param string $class The entity being filtered.
+     *
+     * @return array friendly field names
+     */
+    public static function unfilterableFields($class)
+    {
+        $map = self::sensitiveFieldMap();
+        $classname = strtolower(trim((string)$class));
+        return array_values(
+            array_unique(
+                array_merge(
+                    (array)($map['always'][$classname] ?? []),
+                    (array)($map['fields'][$classname] ?? [])
+                )
+            )
+        );
+    }
+    /**
+     * Refuses a request that filters on a field the emitter would strip.
+     *
+     * Rejected rather than silently ignored. Dropping the key would answer
+     * with the UNFILTERED set, which is a worse surprise than an error --
+     * a caller asking for one host would get all of them. The field names
+     * are already public in the OpenAPI document, so naming them here tells
+     * an attacker nothing they could not read from /system/openapi.
+     *
+     * @param array  $whereItems The request-supplied filter.
+     * @param string $class      The entity being filtered.
+     *
+     * @return void
+     */
+    private static function _assertNoSensitiveFilter($whereItems, $class)
+    {
+        $blocked = array_intersect(
+            array_keys((array)$whereItems),
+            self::unfilterableFields($class)
+        );
+        if (count($blocked) < 1) {
+            return;
+        }
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_BAD_REQUEST,
+            json_encode(
+                [
+                    'error' => sprintf(
+                        _('Cannot filter %s on: %s'),
+                        strtolower($class),
+                        implode(', ', $blocked)
+                    )
                 ]
             )
         );
@@ -2094,6 +2178,35 @@ class Route extends FOGBase
                 ]
             );
 
+            // A field the emitter strips must not be searchable either.
+            //
+            // Marked unsearchable rather than dropped, because these columns
+            // are load bearing for callers that are not the API. listem() is
+            // shared with the web tier: product_keys.report.php calls
+            // listem('host') and has nothing to report without productKey.
+            // Removing the column would break the report to close a search;
+            // stripSensitive() at the emitter is what keeps it off the wire.
+            //
+            // Searching is the part with no legitimate use. The value never
+            // comes back, so a match can only ever be read as an answer about
+            // a value the caller is not allowed to see -- and DataTables
+            // filters are substring LIKEs, so the answer is repeatable one
+            // character at a time. host.sec_tok and user.token are stored in
+            // plaintext and matched exactly at authentication, which is what
+            // makes this worth closing rather than noting.
+            //
+            // Applied after CUSTOMIZE_DT_COLUMNS so a column a plugin adds
+            // for its own declared secret is covered too, and keyed on 'dt'
+            // because that is the name a DataTables request asks for.
+            $unsearchable = self::unfilterableFields($classname);
+            if (count($unsearchable)) {
+                foreach ($columns as $ci => $col) {
+                    if (in_array($col['dt'] ?? '', $unsearchable, true)) {
+                        $columns[$ci]['nosearch'] = true;
+                    }
+                }
+            }
+
             self::$data = FOGManagerController::complex(
                 isset($pass_vars) ? $pass_vars : '',
                 $table,
@@ -3264,6 +3377,7 @@ class Route extends FOGBase
                 true
             );
             $find = [];
+            $classname = $class;
             $class = new $class;
             foreach ($classVars['databaseFields'] as &$key) {
                 $key = $class->key($key);
@@ -3272,6 +3386,13 @@ class Route extends FOGBase
                 }
                 unset($key);
             }
+            // The other request-facing filter entry point. Intersecting with
+            // the class's own fields, which is all this used to do, admits
+            // every sensitive field -- they ARE the class's fields. Only
+            // _assertNoSensitiveFilter() is called, not the full key check:
+            // this body has always ignored keys it does not recognise, and
+            // starting to 400 on them would be a separate behaviour change.
+            self::_assertNoSensitiveFilter($find, $classname);
 
             // Request-supplied, so the caller-facing '*'/'+' wildcards apply
             // here (they used to be expanded down in _buildSql, which also

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1140,6 +1140,10 @@ msgstr "Verbindung zum FTP-Server nicht möglich"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Es können keine Tasks auf ausstehende Hosts ausgeführt werden!"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1144,6 +1144,10 @@ msgstr "Cannot connect to database"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Cannot set taskings to pending or invalid items"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1160,6 +1160,10 @@ msgstr "Error: No se pudo descargar kernel"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "No se puede establecer taskings de pendiente o elementos no válidos"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1140,6 +1140,10 @@ msgstr "Verbindung zum FTP-Server nicht möglich"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Es können keine Tasks auf ausstehende Hosts ausgeführt werden!"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1145,6 +1145,10 @@ msgstr "Impossible de se connecter à la base de données"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Impossible de définir les affectations en cours ou éléments non valides"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1102,6 +1102,10 @@ msgstr "Impossibile connettersi al server ftp"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Impossibile affidare attività ad host in attesa"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1083,6 +1083,10 @@ msgstr "FTP サーバーに接続できません"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "保留中のホストにタスクを設定できません"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -965,6 +965,10 @@ msgstr ""
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 msgid "Cannot task pending hosts"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1144,6 +1144,10 @@ msgstr "Não é possível conectar ao banco de dados"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Não é possível definir taskings para pendente ou artigos inválidos"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1144,6 +1144,10 @@ msgstr "无法连接到数据库"
 msgid "Cannot delete the primary mac address, please reselect"
 msgstr ""
 
+#, php-format
+msgid "Cannot filter %s on: %s"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "无法设置taskings未决的或无效的项目"

--- a/tests/sensitive-fields-unfilterable.test.php
+++ b/tests/sensitive-fields-unfilterable.test.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * A field the emitter strips must not be filterable or searchable.
+ *
+ * Route knows what to strip from a payload (sensitiveFieldMap) and it knows
+ * what a request may filter and search on. Those were three independent
+ * decisions written in three places, and nothing kept them in agreement:
+ * every sensitive field was filterable by name on every list route, and
+ * '*'/'+' expand to '%' at the request-facing entry points, so the filter
+ * was a PREFIX match. Match/no-match then recovers a value the response
+ * never contains, one character at a time.
+ *
+ * That matters because of what the columns hold. user.token is a plaintext
+ * 128-character hex string and _testAuth() matches it exactly; host.sec_tok
+ * is plaintext and authenticates the client protocol; the ldap plugin's
+ * bindPwd is cleartext by its own docstring. (host.ADPass and productKey are
+ * encrypted at rest, so the same trick reaches ciphertext -- which is why
+ * the rule is "what the emitter strips" and not "what looks alarming".)
+ *
+ * One derived list is the fix, and this test exists to keep it derived. The
+ * failure mode is not a bug in the rule, it is a fourth place growing its own
+ * copy -- so what is asserted here is that the deciding functions call
+ * unfilterableFields(), not that any particular field appears in it.
+ *
+ * DB-free: reads the source.
+ *
+ * Usage: php tests/sensitive-fields-unfilterable.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$routeFile = $webroot . '/lib/router/route.class.php';
+$mgrFile = $webroot . '/lib/fog/fogmanagercontroller.class.php';
+
+foreach ([$routeFile, $mgrFile] as $needed) {
+    if (!is_readable($needed)) {
+        fwrite(STDERR, "FAIL: cannot read $needed\n");
+        exit(1);
+    }
+}
+
+$route = file_get_contents($routeFile);
+$mgr = file_get_contents($mgrFile);
+
+$failures = [];
+$checks = 0;
+
+/**
+ * Returns the source of a named method, signature to the following one.
+ */
+$bodyOf = function ($src, $needle) {
+    $start = strpos($src, $needle);
+    if (false === $start) {
+        return null;
+    }
+    $next = preg_match(
+        '/\n    (?:public|private|protected)[ a-z]* function /',
+        $src,
+        $m,
+        PREG_OFFSET_CAPTURE,
+        $start + strlen($needle)
+    );
+    return $next
+        ? substr($src, $start, $m[0][1] - $start)
+        : substr($src, $start);
+};
+
+// 1. The single source exists and reads the emitter's own map.
+$checks++;
+$derive = $bodyOf($route, 'public static function unfilterableFields(');
+if (null === $derive) {
+    $failures[] = 'Route::unfilterableFields() is gone -- the one place the '
+        . 'filter rule is derived from';
+} elseif (false === strpos($derive, 'sensitiveFieldMap()')) {
+    $checks++;
+    $failures[] = 'unfilterableFields() no longer reads sensitiveFieldMap(). '
+        . 'A hand-maintained list is the bug this replaced: it drifts from '
+        . 'what the emitter strips, silently, and misses anything a plugin '
+        . 'declares through API_SENSITIVE_FIELDS.';
+}
+
+// 2. Both request-facing filter entry points refuse a blocked field.
+//    getsearchbody() is the JSON body; handleWhereItems() is the URL
+//    segment, via _assertFilterKeys().
+foreach (
+    [
+        'public static function getsearchbody(' => 'the JSON search body',
+        'private static function _assertFilterKeys(' => 'the URL filter segment'
+    ] as $needle => $what
+) {
+    $checks++;
+    $body = $bodyOf($route, $needle);
+    if (null === $body) {
+        $failures[] = "could not find $needle in route; has it been renamed?";
+        continue;
+    }
+    if (false === strpos($body, '_assertNoSensitiveFilter(')) {
+        $failures[] = "$what no longer calls _assertNoSensitiveFilter(), so a "
+            . 'request can filter on a field the emitter strips';
+    }
+}
+
+// 3. The refusal is a refusal, not a silent drop. Dropping the key answers
+//    with the UNFILTERED set, which is a worse surprise than an error.
+$checks++;
+$assert = $bodyOf($route, 'private static function _assertNoSensitiveFilter(');
+if (null === $assert) {
+    $failures[] = '_assertNoSensitiveFilter() is gone';
+} elseif (false === strpos($assert, 'HTTP_BAD_REQUEST')) {
+    $failures[] = '_assertNoSensitiveFilter() no longer answers 400; a '
+        . 'silently dropped filter returns every row instead of the one asked '
+        . 'for';
+}
+
+// 4. The grid path marks those columns unsearchable, and filter() honours it.
+//    Not removed from the column list: listem() is shared with the web tier
+//    and product_keys.report.php needs productKey to report anything.
+$checks++;
+$listem = $bodyOf($route, 'public static function listem(');
+if (null === $listem) {
+    $failures[] = 'could not find Route::listem()';
+} elseif (false === strpos($listem, "'nosearch'")) {
+    $failures[] = 'listem() no longer marks sensitive columns nosearch, so '
+        . 'the DataTables grid can search a field the emitter strips';
+}
+
+$checks++;
+$filter = $bodyOf($mgr, 'public static function filter(');
+if (null === $filter) {
+    $failures[] = 'could not find FOGManagerController::filter()';
+} else {
+    // Once per loop: the global search and the per-column search. Counted
+    // on the isset(), which appears exactly once per guard -- the guard
+    // names $column['nosearch'] twice, so counting that would still pass
+    // with one whole loop unguarded.
+    $honoured = substr_count($filter, "isset(\$column['nosearch'])");
+    if ($honoured < 2) {
+        $failures[] = "filter() honours nosearch in $honoured of its 2 "
+            . 'search loops. Both build a LIKE from a client-named column, '
+            . 'so a gap in either one reopens the whole thing.';
+    }
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks sensitive-filter checks\n";
+exit(0);


### PR DESCRIPTION
Hardening, from the sweep that followed #1086.

`Route` knew three separate things, and only one of them was derived from anything:

| Question | Answered by | Derived? |
|---|---|---|
| What do we strip from a payload? | `sensitiveFieldMap()` | yes — plugins contribute via `API_SENSITIVE_FIELDS` |
| What may a request filter on? | `getsearchbody()`, `_assertFilterKeys()` | no |
| What may a grid search on? | the DataTables column list | no |

The last two admitted every sensitive field, because those fields are ordinary members of `$databaseFields` and nothing said otherwise.

## Why it matters even though the value never comes back

Whether a *row* comes back is itself an answer about the value — and `*`/`+` expand to `%` at both request-facing entry points (`expandSearchWildcards()`), with `_buildSql` switching to `LIKE` on seeing one. So the answer can be narrowed rather than guessed. Same shape as the settings case in #1086, on fields that aren't settings: `user.token` and `host.sec_tok` are stored as written and compared exactly at authentication.

Worth noting for calibration: `host.ADPass` and `productKey` are encrypted at rest (`route.class.php:3511`), so the same trick reaches ciphertext. That's why the rule is "whatever the emitter strips" rather than a hand-picked list of alarming-looking names.

## One derived list

`Route::unfilterableFields()` reads the emitter's own map, both tiers. Nothing to keep in sync, and a plugin's declared secret is covered without the plugin knowing the rule exists.

**Filtering is refused with 400, not ignored.** Dropping the key answers with the *unfiltered* set — a caller asking for one host gets all of them. The field names are already in `/system/openapi`, so naming them in the error costs nothing. The advertised `valid` list drops them too; an error offering the refused field as an alternative is worse than no error.

**Grid columns are marked `nosearch`, not removed** — and that distinction is load bearing. `listem()` is shared with the web tier, and `product_keys.report.php` calls `listem('host')` with nothing to report without `productKey`. Removing the column would break a report to close a search. The request's own `searchable` flag can't serve either: the client sends it. Applied after `CUSTOMIZE_DT_COLUMNS` so plugin columns are covered, and honored in **both** of `filter()`'s loops — a gap in either reopens all of it.

## What is deliberately not here

`globalSettings` values. A setting's value is ordinary configuration for all but a handful of keys, so it stays searchable and credential *rows* are dropped instead (#1087). Blocking the field would take "which setting holds `bzImage`" away to protect four passwords. The grid path still needs that same row-level treatment — that's a separate PR, not this one.

## Unaffected

Internal callers. Both checks run only where the filter came from the request; an array built in PHP reaches `handleWhereItems()` without a class and is not validated. Client and API authentication go through `FOGController::load()`, not Route filters.

## Verification

```
sh tests/run-all.sh    # 20 passed, 0 failed
```

`tests/sensitive-fields-unfilterable.test.php` asserts the deciding functions *call* `unfilterableFields()` rather than asserting any particular field is in it — the failure mode is a fourth place growing its own copy. Verified it fails when either of `filter()`'s two loops loses its guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR