### PR TITLE
Stop the site migration blinding the next account created

### DIFF
--- a/packages/web/lib/fog/FOGPagePost.class.php
+++ b/packages/web/lib/fog/FOGPagePost.class.php
@@ -491,4 +491,26 @@ trait FOGPagePost
                 [[$objectID, $siteID]]
             );
     }
+    /**
+     * Applies the create form's Site field to the object just created.
+     *
+     * Same rule as the edit tab, so it is the same code -- but only when
+     * the field was actually posted. siteAddField() renders nothing on a
+     * server with no sites, and a hook may drop it; in either case the
+     * absent field means "nothing was asked for", not "no site", and
+     * treating it as the latter would delete the catch-all membership
+     * User::save() had just given a brand new account.
+     *
+     * @param string $node the owning node (host|user|group|usergroup)
+     * @param object $obj  the object just created
+     *
+     * @return void
+     */
+    protected function siteAddPost($node, $obj)
+    {
+        if (null === filter_input(INPUT_POST, 'site')) {
+            return;
+        }
+        $this->siteTabPost($node, $obj);
+    }
 }

--- a/packages/web/lib/fog/FOGPageRender.class.php
+++ b/packages/web/lib/fog/FOGPageRender.class.php
@@ -785,6 +785,51 @@ trait FOGPageRender
         );
     }
     /**
+     * The Site field for a "Create New X" form, or nothing if this install
+     * has no sites at all.
+     *
+     * Creating an object and then having to open it again to say where it
+     * lives is the shape the site plugin had, and for a USER it is worse
+     * than tedious: site scope is deny-all, so between the two steps the
+     * account exists and sees nothing.
+     *
+     * The default differs by what the server is doing, and deliberately:
+     *
+     *   - no real site yet -- the catch-all is the only option there is, so
+     *     it is preselected. This is the same answer User::save() reaches
+     *     on its own for the paths with no form behind them; the field is
+     *     here so the page agrees with what is about to happen rather than
+     *     appearing to offer a choice it does not have.
+     *   - real sites exist -- blank. Which site a new object belongs to is
+     *     the admin's call at that point, and preselecting the catch-all
+     *     would quietly grant every new account sight of everything.
+     *
+     * Returns [] when there are no sites and no catch-all, which is the
+     * pre-schema-333 window: rendering a select box out of a table that
+     * may not exist yet would take the create page down with it.
+     *
+     * @param string $labelClass the form's label class
+     *
+     * @return array fields fragment to merge onto the create form
+     */
+    protected static function siteAddField($labelClass = 'col-sm-3 col-form-label')
+    {
+        if (SiteScope::catchAllID() < 1 && !SiteScope::sitesInUse()) {
+            return [];
+        }
+        $siteID = (
+            (int)filter_input(INPUT_POST, 'site') ?:
+            (SiteScope::sitesInUse() ? 0 : SiteScope::catchAllID())
+        );
+        return [
+            self::makeLabel(
+                $labelClass,
+                'site',
+                _('Site')
+            ) => self::getClass('SiteManager')->buildSelectBox($siteID, 'site')
+        ];
+    }
+    /**
      * Renders the Site tab shared by the host, user, group and usergroup
      * edit pages.
      *

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -811,7 +811,7 @@ class Authorization extends FOGBase
         // no sites behaves as it always did, and a catch-all member is not
         // narrowed to an enumerated list (which would stop covering
         // objects created after the catch-all was made).
-        if (!SiteScope::anySitesExist() || SiteScope::isUnscoped($userID)) {
+        if (!SiteScope::sitesInUse() || SiteScope::isUnscoped($userID)) {
             return null;
         }
         return SiteScope::allInScopeIDs($node, $userID);

--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -30,14 +30,27 @@
  *      covered by it too. An enumerated list would look identical on
  *      upgrade day and then quietly stop containing new objects.
  *
- *   2. If NO sites exist at all, everything is in scope. Redundant once
- *      schema step 333 has created the catch-all -- and that is exactly why
- *      it is here. Between deploying new code and running the schema
- *      updater a server has this class and an empty (or absent) `sites`
- *      table, and endpoints that do not route through the updater gate
- *      would otherwise deny every non-'*' user everything. A server with a
- *      pending schema deploy must behave like today, not lock its admin
- *      out of the page they need in order to fix it.
+ *   2. If no site is IN USE -- meaning no site exists other than the
+ *      catch-all -- everything is in scope. Two states share that answer
+ *      and both need it:
+ *
+ *        - the window between deploying this code and running the schema
+ *          updater, where `sites` is empty or absent. Endpoints that do
+ *          not route through the updater gate would otherwise deny every
+ *          non-'*' user everything, and a server with a pending schema
+ *          deploy must behave like today rather than lock its admin out of
+ *          the page that fixes it.
+ *        - a server that migrated and then never created a site. Step 333
+ *          always creates the catch-all, so counting rows would answer
+ *          "sites exist" forever, on every install in the world, including
+ *          ones that never had the plugin. Scoping would be switched on
+ *          for a feature nobody turned on -- and the first account created
+ *          after the upgrade, which nothing adds to the catch-all, would
+ *          be denied everything while every account that existed the day
+ *          before kept working.
+ *
+ *      So the question this asks is "is anybody actually using sites",
+ *      not "does the table have rows in it".
  *
  * A node this does not scope is always in scope. Images, snapins and
  * printers are deliberately not scoped: each needs its own answer to what a
@@ -91,11 +104,18 @@ class SiteScope extends FOGBase
      */
     private static $_catchAll = [];
     /**
-     * Per-request cache of "does any site exist". Null until asked.
+     * Per-request cache of "is any site in use". Null until asked.
      *
      * @var bool|null
      */
-    private static $_anySites = null;
+    private static $_sitesInUse = null;
+    /**
+     * Per-request cache of the catch-all site id. Null until asked, 0 when
+     * there is not one.
+     *
+     * @var int|null
+     */
+    private static $_catchAllID = null;
     /**
      * Drops the per-request caches.
      *
@@ -110,7 +130,8 @@ class SiteScope extends FOGBase
     {
         self::$_userSites = [];
         self::$_catchAll = [];
-        self::$_anySites = null;
+        self::$_sitesInUse = null;
+        self::$_catchAllID = null;
     }
     /**
      * Runs a scalar count, treating an unusable table as zero.
@@ -139,18 +160,90 @@ class SiteScope extends FOGBase
         return is_array($row) && isset($row['cnt']) ? (int)$row['cnt'] : 0;
     }
     /**
-     * Does this install have any sites at all?
+     * Is this install actually using sites?
+     *
+     * The catch-all is excluded deliberately and is the whole point of the
+     * method: it is created by the schema updater on every server, so a
+     * plain row count answers yes on installs that have never seen a site
+     * in their lives. See the class docblock.
      *
      * @return bool
      */
-    public static function anySitesExist()
+    public static function sitesInUse()
     {
-        if (null === self::$_anySites) {
-            self::$_anySites = self::_count(
-                'SELECT COUNT(*) AS `cnt` FROM `sites`'
+        if (null === self::$_sitesInUse) {
+            self::$_sitesInUse = self::_count(
+                'SELECT COUNT(*) AS `cnt` FROM `sites` '
+                . 'WHERE `siteCatchAll` IS NULL'
             ) > 0;
         }
-        return self::$_anySites;
+        return self::$_sitesInUse;
+    }
+    /**
+     * The catch-all site's id, or 0 if this install has not got one.
+     *
+     * `siteCatchAll` is UNIQUE and CHECK-constrained to 1, so at most one
+     * row can ever answer this -- the LIMIT is belt and braces, not a
+     * choice between candidates.
+     *
+     * @return int
+     */
+    public static function catchAllID()
+    {
+        if (null === self::$_catchAllID) {
+            self::$_catchAllID = self::_count(
+                'SELECT `siteID` AS `cnt` FROM `sites` '
+                . 'WHERE `siteCatchAll` IS NOT NULL LIMIT 1'
+            );
+        }
+        return self::$_catchAllID;
+    }
+    /**
+     * Puts a user in the catch-all site, if there is one.
+     *
+     * Exists because a user created after the migration would otherwise be
+     * the only account on the server in no site at all. Step 333 enrolled
+     * every account that existed on upgrade day; this is the same rule
+     * applied to the ones created afterwards, and it lives here rather than
+     * in each of the four creation paths (the add page, the add modal, a
+     * REST POST, and the ldap plugin's auto-provision on first login)
+     * because only the last of those involves anybody clicking anything.
+     *
+     * Callers gate on sitesInUse(): once real sites exist, which site a new
+     * user belongs to is an administrative decision and defaulting it to
+     * "all of them" would be an access-control decision made by accident.
+     *
+     * INSERT IGNORE rather than a check-then-insert: the pair is UNIQUE, so
+     * the database already answers "already a member" without a round trip.
+     *
+     * @param int $userID the user id
+     *
+     * @return bool whether the user is now in the catch-all
+     */
+    public static function joinCatchAll($userID)
+    {
+        $userID = (int)$userID;
+        $siteID = self::catchAllID();
+        if ($userID < 1 || $siteID < 1) {
+            return false;
+        }
+        try {
+            $res = self::$DB->query(
+                'INSERT IGNORE INTO `siteUserMembers` '
+                . '(`sumSiteID`, `sumUserID`) VALUES (:sid, :uid)',
+                [],
+                ['sid' => $siteID, 'uid' => $userID]
+            );
+            if (false !== $res->error) {
+                return false;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+        // The membership caches now describe a world one row out of date,
+        // and this user's own request continues after the save.
+        self::forgetCaches();
+        return true;
     }
     /**
      * Is this user a member of a catch-all site?
@@ -337,7 +430,7 @@ class SiteScope extends FOGBase
         if (!isset(self::$_nodes[$node]) && 'task' !== $node) {
             return true;
         }
-        if (!self::anySitesExist()) {
+        if (!self::sitesInUse()) {
             return true;
         }
         if (self::isUnscoped($userID)) {
@@ -391,7 +484,7 @@ class SiteScope extends FOGBase
         if (!isset(self::$_nodes[$node]) && 'task' !== $node) {
             return $ids;
         }
-        if (!self::anySitesExist() || self::isUnscoped($userID)) {
+        if (!self::sitesInUse() || self::isUnscoped($userID)) {
             return $ids;
         }
         if (empty($ids)) {

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -560,11 +560,31 @@ class User extends FOGController
      * assocSetter no-ops unless 'roles' has been loaded/set, so save
      * paths that never touch roles (e.g. password migration) are safe.
      *
+     * A brand new user is put in the catch-all site, but only while no real
+     * site exists. Schema step 333 enrolled every account that was on the
+     * server the day it upgraded; without this the next account created
+     * would be the only one on that server in no site at all, and site
+     * scope is deny-all, so it would see nothing. That asymmetry -- every
+     * old account works, every new one is blank -- is the bug. Once an
+     * admin has created a real site, which sites a new user belongs to is
+     * their decision and defaulting it to "all of them" would be an
+     * access-control call made by accident, so the gate stays.
+     *
+     * It lives here rather than in the creation pages because two of the
+     * four creation paths involve nobody clicking anything: a REST POST and
+     * the ldap plugin auto-provisioning on first login. FOGController::save
+     * fires no event, so a hook could not have covered them either.
+     *
      * @return bool
      */
     public function save()
     {
+        // Captured before the save, because that is what stamps the id on.
+        $isNew = (int)$this->get('id') < 1;
         parent::save();
+        if ($isNew && !SiteScope::sitesInUse()) {
+            SiteScope::joinCatchAll((int)$this->get('id'));
+        }
         return $this
             ->assocSetter('RoleUser', 'role')
             ->assocSetter('UserGroupMember', 'usergroup', true)

--- a/packages/web/lib/pages/UserGroupManagement.page.php
+++ b/packages/web/lib/pages/UserGroupManagement.page.php
@@ -59,7 +59,7 @@ class UserGroupManagement extends FOGPage
 
         $labelClass = 'col-sm-3 col-form-label';
 
-        return [
+        $fields = [
             self::makeLabel(
                 $labelClass,
                 'usergroup',
@@ -85,6 +85,8 @@ class UserGroupManagement extends FOGPage
                 $description
             )
         ];
+
+        return self::fastmerge($fields, self::siteAddField($labelClass));
     }
     /**
      * Create new user group.
@@ -147,6 +149,7 @@ class UserGroupManagement extends FOGPage
                     $serverFault = true;
                     throw new \Exception(_('Add user group failed!'));
                 }
+                $this->siteAddPost('usergroup', $UserGroup);
                 return $UserGroup;
             }
         );

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -80,7 +80,7 @@ class GroupManagement extends FOGPage
         $labelClass = 'col-sm-3 col-form-label';
 
         // The fields to display
-        return [
+        $fields = [
             self::makeLabel(
                 $labelClass,
                 'group',
@@ -154,6 +154,8 @@ class GroupManagement extends FOGPage
                 $dev
             )
         ];
+
+        return self::fastmerge($fields, self::siteAddField($labelClass));
     }
     /**
      * Create a new group.
@@ -232,6 +234,7 @@ class GroupManagement extends FOGPage
                     $serverFault = true;
                     throw new \Exception(_('Add group failed!'));
                 }
+                $this->siteAddPost('group', $Group);
                 return $Group;
             }
         );

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -75,7 +75,7 @@ class UserManagement extends FOGPage
 
         $labelClass = 'col-sm-3 col-form-label';
 
-        return [
+        $fields = [
             self::makeLabel(
                 $labelClass,
                 'user',
@@ -180,6 +180,10 @@ class UserManagement extends FOGPage
                 (isset($_POST['apienabled']) ? 'checked' : '')
             )
         ];
+
+        // A user created into no site at all sees nothing, so this one
+        // matters more than the group/usergroup equivalents.
+        return self::fastmerge($fields, self::siteAddField($labelClass));
     }
     /**
      * Page to enable creating a new user.
@@ -263,6 +267,7 @@ class UserManagement extends FOGPage
                 $serverFault = true;
                 throw new \Exception(_('Add user failed!'));
             }
+            $this->siteAddPost('user', $User);
             $code = HTTPResponseCodes::HTTP_CREATED;
             $hook = 'USER_ADD_SUCCESS';
             $msg = json_encode(

--- a/tests/site-new-account-default.test.php
+++ b/tests/site-new-account-default.test.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * A user created after the site migration must not be the only account on
+ * the server that can see nothing.
+ *
+ * Schema step 333 creates the catch-all site and puts every account that
+ * existed on upgrade day into it, so the migration changes nothing for
+ * anybody. The next account created is the one nothing covers: site scope
+ * is deny-all, so a user in no site sees no hosts, no users and no groups,
+ * with no error anywhere to say why. Every account from the day before
+ * works; the first one after does not. That asymmetry is the bug, and it
+ * only appears on servers where sites are not otherwise in use -- exactly
+ * the servers whose admins never asked for sites at all.
+ *
+ * Two halves, and both are needed:
+ *
+ *   - User::save() joins the catch-all on insert, because two of the four
+ *     ways a user gets created involve nobody clicking anything (a REST
+ *     POST, and the ldap plugin auto-provisioning on first login).
+ *     FOGController::save() fires no event, so a hook could not have
+ *     reached those.
+ *   - the create forms carry a Site field, so the choice is available at
+ *     creation time rather than requiring a second trip through the edit
+ *     page -- during which, for a user, the account exists and is blind.
+ *
+ * The gate is the part most likely to be "simplified" away later, so it is
+ * asserted on its own: joining unconditionally would mean a user created
+ * for one site is silently placed in the catch-all as well, and catch-all
+ * membership short circuits ABOVE the per-site query. Every such user
+ * would see every site. That is an access-control default, not a tidiness
+ * preference.
+ *
+ * DB-free: reads the source. The behaviour of the SiteScope helpers these
+ * call is covered against a fake database in site-scope.test.php.
+ *
+ * Usage: php tests/site-new-account-default.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+
+$failures = [];
+$checks = 0;
+
+/**
+ * Returns the source of a named method, signature to the following one.
+ */
+$bodyOf = function ($src, $needle) {
+    $start = strpos($src, $needle);
+    if (false === $start) {
+        return null;
+    }
+    $next = preg_match(
+        '/\n    (?:public|private|protected)[ a-z]* function /',
+        $src,
+        $m,
+        PREG_OFFSET_CAPTURE,
+        $start + strlen($needle)
+    );
+    return $next
+        ? substr($src, $start, $m[0][1] - $start)
+        : substr($src, $start);
+};
+
+$read = function ($path) use ($webroot) {
+    $full = $webroot . '/' . $path;
+    if (!is_readable($full)) {
+        fwrite(STDERR, "FAIL: cannot read $full\n");
+        exit(1);
+    }
+    return file_get_contents($full);
+};
+
+$check = function ($label, $cond) use (&$failures, &$checks) {
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+};
+
+$user = $read('lib/fog/user.class.php');
+$save = $bodyOf($user, 'public function save(');
+
+if (null === $save) {
+    fwrite(STDERR, "FAIL: could not find User::save()\n");
+    exit(1);
+}
+
+// Comments explain all of this, so they must not satisfy any of it.
+$saveCode = preg_replace('#//[^\n]*#', '', $save);
+
+$check(
+    'User::save() no longer joins the catch-all, so an account created '
+    . 'after the migration is in no site and sees nothing',
+    false !== strpos($saveCode, 'SiteScope::joinCatchAll(')
+);
+
+$check(
+    'User::save() joins the catch-all without gating on sitesInUse(). '
+    . 'Unconditional means a user created for one site is put in the '
+    . 'catch-all too, and catch-all membership short circuits above the '
+    . 'per-site query -- so they would see every site on the server.',
+    false !== strpos($saveCode, 'SiteScope::sitesInUse()')
+);
+
+// Ordering: the id only exists after the save, and "was this an insert"
+// only exists before it. Getting either the wrong side of parent::save()
+// gives a join that silently never happens, or happens on every update.
+$posNew = strpos($saveCode, '$isNew');
+$posSave = strpos($saveCode, 'parent::save()');
+$posJoin = strpos($saveCode, 'SiteScope::joinCatchAll(');
+$check(
+    'User::save() must decide it is an insert BEFORE parent::save() (which '
+    . 'is what assigns the id) and join AFTER it (which is when there is an '
+    . 'id to join with)',
+    false !== $posNew && false !== $posSave && false !== $posJoin
+    && $posNew < $posSave && $posSave < $posJoin
+);
+
+/*
+ * The create-form field. Two calls make it correct rather than merely
+ * present: catchAllID() is what it preselects, and sitesInUse() is what
+ * decides whether preselecting is appropriate at all.
+ */
+$render = $read('lib/fog/FOGPageRender.class.php');
+$field = $bodyOf($render, 'protected static function siteAddField(');
+$check(
+    'FOGPageRender::siteAddField() is gone',
+    null !== $field
+);
+if (null !== $field) {
+    $fieldCode = preg_replace('#//[^\n]*#', '', $field);
+    $check(
+        'siteAddField() no longer asks catchAllID(), so it cannot '
+        . 'preselect the catch-all or tell a pre-migration server apart '
+        . 'from one with no sites',
+        false !== strpos($fieldCode, 'SiteScope::catchAllID()')
+    );
+    $check(
+        'siteAddField() no longer asks sitesInUse(), so it would '
+        . 'preselect the catch-all on a server that genuinely uses sites '
+        . '-- every new object would default to seeing everything',
+        false !== strpos($fieldCode, 'SiteScope::sitesInUse()')
+    );
+}
+
+/*
+ * The create-form post. It must do nothing when the field was not posted:
+ * siteAddField() renders nothing on a server with no sites, and a hook may
+ * remove it. An absent field means "nothing was asked for" -- read as "no
+ * site" it would delete the catch-all membership User::save() had just
+ * granted, which is the bug this whole file is about, reintroduced from
+ * the other end.
+ */
+$post = $read('lib/fog/FOGPagePost.class.php');
+$addPost = $bodyOf($post, 'protected function siteAddPost(');
+$check(
+    'FOGPagePost::siteAddPost() is gone',
+    null !== $addPost
+);
+if (null !== $addPost) {
+    $addCode = preg_replace('#//[^\n]*#', '', $addPost);
+    $check(
+        'siteAddPost() no longer distinguishes an absent Site field from '
+        . 'an empty one, so a create form without the field would strip '
+        . 'the membership the save had just granted',
+        false !== strpos($addCode, "filter_input(INPUT_POST, 'site')")
+        && false !== strpos($addCode, 'return;')
+    );
+}
+
+/*
+ * And the pages are wired to both. A helper nothing calls is the failure
+ * mode these two checks exist for.
+ */
+$pages = [
+    'user' => 'lib/pages/usermanagement.page.php',
+    'group' => 'lib/pages/groupmanagement.page.php',
+    'usergroup' => 'lib/pages/UserGroupManagement.page.php',
+];
+foreach ($pages as $node => $path) {
+    $src = $read($path);
+    $check(
+        "the $node create form does not render the Site field",
+        false !== strpos($src, 'self::siteAddField(')
+    );
+    $check(
+        "the $node create does not apply the Site field it rendered",
+        false !== strpos($src, "\$this->siteAddPost('$node',")
+    );
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks new-account site default checks\n";
+exit(0);

--- a/tests/site-scope.test.php
+++ b/tests/site-scope.test.php
@@ -11,10 +11,15 @@
  * Two of the cases below are not about correctness of the membership query
  * at all, they are about it NOT RUNNING:
  *
- *   - a server with no sites yet must allow everything. That is the window
- *     between deploying this code and running the schema updater, and if it
- *     denied instead, the admin would be locked out of the very page that
- *     fixes it.
+ *   - a server with no site IN USE must allow everything. In use means "a
+ *     site other than the catch-all", and the distinction is the whole
+ *     point: schema step 333 creates the catch-all on every server that
+ *     upgrades, so a plain row count answers "sites exist" forever, on
+ *     installs that never had the plugin. Scoping would switch itself on
+ *     for a feature nobody turned on. It also covers the original reason
+ *     this short circuit exists -- the window between deploying this code
+ *     and running the schema updater, where denying would lock the admin
+ *     out of the very page that fixes it.
  *   - a catch-all member must be allowed without consulting membership,
  *     because the catch-all is a flag rather than a list. If it were
  *     satisfied by enumerating members it would look identical on upgrade
@@ -158,6 +163,11 @@ $scenario = function (array $tables) use ($dbProp) {
                 $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
                 return ['cnt' => $hit ? 1 : 0];
             }
+            // The catch-all's id. Recognised before the plain count for the
+            // same reason -- both read `sites`.
+            if (false !== strpos($sql, 'IS NOT NULL LIMIT 1')) {
+                return ['cnt' => (int)($tables['catchAllID'] ?? 0)];
+            }
             if (false !== strpos($sql, 'FROM `sites`')) {
                 if (isset($tables['sitesThrows'])) {
                     throw new \Exception('no such table');
@@ -165,7 +175,16 @@ $scenario = function (array $tables) use ($dbProp) {
                 if (isset($tables['sitesErrors'])) {
                     return '__ERROR__';
                 }
+                // siteCount is the count of sites IN USE, so a fixture
+                // saying 0 is a server holding nothing but the catch-all
+                // as well as one holding no sites at all.
                 return ['cnt' => (int)($tables['siteCount'] ?? 0)];
+            }
+            if (0 === strpos($sql, 'INSERT')) {
+                if (isset($tables['insertErrors'])) {
+                    return '__ERROR__';
+                }
+                return ['cnt' => 1];
             }
             if (false !== strpos($sql, 'FROM `siteUserMembers` WHERE')) {
                 $uid = (int)$params['uid'];
@@ -232,6 +251,86 @@ check(
 check(
     'zero-site server: membership never queried',
     !$touchedMembership($db),
+    $failures,
+    $checks
+);
+
+/*
+ * 1a. And the question asked has to be the right one. Every fixture above
+ *     would pass just as happily against `SELECT COUNT(*) FROM sites`, so
+ *     the SQL itself is asserted: the catch-all row is created by schema
+ *     step 333 on every server that upgrades, so counting it makes "sites
+ *     exist" permanently true everywhere and switches deny-all on for
+ *     installs that never had the plugin.
+ */
+$countSql = '';
+foreach ($db->log as $sql) {
+    if (false !== strpos($sql, 'FROM `sites`')
+        && false === strpos($sql, 'INNER JOIN')
+    ) {
+        $countSql = $sql;
+    }
+}
+check(
+    'the in-use question excludes the catch-all row',
+    false !== strpos($countSql, '`siteCatchAll` IS NULL'),
+    $failures,
+    $checks
+);
+
+/*
+ * 1b. The catch-all id, and putting a user in it. This is what stops a
+ *     brand new account being the only one on the server in no site --
+ *     step 333 enrolled everybody who existed on upgrade day, and User
+ *     ::save() applies the same rule to everybody created afterwards.
+ */
+$db = $scenario(['siteCount' => 0, 'catchAllID' => 11]);
+check(
+    'catchAllID finds the catch-all',
+    SiteScope::catchAllID() === 11,
+    $failures,
+    $checks
+);
+check(
+    'joinCatchAll enrols the user',
+    SiteScope::joinCatchAll(4) === true,
+    $failures,
+    $checks
+);
+$insert = '';
+foreach ($db->log as $sql) {
+    if (0 === strpos($sql, 'INSERT')) {
+        $insert = $sql;
+    }
+}
+check(
+    // Membership is UNIQUE, so the database already answers "already a
+    // member" -- a check-then-insert would be a second round trip and a
+    // race besides.
+    'joinCatchAll inserts, ignoring an existing membership',
+    false !== strpos($insert, 'INSERT IGNORE INTO `siteUserMembers`'),
+    $failures,
+    $checks
+);
+$db = $scenario(['siteCount' => 0, 'catchAllID' => 0]);
+check(
+    'joinCatchAll does nothing without a catch-all',
+    SiteScope::joinCatchAll(4) === false,
+    $failures,
+    $checks
+);
+check(
+    'joinCatchAll issues no insert without a catch-all',
+    !preg_grep('/^INSERT/', $db->log),
+    $failures,
+    $checks
+);
+$db = $scenario(
+    ['siteCount' => 0, 'catchAllID' => 11, 'insertErrors' => true]
+);
+check(
+    'a failed enrolment reports failure rather than claiming success',
+    SiteScope::joinCatchAll(4) === false,
     $failures,
     $checks
 );


### PR DESCRIPTION
## Problem

Schema step 333 creates the catch-all site and enrols every account that exists on upgrade day, so the migration changes nothing for anybody. The account created the *day after* is the one nothing covers: site scope is deny-all, so a user in no site sees no hosts, no users and no groups, with nothing anywhere to say why.

Every account from before the upgrade works. The first one after does not. That asymmetry is the bug, and it lands hardest on servers whose admins never asked for sites at all.

## Two causes

**`SiteScope::anySitesExist()` counted every row in `sites`.** Step 333 guarantees there is always at least one, so it answered `true` forever, on every server in the world, including ones that never had the site plugin — switching scope enforcement on for a feature nobody turned on. It is now `sitesInUse()`, counting sites *other than* the catch-all, which is the question all three callers were actually asking.

**Nothing put a new user in the catch-all.** `User::save()` now does, on insert only, and only while no real site exists.

The gate is deliberate: joining unconditionally would put a user created for one site in the catch-all as well, and catch-all membership short circuits *above* the per-site query — so that user would see every site on the server. On a server with real sites, deny-by-default for an unassigned user is the right answer.

It lives in `save()` rather than in the create pages because two of the four creation paths involve nobody clicking anything: a REST POST, and the ldap plugin auto-provisioning on first login. `FOGController::save()` fires no event, so a hook could not have reached those either.

## Also

The user, group and usergroup create forms gain a Site field — preselected to the catch-all when no real site exists, blank when one does. Creating an object and then reopening it to say where it lives was the plugin's shape; for a user it also meant the account spent the gap between the two steps unable to see anything.

## Tests

- `tests/site-new-account-default.test.php` (new) — pins both halves and the gate.
- `tests/site-scope.test.php` — now asserts the in-use query excludes the catch-all. Worth saying: every existing fixture passed against *either* query, so the SQL itself is checked. Also covers `catchAllID()` and `joinCatchAll()` against the fake DB.

21 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR