### PR TITLE
Refuse API writes to fields the server maintains

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -502,6 +502,28 @@ Global configuration lives in the `globalSettings` table.
 
   Prefer `always` unless you can name the consumer that reads the field back.
 
+- **Columns only your code should write:** `Route::edit()` and `Route::create()`
+  copy a JSON body straight into your model's `databaseFields`, so by default
+  anyone who can reach the API can set any column you declare. Declare the ones
+  your server-side code maintains — a token you issue, a counter, a timestamp
+  you stamp — through `API_SERVER_OWNED_FIELDS`:
+
+  ```php
+  public function declareServerOwnedFields($arguments)
+  {
+      $arguments['fields'][$this->node][] = 'apiToken';
+  }
+  ```
+
+  A request that tries to **change** one gets a 400. A request that carries the
+  same value it already had is let through, so a client that GETs your object
+  and PUTs the whole thing back keeps working — don't "fix" that by rejecting
+  the field's mere presence.
+
+  This is a different question from `API_SENSITIVE_FIELDS`, which is about what
+  leaves the server. A field can be one, the other, or both: `host.ADPass` is
+  sensitive but genuinely settable over the API, so it is only in the first list.
+
 ---
 
 ## 9. Common hook events
@@ -516,6 +538,7 @@ Global configuration lives in the `globalSettings` table.
 | `PERMISSION_REGISTRY_DATA` | register the node and its actions — **required**, see §4.5 |
 | `API_VALID_CLASSES` | expose the node over the REST API (name classes after your permission node — see §4.5) |
 | `API_SENSITIVE_FIELDS` | keep credential columns out of API and boot-endpoint output — see §8 |
+| `API_SERVER_OWNED_FIELDS` | refuse API writes to columns your own code maintains — see §8 |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
 

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -497,6 +497,11 @@ class OpenAPI extends FOGBase
             ? array_values((array)$vars['databaseFieldsRequired'])
             : [];
         $sensitive = self::_sensitiveFields($class);
+        // Read through Route for the same reason the sensitive tiers are:
+        // a plugin declares its own via API_SERVER_OWNED_FIELDS.
+        $serverOwned = method_exists('Route', 'serverOwnedFields')
+            ? array_map('strtolower', (array)Route::serverOwnedFields($class))
+            : [];
 
         $properties = [];
         foreach ($fields as $property => $column) {
@@ -521,6 +526,19 @@ class OpenAPI extends FOGBase
                 $schema['x-fog-sensitive'] = 'list';
                 $schema['description'] = _(
                     'Omitted from list responses; returned only on a single GET by id.'
+                );
+            }
+            // Server-maintained fields answer 400 to a write that would
+            // change them, so documenting them as settable would document
+            // a request the router refuses. readOnly rather than omitted:
+            // several are still RETURNED, and a client may legitimately
+            // send one back unchanged.
+            if (in_array(strtolower($property), $serverOwned, true)) {
+                $schema['x-fog-server-owned'] = true;
+                $schema['readOnly'] = true;
+                $schema['description'] = _(
+                    'Maintained by the server. It may be sent back unchanged, '
+                    . 'but a request that would change it is refused.'
                 );
             }
             $properties[$property] = $schema;

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -211,6 +211,72 @@ class Route extends FOGBase
      */
     private static $_sensitiveMap = null;
     /**
+     * Fields the SERVER maintains: class => [friendly keys].
+     *
+     * edit() and create() copy a JSON body straight into a model's
+     * databaseFields, so before this list every column of every class in
+     * $validClasses was settable by anyone who could reach the route --
+     * and the route's own auth is thin: an api-enabled non-admin passes.
+     * Reported by Aisle Research alongside 020.
+     *
+     * A field belongs here when the server is its only legitimate writer
+     * AND it is a credential or telemetry. That is narrower than "looks
+     * important" on purpose:
+     *
+     *   - task telemetry is written by service/progress.php through the
+     *     ORM, never through this router, so nothing legitimate loses a
+     *     write. Left open, an api user can rewrite another host's
+     *     imaging progress -- and on dev-branch three of those five
+     *     fields reach the page unescaped.
+     *   - the host token set is what the fog-client protocol
+     *     authenticates with. Choosing a host's sec_tok is impersonating
+     *     that host. Every in-repo writer is server-side ORM
+     *     (fogpage.class.php, taskqueue.class.php).
+     *   - user.token is the API credential itself; writing it is taking
+     *     over that account's API access. Written by the UI reset and by
+     *     Route's own issue path, both server-side.
+     *
+     * Deliberately NOT here: host.ADPass, ADPassLegacy and productKey.
+     * They are secrets, and they are also things an admin legitimately
+     * sets through the API -- the emitter strips them from list output,
+     * which is a different question from who may write them. Nor
+     * user.password: User::set() hashes it, so a supplied one is a real
+     * and supported write.
+     *
+     * Read through serverOwnedFields(), never this property directly, or
+     * plugin-declared entries are skipped.
+     *
+     * @var array
+     */
+    public static $serverOwnedFields = [
+        'task' => [
+            'pct',
+            'bpm',
+            'timeElapsed',
+            'timeRemaining',
+            'dataCopied',
+            'dataTotal',
+            'percent',
+        ],
+        'host' => [
+            'pub_key',
+            'sec_tok',
+            'prev_sec_tok',
+            'sec_time',
+            'token',
+        ],
+        'user' => [
+            'token',
+        ],
+    ];
+    /**
+     * Memoized union of the list above and what plugins declare through
+     * API_SERVER_OWNED_FIELDS. Null until first built.
+     *
+     * @var array|null
+     */
+    private static $_serverOwnedMap = null;
+    /**
      * globalSettings rows whose VALUE is a credential.
      *
      * Settings are the odd one out: they are key/value rows, so the secret is
@@ -2763,17 +2829,32 @@ class Route extends FOGBase
                     HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR
                 );
             }
+            $serverOwned = self::serverOwnedFields($classname);
             foreach ($classVars['databaseFields'] as &$key) {
                 $key = $class->key($key);
-                if (!isset($vars->$key)) {
-                    $val = $class->get($key);
-                } else {
-                    $val = $vars->$key;
-                }
                 if ($key == 'id') {
+                    unset($key);
                     continue;
                 }
-                $class->set($key, $val);
+                // A field the body did not mention is left exactly as
+                // loaded. It used to be re-set to its own current value,
+                // which looks like a no-op and is not: set() may
+                // transform, and User::set() hashes any non-override
+                // write to 'password'. So every PUT to a user re-hashed
+                // the stored hash and locked that account out for good.
+                // save() writes from $this->data for every databaseField
+                // regardless of what was set(), so skipping is otherwise
+                // byte-identical.
+                if (!isset($vars->$key)) {
+                    unset($key);
+                    continue;
+                }
+                if (in_array($key, $serverOwned, true)) {
+                    self::_refuseServerOwned($class, $key, $vars->$key);
+                    unset($key);
+                    continue;
+                }
+                $class->set($key, $vars->$key);
                 unset($key);
             }
             switch ($classname) {
@@ -3064,6 +3145,7 @@ class Route extends FOGBase
                     HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR
                 );
             }
+            $serverOwned = self::serverOwnedFields($classname);
             foreach ($classVars['databaseFields'] as &$key) {
                 $key = $class->key($key);
                 if (property_exists($vars, $key)) {
@@ -3074,6 +3156,14 @@ class Route extends FOGBase
                 if ('id' == $key
                     || null === $val
                 ) {
+                    continue;
+                }
+                // Null passed above rather than the object: there is no
+                // stored value to compare a create against, so the test
+                // is whether a value was asked for at all.
+                if (in_array($key, $serverOwned, true)) {
+                    self::_refuseServerOwned(null, $key, $val);
+                    unset($key);
                     continue;
                 }
                 $class->set($key, $val);
@@ -4073,6 +4163,75 @@ class Route extends FOGBase
             'fields' => (array)$fields,
             'always' => (array)$always
         ];
+    }
+    /**
+     * The fields of a class that only the server may write.
+     *
+     * @param string $class The class name (any case).
+     *
+     * @return array friendly keys
+     */
+    public static function serverOwnedFields($class)
+    {
+        if (null === self::$_serverOwnedMap) {
+            $fields = self::$serverOwnedFields;
+            self::$HookManager->processEvent(
+                'API_SERVER_OWNED_FIELDS',
+                ['fields' => &$fields]
+            );
+            self::$_serverOwnedMap = (array)$fields;
+        }
+        $classname = strtolower((string)$class);
+        return isset(self::$_serverOwnedMap[$classname])
+            ? (array)self::$_serverOwnedMap[$classname]
+            : [];
+    }
+    /**
+     * Refuses a write to a server-maintained field.
+     *
+     * Answers 400 rather than dropping the field, so a caller that meant
+     * to set it learns that it did not happen -- silently ignoring a
+     * requested write is how a client ends up believing state it never
+     * achieved.
+     *
+     * But it refuses only an actual CHANGE. Reading an object and PUTting
+     * the whole thing back is ordinary REST, a single-entity GET returns
+     * these fields, and a body that carries a value identical to the
+     * stored one is asking for nothing. Rejecting that would break every
+     * round-tripping client to close a hole none of them are in.
+     *
+     * @param object $class The loaded object, or null on create.
+     * @param string $key   The friendly key being written.
+     * @param mixed  $value The value the body supplied.
+     *
+     * @return void
+     */
+    private static function _refuseServerOwned($class, $key, $value)
+    {
+        if (null !== $class) {
+            $stored = $class->get($key);
+            // Scalars only: a non-scalar can never equal a column value,
+            // and casting an array to string is a fatal.
+            if (is_scalar($value) || null === $value) {
+                if ((string)$value === (string)$stored) {
+                    return;
+                }
+            }
+        } elseif (null === $value
+            || (is_scalar($value) && '' === trim((string)$value))
+        ) {
+            // On create there is nothing to compare against, so the test
+            // is "did you ask for a value". An empty one is what the
+            // server was going to store anyway.
+            return;
+        }
+        self::setErrorMessage(
+            sprintf(
+                _('%s is maintained by the server and cannot be set'),
+                $key
+            ),
+            HTTPResponseCodes::HTTP_BAD_REQUEST
+        );
     }
     /**
      * Removes decrypted secrets from a related/list object so they are only

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -75,6 +75,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4457,6 +4461,9 @@ msgstr "Hauptmenü"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Regel Zuordnung"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -80,6 +80,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4457,6 +4461,9 @@ msgstr "Main Menu"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Image Association"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -78,6 +78,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4570,6 +4574,9 @@ msgstr "Ocultar menú"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Asociación para la imagen"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -75,6 +75,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4458,6 +4462,9 @@ msgstr "Hauptmenü"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Regel Zuordnung"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -81,6 +81,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4459,6 +4463,9 @@ msgstr "Menu principal"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Association Image"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -80,6 +80,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4287,6 +4291,9 @@ msgstr "Menu principale"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Regole di associazione"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -71,6 +71,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4240,6 +4244,9 @@ msgstr "メインメニュー"
 #, fuzzy
 msgid "Main navigation"
 msgstr "メインの関連付け"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -56,6 +56,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -3755,6 +3759,9 @@ msgid "Main Menu"
 msgstr ""
 
 msgid "Main navigation"
+msgstr ""
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
 msgstr ""
 
 msgid "Make default"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -80,6 +80,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4458,6 +4462,9 @@ msgstr "Menu principal"
 #, fuzzy
 msgid "Main navigation"
 msgstr "Associação imagem"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -80,6 +80,10 @@ msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
 #, php-format
+msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
 msgid "%s is not a readable .tar.gz archive."
 msgstr ""
 
@@ -4458,6 +4462,9 @@ msgstr "主菜单"
 #, fuzzy
 msgid "Main navigation"
 msgstr "图像协会"
+
+msgid "Maintained by the server. It may be sent back unchanged, but a request that would change it is refused."
+msgstr ""
 
 #, fuzzy
 msgid "Make default"

--- a/tests/api-server-owned-fields.test.php
+++ b/tests/api-server-owned-fields.test.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * The API must not let a caller write fields the server maintains.
+ *
+ * Route::edit() and Route::create() copy a JSON body straight into a
+ * model's databaseFields. Every column of every class in $validClasses was
+ * therefore settable by anyone who could reach the route, and the route's
+ * own auth is thin -- an api-enabled non-admin passes. Reported by Aisle
+ * Research alongside finding 020.
+ *
+ * Three properties are asserted, and each exists because the obvious
+ * implementation gets it wrong in a different direction:
+ *
+ *   1. The list is DERIVED, through serverOwnedFields(), so a plugin can
+ *      declare its own via API_SERVER_OWNED_FIELDS. A second hand-written
+ *      copy somewhere is the failure this project has already had once,
+ *      with the sensitive-field lists.
+ *   2. A refusal is a 400, not a silent drop. Ignoring a requested write
+ *      leaves the caller believing state it never achieved.
+ *   3. An UNCHANGED value is allowed through. A single-entity GET returns
+ *      these fields, so reading an object and PUTting the whole thing back
+ *      is ordinary REST; rejecting that would break every round-tripping
+ *      client in order to close a hole none of them are in. This is the
+ *      check most likely to be lost to a "simplification", and losing it
+ *      is a compatibility break rather than a security one -- so it gets
+ *      its own case in both directions.
+ *
+ * Also pinned here because it lives in the same twelve lines: edit() must
+ * not re-set a field the body did not mention. It used to assign every
+ * column back to its own current value, which reads as a no-op and is not
+ * -- User::set() hashes any non-override write to 'password', so a PUT to
+ * a user re-hashed the stored hash and locked that account out for good.
+ *
+ * DB-free: Route resolves through the autoloader with a stub HookManager
+ * and never touches FOGBase::$DB on these paths.
+ *
+ * Every guard case runs in a CHILD process, allow and refuse alike, and
+ * that is not symmetry for its own sake. setErrorMessage() ends the
+ * request with a bare exit(), which is status 0 -- so a guard that wrongly
+ * refuses would kill this file mid-run and the runner, which keys on exit
+ * status, would report a pass. Asserting on a child's OUTPUT is the only
+ * way round that; the parent survives to fail.
+ *
+ * Usage: php tests/api-server-owned-fields.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-server-owned-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+/** Route fires hooks on these paths; nothing else about it is needed. */
+class ServerOwnedStubHooks
+{
+    public function processEvent($event, $arguments = [])
+    {
+    }
+}
+
+/** Stands in for a loaded model: _refuseServerOwned only calls get(). */
+class ServerOwnedStubObj
+{
+    private $_d;
+
+    public function __construct(array $d)
+    {
+        $this->_d = $d;
+    }
+
+    public function get($key = '')
+    {
+        return isset($this->_d[$key]) ? $this->_d[$key] : null;
+    }
+}
+
+$hooks = new \ReflectionProperty('FOGBase', 'HookManager');
+$hooks->setAccessible(true);
+$hooks->setValue(null, new ServerOwnedStubHooks());
+
+$refuse = new \ReflectionMethod('Route', '_refuseServerOwned');
+$refuse->setAccessible(true);
+
+/*
+ * The guard cases. 'refuse' => must be rejected, 'allow' => must be let
+ * through. Each runs as a child; see the file header for why the allow
+ * side cannot be run in-process.
+ */
+$stored = new ServerOwnedStubObj(['sec_tok' => 'abc123']);
+$cases = [
+    // name => [expectation, object|null, value, why it matters]
+    'change-existing' => [
+        'refuse', $stored, 'evil',
+        'a caller can rewrite a server-maintained field'
+    ],
+    'non-scalar' => [
+        'refuse', $stored, ['evil'],
+        'an array body slips past the comparison'
+    ],
+    'set-on-create' => [
+        'refuse', null, 'evil',
+        'a create can choose the value edit() refuses to change'
+    ],
+    'unchanged-roundtrip' => [
+        'allow', $stored, 'abc123',
+        'reading an object and PUTting it back unchanged now 400s, '
+        . 'which breaks every round-tripping client'
+    ],
+    'empty-on-create' => [
+        'allow', null, '',
+        'a create that carries the field empty now 400s, though it asks '
+        . 'for nothing the server was not going to store anyway'
+    ],
+];
+if (isset($argv[1]) && '--child' === $argv[1]) {
+    $case = isset($argv[2]) ? $argv[2] : '';
+    if (!isset($cases[$case])) {
+        fwrite(STDERR, "unknown child case: $case\n");
+        exit(2);
+    }
+    list(, $obj, $value) = $cases[$case];
+    $refuse->invoke(null, $obj, 'sec_tok', $value);
+    // Only reached when the guard let it through.
+    echo 'ALLOWED';
+    exit(0);
+}
+
+$failures = [];
+$checks = 0;
+
+$check = function ($label, $cond) use (&$failures, &$checks) {
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+};
+
+/*
+ * 1. The derived list. Membership itself is asserted for the three classes
+ *    the finding covers, because each is a different kind of field and
+ *    dropping any one of them is a silent regression.
+ */
+$task = Route::serverOwnedFields('task');
+$check(
+    'task telemetry is not server-owned, so an api user can rewrite '
+    . "another host's imaging progress",
+    [] === array_diff(
+        [
+            'pct', 'bpm', 'timeElapsed', 'timeRemaining',
+            'dataCopied', 'dataTotal', 'percent'
+        ],
+        $task
+    )
+);
+
+$check(
+    'the host client-protocol token set is not server-owned; choosing a '
+    . "host's sec_tok is impersonating that host",
+    [] === array_diff(
+        ['pub_key', 'sec_tok', 'prev_sec_tok', 'sec_time', 'token'],
+        Route::serverOwnedFields('host')
+    )
+);
+
+$check(
+    'user.token is not server-owned; writing it takes over that account '
+    . "'s API access",
+    in_array('token', Route::serverOwnedFields('user'), true)
+);
+
+// The router hands class names in mixed case (the URL segment is
+// lowercased, the model name is not), so the lookup cannot be case
+// sensitive or the guard silently finds nothing.
+$check(
+    'serverOwnedFields() is case sensitive, so a mixed-case class name '
+    . 'finds no fields and the guard does nothing at all',
+    Route::serverOwnedFields('Host') === Route::serverOwnedFields('host')
+);
+
+$check(
+    'an unlisted class reports fields as server-owned; only the listed '
+    . 'ones may be refused',
+    [] === Route::serverOwnedFields('image')
+);
+
+/*
+ * 2. The guard itself, in both directions. A refusal must carry the 400
+ *    message rather than dropping the field, and an allowance must
+ *    actually come back.
+ */
+foreach ($cases as $case => $spec) {
+    list($expect, , , $why) = $spec;
+    $checks++;
+    $out = (string)shell_exec(
+        sprintf(
+            '%s %s --child %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__FILE__),
+            escapeshellarg($case)
+        )
+    );
+    $allowed = false !== strpos($out, 'ALLOWED');
+    $refused = false !== strpos($out, 'cannot be set');
+    if ('refuse' === $expect && !$refused) {
+        $failures[] = "$case: $why"
+            . ($allowed ? '' : ' (no refusal message: ' . trim($out) . ')');
+    }
+    if ('allow' === $expect && !$allowed) {
+        $failures[] = "$case: $why";
+    }
+}
+
+/*
+ * 4. Both entry points are wired to it, and edit() no longer re-sets what
+ *    the body did not send.
+ */
+$route = file_get_contents($webroot . '/lib/router/route.class.php');
+
+$bodyOf = function ($src, $needle) {
+    $start = strpos($src, $needle);
+    if (false === $start) {
+        return null;
+    }
+    $next = preg_match(
+        '/\n    (?:public|private|protected)[ a-z]* function /',
+        $src,
+        $m,
+        PREG_OFFSET_CAPTURE,
+        $start + strlen($needle)
+    );
+    return $next
+        ? substr($src, $start, $m[0][1] - $start)
+        : substr($src, $start);
+};
+
+foreach (
+    [
+        'public static function edit(' => 'edit',
+        'public static function create(' => 'create'
+    ] as $needle => $what
+) {
+    $check(
+        "Route::$what() is gone or renamed",
+        null !== $bodyOf($route, $needle)
+    );
+    $body = (string)$bodyOf($route, $needle);
+    $check(
+        "Route::$what() no longer refuses server-maintained fields",
+        false !== strpos($body, '_refuseServerOwned(')
+        && false !== strpos($body, 'serverOwnedFields(')
+    );
+}
+
+$edit = (string)$bodyOf($route, 'public static function edit(');
+$check(
+    'Route::edit() assigns a field back to its own stored value again. '
+    . 'That is not a no-op: User::set() hashes any non-override write to '
+    . "'password', so every PUT to a user re-hashes the stored hash and "
+    . 'locks the account out permanently.',
+    false === strpos($edit, '$val = $class->get($key);')
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks server-owned field checks\n";
+exit(0);


### PR DESCRIPTION
Closes the last open *defect* from the Aisle Research disclosure (D4, adjacent to 020) ahead of the 2026-08-24 publication date. Everything else on that list is closed or open by an explicit decision.

## The hole

`Route::edit()` and `Route::create()` copy a JSON body straight into a model's `databaseFields`. Every column of every class in `$validClasses` was settable by anyone who could reach the route, and that route's auth is thin — an api-enabled non-admin passes. `multicasttask.class.php:705` already carries a comment saying exactly this; it's why 065 had to be fixed at the sink.

## The fix

`Route::$serverOwnedFields`, read through `serverOwnedFields()` so a plugin can add its own via the new `API_SERVER_OWNED_FIELDS` event — same shape as `sensitiveFieldMap()`, because "a fourth hand-written copy" is the failure this project has already had once.

| Group | Why | Legitimate writer today |
|---|---|---|
| task telemetry (7 fields) | the finding's stated minimum; an api user could rewrite another host's imaging progress | `service/progress.php`, via the ORM |
| `host.pub_key/sec_tok/prev_sec_tok/sec_time/token` | what the fog-client protocol authenticates with — choosing a host's `sec_tok` is impersonating it | `fogpage.class.php`, `taskqueue.class.php`, both server-side |
| `user.token` | the API credential itself | UI reset + Route's own issue path |

**Deliberately not listed:** `host.ADPass`, `ADPassLegacy`, `productKey`, `user.password`. All secrets, all legitimately set by a client. What the emitter *strips* is a separate question from who may *write*.

## The compatibility decision worth reviewing

A refusal is **400, not a silent drop** — but only an actual **change** is refused. A single-entity GET returns these fields, so GET-modify-PUT is ordinary REST. Rejecting the field's mere presence would break every round-tripping client to close a hole none of them are in.

That carve-out is the thing most likely to be "simplified" away later, so the test asserts it in both directions.

## Bug found in the same twelve lines

`edit()` assigned every column back to its own current value when the body didn't mention it. That reads as a no-op and isn't — `User::set()` hashes any non-override write to `password`, so **one `PUT /fog/user/<id>/edit` re-hashed the stored hash and locked that account out permanently.**

```
verify(plain,      stored)   = true
verify(plain,      rehashed) = false     <- the user can never log in again
verify(storedHash, rehashed) = true
```

`save()` builds its statement from `$this->data` for every `databaseField` regardless of what was `set()`, so skipping the assignment is otherwise byte-identical.

## Also

- OpenAPI marks these `readOnly`, so the docs stop advertising a write the router refuses. Verified against the generator: `pct`/`timeElapsed` → `readOnly: true`, `name`/`hostID` untouched.
- `docs/plugin-development.md` documents the new event and the sensitive-vs-server-owned distinction.

## Tests

`tests/api-server-owned-fields.test.php` — 15 checks. Every guard case runs in a **child process**, allow and refuse alike: `setErrorMessage()` ends the request with a bare `exit()`, which is status 0, so a guard that wrongly *refuses* would kill the test file and `run-all.sh` would report a pass. Negative-tested all three assertions by breaking each one in turn.

22 passed, 0 failed. No schema change, no `FOG_BCACHE_VER` bump (no JS/CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR