### PR TITLE
Stop a user PUT locking that account out permanently

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -832,15 +832,25 @@ class Route extends FOGBase
         }
         foreach ($classVars['databaseFields'] as &$key) {
             $key = $class->key($key);
-            if (!isset($vars->$key)) {
-                $val = $class->get($key);
-            } else {
-                $val = $vars->$key;
-            }
             if ($key == 'id') {
+                unset($key);
                 continue;
             }
-            $class->set($key, $val);
+            // A field the body did not mention is left exactly as loaded.
+            // It used to be re-set to its own current value, which reads
+            // as a no-op and is not: set() may transform, and User::set()
+            // hashes any non-override write to 'password'. So every PUT to
+            // a user re-hashed the stored hash -- password_verify() then
+            // fails against the real password and that account is locked
+            // out permanently, with the request answering 200. save()
+            // builds its statement from $this->data for every
+            // databaseField regardless of what was set(), so skipping is
+            // otherwise byte-identical.
+            if (!isset($vars->$key)) {
+                unset($key);
+                continue;
+            }
+            $class->set($key, $vars->$key);
             unset($key);
         }
         switch ($classname) {


### PR DESCRIPTION
Port of the account-lockout half of working-1.6 #1091. Verified present on this branch before porting — the loop and `User::set()` are identical here.

## The bug

`Route::edit()` assigned every column back to its own current value when the body didn't mention it. That reads as a no-op and isn't — `User::set()` hashes any non-override write to `password`, so **one `PUT /fog/user/<id>/edit` re-hashes the stored bcrypt hash and that account can never log in again.** The request answers 200 and returns an object that looks correct; nothing surfaces the damage.

```
password_verify(plain,      stored)   = true
password_verify(plain,      rehashed) = false     <- locked out
password_verify(storedHash, rehashed) = true
```

There is no way to spot an affected account by inspection: the result is a structurally valid bcrypt hash. The only recovery is a password reset.

## The fix

Skip fields the body did not send — which is what a PUT to `/edit|update` should have meant anyway. Safe because `save()` builds its statement from `$this->data` for every `databaseField` regardless of what was `set()`, so nothing else about the write changes. Confirmed against this branch's own `FOGController::save()`, not assumed from 1.6.

## Scope

Only the lockout half is ported. #1091 also added `Route::$serverOwnedFields`, the guard the Aisle Research finding is really about — that is new behaviour and belongs on `working-1.6` first per the branch policy. This one is a plain bug fix.

`tests/route-filter-fields.test.php` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR