### PR TITLE
Stop 11 models reporting a failed save as a success

### DIFF
--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -96,7 +96,12 @@ class Group extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('Group', 'host')
             ->load();

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -242,7 +242,12 @@ class Host extends FOGController
                 . 'a-z 0-9 ! @ # $ % ^ ( ) - \' { } . ~ _'
             );
         }
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         if (array_key_exists('mac', $this->data)) {
             self::getClass('MACAddressAssociation')
                 ->set('mac', $this->get('mac'))

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -128,7 +128,12 @@ class Image extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         // isDirty(), not isPopulated(): isPopulated() is also true when
         // 'hosts' was merely lazy-loaded for reading, which would make an
         // unrelated image save (e.g. renaming it) re-run this whole

--- a/packages/web/lib/fog/module.class.php
+++ b/packages/web/lib/fog/module.class.php
@@ -132,7 +132,12 @@ class Module extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('Module', 'host')
             ->load();

--- a/packages/web/lib/fog/powermanagement.class.php
+++ b/packages/web/lib/fog/powermanagement.class.php
@@ -102,7 +102,12 @@ class PowerManagement extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('PowerManagement', 'host', true)
             ->load();

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -70,7 +70,12 @@ class Printer extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('Printer', 'host')
             ->load();

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -168,7 +168,12 @@ class Role extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('RoleUser', 'user')
             ->assocSetter('RoleUserGroup', 'usergroup')

--- a/packages/web/lib/fog/snapin.class.php
+++ b/packages/web/lib/fog/snapin.class.php
@@ -136,7 +136,12 @@ class Snapin extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
 
         $primary = Route::getIds(
             'snapingroupassociation',

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -473,7 +473,12 @@ class StorageGroup extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         // No assocSetter('StorageGroup', 'storagenode') here: it derived the
         // plural 'storagenodes', which is not in $additionalFields and has no
         // loader, so the key could never hold data and the call was dead.

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -581,7 +581,12 @@ class User extends FOGController
     {
         // Captured before the save, because that is what stamps the id on.
         $isNew = (int)$this->get('id') < 1;
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         if ($isNew && !SiteScope::sitesInUse()) {
             SiteScope::joinCatchAll((int)$this->get('id'));
         }

--- a/packages/web/lib/fog/usergroup.class.php
+++ b/packages/web/lib/fog/usergroup.class.php
@@ -129,7 +129,12 @@ class UserGroup extends FOGController
      */
     public function save()
     {
-        parent::save();
+        // Propagate a failed write rather than reporting success; the
+        // association work below has no row to attach to either. See
+        // tests/save-propagates-failure.test.php.
+        if (!parent::save()) {
+            return false;
+        }
         return $this
             ->assocSetter('UserGroupMember', 'user', true)
             ->assocSetter('RoleUserGroup', 'role')

--- a/tests/save-propagates-failure.test.php
+++ b/tests/save-propagates-failure.test.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * A model that overrides save() must propagate a failed parent write.
+ *
+ * FOGController::save() returns $this on success and false when the write
+ * threw -- it catches, logs to history, and returns false. Every model that
+ * overrides save() to add association work called it and dropped the
+ * result, then returned $this->load(). load() returns an object, so the
+ * override was truthy no matter what happened underneath.
+ *
+ * The consequence is not subtle once you see it: `if (!$obj->save())` is
+ * dead code in every caller, and there are a lot of them. A create answers
+ * 201 with a success message having written nothing, and the only trace is
+ * a "Database save failed" line in the history table that nobody is
+ * looking at. That is exactly how the site create page shipped broken --
+ * `siteCatchAll` hit a CHECK constraint, MySQL threw 1366, and the page
+ * cheerfully reported "Site added!" for every attempt.
+ *
+ * The association work is the second reason. assocSetter() and the MAC,
+ * snapin and permission blocks all key off $this->get('id'); when the
+ * parent write did not land there is no row for them to attach to, so
+ * continuing writes orphans or silently no-ops.
+ *
+ * So the invariant is: an override that calls parent::save() must test the
+ * result. This asserts the shape rather than the exact spelling, because
+ * the point is that the value is CONSUMED -- a model that assigns it and
+ * branches some other way is fine, one that discards it is not.
+ *
+ * Chaining is safe to break this way: a repo-wide search finds no
+ * `->save()->` anywhere in packages/web, so returning false cannot turn a
+ * failed save into a fatal on a method call against a boolean.
+ *
+ * DB-free: reads the source.
+ *
+ * Usage: php tests/save-propagates-failure.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$dir = dirname(__DIR__) . '/packages/web/lib/fog';
+if (!is_dir($dir)) {
+    fwrite(STDERR, "FAIL: cannot read $dir\n");
+    exit(1);
+}
+
+$failures = [];
+$checked = 0;
+
+foreach (glob($dir . '/*.class.php') as $file) {
+    $src = file_get_contents($file);
+    $name = basename($file);
+
+    // The override, from its signature to the closing brace at class level.
+    $start = strpos($src, 'public function save()');
+    if (false === $start) {
+        continue;
+    }
+    $end = strpos($src, "\n    }", $start);
+    $body = false === $end
+        ? substr($src, $start)
+        : substr($src, $start, $end - $start);
+
+    if (false === strpos($body, 'parent::save()')) {
+        continue;
+    }
+    $checked++;
+
+    // Comments explain the guard, so they must not satisfy it.
+    $code = preg_replace('#//[^\n]*#', '', $body);
+
+    // Consumed = tested, assigned, or returned. Discarded = a statement
+    // that is nothing but the call.
+    if (preg_match('/(^|\n)\s*parent::save\(\)\s*;/', $code)) {
+        $failures[] = "$name discards parent::save()'s return, so a failed "
+            . 'database write is reported to the caller as a success and the '
+            . 'association work below runs against a row that does not exist';
+    }
+}
+
+if ($checked < 1) {
+    fwrite(STDERR, "FAIL: found no save() override calling parent::save(); "
+        . "has the pattern changed? This test would pass vacuously.\n");
+    exit(1);
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checked):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checked save() overrides propagate failure\n";
+exit(0);


### PR DESCRIPTION
## The bug

`FOGController::save()` returns `$this` on success and **`false`** when the write threw — it catches, logs `Database save failed` to history, and returns false.

Every model that overrides `save()` to add association work called it and dropped the result:

```php
public function save()
{
    parent::save();                    // <- return discarded
    return $this
        ->assocSetter('Printer', 'host')
        ->load();                      // <- an object, so always truthy
}
```

So `if (!$obj->save())` is dead code in every caller. **A create answers 201 with a success message having written nothing**, and the only trace is a history row nobody is reading.

This is not hypothetical — it's how the site create page shipped broken last week: `siteCatchAll` hit a CHECK constraint, MySQL threw 1366, and the page reported "Site added!" on every attempt. `Site` was fixed then; these are the other 11.

The association work is the second reason to stop early. `assocSetter()` and the MAC, snapin and permission blocks all key off `$this->get('id')` — with no row written there is nothing to attach to, so continuing either orphans rows or silently no-ops.

## Scope

`group`, `host`, `image`, `module`, `powermanagement`, `printer`, `role`, `snapin`, `storagegroup`, `user`, `usergroup` — one guard each, mechanically identical.

## Behaviour change, stated plainly

**A save that has been failing quietly now surfaces as a failure to the caller.** That is the point of the change, but it means an error that was being swallowed becomes visible — most likely as a 500 on a path that previously answered 200 and did nothing.

Safe to return `false` rather than an object: a repo-wide search finds **no `->save()->` anywhere** in `packages/web`, so no caller chains off the result and this cannot turn a failed save into a fatal method call on a boolean.

## Test

`tests/save-propagates-failure.test.php` — walks every `*.class.php` in `lib/fog`, finds the 14 `save()` overrides that call `parent::save()`, and asserts the return is **consumed** rather than matching an exact spelling. It also fails loudly if it ever finds zero overrides to check, so it cannot start passing vacuously if the pattern is refactored away. Negative-tested by reverting one model.

23 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR