### PR TITLE
Fix PluginTask being unloadable, and gate on classes actually loading

### DIFF
--- a/packages/web/lib/fog/plugintask.class.php
+++ b/packages/web/lib/fog/plugintask.class.php
@@ -110,11 +110,18 @@ abstract class PluginTask extends FOGBase
      * constructor, so the static call reaches the running daemon's log rather
      * than needing the task to hold a reference to it.
      *
+     * Named logLine() rather than log(): FOGBase::log() is `public static`,
+     * and PHP refuses to let a subclass redeclare an inherited static method
+     * as an instance one. That is a fatal at class-declaration time, so
+     * naming this log() made PluginTask itself unloadable -- and since
+     * PluginRunner reaches every task through is_subclass_of($class,
+     * 'PluginTask'), it took the runner down with it.
+     *
      * @param string $message the line to write
      *
      * @return void
      */
-    protected function log($message)
+    protected function logLine($message)
     {
         PluginRunner::outall(
             sprintf(

--- a/tests/all-classes-load.test.php
+++ b/tests/all-classes-load.test.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Every class FOG declares must actually load.
+ *
+ * Sounds tautological. It is not, and the tree has already proved it: a
+ * `protected function log()` added to PluginTask collided with the
+ * `public static function log()` it inherits from FOGBase, and PHP refuses
+ * that at class-declaration time. So PluginTask became unloadable, and
+ * because PluginRunner reaches every plugin task through
+ * `is_subclass_of($class, 'PluginTask')`, the whole plugin task runner went
+ * with it. Nothing caught it: the file lints, php-cs-fixer is happy, every
+ * source-scanning test in this directory passes, and the daemon is the only
+ * thing that ever loads the class.
+ *
+ * That is the general shape of what this covers -- errors PHP raises when it
+ * *declares* a class, which no amount of reading the file will show you:
+ *
+ *   - an instance method overriding an inherited static one, or vice versa
+ *   - an incompatible signature against an abstract parent or interface
+ *   - a missing parent, interface or trait
+ *   - two files declaring the same name
+ *   - a trait/property conflict
+ *
+ * Each class is loaded on its own so a failure names the culprit rather than
+ * stopping at the first one. A declaration error is a FATAL, uncatchable in
+ * process, so the loading runs in a CHILD php and the parent resumes past
+ * whatever killed it. That costs one extra process per broken class and none
+ * at all when the tree is clean.
+ *
+ * Usage: php tests/all-classes-load.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+// Child mode. Loads from $argv[2] onward, logging each name BEFORE trying it
+// so the parent can tell which one killed the process.
+if (isset($argv[1]) && '--load' === $argv[1]) {
+    _childLoad((int) $argv[2], $argv[3], $argv[4]);
+    exit(0);
+}
+
+$classes = _declaredClasses();
+
+if (count($classes) < 200) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($classes) . " class(es) found, expected the "
+        . "whole tree. Is this a git checkout?\n"
+    );
+    exit(1);
+}
+
+$listFile = tempnam(sys_get_temp_dir(), 'fog-load-list');
+$progressFile = tempnam(sys_get_temp_dir(), 'fog-load-progress');
+file_put_contents($listFile, json_encode($classes));
+register_shutdown_function(
+    function () use ($listFile, $progressFile) {
+        @unlink($listFile);
+        @unlink($progressFile);
+    }
+);
+
+$broken = [];
+$start = 0;
+$total = count($classes);
+$guard = 0;
+
+while ($start < $total) {
+    // A runaway loop here would fork forever; the tree cannot have more
+    // broken classes than it has classes.
+    if (++$guard > $total + 1) {
+        fwrite(STDERR, "FAIL: resume loop did not converge\n");
+        exit(1);
+    }
+    file_put_contents($progressFile, '');
+    $cmd = sprintf(
+        '%s %s --load %d %s %s 2>&1',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg(__FILE__),
+        $start,
+        escapeshellarg($listFile),
+        escapeshellarg($progressFile)
+    );
+    exec($cmd, $output, $status);
+    if (0 === $status) {
+        break;
+    }
+    $progress = trim((string) file_get_contents($progressFile));
+    if ('' === $progress) {
+        fwrite(
+            STDERR,
+            "FAIL: child died before reporting progress:\n  "
+            . implode("\n  ", array_slice($output, 0, 10)) . "\n"
+        );
+        exit(1);
+    }
+    list($index, $name) = explode(' ', $progress, 2);
+    $broken[] = [
+        'name' => $name,
+        'file' => $classes[(int) $index]['file'],
+        'why' => _firstError($output)
+    ];
+    $start = (int) $index + 1;
+    $output = [];
+}
+
+if (count($broken) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($broken) . " class(es) do not load:\n");
+    foreach ($broken as $b) {
+        fwrite(STDERR, sprintf("  %s (%s)\n      %s\n", $b['name'], $b['file'], $b['why']));
+    }
+    exit(1);
+}
+
+printf("ok: all %d declared class(es) load\n", $total);
+exit(0);
+
+/**
+ * Load every class from $start onward, in this process.
+ *
+ * @param int    $start        index to resume at
+ * @param string $listFile     JSON list of ['name' => , 'file' => ]
+ * @param string $progressFile written before each attempt
+ *
+ * @return void
+ */
+function _childLoad($start, $listFile, $progressFile)
+{
+    $classes = json_decode((string) file_get_contents($listFile), true);
+
+    $tmp = sys_get_temp_dir() . '/fog-load-test-' . getmypid();
+    foreach (['cache', 'log', 'plugins'] as $sub) {
+        @mkdir($tmp . '/' . $sub, 0700, true);
+    }
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+    define('FOG_LOG_DIR', $tmp . '/log');
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+    require_once dirname(__DIR__) . '/packages/web/commons/init.php';
+    new Initiator();
+
+    for ($i = $start, $n = count($classes); $i < $n; $i++) {
+        $name = $classes[$i]['name'];
+        file_put_contents($progressFile, $i . ' ' . $name);
+        // Autoload on. A declaration error is fatal and takes the process;
+        // that is what the parent's resume loop is for.
+        if (!class_exists($name)
+            && !interface_exists($name)
+            && !trait_exists($name)
+        ) {
+            fwrite(STDERR, "not declared by its own file: $name\n");
+            exit(1);
+        }
+    }
+}
+
+/**
+ * The first line of child output that reads like the reason it died.
+ *
+ * @param array $output child stdout+stderr
+ *
+ * @return string
+ */
+function _firstError(array $output)
+{
+    foreach ($output as $line) {
+        if (false !== stripos($line, 'error')
+            || false !== stripos($line, 'not declared')
+        ) {
+            return trim($line);
+        }
+    }
+    return trim((string) end($output));
+}
+
+/**
+ * Every class/interface/trait declared by a tracked, non-vendored file.
+ *
+ * @return array of ['name' => string, 'file' => string]
+ */
+function _declaredClasses()
+{
+    $files = array_filter(
+        explode("\n", (string) shell_exec('git ls-files "*.php"')),
+        function ($f) {
+            return '' !== $f
+                && is_readable($f)
+                && 0 !== strpos($f, 'packages/web/vendor/')
+                && 0 !== strpos($f, 'tests/');
+        }
+    );
+
+    $out = [];
+    foreach ($files as $file) {
+        $tokens = token_get_all(file_get_contents($file));
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            if (!is_array($tokens[$i])
+                || !in_array(
+                    $tokens[$i][0],
+                    [T_CLASS, T_INTERFACE, T_TRAIT],
+                    true
+                )
+            ) {
+                continue;
+            }
+            $back = $i;
+            while (--$back >= 0
+                && is_array($tokens[$back])
+                && T_WHITESPACE === $tokens[$back][0]
+            ) {
+                continue;
+            }
+            if (isset($tokens[$back])
+                && is_array($tokens[$back])
+                && T_DOUBLE_COLON === $tokens[$back][0]
+            ) {
+                continue;
+            }
+            $j = $i + 1;
+            while ($j < $count
+                && is_array($tokens[$j])
+                && T_WHITESPACE === $tokens[$j][0]
+            ) {
+                $j++;
+            }
+            if (isset($tokens[$j])
+                && is_array($tokens[$j])
+                && T_STRING === $tokens[$j][0]
+            ) {
+                $out[] = ['name' => $tokens[$j][1], 'file' => $file];
+            }
+        }
+    }
+    return $out;
+}


### PR DESCRIPTION
**`PluginTask` has been impossible to load since `b6d5cfb13` (2026-08-14), which takes the entire plugin task runner down with it.**

It declares `protected function log($message)` and extends `FOGBase`, which declares `public static function log(...)`. PHP refuses to let a subclass redeclare an inherited static method as an instance one — and it refuses at class-**declaration** time:

```
PHP Fatal error: Cannot make static method FOGBase::log() non static in class PluginTask
```

That is a fatal, so nothing that touches `PluginTask` survives. `PluginRunner` reaches every plugin task through `is_subclass_of($class, 'PluginTask')` (`pluginrunner.class.php:226`), which triggers the load — so the collision killed the runner, not just the one class.

Reproduced on `working-1.6` at `5d3cac339`:

```
$ php -r 'require "packages/web/commons/init.php"; new Initiator(); var_dump(class_exists("PluginTask"));'
PHP Fatal error:  Cannot make static method FOGBase::log() non static in class PluginTask
```

## The fix

Renamed to `logLine()`. **Nothing can be depending on the old name** — the class could not load, so no subclass of it has ever run. The only caller in the tree is the helloworld demo task, updated alongside in FOGProject/fog-plugins#TBD.

## Why it went unnoticed, and the gate that closes it

The file lints. `php-cs-fixer` is happy. Every source-scanning test in `tests/` passes. The only thing in FOG that ever loads a `PluginTask` is a background daemon, so nothing in a web request would have surfaced it.

`tests/all-classes-load.test.php` now asserts the thing that was silently untrue: **every class FOG declares can actually be declared.** That covers the whole family of errors PHP raises only at declaration time, which no amount of reading the file reveals:

- an instance method overriding an inherited static one, or vice versa
- an incompatible signature against an abstract parent or interface
- a missing parent, interface or trait
- two files declaring the same name
- a trait or property conflict

Each class loads on its own so a failure names the culprit rather than stopping at the first. Because a declaration error is an **uncatchable fatal**, the loading runs in a child process and the parent resumes past whatever killed it — one extra process per broken class, none at all when the tree is clean. Runs in 0.25s, and refuses to pass if it finds implausibly few classes.

Negative-tested by putting the collision back:

```
FAIL: 1 class(es) do not load:
  PluginTask (packages/web/lib/fog/plugintask.class.php)
      PHP Fatal error:  Cannot make static method FOGBase::log() non static in class PluginTask ... on line 124
```

## Verification

```
$ php tests/all-classes-load.test.php
ok: all 242 declared class(es) load
$ sh tests/run-all.sh
26 passed, 0 failed
```

**No OpenAPI change needed** — no route was added, removed or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR