### PR TITLE
Declare FOG's classes in the FOG\ namespace (Phase 3)

### DIFF
--- a/bin/namespace-fog-classes.php
+++ b/bin/namespace-fog-classes.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Moves FOG's class files into the FOG\ namespace, one file at a time.
+ *
+ * Phase 3 of the refactor. Each file gets exactly two additions and nothing
+ * else:
+ *
+ *   1. `namespace FOG;` after the file-level docblock.
+ *   2. `class_alias(__NAMESPACE__ . '\Name', 'Name');` at the end.
+ *
+ * The alias is the whole compatibility story and it is not a transitional
+ * convenience -- it is the 1.6 plugin ABI. Every consumer of a class name
+ * keeps working through it: `new Host`, `$obj instanceof $str`,
+ * `class_exists('host')` (lookup stays case-insensitive), Reflection,
+ * `is_subclass_of($c, 'PluginTask')`, and all 350 getClass() literals. None
+ * of them are edited, here or ever.
+ *
+ * Cross-references inside a converted file are left unqualified on purpose.
+ * `class Child extends FOGController` inside `namespace FOG;` asks the
+ * autoloader for FOG\FOGController, and Initiator::_bridgeNamespaced()
+ * answers that whether or not fogcontroller.class.php has itself been
+ * converted yet. That is what makes a partially converted tree work, and so
+ * what makes this safe to run in batches.
+ *
+ * References to PHP's own classes are already backslash-prefixed tree-wide
+ * (Phase 0.1, guarded by tests/global-class-prefix.test.php), so nothing
+ * here has to reason about them. Functions and constants need no prefix:
+ * both fall back to the global scope from inside a namespace.
+ *
+ * Usage:
+ *   php bin/namespace-fog-classes.php --check [path...]   # list, exit 1 if any
+ *   php bin/namespace-fog-classes.php --fix   [path...]   # convert
+ *
+ * With no paths, walks every tracked PHP file. Idempotent: a file that
+ * already declares a namespace is skipped.
+ *
+ * @category Tooling
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+const NS = 'FOG';
+
+/**
+ * Never converted, each for its own reason.
+ *
+ * The two vendored libraries are swap candidates for their Packagist
+ * releases (ifsnop/mysqldump-php and altorouter/altorouter, both of which
+ * still carry their real namespace commented out at the top). Hand-editing
+ * them here would make those swaps harder, and mysqldump.class.php declares
+ * thirteen types in one file besides.
+ *
+ * Initiator IS the autoloader. A namespaced autoloader that has to load
+ * itself is a bootstrap problem in exchange for nothing.
+ */
+const EXCLUDE = [
+    'packages/web/lib/db/mysqldump.class.php',
+    'packages/web/lib/router/altorouter.class.php',
+    'packages/web/lib/router/altotransformer.class.php',
+    'packages/web/commons/init.php',
+];
+
+$args = array_slice($argv, 1);
+$mode = '';
+$paths = [];
+foreach ($args as $arg) {
+    if ('--check' === $arg || '--fix' === $arg) {
+        $mode = $arg;
+        continue;
+    }
+    $paths[] = $arg;
+}
+if ('' === $mode) {
+    fwrite(STDERR, "usage: {$argv[0]} --check|--fix [path...]\n");
+    exit(2);
+}
+
+$root = dirname(__DIR__);
+chdir($root);
+
+if (0 === count($paths)) {
+    $paths = array_filter(
+        explode("\n", (string) shell_exec('git ls-files "*.php"'))
+    );
+}
+
+$pending = [];
+$converted = 0;
+$skipped = 0;
+
+foreach ($paths as $path) {
+    $path = trim($path);
+    if ('' === $path || !is_readable($path) || !is_file($path)) {
+        continue;
+    }
+    if (0 === strpos($path, 'packages/web/vendor/')
+        || 0 === strpos($path, 'tests/')
+        || in_array($path, EXCLUDE, true)
+    ) {
+        $skipped++;
+        continue;
+    }
+
+    $src = file_get_contents($path);
+    $info = inspect($src);
+
+    if (null === $info) {
+        // No type declared, or already namespaced. Nothing to do either way.
+        $skipped++;
+        continue;
+    }
+
+    if ('--check' === $mode) {
+        $pending[] = $path . '  (' . $info['name'] . ')';
+        continue;
+    }
+
+    file_put_contents($path, convert($src, $info));
+    $converted++;
+    printf("converted %-58s %s\n", $path, $info['name']);
+}
+
+if ('--check' === $mode) {
+    if (0 === count($pending)) {
+        printf("ok: nothing left to namespace (%d file(s) skipped)\n", $skipped);
+        exit(0);
+    }
+    fwrite(STDERR, count($pending) . " file(s) not yet namespaced:\n");
+    foreach ($pending as $p) {
+        fwrite(STDERR, "  $p\n");
+    }
+    exit(1);
+}
+
+printf("\n%d converted, %d skipped\n", $converted, $skipped);
+exit(0);
+
+/**
+ * What a file declares, and where its namespace line belongs.
+ *
+ * Returns null when there is nothing to do: no class/interface/trait, or a
+ * namespace already present.
+ *
+ * @param string $src the file's contents
+ *
+ * @return array|null ['name' => string, 'offset' => int]
+ */
+function inspect($src)
+{
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+    $name = null;
+    // Byte offset the namespace line is inserted at. Defaults to just past
+    // `<?php`; moves past a declare() and the file docblock when present.
+    $offset = null;
+    $sawDocblock = false;
+    $cursor = 0;
+
+    for ($i = 0; $i < $count; $i++) {
+        $token = $tokens[$i];
+        $text = is_array($token) ? $token[1] : $token;
+
+        if (is_array($token)) {
+            if (T_NAMESPACE === $token[0]) {
+                // Already done. Idempotent by design -- see the header.
+                return null;
+            }
+            if (T_OPEN_TAG === $token[0]) {
+                $offset = $cursor + strlen($text);
+            }
+            if (T_DOC_COMMENT === $token[0] && !$sawDocblock) {
+                // The FIRST docblock is the file docblock. FOG's files then
+                // repeat it as the class docblock, and that second one must
+                // stay attached to the class -- so only the first one moves
+                // the insertion point.
+                $sawDocblock = true;
+                $offset = $cursor + strlen($text);
+            }
+            if (T_DECLARE === $token[0]) {
+                // namespace must follow declare(strict_types=1);
+                $semi = $i;
+                while ($semi < $count && ';' !== $tokens[$semi]) {
+                    $semi++;
+                }
+                $upto = 0;
+                for ($k = 0; $k <= $semi && $k < $count; $k++) {
+                    $upto += strlen(
+                        is_array($tokens[$k]) ? $tokens[$k][1] : $tokens[$k]
+                    );
+                }
+                $offset = $upto;
+            }
+            if (in_array($token[0], [T_CLASS, T_INTERFACE, T_TRAIT], true)
+                && null === $name
+            ) {
+                // Skip `X::class` and anonymous classes.
+                $back = $i;
+                while (--$back >= 0
+                    && is_array($tokens[$back])
+                    && T_WHITESPACE === $tokens[$back][0]
+                ) {
+                    continue;
+                }
+                if (!isset($tokens[$back])
+                    || !is_array($tokens[$back])
+                    || T_DOUBLE_COLON !== $tokens[$back][0]
+                ) {
+                    $j = $i + 1;
+                    while ($j < $count
+                        && is_array($tokens[$j])
+                        && T_WHITESPACE === $tokens[$j][0]
+                    ) {
+                        $j++;
+                    }
+                    if (isset($tokens[$j])
+                        && is_array($tokens[$j])
+                        && T_STRING === $tokens[$j][0]
+                    ) {
+                        $name = $tokens[$j][1];
+                    }
+                }
+            }
+        }
+        $cursor += strlen($text);
+    }
+
+    if (null === $name || null === $offset) {
+        return null;
+    }
+    return ['name' => $name, 'offset' => $offset];
+}
+
+/**
+ * Insert the namespace declaration and append the compatibility alias.
+ *
+ * @param string $src  the file's contents
+ * @param array  $info from inspect()
+ *
+ * @return string
+ */
+function convert($src, array $info)
+{
+    $head = substr($src, 0, $info['offset']);
+    $tail = substr($src, $info['offset']);
+
+    $out = rtrim($head, "\n") . "\n\nnamespace " . NS . ";\n\n"
+        . ltrim($tail, "\n");
+
+    $alias = sprintf(
+        "\n/*\n"
+        . " * Compatibility alias. Every consumer of this class' name -- core,\n"
+        . " * bundled plugins and third-party plugins alike -- keeps working\n"
+        . " * unqualified through this, so no call site had to be edited.\n"
+        . " * Supported for all of 1.6; see docs/adr/0013.\n"
+        . " */\n"
+        . "class_alias(__NAMESPACE__ . '\\\\%s', '%s');\n",
+        $info['name'],
+        $info['name']
+    );
+
+    return rtrim($out, "\n") . "\n" . $alias;
+}

--- a/bin/namespace-fog-classes.php
+++ b/bin/namespace-fog-classes.php
@@ -88,6 +88,7 @@ if (0 === count($paths)) {
 
 $pending = [];
 $converted = 0;
+$qualified = 0;
 $skipped = 0;
 
 foreach ($paths as $path) {
@@ -106,35 +107,63 @@ foreach ($paths as $path) {
     $src = file_get_contents($path);
     $info = inspect($src);
 
-    if (null === $info) {
-        // No type declared, or already namespaced. Nothing to do either way.
-        $skipped++;
-        continue;
+    if (null !== $info) {
+        if ('--check' === $mode) {
+            $pending[] = $path . '  (' . $info['name'] . ') -- not namespaced';
+            continue;
+        }
+        $src = convert($src, $info);
+        $converted++;
+        printf("converted %-58s %s\n", $path, $info['name']);
     }
 
+    // Second pass, and it runs on ALREADY-converted files too. See
+    // qualifyExcluded() for why this is not optional.
+    $refs = qualifyExcluded($src);
+    if (0 === count($refs['names'])) {
+        if (null === $info) {
+            $skipped++;
+        }
+        continue;
+    }
     if ('--check' === $mode) {
-        $pending[] = $path . '  (' . $info['name'] . ')';
+        $pending[] = sprintf(
+            '%s  -- %d unqualified reference(s) to excluded class(es): %s',
+            $path,
+            $refs['count'],
+            implode(', ', array_keys($refs['names']))
+        );
         continue;
     }
-
-    file_put_contents($path, convert($src, $info));
-    $converted++;
-    printf("converted %-58s %s\n", $path, $info['name']);
+    file_put_contents($path, $refs['src']);
+    $qualified += $refs['count'];
+    printf(
+        "qualified %-58s %d ref(s): %s\n",
+        $path,
+        $refs['count'],
+        implode(', ', array_keys($refs['names']))
+    );
+    $src = $refs['src'];
 }
 
 if ('--check' === $mode) {
     if (0 === count($pending)) {
-        printf("ok: nothing left to namespace (%d file(s) skipped)\n", $skipped);
+        printf("ok: nothing left to do (%d file(s) skipped)\n", $skipped);
         exit(0);
     }
-    fwrite(STDERR, count($pending) . " file(s) not yet namespaced:\n");
+    fwrite(STDERR, count($pending) . " file(s) need work:\n");
     foreach ($pending as $p) {
         fwrite(STDERR, "  $p\n");
     }
     exit(1);
 }
 
-printf("\n%d converted, %d skipped\n", $converted, $skipped);
+printf(
+    "\n%d converted, %d reference(s) qualified, %d skipped\n",
+    $converted,
+    $qualified,
+    $skipped
+);
 exit(0);
 
 /**
@@ -261,4 +290,145 @@ function convert($src, array $info)
     );
 
     return rtrim($out, "\n") . "\n" . $alias;
+}
+
+/**
+ * Backslash-prefix references to classes that are NEVER namespaced.
+ *
+ * The excluded files stay in the global namespace, so from inside
+ * `namespace FOG;` an unqualified `Initiator::e($x)` resolves to
+ * FOG\Initiator -- which does not exist and, in Initiator's case, never can:
+ * commons/init.php is not a *.class.php file, so it is not in the
+ * autoloader's map at all and no bridge can reach it.
+ *
+ * This is the one part of the migration that unit tests cannot catch. Class
+ * resolution passes, every source scan passes, and the application is still
+ * completely broken -- Initiator::e() is the output escaper, so it is on
+ * essentially every page. It was found by booting the tree against a live
+ * database, and it is why bin/... --check is wired into the test suite.
+ *
+ * Runs on already-converted files as well as newly converted ones, so it can
+ * be applied after the fact.
+ *
+ * @param string $src the file's contents
+ *
+ * @return array ['src' => string, 'count' => int, 'names' => array]
+ */
+function qualifyExcluded($src)
+{
+    static $excluded = null;
+    if (null === $excluded) {
+        $excluded = [];
+        foreach (EXCLUDE as $file) {
+            if (!is_readable($file)) {
+                continue;
+            }
+            foreach (declaredIn($file) as $name) {
+                $excluded[$name] = true;
+            }
+        }
+    }
+
+    $out = ['src' => $src, 'count' => 0, 'names' => []];
+    if (false === strpos($src, 'namespace ' . NS . ';')) {
+        return $out;
+    }
+
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+    $pieces = [];
+    for ($i = 0; $i < $count; $i++) {
+        $token = $tokens[$i];
+        $text = is_array($token) ? $token[1] : $token;
+        if (!is_array($token)
+            || T_STRING !== $token[0]
+            || !isset($excluded[$token[1]])
+        ) {
+            $pieces[] = $text;
+            continue;
+        }
+        // Previous meaningful token decides whether this is a class
+        // reference at all.
+        $back = $i;
+        while (--$back >= 0
+            && is_array($tokens[$back])
+            && T_WHITESPACE === $tokens[$back][0]
+        ) {
+            continue;
+        }
+        $prev = isset($tokens[$back]) ? $tokens[$back] : null;
+        $skip = is_array($prev)
+            && in_array(
+                $prev[0],
+                [
+                    T_NS_SEPARATOR,      // already qualified
+                    T_OBJECT_OPERATOR,   // ->Initiator(...)
+                    T_DOUBLE_COLON,      // Foo::Initiator
+                    T_FUNCTION,          // function Initiator()
+                    T_CLASS,             // class Initiator
+                    T_INTERFACE,
+                    T_TRAIT,
+                    T_CONST,
+                ],
+                true
+            );
+        if ($skip) {
+            $pieces[] = $text;
+            continue;
+        }
+        $pieces[] = '\\' . $text;
+        $out['count']++;
+        $out['names'][$token[1]] = true;
+    }
+
+    $out['src'] = implode('', $pieces);
+    return $out;
+}
+
+/**
+ * Names of every class, interface and trait a file declares.
+ *
+ * @param string $file path to read
+ *
+ * @return array of string
+ */
+function declaredIn($file)
+{
+    $tokens = token_get_all(file_get_contents($file));
+    $count = count($tokens);
+    $names = [];
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i])
+            || !in_array($tokens[$i][0], [T_CLASS, T_INTERFACE, T_TRAIT], true)
+        ) {
+            continue;
+        }
+        $back = $i;
+        while (--$back >= 0
+            && is_array($tokens[$back])
+            && T_WHITESPACE === $tokens[$back][0]
+        ) {
+            continue;
+        }
+        if (isset($tokens[$back])
+            && is_array($tokens[$back])
+            && T_DOUBLE_COLON === $tokens[$back][0]
+        ) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $count
+            && is_array($tokens[$j])
+            && T_WHITESPACE === $tokens[$j][0]
+        ) {
+            $j++;
+        }
+        if (isset($tokens[$j])
+            && is_array($tokens[$j])
+            && T_STRING === $tokens[$j][0]
+        ) {
+            $names[] = $tokens[$j][1];
+        }
+    }
+    return $names;
 }

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -445,6 +445,19 @@ class Initiator
             return;
         }
         include_once self::$classMap[$key];
+        // Phase 3: the file may declare the namespaced name ITSELF, and then
+        // alias the global one back the other way. There is nothing left to
+        // bridge in that case, and aliasing again would be a "Cannot declare
+        // class FOG\X, because the name is already in use" warning on every
+        // single class load. Checked before the branch below, because that
+        // branch's own condition is satisfied too -- the file's own
+        // class_alias() has by now declared the short name.
+        if (class_exists($class, false)
+            || interface_exists($class, false)
+            || trait_exists($class, false)
+        ) {
+            return;
+        }
         // Checked with autoload OFF. With it on, a file whose declared class
         // name does not match its basename would re-enter autoload() for the
         // same short name and hit the "Cannot declare class X" fatal the

--- a/packages/web/lib/client/autologout.class.php
+++ b/packages/web/lib/client/autologout.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles auto log information as requested.
  *
@@ -47,3 +50,11 @@ class Autologout extends FOGClient
         return ['time' => $time * 60];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Autologout', 'Autologout');

--- a/packages/web/lib/client/displaymanager.class.php
+++ b/packages/web/lib/client/displaymanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles display manager
  *
@@ -35,3 +38,11 @@ class DisplayManager extends FOGClient
         ];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\DisplayManager', 'DisplayManager');

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -82,7 +82,7 @@ abstract class FOGClient extends FOGBase
                 $moduleid = filter_input(INPUT_GET, 'moduleid');
             }
             if ($moduleid) {
-                $this->shortName = Initiator::sanitizeItems(
+                $this->shortName = \Initiator::sanitizeItems(
                     $moduleid
                 );
                 switch ($this->shortName) {

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Base element for client services
  *
@@ -192,3 +195,11 @@ abstract class FOGClient extends FOGBase
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGClient', 'FOGClient');

--- a/packages/web/lib/client/hostnamechanger.class.php
+++ b/packages/web/lib/client/hostnamechanger.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Sends the client with the hostname and domain
  * information needed to perform the client actions.
@@ -109,3 +112,11 @@ class HostnameChanger extends FOGClient
         return $val;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostnameChanger', 'HostnameChanger');

--- a/packages/web/lib/client/jobs.class.php
+++ b/packages/web/lib/client/jobs.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Tells the client if there's a task waiting for the host
  *
@@ -60,3 +63,11 @@ class Jobs extends FOGClient
         return [$field => $answer];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Jobs', 'Jobs');

--- a/packages/web/lib/client/pm.class.php
+++ b/packages/web/lib/client/pm.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Powermanagement Client information
  *
@@ -96,3 +99,11 @@ class PM extends FOGClient
         return $data;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PM', 'PM');

--- a/packages/web/lib/client/printerclient.class.php
+++ b/packages/web/lib/client/printerclient.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Sends the printer information for the FOG Client
  *
@@ -117,3 +120,11 @@ class PrinterClient extends FOGClient
         ];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PrinterClient', 'PrinterClient');

--- a/packages/web/lib/client/registerclient.class.php
+++ b/packages/web/lib/client/registerclient.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Registers mac's to the host.
  * If using the new client can also register new hosts
@@ -141,3 +144,11 @@ class RegisterClient extends FOGClient
         return ['error' => 'ig'];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RegisterClient', 'RegisterClient');

--- a/packages/web/lib/client/servicemodule.class.php
+++ b/packages/web/lib/client/servicemodule.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The service module checks
  *
@@ -120,3 +123,11 @@ class ServiceModule extends FOGClient
         $this->send = "#!ok\n";
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ServiceModule', 'ServiceModule');

--- a/packages/web/lib/client/servicemodule.class.php
+++ b/packages/web/lib/client/servicemodule.class.php
@@ -41,7 +41,7 @@ class ServiceModule extends FOGClient
             $moduleid = filter_input(INPUT_GET, 'moduleid');
         }
         $mod = strtolower(
-            Initiator::sanitizeItems(
+            \Initiator::sanitizeItems(
                 $moduleid
             )
         );

--- a/packages/web/lib/client/snapinclient.class.php
+++ b/packages/web/lib/client/snapinclient.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles snapins for the host
  *
@@ -561,3 +564,11 @@ class SnapinClient extends FOGClient
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinClient', 'SnapinClient');

--- a/packages/web/lib/client/usertrack.class.php
+++ b/packages/web/lib/client/usertrack.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Logs the user who logged in
  *
@@ -92,3 +95,11 @@ class UserTrack extends FOGClient
         return ['' => ''];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserTrack', 'UserTrack');

--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Database Manager Handles communication from fog to db class.
  *
@@ -367,3 +370,11 @@ class DatabaseManager extends FOGCore
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\DatabaseManager', 'DatabaseManager');

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * PDODB, the database connector.
  *
@@ -900,3 +903,11 @@ class PDODB extends DatabaseManager
         self::$_queryResult->bindValue($param, $value, $type);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PDODB', 'PDODB');

--- a/packages/web/lib/events/hostlist.event.php
+++ b/packages/web/lib/events/hostlist.event.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Host list event
  *
@@ -55,3 +58,11 @@ class HostList extends Event
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostList', 'HostList');

--- a/packages/web/lib/fog/FOGPagePost.class.php
+++ b/packages/web/lib/fog/FOGPagePost.class.php
@@ -18,6 +18,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 trait FOGPagePost
 {
     /**
@@ -514,3 +517,11 @@ trait FOGPagePost
         $this->siteTabPost($node, $obj);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGPagePost', 'FOGPagePost');

--- a/packages/web/lib/fog/FOGPageRender.class.php
+++ b/packages/web/lib/fog/FOGPageRender.class.php
@@ -202,8 +202,8 @@ trait FOGPageRender
             'btn btn-secondary float-end',
             sprintf(
                 ' type="button" data-create-node="%s" data-assoc-action="%s" ',
-                Initiator::e($createNode),
-                Initiator::e(
+                \Initiator::e($createNode),
+                \Initiator::e(
                     self::makeTabUpdateURL($tabSlug, $ownerId)
                 )
             )
@@ -213,7 +213,7 @@ trait FOGPageRender
             $label,
             sprintf(
                 '<div id="%s-create-form"></div>',
-                Initiator::e($tabSlug)
+                \Initiator::e($tabSlug)
             ),
             self::makeButton(
                 "$tabSlug-create-cancel",
@@ -928,7 +928,7 @@ trait FOGPageRender
                         . 'than one.'
                     ),
                     count($current),
-                    Initiator::e(implode(', ', $names))
+                    \Initiator::e(implode(', ', $names))
                 )
                 . '</div>';
         }

--- a/packages/web/lib/fog/FOGPageRender.class.php
+++ b/packages/web/lib/fog/FOGPageRender.class.php
@@ -18,6 +18,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 trait FOGPageRender
 {
     /**
@@ -942,3 +945,11 @@ trait FOGPageRender
         echo $createModal;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGPageRender', 'FOGPageRender');

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Authorization service — native role-based permission checks.
  *
@@ -1339,3 +1342,11 @@ class Authorization extends FOGBase
         self::resetCache();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Authorization', 'Authorization');

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Boot menu for the fog pxe system
  *
@@ -2353,3 +2356,11 @@ class BootMenu extends FOGBase
         $this->_parseMe($Send);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\BootMenu', 'BootMenu');

--- a/packages/web/lib/fog/csrf.class.php
+++ b/packages/web/lib/fog/csrf.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * CSRF, hopefully more secure handling centralized.
  *
@@ -104,3 +107,11 @@ class CSRF
         // Often lenient to avoid breaking weird client setups.
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\CSRF', 'CSRF');

--- a/packages/web/lib/fog/dmikey.class.php
+++ b/packages/web/lib/fog/dmikey.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * DMI Key tracker.
  *
@@ -45,3 +48,11 @@ class DMIKey extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\DMIKey', 'DMIKey');

--- a/packages/web/lib/fog/dmikeymanager.class.php
+++ b/packages/web/lib/fog/dmikeymanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * DMI Key handler class (informative).
  *
@@ -22,3 +25,11 @@
 class DMIKeyManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\DMIKeyManager', 'DMIKeyManager');

--- a/packages/web/lib/fog/event.class.php
+++ b/packages/web/lib/fog/event.class.php
@@ -13,6 +13,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Allows Events and defines how they operate.
  * Because of the similarities of use for events and hooks
@@ -188,3 +191,11 @@ abstract class Event extends FOGBase
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Event', 'Event');

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * EventManager handles registering and loading
  * events and hooks.
@@ -264,3 +267,11 @@ class EventManager extends FOGBase
         self::startClassFromFiles($startfiles, $strlen);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\EventManager', 'EventManager');

--- a/packages/web/lib/fog/filedeletequeue.class.php
+++ b/packages/web/lib/fog/filedeletequeue.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * File Delete Queue.
  *
@@ -75,3 +78,11 @@ class FileDeleteQueue extends FOGController
         return parent::save();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FileDeleteQueue', 'FileDeleteQueue');

--- a/packages/web/lib/fog/filedeletequeuemanager.class.php
+++ b/packages/web/lib/fog/filedeletequeuemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * File Delete Queue handler class (informative).
  *
@@ -82,3 +85,11 @@ class FileDeleteQueueManager extends FOGManagerController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FileDeleteQueueManager', 'FileDeleteQueueManager');

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -480,9 +480,9 @@ abstract class FOGBase
             }
             printf(
                 '<option value="%s"%s>%s</option>',
-                Initiator::e($value),
+                \Initiator::e($value),
                 (self::$selected == $value ? ' selected' : ''),
-                Initiator::e($option)
+                \Initiator::e($option)
             );
         };
         /**
@@ -1627,7 +1627,7 @@ abstract class FOGBase
                 $array[$old_key],
                 'utf-8'
             );
-            $array[$new_key] = Initiator::sanitizeItems(
+            $array[$new_key] = \Initiator::sanitizeItems(
                 $item
             );
         } else {
@@ -3014,9 +3014,9 @@ abstract class FOGBase
         return sprintf(
             '<a href="../management/index.php?node=%s&sub=edit&id=%d">'
             . '%s - (%d)</a>',
-            Initiator::e($node),
+            \Initiator::e($node),
             (int)$id,
-            Initiator::e($name),
+            \Initiator::e($name),
             (int)$id
         );
     }
@@ -3082,7 +3082,7 @@ abstract class FOGBase
             $val = $tmp;
         }
 
-        return Initiator::e(trim($val));
+        return \Initiator::e(trim($val));
     }
     /**
      * Strips and decodes a mac, or a '|' separated list of macs.
@@ -3106,16 +3106,16 @@ abstract class FOGBase
     {
         $mac = trim((string) ($mac ?? ''));
         if ($mac === '' || self::isMacList($mac)) {
-            return Initiator::e($mac);
+            return \Initiator::e($mac);
         }
         $decoded = trim(base64_decode(str_replace(' ', '+', $mac)));
         if (self::isMacList($decoded)) {
-            return Initiator::e($decoded);
+            return \Initiator::e($decoded);
         }
 
         // Neither shape matched; hand back the plain value so the caller
         // reports the mac it was actually sent.
-        return Initiator::e($mac);
+        return \Initiator::e($mac);
     }
     /**
      * Tests whether a string is a '|' separated list of mac addresses.
@@ -3626,7 +3626,7 @@ abstract class FOGBase
         // kept path is wrapped as a [0 => path] match array to preserve the
         // shape the closure below and startClassFromFiles() expect.
         $files = [];
-        foreach (Initiator::classFileList() as $path) {
+        foreach (\Initiator::classFileList() as $path) {
             if (preg_match($regext, $path)) {
                 $files[] = [$path];
             }

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * FOGBase, the base class for pretty much all of fog.
  *
@@ -4166,3 +4169,11 @@ abstract class FOGBase
         error_log($contents);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGBase', 'FOGBase');

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -13,6 +13,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * FOGController, individual SQL getters/setters.
  *
@@ -1648,3 +1651,11 @@ abstract class FOGController extends FOGBase
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGController', 'FOGController');

--- a/packages/web/lib/fog/fogcore.class.php
+++ b/packages/web/lib/fog/fogcore.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The core elements accessible for all else
  *
@@ -232,3 +235,11 @@ class FOGCore extends FOGBase
         return self::getClass(__CLASS__);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGCore', 'FOGCore');

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The cron validation
  *
@@ -323,3 +326,11 @@ class FOGCron extends FOGBase
         return (bool)($time <= $currTime);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGCron', 'FOGCron');

--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles FTP connections and operations for FOG
  *
@@ -460,3 +463,11 @@ class FOGFTP
         return in_array($path, $dirlisting);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGFTP', 'FOGFTP');

--- a/packages/web/lib/fog/foglogpaths.class.php
+++ b/packages/web/lib/fog/foglogpaths.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The one place that knows which directories hold FOG's logs.
  *
@@ -143,3 +146,11 @@ class FOGLogPaths
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGLogPaths', 'FOGLogPaths');

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * FOG Manager Controller, main object mass getter.
  *
@@ -1467,3 +1470,11 @@ abstract class FOGManagerController extends FOGBase
         return $this->sqlTotalStr;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGManagerController', 'FOGManagerController');

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1194,7 +1194,7 @@ abstract class FOGManagerController extends FOGBase
                 continue;
             }
             echo '<option value="'
-                . Initiator::e($Item->{$useKey})
+                . \Initiator::e($Item->{$useKey})
                 . '"'
                 . (
                     $matchID == $Item->{$useKey} ?
@@ -1206,8 +1206,8 @@ abstract class FOGManagerController extends FOGBase
                     )
                 )
                 . '>'
-                . Initiator::e($Item->name)
-                . ' - (' . Initiator::e($Item->id) . ')'
+                . \Initiator::e($Item->name)
+                . ' - (' . \Initiator::e($Item->id) . ')'
                 . '</option>';
             unset($Item);
         }

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Presents many defaults for the pages and is
  * the calling point by all other page items.
@@ -5712,3 +5715,11 @@ abstract class FOGPage extends FOGBase
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGPage', 'FOGPage');

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1229,8 +1229,8 @@ abstract class FOGPage extends FOGBase
             $pause,
             trim($class . ' reload-toggle'),
             'type="button" data-paused="0"'
-            . ' data-pause-label="' . Initiator::e($pause) . '"'
-            . ' data-resume-label="' . Initiator::e($resume) . '"'
+            . ' data-pause-label="' . \Initiator::e($pause) . '"'
+            . ' data-resume-label="' . \Initiator::e($resume) . '"'
         );
     }
     /**
@@ -1680,7 +1680,7 @@ abstract class FOGPage extends FOGBase
                 $name
             );
             $val = trim($val);
-            $this->dataReplace[] = Initiator::e($val);
+            $this->dataReplace[] = \Initiator::e($val);
             unset($val);
         }
     }
@@ -1708,7 +1708,7 @@ abstract class FOGPage extends FOGBase
             $escapedReplace = array_map(
                 function ($value) {
                     if (is_scalar($value) || $value === null) {
-                        return Initiator::e((string)$value);
+                        return \Initiator::e((string)$value);
                     }
                     return '';
                 },
@@ -1860,14 +1860,14 @@ abstract class FOGPage extends FOGBase
                 $useAD = $this->obj->get('useAD');
             }
             if (empty($ADDomain)) {
-                $ADDomain = Initiator::e($this->obj->get('ADDomain'));
+                $ADDomain = \Initiator::e($this->obj->get('ADDomain'));
             }
             if (empty($ADOU)) {
                 $ADOU = trim($this->obj->get('ADOU'));
-                $ADOU = str_replace(';', '', Initiator::e($ADOU));
+                $ADOU = str_replace(';', '', \Initiator::e($ADOU));
             }
             if (empty($ADUser)) {
-                $ADUser = Initiator::e($this->obj->get('ADUser'));
+                $ADUser = \Initiator::e($this->obj->get('ADUser'));
             }
             if (empty($ADPass)) {
                 $ADPass = (
@@ -1881,12 +1881,12 @@ abstract class FOGPage extends FOGBase
             array_filter(
                 explode(
                     '|',
-                    Initiator::e(self::getSetting('FOG_AD_DEFAULT_OU'))
+                    \Initiator::e(self::getSetting('FOG_AD_DEFAULT_OU'))
                 )
             )
         );
         $ADOU = trim($ADOU);
-        $ADOU = str_replace(';', '', Initiator::e($ADOU));
+        $ADOU = str_replace(';', '', \Initiator::e($ADOU));
         $optFound = $ADOU;
         if (count($OUs ?: []) > 1) {
             ob_start();
@@ -1904,11 +1904,11 @@ abstract class FOGPage extends FOGBase
                     $optFound = $ou;
                 }
                 echo '<option value="'
-                    . Initiator::e($ou)
+                    . \Initiator::e($ou)
                     . '"'
                     . ($optFound == $ou ? ' selected' : '')
                     . '>'
-                    . Initiator::e($ou)
+                    . \Initiator::e($ou)
                     . '</option>';
                 unset($OU);
             }
@@ -2037,7 +2037,7 @@ abstract class FOGPage extends FOGBase
                 'active-directory-form',
                 self::makeTabUpdateURL(
                     $node . '-active-directory',
-                    Initiator::e($this->obj->get('id'))
+                    \Initiator::e($this->obj->get('id'))
                 ),
                 'post',
                 'application/x-www-form-urlencoded',
@@ -2715,7 +2715,7 @@ abstract class FOGPage extends FOGBase
             'deleteModal',
             _('Delete')
             . ': '
-            . Initiator::e($this->obj->get('name')),
+            . \Initiator::e($this->obj->get('name')),
             _("Confirm you would like to delete this $node")
             . $extra,
             self::makeButton(
@@ -3300,7 +3300,7 @@ abstract class FOGPage extends FOGBase
                 throw new \Exception(
                     _('Failed to remove')
                     . ': '
-                    . Initiator::e($this->obj->get('name'))
+                    . \Initiator::e($this->obj->get('name'))
                 );
             }
             $hook = "{$ucnode}_DELETE_SUCCESS";
@@ -3309,7 +3309,7 @@ abstract class FOGPage extends FOGBase
                 [
                     'msg' => _('Successfully deleted')
                     . ': '
-                    . Initiator::e($this->obj->get('name')),
+                    . \Initiator::e($this->obj->get('name')),
                     'title' => _('Delete Success')
                 ]
             );
@@ -3459,7 +3459,7 @@ abstract class FOGPage extends FOGBase
         echo self::makeFormTag(
             '',
             'import-form',
-            Initiator::e($this->formAction),
+            \Initiator::e($this->formAction),
             'post',
             'multipart/form-data',
             true
@@ -4669,8 +4669,8 @@ abstract class FOGPage extends FOGBase
                 '<option value="%s"%s>%s</option>',
                 (
                     $useidsel ?
-                    Initiator::e($id) :
-                    Initiator::e($item)
+                    \Initiator::e($id) :
+                    \Initiator::e($item)
                 ),
                 (
                     $useidsel ? (
@@ -4685,8 +4685,8 @@ abstract class FOGPage extends FOGBase
                 ),
                 (
                     $addidtodisplay ?
-                    Initiator::e($item) . ' - (' . Initiator::e($id) . ')' :
-                    Initiator::e($item)
+                    \Initiator::e($item) . ' - (' . \Initiator::e($id) . ')' :
+                    \Initiator::e($item)
                 )
             );
             unset($item);
@@ -4805,7 +4805,7 @@ abstract class FOGPage extends FOGBase
             . '-form',
             self::makeTabUpdateURL(
                 $node . '-powermanagement',
-                Initiator::e($this->obj->get('id'))
+                \Initiator::e($this->obj->get('id'))
             ),
             'post',
             'application/x-www-form-urlencoded',
@@ -5247,17 +5247,17 @@ abstract class FOGPage extends FOGBase
         $opts = '<option value="">- '
             . (
                 $blankLabel !== '' ?
-                Initiator::e($blankLabel) :
+                \Initiator::e($blankLabel) :
                 self::$foglang['PleaseSelect']
             )
             . ' -</option>';
         foreach ($files as $file) {
             $opts .= '<option value="'
-                . Initiator::e($file)
+                . \Initiator::e($file)
                 . '"'
                 . ($file === $current ? ' selected' : '')
                 . '>'
-                . Initiator::e($file)
+                . \Initiator::e($file)
                 . (
                     $missing && $file === $current ?
                     ' (' . _('not found on disk') . ')' :
@@ -5318,7 +5318,7 @@ abstract class FOGPage extends FOGBase
             . 'placeholder="' . $placeholder . '" '
             . 'type="' . $type . '" '
             . 'id="' . $id . '" '
-            . 'value="' . Initiator::e($value) . '" '
+            . 'value="' . \Initiator::e($value) . '" '
             . ($required ? 'required ' : '')
             . ($readonly ? 'readonly ' : '')
             . ($disabled ? 'disabled ' : '')
@@ -5425,7 +5425,7 @@ abstract class FOGPage extends FOGBase
             . 'autocomplete="' . ($autocomplete ? 'on' : 'off') . '"'
             . ($extra ? " $extra" : '')
             . '>'
-            . Initiator::e($value)
+            . \Initiator::e($value)
             . '</textarea>';
     }
     /**

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Manages and presents the page items
  *
@@ -321,3 +324,11 @@ class FOGPageManager extends FOGBase
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGPageManager', 'FOGPageManager');

--- a/packages/web/lib/fog/fogrollingurl.class.php
+++ b/packages/web/lib/fog/fogrollingurl.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The request for rolling urls.
  *
@@ -85,3 +88,11 @@ class FOGRollingURL
         $this->options = [];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGRollingURL', 'FOGRollingURL');

--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles FTP connections and operations for FOG
  *
@@ -406,3 +409,11 @@ class FOGSSH
         return $this;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGSSH', 'FOGSSH');

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Processes URL requests for our needs.
  *
@@ -686,3 +689,11 @@ class FOGURLRequests extends FOGBase
         return $output;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGURLRequests', 'FOGURLRequests');

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Main class for group objects.
  *
@@ -1073,3 +1076,11 @@ class Group extends FOGController
         $this->getHostCount();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Group', 'Group');

--- a/packages/web/lib/fog/groupassociation.class.php
+++ b/packages/web/lib/fog/groupassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Group association between host -> group links.
  *
@@ -65,3 +68,11 @@ class GroupAssociation extends FOGController
         return new Host($this->get('hostID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\GroupAssociation', 'GroupAssociation');

--- a/packages/web/lib/fog/groupassociationmanager.class.php
+++ b/packages/web/lib/fog/groupassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Group association manager class
  *
@@ -28,3 +31,11 @@ class GroupAssociationManager extends FOGManagerController
      */
     public $tablename = 'groupMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\GroupAssociationManager', 'GroupAssociationManager');

--- a/packages/web/lib/fog/groupmanager.class.php
+++ b/packages/web/lib/fog/groupmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Group manager mass management class
  *
@@ -28,3 +31,11 @@ class GroupManager extends FOGManagerController
      */
     public $tablename = 'groupMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\GroupManager', 'GroupManager');

--- a/packages/web/lib/fog/history.class.php
+++ b/packages/web/lib/fog/history.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Stores any actions to the database.
  *
@@ -40,3 +43,11 @@ class History extends FOGController
         'ip' => 'hIP'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\History', 'History');

--- a/packages/web/lib/fog/historymanager.class.php
+++ b/packages/web/lib/fog/historymanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * History manager class.
  *
@@ -28,3 +31,11 @@ class HistoryManager extends FOGManagerController
      */
     public $tablename = 'history';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HistoryManager', 'HistoryManager');

--- a/packages/web/lib/fog/hook.class.php
+++ b/packages/web/lib/fog/hook.class.php
@@ -15,6 +15,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Hooks allow customization between different aspects.
  *
@@ -121,3 +124,11 @@ abstract class Hook extends Event
         $arguments['files'][] = $filepaths;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Hook', 'Hook');

--- a/packages/web/lib/fog/hookevent.class.php
+++ b/packages/web/lib/fog/hookevent.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Hook event tracker.
  *
@@ -45,3 +48,11 @@ class HookEvent extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HookEvent', 'HookEvent');

--- a/packages/web/lib/fog/hookeventmanager.class.php
+++ b/packages/web/lib/fog/hookeventmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Hook event manager handler class (informative).
  *
@@ -22,3 +25,11 @@
 class HookEventManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HookEventManager', 'HookEventManager');

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * HookManager handles registering and loading
  * events and hooks.
@@ -112,3 +115,11 @@ class HookManager extends EventManager
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HookManager', 'HookManager');

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The host object (main item FOG deals with
  *
@@ -1998,3 +2001,11 @@ class Host extends FOGController
         return $this->get('snapinjob');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Host', 'Host');

--- a/packages/web/lib/fog/hostautologout.class.php
+++ b/packages/web/lib/fog/hostautologout.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Presents the client with auto logout info.
  *
@@ -56,3 +59,11 @@ class HostAutoLogout extends FOGController
         return new Host($this->get('hostID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostAutoLogout', 'HostAutoLogout');

--- a/packages/web/lib/fog/hostautologoutmanager.class.php
+++ b/packages/web/lib/fog/hostautologoutmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Host auto logout manager class.
  *
@@ -28,3 +31,11 @@ class HostAutoLogoutManager extends FOGManagerController
      */
     public $tablename = 'hostAutoLogout';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostAutoLogoutManager', 'HostAutoLogoutManager');

--- a/packages/web/lib/fog/hostmanager.class.php
+++ b/packages/web/lib/fog/hostmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Manager class for Hosts.
  *
@@ -232,3 +235,11 @@ class HostManager extends FOGManagerController
         self::$Host = new Host(self::maxId($MACHost));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostManager', 'HostManager');

--- a/packages/web/lib/fog/hostscreensetting.class.php
+++ b/packages/web/lib/fog/hostscreensetting.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Host screen settings class.
  *
@@ -60,3 +63,11 @@ class HostScreenSetting extends FOGController
         return new Host($this->get('hostID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostScreenSetting', 'HostScreenSetting');

--- a/packages/web/lib/fog/hostscreensettingmanager.class.php
+++ b/packages/web/lib/fog/hostscreensettingmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Host screen settings manager class.
  *
@@ -28,3 +31,11 @@ class HostScreenSettingManager extends FOGManagerController
      */
     public $tablename = 'hostScreenSettings';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostScreenSettingManager', 'HostScreenSettingManager');

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The image object
  *
@@ -473,3 +476,11 @@ class Image extends FOGController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Image', 'Image');

--- a/packages/web/lib/fog/imageassociation.class.php
+++ b/packages/web/lib/fog/imageassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The image storage group association class.
  *
@@ -101,3 +104,11 @@ class ImageAssociation extends FOGController
         return (bool)$this->get('primary') > 0;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageAssociation', 'ImageAssociation');

--- a/packages/web/lib/fog/imageassociationmanager.class.php
+++ b/packages/web/lib/fog/imageassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image association manager class
  *
@@ -28,3 +31,11 @@ class ImageAssociationManager extends FOGManagerController
      */
     public $tablename = 'imageGroupAssoc';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageAssociationManager', 'ImageAssociationManager');

--- a/packages/web/lib/fog/imagemanager.class.php
+++ b/packages/web/lib/fog/imagemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image manager mass management class
  *
@@ -28,3 +31,11 @@ class ImageManager extends FOGManagerController
      */
     public $tablename = 'images';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageManager', 'ImageManager');

--- a/packages/web/lib/fog/imagepartitiontype.class.php
+++ b/packages/web/lib/fog/imagepartitiontype.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image partition type class.
  *
@@ -47,3 +50,11 @@ class ImagePartitionType extends FOGController
         'type'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImagePartitionType', 'ImagePartitionType');

--- a/packages/web/lib/fog/imagepartitiontypemanager.class.php
+++ b/packages/web/lib/fog/imagepartitiontypemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image partition type manager class.
  *
@@ -22,3 +25,11 @@
 class ImagePartitionTypeManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImagePartitionTypeManager', 'ImagePartitionTypeManager');

--- a/packages/web/lib/fog/imagetype.class.php
+++ b/packages/web/lib/fog/imagetype.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The image type class.
  *
@@ -47,3 +50,11 @@ class ImageType extends FOGController
         'type'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageType', 'ImageType');

--- a/packages/web/lib/fog/imagetypemanager.class.php
+++ b/packages/web/lib/fog/imagetypemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https;//fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image type manager class.
  *
@@ -22,3 +25,11 @@
 class ImageTypeManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageTypeManager', 'ImageTypeManager');

--- a/packages/web/lib/fog/imaginglog.class.php
+++ b/packages/web/lib/fog/imaginglog.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The imaging log class.
  *
@@ -112,3 +115,11 @@ class ImagingLog extends FOGController
         return $this->get('images');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImagingLog', 'ImagingLog');

--- a/packages/web/lib/fog/imaginglogmanager.class.php
+++ b/packages/web/lib/fog/imaginglogmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The imaging log manager class.
  *
@@ -22,3 +25,11 @@
 class ImagingLogManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImagingLogManager', 'ImagingLogManager');

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The inventory class.
  *
@@ -146,3 +149,11 @@ class Inventory extends FOGController
         return self::formatByteSize(((int)$memar * 1024));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Inventory', 'Inventory');

--- a/packages/web/lib/fog/inventorymanager.class.php
+++ b/packages/web/lib/fog/inventorymanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The inventory manaager class.
  *
@@ -22,3 +25,11 @@
 class InventoryManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\InventoryManager', 'InventoryManager');

--- a/packages/web/lib/fog/ipxe.class.php
+++ b/packages/web/lib/fog/ipxe.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The ipxe class.
  *
@@ -43,3 +46,11 @@ class Ipxe extends FOGController
         'version' => 'ipxeVersion'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Ipxe', 'Ipxe');

--- a/packages/web/lib/fog/ipxemanager.class.php
+++ b/packages/web/lib/fog/ipxemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The ipxe manager class.
  *
@@ -22,3 +25,11 @@
 class IpxeManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\IpxeManager', 'IpxeManager');

--- a/packages/web/lib/fog/keysequence.class.php
+++ b/packages/web/lib/fog/keysequence.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The key sequence class.
  *
@@ -47,3 +50,11 @@ class KeySequence extends FOGController
         'ascii'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\KeySequence', 'KeySequence');

--- a/packages/web/lib/fog/keysequencemanager.class.php
+++ b/packages/web/lib/fog/keysequencemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The key sequence manager class.
  *
@@ -22,3 +25,11 @@
 class KeySequenceManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\KeySequenceManager', 'KeySequenceManager');

--- a/packages/web/lib/fog/loadglobals.class.php
+++ b/packages/web/lib/fog/loadglobals.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Loads our global values
  *
@@ -80,3 +83,11 @@ class LoadGlobals extends FOGBase
         parent::__construct();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\LoadGlobals', 'LoadGlobals');

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * A mac address verifier and getter.
  *
@@ -504,3 +507,11 @@ class MACAddress extends FOGBase
         return $ret;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MACAddress', 'MACAddress');

--- a/packages/web/lib/fog/macaddressassociation.class.php
+++ b/packages/web/lib/fog/macaddressassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * MAC Address associations
  *
@@ -109,3 +112,11 @@ class MACAddressAssociation extends FOGController
             && !$this->get('pending');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MACAddressAssociation', 'MACAddressAssociation');

--- a/packages/web/lib/fog/macaddressassociationmanager.class.php
+++ b/packages/web/lib/fog/macaddressassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * MAC association manager mass management class.
  *
@@ -28,3 +31,11 @@ class MACAddressAssociationManager extends FOGManagerController
      */
     public $tablename = 'hostMAC';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MACAddressAssociationManager', 'MACAddressAssociationManager');

--- a/packages/web/lib/fog/module.class.php
+++ b/packages/web/lib/fog/module.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The module class.
  *
@@ -143,3 +146,11 @@ class Module extends FOGController
             ->load();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Module', 'Module');

--- a/packages/web/lib/fog/moduleassociation.class.php
+++ b/packages/web/lib/fog/moduleassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The module association class.
  *
@@ -66,3 +69,11 @@ class ModuleAssociation extends FOGController
         return new Host($this->get('hostID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ModuleAssociation', 'ModuleAssociation');

--- a/packages/web/lib/fog/moduleassociationmanager.class.php
+++ b/packages/web/lib/fog/moduleassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Module association manager class.
  *
@@ -22,3 +25,11 @@
 class ModuleAssociationManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ModuleAssociationManager', 'ModuleAssociationManager');

--- a/packages/web/lib/fog/modulemanager.class.php
+++ b/packages/web/lib/fog/modulemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The module manager class.
  *
@@ -28,3 +31,11 @@ class ModuleManager extends FOGManagerController
      */
     public $tablename = 'modules';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ModuleManager', 'ModuleManager');

--- a/packages/web/lib/fog/multicastsession.class.php
+++ b/packages/web/lib/fog/multicastsession.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles the session in db.
  *
@@ -422,3 +425,11 @@ class MulticastSession extends FOGController
             ->save();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastSession', 'MulticastSession');

--- a/packages/web/lib/fog/multicastsessionassociation.class.php
+++ b/packages/web/lib/fog/multicastsessionassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The multicast association class.
  *
@@ -65,3 +68,11 @@ class MulticastSessionAssociation extends FOGController
         return new Task($this->get('taskID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastSessionAssociation', 'MulticastSessionAssociation');

--- a/packages/web/lib/fog/multicastsessionassociationmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The multicast association manager class.
  *
@@ -22,3 +25,11 @@
 class MulticastSessionAssociationManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastSessionAssociationManager', 'MulticastSessionAssociationManager');

--- a/packages/web/lib/fog/multicastsessionmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Multicast session manager mass management class.
  *
@@ -89,3 +92,11 @@ class MulticastSessionManager extends FOGManagerController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastSessionManager', 'MulticastSessionManager');

--- a/packages/web/lib/fog/nodefailure.class.php
+++ b/packages/web/lib/fog/nodefailure.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The node failure class.
  *
@@ -138,3 +141,11 @@ class NodeFailure extends FOGController
         return $this->get('storagegroup');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\NodeFailure', 'NodeFailure');

--- a/packages/web/lib/fog/nodefailuremanager.class.php
+++ b/packages/web/lib/fog/nodefailuremanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The node failure manager class.
  *
@@ -22,3 +25,11 @@
 class NodeFailureManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\NodeFailureManager', 'NodeFailureManager');

--- a/packages/web/lib/fog/notifyevent.class.php
+++ b/packages/web/lib/fog/notifyevent.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Notify event tracker.
  *
@@ -45,3 +48,11 @@ class NotifyEvent extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\NotifyEvent', 'NotifyEvent');

--- a/packages/web/lib/fog/notifyeventmanager.class.php
+++ b/packages/web/lib/fog/notifyeventmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Notify Event manager handler class (informative).
  *
@@ -22,3 +25,11 @@
 class NotifyEventManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\NotifyEventManager', 'NotifyEventManager');

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * OpenAPI description of the FOG REST API, generated from FOG's own metadata.
  *
@@ -1703,3 +1706,11 @@ class OpenAPI extends FOGBase
         ];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\OpenAPI', 'OpenAPI');

--- a/packages/web/lib/fog/os.class.php
+++ b/packages/web/lib/fog/os.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The os class.
  *
@@ -46,3 +49,11 @@ class OS extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\OS', 'OS');

--- a/packages/web/lib/fog/osmanager.class.php
+++ b/packages/web/lib/fog/osmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The os manager class.
  *
@@ -22,3 +25,11 @@
 class OSManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\OSManager', 'OSManager');

--- a/packages/web/lib/fog/oui.class.php
+++ b/packages/web/lib/fog/oui.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.rog
  */
+
+namespace FOG;
+
 /**
  * The oui class.
  *
@@ -47,3 +50,11 @@ class OUI extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\OUI', 'OUI');

--- a/packages/web/lib/fog/ouimanager.class.php
+++ b/packages/web/lib/fog/ouimanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.rog
  */
+
+namespace FOG;
+
 /**
  * The oui manager class.
  *
@@ -22,3 +25,11 @@
 class OUIManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\OUIManager', 'OUIManager');

--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -532,9 +532,9 @@ class Page extends FOGBase
                         echo '<div class="app-content-header">';
                         echo '<div class="container-fluid">';
                         echo '<h1 id="sectionTitle">';
-                        echo Initiator::e($this->sectionTitle);
+                        echo \Initiator::e($this->sectionTitle);
                         echo '<small id="pageTitle">';
-                        echo Initiator::e($this->pageTitle);
+                        echo \Initiator::e($this->pageTitle);
                         echo '</small>';
                         echo '</h1>';
                         echo '</div>';

--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The page display/modifier
  *
@@ -561,3 +564,11 @@ class Page extends FOGBase
         return (bool)filter_input(INPUT_GET, 'contentOnly');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Page', 'Page');

--- a/packages/web/lib/fog/ping.class.php
+++ b/packages/web/lib/fog/ping.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles pinging hosts.
  *
@@ -120,3 +123,11 @@ class Ping
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Ping', 'Ping');

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -760,7 +760,7 @@ class Plugin extends FOGController
         // the new plugin stays invisible for up to five minutes: its manager,
         // page and hook classes do not resolve, installing it applies no
         // schema and registers no hooks, and it all reports success.
-        Initiator::forgetClassFileList();
+        \Initiator::forgetClassFileList();
 
         return ['name' => $name, 'upgrade' => null !== $backup];
     }

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Plugin class.
  *
@@ -1156,3 +1159,11 @@ class Plugin extends FOGController
         return (int)$this->get('schema') < count((array)$manager->schema());
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Plugin', 'Plugin');

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Plugin manager class.
  *
@@ -47,3 +50,11 @@ class PluginManager extends FOGManagerController
         return $needing;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PluginManager', 'PluginManager');

--- a/packages/web/lib/fog/plugintask.class.php
+++ b/packages/web/lib/fog/plugintask.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Base class for background work a plugin declares.
  *
@@ -132,3 +135,11 @@ abstract class PluginTask extends FOGBase
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PluginTask', 'PluginTask');

--- a/packages/web/lib/fog/powermanagement.class.php
+++ b/packages/web/lib/fog/powermanagement.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * PowerManagement class handler
  *
@@ -157,3 +160,11 @@ class PowerManagement extends FOGController
         $this->getHost()->wakeOnLAN();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PowerManagement', 'PowerManagement');

--- a/packages/web/lib/fog/powermanagementmanager.class.php
+++ b/packages/web/lib/fog/powermanagementmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Powermanagement manager mass management class.
  *
@@ -93,3 +96,11 @@ class PowerManagementManager extends FOGManagerController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PowerManagementManager', 'PowerManagementManager');

--- a/packages/web/lib/fog/powermanagementmanager.class.php
+++ b/packages/web/lib/fog/powermanagementmanager.class.php
@@ -57,7 +57,7 @@ class PowerManagementManager extends FOGManagerController
         foreach ((array) $types as $val => &$text) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                Initiator::e(trim($val)),
+                \Initiator::e(trim($val)),
                 (
                     (isset($template) && $template !== false)
                     && trim($template) === trim($val) ?
@@ -68,7 +68,7 @@ class PowerManagementManager extends FOGManagerController
                         ''
                     )
                 ),
-                Initiator::e($text)
+                \Initiator::e($text)
             );
         }
 

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The printer class
  *
@@ -234,3 +237,11 @@ class Printer extends FOGController
         return parent::destroy($key);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Printer', 'Printer');

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -197,13 +197,13 @@ class Printer extends FOGController
         foreach ((array)$printerTypes as $short => &$long) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                Initiator::e($short),
+                \Initiator::e($short),
                 (
                     filter_input(INPUT_POST, 'printertype') === $short ?
                     ' selected' :
                     ''
                 ),
-                Initiator::e($long)
+                \Initiator::e($long)
             );
             unset($short, $long);
         }

--- a/packages/web/lib/fog/printerassociation.class.php
+++ b/packages/web/lib/fog/printerassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The printer association class.
  *
@@ -80,3 +83,11 @@ class PrinterAssociation extends FOGController
         return (bool)($this->get('isDefault') === 1);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PrinterAssociation', 'PrinterAssociation');

--- a/packages/web/lib/fog/printerassociationmanager.class.php
+++ b/packages/web/lib/fog/printerassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Printer association manager mass management class.
  *
@@ -28,3 +31,11 @@ class PrinterAssociationManager extends FOGManagerController
      */
     public $tablename = 'printerAssoc';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PrinterAssociationManager', 'PrinterAssociationManager');

--- a/packages/web/lib/fog/printermanager.class.php
+++ b/packages/web/lib/fog/printermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Group manager mass management class
  *
@@ -22,3 +25,11 @@
 class PrinterManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PrinterManager', 'PrinterManager');

--- a/packages/web/lib/fog/pxemenuoptions.class.php
+++ b/packages/web/lib/fog/pxemenuoptions.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Pxe menu items class.
  *
@@ -52,3 +55,11 @@ class PXEMenuOptions extends FOGController
         'name'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PXEMenuOptions', 'PXEMenuOptions');

--- a/packages/web/lib/fog/pxemenuoptionsmanager.class.php
+++ b/packages/web/lib/fog/pxemenuoptionsmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Pxe menu items manager class.
  *
@@ -88,3 +91,11 @@ class PXEMenuOptionsManager extends FOGManagerController
         return self::$_regVals[$id];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PXEMenuOptionsManager', 'PXEMenuOptionsManager');

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role — native role-based access control.
  *
@@ -330,3 +333,11 @@ class Role extends FOGController
         return parent::destroy($key);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Role', 'Role');

--- a/packages/web/lib/fog/rolemanager.class.php
+++ b/packages/web/lib/fog/rolemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role manager class.
  *
@@ -28,3 +31,11 @@ class RoleManager extends FOGManagerController
      */
     public $tablename = 'roles';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleManager', 'RoleManager');

--- a/packages/web/lib/fog/rolepermission.class.php
+++ b/packages/web/lib/fog/rolepermission.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Permission granted to a role.
  *
@@ -79,3 +82,11 @@ class RolePermission extends FOGController
         return parent::save();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RolePermission', 'RolePermission');

--- a/packages/web/lib/fog/rolepermissionmanager.class.php
+++ b/packages/web/lib/fog/rolepermissionmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role permission manager class.
  *
@@ -28,3 +31,11 @@ class RolePermissionManager extends FOGManagerController
      */
     public $tablename = 'rolePermissions';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RolePermissionManager', 'RolePermissionManager');

--- a/packages/web/lib/fog/roleuserassociation.class.php
+++ b/packages/web/lib/fog/roleuserassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role association between user -> role links.
  *
@@ -69,3 +72,11 @@ class RoleUserAssociation extends FOGController
         return new User($this->get('userID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleUserAssociation', 'RoleUserAssociation');

--- a/packages/web/lib/fog/roleuserassociationmanager.class.php
+++ b/packages/web/lib/fog/roleuserassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role user association manager class.
  *
@@ -28,3 +31,11 @@ class RoleUserAssociationManager extends FOGManagerController
      */
     public $tablename = 'roleUserAssoc';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleUserAssociationManager', 'RoleUserAssociationManager');

--- a/packages/web/lib/fog/roleusergroupassociation.class.php
+++ b/packages/web/lib/fog/roleusergroupassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role association between user group -> role links.
  *
@@ -71,3 +74,11 @@ class RoleUserGroupAssociation extends FOGController
         return new Role($this->get('roleID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleUserGroupAssociation', 'RoleUserGroupAssociation');

--- a/packages/web/lib/fog/roleusergroupassociationmanager.class.php
+++ b/packages/web/lib/fog/roleusergroupassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role user group association manager class.
  *
@@ -28,3 +31,11 @@ class RoleUserGroupAssociationManager extends FOGManagerController
      */
     public $tablename = 'roleUserGroupAssoc';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleUserGroupAssociationManager', 'RoleUserGroupAssociationManager');

--- a/packages/web/lib/fog/scheduledtask.class.php
+++ b/packages/web/lib/fog/scheduledtask.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Scheduled task class.
  *
@@ -191,3 +194,11 @@ class ScheduledTask extends FOGController
         return $this->destroy();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ScheduledTask', 'ScheduledTask');

--- a/packages/web/lib/fog/scheduledtaskmanager.class.php
+++ b/packages/web/lib/fog/scheduledtaskmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Scheduled task manager class.
  *
@@ -42,3 +45,11 @@ class ScheduledTaskManager extends FOGManagerController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ScheduledTaskManager', 'ScheduledTaskManager');

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles the database insert/export
  *
@@ -832,3 +835,11 @@ class Schema extends FOGController
         return $inserted;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Schema', 'Schema');

--- a/packages/web/lib/fog/schemamanager.class.php
+++ b/packages/web/lib/fog/schemamanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Schema manager class
  *
@@ -22,3 +25,11 @@
 class SchemaManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SchemaManager', 'SchemaManager');

--- a/packages/web/lib/fog/schemareconciler.class.php
+++ b/packages/web/lib/fog/schemareconciler.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Repairs a database whose structure has fallen behind this release.
  *
@@ -321,3 +324,11 @@ class SchemaReconciler extends FOGBase
         return true;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SchemaReconciler', 'SchemaReconciler');

--- a/packages/web/lib/fog/setting.class.php
+++ b/packages/web/lib/fog/setting.class.php
@@ -129,13 +129,13 @@ class Setting extends FOGController
             }
             $options .= sprintf(
                 '<option value="%s"%s>%s</option>',
-                Initiator::e($value),
+                \Initiator::e($value),
                 (
                     strtolower($selected) == $value ?
                     ' selected' :
                     ''
                 ),
-                Initiator::e($show)
+                \Initiator::e($show)
             );
             unset($viewop);
         }

--- a/packages/web/lib/fog/setting.class.php
+++ b/packages/web/lib/fog/setting.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The global settings class.
  *
@@ -140,3 +143,11 @@ class Setting extends FOGController
         return $options.'</select>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Setting', 'Setting');

--- a/packages/web/lib/fog/settingmanager.class.php
+++ b/packages/web/lib/fog/settingmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The global settings manager class.
  *
@@ -28,3 +31,11 @@ class SettingManager extends FOGManagerController
      */
     public $tablename = 'globalSettings';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SettingManager', 'SettingManager');

--- a/packages/web/lib/fog/site.class.php
+++ b/packages/web/lib/fog/site.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * A site: a named group of hosts, users, groups and user groups.
  *
@@ -395,3 +398,11 @@ class Site extends FOGController
         return parent::destroy($key);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Site', 'Site');

--- a/packages/web/lib/fog/sitegroupmember.class.php
+++ b/packages/web/lib/fog/sitegroupmember.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Membership association between site -> host group links.
  *
@@ -52,3 +55,11 @@ class SiteGroupMember extends FOGController
         'groupID'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteGroupMember', 'SiteGroupMember');

--- a/packages/web/lib/fog/sitegroupmembermanager.class.php
+++ b/packages/web/lib/fog/sitegroupmembermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * SiteGroupMember manager class.
  *
@@ -28,3 +31,11 @@ class SiteGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'siteGroupMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteGroupMemberManager', 'SiteGroupMemberManager');

--- a/packages/web/lib/fog/sitehostmember.class.php
+++ b/packages/web/lib/fog/sitehostmember.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Membership association between site -> host links.
  *
@@ -52,3 +55,11 @@ class SiteHostMember extends FOGController
         'hostID'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteHostMember', 'SiteHostMember');

--- a/packages/web/lib/fog/sitehostmembermanager.class.php
+++ b/packages/web/lib/fog/sitehostmembermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * SiteHostMember manager class.
  *
@@ -28,3 +31,11 @@ class SiteHostMemberManager extends FOGManagerController
      */
     public $tablename = 'siteHostMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteHostMemberManager', 'SiteHostMemberManager');

--- a/packages/web/lib/fog/sitemanager.class.php
+++ b/packages/web/lib/fog/sitemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Site manager.
  *
@@ -33,3 +36,11 @@ class SiteManager extends FOGManagerController
      */
     public $tablename = 'sites';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteManager', 'SiteManager');

--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Resolves whether an object is inside a user's site scope.
  *
@@ -535,3 +538,11 @@ class SiteScope extends FOGBase
         return array_values(array_intersect($ids, $inScope));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteScope', 'SiteScope');

--- a/packages/web/lib/fog/siteusergroupmember.class.php
+++ b/packages/web/lib/fog/siteusergroupmember.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Membership association between site -> user group links.
  *
@@ -52,3 +55,11 @@ class SiteUserGroupMember extends FOGController
         'usergroupID'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserGroupMember', 'SiteUserGroupMember');

--- a/packages/web/lib/fog/siteusergroupmembermanager.class.php
+++ b/packages/web/lib/fog/siteusergroupmembermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * SiteUserGroupMember manager class.
  *
@@ -28,3 +31,11 @@ class SiteUserGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'siteUserGroupMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserGroupMemberManager', 'SiteUserGroupMemberManager');

--- a/packages/web/lib/fog/siteusermember.class.php
+++ b/packages/web/lib/fog/siteusermember.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Membership association between site -> user links.
  *
@@ -52,3 +55,11 @@ class SiteUserMember extends FOGController
         'userID'
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserMember', 'SiteUserMember');

--- a/packages/web/lib/fog/siteusermembermanager.class.php
+++ b/packages/web/lib/fog/siteusermembermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * SiteUserMember manager class.
  *
@@ -28,3 +31,11 @@ class SiteUserMemberManager extends FOGManagerController
      */
     public $tablename = 'siteUserMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserMemberManager', 'SiteUserMemberManager');

--- a/packages/web/lib/fog/snapin.class.php
+++ b/packages/web/lib/fog/snapin.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin object.
  *
@@ -709,3 +712,11 @@ class Snapin extends FOGController
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Snapin', 'Snapin');

--- a/packages/web/lib/fog/snapinassociation.class.php
+++ b/packages/web/lib/fog/snapinassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin association class.
  *
@@ -66,3 +69,11 @@ class SnapinAssociation extends FOGController
         return new Snapin($this->get('snapinID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinAssociation', 'SnapinAssociation');

--- a/packages/web/lib/fog/snapinassociationmanager.class.php
+++ b/packages/web/lib/fog/snapinassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin association manager class.
  *
@@ -22,3 +25,11 @@
 class SnapinAssociationManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinAssociationManager', 'SnapinAssociationManager');

--- a/packages/web/lib/fog/snapingroupassociation.class.php
+++ b/packages/web/lib/fog/snapingroupassociation.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin group association handling.
  *
@@ -101,3 +104,11 @@ class SnapinGroupAssociation extends FOGController
         return (bool)$this->get('primary');
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinGroupAssociation', 'SnapinGroupAssociation');

--- a/packages/web/lib/fog/snapingroupassociationmanager.class.php
+++ b/packages/web/lib/fog/snapingroupassociationmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin group association manager class.
  *
@@ -22,3 +25,11 @@
 class SnapinGroupAssociationManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinGroupAssociationManager', 'SnapinGroupAssociationManager');

--- a/packages/web/lib/fog/snapinjob.class.php
+++ b/packages/web/lib/fog/snapinjob.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin job handler class.
  *
@@ -99,3 +102,11 @@ class SnapinJob extends FOGController
         return $this->getManager()->cancel($this->get('id'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinJob', 'SnapinJob');

--- a/packages/web/lib/fog/snapinjobmanager.class.php
+++ b/packages/web/lib/fog/snapinjobmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin job handler class.
  *
@@ -141,3 +144,11 @@ class SnapinJobManager extends FOGManagerController
         return true;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinJobManager', 'SnapinJobManager');

--- a/packages/web/lib/fog/snapinmanager.class.php
+++ b/packages/web/lib/fog/snapinmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin manager mass management class.
  *
@@ -28,3 +31,11 @@ class SnapinManager extends FOGManagerController
      */
     public $tablename = 'snapins';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinManager', 'SnapinManager');

--- a/packages/web/lib/fog/snapinsaveexception.class.php
+++ b/packages/web/lib/fog/snapinsaveexception.class.php
@@ -14,6 +14,17 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 class SnapinSaveException extends \RuntimeException
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinSaveException', 'SnapinSaveException');

--- a/packages/web/lib/fog/snapintask.class.php
+++ b/packages/web/lib/fog/snapintask.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The snapin task class.
  *
@@ -121,3 +124,11 @@ class SnapinTask extends FOGController
         return new TaskState($this->get('stateID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinTask', 'SnapinTask');

--- a/packages/web/lib/fog/snapintaskmanager.class.php
+++ b/packages/web/lib/fog/snapintaskmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin Task Manager mass management class
  *
@@ -126,3 +129,11 @@ class SnapinTaskManager extends FOGManagerController
         return true;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinTaskManager', 'SnapinTaskManager');

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLV3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Storage Group object
  *
@@ -490,3 +493,11 @@ class StorageGroup extends FOGController
             ->load();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageGroup', 'StorageGroup');

--- a/packages/web/lib/fog/storagegroupmanager.class.php
+++ b/packages/web/lib/fog/storagegroupmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLV3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Storage Group Manager class.
  *
@@ -22,3 +25,11 @@
 class StorageGroupManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageGroupManager', 'StorageGroupManager');

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Storage node handler class.
  *
@@ -456,3 +459,11 @@ class StorageNode extends FOGController
         return $countTasks;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageNode', 'StorageNode');

--- a/packages/web/lib/fog/storagenodemanager.class.php
+++ b/packages/web/lib/fog/storagenodemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Storage node manager class.
  *
@@ -22,3 +25,11 @@
 class StorageNodeManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageNodeManager', 'StorageNodeManager');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * System, the basic system layout.
  *
@@ -127,3 +130,11 @@ class System
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\System', 'System');

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task handler class.
  *
@@ -459,3 +462,11 @@ class Task extends TaskType
             || $this->get('isDebug'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Task', 'Task');

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task log class.
  *
@@ -80,3 +83,11 @@ class TaskLog extends FOGController
         return $this->getTask()->getHost();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskLog', 'TaskLog');

--- a/packages/web/lib/fog/tasklogmanager.class.php
+++ b/packages/web/lib/fog/tasklogmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task log manager class.
  *
@@ -22,3 +25,11 @@
 class TaskLogManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskLogManager', 'TaskLogManager');

--- a/packages/web/lib/fog/taskmanager.class.php
+++ b/packages/web/lib/fog/taskmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task manager class.
  *
@@ -120,3 +123,11 @@ class TaskManager extends FOGManagerController
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskManager', 'TaskManager');

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The task state class.
  *
@@ -141,3 +144,11 @@ class TaskState extends FOGController
         return $cancelledState;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskState', 'TaskState');

--- a/packages/web/lib/fog/taskstatemanager.class.php
+++ b/packages/web/lib/fog/taskstatemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The task state manager class.
  *
@@ -28,3 +31,11 @@ class TaskStateManager extends FOGManagerController
      */
     public $tablename = 'taskStates';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskStateManager', 'TaskStateManager');

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -151,10 +151,10 @@ class TaskType extends FOGController
         foreach ((array) $icons as $name => &$unicode) {
             printf(
                 '<option value="%s"%s>%s %s</option>',
-                Initiator::e($name),
+                \Initiator::e($name),
                 $selected == $name ? ' selected' : '',
-                Initiator::e($unicode),
-                Initiator::e($name)
+                \Initiator::e($unicode),
+                \Initiator::e($name)
             );
             unset($unicode, $name);
         }

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task type class.
  *
@@ -423,3 +426,11 @@ class TaskType extends FOGController
             );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskType', 'TaskType');

--- a/packages/web/lib/fog/tasktypemanager.class.php
+++ b/packages/web/lib/fog/tasktypemanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Task type class.
  *
@@ -22,3 +25,11 @@
 class TaskTypeManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskTypeManager', 'TaskTypeManager');

--- a/packages/web/lib/fog/timer.class.php
+++ b/packages/web/lib/fog/timer.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Creates the timer item so we know when
  * something is supposed to occur.
@@ -153,3 +156,11 @@ class Timer extends FOGCron
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Timer', 'Timer');

--- a/packages/web/lib/fog/uploadexception.class.php
+++ b/packages/web/lib/fog/uploadexception.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Upload exception handler.
  *
@@ -85,3 +88,11 @@ class UploadException extends \Exception
         return $message;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UploadException', 'UploadException');

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handler of the user as authenticated
  *
@@ -705,3 +708,11 @@ class User extends FOGController
         return parent::destroy($key);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\User', 'User');

--- a/packages/web/lib/fog/userauth.class.php
+++ b/packages/web/lib/fog/userauth.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handler of the user as authenticated
  *
@@ -82,3 +85,11 @@ class UserAuth extends FOGController
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserAuth', 'UserAuth');

--- a/packages/web/lib/fog/userauthmanager.class.php
+++ b/packages/web/lib/fog/userauthmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User auth manager class.
  *
@@ -22,3 +25,11 @@
 class UserAuthManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserAuthManager', 'UserAuthManager');

--- a/packages/web/lib/fog/usergroup.class.php
+++ b/packages/web/lib/fog/usergroup.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * UserGroup — a named group of users for role assignment.
  *
@@ -200,3 +203,11 @@ class UserGroup extends FOGController
         return parent::destroy($key);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserGroup', 'UserGroup');

--- a/packages/web/lib/fog/usergroupmanager.class.php
+++ b/packages/web/lib/fog/usergroupmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User group manager class.
  *
@@ -28,3 +31,11 @@ class UserGroupManager extends FOGManagerController
      */
     public $tablename = 'userGroups';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserGroupManager', 'UserGroupManager');

--- a/packages/web/lib/fog/usergroupmember.class.php
+++ b/packages/web/lib/fog/usergroupmember.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Membership association between user group -> user links.
  *
@@ -70,3 +73,11 @@ class UserGroupMember extends FOGController
         return new User($this->get('userID'));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserGroupMember', 'UserGroupMember');

--- a/packages/web/lib/fog/usergroupmembermanager.class.php
+++ b/packages/web/lib/fog/usergroupmembermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User group member manager class.
  *
@@ -28,3 +31,11 @@ class UserGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'userGroupMembers';
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserGroupMemberManager', 'UserGroupMemberManager');

--- a/packages/web/lib/fog/usermanager.class.php
+++ b/packages/web/lib/fog/usermanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User manager class.
  *
@@ -22,3 +25,11 @@
 class UserManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserManager', 'UserManager');

--- a/packages/web/lib/fog/usertracking.class.php
+++ b/packages/web/lib/fog/usertracking.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * UserTracking handles tracking users from client to client
  *
@@ -73,3 +76,11 @@ class UserTracking extends FOGController
         ]
     ];
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserTracking', 'UserTracking');

--- a/packages/web/lib/fog/usertrackingmanager.class.php
+++ b/packages/web/lib/fog/usertrackingmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * UserTrackingManager handles tracking users from client to client
  *
@@ -22,3 +25,11 @@
 class UserTrackingManager extends FOGManagerController
 {
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserTrackingManager', 'UserTrackingManager');

--- a/packages/web/lib/fog/wakeonlan.class.php
+++ b/packages/web/lib/fog/wakeonlan.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Wake on lan management class.
  *
@@ -72,3 +75,11 @@ class WakeOnLan extends FOGBase
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\WakeOnLan', 'WakeOnLan');

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * How to edit the boot menu via hooks.
  *
@@ -177,3 +180,11 @@ class BootItem extends Hook
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\BootItem', 'BootItem');

--- a/packages/web/lib/hooks/boottask.hook.php
+++ b/packages/web/lib/hooks/boottask.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Alters the boot task to make a custom entry.
  *
@@ -97,3 +100,11 @@ class BootTask extends Hook
             )->save();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\BootTask', 'BootTask');

--- a/packages/web/lib/hooks/changehostname.hook.php
+++ b/packages/web/lib/hooks/changehostname.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Change host name hook.
  *
@@ -79,3 +82,11 @@ class ChangeHostname extends Hook
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ChangeHostname', 'ChangeHostname');

--- a/packages/web/lib/hooks/hookdebugger.hook.php
+++ b/packages/web/lib/hooks/hookdebugger.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Change host name hook.
  *
@@ -100,3 +103,11 @@ class HookDebugger extends Hook
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HookDebugger', 'HookDebugger');

--- a/packages/web/lib/hooks/hostaddvnclink.hook.php
+++ b/packages/web/lib/hooks/hostaddvnclink.hook.php
@@ -77,10 +77,10 @@ class HostAddVNCLink extends Hook
             $arguments['data']['data'][$i]['vnclink'] = sprintf(
                 '<a href="vnc://%s:%d" target="_blank" title='
                 . '"%s: %s">%s</a>',
-                Initiator::e($data['name']),
+                \Initiator::e($data['name']),
                 self::$_port,
                 _('Open VNC Connection To'),
-                Initiator::e($data['name']),
+                \Initiator::e($data['name']),
                 _('VNC')
             );
             unset($data);

--- a/packages/web/lib/hooks/hostaddvnclink.hook.php
+++ b/packages/web/lib/hooks/hostaddvnclink.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Add host VNC link
  *
@@ -84,3 +87,11 @@ class HostAddVNCLink extends Hook
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostAddVNCLink', 'HostAddVNCLink');

--- a/packages/web/lib/hooks/logviewerhook.hook.php
+++ b/packages/web/lib/hooks/logviewerhook.hook.php
@@ -19,6 +19,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Just allows user to add in any logs they feel they need on the log viewer.
  *
@@ -115,3 +118,11 @@ class LogViewerHook extends Hook
         $arguments['folders'][] = '/var/log/';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\LogViewerHook', 'LogViewerHook');

--- a/packages/web/lib/hooks/mainmenudata.hook.php
+++ b/packages/web/lib/hooks/mainmenudata.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Main menu hook changer.
  *
@@ -88,3 +91,11 @@ class MainMenuData extends Hook
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MainMenuData', 'MainMenuData');

--- a/packages/web/lib/hooks/setsnapintaskstate.hook.php
+++ b/packages/web/lib/hooks/setsnapintaskstate.hook.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Sets snapin task states
  *
@@ -127,3 +130,11 @@ class SetSnapinTaskState extends Hook
         ];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SetSnapinTaskState', 'SetSnapinTaskState');

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Sub menu hook changer.
  *
@@ -127,3 +130,11 @@ class SubMenuData extends Hook
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SubMenuData', 'SubMenuData');

--- a/packages/web/lib/hooks/template.hook.php
+++ b/packages/web/lib/hooks/template.hook.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Template for others to work from.
  *
@@ -70,3 +73,11 @@ class Template extends Hook
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Template', 'Template');

--- a/packages/web/lib/pages/UserGroupManagement.page.php
+++ b/packages/web/lib/pages/UserGroupManagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User group management page — native role-based access control.
  *
@@ -535,3 +538,11 @@ class UserGroupManagement extends FOGPage
         $this->siteTabPost('usergroup', $this->obj);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserGroupManagement', 'UserGroupManagement');

--- a/packages/web/lib/pages/apidocumentation.page.php
+++ b/packages/web/lib/pages/apidocumentation.page.php
@@ -13,6 +13,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * API Documentation Page
  *
@@ -142,3 +145,11 @@ class ApiDocumentation extends FOGPage
         echo '</div></div>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ApiDocumentation', 'ApiDocumentation');

--- a/packages/web/lib/pages/clientmanagement.page.php
+++ b/packages/web/lib/pages/clientmanagement.page.php
@@ -13,6 +13,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Client Management Page
  *
@@ -149,3 +152,11 @@ class ClientManagement extends FOGPage
         echo '</div>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ClientManagement', 'ClientManagement');

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -115,10 +115,10 @@ class DashboardPage extends FOGPage
             $url = self::$httpproto.'://' . $url;
             self::$_nodeOpts[] = sprintf(
                 '<option value="%s" data-name="%s"%s>%s</option>',
-                Initiator::e($StorageNode->id),
-                Initiator::e($StorageNode->name),
+                \Initiator::e($StorageNode->id),
+                \Initiator::e($StorageNode->name),
                 ($StorageNode->isMaster ? ' data-master="1"' : ''),
-                Initiator::e($StorageNode->name)
+                \Initiator::e($StorageNode->name)
             );
             self::$_nodeNames[] = $StorageNode->name;
             self::$_nodeURLs[] = sprintf(
@@ -133,8 +133,8 @@ class DashboardPage extends FOGPage
         foreach ($Groups as &$StorageGroup) {
             self::$_groupOpts .= sprintf(
                 '<option value="%s">%s</option>',
-                Initiator::e($StorageGroup->id),
-                Initiator::e($StorageGroup->name)
+                \Initiator::e($StorageGroup->id),
+                \Initiator::e($StorageGroup->name)
             );
             unset($StorageGroup);
         }

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Presents the home/dashboard page.
  *
@@ -785,3 +788,11 @@ class DashboardPage extends FOGPage
         $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode($versions));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\DashboardPage', 'DashboardPage');

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -365,10 +365,10 @@ class FOGConfigurationPage extends FOGPage
                 . _('published as ca.cert.der and pinned by every fog-client')
                 . '</p>';
             if ($subject) {
-                $body .= '<pre>' . Initiator::e($subject) . '</pre>';
+                $body .= '<pre>' . \Initiator::e($subject) . '</pre>';
             }
             $body .= '<p><strong>' . _('SHA-256') . '</strong></p>';
-            $body .= '<pre>' . Initiator::e(
+            $body .= '<pre>' . \Initiator::e(
                 strtoupper(
                     implode(':', str_split(hash_file('sha256', $capem), 2))
                 )
@@ -400,8 +400,8 @@ class FOGConfigurationPage extends FOGPage
                 . 'run code in this web application can copy them.'
             ) . '</p><ul>';
             foreach ($exposed as $label => $path) {
-                $warn .= '<li><strong>' . Initiator::e($label) . '</strong> &mdash; <code>'
-                    . Initiator::e($path) . '</code></li>';
+                $warn .= '<li><strong>' . \Initiator::e($label) . '</strong> &mdash; <code>'
+                    . \Initiator::e($path) . '</code></li>';
             }
             $warn .= '</ul><p>' . _(
                 'Re-run the installer, which restricts them to root. If this '
@@ -423,7 +423,7 @@ class FOGConfigurationPage extends FOGPage
                 . 'of this web application but not from a compromise of the '
                 . 'machine. Moving it to a vault is a separate step:'
             ) . '</p>';
-            $body .= '<pre>' . Initiator::e(FOG_BASE_DIR . '/bin/fog-offline-ca-key /mnt/vault')
+            $body .= '<pre>' . \Initiator::e(FOG_BASE_DIR . '/bin/fog-offline-ca-key /mnt/vault')
                 . '</pre>';
             $body .= '<p>' . _(
                 'Nothing needs it day to day. Restore it only to issue a new '
@@ -498,7 +498,7 @@ class FOGConfigurationPage extends FOGPage
             )
         ) . '</p>';
         $body .= '<p><strong>' . _('Certificate SHA-256') . '</strong></p>';
-        $body .= '<pre>' . Initiator::e($fingerprint) . '</pre>';
+        $body .= '<pre>' . \Initiator::e($fingerprint) . '</pre>';
         $body .= '<p>' . _(
             'Check this value against what the enrolment tool shows before '
             . 'confirming, whether the certificate reached the client on a '
@@ -506,7 +506,7 @@ class FOGConfigurationPage extends FOGPage
             . 'the wrong key being trusted.'
         ) . '</p>';
         $body .= '<p><strong>' . _('Certificate SHA-1') . '</strong></p>';
-        $body .= '<pre>' . Initiator::e($fingerprintSha1) . '</pre>';
+        $body .= '<pre>' . \Initiator::e($fingerprintSha1) . '</pre>';
         $body .= '<p>' . _(
             'This is what MokManager\'s own View key screen shows after '
             . 'enrolling from the PXE menu -- that route never runs the '
@@ -527,8 +527,8 @@ class FOGConfigurationPage extends FOGPage
             }
             $body .= sprintf(
                 '<li><a href="%1$s/%2$s">%2$s</a></li>',
-                Initiator::e($kiturl),
-                Initiator::e($file)
+                \Initiator::e($kiturl),
+                \Initiator::e($file)
             );
         }
         $body .= '</ul>';
@@ -539,7 +539,7 @@ class FOGConfigurationPage extends FOGPage
                 . 'straight from the PXE boot menu, with no USB stick, are '
                 . 'in the Secure Boot guide:'
             ),
-            Initiator::e('https://docs.fogproject.org/en/latest/secure-boot-signing'),
+            \Initiator::e('https://docs.fogproject.org/en/latest/secure-boot-signing'),
             _('Secure Boot: signing FOS with your own key')
         ) . '</p>';
         echo $this->_box(_('Secure Boot'), $body, ['color' => 'info']);
@@ -1595,7 +1595,7 @@ class FOGConfigurationPage extends FOGPage
             . '">';
         foreach ($vals as $text => $val) {
             $html .= '<option value="'
-                . Initiator::e($val)
+                . \Initiator::e($val)
                 . '"'
                 . (
                     $val == $value ?
@@ -1603,7 +1603,7 @@ class FOGConfigurationPage extends FOGPage
                     ''
                 )
                 . '>'
-                . Initiator::e($text)
+                . \Initiator::e($text)
                 . '</option>';
         }
         $html .= '</select>';
@@ -1794,15 +1794,15 @@ class FOGConfigurationPage extends FOGPage
                     );
                     printf(
                         '<option value="%s"%s>%s [%s %s]</option>',
-                        Initiator::e($tz),
+                        \Initiator::e($tz),
                         (
                             $row['settingValue'] == $tz ?
                             ' selected' :
                             ''
                         ),
-                        Initiator::e($tz),
-                        Initiator::e($abbr),
-                        Initiator::e($offset)
+                        \Initiator::e($tz),
+                        \Initiator::e($abbr),
+                        \Initiator::e($offset)
                     );
                     unset(
                         $current_tz,
@@ -2433,7 +2433,7 @@ class FOGConfigurationPage extends FOGPage
                 . '<summary>' . (int) count($stats['cachedKeys'])
                 . ' ' . _('keys') . '</summary>'
                 . '<small class="text-muted">'
-                . Initiator::e(implode(', ', array_keys($stats['cachedKeys'])))
+                . \Initiator::e(implode(', ', array_keys($stats['cachedKeys'])))
                 . '</small></details></dd>';
         }
         echo '</dl>';
@@ -2489,8 +2489,8 @@ class FOGConfigurationPage extends FOGPage
         $first = true;
         foreach ($byCat as $cat => $catRows) {
             echo '<li class="settings-nav-item' . ($first ? ' active' : '') . '">'
-                . '<a href="#" data-cat="' . Initiator::e($cat) . '">'
-                . Initiator::e($cat)
+                . '<a href="#" data-cat="' . \Initiator::e($cat) . '">'
+                . \Initiator::e($cat)
                 . ' <span class="badge">' . count($catRows) . '</span>'
                 . '</a></li>';
             $first = false;
@@ -2503,12 +2503,12 @@ class FOGConfigurationPage extends FOGPage
         $first = true;
         foreach ($byCat as $cat => $catRows) {
             echo '<div class="settings-panel' . ($first ? ' active' : '') . '" '
-                . 'data-cat="' . Initiator::e($cat) . '">';
+                . 'data-cat="' . \Initiator::e($cat) . '">';
             // Doubles as a section heading on desktop and an accordion toggle
             // on mobile (see fog.about.settings.js / fog-default-ui.scss).
             echo '<h4 class="settings-panel-title" '
-                . 'data-cat="' . Initiator::e($cat) . '">'
-                . '<span>' . Initiator::e($cat) . '</span>'
+                . 'data-cat="' . \Initiator::e($cat) . '">'
+                . '<span>' . \Initiator::e($cat) . '</span>'
                 . '<i class="fa fa-chevron-down settings-panel-caret"></i>'
                 . '</h4>';
             echo '<div class="settings-panel-body">';
@@ -2537,15 +2537,15 @@ class FOGConfigurationPage extends FOGPage
                 }
                 echo '<div class="form-group settings-row" '
                     . 'data-search="'
-                    . Initiator::e($haystack)
+                    . \Initiator::e($haystack)
                     . '">';
                 echo '<label class="col-form-label settings-label" for="'
-                    . Initiator::e($row['settingKey']) . '"';
+                    . \Initiator::e($row['settingKey']) . '"';
                 if ($tip !== '') {
                     echo ' data-bs-toggle="tooltip" data-bs-placement="top" title="'
-                        . Initiator::e($tip) . '"';
+                        . \Initiator::e($tip) . '"';
                 }
-                echo '>' . Initiator::e($row['settingKey']);
+                echo '>' . \Initiator::e($row['settingKey']);
                 if ($wantsrefresh) {
                     // Visual marker only (no own tooltip); the label tooltip
                     // above already carries the reload note.
@@ -2873,14 +2873,14 @@ class FOGConfigurationPage extends FOGPage
                 }
                 printf(
                     '<option value="%s||%s"%s>%s</option>',
-                    Initiator::e(base64_encode($ip[$nodename])),
-                    Initiator::e($file),
+                    \Initiator::e(base64_encode($ip[$nodename])),
+                    \Initiator::e($file),
                     (
                         isset($_POST['logtype']) && $value == $_POST['logtype'] ?
                         ' selected' :
                         ''
                     ),
-                    Initiator::e($value)
+                    \Initiator::e($value)
                 );
                 unset($file);
             }
@@ -2905,7 +2905,7 @@ class FOGConfigurationPage extends FOGPage
         foreach ((array)$vals as $i => &$value) {
             printf(
                 '<option value="%s"%s>%s</option>',
-                Initiator::e($value),
+                \Initiator::e($value),
                 (
                     $value == filter_input(
                         INPUT_POST,
@@ -2915,7 +2915,7 @@ class FOGConfigurationPage extends FOGPage
                     ' selected' :
                     ''
                 ),
-                Initiator::e($value)
+                \Initiator::e($value)
             );
             unset($value);
         }

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The FOG Configuration Page display.
  *
@@ -3235,3 +3238,11 @@ class FOGConfigurationPage extends FOGPage
         ));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGConfigurationPage', 'FOGConfigurationPage');

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Group management page
  *
@@ -3628,3 +3631,11 @@ class GroupManagement extends FOGPage
         $this->siteTabPost('group', $this->obj);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\GroupManagement', 'GroupManagement');

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -324,7 +324,7 @@ class GroupManagement extends FOGPage
         if ($info['value'] === '') {
             return _('(empty on all)');
         }
-        return Initiator::e($info['value']) . ' ' . _('(all)');
+        return \Initiator::e($info['value']) . ' ' . _('(all)');
     }
     /**
      * Summary box of the members' current Active Directory state, shown above
@@ -404,7 +404,7 @@ class GroupManagement extends FOGPage
         } elseif ($info['value'] === '' || $info['value'] === '0') {
             $text = _('(default on all)');
         } else {
-            $text = Initiator::e($info['value']) . ' ' . _('min (all)');
+            $text = \Initiator::e($info['value']) . ' ' . _('min (all)');
         }
         // Server-rendered from the members' current values, so it goes stale as
         // soon as the card is applied over AJAX (the tab is never re-rendered).
@@ -415,9 +415,9 @@ class GroupManagement extends FOGPage
         // picks. data-alo-min is what keeps the JS from hardcoding the rule.
         return '<p class="form-text help-block-tight" id="alo-shared-hint"'
             . ' data-alo-min="' . self::ALO_MIN_MINUTES . '"'
-            . ' data-hosts-label="' . Initiator::e(_('Hosts:')) . '"'
-            . ' data-default-label="' . Initiator::e(_('(default on all)')) . '"'
-            . ' data-min-label="' . Initiator::e(_('min (all)')) . '">'
+            . ' data-hosts-label="' . \Initiator::e(_('Hosts:')) . '"'
+            . ' data-default-label="' . \Initiator::e(_('(default on all)')) . '"'
+            . ' data-min-label="' . \Initiator::e(_('min (all)')) . '">'
             . _('Hosts:') . ' ' . $text
             . '</p>';
     }
@@ -1408,9 +1408,9 @@ class GroupManagement extends FOGPage
             // the same way makeReloadToggle() hands its labels over. Translation
             // stays here; the JS only picks.
             . '<p class="form-text help-block-tight" id="enforce-shared-hint"'
-            . ' data-hosts-label="' . Initiator::e(_('Hosts:')) . '"'
-            . ' data-enabled-label="' . Initiator::e(_('enabled (all)')) . '"'
-            . ' data-disabled-label="' . Initiator::e(_('disabled (all)')) . '">'
+            . ' data-hosts-label="' . \Initiator::e(_('Hosts:')) . '"'
+            . ' data-enabled-label="' . \Initiator::e(_('enabled (all)')) . '"'
+            . ' data-disabled-label="' . \Initiator::e(_('disabled (all)')) . '">'
             . _('Hosts:') . ' ' . $enfText
             . '</p>';
         $fields = [
@@ -2854,7 +2854,7 @@ class GroupManagement extends FOGPage
         } else {
             $defText = (
                 isset($printers[$def['value']])
-                ? Initiator::e($printers[$def['value']])
+                ? \Initiator::e($printers[$def['value']])
                 : ('#' . $def['value'])
             ) . ' ' . _('(all)');
         }

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Host management page
  *
@@ -4603,3 +4606,11 @@ class HostManagement extends FOGPage
         $this->siteTabPost('host', $this->obj);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HostManagement', 'HostManagement');

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -2803,7 +2803,7 @@ class HostManagement extends FOGPage
                     '',
                     'text',
                     '',
-                    Initiator::e($sysuuid),
+                    \Initiator::e($sysuuid),
                     false,
                     false,
                     -1,

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image management page
  *
@@ -1649,3 +1652,11 @@ class ImageManagement extends FOGPage
         ));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageManagement', 'ImageManagement');

--- a/packages/web/lib/pages/ipxemanagement.page.php
+++ b/packages/web/lib/pages/ipxemanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The Bootmenu Management Page
  *
@@ -555,3 +558,11 @@ class IpxeManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\IpxeManagement', 'IpxeManagement');

--- a/packages/web/lib/pages/modulemanagement.page.php
+++ b/packages/web/lib/pages/modulemanagement.page.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Module management page
  *
@@ -446,3 +449,11 @@ class ModuleManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ModuleManagement', 'ModuleManagement');

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -280,7 +280,7 @@ class PluginManagement extends FOGPage
         $blocked = self::uploadsBlocked();
         if ('' !== $blocked) {
             echo '<div class="alert alert-warning mb-0">'
-                . Initiator::e($blocked)
+                . \Initiator::e($blocked)
                 . '</div>';
             exit;
         }

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Plugin management page
  *
@@ -1095,3 +1098,11 @@ class PluginManagement extends FOGPage
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PluginManagement', 'PluginManagement');

--- a/packages/web/lib/pages/printermanagement.page.php
+++ b/packages/web/lib/pages/printermanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Printer management page.
  *
@@ -949,3 +952,11 @@ class PrinterManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PrinterManagement', 'PrinterManagement');

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Processes the current login.
  *
@@ -302,3 +305,11 @@ class ProcessLogin extends FOGPage
         echo '</div>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ProcessLogin', 'ProcessLogin');

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -56,11 +56,11 @@ class ProcessLogin extends FOGPage
         $langmenu = '<select class="form-control fog-select2" name="ulang" id="ulang">';
         foreach ($foglang['Language'] as $base => &$lang) {
             $langmenu .= '<option value="'
-                . Initiator::e($base)
+                . \Initiator::e($base)
                 . '"'
                 . ($base == $selected ? ' selected' : '')
                 . '>'
-                . Initiator::e($lang)
+                . \Initiator::e($lang)
                 . '</option>';
             unset($lang);
         }
@@ -82,7 +82,7 @@ class ProcessLogin extends FOGPage
             $type = self::$FOGUser->get('type');
             if ($ulang && isset($_SESSION['FOG_LANG']) && $_SESSION['FOG_LANG'] != $ulang) {
                 $_SESSION['FOG_LANG'] = $ulang;
-                Initiator::language($_SESSION['FOG_LANG']);
+                \Initiator::language($_SESSION['FOG_LANG']);
             }
             self::$HookManager->processEvent(
                 'USER_TYPE_HOOK',
@@ -259,7 +259,7 @@ class ProcessLogin extends FOGPage
             true
         );
         echo '<button type="button" class="input-group-text fog-password-toggle"'
-            . ' aria-label="' . Initiator::e(_('Show password')) . '"'
+            . ' aria-label="' . \Initiator::e(_('Show password')) . '"'
             . ' aria-pressed="false" tabindex="-1">'
             . '<span class="fa fa-eye"></span></button>';
         echo '</div>';

--- a/packages/web/lib/pages/reportmanagement.page.php
+++ b/packages/web/lib/pages/reportmanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Displays 'reports' for the admins.
  *
@@ -185,3 +188,11 @@ class ReportManagement extends FOGPage
         echo '</form>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ReportManagement', 'ReportManagement');

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Role management page — native role-based access control.
  *
@@ -771,3 +774,11 @@ class RoleManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\RoleManagement', 'RoleManagement');

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -359,7 +359,7 @@ class RoleManagement extends FOGPage
         foreach ($actions as $action) {
             $label = $actionLabels[$action] ?? ucfirst($action);
             echo '<th class="text-center">'
-                . Initiator::e($label)
+                . \Initiator::e($label)
                 . '</th>';
         }
         echo '</tr></thead>';
@@ -367,7 +367,7 @@ class RoleManagement extends FOGPage
         foreach ($registry as $rnode => $nodeActions) {
             $label = $nodeLabels[$rnode] ?? ucfirst($rnode);
             echo '<tr>';
-            echo '<td>' . Initiator::e($label) . '</td>';
+            echo '<td>' . \Initiator::e($label) . '</td>';
             foreach ($actions as $action) {
                 echo '<td class="text-center">';
                 if (in_array($action, (array)$nodeActions, true)) {

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -113,19 +113,19 @@ class SchemaUpdaterPage extends FOGPage
                     . '<a href="../management/index.php?node=logout" '
                     . 'class="alert-link">%s</a>'
                     . '</div></div>',
-                    Initiator::e(
+                    \Initiator::e(
                         sprintf(
                             _('Signed in as %s.'),
                             self::$FOGUser->get('name')
                         )
                     ),
-                    Initiator::e(
+                    \Initiator::e(
                         _(
                             'Applying a database schema update requires an '
                             . 'administrator account.'
                         )
                     ),
-                    Initiator::e(_('Log out and sign in as an administrator'))
+                    \Initiator::e(_('Log out and sign in as an administrator'))
                 );
                 return;
             }
@@ -154,7 +154,7 @@ class SchemaUpdaterPage extends FOGPage
         // this path, which is the whole of GH-927.
         if (self::installTokenParam()) {
             echo '<input type="hidden" name="fogtoken" value="'
-                . Initiator::e(FOG_SCHEMA_INSTALL_TOKEN)
+                . \Initiator::e(FOG_SCHEMA_INSTALL_TOKEN)
                 . '"/>';
         }
         echo '<div class="card" id="schema-modify">';

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles the display of schema and schema updating in general.
  *
@@ -551,3 +554,11 @@ class SchemaUpdaterPage extends FOGPage
         $this->jsonSend($code, $msg);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SchemaUpdaterPage', 'SchemaUpdaterPage');

--- a/packages/web/lib/pages/serverinfo.page.php
+++ b/packages/web/lib/pages/serverinfo.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Presents server information when clicked.
  *
@@ -340,3 +343,11 @@ class ServerInfo extends FOGPage
         echo '</div>';
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ServerInfo', 'ServerInfo');

--- a/packages/web/lib/pages/serverinfo.page.php
+++ b/packages/web/lib/pages/serverinfo.page.php
@@ -287,14 +287,14 @@ class ServerInfo extends FOGPage
                 $vendor = isset($NICVendorInfo[$nicname])
                     ? $NICVendorInfo[$nicname]
                     : '';
-                $macDisplay = Initiator::e($mac);
+                $macDisplay = \Initiator::e($mac);
                 if ($vendor !== '') {
                     // Mirror the OUI vendor icon used everywhere a MAC renders:
                     // an fa-info-circle whose tooltip carries the vendor name.
                     $macDisplay .= ' <i class="fa fa-info-circle text-muted '
                         . 'mac-vendor-icon" data-bs-toggle="tooltip" '
                         . 'data-bs-placement="right" data-container="body" title="'
-                        . Initiator::e($vendor)
+                        . \Initiator::e($vendor)
                         . '"></i>';
                 }
                 $fields[$NICMac[$nicname]] = $macDisplay;

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Configure global level module/services.
  * These are things like hostname changer, display, etc...
@@ -758,3 +761,11 @@ class ServiceConfigurationPage extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ServiceConfigurationPage', 'ServiceConfigurationPage');

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Site management page.
  *
@@ -621,3 +624,11 @@ class SiteManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteManagement', 'SiteManagement');

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -95,10 +95,10 @@ class SnapinManagement extends FOGPage
         foreach (self::$_argTypes as $type => &$cmd) {
             printf(
                 '<option value="%s" rwargs="%s" args="%s">%s</option>',
-                Initiator::e($cmd[0]),
-                Initiator::e($cmd[1]),
-                Initiator::e($cmd[2]),
-                Initiator::e($type)
+                \Initiator::e($cmd[0]),
+                \Initiator::e($cmd[1]),
+                \Initiator::e($cmd[2]),
+                \Initiator::e($type)
             );
             unset($cmd);
         }
@@ -175,13 +175,13 @@ class SnapinManagement extends FOGPage
         foreach ($args as $type => &$cmd) {
             printf(
                 '<option file="%s" args="%s">%s</option>',
-                Initiator::e($cmd[0]),
+                \Initiator::e($cmd[0]),
                 (
                     isset($cmd[1]) ?
-                    Initiator::e($cmd[1]) :
+                    \Initiator::e($cmd[1]) :
                     ''
                 ),
-                Initiator::e($type)
+                \Initiator::e($type)
             );
             unset($cmd);
         }

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin management page
  *
@@ -1609,3 +1612,11 @@ class SnapinManagement extends FOGPage
         ));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinManagement', 'SnapinManagement');

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Displays the storage group information.
  *
@@ -1007,3 +1010,11 @@ class StorageGroupManagement extends FOGPage
         ));
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageGroupManagement', 'StorageGroupManagement');

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Displays the storage node information.
  *
@@ -1322,3 +1325,11 @@ class StorageNodeManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\StorageNodeManagement', 'StorageNodeManagement');

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Displays tasks to the user.
  *
@@ -1259,3 +1262,11 @@ class TaskManagement extends FOGPage
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskManagement', 'TaskManagement');

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * User management page.
  *
@@ -908,3 +911,11 @@ class UserManagement extends FOGPage
         $this->siteTabPost('user', $this->obj);
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\UserManagement', 'UserManagement');

--- a/packages/web/lib/reg-task/blame.class.php
+++ b/packages/web/lib/reg-task/blame.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * If a node fails with a host we write the information
  * into the db using this script.
@@ -56,3 +59,11 @@ class Blame extends TaskingElement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Blame', 'Blame');

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Performs host registration
  *
@@ -514,3 +517,11 @@ class Registration extends FOGBase
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Registration', 'Registration');

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -145,7 +145,7 @@ abstract class TaskingElement extends FOGBase
                 }
             }
         } catch (\Exception $e) {
-            echo Initiator::e($e->getMessage());
+            echo \Initiator::e($e->getMessage());
             exit;
         }
     }

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The tasking element base class.
  *
@@ -331,3 +334,11 @@ abstract class TaskingElement extends FOGBase
             ->save();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskingElement', 'TaskingElement');

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The queue handling system for FOG's checkin/checkout processes.
  *
@@ -599,3 +602,11 @@ class TaskQueue extends TaskingElement
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskQueue', 'TaskQueue');

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -256,7 +256,7 @@ class TaskQueue extends TaskingElement
             );
             echo '##@GO';
         } catch (\Exception $e) {
-            echo Initiator::e($e->getMessage());
+            echo \Initiator::e($e->getMessage());
         }
     }
     /**

--- a/packages/web/lib/reports/file_deleter.report.php
+++ b/packages/web/lib/reports/file_deleter.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * File Deleter report
  *
@@ -82,3 +85,11 @@ class File_Deleter extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\File_Deleter', 'File_Deleter');

--- a/packages/web/lib/reports/history_report.report.php
+++ b/packages/web/lib/reports/history_report.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Prints the history of all items.
  *
@@ -68,3 +71,11 @@ class History_Report extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\History_Report', 'History_Report');

--- a/packages/web/lib/reports/host_list.report.php
+++ b/packages/web/lib/reports/host_list.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Reports hosts within.
  *
@@ -69,3 +72,11 @@ class Host_List extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Host_List', 'Host_List');

--- a/packages/web/lib/reports/hosts_and_users.report.php
+++ b/packages/web/lib/reports/hosts_and_users.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Reports hosts and the users within.
  *
@@ -67,3 +70,11 @@ class Hosts_And_Users extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Hosts_And_Users', 'Hosts_And_Users');

--- a/packages/web/lib/reports/imaging_log.report.php
+++ b/packages/web/lib/reports/imaging_log.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Imaging Log report
  *
@@ -74,3 +77,11 @@ class Imaging_Log extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Imaging_Log', 'Imaging_Log');

--- a/packages/web/lib/reports/inventory_report.report.php
+++ b/packages/web/lib/reports/inventory_report.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Prints the inventory of all items.
  *
@@ -134,3 +137,11 @@ class Inventory_Report extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Inventory_Report', 'Inventory_Report');

--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Pending MAC report.
  *
@@ -67,3 +70,11 @@ class Pending_MAC_List extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Pending_MAC_List', 'Pending_MAC_List');

--- a/packages/web/lib/reports/product_keys.report.php
+++ b/packages/web/lib/reports/product_keys.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Reports Host product keys.
  *
@@ -67,3 +70,11 @@ class Product_Keys extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Product_Keys', 'Product_Keys');

--- a/packages/web/lib/reports/snapin_list.report.php
+++ b/packages/web/lib/reports/snapin_list.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Snapin List report
  *
@@ -73,3 +76,11 @@ class Snapin_List extends ReportManagement
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Snapin_List', 'Snapin_List');

--- a/packages/web/lib/router/httpresponsecodes.class.php
+++ b/packages/web/lib/router/httpresponsecodes.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.com/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org/
  */
+
+namespace FOG;
+
 /**
  * Builds the response codes.
  *
@@ -265,3 +268,11 @@ class HTTPResponseCodes
         exit;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\HTTPResponseCodes', 'HTTPResponseCodes');

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org/
  */
+
+namespace FOG;
+
 class Route extends FOGBase
 {
     /**
@@ -6027,3 +6030,11 @@ class Route extends FOGBase
         ];
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Route', 'Route');

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -558,7 +558,7 @@ class Route extends FOGBase
          * webroot. AltoRouter wants it without the trailing slash, and an
          * install served from the document root itself wants it empty.
          */
-        self::$router = new AltoRouter(
+        self::$router = new \AltoRouter(
             [],
             rtrim(self::$_webrootbase, '/')
         );
@@ -1840,7 +1840,7 @@ class Route extends FOGBase
                                 . 'sub=edit&id='
                                 . $d
                                 . '">'
-                                . '(' . $d . ') - ' . Initiator::e($row['hostName'])
+                                . '(' . $d . ') - ' . \Initiator::e($row['hostName'])
                                 . '</a>';
                         }
                     ];
@@ -2206,7 +2206,7 @@ class Route extends FOGBase
                         'db' => 'utUserName',
                         'dt' => 'username',
                         'formatter' => function ($d, $row) {
-                            return Initiator::e($d);
+                            return \Initiator::e($d);
                         }
                     ];
                     $columns[] = [
@@ -2219,7 +2219,7 @@ class Route extends FOGBase
                             );
                         },
                         'formatter' => function ($d, $row) {
-                            return Initiator::e(self::rel('Host', $d)->get('name'));
+                            return \Initiator::e(self::rel('Host', $d)->get('name'));
                         }
                     ];
                     $columns[] = [
@@ -5929,7 +5929,7 @@ class Route extends FOGBase
                     }
                     // Escaped because this is text straight out of the GitHub
                     // feed and DataTables renders cell data as HTML.
-                    $k_i_type = Initiator::e($k_i_type);
+                    $k_i_type = \Initiator::e($k_i_type);
                     if ($k_hint === ' (experimental)') {
                         // The badge replaces the plain text rather than sitting
                         // next to it -- appending one leaves the cell reading

--- a/packages/web/lib/service/filedeleter.class.php
+++ b/packages/web/lib/service/filedeleter.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles file deletetion queued tasks.
  *
@@ -326,3 +329,11 @@ class FileDeleter extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FileDeleter', 'FileDeleter');

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles the fog linux services
  *
@@ -1123,3 +1126,11 @@ abstract class FOGService extends FOGBase
         }
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\FOGService', 'FOGService');

--- a/packages/web/lib/service/imagereplicator.class.php
+++ b/packages/web/lib/service/imagereplicator.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Replication service for images
  *
@@ -324,3 +327,11 @@ class ImageReplicator extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageReplicator', 'ImageReplicator');

--- a/packages/web/lib/service/imagesize.class.php
+++ b/packages/web/lib/service/imagesize.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Image size service for images.
  *
@@ -270,3 +273,11 @@ class ImageSize extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\ImageSize', 'ImageSize');

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * The multicast manager service
  *
@@ -830,3 +833,11 @@ class MulticastManager extends FOGService
         $this->_serviceLoop();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastManager', 'MulticastManager');

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Multicast task generator/finder
  *
@@ -1285,3 +1288,11 @@ class MulticastTask extends FOGService
         $this->_taskIDs = $newTaskIDs;
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\MulticastTask', 'MulticastTask');

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Gets the current ping code of each host and
  * updates the hosts related to them.
@@ -201,3 +204,11 @@ class PingHosts extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PingHosts', 'PingHosts');

--- a/packages/web/lib/service/pluginrunner.class.php
+++ b/packages/web/lib/service/pluginrunner.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Runs background work declared by installed, active plugins.
  *
@@ -413,3 +416,11 @@ class PluginRunner extends FOGService
         );
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\PluginRunner', 'PluginRunner');

--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Hashing service for snapins
  *
@@ -257,3 +260,11 @@ class SnapinHash extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinHash', 'SnapinHash');

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Replication service for snapins
  *
@@ -314,3 +317,11 @@ class SnapinReplicator extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SnapinReplicator', 'SnapinReplicator');

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+namespace FOG;
+
 /**
  * Handles scheduled tasks and performs other "ondemand" related tasks.
  *
@@ -327,3 +330,11 @@ class TaskScheduler extends FOGService
         parent::serviceRun();
     }
 }
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskScheduler', 'TaskScheduler');

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -129,6 +129,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Kernel-Argumente"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 Stunde"
@@ -1648,6 +1651,9 @@ msgstr "Benutzer erfolgreich erstellt"
 msgid "Create a %s"
 msgstr "Neue %s erstellen"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Neues Snapin erstellen"
@@ -1680,6 +1686,9 @@ msgstr "Erstellt von"
 
 msgid "Created by FOG Reg on"
 msgstr "Erstellt von FOG Reg am"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2153,6 +2162,10 @@ msgstr "Ereignisname muss eine Zeichenfolge sein."
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Keine Datei wurde hochgeladen"
 
 msgid "Exists item must be boolean"
 msgstr "Bestehendes Objekt muss boolean sein"
@@ -3293,6 +3306,9 @@ msgstr "Icon-Datei nicht gefunden"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4741,6 +4757,10 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Diff Parameter muss numerisch sein"
+
 msgid "Need the table name to drop"
 msgstr "Der Name der zu entfernenden Tabelle wird benötigt."
 
@@ -5211,6 +5231,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
@@ -5285,6 +5308,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5679,6 +5705,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "Snapin-Replikation"
 
 #, fuzzy
 msgid "Primary"
@@ -6088,6 +6124,9 @@ msgstr "Routen sollten ein Array oder eine Instanz von Traversable sein"
 msgid "Row"
 msgstr "Zeile"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6096,6 +6135,13 @@ msgid "Rows in this page."
 msgstr "Knoten enthalten dieses Image"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snapin läuft mit Argument"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6250,6 +6296,9 @@ msgstr "Service-Status"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6317,11 +6366,14 @@ msgstr "Server-Shell"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Service-Konfiguration"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Kernel-Versionen"
 
 msgid "Service"
@@ -7472,6 +7524,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungültig"
@@ -7520,6 +7575,9 @@ msgstr ""
 
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
+
+msgid "The same rules in prose, for a client reading this at runtime."
+msgstr ""
 
 #, fuzzy
 msgid "The selected site no longer exists"
@@ -7829,6 +7887,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Übertragen"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7952,7 +8017,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "Authentifizieren nicht möglich"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8099,6 +8164,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Snapins einer Speichergruppe zu"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8365,7 +8434,7 @@ msgid "Version"
 msgstr "Version"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG-Versionsinformationen"
 
 #, fuzzy
@@ -9015,6 +9084,12 @@ msgstr ""
 msgid "month"
 msgstr "Monat"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
@@ -9118,6 +9193,9 @@ msgstr ""
 
 msgid "read-only"
 msgstr "nur lesen"
+
+msgid "reboot, shutdown, or empty."
+msgstr ""
 
 #, fuzzy
 msgid "recommended"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -134,6 +134,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Kernel Arguments"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 hour"
@@ -1651,6 +1654,9 @@ msgstr "User created"
 msgid "Create a %s"
 msgstr "Create New %s"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Create New %s"
@@ -1683,6 +1689,9 @@ msgstr "Created By"
 
 msgid "Created by FOG Reg on"
 msgstr "Created by FOG Reg on"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2155,6 +2164,10 @@ msgstr "Event must be a string"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "No file was uploaded"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -3295,6 +3308,9 @@ msgstr "Icon File not found"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4741,6 +4757,10 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "You must enter a name"
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -5211,6 +5231,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Error, Is an image associated with this host"
@@ -5285,6 +5308,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5679,6 +5705,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "Snapin Replicator"
 
 #, fuzzy
 msgid "Primary"
@@ -6088,6 +6124,9 @@ msgstr ""
 msgid "Row"
 msgstr "Row"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6096,6 +6135,13 @@ msgid "Rows in this page."
 msgstr "Could not find any nodes containing this image"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snapin Run With Argument"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6250,6 +6296,9 @@ msgstr "Service Status"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6317,11 +6366,14 @@ msgstr "Server Shell"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Service Configuration"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Kernel Versions"
 
 msgid "Service"
@@ -7470,6 +7522,9 @@ msgstr "Failed to create task"
 msgid "The current user is invalid."
 msgstr "Task type is not valid"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "The storage groups associated storage node is not valid"
@@ -7517,6 +7572,9 @@ msgid "The plugin will run but its JS and CSS will 404."
 msgstr ""
 
 msgid "The primary mac associated is"
+msgstr ""
+
+msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
@@ -7827,6 +7885,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Transmit"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Storage Group Updated"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7950,7 +8015,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "Error contacting server"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8097,6 +8162,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Snapin Storage Group"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8363,7 +8432,7 @@ msgid "Version"
 msgstr "Version"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG Version Information"
 
 #, fuzzy
@@ -9010,6 +9079,12 @@ msgstr ""
 msgid "month"
 msgstr "Monthly"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -9112,6 +9187,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -132,6 +132,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Argumentos grupo Kernel"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 hora"
@@ -1671,6 +1674,9 @@ msgstr "creado por el usuario"
 msgid "Create a %s"
 msgstr "Crear nuevo grupo"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Crear nuevo grupo"
@@ -1703,6 +1709,9 @@ msgid "Created Time"
 msgstr "Creado"
 
 msgid "Created by FOG Reg on"
+msgstr ""
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
 msgstr ""
 
 msgid "Credentials"
@@ -2194,6 +2203,10 @@ msgstr "Evento debe ser una cadena"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Ningún archivo fue subido"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -3370,6 +3383,9 @@ msgstr "Icono de archivo no encontrado"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4866,6 +4882,10 @@ msgstr ""
 msgid "Name"
 msgstr "Nombre"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Evento debe ser una cadena"
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -5344,6 +5364,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Error, es una imagen asociada con este anfitrión"
@@ -5420,6 +5443,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5819,6 +5845,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "snapin replicador"
 
 #, fuzzy
 msgid "Primary"
@@ -6239,6 +6275,9 @@ msgstr ""
 msgid "Row"
 msgstr "Fila"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6247,6 +6286,13 @@ msgid "Rows in this page."
 msgstr "No se pudo encontrar ningún nodos que contienen esta imagen"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Nombre snapin"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6403,6 +6449,9 @@ msgstr "Estado del servicio"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6470,11 +6519,14 @@ msgstr "servidor TFTP"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Configuración de servicio"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Las versiones del kernel"
 
 #, fuzzy
@@ -7657,6 +7709,9 @@ msgstr "No se pudo crear la tarea"
 msgid "The current user is invalid."
 msgstr "tipo de tarea no es válida"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
@@ -7707,6 +7762,9 @@ msgstr ""
 #, fuzzy
 msgid "The primary mac associated is"
 msgstr "Error, es una imagen asociada con este anfitrión"
+
+msgid "The same rules in prose, for a client reading this at runtime."
+msgstr ""
 
 msgid "The selected site no longer exists"
 msgstr ""
@@ -8009,6 +8067,13 @@ msgstr ""
 msgid "Transmit"
 msgstr ""
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Nombre del grupo de almacenamiento"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -8131,7 +8196,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "servidor de ponerse en contacto con el error"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8280,6 +8345,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Grupo de almacenamiento primaria"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8551,7 +8620,7 @@ msgid "Version"
 msgstr "Versión"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG Información de la versión"
 
 #, fuzzy
@@ -9198,6 +9267,12 @@ msgstr ""
 msgid "month"
 msgstr "Mensual"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -9301,6 +9376,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -129,6 +129,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Kernel-Argumente"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 Stunde"
@@ -1648,6 +1651,9 @@ msgstr "Benutzer erfolgreich erstellt"
 msgid "Create a %s"
 msgstr "Neue %s erstellen"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Neues Snapin erstellen"
@@ -1680,6 +1686,9 @@ msgstr "Erstellt von"
 
 msgid "Created by FOG Reg on"
 msgstr "Erstellt von FOG Reg am"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2153,6 +2162,10 @@ msgstr "Ereignisname muss eine Zeichenfolge sein."
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Keine Datei wurde hochgeladen"
 
 msgid "Exists item must be boolean"
 msgstr "Bestehendes Objekt muss boolean sein"
@@ -3293,6 +3306,9 @@ msgstr "Icon-Datei nicht gefunden"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4742,6 +4758,10 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Diff Parameter muss numerisch sein"
+
 msgid "Need the table name to drop"
 msgstr "Der Name der zu entfernenden Tabelle wird benötigt."
 
@@ -5212,6 +5232,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
@@ -5286,6 +5309,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5680,6 +5706,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "Snapin-Replikation"
 
 #, fuzzy
 msgid "Primary"
@@ -6089,6 +6125,9 @@ msgstr "Routen sollten ein Array oder eine Instanz von Traversable sein"
 msgid "Row"
 msgstr "Zeile"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6097,6 +6136,13 @@ msgid "Rows in this page."
 msgstr "Knoten enthalten dieses Image"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snapin läuft mit Argument"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6251,6 +6297,9 @@ msgstr "Service-Status"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6318,11 +6367,14 @@ msgstr "Server-Shell"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Service-Konfiguration"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Kernel-Versionen"
 
 msgid "Service"
@@ -7473,6 +7525,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungültig"
@@ -7521,6 +7576,9 @@ msgstr ""
 
 msgid "The primary mac associated is"
 msgstr "Die zugeordnete Primär-MAC lautet"
+
+msgid "The same rules in prose, for a client reading this at runtime."
+msgstr ""
 
 #, fuzzy
 msgid "The selected site no longer exists"
@@ -7830,6 +7888,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Übertragen"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7953,7 +8018,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "Authentifizieren nicht möglich"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8100,6 +8165,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Snapins einer Speichergruppe zu"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8366,7 +8435,7 @@ msgid "Version"
 msgstr "Version"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG-Versionsinformationen"
 
 #, fuzzy
@@ -9016,6 +9085,12 @@ msgstr ""
 msgid "month"
 msgstr "Monat"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
@@ -9119,6 +9194,9 @@ msgstr ""
 
 msgid "read-only"
 msgstr "nur lesen"
+
+msgid "reboot, shutdown, or empty."
+msgstr ""
 
 #, fuzzy
 msgid "recommended"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -135,6 +135,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Arguments du noyau"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 heure"
@@ -1653,6 +1656,9 @@ msgstr "utilisateur créé"
 msgid "Create a %s"
 msgstr "Créer un nouveau %s"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Créer un nouveau %s"
@@ -1685,6 +1691,9 @@ msgstr "Créé par"
 
 msgid "Created by FOG Reg on"
 msgstr "Créé par FOG Reg sur"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2157,6 +2166,10 @@ msgstr "Événement doit être une chaîne"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Aucun fichier a été téléchargé"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -3297,6 +3310,9 @@ msgstr "Icône Fichier introuvable"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4743,6 +4759,10 @@ msgstr ""
 msgid "Name"
 msgstr "prénom"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Vous devez entrer un nom"
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -5213,6 +5233,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Erreur, est une image associée à cet hôte"
@@ -5287,6 +5310,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5681,6 +5707,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "snapin Replicator"
 
 #, fuzzy
 msgid "Primary"
@@ -6090,6 +6126,9 @@ msgstr ""
 msgid "Row"
 msgstr "Rangée"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6098,6 +6137,13 @@ msgid "Rows in this page."
 msgstr "Impossible de trouver des noeuds contenant cette image"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snapin Run With Argument"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6252,6 +6298,9 @@ msgstr "État du service"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6319,11 +6368,14 @@ msgstr "serveur Shell"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Configuration du service"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Kernel versions"
 
 msgid "Service"
@@ -7472,6 +7524,9 @@ msgstr "Impossible de créer la tâche"
 msgid "The current user is invalid."
 msgstr "Type de tâche n'est pas valide"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "Le nœud de stockage des groupes de stockage associé est pas valide"
@@ -7519,6 +7574,9 @@ msgid "The plugin will run but its JS and CSS will 404."
 msgstr ""
 
 msgid "The primary mac associated is"
+msgstr ""
+
+msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
@@ -7829,6 +7887,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Transmettre"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Groupe de stockage Mise à jour"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7952,7 +8017,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "Erreur serveur contactant"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8099,6 +8164,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Storage Group Snapin"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8365,7 +8434,7 @@ msgid "Version"
 msgstr "Version"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG Informations de version"
 
 #, fuzzy
@@ -9012,6 +9081,12 @@ msgstr ""
 msgid "month"
 msgstr "Mensuel"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -9114,6 +9189,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -134,6 +134,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "argomenti del kernel"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 msgid "1 Hour"
 msgstr "1 ora"
 
@@ -1591,6 +1594,9 @@ msgstr "Creazione utente riuscita"
 msgid "Create a %s"
 msgstr "Crea nuovo %s"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Crea nuovo snapin"
@@ -1623,6 +1629,9 @@ msgstr "Creato da"
 
 msgid "Created by FOG Reg on"
 msgstr "Creato da FOG Reg su"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2087,6 +2096,10 @@ msgstr "Evento deve essere una stringa"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Nessun file è stato caricato"
 
 msgid "Exists item must be boolean"
 msgstr "Exists deve essere boolean"
@@ -3188,6 +3201,9 @@ msgstr "File Icona non trovato"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4567,6 +4583,10 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Il parametro Diff deve essere numerico"
+
 msgid "Need the table name to drop"
 msgstr "Necessario il nome tabella da cancellare"
 
@@ -5021,6 +5041,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 msgid "One or more macs are associated with a host"
 msgstr "Uno o più MAC sono associati a questo host"
 
@@ -5092,6 +5115,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5474,6 +5500,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "Replica snapin"
 
 #, fuzzy
 msgid "Primary"
@@ -5868,6 +5904,9 @@ msgstr "I percorsi devono essere un array o un'istanza di Traversable"
 msgid "Row"
 msgstr "Riga"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -5876,6 +5915,13 @@ msgid "Rows in this page."
 msgstr "nodi che contengono questa immagine"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snap-Run con l'argomento"
+
+msgid "Run With interpreter."
 msgstr ""
 
 msgid "Running Windows"
@@ -6022,6 +6068,9 @@ msgstr "Stato servizio"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6089,11 +6138,14 @@ msgstr "Server Shell"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Configurazione del servizio"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "versioni del kernel"
 
 msgid "Service"
@@ -7185,6 +7237,9 @@ msgstr "Impossibile creare un'attività"
 msgid "The current user is invalid."
 msgstr "Tipo di attività non è valido"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "Il nodo di archiviazione gruppi di archiviazione associato non è valido"
@@ -7232,6 +7287,9 @@ msgstr ""
 
 msgid "The primary mac associated is"
 msgstr "Il MAC primario associato è"
+
+msgid "The same rules in prose, for a client reading this at runtime."
+msgstr ""
 
 #, fuzzy
 msgid "The selected site no longer exists"
@@ -7531,6 +7589,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Trasmettere"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Aggiornamento Gruppo di archiviazione fallito"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7650,7 +7715,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "Impossibile contattare il server"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -7794,6 +7859,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Snap in un gruppo di archiviazione"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8049,7 +8118,7 @@ msgid "Version"
 msgstr "Versione"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG Informazioni sulla versione"
 
 #, fuzzy
@@ -8657,6 +8726,12 @@ msgstr ""
 msgid "month"
 msgstr "mese"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr "più posti per ottenere l'immagine"
 
@@ -8755,6 +8830,9 @@ msgstr ""
 
 msgid "read-only"
 msgstr "sola lettura"
+
+msgid "reboot, shutdown, or empty."
+msgstr ""
 
 #, fuzzy
 msgid "recommended"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -125,6 +125,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "カーネル引数"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 msgid "1 Hour"
 msgstr "1時間"
 
@@ -1571,6 +1574,9 @@ msgstr "タスクタイプを作成"
 msgid "Create a %s"
 msgstr "新しい %s を作成"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "現在のセッション"
@@ -1604,6 +1610,9 @@ msgstr "ジョブ作成時刻"
 
 msgid "Created by FOG Reg on"
 msgstr "FOG Reg により作成:"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 #, fuzzy
 msgid "Credentials"
@@ -2068,6 +2077,10 @@ msgstr "イベントは文字列で指定してください"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "ファイルはアップロードされませんでした"
 
 msgid "Exists item must be boolean"
 msgstr "Exists 項目はブール値である必要があります"
@@ -3157,6 +3170,9 @@ msgstr "アイコンファイルが見つかりません"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4520,6 +4536,10 @@ msgstr "フォーラムは、最も一般的で迅速なサポートを受ける
 msgid "Name"
 msgstr "名前"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Diff パラメーターは数値で指定してください"
+
 msgid "Need the table name to drop"
 msgstr "削除するテーブル名が必要です"
 
@@ -4974,6 +4994,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr "\"snapinfiles[]\" マルチパートフィールドを使用して、1 つ以上のファイルをアップロードする必要があります"
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 msgid "One or more macs are associated with a host"
 msgstr "1 つ以上の MAC アドレスがホストに関連付けられています"
 
@@ -5046,6 +5069,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5430,6 +5456,16 @@ msgstr ""
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "スナップインレプリケーション"
+
 #, fuzzy
 msgid "Primary"
 msgstr "プライマリ MAC アドレス"
@@ -5811,6 +5847,9 @@ msgstr "ルートは配列または Traversable のインスタンスである�
 msgid "Row"
 msgstr "行"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -5819,6 +5858,13 @@ msgid "Rows in this page."
 msgstr "このイメージを含むノード"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "スナップイン実行時の引数"
+
+msgid "Run With interpreter."
 msgstr ""
 
 msgid "Running Windows"
@@ -5968,6 +6014,9 @@ msgstr "設定"
 msgid "Second paramater must be in [class,function]"
 msgstr "2 番目のパラメーターは array(class,function) 形式である必要があります"
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6033,11 +6082,14 @@ msgstr "サーバーシェル"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "サービス設定"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "カーネルバージョン"
 
 msgid "Service"
@@ -7111,6 +7163,9 @@ msgstr "タスクの作成に失敗しました"
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "ストレージグループに関連付けられたストレージノードが無効です"
@@ -7159,6 +7214,9 @@ msgstr ""
 
 msgid "The primary mac associated is"
 msgstr "関連付けられたプライマリ MAC アドレス:"
+
+msgid "The same rules in prose, for a client reading this at runtime."
+msgstr ""
 
 #, fuzzy
 msgid "The selected site no longer exists"
@@ -7459,6 +7517,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "送信"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "ストレージグループに到達可能なマスターノードがありません"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7575,7 +7640,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "認証できません"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -7720,6 +7785,10 @@ msgstr "アップロードできるファイルの拡張子は jpg、jpeg、png 
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "スナップインをストレージグループへ"
 
 #, fuzzy
 msgid "Uploaded file too large."
@@ -7979,7 +8048,7 @@ msgid "Version"
 msgstr "バージョン"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG バージョン情報"
 
 #, fuzzy
@@ -8575,6 +8644,12 @@ msgstr ""
 msgid "month"
 msgstr "月"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr "イメージの取得元が複数ある"
 
@@ -8673,6 +8748,9 @@ msgstr ""
 
 msgid "read-only"
 msgstr "読み取り専用"
+
+msgid "reboot, shutdown, or empty."
+msgstr ""
 
 #, fuzzy
 msgid "recommended"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -110,6 +110,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr ""
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 msgid "1 Hour"
 msgstr ""
 
@@ -1385,6 +1388,9 @@ msgstr ""
 msgid "Create a %s"
 msgstr ""
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 msgid "Create new Session Task"
 msgstr ""
 
@@ -1411,6 +1417,9 @@ msgid "Created Time"
 msgstr ""
 
 msgid "Created by FOG Reg on"
+msgstr ""
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
 msgstr ""
 
 msgid "Credentials"
@@ -1826,6 +1835,9 @@ msgid "Event must be a string"
 msgstr ""
 
 msgid "Every configured multicast port is already in use"
+msgstr ""
+
+msgid "Every file was uploaded."
 msgstr ""
 
 msgid "Exists item must be boolean"
@@ -2786,6 +2798,9 @@ msgstr ""
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4001,6 +4016,9 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+msgid "Name. Must be unique."
+msgstr ""
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -4407,6 +4425,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 msgid "One or more macs are associated with a host"
 msgstr ""
 
@@ -4476,6 +4497,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -4803,6 +4827,15 @@ msgid "PowerShell x64 Script"
 msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
+msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+msgid "Present means include in replication."
 msgstr ""
 
 msgid "Primary"
@@ -5159,6 +5192,9 @@ msgstr ""
 msgid "Row"
 msgstr ""
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -5166,6 +5202,12 @@ msgid "Rows in this page."
 msgstr ""
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+msgid "Run With arguments."
+msgstr ""
+
+msgid "Run With interpreter."
 msgstr ""
 
 msgid "Running Windows"
@@ -5298,6 +5340,9 @@ msgstr ""
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -5356,10 +5401,13 @@ msgstr ""
 msgid "Server is only configured to run %d multicast tasks"
 msgstr ""
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr ""
 
 msgid "Service"
@@ -6319,6 +6367,9 @@ msgstr ""
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The file itself."
+msgstr ""
+
 msgid "The image associated does not have a valid OS!"
 msgstr ""
 
@@ -6360,6 +6411,9 @@ msgid "The plugin will run but its JS and CSS will 404."
 msgstr ""
 
 msgid "The primary mac associated is"
+msgstr ""
+
+msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 msgid "The selected site no longer exists"
@@ -6641,6 +6695,12 @@ msgstr ""
 msgid "Transmit"
 msgstr ""
 
+msgid "Transport failed, or the group has no reachable master node."
+msgstr ""
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -6740,7 +6800,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr ""
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -6864,6 +6924,9 @@ msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
 
 msgid "Upload plugin"
+msgstr ""
+
+msgid "Upload snapin files to a storage group"
 msgstr ""
 
 msgid "Uploaded file too large."
@@ -7091,7 +7154,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr ""
 
 msgid "Versions"
@@ -7648,6 +7711,12 @@ msgstr ""
 msgid "month"
 msgstr ""
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -7742,6 +7811,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -134,6 +134,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "Argumentos de kernel"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1 hora"
@@ -1652,6 +1655,9 @@ msgstr "usuário criado"
 msgid "Create a %s"
 msgstr "Criar novo %s"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "Criar novo %s"
@@ -1684,6 +1690,9 @@ msgstr "Criado por"
 
 msgid "Created by FOG Reg on"
 msgstr "Criado por FOG Reg em"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2156,6 +2165,10 @@ msgstr "Evento deve ser uma string"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "Nenhum arquivo foi transferido"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -3296,6 +3309,9 @@ msgstr "Ícone do Arquivo não encontrado"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4742,6 +4758,10 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "Você deve digitar um nome"
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -5212,6 +5232,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Erro, é uma imagem associada com este anfitrião"
@@ -5286,6 +5309,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5680,6 +5706,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "Snapin Replicator"
 
 #, fuzzy
 msgid "Primary"
@@ -6089,6 +6125,9 @@ msgstr ""
 msgid "Row"
 msgstr "Linha"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6097,6 +6136,13 @@ msgid "Rows in this page."
 msgstr "Não foi possível encontrar todos os nós que contêm esta imagem"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "Snapin Run com o argumento"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6251,6 +6297,9 @@ msgstr "status do serviço"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6318,11 +6367,14 @@ msgstr "Shell servidor"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "Configuração de serviço"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "Versões do kernel"
 
 msgid "Service"
@@ -7471,6 +7523,9 @@ msgstr "Falha ao criar tarefa"
 msgid "The current user is invalid."
 msgstr "tipo de tarefa não é válido"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "O nó de armazenamento grupos de armazenamento associado não é válido"
@@ -7518,6 +7573,9 @@ msgid "The plugin will run but its JS and CSS will 404."
 msgstr ""
 
 msgid "The primary mac associated is"
+msgstr ""
+
+msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
@@ -7828,6 +7886,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "Transmite"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "Grupo de armazenamento Atualizado"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7951,7 +8016,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "servidor entrar em contato com erro"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8098,6 +8163,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "Snapin grupo de armazenamento"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8364,7 +8433,7 @@ msgid "Version"
 msgstr "Versão"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG Informação da versão"
 
 #, fuzzy
@@ -9011,6 +9080,12 @@ msgstr ""
 msgid "month"
 msgstr "Por mês"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -9113,6 +9188,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -134,6 +134,9 @@ msgstr ""
 msgid ", Arguments = %s"
 msgstr "内核参数"
 
+msgid "0 is a normal snapin, 1 a snapin pack the client extracts before running."
+msgstr ""
+
 #, fuzzy
 msgid "1 Hour"
 msgstr "1小时"
@@ -1652,6 +1655,9 @@ msgstr "用户创建"
 msgid "Create a %s"
 msgstr "新建%s"
 
+msgid "Create a snapin and upload its file"
+msgstr ""
+
 #, fuzzy
 msgid "Create new Session Task"
 msgstr "新建%s"
@@ -1684,6 +1690,9 @@ msgstr "由...制作"
 
 msgid "Created by FOG Reg on"
 msgstr "创建者FOG上注册"
+
+msgid "Created. The body is the new snapin, the same shape as GET /snapin/{id}."
+msgstr ""
 
 msgid "Credentials"
 msgstr ""
@@ -2156,6 +2165,10 @@ msgstr "事件必须是字符串"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Every file was uploaded."
+msgstr "没有文件被上传"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -3296,6 +3309,9 @@ msgstr "图标文件未找到"
 
 #, php-format
 msgid "Id and name pairs for %s"
+msgstr ""
+
+msgid "Id of the storage group whose master receives the file."
 msgstr ""
 
 #, php-format
@@ -4742,6 +4758,10 @@ msgstr ""
 msgid "Name"
 msgstr "名称"
 
+#, fuzzy
+msgid "Name. Must be unique."
+msgstr "您必须输入一个名称"
+
 msgid "Need the table name to drop"
 msgstr ""
 
@@ -5212,6 +5232,9 @@ msgstr ""
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+msgid "One or more files. The field name carries the [] suffix on the wire: snapinfiles[]."
+msgstr ""
+
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "错误，与此主机关联的图像"
@@ -5286,6 +5309,9 @@ msgid "PLUGIN OPTIONS"
 msgstr ""
 
 msgid "Page node is not registered as a permission node"
+msgstr ""
+
+msgid "Page size cap applied to an expand request even when a larger length was asked for, so a page can be smaller than requested. Advance by the rows returned, not the length requested."
 msgstr ""
 
 msgid "Page size. Send it, together with start, on every list call: a request with no start is capped at MAX_ROWS and returns a partial result with truncated set."
@@ -5680,6 +5706,16 @@ msgstr ""
 
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
+
+msgid "Present means enabled."
+msgstr ""
+
+msgid "Present means hidden from the UI list."
+msgstr ""
+
+#, fuzzy
+msgid "Present means include in replication."
+msgstr "管理单元复制"
 
 #, fuzzy
 msgid "Primary"
@@ -6089,6 +6125,9 @@ msgstr ""
 msgid "Row"
 msgstr "行"
 
+msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
+msgstr ""
+
 msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
@@ -6097,6 +6136,13 @@ msgid "Rows in this page."
 msgstr "找不到包含该图像的任何节点"
 
 msgid "Rows matching the filter. Rewritten to the post-scoping count for site-restricted users, so treat it as a floor rather than a total."
+msgstr ""
+
+#, fuzzy
+msgid "Run With arguments."
+msgstr "管理单元运行带有参数"
+
+msgid "Run With interpreter."
 msgstr ""
 
 #, fuzzy
@@ -6251,6 +6297,9 @@ msgstr "服务状态"
 msgid "Second paramater must be in [class,function]"
 msgstr ""
 
+msgid "Seconds before the client gives up. 0 is no timeout."
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -6318,11 +6367,14 @@ msgstr "服务器外壳"
 msgid "Server is only configured to run %d multicast tasks"
 msgstr "服务配置"
 
+msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
+msgstr ""
+
 msgid "Server status, export and metadata."
 msgstr ""
 
 #, fuzzy
-msgid "Server version"
+msgid "Server version and paging bounds"
 msgstr "内核版本"
 
 msgid "Service"
@@ -7471,6 +7523,9 @@ msgstr "无法创建任务"
 msgid "The current user is invalid."
 msgstr "任务类型无效"
 
+msgid "The file itself."
+msgstr ""
+
 #, fuzzy
 msgid "The image associated does not have a valid OS!"
 msgstr "存储组相关联的存储节点无效"
@@ -7518,6 +7573,9 @@ msgid "The plugin will run but its JS and CSS will 404."
 msgstr ""
 
 msgid "The primary mac associated is"
+msgstr ""
+
+msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
@@ -7828,6 +7886,13 @@ msgstr ""
 msgid "Transmit"
 msgstr "发送"
 
+#, fuzzy
+msgid "Transport failed, or the group has no reachable master node."
+msgstr "存储组更新"
+
+msgid "Transport to the master storage node failed, or the row would not save after the file had landed."
+msgstr ""
+
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
 msgstr ""
 
@@ -7951,7 +8016,7 @@ msgstr ""
 msgid "Unauthenticated."
 msgstr "服务器连接出错"
 
-msgid "Unauthenticated. Also reachable as /system/status."
+msgid "Unauthenticated. Also reachable as /system/status. The cheap way to read the paging bounds -- the same values appear as x-fog-paging on this document, which is several hundred kilobytes larger."
 msgstr ""
 
 msgid "Unauthorized"
@@ -8098,6 +8163,10 @@ msgstr ""
 
 msgid "Upload plugin"
 msgstr ""
+
+#, fuzzy
+msgid "Upload snapin files to a storage group"
+msgstr "管理单元存储组"
 
 msgid "Uploaded file too large."
 msgstr ""
@@ -8364,7 +8433,7 @@ msgid "Version"
 msgstr "版"
 
 #, fuzzy
-msgid "Version information."
+msgid "Version information and paging bounds."
 msgstr "FOG版本信息"
 
 #, fuzzy
@@ -9011,6 +9080,12 @@ msgstr ""
 msgid "month"
 msgstr "每月一次"
 
+msgid "multipart/form-data, not JSON. The file goes to the master storage node of the group given, and FOGSnapinReplicator propagates it to the rest of the group on its normal cycle. A file already present under the same basename is overwritten, matching the UI. Names matching /ssl/i are refused -- that path is reserved."
+msgstr ""
+
+msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
+msgstr ""
+
 msgid "multiple places to get your image"
 msgstr ""
 
@@ -9113,6 +9188,9 @@ msgid "re-run the installer and check the installation log for a key generation 
 msgstr ""
 
 msgid "read-only"
+msgstr ""
+
+msgid "reboot, shutdown, or empty."
 msgstr ""
 
 msgid "recommended"

--- a/tests/grid-order-clause.test.php
+++ b/tests/grid-order-clause.test.php
@@ -45,6 +45,17 @@ class DatabaseManager
 {
 }
 
+/*
+ * The target is required directly, so no autoloader is running to bridge
+ * names for us. Since Phase 3 the file declares `namespace FOG;` and its
+ * `extends FOGBase` therefore resolves to FOG\FOGBase -- which the stubs
+ * above do not provide. Aliasing them into FOG\ is the same move the real
+ * class files make in the opposite direction, and it keeps the stubs
+ * readable as the global names the rest of this file uses.
+ */
+class_alias('FOGBase', 'FOG\\FOGBase');
+class_alias('DatabaseManager', 'FOG\\DatabaseManager');
+
 require $target;
 
 /**

--- a/tests/namespaced-tree.test.php
+++ b/tests/namespaced-tree.test.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * The FOG\ namespacing stays complete and stays correct.
+ *
+ * Two questions, both of which bin/namespace-fog-classes.php already answers
+ * -- this wires its --check mode into the suite so a new file cannot quietly
+ * regress either one.
+ *
+ *   1. Every class file declares `namespace FOG;` and aliases its own name
+ *      back into the global namespace. Miss the alias and every existing
+ *      caller of that class -- core, bundled plugins, third-party plugins --
+ *      stops resolving.
+ *
+ *   2. No namespaced file references one of the four deliberately-global
+ *      classes unqualified. This is the one that unit tests cannot otherwise
+ *      see: `Initiator::e($x)` inside `namespace FOG;` resolves to
+ *      FOG\Initiator, which does not exist and for Initiator never can --
+ *      commons/init.php is not a *.class.php file, so it is not in the
+ *      autoloader's map and no bridge reaches it. The tree passed all 26
+ *      other tests, and resolved all 226 classes under both spellings, while
+ *      being completely unable to render a page.
+ *
+ * Usage: php tests/namespaced-tree.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$tool = $root . '/bin/namespace-fog-classes.php';
+
+if (!is_readable($tool)) {
+    fwrite(STDERR, "FAIL: missing $tool\n");
+    exit(1);
+}
+
+$cmd = sprintf(
+    '%s %s --check 2>&1',
+    escapeshellarg(PHP_BINARY),
+    escapeshellarg($tool)
+);
+exec($cmd, $output, $status);
+
+if (0 !== $status) {
+    fwrite(STDERR, "FAIL: the tree is not fully namespaced.\n");
+    foreach ($output as $line) {
+        fwrite(STDERR, "  $line\n");
+    }
+    fwrite(
+        STDERR,
+        "\nRun: php bin/namespace-fog-classes.php --fix\n"
+    );
+    exit(1);
+}
+
+echo trim(implode(' ', $output)) . "\n";
+exit(0);


### PR DESCRIPTION
Phase 3 of the refactor. **226 files move into `namespace FOG;`, and not one call site had to be edited** — in core or in any plugin.

Four commits, each green on its own:

| | |
|---|---|
| `7a26693f7` | Teach the `FOG\` bridge that a file may already be namespaced |
| `79c5a921b` | Declare FOG's classes in the `FOG\` namespace (226 files) |
| `940702daf` | Qualify references to the four classes that stay global |
| `793957dee` | Gate the namespacing so it stays complete and stays correct |

## How it works

Each file gets exactly two additions:

```php
namespace FOG;                                    // after the file docblock
class_alias(__NAMESPACE__ . '\Host', 'Host');     // at the end
```

The alias is not a transitional convenience — **it is the 1.6 plugin ABI.** PHP resolves a class *reference* through an alias transparently, so `new Host`, `$obj instanceof $str`, `class_exists('host')` (lookup stays case-insensitive), Reflection, `is_subclass_of()` and all 350 `getClass()` literals keep working untouched. 169 tracked plugin files inherit from these classes and need no change.

What an alias does *not* survive is the other direction — `get_class()` reports the **declared** name — which is why the 35 derivation sites went through `FOGBase::shortName()` first, in #1099, before any of this.

**Batching was safe** because a converted file's unqualified `extends FOGController` asks the autoloader for `FOG\FOGController`, and the bridge answers that whether or not the parent has been converted yet.

## Flat `FOG\`, not `FOG\Model` / `FOG\Manager`

`FOGController::getManager()` derives its manager from the model's own name (`get_class($this).'Manager'`), and `FOGManagerController` does the inverse. Flat gives `FOG\Host` → `FOG\HostManager`, which resolves. Splitting models from managers would produce `FOG\Model\HostManager`, which does not exist, on the most-travelled path in the ORM — so it would mean rewriting both derivations and creating two new instances of the exact bug class Phase 3 exists to remove. It would also invalidate the shipped Phase 0.2 bridge and break any plugin that took the documented advice to write `FOG\Host`.

Full reasoning in `docs/refactor-phase3-plan.md`. New subsystems under `packages/web/src/` may still nest — nothing there derives a name arithmetically.

**Not converted:** `mysqldump.class.php` and `altorouter.class.php`/`altotransformer.class.php` (vendored, and swap candidates for their Packagist releases), and `commons/init.php` (it *is* the autoloader).

## The bug only a live boot could find

Commit 2 alone passed all 26 tests and resolved all 226 classes under both spellings — **and could not render a single page.** From inside `namespace FOG;`, `Initiator::e($x)` resolves to `FOG\Initiator`, which does not exist and for `Initiator` never can: `commons/init.php` is not a `*.class.php` file, so it is not in the autoloader's map at all.

```
Uncaught Error: Class "FOG\Initiator" not found
  in fogbase.class.php:3017 (FOGBase::entityLink)
```

133 references across 26 files, 132 of them to `Initiator` — which is FOG's output escaper, so it is on essentially every page. Commit 3 qualifies all of them; commit 4 makes it a test.

## Verification, against the live 1.6 server's database

Booted from the source tree against `/var/www/html/fog-1.6`'s real config and database, read-only, and diffed against `origin/working-1.6` **run from the same directory** so path was not a variable:

| Check | control | namespaced |
|---|---|---|
| `Host` declared name | `Host` | **`FOG\Host`** ← intended |
| `Host->getManager()` class | `HostManager` | **`FOG\HostManager`** ← intended |
| `HostManager->childClass` | `Host` | `Host` |
| `ImageManager->childClass` | `Image` | `Image` |
| HookManager events / EventManager events | 40 / 6 | **40 / 6** |
| `Route::getCount(image)` / `(user)` | 29 / 10 | 29 / 10 |
| `Host` bare vs `FOG\Host` | same entity | same entity |
| overall | `23 ok, 4 problem(s)` | `23 ok, 4 problem(s)` |

The three differences are the three intended ones. **40 events / 86 listeners registering matters most**: they all go through `EventManager::register()`'s `switch` with its throwing `default`, which is the path that would have registered nothing at all — silently — had the namespacing broken it.

Also verified: all 242 classes load, every one of the 226 resolves under both spellings and reports `FOG\<Name>`, and no warnings under `error_reporting=E_ALL` with `display_errors=1`.

```
$ sh tests/run-all.sh
27 passed, 0 failed
```

## Follow-ups, not in this PR

ADR 0013 and the `docs/plugin-development.md` guidance (plugins should adopt `FOG\` names; `get_class($this)` now returns `FOG\Foo`, so any plugin comparing it to a literal needs `shortName()`), plus the 1.7 deprecation note for the aliases.

**No OpenAPI change needed** — no route was added, removed or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR