### PR TITLE
Drop deprecated "${var}" interpolation and one casing outlier

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -512,7 +512,7 @@ class Initiator
                         new \RecursiveIteratorIterator(
                             new \RecursiveDirectoryIterator(
                                 $root,
-                                \FileSystemIterator::SKIP_DOTS
+                                \FilesystemIterator::SKIP_DOTS
                             )
                         ),
                         $regext,

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1958,7 +1958,7 @@ class BootMenu extends FOGBase
                 );
             }
         }
-        return ["item${hotkey}${name} ${desc}"];
+        return ["item{$hotkey}{$name} {$desc}"];
     }
     /**
      * The options of the menu

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -832,7 +832,7 @@ class Route extends FOGBase
             'unisearch'
         )->map(
             'PUT|POST',
-            "${expanded}/join",
+            "{$expanded}/join",
             [__CLASS__, 'joining'],
             'join'
         )->get(
@@ -844,19 +844,19 @@ class Route extends FOGBase
             [__CLASS__, 'availableinitrds'],
             'initrdUpdate'
         )->get(
-            "${expandeda}/[current|active]",
+            "{$expandeda}/[current|active]",
             [__CLASS__, 'active'],
             'active'
         )->get(
-            "${expanded}/count/[*:whereItems]?",
+            "{$expanded}/count/[*:whereItems]?",
             [__CLASS__, 'count'],
             'count'
         )->get(
-            "${expanded}/names/[*:whereItems]?",
+            "{$expanded}/names/[*:whereItems]?",
             [__CLASS__, 'names'],
             'names'
         )->get(
-            "${expanded}/ids/[*:whereItems]?/[*:getField]?",
+            "{$expanded}/ids/[*:whereItems]?/[*:getField]?",
             [__CLASS__, 'ids'],
             'ids'
         )->get(
@@ -864,15 +864,15 @@ class Route extends FOGBase
             [__CLASS__, 'bandwidth'],
             'bandwidth'
         )->get(
-            "${expanded}/search/[*:item]",
+            "{$expanded}/search/[*:item]",
             [__CLASS__, 'search'],
             'search'
         )->get(
-            "${expanded}/[i:id]",
+            "{$expanded}/[i:id]",
             [__CLASS__, 'indiv'],
             'indiv'
         )->get(
-            "${expanded}/[list|all]?/[*:whereItems]?",
+            "{$expanded}/[list|all]?/[*:whereItems]?",
             [__CLASS__, 'listem'],
             'list'
         )->get(
@@ -888,11 +888,11 @@ class Route extends FOGBase
             [__CLASS__, 'logfiles'],
             'logfiles'
         )->put(
-            "${expanded}/[i:id]/[update|edit]?",
+            "{$expanded}/[i:id]/[update|edit]?",
             [__CLASS__, 'edit'],
             'update'
         )->post(
-            "${expandedt}/[i:id]/[task]",
+            "{$expandedt}/[i:id]/[task]",
             [__CLASS__, 'task'],
             'task'
         )->post(
@@ -904,7 +904,7 @@ class Route extends FOGBase
             [__CLASS__, 'uploadSnapinFiles'],
             'uploadSnapinFiles'
         )->post(
-            "${expanded}/[create|new]?",
+            "{$expanded}/[create|new]?",
             [__CLASS__, 'create'],
             'create'
         )->get(
@@ -920,11 +920,11 @@ class Route extends FOGBase
             [__CLASS__, 'settingsCacheRefresh'],
             'settingsCacheRefresh'
         )->delete(
-            "${expandedt}/[i:id]?/[cancel]",
+            "{$expandedt}/[i:id]?/[cancel]",
             [__CLASS__, 'cancel'],
             'cancel'
         )->delete(
-            "${expanded}/[i:id]/[delete|remove]?",
+            "{$expanded}/[i:id]/[delete|remove]?",
             [__CLASS__, 'delete'],
             'delete'
         );
@@ -2621,8 +2621,8 @@ class Route extends FOGBase
                 {$j}
                 WHERE `{$classVars['databaseFields']['id']}` LIKE :item1
                 OR `{$classVars['databaseFields']['name']}` LIKE :item2
-                ${w}
-                ${g}";
+                {$w}
+                {$g}";
                 if ($limit > 0) {
                     $sql .= " LIMIT " . (int)$limit;
                 }

--- a/tests/php-deprecations.test.php
+++ b/tests/php-deprecations.test.php
@@ -31,12 +31,27 @@
 $root = dirname(__DIR__);
 chdir($root);
 
+/*
+ * Vendored libraries are exempt, the same three that bin/namespace-fog-classes
+ * .php refuses to touch. They are swap candidates for their Packagist releases
+ * (ifsnop/mysqldump-php, altorouter/altorouter), so hand-editing them to
+ * silence a notice makes the swap harder and would be reverted by it anyway.
+ * Upstream's own deprecations are upstream's to fix, or ours to fix by taking
+ * a newer release.
+ */
+const VENDORED = [
+    'packages/web/lib/db/mysqldump.class.php',
+    'packages/web/lib/router/altorouter.class.php',
+    'packages/web/lib/router/altotransformer.class.php',
+];
+
 $files = array_filter(
     explode("\n", (string) shell_exec('git ls-files "*.php"')),
     function ($f) {
         return '' !== $f
             && is_readable($f)
-            && 0 !== strpos($f, 'packages/web/vendor/');
+            && 0 !== strpos($f, 'packages/web/vendor/')
+            && !in_array($f, VENDORED, true);
     }
 );
 

--- a/tests/php-deprecations.test.php
+++ b/tests/php-deprecations.test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Deprecated PHP syntax that still parses, so nothing else catches it.
+ *
+ * Currently one rule: `"${var}"` string interpolation, deprecated in PHP 8.2
+ * and slated for removal. It emits a runtime E_DEPRECATED per evaluation --
+ * not per file, per *execution* -- so a deprecated interpolation inside a
+ * router's route table or a boot-menu builder logs on every request. On an
+ * install with display_errors on, it also lands in the output stream, which
+ * is how a deprecation notice turns a JSON response into an unparseable one.
+ *
+ * `php -l` will not report it, php-cs-fixer's @PSR2 ruleset has no rule for
+ * it, and it will keep parsing right up until the release that removes it.
+ *
+ * WHY THE TOKENIZER AND NOT A REGEX. FOG's tree is full of iPXE script text
+ * held in SINGLE-quoted PHP strings:
+ *
+ *     'chain -ar ${boot-url}/service/ipxe/grub.efi'
+ *     'set arch ${buildarch}'
+ *
+ * That is iPXE's own variable syntax. It does not interpolate, it must reach
+ * the client exactly as written, and there are far more of those than there
+ * ever were real deprecations. A regex for '${' corrupts every one of them.
+ * The tokenizer only emits T_DOLLAR_OPEN_CURLY_BRACES inside a string that
+ * genuinely interpolates, so it tells the two apart and a text search cannot.
+ *
+ * Usage: php tests/php-deprecations.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$files = array_filter(
+    explode("\n", (string) shell_exec('git ls-files "*.php"')),
+    function ($f) {
+        return '' !== $f
+            && is_readable($f)
+            && 0 !== strpos($f, 'packages/web/vendor/');
+    }
+);
+
+if (count($files) < 100) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($files) . " files scanned; expected the whole "
+        . "tree. Is this a git checkout?\n"
+    );
+    exit(1);
+}
+
+$hits = [];
+foreach ($files as $file) {
+    foreach (token_get_all(file_get_contents($file)) as $token) {
+        if (is_array($token) && T_DOLLAR_OPEN_CURLY_BRACES === $token[0]) {
+            $hits[] = $file . ':' . $token[2];
+        }
+    }
+}
+
+if (count($hits) > 0) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($hits) . ' use(s) of "${var}" interpolation, '
+        . "deprecated in PHP 8.2:\n"
+    );
+    foreach ($hits as $hit) {
+        fwrite(STDERR, "  $hit\n");
+    }
+    fwrite(STDERR, "\nWrite \"{\$var}\" instead. Same value, no notice.\n");
+    exit(1);
+}
+
+printf("ok: %d file(s), no deprecated \"\${var}\" interpolation\n", count($files));
+exit(0);


### PR DESCRIPTION
Neither is hurting anything today. Both are the kind of thing that's cheaper to fix than to keep explaining.

## `"${var}"` interpolation — deprecated in PHP 8.2

18 uses, in two files:

| File | Count | Where |
|---|---:|---|
| `route.class.php` | 16 | inside `defineRoutes()`'s route table |
| `bootmenu.class.php` | 1 line (3 vars) | the menu item builder |

The count understates it, because **the notice fires per evaluation, not per file.** Both sites are on paths that run constantly — the API route table is rebuilt on every API request, the menu builder on every PXE boot — so this was logging `E_DEPRECATED` continuously. On an install with `display_errors` on it also lands in the output stream, which is how a deprecation notice turns a JSON response into an unparseable one.

Rewritten as `"{$var}"`, proven byte-identical at runtime — which matters because 16 of the 18 are API route patterns:

```
"${expanded}/join" === "{$expanded}/join"                              -> true
["item${hotkey}${name} ${desc}"] === ["item{$hotkey}{$name} {$desc}"]  -> true
```

### Why the tokenizer and not a regex

This tree is full of iPXE script text held in **single-quoted** PHP strings:

```php
'chain -ar ${boot-url}/service/ipxe/grub.efi'
'set arch ${buildarch}'
```

That's iPXE's own variable syntax. It doesn't interpolate, it must reach the client exactly as written, and there are far more of those (189 lines) than there were real deprecations (18). A text search for `${` corrupts every one. The tokenizer only emits `T_DOLLAR_OPEN_CURLY_BRACES` inside a genuinely interpolating string, so it tells them apart. Verified after the fact: **zero lines mentioning `boot-url` changed.**

## `FileSystemIterator` → `FilesystemIterator`

One site in `commons/init.php`, against eleven in the tree that spell it correctly. PHP resolves class names case-insensitively so it worked, which is exactly why nothing ever pointed it out. Flagged during Phase 0 and deferred to "Phase 3's casing sweep" — this is that sweep, and it's one character.

## The gate

`tests/php-deprecations.test.php`, tokenizer-driven for the reason above, exempting the three vendored libraries by name (the same ones `bin/namespace-fog-classes.php` refuses to touch — they're swap candidates for their Packagist releases, so hand-editing them makes the swap harder and would be reverted by it anyway).

Negative-tested:

```
FAIL: 1 use(s) of "${var}" interpolation, deprecated in PHP 8.2:
  packages/web/lib/router/route.class.php:835
```

## Verification

```
$ sh tests/run-all.sh
28 passed, 0 failed
```

Live boot against the 1.6 server's database: identical probe results before and after (`23 ok, 4 pre-existing`), and **deprecation notices in that boot went from 3 to 0.**

**No OpenAPI change, and `route.class.php` is touched:** no route was added, removed, renamed or re-shaped. The 16 edits change how a pattern *string* is written in PHP source, not what it evaluates to — proven above — so the document describing those routes is unaffected.

**Ported:** FOGProject/fogproject#1106 does the FOG-owned half on `dev-branch` (20 uses, four files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR