### PR TITLE
Drop deprecated "${var}" interpolation

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1880,7 +1880,7 @@ class BootMenu extends FOGBase
                 );
             }
         }
-        return array("item${hotkey}${name} ${desc}");
+        return array("item{$hotkey}{$name} {$desc}");
     }
     /**
      * The options of the menu

--- a/packages/web/lib/plugins/location/hooks/changeitems.hook.php
+++ b/packages/web/lib/plugins/location/hooks/changeitems.hook.php
@@ -298,10 +298,10 @@ class ChangeItems extends Hook
                 $initrd = $arguments['initrd'];
             }
             $arguments['webserver'] = $ip;
-            $arguments['memdisk'] = "http://${ip}/fog/service/ipxe/$memdisk";
-            $arguments['memtest'] = "http://${ip}/fog/service/ipxe/$memtest";
-            $arguments['bzImage'] = "http://${ip}/fog/service/ipxe/$bzImage";
-            $arguments['imagefile'] = "http://${ip}/fog/service/ipxe/$initrd";
+            $arguments['memdisk'] = "http://{$ip}/fog/service/ipxe/$memdisk";
+            $arguments['memtest'] = "http://{$ip}/fog/service/ipxe/$memtest";
+            $arguments['bzImage'] = "http://{$ip}/fog/service/ipxe/$bzImage";
+            $arguments['imagefile'] = "http://{$ip}/fog/service/ipxe/$initrd";
             unset($Location);
         }
     }

--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -228,7 +228,7 @@ class Pending_MAC_List extends ReportManagementPage
         echo '</h4>';
         echo '</div>';
         echo '<div class="panel-body text-center">';
-        echo _("The follow MACs have been ${msg}.");
+        echo _("The follow MACs have been {$msg}.");
         echo '<br/>';
         echo '<ul class="nav nav-pills nav-stacked">';
         echo '<li><a href="#">';

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -343,47 +343,47 @@ class Route extends FOGBase
                 'export'
             )
             ->get(
-                "${expandeda}/[current|active]",
+                "{$expandeda}/[current|active]",
                 array(__CLASS__, 'active'),
                 'active'
             )
             ->get(
-                "${expanded}/search/[*:item]",
+                "{$expanded}/search/[*:item]",
                 array(__CLASS__, 'search'),
                 'search'
             )
             ->get(
-                "${expanded}/[list|all]?",
+                "{$expanded}/[list|all]?",
                 array(__CLASS__, 'listem'),
                 'list'
             )
             ->get(
-                "${expanded}/[details]/?[*:item]?",
+                "{$expanded}/[details]/?[*:item]?",
                 array(__CLASS__, 'listdetails'),
                 'listdetails'
             )
             ->get(
-                "${expanded}/[i:id]/?[*:item]?",
+                "{$expanded}/[i:id]/?[*:item]?",
                 array(__CLASS__, 'indiv'),
                 'indiv'
             )
             ->get(
-                "${expanded}/names/[*:whereItems]?",
+                "{$expanded}/names/[*:whereItems]?",
                 array(__CLASS__, 'names'),
                 'names'
             )
             ->get(
-                "${expanded}/ids/[*:whereItems]?/[*:getField]?",
+                "{$expanded}/ids/[*:whereItems]?/[*:getField]?",
                 array(__CLASS__, 'ids'),
                 'ids'
             )
             ->put(
-                "${expanded}/[i:id]/[update|edit]?",
+                "{$expanded}/[i:id]/[update|edit]?",
                 array(__CLASS__, 'edit'),
                 'update'
             )
             ->post(
-                "${expandedt}/[i:id]/[task]",
+                "{$expandedt}/[i:id]/[task]",
                 array(__CLASS__, 'task'),
                 'task'
             )
@@ -398,17 +398,17 @@ class Route extends FOGBase
                 'uploadSnapinFiles'
             )
             ->post(
-                "${expanded}/[create|new]?",
+                "{$expanded}/[create|new]?",
                 array(__CLASS__, 'create'),
                 'create'
             )
             ->delete(
-                "${expandedt}/[i:id]?/[cancel]",
+                "{$expandedt}/[i:id]?/[cancel]",
                 array(__CLASS__, 'cancel'),
                 'cancel'
             )
             ->delete(
-                "${expanded}/[i:id]/[delete|remove]?",
+                "{$expanded}/[i:id]/[delete|remove]?",
                 array(__CLASS__, 'delete'),
                 'delete'
             );

--- a/tests/php-deprecations.test.php
+++ b/tests/php-deprecations.test.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Deprecated PHP syntax that still parses, so nothing else catches it.
+ *
+ * Currently one rule: `"${var}"` string interpolation, deprecated in PHP 8.2
+ * and slated for removal. It emits a runtime E_DEPRECATED per evaluation --
+ * not per file, per *execution* -- so a deprecated interpolation inside a
+ * router's route table or a boot-menu builder logs on every request. On an
+ * install with display_errors on, it also lands in the output stream, which
+ * is how a deprecation notice turns a JSON response into an unparseable one.
+ *
+ * `php -l` will not report it, php-cs-fixer's @PSR2 ruleset has no rule for
+ * it, and it will keep parsing right up until the release that removes it.
+ *
+ * WHY THE TOKENIZER AND NOT A REGEX. FOG's tree is full of iPXE script text
+ * held in SINGLE-quoted PHP strings:
+ *
+ *     'chain -ar ${boot-url}/service/ipxe/grub.efi'
+ *     'set arch ${buildarch}'
+ *
+ * That is iPXE's own variable syntax. It does not interpolate, it must reach
+ * the client exactly as written, and there are far more of those than there
+ * ever were real deprecations. A regex for '${' corrupts every one of them.
+ * The tokenizer only emits T_DOLLAR_OPEN_CURLY_BRACES inside a string that
+ * genuinely interpolates, so it tells the two apart and a text search cannot.
+ *
+ * Usage: php tests/php-deprecations.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+/*
+ * Vendored libraries are exempt, the same three that bin/namespace-fog-classes
+ * .php refuses to touch. They are swap candidates for their Packagist releases
+ * (ifsnop/mysqldump-php, altorouter/altorouter), so hand-editing them to
+ * silence a notice makes the swap harder and would be reverted by it anyway.
+ * Upstream's own deprecations are upstream's to fix, or ours to fix by taking
+ * a newer release.
+ */
+const VENDORED = [
+    'packages/web/lib/db/mysqldump.class.php',
+    'packages/web/lib/router/altorouter.class.php',
+    'packages/web/lib/router/altotransformer.class.php',
+];
+
+$files = array_filter(
+    explode("\n", (string) shell_exec('git ls-files "*.php"')),
+    function ($f) {
+        return '' !== $f
+            && is_readable($f)
+            && 0 !== strpos($f, 'packages/web/vendor/')
+            && !in_array($f, VENDORED, true);
+    }
+);
+
+if (count($files) < 100) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($files) . " files scanned; expected the whole "
+        . "tree. Is this a git checkout?\n"
+    );
+    exit(1);
+}
+
+$hits = [];
+foreach ($files as $file) {
+    foreach (token_get_all(file_get_contents($file)) as $token) {
+        if (is_array($token) && T_DOLLAR_OPEN_CURLY_BRACES === $token[0]) {
+            $hits[] = $file . ':' . $token[2];
+        }
+    }
+}
+
+if (count($hits) > 0) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($hits) . ' use(s) of "${var}" interpolation, '
+        . "deprecated in PHP 8.2:\n"
+    );
+    foreach ($hits as $hit) {
+        fwrite(STDERR, "  $hit\n");
+    }
+    fwrite(STDERR, "\nWrite \"{\$var}\" instead. Same value, no notice.\n");
+    exit(1);
+}
+
+printf("ok: %d file(s), no deprecated \"\${var}\" interpolation\n", count($files));
+exit(0);


### PR DESCRIPTION
Port of #1105. Verified present here before porting: **20 uses in FOG-owned code**, across four files.

| File | Count | Where |
|---|---:|---|
| `route.class.php` | 12 | `defineRoutes()`'s route table |
| `bootmenu.class.php` | 3 | one line in the menu item builder |
| `plugins/location/hooks/changeitems.hook.php` | 4 | the iPXE URLs |
| `pending_mac_list.report.php` | 1 | |

`"${var}"` was deprecated in PHP 8.2. **The notice fires per evaluation, not per file**, and the two heaviest sites are the API route table and the boot menu builder — so this logged `E_DEPRECATED` on every API request and every PXE boot. On an install with `display_errors` on it also reaches the output stream, which is how a deprecation notice turns a JSON response into an unparseable one.

Rewritten as `"{$var}"`, which evaluates identically — worth stating because 12 of the 20 are API route patterns.

### Why the tokenizer and not a regex

This tree holds a lot of iPXE script text in **single-quoted** PHP strings (`'chain -ar ${boot-url}/...'`, `'set arch ${buildarch}'`) — iPXE's own syntax, which doesn't interpolate and must reach the client byte for byte. A text search for `${` corrupts every one. The tokenizer only reports `T_DOLLAR_OPEN_CURLY_BRACES` inside a genuinely interpolating string. Verified after: zero lines mentioning `boot-url` changed.

### The vendored libraries are left alone

This branch's older copy of `lib/db/mysqldump.class.php` carries **30 more** of these. It's `ifsnop/mysqldump-php` and a swap candidate for its Packagist release, so hand-editing it makes that swap harder and would be reverted by it anyway. `working-1.6` already carries a newer copy with none, which is the shape the real fix takes there. The new test exempts the three vendored files by name and says so.

`tests/php-deprecations.test.php` runs standalone — this branch has no `tests/run-all.sh`. Negative-tested:

```
FAIL: 1 use(s) of "${var}" interpolation, deprecated in PHP 8.2:
  packages/web/lib/reports/pending_mac_list.report.php:231
```

**No OpenAPI change, and `route.class.php` is touched:** no route was added, removed, renamed or re-shaped. The edits change how a pattern string is written in source, not what it evaluates to.

### Deliberately not done here

This branch spells `FilesystemIterator` as `FileSystemIterator` in five places. On `working-1.6` that was a single outlier against eleven correct spellings and worth resolving; here it's **uniform**, so there's no inconsistency to fix and changing it would be churn on the patches line.

```
$ php tests/php-deprecations.test.php
ok: 433 file(s), no deprecated "${var}" interpolation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR