### PR TITLE
Fix untranslatable, misspelled copy on the pending-MAC report

### DIFF
--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -205,30 +205,43 @@ class Pending_MAC_List extends ReportManagementPage
             array('id' => $pendmac),
             'mac'
         );
+        /**
+         * Built per branch rather than interpolating the action word into a
+         * _() call. gettext extracts the literal source string, so the msgid
+         * in the catalog was "MACs $msg successfully" while the string looked
+         * up at runtime was "MACs approved successfully" -- a lookup that can
+         * never match, leaving both lines permanently untranslated. Also
+         * unavoidable for translators, who need the whole sentence to inflect
+         * it. Initialized so a POST with neither button set does not warn.
+         */
+        $title = '';
+        $body = '';
         if (isset($_POST['approvependmac'])) {
             self::getClass('MACAddressAssociationManager')->update(
                 array('id' => $pendmac),
                 '',
                 array('pending' => 0)
             );
-            $msg = 'approved';
+            $title = _('MACs approved successfully');
+            $body = _('The following MACs have been approved.');
         }
         if (isset($_POST['delpendmac'])) {
             self::getClass('MACAddressAssociationManager')->destroy(
                 array('id' => $pendmac)
             );
-            $msg = 'deleted';
+            $title = _('MACs deleted successfully');
+            $body = _('The following MACs have been deleted.');
         }
         unset($pendmac);
         echo '<div class="col-xs-9">';
         echo '<div class="panel panel-success">';
         echo '<div class="panel-heading text-center">';
         echo '<h4 class="title">';
-        echo _("MACs $msg successfully");
+        echo $title;
         echo '</h4>';
         echo '</div>';
         echo '<div class="panel-body text-center">';
-        echo _("The follow MACs have been {$msg}.");
+        echo $body;
         echo '<br/>';
         echo '<ul class="nav nav-pills nav-stacked">';
         echo '<li><a href="#">';

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3822,6 +3822,14 @@ msgstr "MAC-Format ist ungültig"
 msgid "MAC address is already in use by another host"
 msgstr "Die MAC-Adresse wird bereits von einem andern Host verwendet"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "ausgewählte Hosts erfolgreich freigegeben"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Regel erfolgreich gelöscht"
+
 msgid "MB Asset"
 msgstr "Mainboard-Asset"
 
@@ -6410,6 +6418,13 @@ msgstr "Die unten aufgeführten Elemente werden nur für alte Clients genutzt"
 msgid "The clients will checkin with the server from time"
 msgstr "Die Clients prüfen von Zeit zu Zeit,"
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "Alle ausstehenden MACs freigegeben."
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "Die folgenden Fehler sind aufgetreten"
 
@@ -8111,9 +8126,6 @@ msgstr "setzen Sie die Bandbreite auf diesem Knoten auf 1000."
 #, fuzzy
 #~ msgid "Add ou failed!"
 #~ msgstr "Gruppe hinzufügen fehlgeschlagen!"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "Alle ausstehenden MACs freigegeben."
 
 #~ msgid "Could not read temp file"
 #~ msgstr "Temporäre Datei konnte nicht gelesen werden."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3823,6 +3823,14 @@ msgstr "MAC Format is invalid"
 msgid "MAC address is already in use by another host"
 msgstr "MAC address is already in use by another host"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "saved successfully"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Install / Update Successful!"
+
 msgid "MB Asset"
 msgstr "MB Asset"
 
@@ -6408,6 +6416,13 @@ msgstr "This setting defines the username used for the ssh client."
 msgid "The clients will checkin with the server from time"
 msgstr ""
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "All Pending MACs approved."
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "The following errors occured"
 
@@ -8107,9 +8122,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Add ou failed!"
 #~ msgstr "Add snapin failed!"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "All Pending MACs approved."
 
 #~ msgid "Could not read temp file"
 #~ msgstr "Could not read temp file"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3824,6 +3824,14 @@ msgstr "MAC Address inválida!"
 msgid "MAC address is already in use by another host"
 msgstr "La dirección MAC ya está en uso por otro host"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "Borrar equipos seleccionados"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Borrado con éxito!"
+
 msgid "MB Asset"
 msgstr ""
 
@@ -6396,6 +6404,12 @@ msgid "The below items are only used for the old client."
 msgstr ""
 
 msgid "The clients will checkin with the server from time"
+msgstr ""
+
+msgid "The following MACs have been approved."
+msgstr ""
+
+msgid "The following MACs have been deleted."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3368,6 +3368,14 @@ msgstr "Le format de l'adresse MAC est invalide"
 msgid "MAC address is already in use by another host"
 msgstr "L'adresse MAC est déjà utilisée par un autre hôte"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "Les machines sélectionnés ont été approuvés avec succès"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Règle supprimée avec succès !"
+
 msgid "MB Asset"
 msgstr "Actif de la carte mère"
 
@@ -5648,6 +5656,13 @@ msgstr "Les éléments ci-dessous ne sont utilisés que pour l'ancien client."
 msgid "The clients will checkin with the server from time"
 msgstr "Les clients s'enregistreront auprès du serveur de temps"
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "Tous les MACs en attente approuvés."
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "Les erreurs suivantes se sont produites"
 
@@ -7145,9 +7160,6 @@ msgstr "vous définissez le champ de la bande passante sur ce nœud à 1000"
 
 #~ msgid "Add ou failed!"
 #~ msgstr "L'ajout OU a échoué !"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "Tous les MACs en attente approuvés."
 
 #~ msgid "Could not read temp file"
 #~ msgstr "Impossible de lire le fichier temporaire"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3437,6 +3437,14 @@ msgstr "MAC Format non è valido"
 msgid "MAC address is already in use by another host"
 msgstr "L'indirizzo MAC è già in uso da un altro host"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "Host selezionati approvati correttamente"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Regola eliminazione del successo"
+
 msgid "MB Asset"
 msgstr "MB Asset"
 
@@ -5770,6 +5778,13 @@ msgstr "Gli elementi riportati di seguito sono utilizzati solo per il vecchio cl
 msgid "The clients will checkin with the server from time"
 msgstr "I clienti effettueranno il check-in con il server di tanto"
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "Tutti i Mac in sospeso approvati."
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "I seguenti errori si è verificato"
 
@@ -7298,9 +7313,6 @@ msgstr "si imposti il campo di larghezza di banda su quel nodo a 1000"
 #, fuzzy
 #~ msgid "Add ou failed!"
 #~ msgstr "Aggiunta gruppo non riuscito!"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "Tutti i Mac in sospeso approvati."
 
 #~ msgid "Could not read temp file"
 #~ msgstr "Impossibile leggere il file temporaneo"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3330,6 +3330,14 @@ msgstr "MAC アドレス形式が無効です"
 msgid "MAC address is already in use by another host"
 msgstr "MAC アドレスは別のホストで既に使用されています"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "選択したホストを承認しました"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "ルールを削除しました！"
+
 msgid "MB Asset"
 msgstr "MB 資産タグ"
 
@@ -5591,6 +5599,13 @@ msgstr "以下の項目は旧クライアントでのみ使用されます。"
 
 msgid "The clients will checkin with the server from time"
 msgstr "クライアントは一定時間ごとにサーバーへチェックインします"
+
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "保留中のすべての MAC アドレスを承認しました"
+
+msgid "The following MACs have been deleted."
+msgstr ""
 
 msgid "The following errors occured"
 msgstr "次のエラーが発生しました"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3309,6 +3309,12 @@ msgstr ""
 msgid "MAC address is already in use by another host"
 msgstr ""
 
+msgid "MACs approved successfully"
+msgstr ""
+
+msgid "MACs deleted successfully"
+msgstr ""
+
 msgid "MB Asset"
 msgstr ""
 
@@ -5566,6 +5572,12 @@ msgid "The below items are only used for the old client."
 msgstr ""
 
 msgid "The clients will checkin with the server from time"
+msgstr ""
+
+msgid "The following MACs have been approved."
+msgstr ""
+
+msgid "The following MACs have been deleted."
 msgstr ""
 
 msgid "The following errors occured"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3350,6 +3350,14 @@ msgstr "Formato MAC é inválido"
 msgid "MAC address is already in use by another host"
 msgstr "Endereço MAC já está em uso por outro host"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "Hosts selecionados aprovados com sucesso"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "Regra excluída com sucesso!"
+
 msgid "MB Asset"
 msgstr "Ativo da Placa-Mãe"
 
@@ -5619,6 +5627,13 @@ msgstr "Os itens abaixo são usados apenas para o cliente antigo."
 msgid "The clients will checkin with the server from time"
 msgstr "Os clientes farão checkin com o servidor de tempos em tempos"
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "Todos os MACs Pendentes aprovados."
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "Os seguintes erros ocorreram"
 
@@ -7096,9 +7111,6 @@ msgstr "você define o campo de largura de banda naquele nó para 1000"
 
 #~ msgid "Active Multi-cast Tasks"
 #~ msgstr "Tarefas de Multicast Ativas"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "Todos os MACs Pendentes aprovados."
 
 #~ msgid "LDAP Connection  Name"
 #~ msgstr "Nome da Conexão LDAP"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3350,6 +3350,14 @@ msgstr "MAC格式无效"
 msgid "MAC address is already in use by another host"
 msgstr "MAC地址已被其他主机使用"
 
+#, fuzzy
+msgid "MACs approved successfully"
+msgstr "已批准所选主机"
+
+#, fuzzy
+msgid "MACs deleted successfully"
+msgstr "规则删除成功！"
+
 msgid "MB Asset"
 msgstr "主板资产"
 
@@ -5619,6 +5627,13 @@ msgstr "以下选项仅适用于旧版客户端"
 msgid "The clients will checkin with the server from time"
 msgstr "客户会不时与服务器进行签到"
 
+#, fuzzy
+msgid "The following MACs have been approved."
+msgstr "所有待定的MAC批准"
+
+msgid "The following MACs have been deleted."
+msgstr ""
+
 msgid "The following errors occured"
 msgstr "出现以下错误"
 
@@ -7107,9 +7122,6 @@ msgstr "你将该节点的带宽字段设置为1000"
 #, fuzzy
 #~ msgid "Add ou failed!"
 #~ msgstr "添加管理单元失败！"
-
-#~ msgid "All Pending MACs approved."
-#~ msgstr "所有待定的MAC批准"
 
 #~ msgid "Could not read temp file"
 #~ msgstr "无法读取临时文件"


### PR DESCRIPTION
The approve/delete confirmation on the Pending MAC List report built both of its sentences by interpolating an action word into a `_()` call:

```php
echo _("MACs $msg successfully");
echo _("The follow MACs have been {$msg}.");
```

Two problems, one of them invisible.

**The visible one is a typo** — "The follow MACs" should read "The following MACs".

**The invisible one is that neither line could ever be translated.** `xgettext` extracts the *literal source string*, so the msgid landing in the catalog was `"MACs $msg successfully"`. At runtime PHP interpolates first, so gettext is asked to look up `"MACs approved successfully"` — a key no catalog contains. The lookup misses, gettext returns its argument unchanged, and both lines render in English on every install regardless of the selected language. It also gave translators no way to inflect the sentence around the action word, which several languages need.

## The fix

Build the whole sentence in each branch. That yields four complete msgids `xgettext` can actually extract, and the typo goes with them. `$title`/`$body` are initialized so a POST carrying neither button does not warn on an undefined variable.

## Verification

The pre-commit hook regenerated the catalogs, which is the proof rather than an assertion — the new msgids are now present, where the interpolated forms never were:

```
$ grep -n "following MACs\|MACs approved successfully\|MACs deleted successfully" \
    packages/web/management/languages/messages.pot
3312:msgid "MACs approved successfully"
3315:msgid "MACs deleted successfully"
5577:msgid "The following MACs have been approved."
5580:msgid "The following MACs have been deleted."
```

`php -l` clean; `php tests/php-deprecations.test.php` → `ok: 433 file(s)`.

## Branches

**`dev-branch` only.** `working-1.6`'s copy of this report was rewritten and contains neither string — verified, not assumed.

## Not fixed here

The same "interpolate into `_()`" shape exists at ~10 other sites (`fogpage.class.php`, `fogconfigurationpage.class.php`, `hostmanagementpage.class.php`, `fogservice.class.php`). Same untranslatable-msgid consequence, but each needs its own judgement about how to phrase the split — that is a sweep, not this fix.

## Downstream

None. No route, no schema, no API surface — user-visible copy only, so `openapi.class.php` is untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR