### PR TITLE
Sweep gettext msgids that were built at runtime, and gate it

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -815,14 +815,16 @@ abstract class FOGPage extends FOGBase
         $refNode = _($refNode);
         $menu = [];
         $menu = [
+            /**
+             * No _() around the sprintf: $refNode was already translated on
+             * its own above, and a msgid built at runtime can never match the
+             * literal xgettext extracted -- so the outer call was a guaranteed
+             * miss that returned its own argument. Dropping it changes nothing
+             * at runtime and stops the line claiming to be translatable.
+             */
             'list' => sprintf(
                 self::$foglang['ListAll'],
-                _(
-                    sprintf(
-                        '%ss',
-                        $refNode
-                    )
-                )
+                sprintf('%ss', $refNode)
             ),
             'add' => sprintf(
                 self::$foglang['CreateNew'],
@@ -998,7 +1000,7 @@ abstract class FOGPage extends FOGBase
             if ($node == 'ipxe') {
                 $this->title = _('All Boot Menu Items');
             } else {
-                $this->title = _('All ' . $this->childClass . 's');
+                $this->title = sprintf(_('All %s'), $this->childClass . 's');
             }
             $this->indexDivDisplay();
         } else {
@@ -2716,7 +2718,7 @@ abstract class FOGPage extends FOGBase
             _('Delete')
             . ': '
             . \Initiator::e($this->obj->get('name')),
-            _("Confirm you would like to delete this $node")
+            sprintf(_('Confirm you would like to delete this %s'), $node)
             . $extra,
             self::makeButton(
                 'closeDeleteModal',
@@ -2744,8 +2746,11 @@ abstract class FOGPage extends FOGBase
     {
         return self::makeModal(
             "{$item}DelModal",
-            _("Remove $item Associations"),
-            _("Please confirm you would like to dissociate the selected {$item}s"),
+            sprintf(_('Remove %s Associations'), $item),
+            sprintf(
+                _('Please confirm you would like to dissociate the selected %s'),
+                $item . 's'
+            ),
             self::makeButton(
                 "close{$item}DeleteModal",
                 _('Cancel'),
@@ -5514,7 +5519,10 @@ abstract class FOGPage extends FOGBase
             $this->attributes[] = [];
         }
 
-        $this->title = _('Export '. ucfirst(strtolower($this->childClass)) . 's');
+        $this->title = sprintf(
+            _('Export %s'),
+            ucfirst(strtolower($this->childClass)) . 's'
+        );
 
         echo '<div class="card">';
         echo '<div class="card-header">';

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -3195,7 +3195,7 @@ class HostManagement extends FOGPage
                     self::makeLabel(
                         $labelClass,
                         'inventory-gpu-vendor-' . $i,
-                        _("GPU-$i Vendor")
+                        sprintf(_('GPU-%d Vendor'), $i)
                     )
                 ] = self::makeInput(
                     'form-control',
@@ -3215,7 +3215,7 @@ class HostManagement extends FOGPage
                     self::makeLabel(
                         $labelClass,
                         'inventory-gpu-product-' . $i,
-                        _("GPU-$i Product")
+                        sprintf(_('GPU-%d Product'), $i)
                     )
                 ] = self::makeInput(
                     'form-control',

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -117,18 +117,18 @@ class Registration extends FOGBase
             self::getClass('HostManager')->getHostByMacAddresses($this->PriMAC);
             if (self::$Host->isValid()) {
                 throw new \Exception(
-                    _(
-                        'This machine already registered as '
-                        . self::$Host->get('name')
+                    sprintf(
+                        _('This machine already registered as %s'),
+                        self::$Host->get('name')
                     )
                 );
             }
             self::getClass('HostManager')->getHostByMacAddresses($this->MACs);
             if (self::$Host->isValid()) {
                 throw new \Exception(
-                    _(
-                        'This machine already registered as '
-                        . self::$Host->get('name')
+                    sprintf(
+                        _('This machine already registered as %s'),
+                        self::$Host->get('name')
                     )
                 );
             }
@@ -158,9 +158,9 @@ class Registration extends FOGBase
             $hostnameSafe = self::getClass('Host')->isHostnameSafe($host);
             if (!$hostnameSafe) {
                 throw new \Exception(
-                    _(
-                        'Unsafe hostname entered, please try again: '
-                        . $host
+                    sprintf(
+                        _('Unsafe hostname entered, please try again: %s'),
+                        $host
                     )
                 );
             }

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -195,7 +195,10 @@ abstract class TaskingElement extends FOGBase
             );
             if (count($names ?: []) <= 0) {
                 throw new \Exception(
-                    _('There are no ' . $classname . 's on this server')
+                    sprintf(
+                        _('There are no %s on this server'),
+                        $classname . 's'
+                    )
                 );
             }
             foreach ($names as $item) {

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -177,7 +177,7 @@ abstract class FOGService extends FOGBase
         }
         foreach (self::$ips as &$ip) {
             self::outall(
-                _("Interface Ready with IP Address: $ip")
+                sprintf(_('Interface Ready with IP Address: %s'), $ip)
             );
             unset($ip);
         }
@@ -415,7 +415,7 @@ abstract class FOGService extends FOGBase
         if ($groupOrNodeCount < $counttest) {
             self::outall(
                 ' * ' . _('Not syncing') . ' ' . $objType . ' '
-                . _('between') . ' ' . _("{$itemType}s")
+                . _('between') . ' ' . _($itemType) . 's'
             );
             self::outall(
                 ' | ' . $objType . ' ' . _('Name') . ': ' . $Obj->get('name')
@@ -431,7 +431,7 @@ abstract class FOGService extends FOGBase
             . (
                 $groupOrNodeCount == 1 ?
                 _($itemType) :
-                _("{$itemType}s")
+                _($itemType) . 's'
             )
         );
         $nfilename = ($fileOverride ?: $Obj->get('name'));
@@ -496,7 +496,7 @@ abstract class FOGService extends FOGBase
             if (!file_exists($myAdd) || !is_readable($myAdd)) {
                 self::outall(
                     ' * ' . _('Not syncing') . ' ' . $objType
-                    . ' ' . _('between') . ' ' . _("{$itemType}s")
+                    . ' ' . _('between') . ' ' . _($itemType) . 's'
                 );
                 self::outall(
                     ' | ' . ($fileOverride ? _('File') : _($objType))

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -659,8 +659,8 @@ msgstr "Ago muss boolean sein"
 msgid "All"
 msgstr "Alle"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "Alle Hosts"
 
 msgid "All Boot Menu Items"
@@ -1396,6 +1396,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2176,8 +2180,8 @@ msgstr ""
 msgid "Export"
 msgstr "Export"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Export"
 
 #, fuzzy
@@ -2665,6 +2669,14 @@ msgstr "Produktschlüssel der Gruppe"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "BIOS-Anbieter"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Produktschlüssel der Gruppe"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "BIOS-Anbieter"
 
 msgid "General"
@@ -3759,6 +3771,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Schnittstelle"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr "Netzwerkschnittstelle nicht bereit, warte auf deren Start"
@@ -5475,6 +5491,10 @@ msgstr "Bitte wählen Sie ein Image"
 msgid "Please confirm you want to delete"
 msgstr "Löschen bitte bestätigen"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Löschen bitte bestätigen"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5937,6 +5957,10 @@ msgstr "Remote-Adresse versucht, sich anzumelden"
 
 msgid "Remove"
 msgstr "Entfernen"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Regel Zuordnung"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7622,9 +7646,9 @@ msgstr "Es gibt"
 msgid "There are many reasons why this could be the case"
 msgstr "Es gibt mehrere Möglichkeiten, wieso das so ist."
 
-#, fuzzy
-msgid "There are no "
-msgstr "Es gibt"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7725,8 +7749,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
 #, fuzzy
@@ -8089,7 +8113,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9946,6 +9971,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "Es gibt"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -663,8 +663,8 @@ msgstr ""
 msgid "All"
 msgstr "All"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "All Hosts"
 
 msgid "All Boot Menu Items"
@@ -1399,6 +1399,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Error: Failed to download kernel"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2178,8 +2182,8 @@ msgstr ""
 msgid "Export"
 msgstr "Export"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Export"
 
 #, fuzzy
@@ -2667,6 +2671,14 @@ msgstr "Group Product Key"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "BIOS Vendor"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Group Product Key"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "BIOS Vendor"
 
 msgid "General"
@@ -3761,6 +3773,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interface"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
@@ -5475,6 +5491,10 @@ msgstr "Please choose an image"
 msgid "Please confirm you want to delete"
 msgstr "Please confirm you want to delete"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Please confirm you want to delete"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5937,6 +5957,10 @@ msgstr ""
 
 msgid "Remove"
 msgstr "Remove"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Image Association"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7620,9 +7644,9 @@ msgstr "There are"
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-#, fuzzy
-msgid "There are no "
-msgstr "There are"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "There are no groups on this server."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7722,8 +7746,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Already registered as"
 
 #, fuzzy
@@ -8087,7 +8111,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9926,6 +9951,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Printer already exists"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "There are"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -675,8 +675,8 @@ msgstr ""
 msgid "All"
 msgstr "Todas"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "Hospedadores"
 
 msgid "All Boot Menu Items"
@@ -1420,6 +1420,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Error: No se pudo descargar kernel"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2217,8 +2221,8 @@ msgstr ""
 msgid "Export"
 msgstr "Exportar"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Exportar"
 
 #, fuzzy
@@ -2722,6 +2726,14 @@ msgstr "Clave del producto Grupo"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "Vendedor del BIOS"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Clave del producto Grupo"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "Vendedor del BIOS"
 
 msgid "General"
@@ -3844,6 +3856,10 @@ msgid "Intel 64 Bit"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
 msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
@@ -5613,6 +5629,10 @@ msgstr "Por favor, seleccione una imagen"
 msgid "Please confirm you want to delete"
 msgstr "Por favor, confirme que desea borrar"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Por favor, confirme que desea borrar"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -6085,6 +6105,10 @@ msgstr ""
 
 msgid "Remove"
 msgstr "retirar"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Asociación para la imagen"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7809,9 +7833,9 @@ msgstr "Existen"
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-#, fuzzy
-msgid "There are no "
-msgstr "Existen"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7910,8 +7934,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Impresora ya existe"
 
 #, fuzzy
@@ -8269,7 +8293,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -10109,6 +10134,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impresora ya existe"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "Existen"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -659,8 +659,8 @@ msgstr "Ago muss boolean sein"
 msgid "All"
 msgstr "Alle"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "Alle Hosts"
 
 msgid "All Boot Menu Items"
@@ -1396,6 +1396,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2176,8 +2180,8 @@ msgstr ""
 msgid "Export"
 msgstr "Export"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Export"
 
 #, fuzzy
@@ -2665,6 +2669,14 @@ msgstr "Produktschlüssel der Gruppe"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "BIOS-Anbieter"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Produktschlüssel der Gruppe"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "BIOS-Anbieter"
 
 msgid "General"
@@ -3759,6 +3771,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Schnittstelle"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 #, fuzzy
 msgid "Interface not ready, waiting for it to come up"
@@ -5476,6 +5492,10 @@ msgstr "Bitte wählen Sie ein Image"
 msgid "Please confirm you want to delete"
 msgstr "Löschen bitte bestätigen"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Löschen bitte bestätigen"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5938,6 +5958,10 @@ msgstr "Remote-Adresse versucht, sich anzumelden"
 
 msgid "Remove"
 msgstr "Entfernen"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Regel Zuordnung"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7623,9 +7647,9 @@ msgstr "Es gibt"
 msgid "There are many reasons why this could be the case"
 msgstr "Es gibt mehrere Möglichkeiten, wieso das so ist."
 
-#, fuzzy
-msgid "There are no "
-msgstr "Es gibt"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7726,8 +7750,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
 #, fuzzy
@@ -8090,7 +8114,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9947,6 +9972,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "Es gibt"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -664,8 +664,8 @@ msgstr ""
 msgid "All"
 msgstr "Tout"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "Tous les hôtes"
 
 msgid "All Boot Menu Items"
@@ -1401,6 +1401,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Erreur: Impossible de télécharger le noyau"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2180,8 +2184,8 @@ msgstr ""
 msgid "Export"
 msgstr "Exportation"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Exportation"
 
 #, fuzzy
@@ -2669,6 +2673,14 @@ msgstr "Groupe clé de produit"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "Vendor BIOS"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Groupe clé de produit"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "Vendor BIOS"
 
 msgid "General"
@@ -3763,6 +3775,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interface"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
@@ -5477,6 +5493,10 @@ msgstr "S'il vous plaît choisir une image"
 msgid "Please confirm you want to delete"
 msgstr "S'il vous plaît confirmer que vous souhaitez supprimer"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "S'il vous plaît confirmer que vous souhaitez supprimer"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5939,6 +5959,10 @@ msgstr ""
 
 msgid "Remove"
 msgstr "Retirer"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Association Image"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7622,9 +7646,9 @@ msgstr "Il y a"
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-#, fuzzy
-msgid "There are no "
-msgstr "Il y a"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "Il n'y a pas de groupes sur ce serveur."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7724,8 +7748,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Déjà inscrit comme"
 
 #, fuzzy
@@ -8089,7 +8113,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9932,6 +9957,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Imprimante existe déjà"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "Il y a"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -637,8 +637,8 @@ msgstr "Fa deve essere boolean"
 msgid "All"
 msgstr "Tutti"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "tutti gli host"
 
 msgid "All Boot Menu Items"
@@ -1347,6 +1347,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Errore: Impossibile scaricare il kernel"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2110,8 +2114,8 @@ msgstr ""
 msgid "Export"
 msgstr "Esportare"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Esportare"
 
 #, fuzzy
@@ -2580,6 +2584,14 @@ msgstr "Product Key Group"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "Venditore BIOS"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Product Key Group"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "Venditore BIOS"
 
 msgid "General"
@@ -3633,6 +3645,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interfaccia"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr "Interfaccia non pronta, in attesa che venga visualizzata"
@@ -5276,6 +5292,10 @@ msgstr "Scegliere un immagine"
 msgid "Please confirm you want to delete"
 msgstr "Conferma che desideri eliminare"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Conferma che desideri eliminare"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5725,6 +5745,10 @@ msgstr "Indirizzo remoto che cerca di accedere"
 
 msgid "Remove"
 msgstr "Rimuovere"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Regole di associazione"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7332,9 +7356,9 @@ msgstr "Ci sono"
 msgid "There are many reasons why this could be the case"
 msgstr "Ci sono molte ragioni per cui questo potrebbe essere il caso"
 
-#, fuzzy
-msgid "There are no "
-msgstr "Ci sono"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "Non ci sono gruppi su questo server"
 
 msgid "There are no groups on this server"
 msgstr "Non ci sono gruppi su questo server"
@@ -7431,8 +7455,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Già registrato come"
 
 #, fuzzy
@@ -7784,7 +7808,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9549,6 +9574,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Questo host esiste già"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "Ci sono"
 
 #~ msgid "There are no locations on this server"
 #~ msgstr "Non ci sono posizioni su questo server"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -618,8 +618,8 @@ msgstr "Ago はブール値である必要があります"
 msgid "All"
 msgstr "すべて"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "すべてのホスト"
 
 #, fuzzy
@@ -1329,6 +1329,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "エラー: initrd のダウンロードに失敗しました"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2091,8 +2095,8 @@ msgstr ""
 msgid "Export"
 msgstr "エクスポート"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "エクスポート"
 
 #, fuzzy
@@ -2552,6 +2556,14 @@ msgid "GPU Products"
 msgstr "GPU 製品"
 
 msgid "GPU Vendors"
+msgstr "GPU ベンダー"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "GPU 製品"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "GPU ベンダー"
 
 msgid "General"
@@ -3595,6 +3607,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "インターフェイス"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr "インターフェイスの準備ができていません。起動を待機しています"
@@ -5230,6 +5246,10 @@ msgstr "イメージを選択してください"
 msgid "Please confirm you want to delete"
 msgstr "削除してもよろしいですか"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "削除してもよろしいですか"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5676,6 +5696,10 @@ msgstr "ログインを試行したリモートアドレス"
 
 msgid "Remove"
 msgstr "削除"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "ルールの関連付け"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7260,9 +7284,9 @@ msgstr "あります"
 msgid "There are many reasons why this could be the case"
 msgstr "この問題にはさまざまな原因が考えられます"
 
-#, fuzzy
-msgid "There are no "
-msgstr "あります"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "このサーバーにはグループがありません"
 
 msgid "There are no groups on this server"
 msgstr "このサーバーにはグループがありません"
@@ -7358,8 +7382,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "既に次の名前で登録されています:"
 
 #, fuzzy
@@ -7709,8 +7733,9 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
-msgstr ""
+#, fuzzy, php-format
+msgid "Unsafe hostname entered, please try again: %s"
+msgstr "ロケーションは既に存在します。再試行してください。"
 
 msgid "Unset"
 msgstr ""
@@ -10818,6 +10843,10 @@ msgstr ""
 
 #~ msgid "There are currently"
 #~ msgstr "現在"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "あります"
 
 #~ msgid "There are no locations on this server"
 #~ msgstr "このサーバーにはロケーションがありません"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -551,7 +551,8 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-msgid "All "
+#, php-format
+msgid "All %s"
 msgstr ""
 
 msgid "All Boot Menu Items"
@@ -1185,6 +1186,10 @@ msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
+msgstr ""
+
+#, php-format
+msgid "Confirm you would like to delete this %s"
 msgstr ""
 
 msgid "Confirm you would like to download a new initrd"
@@ -1849,7 +1854,8 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-msgid "Export "
+#, php-format
+msgid "Export %s"
 msgstr ""
 
 msgid "Export Broadcasts"
@@ -2266,6 +2272,14 @@ msgid "GPU Products"
 msgstr ""
 
 msgid "GPU Vendors"
+msgstr ""
+
+#, php-format
+msgid "GPU-%d Product"
+msgstr ""
+
+#, php-format
+msgid "GPU-%d Vendor"
 msgstr ""
 
 msgid "General"
@@ -3173,6 +3187,10 @@ msgid "Intel 64 Bit"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
 msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
@@ -4640,6 +4658,10 @@ msgstr ""
 msgid "Please confirm you want to delete"
 msgstr ""
 
+#, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr ""
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5033,6 +5055,10 @@ msgid "Remote address attempting to login"
 msgstr ""
 
 msgid "Remove"
+msgstr ""
+
+#, php-format
+msgid "Remove %s Associations"
 msgstr ""
 
 msgid "Remove Fail"
@@ -6456,7 +6482,8 @@ msgstr ""
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-msgid "There are no "
+#, php-format
+msgid "There are no %s on this server"
 msgstr ""
 
 msgid "There are no groups on this server"
@@ -6548,7 +6575,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-msgid "This machine already registered as "
+#, php-format
+msgid "This machine already registered as %s"
 msgstr ""
 
 msgid "This node could not be found"
@@ -6862,7 +6890,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -663,8 +663,8 @@ msgstr ""
 msgid "All"
 msgstr "Todos"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "Todos os hosts"
 
 msgid "All Boot Menu Items"
@@ -1400,6 +1400,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "Erro: falha ao baixar do kernel"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2179,8 +2183,8 @@ msgstr ""
 msgid "Export"
 msgstr "Exportar"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "Exportar"
 
 #, fuzzy
@@ -2668,6 +2672,14 @@ msgstr "Grupo de Chave de Produto"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "BIOS Vendor"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Grupo de Chave de Produto"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "BIOS Vendor"
 
 msgid "General"
@@ -3762,6 +3774,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interface"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
@@ -5476,6 +5492,10 @@ msgstr "Por favor, escolha uma imagem"
 msgid "Please confirm you want to delete"
 msgstr "Por favor, confirme que você deseja excluir"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "Por favor, confirme que você deseja excluir"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5938,6 +5958,10 @@ msgstr ""
 
 msgid "Remove"
 msgstr "Remover"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "Associação imagem"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7621,9 +7645,9 @@ msgstr "tem"
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-#, fuzzy
-msgid "There are no "
-msgstr "tem"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "Não existem grupos neste servidor."
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7723,8 +7747,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "Já está registado como"
 
 #, fuzzy
@@ -8088,7 +8112,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9931,6 +9956,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impressora já existe"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "tem"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -663,8 +663,8 @@ msgstr ""
 msgid "All"
 msgstr "所有"
 
-#, fuzzy
-msgid "All "
+#, fuzzy, php-format
+msgid "All %s"
 msgstr "所有主机"
 
 msgid "All Boot Menu Items"
@@ -1400,6 +1400,10 @@ msgstr ""
 
 msgid "Confirm that you would like to update the MAC vendor listing"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Confirm you would like to delete this %s"
+msgstr "错误：无法下载内核"
 
 #, fuzzy
 msgid "Confirm you would like to download a new initrd"
@@ -2179,8 +2183,8 @@ msgstr ""
 msgid "Export"
 msgstr "出口"
 
-#, fuzzy
-msgid "Export "
+#, fuzzy, php-format
+msgid "Export %s"
 msgstr "出口"
 
 #, fuzzy
@@ -2668,6 +2672,14 @@ msgstr "集团产品密钥"
 
 #, fuzzy
 msgid "GPU Vendors"
+msgstr "BIOS供应商"
+
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "集团产品密钥"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
 msgstr "BIOS供应商"
 
 msgid "General"
@@ -3762,6 +3774,10 @@ msgstr ""
 
 msgid "Interface"
 msgstr "接口"
+
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
 
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
@@ -5476,6 +5492,10 @@ msgstr "请选择一个图像"
 msgid "Please confirm you want to delete"
 msgstr "请确认您要删除"
 
+#, fuzzy, php-format
+msgid "Please confirm you would like to dissociate the selected %s"
+msgstr "请确认您要删除"
+
 msgid "Please confirm you would like to dissociate the selected directory groups"
 msgstr ""
 
@@ -5938,6 +5958,10 @@ msgstr ""
 
 msgid "Remove"
 msgstr "去掉"
+
+#, fuzzy, php-format
+msgid "Remove %s Associations"
+msgstr "图像协会"
 
 #, fuzzy
 msgid "Remove Fail"
@@ -7621,9 +7645,9 @@ msgstr "有"
 msgid "There are many reasons why this could be the case"
 msgstr ""
 
-#, fuzzy
-msgid "There are no "
-msgstr "有"
+#, fuzzy, php-format
+msgid "There are no %s on this server"
+msgstr "有此服务器上没有组。"
 
 #, fuzzy
 msgid "There are no groups on this server"
@@ -7723,8 +7747,8 @@ msgstr ""
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
-#, fuzzy
-msgid "This machine already registered as "
+#, fuzzy, php-format
+msgid "This machine already registered as %s"
 msgstr "已注册为"
 
 #, fuzzy
@@ -8088,7 +8112,8 @@ msgstr ""
 msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
 msgstr ""
 
-msgid "Unsafe hostname entered, please try again: "
+#, php-format
+msgid "Unsafe hostname entered, please try again: %s"
 msgstr ""
 
 msgid "Unset"
@@ -9931,6 +9956,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "打印机已经存在"
+
+#, fuzzy
+#~ msgid "There are no "
+#~ msgstr "有"
 
 #, fuzzy
 #~ msgid "There are no locations on this server"

--- a/tests/gettext-literal-msgid.test.php
+++ b/tests/gettext-literal-msgid.test.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * A gettext msgid must be a literal, not a sentence built at runtime.
+ *
+ * xgettext extracts the LITERAL SOURCE TEXT of a _() argument. PHP evaluates
+ * that argument before _() is ever called. So when the two differ, the msgid
+ * in the catalog and the string looked up at runtime are different strings,
+ * and the lookup can never hit:
+ *
+ *     echo _("MACs $msg successfully");
+ *
+ *     msgid in messages.pot:  "MACs $msg successfully"
+ *     looked up at runtime:   "MACs approved successfully"
+ *
+ * gettext misses, returns its argument unchanged, and the line renders in
+ * English on every install regardless of the selected language. Nothing
+ * errors and nothing logs -- the only symptom is a string that is never
+ * translated, which is invisible to anyone testing in English. It also
+ * leaves translators no way to inflect the sentence around the variable,
+ * which several of the shipped languages need.
+ *
+ * WHAT THIS FORBIDS: mixing literal text with a variable in one msgid.
+ *   _("Add selected $type")           -> sprintf(_('Add selected %s'), $type)
+ *   _('Remove ' . $type)              -> sprintf(_('Remove %s'), $type)
+ *   _(sprintf('Invalid %s', $var))    -> sprintf(_('Invalid %s'), $var)
+ *
+ * The fix is always the same shape: the literal goes INSIDE _(), the variable
+ * is substituted OUTSIDE it. That gives xgettext a complete format string to
+ * extract and gives the translator a placeholder they can move.
+ *
+ * WHAT THIS ALLOWS, deliberately: a bare runtime lookup with no literal text
+ * of its own, e.g. _($node) or _(ucwords($report)). That is a different and
+ * much weaker problem -- it resolves correctly whenever the VALUE is itself a
+ * msgid extracted from some other literal site, which is how FOG translates
+ * class and node names. xgettext cannot verify that, so it stays fragile, but
+ * it is not broken by construction the way the mixed form is. Drawing the
+ * line here needs no allowlist: an argument either carries literal text or it
+ * does not.
+ *
+ * Usage: php tests/gettext-literal-msgid.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$files = array_filter(
+    explode("\n", (string) shell_exec('git ls-files "*.php"')),
+    function ($f) {
+        return '' !== $f
+            && is_readable($f)
+            && 0 !== strpos($f, 'packages/web/vendor/');
+    }
+);
+
+if (count($files) < 100) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($files) . " files scanned; expected the whole "
+        . "tree. Is this a git checkout?\n"
+    );
+    exit(1);
+}
+
+/**
+ * Collect the tokens of a call's first argument.
+ *
+ * @param array $t     full token stream
+ * @param int   $open  index of the opening parenthesis
+ *
+ * @return array tokens between the parens, stopping at a depth-1 comma
+ */
+function firstArgument(array $t, $open)
+{
+    $depth = 0;
+    $arg = [];
+    for ($k = $open, $n = count($t); $k < $n; $k++) {
+        $c = $t[$k];
+        if (!is_array($c)) {
+            if ('(' === $c || '[' === $c || '{' === $c) {
+                $depth++;
+            } elseif (')' === $c || ']' === $c || '}' === $c) {
+                if (0 === --$depth) {
+                    break;
+                }
+            } elseif (',' === $c && 1 === $depth) {
+                break;
+            }
+        }
+        if ($depth >= 1 && $k > $open) {
+            $arg[] = $c;
+        }
+    }
+    return $arg;
+}
+
+$hits = [];
+foreach ($files as $file) {
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        $tok = $t[$i];
+        if (!is_array($tok) || T_STRING !== $tok[0]) {
+            continue;
+        }
+        if ('_' !== $tok[1] && 'gettext' !== $tok[1]) {
+            continue;
+        }
+        /*
+         * Skip anything that is not a plain call: ->_(, ::_(, function _(.
+         * A method happening to be named _ is not gettext.
+         */
+        $p = $i - 1;
+        while ($p >= 0 && is_array($t[$p])
+            && in_array($t[$p][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            $p--;
+        }
+        if ($p >= 0 && is_array($t[$p]) && in_array(
+            $t[$p][0],
+            [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_NEW],
+            true
+        )) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || '(' !== $t[$j]) {
+            continue;
+        }
+
+        $arg = firstArgument($t, $j);
+        // Leading whitespace is real -- _( sprintf(...) ) is written that way
+        // in the tree -- so find the first token that is not whitespace and
+        // compare against that, not against index 0.
+        $lead = null;
+        foreach ($arg as $idx => $a) {
+            if (!is_array($a) || T_WHITESPACE !== $a[0]) {
+                $lead = $idx;
+                break;
+            }
+        }
+        $kind = null;
+        $depth = 0;
+        foreach ($arg as $idx => $a) {
+            if (!is_array($a)) {
+                if ('(' === $a || '[' === $a) {
+                    $depth++;
+                    continue;
+                }
+                if (')' === $a || ']' === $a) {
+                    $depth--;
+                    continue;
+                }
+                /*
+                 * A double-quoted string that interpolates is tokenized as a
+                 * bare '"' delimiter with parts between; one that does not is
+                 * a single T_CONSTANT_ENCAPSED_STRING. So a bare '"' here IS
+                 * the interpolation.
+                 */
+                if ('"' === $a) {
+                    $kind = 'interpolated string';
+                    break;
+                }
+                // Concatenation, but only when a variable is one of the
+                // operands -- xgettext folds 'a' . 'b' into one msgid fine.
+                if ('.' === $a && 0 === $depth) {
+                    foreach ($arg as $b) {
+                        if (is_array($b) && T_VARIABLE === $b[0]) {
+                            $kind = 'concatenated with a variable';
+                            break 2;
+                        }
+                    }
+                }
+                continue;
+            }
+            if (T_START_HEREDOC === $a[0]) {
+                $kind = 'heredoc';
+                break;
+            }
+            /*
+             * sprintf() INSIDE _() is the same bug wearing a placeholder: the
+             * format string is the msgid and it has to be the _() argument,
+             * not sprintf's. Only flag the outermost call, i.e. sprintf as
+             * the whole argument.
+             */
+            if (T_STRING === $a[0] && 0 === $depth && $idx === $lead
+                && in_array(strtolower($a[1]), ['sprintf', 'vsprintf'], true)
+            ) {
+                $kind = 'sprintf inside _()';
+                break;
+            }
+        }
+        if (null === $kind) {
+            continue;
+        }
+        $src = '';
+        foreach ($arg as $a) {
+            $src .= is_array($a) ? $a[1] : $a;
+        }
+        $src = trim(preg_replace('/\s+/', ' ', $src));
+        if (strlen($src) > 70) {
+            $src = substr($src, 0, 67) . '...';
+        }
+        $hits[] = sprintf('%s:%d  [%s]  _(%s)', $file, $tok[2], $kind, $src);
+    }
+}
+
+if (count($hits) > 0) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($hits) . " gettext msgid(s) built at runtime, so the "
+        . "extracted\nmsgid can never match the string looked up:\n"
+    );
+    foreach ($hits as $hit) {
+        fwrite(STDERR, "  $hit\n");
+    }
+    fwrite(
+        STDERR,
+        "\nPut the literal inside _() and substitute outside it:\n"
+        . "  sprintf(_('Add selected %s'), \$type)\n"
+    );
+    exit(1);
+}
+
+printf("ok: %d file(s), every gettext msgid is a literal\n", count($files));
+exit(0);


### PR DESCRIPTION
`xgettext` extracts the **literal source text** of a `_()` argument, but PHP evaluates that argument before `_()` is ever called. Where the two differ, the msgid sitting in the catalog and the string looked up at runtime are different strings, and the lookup can never hit.

```php
echo _("Add selected $getType");

// msgid in messages.pot:  "Add selected $getType"
// looked up at runtime:   "Add selected Image"
```

gettext misses, returns its argument unchanged, and the string renders **in English on every install whatever language is selected**. Nothing errors and nothing logs. The only symptom is a string that is never translated — invisible to anyone testing in English, which is why so many had accumulated.

This is the sweep of the bug class #1108 fixed one instance of.

## The fix

Same shape throughout: the literal goes **inside** `_()`, the variable is substituted **outside** it. That is already the house style — `openapi.class.php` uses it a dozen times and `$foglang['ListAll']` is literally `_('List All %s')`. It hands `xgettext` a complete format string and hands the translator a placeholder they can move, which matters: several shipped languages cannot keep English's word order.

Two sites needed something else:

- The submenu builder wrapped `_()` around a `sprintf` whose argument had **already been translated** a few lines above. The outer call was a guaranteed miss returning its own argument, so it is simply removed — a no-op at runtime.
- `fogservice.class.php`'s `_("{$itemType}s")` becomes `_($itemType) . 's'`, matching the `_($itemType)` already sitting three lines away in the same expression. Same rendered output, and it can now resolve.

## The gate

`tests/gettext-literal-msgid.test.php` draws its line at **does this msgid mix literal text with a variable**. It deliberately still *allows* a bare runtime lookup like `_($node)`: that resolves correctly whenever the value is itself a msgid extracted from some other literal site, which is how FOG translates node and class names. Fragile, since `xgettext` cannot verify it — but not broken by construction the way the mixed form is. The distinction needs no allowlist: an argument either carries literal text or it does not.

Tokenizer-based, for the same reason `php-deprecations.test.php` is: a regex cannot tell an interpolating `"…"` from a non-interpolating one, and cannot tell `_(` the gettext call from `->_(` a method.

## Verification

The proof is the catalog the pre-commit hook regenerated, not an assertion — every new msgid is now extractable where the composed forms never were:

```
All %s
Confirm you would like to delete this %s
Remove %s Associations
Please confirm you would like to dissociate the selected %s
Export %s
GPU-%d Vendor / GPU-%d Product
This machine already registered as %s
Unsafe hostname entered, please try again: %s
There are no %s on this server
Interface Ready with IP Address: %s
```

`php -l` clean on every changed file; the new gate passes on both branches.

## Not fixed here

`fogservice.class.php` builds its log lines by concatenating separately-translated fragments (`_('Not syncing')` + type + `_('between')` + …). That is a real i18n problem, but rewriting those into whole sentences changes daemon log output people grep, so it wants its own change.

## Downstream

None. No route, no schema, no API surface — `openapi.class.php` untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
