### PR TITLE
Sweep gettext msgids that were built at runtime, and gate it

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -436,14 +436,16 @@ abstract class FOGPage extends FOGBase
         $exportMenu = sprintf('Export%s', $this->childClass);
         $importMenu = sprintf('Import%s', $this->childClass);
         $this->menu = array(
+            /**
+             * No _() around the sprintf: a msgid built at runtime can never
+             * match the literal xgettext extracted, so the outer call was a
+             * guaranteed miss that returned its own argument. Dropping it
+             * changes nothing at runtime and stops the line claiming to be
+             * translatable.
+             */
             'list' => sprintf(
                 self::$foglang['ListAll'],
-                _(
-                    sprintf(
-                        '%ss',
-                        $this->childClass
-                    )
-                )
+                sprintf('%ss', $this->childClass)
             ),
             'add' => sprintf(
                 self::$foglang['CreateNew'],
@@ -516,9 +518,8 @@ abstract class FOGPage extends FOGBase
         $this->title = _('Search');
         if (in_array($this->node, self::$searchPages)) {
             $this->title = sprintf(
-                '%s %s',
-                _('All'),
-                _("{$this->childClass}s")
+                _('All %s'),
+                $this->childClass . 's'
             );
             global $node;
             global $sub;
@@ -3958,7 +3959,7 @@ abstract class FOGPage extends FOGBase
             . $this->node
             . '1" class="toggle-checkbox1" id="toggler"/>'
             . '</label>',
-            _(ucfirst($objType) . ' Name')
+            sprintf(_('%s Name'), ucfirst($objType))
         );
         $this->templates = array(
             '<label for="host-${host_id}">'
@@ -4039,7 +4040,7 @@ abstract class FOGPage extends FOGBase
                 . '" id="'
                 . $meShow
                 . '"/>';
-            echo _("Check here to see what $getType can be added");
+            printf(_('Check here to see what %s can be added'), $getType);
             echo '</label>';
             echo '</div>';
             echo '</div>';
@@ -4060,7 +4061,7 @@ abstract class FOGPage extends FOGBase
             echo '<label for="update'
                 . $getType
                 . '" class="control-label col-xs-4">';
-            echo _("Add selected $getType");
+            printf(_('Add selected %s'), $getType);
             echo '</label>';
             echo '<div class="col-xs-8">';
             echo '<button type="submit" name="addHosts" '
@@ -4084,7 +4085,7 @@ abstract class FOGPage extends FOGBase
             '<label for="toggler1">'
             . '<input type="checkbox" name="toggle-checkbox" '
             . 'class="toggle-checkboxAction" id="toggler1"/></label>',
-            _(ucfirst($objType) . ' Name')
+            sprintf(_('%s Name'), ucfirst($objType))
         );
         $this->templates = array(
             '<label for="hostrm-${host_id}">'
@@ -4108,14 +4109,14 @@ abstract class FOGPage extends FOGBase
             echo '<div class="panel panel-warning">';
             echo '<div class="panel-heading text-center">';
             echo '<h4 class="title">';
-            echo _('Remove ' . ucfirst($getType));
+            printf(_('Remove %s'), ucfirst($getType));
             echo '</h4>';
             echo '</div>';
             echo '<div class="panel-body">';
             $this->render(12);
             echo '<div class="form-group">';
             echo '<label for="remhosts" class="control-label col-xs-4">';
-            echo _('Remove selected ' . $getType);
+            printf(_('Remove selected %s'), $getType);
             echo '</label>';
             echo '<div class="col-xs-8">';
             echo '<button type="submit" name="remhosts" class='

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -1918,7 +1918,10 @@ class FOGConfigurationPage extends FOGPage
             unset($DefMenuIDs);
             $msg = json_encode(
                 array(
-                    'msg' => _("$menu_item successfully updated!"),
+                    'msg' => sprintf(
+                        _('%s successfully updated!'),
+                        $menu_item
+                    ),
                     'title' => _('iPXE Item Update Success')
                 )
             );

--- a/packages/web/lib/pages/hostmanagementpage.class.php
+++ b/packages/web/lib/pages/hostmanagementpage.class.php
@@ -2551,8 +2551,8 @@ class HostManagementPage extends FOGPage
             _('Chassis Asset') => $caseast
         );
         for ($i = 0; $i < count($gpuvendorsArray); $i++) {
-            $fields[_("GPU-$i Vendor")] = $gpuvendorsArray[$i];
-            $fields[_("GPU-$i Product")] = $gpuproductsArray[$i];
+            $fields[sprintf(_('GPU-%d Vendor'), $i)] = $gpuvendorsArray[$i];
+            $fields[sprintf(_('GPU-%d Product'), $i)] = $gpuproductsArray[$i];
         }
         if ($this->obj->get('inventory')->isValid()) {
             array_walk($fields, $this->fieldsToData);

--- a/packages/web/lib/pages/taskmanagementpage.class.php
+++ b/packages/web/lib/pages/taskmanagementpage.class.php
@@ -527,7 +527,7 @@ class TaskManagementPage extends FOGPage
             $var = ucfirst($type);
             $$var = self::getClass($var, $id);
             if (!$$var->isValid()) {
-                throw new Exception(_(sprintf('Invalid %s', $var)));
+                throw new Exception(sprintf(_('Invalid %s'), $var));
             }
             $typeID = filter_input(INPUT_GET, 'type');
             $TaskType = new TaskType($typeID);
@@ -649,11 +649,9 @@ class TaskManagementPage extends FOGPage
             $this->templates,
             $this->attributes
         );
-        $this->title = _(
-            sprintf(
-                '%s Advanced Actions',
-                ucfirst($type)
-            )
+        $this->title = sprintf(
+            _('%s Advanced Actions'),
+            ucfirst($type)
         );
         global $id;
         $types = array(

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -168,7 +168,7 @@ abstract class FOGService extends FOGBase
         }
         foreach (self::$ips as &$ip) {
             self::outall(
-                _("Interface Ready with IP Address: $ip")
+                sprintf(_('Interface Ready with IP Address: %s'), $ip)
             );
             unset($ip);
         }
@@ -419,7 +419,7 @@ abstract class FOGService extends FOGBase
                     _('Not syncing'),
                     $objType,
                     _('between'),
-                    _("{$itemType}s")
+                    _($itemType) . 's'
                 )
             );
             self::outall(
@@ -446,7 +446,7 @@ abstract class FOGService extends FOGBase
                     $groupOrNodeCount,
                     (
                         $groupOrNodeCount != 1 ?
-                        _("{$itemType}s") :
+                        _($itemType) . 's'  :
                         _($itemType)
                     )
                 )
@@ -531,7 +531,7 @@ abstract class FOGService extends FOGBase
                             _('Not syncing'),
                             $objType,
                             _('between'),
-                            _("{$itemType}s")
+                            _($itemType) . 's'
                         )
                     );
                     self::outall(

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -36,10 +36,6 @@ msgid " * Task Scheduler is globally disabled"
 msgstr "* Taskplaner ist global deaktiviert"
 
 #, fuzzy
-msgid " Name"
-msgstr " Name"
-
-#, fuzzy
 msgid " No open slots "
 msgstr "Keine offenen Slots"
 
@@ -57,6 +53,10 @@ msgid "$_POST variable is empty, check apache error log."
 msgstr "$_POST Variable ist leer, siehe Apache Errorlog"
 
 #, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Erweiterte Aktionen"
+
+#, fuzzy, php-format
 msgid "%s ID %d is not valid"
 msgstr "%s ID %s ist nicht gültig"
 
@@ -72,9 +72,17 @@ msgstr "%s Manager"
 msgid "%s Menu"
 msgstr "%s Menü"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr " Name"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s ist erforderlich"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "wurde erfolgreich aktualisiert"
 
 #, fuzzy
 msgid "1 Hour"
@@ -467,6 +475,10 @@ msgstr "Hinzufügen einer Rolle fehlgeschlagen"
 msgid "Add rule failed!"
 msgstr "Hinzufügen einer Rolle fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Ausgewählte Drucker hinzufügen"
+
 #, fuzzy
 msgid "Add selected hosts"
 msgstr "Ausgewählte Drucker hinzufügen"
@@ -573,6 +585,10 @@ msgstr "Ago muss boolean sein"
 
 msgid "All"
 msgstr "Alle"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "Alle %s auflisten"
 
 msgid "All Groups"
 msgstr "Alle Gruppen"
@@ -939,6 +955,10 @@ msgstr "Gehäuse-Version"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "Für mehr Echtzeit-Hilfe gibt es auch die Chat-Funktion. "
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "Überprüfen Sie hier, welche Drucker hinzugefügt werden können"
 
 #, fuzzy
 msgid "Check here to see what hosts can be added"
@@ -2267,6 +2287,14 @@ msgstr "Produktschlüssel der Gruppe"
 msgid "GPU Vendors"
 msgstr "BIOS-Anbieter"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Produktschlüssel der Gruppe"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "BIOS-Anbieter"
+
 msgid "General"
 msgstr "Allgemein"
 
@@ -3227,11 +3255,19 @@ msgstr "Integritätseinstellungen"
 msgid "Interface"
 msgstr "Schnittstelle"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "Netzwerkschnittstelle nicht bereit, warte auf deren Start"
 
 #, fuzzy
 msgid "Invalid"
+msgstr "Ungültig"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "Ungültig"
 
 msgid "Invalid Class"
@@ -5082,8 +5118,8 @@ msgstr "Remote-Adresse versucht, sich anzumelden"
 msgid "Remove"
 msgstr "Entfernen"
 
-#, fuzzy
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Entfernen "
 
 #, fuzzy
@@ -5117,8 +5153,8 @@ msgstr "Entfernen "
 msgid "Remove failed"
 msgstr "Entfernen fehlgeschlagen"
 
-#, fuzzy
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Ausgewählte entfernen "
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -41,10 +41,6 @@ msgid " * Task Scheduler is globally disabled"
 msgstr ""
 
 #, fuzzy
-msgid " Name"
-msgstr "Name"
-
-#, fuzzy
 msgid " No open slots "
 msgstr "No open slots"
 
@@ -62,6 +58,10 @@ msgid "$_POST variable is empty, check apache error log."
 msgstr "$_POST variable is empty, check apache error log."
 
 #, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Advanced Actions"
+
+#, fuzzy, php-format
 msgid "%s ID %d is not valid"
 msgstr "%s ID %s is not valid"
 
@@ -77,9 +77,17 @@ msgstr "%s Manager"
 msgid "%s Menu"
 msgstr "%s Menu"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr "Name"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s is required"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "has been successfully updated"
 
 #, fuzzy
 msgid "1 Hour"
@@ -472,6 +480,10 @@ msgstr "Add snapin failed!"
 msgid "Add rule failed!"
 msgstr "Add snapin failed!"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Remove selected printers"
+
 #, fuzzy
 msgid "Add selected hosts"
 msgstr "Remove selected printers"
@@ -578,6 +590,10 @@ msgstr ""
 
 msgid "All"
 msgstr "All"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "List All %s"
 
 msgid "All Groups"
 msgstr "All Groups"
@@ -944,6 +960,10 @@ msgstr "Chassis Version"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "Check here to see what printers can be added"
 
 #, fuzzy
 msgid "Check here to see what hosts can be added"
@@ -2270,6 +2290,14 @@ msgstr "Group Product Key"
 msgid "GPU Vendors"
 msgstr "BIOS Vendor"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Group Product Key"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "BIOS Vendor"
+
 msgid "General"
 msgstr "General"
 
@@ -3228,11 +3256,19 @@ msgstr "Settings"
 msgid "Interface"
 msgstr "Interface"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
 
 #, fuzzy
 msgid "Invalid"
+msgstr "Invalid ID"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "Invalid ID"
 
 msgid "Invalid Class"
@@ -5082,8 +5118,8 @@ msgstr ""
 msgid "Remove"
 msgstr "Remove"
 
-#, fuzzy
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Remove"
 
 #, fuzzy
@@ -5117,8 +5153,8 @@ msgstr "Remove"
 msgid "Remove failed"
 msgstr "Removed"
 
-#, fuzzy
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Remove selected snapins"
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -39,10 +39,6 @@ msgstr ""
 msgid " * Task Scheduler is globally disabled"
 msgstr ""
 
-#, fuzzy
-msgid " Name"
-msgstr "Nombre"
-
 msgid " No open slots "
 msgstr ""
 
@@ -60,6 +56,10 @@ msgstr "No se puede encontrar el nodo de almacenamiento:"
 msgid "$_POST variable is empty, check apache error log."
 msgstr "La variable $_POST está vacía, verifique el registro de errores de apache."
 
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Acciones avanzadas"
+
 #, php-format
 msgid "%s ID %d is not valid"
 msgstr "%s ID %d no es válido"
@@ -76,9 +76,17 @@ msgstr "Gestor %s"
 msgid "%s Menu"
 msgstr "Menú %s"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr "Nombre"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s es obligatorio"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "Creado con éxito"
 
 #, fuzzy
 msgid "1 Hour"
@@ -468,6 +476,10 @@ msgstr "¡Error al añadir un rol!"
 msgid "Add rule failed!"
 msgstr "Fallo al añadir una regla!"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Añadir equipos seleccionados"
+
 msgid "Add selected hosts"
 msgstr "Añadir equipos seleccionados"
 
@@ -573,6 +585,10 @@ msgstr ""
 
 msgid "All"
 msgstr "Todos"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "Listar todos %s"
 
 #, fuzzy
 msgid "All Groups"
@@ -936,6 +952,10 @@ msgid "Chassis Version"
 msgstr "Versión"
 
 msgid "Chat is also available on the forums for more realtime help"
+msgstr ""
+
+#, php-format
+msgid "Check here to see what %s can be added"
 msgstr ""
 
 msgid "Check here to see what hosts can be added"
@@ -2251,6 +2271,14 @@ msgstr "Grupo principal"
 msgid "GPU Vendors"
 msgstr "Versión"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Grupo principal"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "Versión"
+
 msgid "General"
 msgstr ""
 
@@ -3246,11 +3274,19 @@ msgstr "Configuración del cliente"
 msgid "Interface"
 msgstr ""
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
 
 #, fuzzy
 msgid "Invalid"
+msgstr "MAC Address inválida!"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "MAC Address inválida!"
 
 #, fuzzy
@@ -5093,8 +5129,8 @@ msgstr ""
 msgid "Remove"
 msgstr "Eliminar"
 
-#, fuzzy
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Eliminar"
 
 #, fuzzy
@@ -5125,8 +5161,8 @@ msgstr "Eliminar usuarios"
 msgid "Remove failed"
 msgstr "Error al eliminar"
 
-#, fuzzy
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Borrar equipos seleccionados"
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -39,9 +39,6 @@ msgstr " * La réplication de Snapin est globalement désactivée"
 msgid " * Task Scheduler is globally disabled"
 msgstr " * Le planificateur de tâches est globalement désactivé"
 
-msgid " Name"
-msgstr " Nom"
-
 msgid " No open slots "
 msgstr " Pas de slots ouverts "
 
@@ -56,6 +53,10 @@ msgstr " | Impossible de trouver le chemin de l'image"
 
 msgid "$_POST variable is empty, check apache error log."
 msgstr "La variable $_POST est vide, consultez le journal des erreurs Apache."
+
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Actions avancées"
 
 #, php-format
 msgid "%s ID %d is not valid"
@@ -73,9 +74,17 @@ msgstr "%s gestionnaire"
 msgid "%s Menu"
 msgstr "%s Menu"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr " Nom"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s est requis"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "a été mis à jour avec succès"
 
 msgid "1 Hour"
 msgstr "1 heure"
@@ -406,6 +415,10 @@ msgstr "L'ajout de rôle a échoué !"
 msgid "Add rule failed!"
 msgstr "L'ajout de règle a échoué !"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Ajouter les machines sélectionnées"
+
 msgid "Add selected hosts"
 msgstr "Ajouter les machines sélectionnées"
 
@@ -496,6 +509,10 @@ msgstr "Ago doit être un booléen"
 
 msgid "All"
 msgstr "Tout"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "Lister tous les %s"
 
 msgid "All Groups"
 msgstr "Tous les groupes"
@@ -821,6 +838,10 @@ msgstr "Version du châssis"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "Le chat est également disponible sur les forums pour une aide en temps réel"
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "Vérifiez ici pour voir quelles machines peuvent être ajoutées"
 
 msgid "Check here to see what hosts can be added"
 msgstr "Vérifiez ici pour voir quelles machines peuvent être ajoutées"
@@ -2003,6 +2024,14 @@ msgstr "Groupe clé de produit"
 msgid "GPU Vendors"
 msgstr "Vendeur du BIOS"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Groupe clé de produit"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "Vendeur du BIOS"
+
 msgid "General"
 msgstr "Général"
 
@@ -2843,10 +2872,18 @@ msgstr "Paramètres d'intégrité"
 msgid "Interface"
 msgstr "Interface"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "L'interface n'est pas prête, j'attends qu'elle apparaisse"
 
 msgid "Invalid"
+msgstr "Invalide"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "Invalide"
 
 msgid "Invalid Class"
@@ -4508,7 +4545,8 @@ msgstr "L'adresse distante tente de se connecter"
 msgid "Remove"
 msgstr "Retirer"
 
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Retirer "
 
 msgid "Remove Accesscontrol Rules"
@@ -4535,7 +4573,8 @@ msgstr "Retirer des utilisateurs"
 msgid "Remove failed"
 msgstr "La suppression a échoué"
 
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Retirer les sélectionnés "
 
 msgid "Remove selected groups"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -40,9 +40,6 @@ msgstr "* La replica Snapin è disattivata globalmente"
 msgid " * Task Scheduler is globally disabled"
 msgstr "* Il task scheduler è disattivato a livello globale"
 
-msgid " Name"
-msgstr "Nome"
-
 #, fuzzy
 msgid " No open slots "
 msgstr "Nessuno slot aperti"
@@ -60,6 +57,10 @@ msgstr "Impossibile trovare il Nodo Archiviazione master"
 msgid "$_POST variable is empty, check apache error log."
 msgstr "La variabile $ _POST è vuota, controlla il log degli errori di apache."
 
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Azioni Avanzate"
+
 #, php-format
 msgid "%s ID %d is not valid"
 msgstr "%s ID %d non valido"
@@ -76,9 +77,17 @@ msgstr "%s Responsabile"
 msgid "%s Menu"
 msgstr "%s Menu"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr "Nome"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s è richiesto"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "è stato aggiornato con successo"
 
 msgid "1 Hour"
 msgstr "1 ora"
@@ -424,6 +433,10 @@ msgstr "Aggiunta ruolo non riuscita!"
 msgid "Add rule failed!"
 msgstr "Aggiunta ruolo non riuscita!"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Aggiungi stampanti selezionate"
+
 #, fuzzy
 msgid "Add selected hosts"
 msgstr "Aggiungi stampanti selezionate"
@@ -519,6 +532,10 @@ msgstr "Fa deve essere boolean"
 
 msgid "All"
 msgstr "Tutti"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "Elencare tutti %s"
 
 msgid "All Groups"
 msgstr "tutti i gruppi"
@@ -845,6 +862,10 @@ msgstr "Telaio Version"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "La chat è anche disponibile all'interno del forum per una maggiore assistenza in tempo reale"
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "Controllare qui per vedere cosa è possibile aggiungere stampanti"
 
 #, fuzzy
 msgid "Check here to see what hosts can be added"
@@ -2056,6 +2077,14 @@ msgstr "Product Key Group"
 msgid "GPU Vendors"
 msgstr "Venditore BIOS"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Product Key Group"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "Venditore BIOS"
+
 msgid "General"
 msgstr "Generale"
 
@@ -2909,10 +2938,18 @@ msgstr "Impostazioni di integrità"
 msgid "Interface"
 msgstr "Interfaccia"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "Interfaccia non pronta, in attesa che venga visualizzata"
 
 msgid "Invalid"
+msgstr "Non valido"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "Non valido"
 
 msgid "Invalid Class"
@@ -4588,7 +4625,8 @@ msgstr "Indirizzo remoto che cerca di accedere"
 msgid "Remove"
 msgstr "Rimuovere"
 
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Rimuovere"
 
 #, fuzzy
@@ -4619,7 +4657,8 @@ msgstr "Rimuovere"
 msgid "Remove failed"
 msgstr "Rimozione fallita"
 
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Rimuovi i selezionati"
 
 msgid "Remove selected groups"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -32,9 +32,6 @@ msgstr "* スナップインレプリケーションは全体設定で無効に�
 msgid " * Task Scheduler is globally disabled"
 msgstr "* タスクスケジューラは全体設定で無効になっています"
 
-msgid " Name"
-msgstr "名前"
-
 msgid " No open slots "
 msgstr "空きスロットがありません"
 
@@ -49,6 +46,10 @@ msgstr "| イメージパスが見つかりません"
 
 msgid "$_POST variable is empty, check apache error log."
 msgstr "$_POST 変数が空です。Apache のエラーログを確認してください。"
+
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "詳細操作"
 
 #, php-format
 msgid "%s ID %d is not valid"
@@ -66,9 +67,17 @@ msgstr "%s 管理"
 msgid "%s Menu"
 msgstr "%s メニュー"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr "名前"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s は必須です"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "正常に更新されました"
 
 msgid "1 Hour"
 msgstr "1時間"
@@ -396,6 +405,10 @@ msgstr "ロールの追加に失敗しました！"
 msgid "Add rule failed!"
 msgstr "ルールの追加に失敗しました！"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "選択したホストを追加"
+
 msgid "Add selected hosts"
 msgstr "選択したホストを追加"
 
@@ -486,6 +499,10 @@ msgstr "Ago はブール値である必要があります"
 
 msgid "All"
 msgstr "すべて"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "すべての %s を一覧表示"
 
 msgid "All Groups"
 msgstr "すべてのグループ"
@@ -810,6 +827,10 @@ msgstr "シャーシバージョン"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "追加可能なホストを確認するにはここをクリックしてください"
 
 msgid "Check here to see what hosts can be added"
 msgstr "追加可能なホストを確認するにはここをクリックしてください"
@@ -1979,6 +2000,14 @@ msgstr "GPU 製品"
 msgid "GPU Vendors"
 msgstr "GPU ベンダー"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "GPU 製品"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "GPU ベンダー"
+
 msgid "General"
 msgstr "全般"
 
@@ -2813,10 +2842,18 @@ msgstr "整合性設定"
 msgid "Interface"
 msgstr "インターフェイス"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "インターフェイスの準備ができていません。起動を待機しています"
 
 msgid "Invalid"
+msgstr "無効"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "無効"
 
 msgid "Invalid Class"
@@ -4464,7 +4501,8 @@ msgstr "ログインを試行したリモートアドレス"
 msgid "Remove"
 msgstr "削除"
 
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "削除 "
 
 msgid "Remove Accesscontrol Rules"
@@ -4491,7 +4529,8 @@ msgstr "ユーザーを削除"
 msgid "Remove failed"
 msgstr "削除に失敗しました"
 
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "選択した項目を削除"
 
 msgid "Remove selected groups"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -19,9 +19,6 @@ msgstr ""
 msgid " * Task Scheduler is globally disabled"
 msgstr ""
 
-msgid " Name"
-msgstr ""
-
 msgid " No open slots "
 msgstr ""
 
@@ -35,6 +32,10 @@ msgid " | Unable to find image path"
 msgstr ""
 
 msgid "$_POST variable is empty, check apache error log."
+msgstr ""
+
+#, php-format
+msgid "%s Advanced Actions"
 msgstr ""
 
 #, php-format
@@ -54,7 +55,15 @@ msgid "%s Menu"
 msgstr ""
 
 #, php-format
+msgid "%s Name"
+msgstr ""
+
+#, php-format
 msgid "%s is required"
+msgstr ""
+
+#, php-format
+msgid "%s successfully updated!"
 msgstr ""
 
 msgid "1 Hour"
@@ -383,6 +392,10 @@ msgstr ""
 msgid "Add rule failed!"
 msgstr ""
 
+#, php-format
+msgid "Add selected %s"
+msgstr ""
+
 msgid "Add selected hosts"
 msgstr ""
 
@@ -472,6 +485,10 @@ msgid "Ago must be boolean"
 msgstr ""
 
 msgid "All"
+msgstr ""
+
+#, php-format
+msgid "All %s"
 msgstr ""
 
 msgid "All Groups"
@@ -796,6 +813,10 @@ msgid "Chassis Version"
 msgstr ""
 
 msgid "Chat is also available on the forums for more realtime help"
+msgstr ""
+
+#, php-format
+msgid "Check here to see what %s can be added"
 msgstr ""
 
 msgid "Check here to see what hosts can be added"
@@ -1963,6 +1984,14 @@ msgstr ""
 msgid "GPU Vendors"
 msgstr ""
 
+#, php-format
+msgid "GPU-%d Product"
+msgstr ""
+
+#, php-format
+msgid "GPU-%d Vendor"
+msgstr ""
+
 msgid "General"
 msgstr ""
 
@@ -2793,10 +2822,18 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr ""
 
 msgid "Invalid"
+msgstr ""
+
+#, php-format
+msgid "Invalid %s"
 msgstr ""
 
 msgid "Invalid Class"
@@ -4441,7 +4478,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-msgid "Remove "
+#, php-format
+msgid "Remove %s"
 msgstr ""
 
 msgid "Remove Accesscontrol Rules"
@@ -4468,7 +4506,8 @@ msgstr ""
 msgid "Remove failed"
 msgstr ""
 
-msgid "Remove selected "
+#, php-format
+msgid "Remove selected %s"
 msgstr ""
 
 msgid "Remove selected groups"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -39,9 +39,6 @@ msgstr " * Replicação de Snapin está desabilitada globalmente"
 msgid " * Task Scheduler is globally disabled"
 msgstr " * Agendador de Tarefas está desabilitado globalmente"
 
-msgid " Name"
-msgstr " Nome"
-
 msgid " No open slots "
 msgstr " Não há slots abertos "
 
@@ -56,6 +53,10 @@ msgstr " | Não foi possível encontrar o caminho da imagem"
 
 msgid "$_POST variable is empty, check apache error log."
 msgstr "A variável $_POST está vazia, verifique o log de erros do apache."
+
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "Ações Avançadas"
 
 #, php-format
 msgid "%s ID %d is not valid"
@@ -73,9 +74,17 @@ msgstr "Gerenciador de %s"
 msgid "%s Menu"
 msgstr "Menu de %s"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr " Nome"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s é obrigatório"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "foi atualizado com sucesso"
 
 msgid "1 Hour"
 msgstr "1 Hora"
@@ -406,6 +415,10 @@ msgstr "Falha ao adicionar função!"
 msgid "Add rule failed!"
 msgstr "Falha ao adicionar regra!"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "Adicionar hosts selecionados"
+
 msgid "Add selected hosts"
 msgstr "Adicionar hosts selecionados"
 
@@ -496,6 +509,10 @@ msgstr "Campo 'Ago' deve ser booleano"
 
 msgid "All"
 msgstr "Todos"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "Listar Todos os %s"
 
 msgid "All Groups"
 msgstr "Todos os Grupos"
@@ -820,6 +837,10 @@ msgstr "Versão do Chassi"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "O Chat também está disponível nos fóruns para ajuda em tempo real"
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "Verifique aqui para ver quais hosts podem ser adicionados"
 
 msgid "Check here to see what hosts can be added"
 msgstr "Verifique aqui para ver quais hosts podem ser adicionados"
@@ -1992,6 +2013,14 @@ msgstr "Produtos GPU"
 msgid "GPU Vendors"
 msgstr "Fabricantes de GPU"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "Produtos GPU"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "Fabricantes de GPU"
+
 msgid "General"
 msgstr "Geral"
 
@@ -2828,10 +2857,18 @@ msgstr "Configurações de Integridade"
 msgid "Interface"
 msgstr "Interface"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "Interface não está pronta, aguardando inicialização"
 
 msgid "Invalid"
+msgstr "Inválido"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "Inválido"
 
 msgid "Invalid Class"
@@ -4488,7 +4525,8 @@ msgstr "Endereço remoto tentando fazer login"
 msgid "Remove"
 msgstr "Remover"
 
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "Remover "
 
 msgid "Remove Accesscontrol Rules"
@@ -4515,7 +4553,8 @@ msgstr "Remover Usuários"
 msgid "Remove failed"
 msgstr "Falha ao remover"
 
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "Remover selecionados "
 
 msgid "Remove selected groups"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -39,9 +39,6 @@ msgstr "Snapin 复制已全局禁用"
 msgid " * Task Scheduler is globally disabled"
 msgstr "任务调度器已全局禁用"
 
-msgid " Name"
-msgstr "名称"
-
 msgid " No open slots "
 msgstr "没有开放位置"
 
@@ -56,6 +53,10 @@ msgstr "|找不到镜像路径"
 
 msgid "$_POST variable is empty, check apache error log."
 msgstr "$ _POST变量为空，检查apache错误日志。"
+
+#, fuzzy, php-format
+msgid "%s Advanced Actions"
+msgstr "高级操作"
 
 #, php-format
 msgid "%s ID %d is not valid"
@@ -73,9 +74,17 @@ msgstr "%s管理器"
 msgid "%s Menu"
 msgstr "%s菜单"
 
+#, fuzzy, php-format
+msgid "%s Name"
+msgstr "名称"
+
 #, php-format
 msgid "%s is required"
 msgstr "%s是必需的"
+
+#, fuzzy, php-format
+msgid "%s successfully updated!"
+msgstr "已成功更新"
 
 msgid "1 Hour"
 msgstr "1小时"
@@ -406,6 +415,10 @@ msgstr "添加角色失败!"
 msgid "Add rule failed!"
 msgstr "添加规则失败!"
 
+#, fuzzy, php-format
+msgid "Add selected %s"
+msgstr "添加选定的主机"
+
 msgid "Add selected hosts"
 msgstr "添加选定的主机"
 
@@ -496,6 +509,10 @@ msgstr "Ago必须是布尔值"
 
 msgid "All"
 msgstr "所有"
+
+#, fuzzy, php-format
+msgid "All %s"
+msgstr "列出所有%s"
 
 msgid "All Groups"
 msgstr "所有组"
@@ -820,6 +837,10 @@ msgstr "机箱版本"
 
 msgid "Chat is also available on the forums for more realtime help"
 msgstr "访问论坛以获取帮助"
+
+#, fuzzy, php-format
+msgid "Check here to see what %s can be added"
+msgstr "点击以查看可添加主机"
 
 msgid "Check here to see what hosts can be added"
 msgstr "点击以查看可添加主机"
@@ -1992,6 +2013,14 @@ msgstr "GPU产品"
 msgid "GPU Vendors"
 msgstr "GPU供应商"
 
+#, fuzzy, php-format
+msgid "GPU-%d Product"
+msgstr "GPU产品"
+
+#, fuzzy, php-format
+msgid "GPU-%d Vendor"
+msgstr "GPU供应商"
+
 msgid "General"
 msgstr "一般"
 
@@ -2828,10 +2857,18 @@ msgstr "完整性设置"
 msgid "Interface"
 msgstr "接口"
 
+#, php-format
+msgid "Interface Ready with IP Address: %s"
+msgstr ""
+
 msgid "Interface not ready, waiting for it to come up"
 msgstr "接口未准备好，正在等待其启动"
 
 msgid "Invalid"
+msgstr "无效"
+
+#, fuzzy, php-format
+msgid "Invalid %s"
 msgstr "无效"
 
 msgid "Invalid Class"
@@ -4488,7 +4525,8 @@ msgstr "远程地址尝试登录"
 msgid "Remove"
 msgstr "去掉"
 
-msgid "Remove "
+#, fuzzy, php-format
+msgid "Remove %s"
 msgstr "去掉"
 
 msgid "Remove Accesscontrol Rules"
@@ -4515,7 +4553,8 @@ msgstr "移除用户"
 msgid "Remove failed"
 msgstr "移除失败"
 
-msgid "Remove selected "
+#, fuzzy, php-format
+msgid "Remove selected %s"
 msgstr "删除选定"
 
 msgid "Remove selected groups"

--- a/tests/gettext-literal-msgid.test.php
+++ b/tests/gettext-literal-msgid.test.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * A gettext msgid must be a literal, not a sentence built at runtime.
+ *
+ * xgettext extracts the LITERAL SOURCE TEXT of a _() argument. PHP evaluates
+ * that argument before _() is ever called. So when the two differ, the msgid
+ * in the catalog and the string looked up at runtime are different strings,
+ * and the lookup can never hit:
+ *
+ *     echo _("MACs $msg successfully");
+ *
+ *     msgid in messages.pot:  "MACs $msg successfully"
+ *     looked up at runtime:   "MACs approved successfully"
+ *
+ * gettext misses, returns its argument unchanged, and the line renders in
+ * English on every install regardless of the selected language. Nothing
+ * errors and nothing logs -- the only symptom is a string that is never
+ * translated, which is invisible to anyone testing in English. It also
+ * leaves translators no way to inflect the sentence around the variable,
+ * which several of the shipped languages need.
+ *
+ * WHAT THIS FORBIDS: mixing literal text with a variable in one msgid.
+ *   _("Add selected $type")           -> sprintf(_('Add selected %s'), $type)
+ *   _('Remove ' . $type)              -> sprintf(_('Remove %s'), $type)
+ *   _(sprintf('Invalid %s', $var))    -> sprintf(_('Invalid %s'), $var)
+ *
+ * The fix is always the same shape: the literal goes INSIDE _(), the variable
+ * is substituted OUTSIDE it. That gives xgettext a complete format string to
+ * extract and gives the translator a placeholder they can move.
+ *
+ * WHAT THIS ALLOWS, deliberately: a bare runtime lookup with no literal text
+ * of its own, e.g. _($node) or _(ucwords($report)). That is a different and
+ * much weaker problem -- it resolves correctly whenever the VALUE is itself a
+ * msgid extracted from some other literal site, which is how FOG translates
+ * class and node names. xgettext cannot verify that, so it stays fragile, but
+ * it is not broken by construction the way the mixed form is. Drawing the
+ * line here needs no allowlist: an argument either carries literal text or it
+ * does not.
+ *
+ * Usage: php tests/gettext-literal-msgid.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$files = array_filter(
+    explode("\n", (string) shell_exec('git ls-files "*.php"')),
+    function ($f) {
+        return '' !== $f
+            && is_readable($f)
+            && 0 !== strpos($f, 'packages/web/vendor/');
+    }
+);
+
+if (count($files) < 100) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($files) . " files scanned; expected the whole "
+        . "tree. Is this a git checkout?\n"
+    );
+    exit(1);
+}
+
+/**
+ * Collect the tokens of a call's first argument.
+ *
+ * @param array $t     full token stream
+ * @param int   $open  index of the opening parenthesis
+ *
+ * @return array tokens between the parens, stopping at a depth-1 comma
+ */
+function firstArgument(array $t, $open)
+{
+    $depth = 0;
+    $arg = [];
+    for ($k = $open, $n = count($t); $k < $n; $k++) {
+        $c = $t[$k];
+        if (!is_array($c)) {
+            if ('(' === $c || '[' === $c || '{' === $c) {
+                $depth++;
+            } elseif (')' === $c || ']' === $c || '}' === $c) {
+                if (0 === --$depth) {
+                    break;
+                }
+            } elseif (',' === $c && 1 === $depth) {
+                break;
+            }
+        }
+        if ($depth >= 1 && $k > $open) {
+            $arg[] = $c;
+        }
+    }
+    return $arg;
+}
+
+$hits = [];
+foreach ($files as $file) {
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        $tok = $t[$i];
+        if (!is_array($tok) || T_STRING !== $tok[0]) {
+            continue;
+        }
+        if ('_' !== $tok[1] && 'gettext' !== $tok[1]) {
+            continue;
+        }
+        /*
+         * Skip anything that is not a plain call: ->_(, ::_(, function _(.
+         * A method happening to be named _ is not gettext.
+         */
+        $p = $i - 1;
+        while ($p >= 0 && is_array($t[$p])
+            && in_array($t[$p][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            $p--;
+        }
+        if ($p >= 0 && is_array($t[$p]) && in_array(
+            $t[$p][0],
+            [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_NEW],
+            true
+        )) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || '(' !== $t[$j]) {
+            continue;
+        }
+
+        $arg = firstArgument($t, $j);
+        // Leading whitespace is real -- _( sprintf(...) ) is written that way
+        // in the tree -- so find the first token that is not whitespace and
+        // compare against that, not against index 0.
+        $lead = null;
+        foreach ($arg as $idx => $a) {
+            if (!is_array($a) || T_WHITESPACE !== $a[0]) {
+                $lead = $idx;
+                break;
+            }
+        }
+        $kind = null;
+        $depth = 0;
+        foreach ($arg as $idx => $a) {
+            if (!is_array($a)) {
+                if ('(' === $a || '[' === $a) {
+                    $depth++;
+                    continue;
+                }
+                if (')' === $a || ']' === $a) {
+                    $depth--;
+                    continue;
+                }
+                /*
+                 * A double-quoted string that interpolates is tokenized as a
+                 * bare '"' delimiter with parts between; one that does not is
+                 * a single T_CONSTANT_ENCAPSED_STRING. So a bare '"' here IS
+                 * the interpolation.
+                 */
+                if ('"' === $a) {
+                    $kind = 'interpolated string';
+                    break;
+                }
+                // Concatenation, but only when a variable is one of the
+                // operands -- xgettext folds 'a' . 'b' into one msgid fine.
+                if ('.' === $a && 0 === $depth) {
+                    foreach ($arg as $b) {
+                        if (is_array($b) && T_VARIABLE === $b[0]) {
+                            $kind = 'concatenated with a variable';
+                            break 2;
+                        }
+                    }
+                }
+                continue;
+            }
+            if (T_START_HEREDOC === $a[0]) {
+                $kind = 'heredoc';
+                break;
+            }
+            /*
+             * sprintf() INSIDE _() is the same bug wearing a placeholder: the
+             * format string is the msgid and it has to be the _() argument,
+             * not sprintf's. Only flag the outermost call, i.e. sprintf as
+             * the whole argument.
+             */
+            if (T_STRING === $a[0] && 0 === $depth && $idx === $lead
+                && in_array(strtolower($a[1]), ['sprintf', 'vsprintf'], true)
+            ) {
+                $kind = 'sprintf inside _()';
+                break;
+            }
+        }
+        if (null === $kind) {
+            continue;
+        }
+        $src = '';
+        foreach ($arg as $a) {
+            $src .= is_array($a) ? $a[1] : $a;
+        }
+        $src = trim(preg_replace('/\s+/', ' ', $src));
+        if (strlen($src) > 70) {
+            $src = substr($src, 0, 67) . '...';
+        }
+        $hits[] = sprintf('%s:%d  [%s]  _(%s)', $file, $tok[2], $kind, $src);
+    }
+}
+
+if (count($hits) > 0) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($hits) . " gettext msgid(s) built at runtime, so the "
+        . "extracted\nmsgid can never match the string looked up:\n"
+    );
+    foreach ($hits as $hit) {
+        fwrite(STDERR, "  $hit\n");
+    }
+    fwrite(
+        STDERR,
+        "\nPut the literal inside _() and substitute outside it:\n"
+        . "  sprintf(_('Add selected %s'), \$type)\n"
+    );
+    exit(1);
+}
+
+printf("ok: %d file(s), every gettext msgid is a literal\n", count($files));
+exit(0);


### PR DESCRIPTION
`xgettext` extracts the **literal source text** of a `_()` argument, but PHP evaluates that argument before `_()` is ever called. Where the two differ, the msgid sitting in the catalog and the string looked up at runtime are different strings, and the lookup can never hit.

```php
echo _("Add selected $getType");

// msgid in messages.pot:  "Add selected $getType"
// looked up at runtime:   "Add selected Image"
```

gettext misses, returns its argument unchanged, and the string renders **in English on every install whatever language is selected**. Nothing errors and nothing logs. The only symptom is a string that is never translated — invisible to anyone testing in English, which is why so many had accumulated.

This is the sweep of the bug class #1108 fixed one instance of, and the dev-branch port of #1109.

## The fix

Same shape throughout: the literal goes **inside** `_()`, the variable is substituted **outside** it. That is already the house style — `openapi.class.php` uses it a dozen times and `$foglang['ListAll']` is literally `_('List All %s')`. It hands `xgettext` a complete format string and hands the translator a placeholder they can move, which matters: several shipped languages cannot keep English's word order.

Two sites needed something else:

- The submenu builder wrapped `_()` around a `sprintf` whose argument had **already been translated** a few lines above. The outer call was a guaranteed miss returning its own argument, so it is simply removed — a no-op at runtime.
- `fogservice.class.php`'s `_("{$itemType}s")` becomes `_($itemType) . 's'`, matching the `_($itemType)` already sitting three lines away in the same expression. Same rendered output, and it can now resolve.

## The gate

`tests/gettext-literal-msgid.test.php` draws its line at **does this msgid mix literal text with a variable**. It deliberately still *allows* a bare runtime lookup like `_($node)`: that resolves correctly whenever the value is itself a msgid extracted from some other literal site, which is how FOG translates node and class names. Fragile, since `xgettext` cannot verify it — but not broken by construction the way the mixed form is. The distinction needs no allowlist: an argument either carries literal text or it does not.

Tokenizer-based, for the same reason `php-deprecations.test.php` is: a regex cannot tell an interpolating `"…"` from a non-interpolating one, and cannot tell `_(` the gettext call from `->_(` a method.

## Verification

The proof is the catalog the pre-commit hook regenerated, not an assertion — every new msgid is now extractable where the composed forms never were:

```
All %s
Add selected %s
Check here to see what %s can be added
%s Name
Remove %s
Remove selected %s
%s successfully updated!
Invalid %s
%s Advanced Actions
GPU-%d Vendor / GPU-%d Product
Interface Ready with IP Address: %s
```

`php -l` clean on every changed file; the new gate passes on both branches.

## Not fixed here

`fogservice.class.php` builds its log lines by concatenating separately-translated fragments (`_('Not syncing')` + type + `_('between')` + …). That is a real i18n problem, but rewriting those into whole sentences changes daemon log output people grep, so it wants its own change.

## Downstream

None. No route, no schema, no API surface — `openapi.class.php` untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
