### PR TITLE
Make the iPXE advanced menu actually check the login it asks for

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -1435,9 +1435,13 @@ class BootMenu extends FOGBase
         if ($noMenu) {
             $this->noMenu();
         }
-        $tmpUser = self::attemptLogin(
-            $_REQUEST['username'],
-            $_REQUEST['password']
+        // authenticateOnly: iPXE holds no cookie, so a session established
+        // here could never be presented back -- it would just be an
+        // authenticated session nobody owns. The isValid() test below is
+        // the whole point of the call.
+        $tmpUser = self::authenticateOnly(
+            $_REQUEST['username'] ?? '',
+            $_REQUEST['password'] ?? ''
         );
         if ($tmpUser->isValid()) {
             self::$HookManager

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -3444,6 +3444,27 @@ abstract class FOGBase
             ->validatePw($username, $password, $remember);
     }
     /**
+     * Proves a credential without establishing a session.
+     *
+     * For callers that have no browser to carry a session -- the iPXE boot
+     * menu and service/ipxe/advanced.php -- where attemptLogin() would
+     * otherwise stamp $_SESSION['FOG_USER'] for a request that can never
+     * present the cookie back.
+     *
+     * Returns a User either way, exactly like attemptLogin(), so callers
+     * MUST test isValid(). A returned object is never itself the answer.
+     *
+     * @param string $username the username to attempt
+     * @param string $password the password to attempt
+     *
+     * @return object
+     */
+    public static function authenticateOnly($username, $password)
+    {
+        return self::getClass('User')
+            ->authenticate($username, $password);
+    }
+    /**
      * Clears the mac lookup table
      *
      * @return bool

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -235,7 +235,81 @@ class User extends FOGController
         return $passValid;
     }
     /**
+     * Proves an identity, and does nothing else.
+     *
+     * Split out of validatePw() because proving who someone is and giving
+     * them a browser session are two different things, and only one of them
+     * belongs to a caller that has no browser. The iPXE boot menu and
+     * service/ipxe/advanced.php both want a yes/no about a credential; they
+     * went through validatePw(), which unconditionally started a PHP session
+     * and stamped $_SESSION['FOG_USER'] -- so a PXE menu login minted a
+     * server-side authenticated session that nothing would ever present a
+     * cookie for. Harmless-looking, but it is an authenticated session
+     * created by a request that cannot hold one.
+     *
+     * No session, no cookies, no login history entry: passwordValidate()
+     * touches none of those with $remember false, which is what makes this
+     * split clean rather than a reimplementation.
+     *
+     * @param string $username the username
+     * @param string $password the password
+     *
+     * @return self populated on success, an invalid User otherwise
+     */
+    public function authenticate($username, $password)
+    {
+        if (!$this->passwordValidate($username, $password, false)) {
+            return new self(0);
+        }
+        return $this;
+    }
+    /**
+     * Turns an already-proven identity into a logged-in browser session.
+     *
+     * The other half of the authenticate() split. Everything here needs a
+     * session to exist and a browser to carry it, so nothing here may run
+     * for the iPXE callers.
+     *
+     * @return self
+     */
+    public function establishSession()
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        if (self::$FOGUser->isValid()) {
+            $type = self::$FOGUser->get('type');
+            self::$HookManager->processEvent(
+                'USER_TYPE_HOOK',
+                ['type' => &$type]
+            );
+            $this
+                ->set('id', self::$FOGUser->get('id'))
+                ->set('name', self::$FOGUser->get('name'))
+                ->set('password', '', true)
+                ->set('type', $type);
+        }
+        $_SESSION['FOG_USER'] = $this->get('id');
+        self::log(
+            sprintf(
+                '%s %s.',
+                $this->get('name'),
+                _('user successfully logged in')
+            ),
+            0,
+            0,
+            $this,
+            0
+        );
+        $this->_isLoggedIn();
+        return $this;
+    }
+    /**
      * Validates only the user and password
+     *
+     * Authenticates AND establishes a session, which is what every existing
+     * caller expects. Kept whole so third-party callers keep working; the
+     * two halves are available separately above.
      *
      * @param string $username the username
      * @param string $password the password
@@ -263,32 +337,7 @@ class User extends FOGController
             if (!$test) {
                 return new self(0);
             }
-            if (self::$FOGUser->isValid()) {
-                $type = self::$FOGUser->get('type');
-                self::$HookManager->processEvent(
-                    'USER_TYPE_HOOK',
-                    ['type' => &$type]
-                );
-                $this
-                    ->set('id', self::$FOGUser->get('id'))
-                    ->set('name', self::$FOGUser->get('name'))
-                    ->set('password', '', true)
-                    ->set('type', $type);
-            }
-            $_SESSION['FOG_USER'] = $this->get('id');
-            self::log(
-                sprintf(
-                    '%s %s.',
-                    $this->get('name'),
-                    _('user successfully logged in')
-                ),
-                0,
-                0,
-                $this,
-                0
-            );
-            $this->_isLoggedIn();
-            return $this;
+            return $this->establishSession();
         }
         self::log(
             sprintf(

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -33,42 +33,75 @@ $parseMe = function ($Send) {
         printf("%s\n", implode("\n", (array)$val));
     }
 };
+/**
+ * Prompt for a credential and re-chain carrying it.
+ *
+ * iPXE holds no cookie, so there is no session in which a previous login
+ * could be remembered. The credential and the decision to emit the menu
+ * therefore have to happen in the SAME request -- which is why the old
+ * 'loginsuccess' branch, which chained back here with no credential at
+ * all, could never have gated anything.
+ *
+ * @return void
+ */
+$promptForLogin = function () use ($parseMe) {
+    $parseMe(
+        [
+            'loginstuff' => [
+                '#!ipxe',
+                'clear username',
+                'clear password',
+                'login',
+                'params',
+                'param username ${username}',
+                'param password ${password}',
+                'chain ${boot-url}/service/ipxe/advanced.php##params',
+            ]
+        ]
+    );
+    exit;
+};
 $login = isset($_REQUEST['login']);
-$user = trim($_REQUEST['username']);
-$pass = trim($_REQUEST['password']);
+$user = trim($_REQUEST['username'] ?? '');
+$pass = trim($_REQUEST['password'] ?? '');
 if ($login) {
-    $Send['loginstuff'] = [
-        '#!ipxe',
-        'clear username',
-        'clear password',
-        'login',
-        'params',
-        'param username ${username}',
-        'param password ${password}',
-        'chain ${boot-url}/service/ipxe/advanced.php##params',
-    ];
-    $parseMe($Send);
-    unset($_REQUEST['login']);
+    $promptForLogin();
 }
-if (!empty($user)) {
-    $tmp = FOGCore::attemptLogin($user, $pass);
-    if ($tmp) {
-        $Send['loginsuccess'] = [
-            '#!ipxe',
-            'set userID ${username}',
-            'chain ${boot-url}/service/ipxe/advanced.php',
-        ];
-    } else {
-        $Send['loginfail'] = [
-            '#!ipxe',
-            'clear username',
-            'clear password',
-            'echo Invalid login!',
-            'sleep 3',
-            'chain -ar ${boot-url}/service/ipxe/advanced.php',
-        ];
-        $parseMe($Send);
-        unset($user, $pass);
+/**
+ * FOG_ADVANCED_MENU_LOGIN is what the admin sets to mean "the advanced
+ * menu requires a login". It defaults to 0 (schema.php:1871), so the menu
+ * is open unless it was deliberately turned on, and that default is
+ * preserved here.
+ *
+ * It was, however, never enforced by the file that actually serves the
+ * menu: the printf below sat outside every conditional, so FOG_PXE_ADVANCED
+ * was emitted to any caller regardless of the setting or of any credential.
+ * The login was decorative in three separate ways -- the setting was never
+ * read here, attemptLogin() returns a User OBJECT on both paths so the old
+ * `if ($tmp)` could never be false, and the success branch built $Send but
+ * never passed it to $parseMe.
+ */
+if (FOGCore::getSetting('FOG_ADVANCED_MENU_LOGIN')) {
+    if ('' === $user) {
+        $promptForLogin();
+    }
+    // authenticateOnly, not attemptLogin: nothing here can carry a session
+    // cookie, so establishing one would leave an authenticated session that
+    // no request will ever present back. isValid() is the real test.
+    if (!FOGCore::authenticateOnly($user, $pass)->isValid()) {
+        $parseMe(
+            [
+                'loginfail' => [
+                    '#!ipxe',
+                    'clear username',
+                    'clear password',
+                    'echo Invalid login!',
+                    'sleep 3',
+                    'chain -ar ${boot-url}/service/ipxe/advanced.php',
+                ]
+            ]
+        );
+        exit;
     }
 }
 printf(

--- a/tests/ipxe-auth-no-session.test.php
+++ b/tests/ipxe-auth-no-session.test.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Callers with no browser must authenticate without establishing a session.
+ *
+ * FOG has two authentication entry points that are not a browser: the iPXE
+ * boot menu (bootmenu.class.php) and service/ipxe/advanced.php. iPXE holds
+ * no cookie, so a PHP session created for one of those requests can never
+ * be presented back -- it is an authenticated session with no owner, minted
+ * on every PXE menu login.
+ *
+ * Both used to go through attemptLogin() -> validatePw(), which starts a
+ * session and stamps $_SESSION['FOG_USER'] unconditionally. The fix split
+ * User::validatePw() into:
+ *
+ *   authenticate()      prove the credential, no side effects
+ *   establishSession()  turn a proven identity into a logged-in session
+ *
+ * with validatePw() kept whole as authenticate + establishSession, so
+ * third-party callers are unaffected.
+ *
+ * This gate pins the property that makes the split worth having. It is
+ * static on purpose: the behaviour needs a database, a populated
+ * FOG_PXE_ADVANCED and FOG_ADVANCED_MENU_LOGIN toggled on to observe, and a
+ * test that needs all three is a test nobody runs.
+ *
+ * Usage: php tests/ipxe-auth-no-session.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+
+/**
+ * Extract one method's token stream by brace matching.
+ *
+ * @param string $file   path to read
+ * @param string $method method name to find
+ *
+ * @return array|null tokens of the body, or null if not found
+ */
+function methodTokens($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        // Walk to the opening brace, then match to its close.
+        $depth = 0;
+        $body = [];
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return $body;
+                    }
+                } elseif (';' === $c && !$started) {
+                    return null; // abstract/interface declaration
+                }
+            }
+            if ($started) {
+                $body[] = $c;
+            }
+        }
+        return $body;
+    }
+    return null;
+}
+
+$userFile = 'packages/web/lib/fog/user.class.php';
+
+// 1. Both halves of the split must exist.
+foreach (['authenticate', 'establishSession', 'validatePw'] as $m) {
+    if (null === methodTokens($userFile, $m)) {
+        $fails[] = "User::$m() is missing -- the authenticate/establishSession"
+            . " split has been undone";
+    }
+}
+
+// 2. authenticate() must have NO session or login side effects. These are
+//    the exact things that made a PXE login mint a session.
+$body = methodTokens($userFile, 'authenticate');
+if (null !== $body) {
+    $src = '';
+    foreach ($body as $tok) {
+        $src .= is_array($tok) ? $tok[1] : $tok;
+    }
+    $banned = [
+        '$_SESSION' => 'writes session state',
+        'session_start' => 'starts a session',
+        'setAuthCookie' => 'sets a remember-me cookie',
+        '_isLoggedIn' => 'runs the logged-in bookkeeping',
+        'establishSession' => 'establishes a session',
+    ];
+    foreach ($banned as $needle => $why) {
+        if (false !== strpos($src, $needle)) {
+            $fails[] = "User::authenticate() $why ($needle) -- it must prove"
+                . " the credential and nothing else";
+        }
+    }
+}
+
+/*
+ * 3. No browser-less entry point may call attemptLogin(). attemptLogin()
+ *    is authenticate + establishSession; these callers have nowhere to put
+ *    the session. Comments are stripped first so the explanatory prose in
+ *    those files does not trip the check.
+ */
+$browserless = array_merge(
+    glob('packages/web/service/ipxe/*.php') ?: [],
+    ['packages/web/lib/fog/bootmenu.class.php']
+);
+foreach ($browserless as $file) {
+    if (!is_readable($file)) {
+        continue;
+    }
+    foreach (token_get_all(file_get_contents($file)) as $tok) {
+        if (is_array($tok)
+            && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $text = is_array($tok) ? $tok[1] : $tok;
+        if ('attemptLogin' === $text) {
+            $fails[] = "$file calls attemptLogin(), which establishes a"
+                . " session; use authenticateOnly() instead";
+        }
+    }
+}
+
+/*
+ * 4. advanced.php must not emit FOG_PXE_ADVANCED unconditionally. The
+ *    original bug was a printf sitting outside every conditional, so the
+ *    menu went to any caller whatever FOG_ADVANCED_MENU_LOGIN said.
+ */
+$adv = 'packages/web/service/ipxe/advanced.php';
+$advSrc = is_readable($adv) ? file_get_contents($adv) : '';
+if ('' !== $advSrc && false === strpos($advSrc, 'FOG_ADVANCED_MENU_LOGIN')) {
+    $fails[] = "$adv never reads FOG_ADVANCED_MENU_LOGIN, so the setting that"
+        . " promises to gate the advanced menu cannot be enforced";
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: browser-less auth paths establish no session\n";
+exit(0);


### PR DESCRIPTION
Two defects in the auth seams, found while reading the code for Phase 2 planning. Both touch access control, so they are here rather than pushed straight through.

## 1. `service/ipxe/advanced.php` never authenticated anything

`FOG_ADVANCED_MENU_LOGIN` is documented as *"enforces a login parameter to get into the advanced menu"*. The file that serves that menu never read the setting, and its final line

```php
printf("#!ipxe\n%s", FOGCore::getSetting('FOG_PXE_ADVANCED'));
```

sat **outside every conditional** — so the menu was emitted to any caller, whatever the setting said and whatever credential was or was not supplied.

Verified live before the change:

```
no creds:    HTTP 200  7b
bogus creds: HTTP 200  7b     # identical body
```

(7 bytes because `FOG_PXE_ADVANCED` is empty on that box — the exposure is real in shape, and its content is whatever the admin put in the advanced menu.)

The login was decorative in three independent ways:

| | |
|---|---|
| The setting was never consulted | `advanced.php` never mentions `FOG_ADVANCED_MENU_LOGIN` |
| `if ($tmp)` could never be false | `attemptLogin()` returns a User **object** on both paths, so the `else` was dead code |
| The success branch never printed | it built `$Send` but never passed it to `$parseMe`, then chained back to `advanced.php` **carrying no credential** |

That last one is the giveaway that the gate could never have worked: iPXE holds no cookie, so there is no session in which an earlier login could be remembered. `bootmenu.class.php:1442` gets this right (`$tmpUser->isValid()`), which is what makes this look like an oversight rather than a design.

**Fix:** the credential and the decision to emit the menu now happen in the same request. **The default is preserved exactly** — `FOG_ADVANCED_MENU_LOGIN` defaults to `0` (`schema.php:1871`), so an install that never enabled it sees no behavior change at all. Installs that *did* enable it get the enforcement the setting always promised.

## 2. Authenticating minted a session for callers that cannot hold one

`validatePw()` unconditionally starts a session, stamps `$_SESSION['FOG_USER']` and runs `_isLoggedIn()`. Two of its three callers are iPXE endpoints. So **every PXE menu login created a server-side authenticated session that nothing would ever present a cookie for.**

Split into `authenticate()` (prove the credential, no side effects) and `establishSession()` (turn a proven identity into a logged-in session). `validatePw()` is kept whole as the two composed, so third-party callers are unaffected; `FOGBase::authenticateOnly()` is the seam the browser-less callers use. The extraction is clean because `passwordValidate()` was already session-free — this is not a rewrite.

The web UI login path is untouched: `processlogin.page.php` still calls `attemptLogin()` and still gets a session.

This is the refactor Phase 2 of `docs/refactor-brief.md` asks for — *"Split `login()` into `authenticate()` and `establishSession(User)` … This refactor is worth doing on its own merits regardless of SSO"* — landed early because the `advanced.php` fix needs the seam anyway.

## Gate

`tests/ipxe-auth-no-session.test.php` pins all of it: both halves exist, `authenticate()` touches no session state (`$_SESSION`, `session_start`, `setAuthCookie`, `_isLoggedIn`), no browser-less entry point calls `attemptLogin()`, and `advanced.php` reads `FOG_ADVANCED_MENU_LOGIN`. Comments are stripped before the `attemptLogin` scan so the explanatory prose in those files does not trip it.

Proven to catch a regression, not just to pass:

```
$ # revert the bootmenu caller to attemptLogin()
$ php tests/ipxe-auth-no-session.test.php
FAIL: 1 problem(s):
  - packages/web/lib/fog/bootmenu.class.php calls attemptLogin(), which
    establishes a session; use authenticateOnly() instead
```

Suite: **30 passed, 0 failed** (31 with the new gate).

## Branches

Both. The dev-branch port (#1112) is **deliberately narrower** — it adds `authenticate()` but does not extract `establishSession()`, because that branch's `validatePw()` still contains the LDAP-era path that signs a user in when `passwordValidate()` *failed*. Splitting that faithfully would mean blessing it; tightening it is the separate open LDAP/RBAC work.

## Downstream

None. No route, no schema, no API surface — `openapi.class.php` untouched by design. `validatePw()` keeps its signature and behavior, so no plugin breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR