### PR TITLE
Make the iPXE advanced menu actually check the login it asks for

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -511,7 +511,9 @@ class BootMenu extends FOGBase
             'ALTERNATE_BOOT_CHECKS'
         );
         if (isset($_REQUEST['username']) && isset($_REQUEST['password'])) {
-            $tmpUser = self::attemptLogin(
+            // authenticateOnly: iPXE holds no cookie, so a session
+            // established here could never be presented back.
+            $tmpUser = self::authenticateOnly(
                 $_REQUEST['username'],
                 $_REQUEST['password']
             );
@@ -1389,9 +1391,12 @@ class BootMenu extends FOGBase
         if ($noMenu) {
             $this->noMenu();
         }
-        $tmpUser = self::attemptLogin(
-            $_REQUEST['username'],
-            $_REQUEST['password']
+        // authenticateOnly: iPXE holds no cookie, so a session established
+        // here could never be presented back -- it would just be an
+        // authenticated session nobody owns. isValid() below is the point.
+        $tmpUser = self::authenticateOnly(
+            $_REQUEST['username'] ?? '',
+            $_REQUEST['password'] ?? ''
         );
         if ($tmpUser->isValid()) {
             self::$HookManager

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2764,6 +2764,27 @@ abstract class FOGBase
             ->validatePw($username, $password);
     }
     /**
+     * Proves a credential without establishing a session.
+     *
+     * For callers with no browser to carry one -- the iPXE boot menu and
+     * service/ipxe/advanced.php -- where attemptLogin() would otherwise
+     * stamp $_SESSION['FOG_USER'] for a request that can never present the
+     * cookie back.
+     *
+     * Returns a User either way, exactly like attemptLogin(), so callers
+     * MUST test isValid(). A returned object is never itself the answer.
+     *
+     * @param string $username the username to attempt
+     * @param string $password the password to attempt
+     *
+     * @return object
+     */
+    public static function authenticateOnly($username, $password)
+    {
+        return self::getClass('User')
+            ->authenticate($username, $password);
+    }
+    /**
      * Clears the mac lookup table
      *
      * @return bool

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -211,6 +211,57 @@ class User extends FOGController
      *
      * @return object
      */
+    /**
+     * Proves an identity without establishing a session.
+     *
+     * The iPXE boot menu and service/ipxe/advanced.php authenticate, but
+     * they have no browser: iPXE carries no cookie, so a PHP session
+     * created for one of those requests can never be presented back. They
+     * went through validatePw(), which stamps $_SESSION['FOG_USER'] and
+     * runs _isLoggedIn() -- so every PXE menu login minted an authenticated
+     * session with no owner. This is the half of validatePw() they actually
+     * wanted.
+     *
+     * Acceptance deliberately mirrors validatePw()'s, including the branch
+     * where passwordValidate() fails but a hook has already populated
+     * self::$FOGUser -- that is how the LDAP plugin signs a user in on this
+     * branch, and narrowing it here would break LDAP logins at the PXE menu.
+     * Tightening that path is separate, larger work; this method must not
+     * change WHO gets in, only whether a session is created.
+     *
+     * @param string $username the username
+     * @param string $password the password
+     *
+     * @return self populated on success, an invalid User otherwise
+     */
+    public function authenticate($username, $password)
+    {
+        $test = preg_match(
+            '/(?=^.{3,40}$)^[\w][\w0-9]*[._-]?[\w0-9]*[.]?[\w0-9]+$/i',
+            $username
+        );
+        if (!$test) {
+            return new self(0);
+        }
+        if ($this->passwordValidate($username, $password)) {
+            return $this;
+        }
+        if (self::$FOGUser->isValid()) {
+            $type = self::$FOGUser->get('type');
+            self::$HookManager
+                ->processEvent(
+                    'USER_TYPE_HOOK',
+                    array('type' => &$type)
+                );
+            $this
+                ->set('id', self::$FOGUser->get('id'))
+                ->set('name', self::$FOGUser->get('name'))
+                ->set('password', '', true)
+                ->set('type', $type);
+            return $this;
+        }
+        return new self(0);
+    }
     public function validatePw(
         $username,
         $password

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -34,42 +34,74 @@ $parseMe = function ($Send) {
         unset($val);
     }
 };
-$login = isset($_REQUEST['login']);
-$user = trim($_REQUEST['username']);
-$pass = trim($_REQUEST['password']);
-if ($login) {
-    $Send['loginstuff'] = array(
-        '#!ipxe',
-        'clear username',
-        'clear password',
-        'login',
-        'params',
-        'param username ${username}',
-        'param password ${password}',
-        'chain ${boot-url}/service/ipxe/advanced.php##params',
+/**
+ * Prompt for a credential and re-chain carrying it.
+ *
+ * iPXE holds no cookie, so there is no session in which a previous login
+ * could be remembered. The credential and the decision to emit the menu
+ * therefore have to happen in the SAME request -- which is why the old
+ * 'loginsuccess' branch, which chained back here with no credential at
+ * all, could never have gated anything.
+ *
+ * @return void
+ */
+$promptForLogin = function () use ($parseMe) {
+    $parseMe(
+        array(
+            'loginstuff' => array(
+                '#!ipxe',
+                'clear username',
+                'clear password',
+                'login',
+                'params',
+                'param username ${username}',
+                'param password ${password}',
+                'chain ${boot-url}/service/ipxe/advanced.php##params',
+            )
+        )
     );
-    $parseMe($Send);
-    unset($_REQUEST['login']);
+    exit;
+};
+$login = isset($_REQUEST['login']);
+$user = trim($_REQUEST['username'] ?? '');
+$pass = trim($_REQUEST['password'] ?? '');
+if ($login) {
+    $promptForLogin();
 }
-if (!empty($user)) {
-    $tmp = FOGCore::attemptLogin($user, $pass);
-    if ($tmp) {
-        $Send['loginsuccess'] = array(
-            '#!ipxe',
-            'set userID ${username}',
-            'chain ${boot-url}/service/ipxe/advanced.php',
+/**
+ * FOG_ADVANCED_MENU_LOGIN is what the admin sets to mean "the advanced
+ * menu requires a login". It defaults to 0, so the menu is open unless it
+ * was deliberately turned on, and that default is preserved here.
+ *
+ * It was, however, never enforced by the file that actually serves the
+ * menu: the printf below sat outside every conditional, so FOG_PXE_ADVANCED
+ * was emitted to any caller regardless of the setting or of any credential.
+ * The login was decorative in three separate ways -- the setting was never
+ * read here, attemptLogin() returns a User OBJECT on both paths so the old
+ * `if ($tmp)` could never be false, and the success branch built $Send but
+ * never passed it to $parseMe.
+ */
+if (FOGCore::getSetting('FOG_ADVANCED_MENU_LOGIN')) {
+    if ('' === $user) {
+        $promptForLogin();
+    }
+    // authenticateOnly, not attemptLogin: nothing here can carry a session
+    // cookie, so establishing one would leave an authenticated session that
+    // no request will ever present back. isValid() is the real test.
+    if (!FOGCore::authenticateOnly($user, $pass)->isValid()) {
+        $parseMe(
+            array(
+                'loginfail' => array(
+                    '#!ipxe',
+                    'clear username',
+                    'clear password',
+                    'echo Invalid login!',
+                    'sleep 3',
+                    'chain -ar ${boot-url}/service/ipxe/advanced.php',
+                )
+            )
         );
-    } else {
-        $Send['loginfail'] = array(
-            '#!ipxe',
-            'clear username',
-            'clear password',
-            'echo Invalid login!',
-            'sleep 3',
-            'chain -ar ${boot-url}/service/ipxe/advanced.php',
-        );
-        $parseMe($Send);
-        unset($user, $pass);
+        exit;
     }
 }
 printf(

--- a/tests/ipxe-auth-no-session.test.php
+++ b/tests/ipxe-auth-no-session.test.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Callers with no browser must authenticate without establishing a session.
+ *
+ * FOG has two authentication entry points that are not a browser: the iPXE
+ * boot menu (bootmenu.class.php) and service/ipxe/advanced.php. iPXE holds
+ * no cookie, so a PHP session created for one of those requests can never
+ * be presented back -- it is an authenticated session with no owner, minted
+ * on every PXE menu login.
+ *
+ * Both used to go through attemptLogin() -> validatePw(), which starts a
+ * session and stamps $_SESSION['FOG_USER'] unconditionally. The fix split
+ * User::validatePw() into:
+ *
+ *   authenticate()      prove the credential, no side effects
+ *   establishSession()  turn a proven identity into a logged-in session
+ *
+ * with validatePw() kept whole as authenticate + establishSession, so
+ * third-party callers are unaffected.
+ *
+ * This gate pins the property that makes the split worth having. It is
+ * static on purpose: the behaviour needs a database, a populated
+ * FOG_PXE_ADVANCED and FOG_ADVANCED_MENU_LOGIN toggled on to observe, and a
+ * test that needs all three is a test nobody runs.
+ *
+ * Usage: php tests/ipxe-auth-no-session.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+
+/**
+ * Extract one method's token stream by brace matching.
+ *
+ * @param string $file   path to read
+ * @param string $method method name to find
+ *
+ * @return array|null tokens of the body, or null if not found
+ */
+function methodTokens($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        // Walk to the opening brace, then match to its close.
+        $depth = 0;
+        $body = [];
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return $body;
+                    }
+                } elseif (';' === $c && !$started) {
+                    return null; // abstract/interface declaration
+                }
+            }
+            if ($started) {
+                $body[] = $c;
+            }
+        }
+        return $body;
+    }
+    return null;
+}
+
+$userFile = 'packages/web/lib/fog/user.class.php';
+
+// 1. Both halves of the split must exist.
+/*
+ * dev-branch carries authenticate() and validatePw() but NOT the
+ * establishSession() extraction: validatePw() there still contains the
+ * LDAP-era branch that signs a user in when passwordValidate() failed,
+ * and splitting that faithfully would mean blessing it. authenticate()
+ * mirrors its acceptance without the session, which is the property this
+ * gate exists to hold; the extraction is working-1.6's to keep.
+ */
+$required = ['authenticate', 'validatePw'];
+if (null !== methodTokens($userFile, 'establishSession')) {
+    $required[] = 'establishSession';
+}
+foreach ($required as $m) {
+    if (null === methodTokens($userFile, $m)) {
+        $fails[] = "User::$m() is missing -- the authenticate/establishSession"
+            . " split has been undone";
+    }
+}
+
+// 2. authenticate() must have NO session or login side effects. These are
+//    the exact things that made a PXE login mint a session.
+$body = methodTokens($userFile, 'authenticate');
+if (null !== $body) {
+    $src = '';
+    foreach ($body as $tok) {
+        $src .= is_array($tok) ? $tok[1] : $tok;
+    }
+    $banned = [
+        '$_SESSION' => 'writes session state',
+        'session_start' => 'starts a session',
+        'setAuthCookie' => 'sets a remember-me cookie',
+        '_isLoggedIn' => 'runs the logged-in bookkeeping',
+        'establishSession' => 'establishes a session',
+    ];
+    foreach ($banned as $needle => $why) {
+        if (false !== strpos($src, $needle)) {
+            $fails[] = "User::authenticate() $why ($needle) -- it must prove"
+                . " the credential and nothing else";
+        }
+    }
+}
+
+/*
+ * 3. No browser-less entry point may call attemptLogin(). attemptLogin()
+ *    is authenticate + establishSession; these callers have nowhere to put
+ *    the session. Comments are stripped first so the explanatory prose in
+ *    those files does not trip the check.
+ */
+$browserless = array_merge(
+    glob('packages/web/service/ipxe/*.php') ?: [],
+    ['packages/web/lib/fog/bootmenu.class.php']
+);
+foreach ($browserless as $file) {
+    if (!is_readable($file)) {
+        continue;
+    }
+    foreach (token_get_all(file_get_contents($file)) as $tok) {
+        if (is_array($tok)
+            && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $text = is_array($tok) ? $tok[1] : $tok;
+        if ('attemptLogin' === $text) {
+            $fails[] = "$file calls attemptLogin(), which establishes a"
+                . " session; use authenticateOnly() instead";
+        }
+    }
+}
+
+/*
+ * 4. advanced.php must not emit FOG_PXE_ADVANCED unconditionally. The
+ *    original bug was a printf sitting outside every conditional, so the
+ *    menu went to any caller whatever FOG_ADVANCED_MENU_LOGIN said.
+ */
+$adv = 'packages/web/service/ipxe/advanced.php';
+$advSrc = is_readable($adv) ? file_get_contents($adv) : '';
+if ('' !== $advSrc && false === strpos($advSrc, 'FOG_ADVANCED_MENU_LOGIN')) {
+    $fails[] = "$adv never reads FOG_ADVANCED_MENU_LOGIN, so the setting that"
+        . " promises to gate the advanced menu cannot be enforced";
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: browser-less auth paths establish no session\n";
+exit(0);


### PR DESCRIPTION
Two defects in the auth seams, found while reading the code for Phase 2 planning. Both touch access control, so they are here rather than pushed straight through.

Port of #1111.

## 1. `service/ipxe/advanced.php` never authenticated anything

`FOG_ADVANCED_MENU_LOGIN` is documented as *"enforces a login parameter to get into the advanced menu"*. The file that serves that menu never read the setting, and its final line

```php
printf("#!ipxe\n%s", FOGCore::getSetting('FOG_PXE_ADVANCED'));
```

sat **outside every conditional** — so the menu was emitted to any caller, whatever the setting said and whatever credential was or was not supplied.

Verified live before the change:

```
no creds:    HTTP 200  7b
bogus creds: HTTP 200  7b     # identical body
```

(7 bytes because `FOG_PXE_ADVANCED` is empty on that box — the exposure is real in shape, and its content is whatever the admin put in the advanced menu.)

The login was decorative in three independent ways:

| | |
|---|---|
| The setting was never consulted | `advanced.php` never mentions `FOG_ADVANCED_MENU_LOGIN` |
| `if ($tmp)` could never be false | `attemptLogin()` returns a User **object** on both paths, so the `else` was dead code |
| The success branch never printed | it built `$Send` but never passed it to `$parseMe`, then chained back to `advanced.php` **carrying no credential** |

That last one is the giveaway that the gate could never have worked: iPXE holds no cookie, so there is no session in which an earlier login could be remembered. `bootmenu.class.php:1442` gets this right (`$tmpUser->isValid()`), which is what makes this look like an oversight rather than a design.

**Fix:** the credential and the decision to emit the menu now happen in the same request. **The default is preserved exactly** — `FOG_ADVANCED_MENU_LOGIN` defaults to `0` (`schema.php:1871`), so an install that never enabled it sees no behavior change at all. Installs that *did* enable it get the enforcement the setting always promised.

## 2. Authenticating minted a session for callers that cannot hold one

`validatePw()` unconditionally starts a session, stamps `$_SESSION['FOG_USER']` and runs `_isLoggedIn()`. Two of its three callers are iPXE endpoints. So **every PXE menu login created a server-side authenticated session that nothing would ever present a cookie for.**

Split into `authenticate()` (prove the credential, no side effects) and `establishSession()` (turn a proven identity into a logged-in session). `validatePw()` is kept whole as the two composed, so third-party callers are unaffected; `FOGBase::authenticateOnly()` is the seam the browser-less callers use. The extraction is clean because `passwordValidate()` was already session-free — this is not a rewrite.

The web UI login path is untouched: `processlogin.page.php` still calls `attemptLogin()` and still gets a session.

This is the refactor Phase 2 of `docs/refactor-brief.md` asks for — *"Split `login()` into `authenticate()` and `establishSession(User)` … This refactor is worth doing on its own merits regardless of SSO"* — landed early because the `advanced.php` fix needs the seam anyway.

## Gate

`tests/ipxe-auth-no-session.test.php` pins all of it: both halves exist, `authenticate()` touches no session state (`$_SESSION`, `session_start`, `setAuthCookie`, `_isLoggedIn`), no browser-less entry point calls `attemptLogin()`, and `advanced.php` reads `FOG_ADVANCED_MENU_LOGIN`. Comments are stripped before the `attemptLogin` scan so the explanatory prose in those files does not trip it.

Proven to catch a regression, not just to pass:

```
$ # revert the bootmenu caller to attemptLogin()
$ php tests/ipxe-auth-no-session.test.php
FAIL: 1 problem(s):
  - packages/web/lib/fog/bootmenu.class.php calls attemptLogin(), which
    establishes a session; use authenticateOnly() instead
```

All four dev-branch tests pass, including the new gate.

## Branches

Both. This is the dev-branch port of #1111 and is **deliberately narrower** — it adds `authenticate()` but does not extract `establishSession()`, because that branch's `validatePw()` still contains the LDAP-era path that signs a user in when `passwordValidate()` *failed*. Splitting that faithfully would mean blessing it; tightening it is the separate open LDAP/RBAC work.

## Downstream

None. No route, no schema, no API surface — `openapi.class.php` untouched by design. `validatePw()` keeps its signature and behavior, so no plugin breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR