### PR TITLE
Stop handing a session to entry points that cannot carry one

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -164,7 +164,34 @@ class Initiator
         spl_autoload_register([self::class, 'autoload']);
         spl_autoload_register();
 
-        if (session_status() !== PHP_SESSION_ACTIVE) {
+        /*
+         * Start a session only when there is one to resume or something has
+         * asked for one.
+         *
+         * This used to be unconditional, and 62 entry points reach it through
+         * commons/base.inc.php -- including every file under service/ and
+         * status/, the API and the iPXE endpoints. None of those can carry a
+         * cookie back, so each request allocated a session that was written
+         * once, never read again, and left for gc to clean up. A PXE boot or
+         * a fleet of fog-clients polling on a timer is a steady stream of
+         * them.
+         *
+         * Browser flows are unaffected: the login page GET declares
+         * FOG_WANTS_SESSION and creates the session, and every request after
+         * that presents the cookie, so the first arm matches. The API accepts
+         * a session cookie when a browser sends one and falls back to token
+         * auth when it does not -- both still work, because the cookie is
+         * exactly the signal being tested.
+         *
+         * Safe because nothing on the browser-less paths uses session state:
+         * there is not one $_SESSION write under service/, status/, lib/
+         * reg-task, lib/client or lib/service, and setMessage() already
+         * returns early when no session is active (fogbase.class.php).
+         */
+        $hasSession = isset($_COOKIE[session_name()]);
+        if (session_status() !== PHP_SESSION_ACTIVE
+            && ($hasSession || defined('FOG_WANTS_SESSION'))
+        ) {
             session_start();
         }
     }

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -14,6 +14,15 @@ declare(strict_types=1);
  * @version  1.1
  */
 
+/*
+ * The web UI is the one entry point that needs a session created for a
+ * visitor who arrives without a cookie -- the login form's CSRF token has to
+ * live somewhere before anyone has logged in. Every other entry point either
+ * presents an existing session cookie or does not use sessions at all, so
+ * Initiator only starts one when this is defined or a cookie is present.
+ */
+define('FOG_WANTS_SESSION', true);
+
 require '../commons/base.inc.php';
 
 // Initialize required classes

--- a/tests/no-session-for-browserless.test.php
+++ b/tests/no-session-for-browserless.test.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Browser-less entry points must not be handed a session.
+ *
+ * Initiator used to call session_start() unconditionally, and 62 entry
+ * points reach it through commons/base.inc.php. Everything under service/
+ * and status/, the API and the iPXE endpoints inherited it -- and none of
+ * them can carry a cookie back, so each request allocated a session record
+ * that was written once, never read again, and left for gc. A PXE boot, or
+ * a fleet of fog-clients polling on a timer, is a steady stream of them.
+ *
+ * It is now conditional on a session cookie being presented or the entry
+ * point declaring FOG_WANTS_SESSION. This gate pins the three properties
+ * that make that safe, so a future edit cannot quietly undo them.
+ *
+ * Static on purpose: proving it over HTTP needs a running server with a
+ * database, and a test that needs those is a test nobody runs. The HTTP
+ * behaviour was verified by hand when the change landed -- see the PR.
+ *
+ * Usage: php tests/no-session-for-browserless.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+
+// 1. The session_start() in Initiator must be guarded.
+$init = 'packages/web/commons/init.php';
+$raw = is_readable($init) ? file_get_contents($init) : '';
+if ('' === $raw) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+/*
+ * Strip comments before looking for the guard. The block explaining WHY the
+ * guard exists names both FOG_WANTS_SESSION and session_name(), so searching
+ * the raw file would pass on the strength of its own documentation even with
+ * the condition deleted.
+ */
+$src = '';
+foreach (token_get_all($raw) as $tok) {
+    if (is_array($tok)
+        && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)
+    ) {
+        continue;
+    }
+    $src .= is_array($tok) ? $tok[1] : $tok;
+}
+if (false === strpos($src, 'FOG_WANTS_SESSION')) {
+    $fails[] = "$init no longer consults FOG_WANTS_SESSION -- session_start()"
+        . " is unconditional again";
+}
+if (false === strpos($src, 'session_name()')) {
+    $fails[] = "$init no longer tests for an incoming session cookie, so a"
+        . " returning browser would be handed a NEW session every request";
+}
+
+/*
+ * 2. Exactly one entry point may declare FOG_WANTS_SESSION: the web UI. If a
+ *    service or status endpoint starts declaring it, the saving is gone --
+ *    and it would be declaring it because something there started using
+ *    session state, which check 3 is what really catches.
+ */
+$declarers = [];
+foreach (['packages/web/service', 'packages/web/status', 'packages/web/api',
+    'packages/web/management', 'packages/web/maintenance'] as $dir) {
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($it as $f) {
+        if (!$f->isFile() || 'php' !== $f->getExtension()) {
+            continue;
+        }
+        $p = $f->getPathname();
+        if (false !== strpos(file_get_contents($p), "define('FOG_WANTS_SESSION'")) {
+            $declarers[] = $p;
+        }
+    }
+}
+sort($declarers);
+if ($declarers !== ['packages/web/management/index.php']) {
+    $fails[] = 'FOG_WANTS_SESSION should be declared by the web UI alone, but'
+        . ' is declared by: ' . (count($declarers) ? implode(', ', $declarers) : 'nothing');
+}
+
+/*
+ * 3. The load-bearing one. Browser-less code must not touch session state --
+ *    if it does, the guard above silently drops whatever it wrote instead of
+ *    failing loudly, which is the worst possible outcome.
+ */
+$browserless = [
+    'packages/web/service',
+    'packages/web/status',
+    'packages/web/lib/reg-task',
+    'packages/web/lib/client',
+    'packages/web/lib/service',
+];
+foreach ($browserless as $dir) {
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($it as $f) {
+        if (!$f->isFile() || 'php' !== $f->getExtension()) {
+            continue;
+        }
+        $p = $f->getPathname();
+        foreach (token_get_all(file_get_contents($p)) as $tok) {
+            if (is_array($tok) && T_VARIABLE === $tok[0] && '$_SESSION' === $tok[1]) {
+                $fails[] = "$p:{$tok[2]} touches \$_SESSION, but nothing"
+                    . ' guarantees a session exists on that path -- the write'
+                    . ' will be silently discarded';
+            }
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: browser-less entry points are handed no session\n";
+exit(0);


### PR DESCRIPTION
Follow-up to #1111, closing the half that change could not reach.

## The problem

`Initiator` called `session_start()` unconditionally, and **62 entry points** reach it through `commons/base.inc.php` — everything under `service/` and `status/`, the API, and the iPXE endpoints. None of those can carry a cookie back, so every such request allocated a session record that was **written once, never read again, and left for gc**. A PXE boot, or a fleet of fog-clients polling on a timer, is a steady stream of them.

#1111 stopped an iPXE login stamping `$_SESSION['FOG_USER']` — an *authenticated* session nobody owns. It could not stop the session being **created**, because creation happens in the boot chain long before any auth code runs.

## The change

One condition. A session starts when one is presented, or when the entry point declares it wants one:

```php
$hasSession = isset($_COOKIE[session_name()]);
if (session_status() !== PHP_SESSION_ACTIVE
    && ($hasSession || defined('FOG_WANTS_SESSION'))
) {
    session_start();
}
```

Only `management/index.php` declares it — the one entry point needing a session for a visitor arriving **without** a cookie, because the login form's CSRF token has to live somewhere before anyone has logged in. Everything after that presents the cookie.

The API is unaffected in both modes: a browser sending a session cookie matches the first arm; a token client needs no session.

## Why this is safe

Not an assumption — checked:

- **Zero `$_SESSION` writes** under `service/`, `status/`, `lib/reg-task`, `lib/client` or `lib/service`. Those paths have been paying for a session they never use.
- `setMessage()` already guards (`fogbase.class.php:975`): `if (session_status() !== PHP_SESSION_ACTIVE) { return; }` — flash messages degrade rather than fatal.

## Verified over HTTP on a live 1.6 install

```
/service/ipxe/advanced.php     HTTP 200   set-cookie: 0
/service/ipxe/boot.php         HTTP 200   set-cookie: 0
/status/bandwidth.php          HTTP 401   set-cookie: 0
/api/system/info               HTTP 403   set-cookie: 0

cookie-less visitor to the web UI:  session issued ✓  csrf token ✓
login POST -> 202 {"msg":"Login successful!"}
host list  -> 200, authenticated content, title "All Hosts"
php-fpm errors: 0
```

## Gate

`tests/no-session-for-browserless.test.php` pins three properties: the guard is still there, the web UI is the **sole** declarer, and no browser-less file touches `$_SESSION` — the last being load-bearing, since such a write would now be *silently discarded* rather than failing loudly.

It strips comments before looking for the guard: the block explaining why the guard exists names both `FOG_WANTS_SESSION` and `session_name()`, so a raw search would pass on the strength of its own documentation. Caught exactly that while writing it.

Both negative cases verified to fail:

```
- init.php no longer consults FOG_WANTS_SESSION -- session_start() is
  unconditional again
- packages/web/service/zz-probe.php:2 touches $_SESSION, but nothing
  guarantees a session exists on that path
```

Suite: **32 passed, 0 failed**.

## Branches

`working-1.6` only for now. dev-branch has the same unconditional `session_start()`, but its entry-point set differs and it is the patches line — worth its own look rather than an assumed port.

## Downstream

None. No route, no schema, no API surface — `openapi.class.php` untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR