### PR TITLE
Backslash-prefix the global iterators in the new session gate

### DIFF
--- a/tests/no-session-for-browserless.test.php
+++ b/tests/no-session-for-browserless.test.php
@@ -69,7 +69,7 @@ foreach (['packages/web/service', 'packages/web/status', 'packages/web/api',
     if (!is_dir($dir)) {
         continue;
     }
-    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
     foreach ($it as $f) {
         if (!$f->isFile() || 'php' !== $f->getExtension()) {
             continue;
@@ -102,7 +102,7 @@ foreach ($browserless as $dir) {
     if (!is_dir($dir)) {
         continue;
     }
-    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
     foreach ($it as $f) {
         if (!$f->isFile() || 'php' !== $f->getExtension()) {
             continue;


### PR DESCRIPTION
The gate added in #1113 used bare `RecursiveIteratorIterator` / `RecursiveDirectoryIterator`, which `tests/global-class-prefix.test.php` rejects:

```
FAIL: 4 bare built-in class references, expected 0
  tests/no-session-for-browserless.test.php:72: RecursiveIteratorIterator
  tests/no-session-for-browserless.test.php:72: RecursiveDirectoryIterator
  tests/no-session-for-browserless.test.php:105: RecursiveIteratorIterator
  tests/no-session-for-browserless.test.php:105: RecursiveDirectoryIterator
```

Phase 0.1 prefixed every unqualified global class reference in the tree precisely so Phase 3 namespacing could not silently turn one into a `FOG\` lookup that fails only at runtime. My new file broke that invariant.

Caught by the suite immediately after the merge — the gate doing its job, on a file that is itself a gate. Suite back to **32 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR