### PR TITLE
Stop handing a session to entry points that cannot carry a cookie

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -93,7 +93,34 @@ class Initiator
         spl_autoload_extensions('.class.php,.page.php,.event.php,.hook.php,.report.php');
         spl_autoload_register();
 
-        if (session_status() !== PHP_SESSION_ACTIVE) {
+        /*
+         * Start a session only when there is one to resume or something has
+         * asked for one.
+         *
+         * This used to be unconditional, and 59 entry points reach it through
+         * commons/base.inc.php -- including every file under service/ and
+         * status/, the API and the iPXE endpoints. None of those can carry a
+         * cookie back, so each request allocated a session that was written
+         * once, never read again, and left for gc to clean up. A PXE boot or
+         * a fleet of fog-clients polling on a timer is a steady stream of
+         * them.
+         *
+         * Browser flows are unaffected: the login page GET declares
+         * FOG_WANTS_SESSION and creates the session, and every request after
+         * that presents the cookie, so the first arm matches. The API accepts
+         * a session cookie when a browser sends one and falls back to token
+         * auth when it does not -- both still work, because the cookie is
+         * exactly the signal being tested.
+         *
+         * Safe because nothing on the browser-less paths uses session state:
+         * there is not one $_SESSION write under service/, status/, lib/
+         * reg-task, lib/client or lib/service, and setMessage() already
+         * returns early when no session is active (fogbase.class.php).
+         */
+        $hasSession = isset($_COOKIE[session_name()]);
+        if (session_status() !== PHP_SESSION_ACTIVE
+            && ($hasSession || defined('FOG_WANTS_SESSION'))
+        ) {
             session_start();
         }
     }

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * The web UI is the one entry point that needs a session created for a
+ * visitor who arrives without a cookie -- the login form's CSRF token has to
+ * live somewhere before anyone has logged in. Every other entry point either
+ * presents an existing session cookie or does not use sessions at all, so
+ * Initiator only starts one when this is defined or a cookie is present.
+ */
+define('FOG_WANTS_SESSION', true);
+
 require '../commons/base.inc.php';
 
 // Initialize required classes

--- a/tests/no-session-for-browserless.test.php
+++ b/tests/no-session-for-browserless.test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Browser-less entry points must not be handed a session.
+ *
+ * Initiator used to call session_start() unconditionally, and 59 entry
+ * points reach it through commons/base.inc.php. Everything under service/
+ * and status/, the API and the iPXE endpoints inherited it -- and none of
+ * them can carry a cookie back, so each request allocated a session record
+ * that was written once, never read again, and left for gc. A PXE boot, or
+ * a fleet of fog-clients polling on a timer, is a steady stream of them.
+ *
+ * It is now conditional on a session cookie being presented or the entry
+ * point declaring FOG_WANTS_SESSION. This gate pins the three properties
+ * that make that safe, so a future edit cannot quietly undo them.
+ *
+ * Static on purpose: proving it over HTTP needs a running server with a
+ * database, and a test that needs those is a test nobody runs. The HTTP
+ * behaviour was verified by hand when the change landed -- see the PR.
+ *
+ * Usage: php tests/no-session-for-browserless.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+
+// 1. The session_start() in Initiator must be guarded.
+$init = 'packages/web/commons/init.php';
+$raw = is_readable($init) ? file_get_contents($init) : '';
+if ('' === $raw) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+/*
+ * Strip comments before looking for the guard. The block explaining WHY the
+ * guard exists names both FOG_WANTS_SESSION and session_name(), so searching
+ * the raw file would pass on the strength of its own documentation even with
+ * the condition deleted.
+ */
+$src = '';
+foreach (token_get_all($raw) as $tok) {
+    if (is_array($tok)
+        && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)
+    ) {
+        continue;
+    }
+    $src .= is_array($tok) ? $tok[1] : $tok;
+}
+if (false === strpos($src, 'FOG_WANTS_SESSION')) {
+    $fails[] = "$init no longer consults FOG_WANTS_SESSION -- session_start()"
+        . " is unconditional again";
+}
+if (false === strpos($src, 'session_name()')) {
+    $fails[] = "$init no longer tests for an incoming session cookie, so a"
+        . " returning browser would be handed a NEW session every request";
+}
+
+/*
+ * 2. Exactly one entry point may declare FOG_WANTS_SESSION: the web UI. If a
+ *    service or status endpoint starts declaring it, the saving is gone --
+ *    and it would be declaring it because something there started using
+ *    session state, which check 3 is what really catches.
+ */
+$declarers = [];
+foreach (['packages/web/service', 'packages/web/status', 'packages/web/api',
+    'packages/web/management', 'packages/web/maintenance',
+    'packages/web/client'] as $dir) {
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($it as $f) {
+        if (!$f->isFile() || 'php' !== $f->getExtension()) {
+            continue;
+        }
+        $p = $f->getPathname();
+        if (false !== strpos(file_get_contents($p), "define('FOG_WANTS_SESSION'")) {
+            $declarers[] = $p;
+        }
+    }
+}
+sort($declarers);
+if ($declarers !== ['packages/web/management/index.php']) {
+    $fails[] = 'FOG_WANTS_SESSION should be declared by the web UI alone, but'
+        . ' is declared by: ' . (count($declarers) ? implode(', ', $declarers) : 'nothing');
+}
+
+/*
+ * 3. The load-bearing one. Browser-less code must not touch session state --
+ *    if it does, the guard above silently drops whatever it wrote instead of
+ *    failing loudly, which is the worst possible outcome.
+ */
+$browserless = [
+    'packages/web/service',
+    'packages/web/status',
+    'packages/web/lib/reg-task',
+    'packages/web/lib/client',
+    'packages/web/lib/service',
+];
+foreach ($browserless as $dir) {
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($it as $f) {
+        if (!$f->isFile() || 'php' !== $f->getExtension()) {
+            continue;
+        }
+        $p = $f->getPathname();
+        foreach (token_get_all(file_get_contents($p)) as $tok) {
+            if (is_array($tok) && T_VARIABLE === $tok[0] && '$_SESSION' === $tok[1]) {
+                $fails[] = "$p:{$tok[2]} touches \$_SESSION, but nothing"
+                    . ' guarantees a session exists on that path -- the write'
+                    . ' will be silently discarded';
+            }
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: browser-less entry points are handed no session\n";
+exit(0);


### PR DESCRIPTION
Port of #1113 from `working-1.6`, re-verified against this tree rather than assumed — the check that makes the change safe is a property of 1.5's own files, not of 1.6's.

## The problem

`Initiator::__construct()` called `session_start()` unconditionally, and **59 entry points** reach it through `commons/base.inc.php`: 40 files under `service/`, 13 under `status/`, the API and the iPXE endpoints. None of those can carry a cookie back, so every one of those requests allocated a session record that was written once, never read again, and left for gc to clean up. A PXE boot, or a fleet of fog-clients polling on a timer, is a steady stream of them.

## The change

```php
$hasSession = isset($_COOKIE[session_name()]);
if (session_status() !== PHP_SESSION_ACTIVE
    && ($hasSession || defined('FOG_WANTS_SESSION'))
) {
    session_start();
}
```

`management/index.php` is the sole declarer of `FOG_WANTS_SESSION`: the login form's CSRF token needs somewhere to live before anyone has logged in, so a cookie-less visitor to the web UI still gets a session. Every request after that presents the cookie, so the first arm matches. The API accepts a session cookie when a browser sends one and falls back to token auth when it does not — both still work, because the cookie is exactly the signal being tested.

## Re-run on this branch, not carried over

A tokenizer sweep for `$_SESSION` across `packages/web` finds **not one write** under `service/`, `status/`, `lib/reg-task`, `lib/client` or `lib/service`. Everything that does touch session state is either a browser page or already guards on `session_status()`:

| Site | Guard |
|---|---|
| `FOGBase::setMessage()` / `getMessages()` | returns early when no session is active |
| `FOGBase::resetRequest()` | same |
| `Initiator::language()` | same |
| `LoadGlobals` `currentUser` lookup | same |
| `User::_isLoggedIn()` regenerate branch | starts one itself if needed |

The iPXE endpoints stopped entering `validatePw()` in #1112, so nothing browser-less writes `FOG_USER` any more either. `Initiator::sanitizeItems()` takes a reference to `$_SESSION`, which is a no-op on the `null` it gets when no session started.

## Gate

`tests/no-session-for-browserless.test.php` pins all three properties: the guard is present, the web UI is the only declarer, and the browser-less directories stay free of `$_SESSION`. It strips comments before searching, so the block explaining the guard cannot satisfy the search for the guard itself — that mistake was made twice already on `working-1.6`.

Verified failing when the guard is removed (both assertions fire) and passing when restored. All five `tests/*.test.php` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR