### PR TITLE
Phase 1: audit httpproto coverage, and fix what the audit found

### DIFF
--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -1,0 +1,446 @@
+# `httpproto` coverage audit, and the conditional HTTPS redirect
+
+> **Headline:** `httpproto` is honoured by every URL the installer emits, so
+> redefining it as *"the protocol FOG uses for its own **non-netboot** URLs"* is
+> safe on the installer side. It is **not** safe yet on three other fronts:
+> three sites still gate the iPXE download, the Secure Boot staging and the
+> local iPXE rebuild on `httpproto` rather than on `netbootproto`; the HTTP→HTTPS
+> redirect and HSTS are both welded to `httpproto` with no separate key; and the
+> redirect's exclusion list was missing a directory iPXE fetches directly.
+> Everything in Part B §4 and §5 was found broken **before** any default was
+> flipped, and is fixed on this branch.
+
+Phase 1 of [#1116](https://github.com/FOGProject/fogproject/issues/1116),
+answering [#1118](https://github.com/FOGProject/fogproject/issues/1118).
+
+This document has two halves and they age very differently.
+
+- **Part A is reference material.** It describes how the protocols, the netboot
+  fetch set and the PKI actually work. It is written to be published as-is and
+  is the intended source for
+  [#1120](https://github.com/FOGProject/fogproject/issues/1120) — see
+  *Publishing notes* at the end.
+- **Part B is a point-in-time audit** of `working-1.6`, with `file:line`
+  references that will drift. Re-verify before trusting a line number.
+
+---
+
+# Part A — Reference
+
+## A1. Three protocols, not one setting
+
+FOG makes three independent protocol decisions that were historically one
+value. Conflating them is what
+[#1116](https://github.com/FOGProject/fogproject/issues/1116) exists to undo.
+
+| Decision | Governed by | Why it is separate |
+| --- | --- | --- |
+| The scheme FOG uses for its **own non-netboot** URLs — the web UI, the API, the client installer download, URLs handed to fog-client | `httpproto` | An ordinary TLS decision. Every consumer here can be told to trust a CA. |
+| The scheme **iPXE** uses to fetch `boot.php` and everything downstream of it | `netbootproto` | iPXE can be told to trust nothing. It validates strictly, has no `--insecure`, and its only route to a private CA is a rebuild that costs the signed Secure Boot chain. |
+| Whether plain HTTP is **redirected** to HTTPS | the redirect, today welded to `httpproto` | Trust reaches a client machine when fog-client installs FOG's CA into that machine's store. On a fresh server nothing has fog-client yet, so a forced redirect breaks exactly the machines that cannot fix themselves. |
+
+>[!important]
+>iPXE can only validate a chain terminating in a **public** root, via its
+>`ca.ipxe.org` cross-signing fallback, and only when the certificate was issued
+>to an **FQDN** — public CAs do not issue for private IPs, and chaining to an IP
+>fails on name mismatch even after the chain validates. A FOG-PKI or internal-CA
+>certificate is perfectly good for browsers, the API and fog-client, and simply
+>cannot work for HTTPS netboot.
+
+### Why PHP derives its scheme from the request, and why that is correct
+
+`FOGBase::$httpproto` is set from `$_SERVER['HTTPS']` — *how this request
+arrived*, not a configured value. For the netboot path this is not an oversight,
+it is the mechanism:
+
+The installer writes `default.ipxe` with `chain <netbootproto>://…/boot.php`.
+`BootMenu` then builds the whole menu, the `web=` kernel argument and every
+`${boot-url}` from `self::$httpproto` — so the entire boot sequence inherits the
+protocol iPXE arrived on, with no PHP configuration at all. Replacing that with
+a configured `httpproto` would break every HTTPS-web / HTTP-netboot install.
+
+Self-derivation is likewise correct for same-origin work: the API-disabled
+redirect, the OpenAPI `servers[0].url`, the Swagger spec URL.
+
+It is **wrong**, or at least insufficient, in two places:
+
+- **Storage-node URLs.** About a dozen call sites pair the *request's* scheme
+  with a *node's* IP. A node's protocol is a per-node property and there is no
+  column for it; the replicator works around this by trying HTTP and retrying
+  HTTPS.
+- **The CLI daemons.** `$_SERVER['HTTPS']` is unset outside a request, so
+  `$httpproto` is unconditionally `http` in every background service.
+
+## A2. Everything iPXE fetches during a boot
+
+This is the set that a forced HTTPS redirect must not touch, and it is **two
+directories**, not one.
+
+| Step | URL | Where it comes from |
+| --- | --- | --- |
+| 0 | `tftp://${next-server}/default.ipxe` | the embedded/autoexec script |
+| 1 | `<netbootproto>://<server><webroot>service/ipxe/boot.php` | `default.ipxe`, written by the installer |
+| 2 | `${boot-url}/service/ipxe/` → `grub.exe`, `refind.conf`, `refind*.efi`, `bg.png` / `bgdark.png`, `advanced.php` | `BootMenu` |
+| 3 | the kernel (`bzImage`) and init (`init.xz`) | **relative** — iPXE resolves them against `boot.php`'s own URI, so they inherit the netboot scheme with no PHP involvement |
+| 4 | `${boot-url}/service/secureboot/MOK.der` (`imgfetch`), `mmx64.efi` / `arm64-efi/mmaa64.efi` (`chain`) | `BootMenu`'s Secure Boot entries |
+| 5 | `web=<proto>://<host><webroot>/` | handed to **FOS**, not fetched by iPXE |
+
+**The rule: exclude every path iPXE itself fetches — `service/ipxe/` and
+`service/secureboot/`.**
+
+>[!warning]
+>Everything else FOS reaches under `${web}` — `jobs.php`, `Post_Stage*.php`,
+>`progress.php`, the Secure Boot `.auth` files, and the rest — is fetched with
+>`curl -Lks`. The `-L` follows the redirect and the `-k` skips verification, so
+>those calls survive a redirect that iPXE could not. **That tolerance is
+>load-bearing and is written down nowhere else.** If any FOS fetch ever drops
+>`-k`, its path has to join the exclusion list.
+
+`service/localboot/` is **not** in this set. It is an admin/browser download of
+binaries to copy onto an ESP by hand, not something firmware fetches at boot.
+
+### Two web servers, two mechanisms
+
+- **nginx** — the redirect must be a `location /`, never a server-level
+  `return`. Measured against real nginx: a server-level `return` runs in the
+  server rewrite phase, *before* location selection, so it fires for every
+  request and every exclusion above it becomes dead code, silently. The
+  exclusions use `^~`, which is what beats `location /`.
+- **Apache** — `RewriteCond` really does guard only the next `RewriteRule`, so
+  the conditions sit immediately before it. Multiple `RewriteCond`s are ANDed,
+  which is what is wanted: skip the redirect only when the request is for
+  none of the excluded paths.
+
+`management/other/ca.cert.der` is exempt in **both**, and deliberately *not*
+under the netboot guard — the client that needs it trusts nothing yet, which has
+nothing to do with which transport netboot uses. Redirecting it would make
+fetching the CA require already trusting the CA.
+
+## A3. PKI artefacts and how long each one lives
+
+Three lifetime classes. The distinction matters because re-issuing something in
+the first class orphans whatever already trusts it.
+
+### Create-once — never re-issued while the file exists
+
+| Artefact | What breaks if it churns |
+| --- | --- |
+| Root CA certificate and key | fog-client pins this as `ca.cert.der`; re-minting orphans every registered client at once |
+| Client-communication key and leaf | every client encrypts to that public half |
+| Web intermediate CA and key | invalidates the leaf beneath it |
+| Web leaf **private key** | a new key forces a new certificate |
+| `dhparam.pem` | expensive to generate, no reason to change |
+| Secure Boot CA and key | enrolled in firmware, per machine, by hand |
+| Secure Boot signing leaf | signed the kernels already deployed |
+| PK / KEK | written into firmware in Setup Mode |
+| MOK (flat fallback) | enrolled through MokManager behind physical presence |
+
+### Re-issued only on a real input change
+
+The **web leaf certificate**, and only it. The decision is a stamp file,
+`.webLeaf.sans`, holding
+
+```
+md5( contents of ca.cnf ‖ sha256 fingerprint of the signing CA )
+```
+
+which covers both the name set and the identity of the CA that signs it. The
+stamp is deleted whenever the leaf's key is regenerated, so the two can never
+disagree.
+
+>[!note]
+>This replaced a guard of `[[ ! -x $sslpubcert ]]`. Certificates are not
+>executable, so that test was true of every certificate ever written and the leaf
+>was re-signed on **every single run**. `tests/pki-idempotence.test.sh` now runs
+>the PKI path twice and fails if anything long-lived changes.
+
+### Derived per run — safe, because it is a function of the above
+
+Ephemeral OpenSSL configs and CSRs (`ca.cnf`, `req.cnf`, the `.csr` files); the
+CA chain and full-chain files, which are concatenations of create-once material;
+and the copies republished under the web root (`ca.cert.pem`, `ca.cert.der`,
+`srvpublic.crt`, the Secure Boot kit) because configuring the web server wipes
+that tree every run.
+
+One case sits deliberately in this class rather than being "fixed": an external
+CA's cert/key/chain are re-imported on every run whenever the source files are
+still readable. That is a re-*import*, not a regeneration, and it is what lets an
+admin rotate their CA — the leaf's stamp includes the CA fingerprint, so a
+genuinely changed CA correctly re-issues the leaf beneath it.
+
+## A4. Which root goes where
+
+Three questions that look like one and are not.
+
+| Question | Answer |
+| --- | --- |
+| What does **fog-client** pin? | The FOG root, published as `ca.cert.der`. |
+| What does the **vhost** serve? | The web leaf plus its chain, terminating in whichever root issued it — FOG's, or an external one. |
+| What does the **server's own OS trust store** need? | The root that the *served chain* terminates in. Otherwise every HTTPS call made on the server to the server fails to verify. |
+
+With FOG's own PKI all three are the same certificate. With `--external-ca` /
+`--web-ca-root` the second and third diverge from the first, because an external
+CA replaces **the CA that signs the vhost leaf, and only that** — the root
+fog-client pins is untouched. So the trust anchor is a **bundle**: FOG's own
+root, plus the root the served chain terminates in, deduplicated by fingerprint.
+
+>[!warning]
+>The chain files are not written in a consistent certificate order — the
+>generated web CA and the node signer write issuer-first with the root appended,
+>while the external-CA import writes the root first. Never select a root from a
+>chain **by position**. Both readers select it by `subject == issuer`.
+>`tests/trust-anchor.test.sh` pins this.
+
+`--no-ca-trust` declines the OS-trust-store step entirely. It does not affect
+browsers: Firefox carries its own NSS store, Chrome reads a per-user one, and the
+browser is usually on another machine.
+
+## A5. Bringing your own certificates
+
+Three separate things an admin may want to supply, at three different levels.
+
+### The web leaf (managed outside FOG)
+
+Set `acmeLeaf="yes"` in `.fogsettings` by hand. FOG then leaves the leaf in
+place and does not lock its private key down to `root:root 0600`, because an
+ACME renewal hook writes that file as whatever user it runs as.
+
+`acmeLeaf` and `publicWebCert` answer different questions — *who manages the
+leaf file* versus *what the leaf chains to*. All four combinations are real;
+internal ACME with step-ca is `acmeLeaf=yes` with `publicWebCert=no`.
+
+### The web CA (external issuer for the vhost leaf)
+
+`--external-ca` with `--web-ca-cert` / `--web-ca-key` / `--web-ca-root`. FOG
+validates that the key matches the certificate, that the certificate is a CA,
+and that it chains to the supplied root, then issues the web leaf beneath it.
+The FOG root and everything fog-client depends on are untouched.
+
+### The client-communication leaf (external issuer)
+
+Drop the certificate at `$sslpath/.srvpublic.crt` with its key at
+`$sslpath/.srvprivate.key`. FOG keeps both from then on and never re-issues.
+
+>[!danger]
+>The two must pair. Every registered fog-client encrypts to the public half of
+>that key, so a mismatched pair does not degrade anything — it locks out every
+>client at once, surfacing per host as a failed check-in with nothing naming
+>either file. FOG now checks the modulus and warns loudly, but it cannot repair
+>it for you.
+
+### Not implemented: sub-CA delegation of the FOG root
+
+The natural fourth option — the admin's CA issues an intermediate that becomes
+FOG's root, so FOG can still sign the communication leaf and node certificates
+while everything chains to corporate trust — is **not wired up**, though most of
+the machinery exists.
+
+`validateExternalCA` is zone-parameterised and its `flat` zone imports into the
+**root** zone's `.fogCA.pem` / `.fogCA.key`, which is exactly delegation. It is
+only ever called for the `web` zone, so that branch is dead code today.
+
+Turning it on is not a one-line change, and the reasons are worth recording:
+
+1. The root is resolved and, on a fresh install, **minted** before the
+   external-CA branch is reached — the communication leaf needs a signing key
+   that early.
+2. Root resolution is create-once and keyed on the certificate existing, so an
+   upgrade would have to be taught to adopt a delegated root without treating it
+   as "already done".
+3. There is a canonical-path symlink between the historic root location and the
+   root zone that both would write.
+4. Decisively: it changes what **every fog-client pins**. That is a migration,
+   not a flag.
+
+This belongs with the certificate-management page
+([#1121](https://github.com/FOGProject/fogproject/issues/1121)), not with the
+installer settings work.
+
+---
+
+# Part B — Audit findings
+
+Point-in-time, against `working-1.6` as of 2026-08-17. Line numbers drift.
+
+## B1. Item 1 — does everything honour `httpproto`?
+
+**Installer: yes, with three exceptions.** Every `curl` to FOG's own web tier
+builds its URL from `$httpproto` — node existence probe (`functions.sh:480`),
+node registration (`:508`), credential update (`:532`), DB backup (`:581`), web
+tier probe (`:619`), schema deploy (`:746`), node certificate request (`:3574`).
+So do every operator-facing URL and the final "setup complete" line.
+
+| Finding | Where | Verdict |
+| --- | --- | --- |
+| `${httpproto:-http}` — the only inline scheme default left | `functions.sh:3574` | will disagree with a `https` global default |
+| No `-L` and no status check; prints `Done` unconditionally | `functions.sh:532` | every other call to that endpoint carries `-L` because a redirect swallows the POST |
+| Every FOG-server `curl` uses `-k` | `:480,508,532,581,619,746,3574` | nothing breaks on HTTPS, but nothing verifies either; `--cacert $sslcapem` is the natural companion change |
+| Doubled slash — `${webroot}` already ends in `/` | `:480,508,532` | same class as the GH-978 fix; message and request disagree |
+| `--netboot-proto` implemented and in longopts, absent from `usage()` | `installfog.sh:501`, `:202` | undocumented flag |
+| Help text hardcodes `http://` examples | `installfog.sh:123-124,384,400` | cosmetic, becomes misleading |
+
+**Flipping `installfog.sh:695` is not sufficient.** `input.sh:302` prompts
+`[y/N]`, so pressing Enter yields HTTP; and `input.sh:309`'s empty arm catches
+`-y`, so `installfog.sh -y` forces HTTP regardless of the default.
+
+**PHP: nothing needs migrating, and nothing can express the setting either.**
+`FOG_WEB_HOST` and `FOG_WEB_ROOT` are scheme-free, and there is no
+`FOG_WEB_PROTOCOL` key. So no stored URL needs rewriting — and there is no
+DB-side source of truth for any code path without `$_SERVER`, which is every
+background daemon.
+
+Classification of the ~20 `self::$httpproto` call sites:
+
+- **Keep self-deriving (netboot):** `bootmenu.class.php:293`, `:294-301`,
+  `:471-472`.
+- **Keep self-deriving (same-origin):** `route.class.php:458-467`,
+  `openapi.class.php:294-303`, `apidocumentation.page.php:76-80`.
+- **Candidates for the configured setting:** `clientmanagement.page.php:65-70`
+  (client installer links), `snapinclient.class.php:170-180` (URL handed to
+  fog-client).
+- **Genuinely per-node — a global setting is the wrong answer:**
+  `storagenode.class.php:299-304`, `dashboardpage.page.php:534-539`,
+  `fogbase.class.php:3340`, `serverinfo.page.php:74-79`,
+  `storagenodemanagement.page.php:1194-1202`, `logtoview.php:180-184`,
+  `route.class.php:2181-2187` and `:3839-3844`,
+  `fogconfigurationpage.page.php:150-158`.
+- **Hardcoded schemes, FOG's own hosts:** `fogservice.class.php:513-522` pins
+  `http`, with `https` retries at `:637-644` and `:671-678`. `:586` probes port
+  **80** hardcoded, so an HTTPS-only node reads as unreachable.
+
+Riding alongside: `/fog/` is hardcoded at `bootmenu.class.php:472` and six other
+sites, so a custom `--webroot` breaks those URLs independently of any protocol
+question (GH-529 leftovers).
+
+## B2. Item 2 — the conditional redirect
+
+**The Apache path did not need the exclusion added — it already had it.** Both
+web servers gate on `[[ $netbootproto != "$httpproto" ]]`. Sub-question one is
+answered: no new mechanism is needed.
+
+**`service/ipxe/` was not the complete set** — see Part A §A2. `service/secureboot/`
+is fetched by iPXE directly and was not excluded, so on an
+`httpproto=https` / `netbootproto=http` install the Secure Boot menu entries were
+redirected onto an HTTPS iPXE cannot validate. **Fixed on this branch.**
+
+**It can be expressed as a rule** — *every path iPXE itself fetches* — rather
+than as an opaque list, but only because FOS's own fetches use `-Lks`. The rule
+is stated in both generated configs now, with the `-k` dependency called out.
+
+**`ca.cert.der` was exempt in Apache only.** nginx's `location /` caught it, so
+on nginx fetching the CA required already trusting the CA. **Fixed on this
+branch.**
+
+**HSTS is the sharper problem, and it is not fixed here.**
+`add_header Strict-Transport-Security max-age=15768000` is emitted on the nginx
+`:443` server in *both* arms (`functions.sh:6046` and `:6179`) — that is, even
+when `httpproto=http`. Apache emits none.
+
+>[!danger]
+>HSTS achieves client-side exactly what the redirect achieves server-side, is
+>sticky for six months, and **is not undone by turning a setting off**. Any
+>browser that has once reached the FOG server over HTTPS will refuse plain HTTP
+>to it regardless of what the vhost later says. When #1119 introduces
+>`httpsRedirect`, HSTS must be tied to *that* key, not to `httpproto` — and the
+>existing unconditional emission needs a decision of its own, because servers in
+>the field have already sent it.
+
+Smaller redirect findings: the targets hardcode literal `https://`
+(`functions.sh:6140`, `:6332`) and use `$host` / `%{HTTP_HOST}` with no port, so
+a non-443 HTTPS deployment is not expressible; Apache's `[R,L]` is a **302**
+while nginx uses **308**, which differ on POST; and `--no-vhost` (`-F`) silently
+decouples `httpproto` from what the web server enforces.
+
+## B3. Item 3 — is anything long-lived regenerated per run?
+
+**No — the class is clean.** Every artefact in Part A §A3's first table is
+guarded on its own existence, and the web leaf is guarded by the SAN stamp. The
+per-run writes are ephemeral configs, derived concatenations, or republished
+copies of create-once material.
+
+This had no automated backstop, which was the actual risk. It has one now
+(`tests/pki-idempotence.test.sh`), verified by reintroducing the historic
+`[[ ! -x $sslpubcert ]]` guard and confirming the test catches it.
+
+## B4. Item 4 — does an external root reach the OS trust store?
+
+**Verified by reading every assignment: it did not.** This was the fix.
+
+`--ca-root` / `--web-ca-root` land in `$extcaroot` / `$webExtCARoot`.
+`validateExternalCA` reads them and writes them into the chain file — and, by its
+own comment, deliberately never assigns `$rootCAPem`. Root resolution has no
+branch that consults either variable, and it runs *before* the external-CA branch
+is reached. So the trust anchor was FOG's own root while the vhost served the
+admin's chain, and every server-side HTTPS call to itself still failed to
+verify — the exact failure the mechanism exists to remove, silently unfixed on
+the installs whose admins had thought hardest about certificates.
+
+Four further defects in the same path, all fixed on this branch:
+
+1. The root was selected from a chain **by position**, and the writers disagree
+   on order (Part A §A4), so a storage node of an external-CA master anchored an
+   intermediate.
+2. The anchor was re-encoded with a single `openssl x509 -in`, which reads only
+   the **first** certificate of a bundle and discards the rest with no error —
+   which would have silently undone the fix.
+3. On a node, `writeUpdateFile` runs *before* the certificate request, so the
+   chain path was never persisted; on later runs the early "already issued"
+   return left `$sslcachain` naming the node's own self-signed CA.
+4. The web leaf's post-issue verification used `-CAfile $rootCAPem`, so it failed
+   on **every** external-CA install and printed a warning telling the admin to
+   widen `--internal-domain` and `rm -rf` the Web zone — advice unrelated to their
+   configuration, one half of which destroys a working PKI. It now verifies
+   against the chain's own root, using `-trusted`.
+
+>[!note]
+>`-trusted`, not `-CAfile`. `-CAfile` **adds to** the default trust locations
+>rather than replacing them, and FOG installs its own CA into the host store by
+>default — so a `-CAfile` check can answer "verified" out of the system store
+>instead of out of the file it was handed. Verified in both directions against a
+>two-CA fixture.
+
+`--web-ca-cert` / `--web-ca-key` / `--web-ca-root` were also **not persisted** in
+`.fogsettings`, unlike the `--ca-*` trio they mirror. Now added.
+
+## B5. What Phase 2 must carry out of this
+
+1. **`functions.sh:1630`, `:1701`, `:1728` must be re-keyed onto
+   `$netbootproto`.** They gate the iPXE release download, the Secure Boot
+   staging and the 10–25 minute local rebuild on `httpproto`. Flipping the
+   default without this forces a source build on every install and stages **no
+   Secure Boot binaries at all**. This is the single largest blast radius in the
+   change.
+2. **Split the redirect out of `httpproto` into `httpsRedirect`** — and take HSTS
+   with it (§B2).
+3. **`_resolveNetbootProto` (`functions.sh:5058`) inverts under the new default.**
+   It currently drops to HTTP only when `httpproto == https` *and* neither
+   `externalca` nor `caCreated` is set. `caCreated` is persisted, so on any
+   re-run of an existing server it is `yes` — meaning once `httpproto` defaults
+   to `https`, every upgraded install resolves `netbootproto=https`. #1116's
+   model (default HTTP, steered to HTTPS only by `publicWebCert` or
+   `rebuildIpxeWithMyCA`) replaces this function outright; it must not merely be
+   tweaked.
+4. **Fix `input.sh` alongside `installfog.sh:695`**, or the new default never
+   takes effect on a fresh install (§B1).
+5. **Document `--netboot-proto` in `usage()`.**
+
+---
+
+## Publishing notes for #1120
+
+Part A is written to `fog-docs` house style already: literal `→` for menu paths,
+Obsidian callouts, no bare line numbers, each wikilink on one line. Front matter
+(`title` / `aliases` / `description` / `context_id` / `tags`) is added at port
+time — it is deliberately absent here, since this repo's `docs/` is plain
+Markdown.
+
+Suggested destinations, cross-linked rather than merged:
+
+| Section | Destination in `fog-docs` |
+| --- | --- |
+| A1, A2 | a new page under `docs/installation/network-setup/` — netboot transport and the redirect |
+| A3, A4 | `docs/kb/reference/pki-zones.md` |
+| A5 | `docs/kb/integrations/external-ca-lets-encrypt.md` |
+
+Part B does not get published. It is working material for #1119, and its line
+numbers are already aging.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5206,7 +5206,45 @@ _createCommLeaf() {
     commLeafKey="$sslpath/.srvprivate.key"
     commLeafPem="$sslpath/.srvpublic.crt"
 
+    # Already present: keep it, whoever issued it. This is also the supported
+    # way to run a comm leaf issued OUTSIDE FOG -- drop the certificate at
+    # $sslpath/.srvpublic.crt with its key at $sslpath/.srvprivate.key and FOG
+    # leaves both alone from then on.
+    #
+    # Checked with the same modulus test the adopt branch below uses, and for
+    # the same reason it gives: a certificate that does not pair with this key
+    # publishes a public key nothing on this server can decrypt against. Every
+    # registered fog-client encrypts to that public half, so a mismatch here
+    # does not degrade anything -- it locks out every client at once, and
+    # FOGBase::certDecrypt() reports it per client as a failed authorize with
+    # nothing pointing back at the certificate. Silently keeping whatever was
+    # there was the one path into this state.
     if [[ -f $commLeafPem ]]; then
+        local haveMod wantMod
+        haveMod=$(openssl x509 -noout -modulus -in "$commLeafPem" 2>/dev/null | openssl md5 2>/dev/null)
+        wantMod=$(openssl rsa -noout -modulus -in "$commLeafKey" 2>/dev/null | openssl md5 2>/dev/null)
+        # No key yet is not a mismatch. An install that has the certificate but
+        # not the key is mid-migration, not broken -- _separateCommKey runs
+        # after this and is what settles that case.
+        if [[ -f $commLeafKey && -n $haveMod && -n $wantMod && $haveMod != "$wantMod" ]]; then
+            echo
+            echo "  ###################################################################"
+            echo "  # WARNING: the client communication certificate does not match    #"
+            echo "  # the client communication private key.                           #"
+            echo "  #                                                                 #"
+            echo "  #   certificate: $commLeafPem"
+            echo "  #   private key: $commLeafKey"
+            echo "  #                                                                 #"
+            echo "  # Every registered fog-client encrypts to the key in that          #"
+            echo "  # certificate, so while these disagree NO client can authenticate #"
+            echo "  # -- it surfaces per host as a failed check-in, not as anything   #"
+            echo "  # naming these files.                                             #"
+            echo "  #                                                                 #"
+            echo "  # Put back the certificate that pairs with this key, or supply    #"
+            echo "  # both halves together if you issue this leaf outside FOG.        #"
+            echo "  ###################################################################"
+            echo
+        fi
         return 0
     fi
     # An existing server already has this certificate, under the web root where

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3617,6 +3617,13 @@ _installNodeWebCert() {
     # would mint a new keypair and a new certificate for no reason.
     if [[ -f $chain && -f $sslpubcert ]] && \
         openssl verify -CAfile "$chain" "$sslpubcert" >>$error_log 2>&1; then
+        # Still point $sslcachain at it. writeUpdateFile runs BEFORE this
+        # function on a node (installfog.sh), so the assignment in the success
+        # branch below is never persisted -- which means on every LATER run
+        # $sslcachain arrives from .fogsettings still naming the node's own
+        # self-signed CA, and _resolveTrustAnchor would anchor out of the wrong
+        # file on exactly the runs that take this early return.
+        sslcachain="$chain"
         return 0
     fi
     dots "Requesting a web certificate from the master"
@@ -3668,39 +3675,112 @@ _caTrustLayout() {
     fi
     return 0
 }
-# Which certificate this box should anchor, which is not the same file in both
-# roles. Sets $trustAnchorPem; returns 1 when there is nothing to anchor yet.
+# Split a PEM bundle into one file per certificate, $2/c1.pem, c2.pem, ...
+# Returns 1 when the source yielded no certificate at all.
 #
-# A master holds the root itself, and the root is what to anchor -- not the Web
-# intermediate. Anchoring the root is what makes the intermediate and every
-# leaf beneath it verify, and it is the same certificate ca.cert.der publishes
-# and fog-client pins, so one certificate describes this server's trust
-# wherever that trust is stated.
+# openssl cannot do this itself. `openssl x509` reads only the FIRST certificate
+# in a bundle and silently ignores the rest -- it does not warn and it does not
+# fail, which is exactly how a multi-certificate anchor gets truncated to one
+# certificate with nothing in any log to say so.
+_splitPemBundle() {
+    local src="$1" dir="$2" f found=1
+    [[ -n $src && -f $src && -n $dir && -d $dir ]] || return 1
+    awk -v d="$dir" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' \
+        "$src" 2>>$error_log
+    for f in "$dir"/c*.pem; do
+        [[ -f $f ]] && { found=0; break; }
+    done
+    return $found
+}
+# Print the self-signed (root) certificate out of a PEM bundle. Returns 1 when
+# the bundle has none, which is a normal state -- a chain the master sent
+# without a root -- and not an error.
 #
-# A storage node never receives the root's key and only ever gets a chain from
-# the master. fog-sign-node-cert writes that chain issuer-first with the root
-# appended when the master has one, so the LAST certificate in it is the root
-# where a root was sent and the Web intermediate where it was not. Either is a
-# correct anchor for the certificates this node will be served.
+# Selected by subject == issuer, never by position. The writers of these bundles
+# do NOT agree on order: createWebIntermediateCA and fog-sign-node-cert both
+# write issuer-first with the root appended, while validateExternalCA writes the
+# root FIRST. A "last certificate in the file" rule therefore picks the root on
+# a FOG-generated CA and the INTERMEDIATE on an external one -- which is how a
+# storage node of an external-CA master came to anchor an intermediate.
+# _writeWebChainFiles selects the same way, for the same reason.
+_rootFromChain() {
+    local bundle="$1" tmpd f subj issuer st=1
+    [[ -n $bundle && -f $bundle ]] || return 1
+    tmpd=$(mktemp -d) || return 1
+    if _splitPemBundle "$bundle" "$tmpd"; then
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            subj=$(openssl x509 -in "$f" -noout -subject 2>/dev/null)
+            issuer=$(openssl x509 -in "$f" -noout -issuer 2>/dev/null)
+            [[ -z $subj ]] && continue
+            # -subject prints "subject=..." and -issuer "issuer=...", so compare
+            # the values rather than the whole line.
+            if [[ ${subj#subject=} == "${issuer#issuer=}" ]]; then
+                cat "$f"
+                st=0
+                break
+            fi
+        done
+    fi
+    rm -rf "$tmpd" >>$error_log 2>&1
+    return $st
+}
+# Which certificates this box should anchor. Sets $trustAnchorPem to a bundle;
+# returns 1 when there is nothing to anchor yet.
+#
+# Two certificates can matter here and they are not always the same one, which
+# is what this used to get wrong. It anchored $rootCAPem on a master, full stop.
+# That is right only while FOG issues the web certificate itself:
+#
+#   * $rootCAPem is FOG's own root. It signs the client-communication leaf and
+#     every storage-node certificate whatever the vhost is serving, and it is
+#     what ca.cert.der publishes and fog-client pins.
+#   * The root the SERVED chain terminates in is a different certificate as soon
+#     as --external-ca/--web-ca-root is in play, because validateExternalCA
+#     deliberately never touches $rootCAPem (see its comment). So the store held
+#     FOG's root while the vhost served the admin's chain, and every HTTPS call
+#     made on this server to this server still failed to verify -- the exact
+#     failure this whole mechanism exists to remove.
+#
+# Anchoring both, deduplicated, is correct in every combination: on a FOG-issued
+# install they are the same certificate and the bundle collapses to one, and on
+# an external-CA install both are genuinely needed.
+#
+# One code path for master and node now. A node has no root of its own, so
+# $rootCAPem simply is not there and the chain supplies everything; the branch
+# only ever existed because the master case skipped the chain entirely.
 _resolveTrustAnchor() {
     trustAnchorPem=""
-    if [[ $installtype == [Ss] ]]; then
-        [[ -n $sslcachain && -f $sslcachain ]] || return 1
-        local out="$(_pkiZoneDir web)/ca/.trustAnchor.pem"
-        # The chain normally lands in this directory, so it normally exists --
-        # but $sslcachain is admin-overridable and can point anywhere, and a
-        # failed redirect here would look exactly like "nothing to anchor".
-        mkdir -p "$(dirname "$out")" >>$error_log 2>&1
-        # Split off the last PEM block. openssl x509 reads only the first
-        # certificate in a bundle, so it cannot do this itself.
-        awk '/-----BEGIN CERTIFICATE-----/{n++; cert[n]=""} n{cert[n]=cert[n] $0 "\n"} END{printf "%s", cert[n]}' \
-            "$sslcachain" > "$out" 2>>$error_log
-        [[ -s $out ]] || return 1
-        trustAnchorPem="$out"
-    else
-        [[ -n $rootCAPem && -f $rootCAPem ]] || return 1
-        trustAnchorPem="$rootCAPem"
+    local out="$(_pkiZoneDir web)/ca/.trustAnchor.pem"
+    local chainroot fp seen=""
+    # The chain normally lands in this directory, so it normally exists -- but
+    # $sslcachain is admin-overridable and can point anywhere, and a failed
+    # redirect here would look exactly like "nothing to anchor".
+    mkdir -p "$(dirname "$out")" >>$error_log 2>&1
+    : > "$out" 2>>$error_log || return 1
+
+    if [[ -n $rootCAPem && -f $rootCAPem ]]; then
+        fp=$(openssl x509 -in "$rootCAPem" -noout -fingerprint -sha256 2>/dev/null)
+        if [[ -n $fp ]]; then
+            cat "$rootCAPem" >> "$out" 2>>$error_log
+            seen="$fp"
+        fi
     fi
+    if [[ -n $sslcachain && -f $sslcachain ]]; then
+        chainroot=$(_rootFromChain "$sslcachain")
+        if [[ -n $chainroot ]]; then
+            fp=$(printf '%s\n' "$chainroot" \
+                | openssl x509 -noout -fingerprint -sha256 2>/dev/null)
+            # Fingerprint, not a path comparison: on a FOG-issued install these
+            # are the same certificate reached by two different routes, and
+            # comparing filenames would append it twice.
+            if [[ -n $fp && $fp != "$seen" ]]; then
+                printf '%s\n' "$chainroot" >> "$out" 2>>$error_log
+            fi
+        fi
+    fi
+    [[ -s $out ]] || return 1
+    trustAnchorPem="$out"
     return 0
 }
 # Anchor this server's own CA in this server's own system trust store.
@@ -3741,6 +3821,13 @@ _installCATrustAnchor() {
     # here rejects a malformed anchor at the point it can be attributed,
     # instead of at refresh time where the store blames some other certificate.
     #
+    # Per certificate, not `openssl x509 -in "$anchor"` over the whole file:
+    # that reads only the FIRST certificate of a bundle and discards the rest
+    # silently. $trustAnchorPem carries two certificates on an external-CA
+    # install, and the single-shot form would have written FOG's root and
+    # dropped the admin's -- reintroducing the bug _resolveTrustAnchor was just
+    # changed to fix, with nothing to show for it in any log.
+    #
     # Staged through a temp file and moved into place only once openssl is
     # happy. Whether a failed `openssl x509 -out` leaves an empty file behind
     # varies by version, and a zero-byte .crt sitting in the anchor directory
@@ -3753,7 +3840,19 @@ _installCATrustAnchor() {
     # replacement. That is the whole reason this is not named after the CA's
     # fingerprint or its date.
     local staged="${caTrustDir}/.fog-server-ca.crt.$$"
-    if openssl x509 -in "$anchor" -out "$staged" >>$error_log 2>&1 && [[ -s $staged ]]; then
+    local tmpd f
+    tmpd=$(mktemp -d) || return 0
+    : > "$staged" 2>>$error_log || st=1
+    if [[ $st -eq 0 ]] && _splitPemBundle "$anchor" "$tmpd"; then
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            openssl x509 -in "$f" >> "$staged" 2>>$error_log || st=1
+        done
+    else
+        st=1
+    fi
+    rm -rf "$tmpd" >>$error_log 2>&1
+    if [[ $st -eq 0 && -s $staged ]]; then
         chmod 0644 "$staged" >>$error_log 2>&1
         mv -f "$staged" "${caTrustDir}/fog-server-ca.crt" >>$error_log 2>&1 || st=1
         [[ $st -eq 0 ]] && { $caTrustCmd >>$error_log 2>&1 || st=1; }
@@ -5253,12 +5352,14 @@ _writeWebChainFiles() {
     # Every certificate in the chain file except self-signed ones. A self-signed
     # certificate in here is the root, and it is the one thing that must not be
     # sent. Splitting on the PEM boundary rather than trusting the file's order,
-    # because validateExternalCA and createWebIntermediateCA both write it
-    # root-first while an admin-supplied chain may be in any order at all.
+    # because the writers disagree -- createWebIntermediateCA and
+    # fog-sign-node-cert write issuer-first with the root appended, while
+    # validateExternalCA writes the root FIRST -- and an admin-supplied chain
+    # may be in any order at all. _rootFromChain selects the other way round off
+    # the same property, so neither reader depends on the order.
     local tmpd f
     tmpd=$(mktemp -d) || return 0
-    awk -v d="$tmpd" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' \
-        "$sslcachain" 2>>$error_log
+    _splitPemBundle "$sslcachain" "$tmpd"
     for f in "$tmpd"/c*.pem; do
         [[ -f $f ]] || continue
         subj=$(openssl x509 -in "$f" -noout -subject 2>/dev/null)

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6041,14 +6041,50 @@ EOF
                         # publicly chainable, so the redirect must NOT catch
                         # iPXE's own fetches -- otherwise it lands right back
                         # on the HTTPS it cannot validate and boot fails.
+                        #
+                        # The rule is "every path iPXE ITSELF fetches", which is
+                        # two directories, not one:
+                        #
+                        #   service/ipxe/       boot.php, advanced.php, the
+                        #                       kernel and init (fetched
+                        #                       relative to boot.php's own URI),
+                        #                       refind, grub, the menu artwork.
+                        #   service/secureboot/ MOK.der, which BootMenu imgfetches
+                        #                       so MokManager can enrol it from
+                        #                       memory, and mmx64.efi /
+                        #                       arm64-efi/mmaa64.efi, which it
+                        #                       chains. See BootMenu's Secure
+                        #                       Boot entries.
+                        #
+                        # Everything else FOS reaches under ${web} is fetched by
+                        # curl -Lks, which follows the redirect and skips
+                        # verification, so it survives one. That tolerance is
+                        # load-bearing and undocumented anywhere else: if a FOS
+                        # fetch ever drops -k, its path has to be added here too.
                         if [[ $netbootproto != "$httpproto" ]]; then
-                            echo "    location ^~ ${webroot}service/ipxe/ {" >> "$etcconf"
-                            echo "        root ${docroot};" >> "$etcconf"
-                            echo "        index index.php;" >> "$etcconf"
-                            echo "        try_files \$uri \$uri/ =404;" >> "$etcconf"
-                            echo "        include ${phploc};" >> "$etcconf"
-                            echo "    }" >> "$etcconf"
+                            local nbdir
+                            for nbdir in ipxe secureboot; do
+                                echo "    location ^~ ${webroot}service/${nbdir}/ {" >> "$etcconf"
+                                echo "        root ${docroot};" >> "$etcconf"
+                                echo "        index index.php;" >> "$etcconf"
+                                echo "        try_files \$uri \$uri/ =404;" >> "$etcconf"
+                                echo "        include ${phploc};" >> "$etcconf"
+                                echo "    }" >> "$etcconf"
+                            done
                         fi
+                        # The CA itself, always reachable over plain HTTP --
+                        # independent of netboot transport, because the client
+                        # that needs this is one that trusts nothing yet.
+                        # Redirecting it to HTTPS makes fetching the CA require
+                        # already trusting the CA. Apache's branch has had this
+                        # exemption since GH-529; nginx never did, so on nginx
+                        # the bootstrap was simply broken.
+                        #
+                        # `location =` is an exact match and beats both the `^~`
+                        # prefixes above and `location /`, whatever their order.
+                        echo "    location = ${webroot}management/other/ca.cert.der {" >> "$etcconf"
+                        echo "        root ${docroot};" >> "$etcconf"
+                        echo "    }" >> "$etcconf"
                         # The redirect is a `location`, NOT a server-level
                         # `return`. nginx runs a server-level return in the
                         # server rewrite phase, which is BEFORE location
@@ -6237,12 +6273,23 @@ EOF
                         # is stripped for you; it has been wrong here since
                         # 2017. Apache's MergeSlashes normally hides it, which
                         # is why it went unreported for so long.
-                        # See the nginx branch: iPXE's own fetches must not be
-                        # redirected to an HTTPS it cannot validate. The
-                        # condition goes immediately before the rule it guards,
-                        # since RewriteCond applies only to the next RewriteRule.
+                        # See the nginx branch for the full reasoning: every
+                        # path iPXE ITSELF fetches must not be redirected to an
+                        # HTTPS it cannot validate, and that is two directories
+                        # -- service/ipxe/ and service/secureboot/, the latter
+                        # because BootMenu imgfetches MOK.der and chains
+                        # mmx64.efi / arm64-efi/mmaa64.efi out of it.
+                        #
+                        # The conditions go immediately before the rule they
+                        # guard, since RewriteCond applies only to the next
+                        # RewriteRule. Multiple RewriteConds are ANDed by
+                        # default, which is what is wanted: skip the redirect
+                        # only when the request is for neither directory.
                         if [[ $netbootproto != "$httpproto" ]]; then
-                            echo "    RewriteCond %{REQUEST_URI} !^${webrootre}service/ipxe/" >> "$etcconf"
+                            local nbdir
+                            for nbdir in ipxe secureboot; do
+                                echo "    RewriteCond %{REQUEST_URI} !^${webrootre}service/${nbdir}/" >> "$etcconf"
+                            done
                         fi
                         echo "    RewriteRule ^/?(.*)\$ https://%{HTTP_HOST}/\$1 [R,L]" >> "$etcconf"
                         echo "</VirtualHost>" >> "$etcconf"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4267,6 +4267,13 @@ writeUpdateFile() {
         caCreated httpproto startrange endrange packages noTftpBuild tftpAdvOpts
         sslpath backupPath php_ver sslprivkey sslcakey sslcapem sslcachain
         externalca extcacert extcakey extcaroot sslcsr sslpubcert sendreports webserver
+        # The Web-zone counterparts of the three above. Persisted for the same
+        # reason they are: without this, a re-run with no flags falls into
+        # validateExternalCA's "reuse a previously imported CA" branch, which
+        # happens to serve the same bytes but has lost any record that the
+        # admin ever pointed FOG at an external CA -- and _resolveTrustAnchor
+        # now needs to know which root the served chain belongs to.
+        webExtCACert webExtCAKey webExtCARoot
         # GH-850: recorded so `grep fogprogramdir .fogsettings` answers "where
         # does this install live" -- but it is a RECORD, not a control. The
         # installer re-asserts the value it resolved from /etc/fog/fog.conf or
@@ -5446,23 +5453,59 @@ _createWebLeaf() {
     # well-formed certificate that no client will accept. Left undetected it
     # surfaces as a browser error days later with nothing connecting it to the
     # rename.
-    if [[ -n $sslcachain && -e $sslcachain ]] && \
-        ! openssl verify -CAfile "$rootCAPem" -untrusted "$sslcachain" "$sslpubcert" >>$error_log 2>&1; then
+    #
+    # Verified against the root the CHAIN terminates in, not against
+    # $rootCAPem. Under --external-ca the leaf chains to the ADMIN's root while
+    # $rootCAPem is still FOG's own -- validateExternalCA never reassigns it --
+    # so the old form failed on every external-CA install and printed the box
+    # below unconditionally, telling the admin to delete a Web zone that was
+    # working correctly.
+    #
+    # -trusted, not -CAfile. -CAfile ADDS to the default trust locations rather
+    # than replacing them, and _installCATrustAnchor puts FOG's own CA into this
+    # host's store by default, so a -CAfile test can answer "verified" out of
+    # the system store instead of out of the file it was handed. -trusted is the
+    # documented "only this file" form.
+    local vtmp
+    local vroot=""
+    vtmp=$(mktemp -d 2>>$error_log)
+    if [[ -n $vtmp && -n $sslcachain && -e $sslcachain ]]; then
+        _rootFromChain "$sslcachain" > "${vtmp}/root.pem" 2>>$error_log
+        if [[ -s ${vtmp}/root.pem ]]; then
+            vroot="${vtmp}/root.pem"
+        elif [[ -n $rootCAPem && -f $rootCAPem ]]; then
+            # A chain carrying no root of its own. FOG's is the only anchor
+            # available, and for a FOG-issued leaf it is also the right one.
+            vroot="$rootCAPem"
+        fi
+    fi
+    if [[ -n $vroot ]] && \
+        ! openssl verify -trusted "$vroot" -untrusted "$sslcachain" "$sslpubcert" >>$error_log 2>&1; then
         echo
         echo "  ###################################################################"
         echo "  # WARNING: the web certificate does not verify against the CA     #"
-        echo "  # that issued it. The usual cause is a name outside that CA's     #"
-        echo "  # name constraints -- this server was renamed, or gained an       #"
-        echo "  # --extra-server-name, after the CA was created.                  #"
-        echo "  #                                                                 #"
-        echo "  # Re-run with the name permitted:                                 #"
-        echo "  #   --internal-domain <domain>                                    #"
-        echo "  # A CA is never re-issued once it exists, so also remove it so    #"
-        echo "  # the new constraints take effect:                                #"
-        echo "  #   rm -rf $(_pkiZoneDir web)"
+        echo "  # that issued it.                                                 #"
+        if [[ $externalca == yes ]]; then
+            echo "  #                                                                 #"
+            echo "  # This server uses an external CA, so check that the leaf, the    #"
+            echo "  # intermediate and the root you supplied really belong together:  #"
+            echo "  #   --web-ca-cert / --web-ca-key / --web-ca-root                   #"
+            echo "  # Nothing under the FOG PKI tree needs removing for this.         #"
+        else
+            echo "  # The usual cause is a name outside that CA's name constraints    #"
+            echo "  # -- this server was renamed, or gained an --extra-server-name,   #"
+            echo "  # after the CA was created.                                       #"
+            echo "  #                                                                 #"
+            echo "  # Re-run with the name permitted:                                 #"
+            echo "  #   --internal-domain <domain>                                    #"
+            echo "  # A CA is never re-issued once it exists, so also remove it so    #"
+            echo "  # the new constraints take effect:                                #"
+            echo "  #   rm -rf $(_pkiZoneDir web)"
+        fi
         echo "  ###################################################################"
         echo
     fi
+    [[ -n $vtmp ]] && rm -rf "$vtmp" >>$error_log 2>&1
     return 0
 }
 FOG_MANAGED_BEGIN='# === FOG MANAGED BLOCK -- DO NOT EDIT BETWEEN THESE LINES (see docs/SUPPORTED_CUSTOMIZATIONS.md) ==='

--- a/tests/pki-idempotence.test.sh
+++ b/tests/pki-idempotence.test.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+#
+# Guards the "long-lived certificate re-issued on every run" bug class.
+#
+#   tests/pki-idempotence.test.sh
+#
+# The web leaf's historic guard was `[[ ! -x $sslpubcert ]]`. Certificates are
+# not executable, so that test was true of every certificate ever written and
+# the leaf was re-signed on EVERY installer run. It was harmless only while one
+# key did every job; the moment the signing key can be offline, or a client has
+# pinned something, re-issuing on an upgrade is a broken server.
+#
+# That one is fixed -- the leaf now re-issues only when its SAN set or its
+# signing CA actually changed, tracked by the .webLeaf.sans stamp. The class was
+# never guarded, which is what this is for: it runs the PKI creation path twice
+# against the same tree and asserts that nothing long-lived changed. A second
+# run must be a no-op for anything a client, a firmware, or an offline key
+# depends on.
+#
+# What "long-lived" means here, and why each one matters if it churns:
+#
+#   root CA            fog-client pins it as ca.cert.der; re-minting orphans
+#                      every registered client at once.
+#   comm key + leaf    every client encrypts to that public half.
+#   web intermediate   re-minting it invalidates the leaf beneath it.
+#   web leaf key       a new key needs a new certificate, so this drags the
+#                      leaf with it.
+#   Secure Boot CA     enrolled in firmware, per machine, by hand.
+#   SB signing leaf    what signed the kernels already deployed.
+#   PK / KEK           written into firmware in Setup Mode.
+#   MOK                enrolled through MokManager behind physical presence.
+#
+# Deliberately drives the PKI helpers directly rather than calling
+# createSSLCA(): that function also mints the vhost, writes under /etc and
+# restarts services. The sequence below mirrors the order createSSLCA calls
+# them in. If it drifts, this test still answers the question it exists to
+# answer -- "does a second pass re-issue anything" -- because each helper owns
+# its own guard.
+#
+# Needs openssl. No network, no root, no install.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+command -v openssl >/dev/null 2>&1 || {
+    echo "SKIP: openssl is not installed"
+    exit 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# Stubs. errorStat exits the whole script on a non-zero status, which in a test
+# run would look like a pass (no failures printed) rather than a failure.
+dots() { :; }
+errorStat() { :; }
+setSELinuxContext() { :; }
+
+# --- a self-contained install tree -------------------------------------------
+fogprogramdir="$WORK/opt/fog"
+snapindir="$WORK/opt/fog/snapins"
+sslpath="$snapindir/ssl"
+webdirdest="$WORK/var/www/fog"
+backupPath="$WORK/backups"
+version="1.6.0-test"
+apacheuser="$(id -un)"
+hostname="fogserver.test.local"
+ipaddress="10.0.0.5"
+ipaddresses="10.0.0.5"
+certip="$ipaddress"
+# Set so _collectPkiNames does not stop to prompt for them.
+internalDomains="test.local"
+extraServerNames=""
+secureboot=1
+recreateKeys=no
+recreateCA=no
+externalca=no
+acmeLeaf=no
+mkdir -p "$sslpath/CA" "$webdirdest" "$backupPath"
+
+# One pass of the PKI creation path, in createSSLCA()'s own order.
+pki_pass() {
+    _resolveSslPath
+    _resolveRootCA
+
+    local sanentries="IP.1 = ${ipaddress}"
+    cat > "$sslpath/ca.cnf" << EOF
+[v3_ca]
+subjectAltName = @alt_names
+[alt_names]
+$sanentries
+DNS.1 = $hostname
+EOF
+    cat > "$sslpath/req.cnf" << EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = $certip
+O = FOG Project
+OU = FOG Client Communication
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+$sanentries
+DNS.1 = $hostname
+EOF
+
+    [[ -z $sslcsr ]] && sslcsr="$sslpath/fog.csr"
+    _separateCommKey
+    if [[ ! -e $sslpath/.srvprivate.key || ! -e $sslcsr ]]; then
+        openssl genrsa -out "$sslpath/.srvprivate.key" 4096 >>$error_log 2>&1
+        openssl req -new -sha512 -key "$sslpath/.srvprivate.key" -out "$sslcsr" \
+            -config "$sslpath/req.cnf" >>$error_log 2>&1
+    fi
+    _createCommLeaf >/dev/null 2>&1
+
+    createWebIntermediateCA
+    _resolveWebLeafPaths
+    _createWebLeaf >/dev/null 2>&1
+    _writeWebChainFiles
+
+    createSecureBootIntermediateCA >/dev/null 2>&1
+    _ensureSecureBootKeys >/dev/null 2>&1
+    _ensureSecureBootPlatformKeys >/dev/null 2>&1
+    return 0
+}
+
+# --- the artefacts a second run must not touch -------------------------------
+artefacts() {
+    printf '%s\n' \
+        "$sslpath/CA/.fogCA.pem|root CA certificate" \
+        "$fogprogramdir/pki/root/ca/.fogCA.key|root CA private key" \
+        "$sslpath/.srvprivate.key|client communication key" \
+        "$sslpath/.srvpublic.crt|client communication leaf" \
+        "$fogprogramdir/pki/web/ca/.fogWebCA.pem|web intermediate CA" \
+        "$fogprogramdir/pki/web/ca/.fogWebCA.key|web intermediate CA key" \
+        "$fogprogramdir/pki/web/leaf/.webLeaf.key|web leaf private key" \
+        "$fogprogramdir/pki/web/leaf/.webLeaf.pem|web leaf certificate" \
+        "$fogprogramdir/pki/secureboot/ca/.fogSBCA.pem|Secure Boot CA" \
+        "$fogprogramdir/pki/secureboot/ca/.fogSBCA.key|Secure Boot CA key" \
+        "$fogprogramdir/pki/secureboot/leaf/sign.key|Secure Boot signing key" \
+        "$fogprogramdir/pki/secureboot/leaf/sign.pem|Secure Boot signing certificate" \
+        "$fogprogramdir/pki/secureboot/PK.key|Platform Key" \
+        "$fogprogramdir/pki/secureboot/PK.pem|Platform Key certificate" \
+        "$fogprogramdir/pki/secureboot/KEK.key|Key Exchange Key" \
+        "$fogprogramdir/pki/secureboot/KEK.pem|Key Exchange Key certificate"
+    # Not listed: the flat MOK.key/MOK.pem pair. It is the FALLBACK for a server
+    # with no Secure Boot CA -- _ensureSecureBootKeys returns early here because
+    # createSecureBootIntermediateCA has already pointed $secureBootKey at the
+    # signing leaf -- so it is genuinely absent in this configuration rather
+    # than missing. sign.key/sign.pem above are what this install enrols.
+}
+
+sumof() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    else
+        openssl dgst -sha256 "$1" 2>/dev/null | awk '{print $NF}'
+    fi
+}
+
+echo "pki idempotence:"
+
+pki_pass
+first_run_log_size=$(wc -c < "$error_log")
+
+# Snapshot everything that exists after the first pass. Anything absent is
+# named rather than passed over: this driver is a stand-in for createSSLCA, so
+# an artefact that stopped being produced would otherwise silently drop out of
+# the comparison and the test would keep reporting a pass over fewer files.
+declare -A BEFORE=()
+present=0
+absent=""
+while IFS='|' read -r path label; do
+    if [[ -f $path ]]; then
+        BEFORE["$path"]=$(sumof "$path")
+        present=$((present + 1))
+    else
+        absent="${absent}${absent:+, }${label}"
+    fi
+done < <(artefacts)
+[[ -n $absent ]] && printf '  note  not produced by this driver: %s\n' "$absent"
+
+if [[ $present -eq 0 ]]; then
+    bad "the first pass created no PKI artefacts at all -- check $error_log"
+    printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+    exit 1
+fi
+ok "first pass created $present PKI artefact(s)"
+
+# The whole point: run it again against the same tree.
+pki_pass
+
+changed=0
+while IFS='|' read -r path label; do
+    [[ -n ${BEFORE[$path]:-} ]] || continue
+    if [[ ! -f $path ]]; then
+        bad "$label disappeared on the second run"
+        changed=$((changed + 1))
+        continue
+    fi
+    if [[ "$(sumof "$path")" != "${BEFORE[$path]}" ]]; then
+        bad "$label was REGENERATED on the second run ($path)"
+        changed=$((changed + 1))
+    fi
+done < <(artefacts)
+
+[[ $changed -eq 0 ]] && ok "no long-lived artefact changed on the second run"
+
+# The stamp is what makes the web leaf's re-issue decision, so prove it is
+# doing the work rather than the leaf surviving by accident: change the name
+# set, and the leaf MUST be re-issued.
+stamp="$fogprogramdir/pki/web/leaf/.webLeaf.sans"
+if [[ -f $stamp ]]; then
+    ok "the web leaf SAN stamp exists"
+    leafbefore=$(sumof "$fogprogramdir/pki/web/leaf/.webLeaf.pem")
+    hostname="renamed.test.local"
+    pki_pass
+    if [[ "$(sumof "$fogprogramdir/pki/web/leaf/.webLeaf.pem")" != "$leafbefore" ]]; then
+        ok "renaming the server DOES re-issue the web leaf"
+    else
+        bad "renaming the server did not re-issue the web leaf -- the stamp is not tracking the name set"
+    fi
+    # ...and nothing above the leaf moved with it.
+    for ca in \
+        "$sslpath/CA/.fogCA.pem" \
+        "$fogprogramdir/pki/web/ca/.fogWebCA.pem" \
+        "$sslpath/.srvpublic.crt"; do
+        [[ -n ${BEFORE[$ca]:-} ]] || continue
+        if [[ "$(sumof "$ca")" != "${BEFORE[$ca]}" ]]; then
+            bad "re-issuing the leaf also changed $ca"
+        fi
+    done
+    ok "re-issuing the leaf left the CAs and the comm leaf alone"
+else
+    bad "the web leaf SAN stamp was never written ($stamp)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || {
+    echo "  (openssl errors, if any, are in $error_log -- first pass wrote ${first_run_log_size} bytes)"
+    exit 1
+}
+exit 0

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -51,9 +51,16 @@ for t in "$testdir"/*.test.php; do
     run_one "$t" php
 done
 
+# bash, not sh. Every *.test.sh here carries a #!/bin/bash shebang and uses
+# bash-only constructs -- [[ ]], arrays, ${BASH_SOURCE[0]} -- because the code
+# they exercise (lib/common/functions.sh) is itself bash and cannot be sourced
+# by anything else. Running them with `sh` works only where /bin/sh happens to
+# BE bash; on Debian and Ubuntu it is dash, and there every one of them died on
+# "Bad substitution" at the line that locates the repo, before running a single
+# assertion. That reads as a failing test suite rather than a mis-invoked one.
 for t in "$testdir"/*.test.sh; do
     [ -f "$t" ] || continue
-    run_one "$t" sh
+    run_one "$t" bash
 done
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/trust-anchor.test.sh
+++ b/tests/trust-anchor.test.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+#
+# Guards what the installer puts in this server's OWN system trust store.
+#
+#   tests/trust-anchor.test.sh
+#
+# _installCATrustAnchor() exists so that HTTPS calls made ON the FOG server TO
+# the FOG server verify. It writes whatever _resolveTrustAnchor() picked into
+# the distro's anchor directory. Picking the wrong certificate there does not
+# fail loudly -- the install completes, the web UI works in a browser, and only
+# the server's own curl/PHP calls to itself quietly go on failing verification,
+# which is the symptom the mechanism was added to remove in the first place.
+#
+# Two ways it got that wrong, both fixed and both pinned here:
+#
+#   1. On a master it anchored $rootCAPem unconditionally. With --external-ca /
+#      --web-ca-root the vhost serves a chain terminating in the ADMIN's root,
+#      while $rootCAPem is still FOG's own -- validateExternalCA deliberately
+#      never reassigns it. So the store learned a root nothing was served under.
+#   2. The node path took the LAST certificate in $sslcachain. The writers of
+#      that file disagree on order: createWebIntermediateCA and
+#      fog-sign-node-cert write issuer-first with the root appended, while
+#      validateExternalCA writes the root FIRST. "Last certificate" therefore
+#      means the root in one case and the INTERMEDIATE in the other.
+#
+# Needs openssl. Runs entirely on generated fixtures -- no install, no network,
+# no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+command -v openssl >/dev/null 2>&1 || {
+    echo "SKIP: openssl is not installed"
+    exit 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# --- fixture -----------------------------------------------------------------
+# Two independent CAs, each root + intermediate, so "chains to MY ca" and
+# "chains to the admin's ca" are genuinely different answers.
+mkca() {
+    # Two statements, not one `local name=... dir="$WORK/$name"`: bash expands
+    # every word of a command before running it, so $name in the same `local`
+    # would still be the caller's (unset) one.
+    local name="$1"
+    local dir="$WORK/$name"
+    mkdir -p "$dir"
+    openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 30 \
+        -subj "/CN=${name} Root" -keyout "$dir/root.key" -out "$dir/root.pem" \
+        >/dev/null 2>&1 || return 1
+    openssl req -new -nodes -newkey rsa:2048 -sha256 \
+        -subj "/CN=${name} Intermediate" \
+        -keyout "$dir/int.key" -out "$dir/int.csr" >/dev/null 2>&1 || return 1
+    printf 'basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n' \
+        > "$dir/int.ext"
+    openssl x509 -req -in "$dir/int.csr" -CA "$dir/root.pem" -CAkey "$dir/root.key" \
+        -CAcreateserial -sha256 -days 30 -extfile "$dir/int.ext" \
+        -out "$dir/int.pem" >/dev/null 2>&1 || return 1
+    return 0
+}
+
+mkca fog || { echo "ERROR: could not build the fog CA fixture" >&2; exit 1; }
+mkca ext || { echo "ERROR: could not build the ext CA fixture" >&2; exit 1; }
+
+fpof() { openssl x509 -in "$1" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//'; }
+
+FOGROOT_FP=$(fpof "$WORK/fog/root.pem")
+FOGINT_FP=$(fpof "$WORK/fog/int.pem")
+EXTROOT_FP=$(fpof "$WORK/ext/root.pem")
+EXTINT_FP=$(fpof "$WORK/ext/int.pem")
+
+# Fingerprints of every certificate in a bundle, one per line.
+bundlefps() {
+    local d f
+    d=$(mktemp -d)
+    awk -v d="$d" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' "$1"
+    for f in "$d"/c*.pem; do
+        [[ -f $f ]] && fpof "$f"
+    done
+    rm -rf "$d"
+}
+
+has_fp() { bundlefps "$1" | grep -qxF "$2"; }
+count_certs() { grep -c 'BEGIN CERTIFICATE' "$1" 2>/dev/null || echo 0; }
+
+# --- load the functions under test -------------------------------------------
+error_log=/dev/null
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# Each case gets its own $fogprogramdir, because _resolveTrustAnchor writes into
+# $(_pkiZoneDir web)/ca and a leftover file from a previous case would be
+# indistinguishable from a pass.
+newcase() {
+    fogprogramdir="$WORK/case$1"
+    mkdir -p "$fogprogramdir"
+    rootCAPem=""
+    sslcachain=""
+    trustAnchorPem=""
+    installtype=""
+}
+
+echo "trust anchor:"
+
+# Case A -- FOG issues everything. $rootCAPem and the chain's root are the same
+# certificate reached two ways; the bundle must collapse to one, not list it
+# twice.
+newcase A
+rootCAPem="$WORK/fog/root.pem"
+sslcachain="$WORK/a-chain.pem"
+cat "$WORK/fog/int.pem" "$WORK/fog/root.pem" > "$sslcachain"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "1" "A: FOG-issued master anchors exactly one certificate"
+    has_fp "$trustAnchorPem" "$FOGROOT_FP" \
+        && ok "A: it is FOG's root" || bad "A: FOG's root is missing"
+else
+    bad "A: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case B -- the regression this was written for. External CA: the vhost chain
+# terminates in the admin's root, $rootCAPem is still FOG's. Both are needed and
+# both must be present. Before the fix this anchored FOG's root alone.
+newcase B
+rootCAPem="$WORK/fog/root.pem"
+sslcachain="$WORK/b-chain.pem"
+# validateExternalCA's order: root FIRST, then the intermediate.
+cat "$WORK/ext/root.pem" "$WORK/ext/int.pem" > "$sslcachain"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "2" "B: external-CA master anchors two certificates"
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "B: the admin's root is anchored" \
+        || bad "B: the admin's root is MISSING -- server-side HTTPS to itself will not verify"
+    has_fp "$trustAnchorPem" "$FOGROOT_FP" \
+        && ok "B: FOG's own root is still anchored" || bad "B: FOG's own root was dropped"
+    has_fp "$trustAnchorPem" "$EXTINT_FP" \
+        && bad "B: the INTERMEDIATE was anchored -- selection fell back to position" \
+        || ok "B: the intermediate is correctly not anchored"
+else
+    bad "B: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case C -- storage node. No root of its own; everything comes from the chain
+# the master sent, written issuer-first with the root appended. This one already
+# worked before the fix and is here to stay working: fog-sign-node-cert always
+# appends the root last, so the old "last certificate" rule happened to be right
+# for nodes. It is the master path above that was wrong.
+newcase C
+installtype=S
+sslcachain="$WORK/c-chain.pem"
+cat "$WORK/fog/int.pem" "$WORK/fog/root.pem" > "$sslcachain"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "1" "C: node anchors exactly one certificate"
+    has_fp "$trustAnchorPem" "$FOGROOT_FP" \
+        && ok "C: it is the root, not the intermediate" \
+        || bad "C: the root is missing"
+else
+    bad "C: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case D -- order independence, stated directly. A root-first chain is exactly
+# what validateExternalCA writes, and selecting by position picks the
+# intermediate out of it.
+newcase D
+installtype=S
+sslcachain="$WORK/d-chain.pem"
+cat "$WORK/ext/root.pem" "$WORK/ext/int.pem" > "$sslcachain"
+if _resolveTrustAnchor; then
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "D: root-first chain still yields the root" \
+        || bad "D: root-first chain yielded the wrong certificate"
+else
+    bad "D: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case E -- a chain with no root at all. The master can legitimately send one,
+# and it must be a clean "nothing extra to add", not a failure and not garbage.
+newcase E
+rootCAPem="$WORK/fog/root.pem"
+sslcachain="$WORK/e-chain.pem"
+cp "$WORK/fog/int.pem" "$sslcachain"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "1" "E: rootless chain contributes nothing extra"
+    has_fp "$trustAnchorPem" "$FOGINT_FP" \
+        && bad "E: an intermediate leaked into the anchor" \
+        || ok "E: no intermediate leaked in"
+else
+    bad "E: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case F -- nothing to anchor yet. Must return 1 so _installCATrustAnchor
+# declines quietly rather than writing an empty .crt into the trust store.
+newcase F
+if _resolveTrustAnchor; then
+    bad "F: returned success with no root and no chain"
+else
+    ok "F: returns non-zero when there is nothing to anchor"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/vhost-netboot-exclusion.test.sh
+++ b/tests/vhost-netboot-exclusion.test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Guards the HTTP->HTTPS redirect's exclusion list in both generated vhosts.
+#
+#   tests/vhost-netboot-exclusion.test.sh
+#
+# When $httpproto is https and $netbootproto is http, the :80 vhost redirects
+# everything to HTTPS -- except the paths iPXE itself fetches, because iPXE
+# validates TLS strictly, has no --insecure, and cannot chain a private CA. A
+# path that falls through to the redirect does not fail visibly on the server;
+# it fails at a PXE-booting machine, as a boot that stops, with nothing in the
+# web server's log to say why.
+#
+# What this checks and what it does not: it asserts on the GENERATOR in
+# lib/common/functions.sh, not on a running web server. Rendering the real thing
+# means calling createSSLCA(), which mints a PKI, writes to /etc and restarts
+# services. The same trade-off as fos's tests/checks/*-config.sh harnesses,
+# which assert on the kernel config rather than on a booted kernel. So this
+# catches "someone dropped a directory from the list" -- the actual regression
+# risk -- and not "nginx parses the result".
+#
+# Three things are pinned:
+#
+#   1. Both netboot-reachable directories are excluded, in BOTH web servers.
+#      service/ipxe/ is the obvious one. service/secureboot/ is not, and was
+#      missing: BootMenu imgfetches MOK.der and chains mmx64.efi /
+#      arm64-efi/mmaa64.efi out of it, so Secure Boot enrolment was being
+#      redirected onto an HTTPS iPXE could not validate.
+#   2. ca.cert.der is reachable over plain HTTP in BOTH web servers. Apache has
+#      had this exemption since GH-529; nginx never did, which made fetching
+#      the CA require already trusting the CA.
+#   3. nginx's redirect stays a `location /`, never a server-level `return`.
+#      That one was measured against real nginx: a server-level return runs in
+#      the server rewrite phase, BEFORE location selection, so it fires for
+#      every request and every exclusion above it becomes dead code -- silently.
+#
+# No openssl, no network, no root.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# countof <fixed-string> -- occurrences of a literal line fragment.
+countof() { grep -cF -- "$1" "$FUNCS" 2>/dev/null || true; }
+
+# want <expected-count> <fixed-string> <label>
+want() {
+    local got
+    got=$(countof "$2")
+    [[ $got == "$1" ]] && ok "$3" || bad "$3 (expected $1 occurrence(s), found $got)"
+}
+
+echo "vhost netboot exclusion:"
+
+# 1. The excluded set, once per web server. Written as a loop over the
+#    directory names so the two branches cannot drift apart -- if this
+#    assertion is what broke, the fix is to add the directory to the loop, not
+#    to relax the test.
+want 2 'for nbdir in ipxe secureboot; do' \
+    "both web servers iterate the same netboot-reachable directory set"
+
+want 1 'location ^~ ${webroot}service/${nbdir}/ {' \
+    "nginx excludes each netboot directory with a prefix location"
+
+want 1 'RewriteCond %{REQUEST_URI} !^${webrootre}service/${nbdir}/' \
+    "apache excludes each netboot directory with a RewriteCond"
+
+# `^~` specifically: a plain prefix location loses to a regex location, and
+# service/ipxe/ has to beat `location /`. Without it the exclusion parses fine
+# and does nothing.
+if grep -qF 'location ^~ ${webroot}service/${nbdir}/ {' "$FUNCS"; then
+    ok "nginx uses ^~, which is what beats location /"
+else
+    bad "nginx netboot location is not ^~ -- it will lose to location /"
+fi
+
+# 2. The CA download, in both. Deliberately NOT under the netbootproto guard:
+#    the client this serves is one that trusts nothing yet, which has nothing
+#    to do with which transport netboot uses.
+want 1 'location = ${webroot}management/other/ca.cert.der {' \
+    "nginx serves ca.cert.der over plain HTTP"
+
+want 1 'RewriteRule /management/other/ca.cert.der$ - [L]' \
+    "apache serves ca.cert.der over plain HTTP"
+
+# 3. The redirect's own shape. Assert the 308 is immediately preceded by the
+#    `location /` that scopes it; a server-level return would not be.
+prev=$(grep -B1 -F 'return 308 https://\$host\$request_uri;' "$FUNCS" \
+    | grep -F 'location / {' | wc -l | tr -d ' ')
+if [[ $prev == "1" ]]; then
+    ok "nginx redirect is scoped by location /, not a server-level return"
+else
+    bad "nginx 308 is not directly inside a 'location / {' block -- every exclusion above it is dead code"
+fi
+
+# 4. Both exclusion sets stay behind the netbootproto guard, so an install
+#    whose netboot already runs on HTTPS is not given pointless carve-outs.
+want 2 'if [[ $netbootproto != "$httpproto" ]]; then' \
+    "both exclusion sets are guarded on netbootproto differing from httpproto"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Phase 1 of #1116, answering #1118.

The audit is `docs/HTTPPROTO_COVERAGE_AUDIT.md`. It turned up three live bugs that already misbehave on `working-1.6` today, before any default is flipped, so this branch fixes them rather than only writing them down.

## The four questions #1118 asked

**1. Does everything honour `httpproto`?** On the installer side, yes — every `curl` to FOG's own web tier and every operator-facing URL builds its scheme from `$httpproto`. The exceptions are one inline `${httpproto:-http}` default, one `curl` with no `-L` and no status check that prints `Done` regardless, and the fact that *every* FOG-server `curl` uses `-k`, so moving the default to HTTPS buys the installer path no verification it did not already lack.

Nothing scheme-bearing reaches `globalSettings` — `FOG_WEB_HOST`/`FOG_WEB_ROOT` are scheme-free — so **no stored URL needs migrating**. The flip side is that no code path without `$_SERVER` has any source of truth for the scheme, which is every background daemon.

The ~20 PHP call sites are classified by consumer, because self-deriving from `$_SERVER['HTTPS']` is *correct* for the netboot and same-origin ones and *wrong* for the per-node ones. Note `bootmenu.class.php` is load-bearing here: chaining `default.ipxe` over `$netbootproto` makes the entire boot sequence follow it with no PHP change, so those sites must keep deriving.

**2. Does the nginx redirect exclusion generalise to Apache?** Apache already had it — both gate on `[[ $netbootproto != "$httpproto" ]]`. The excluded **set** was wrong, which is finding (a) below. It can be stated as a rule rather than a list — *every path iPXE itself fetches* — but only because FOS's own fetches use `curl -Lks` and so tolerate a redirect iPXE cannot. That dependency is now recorded in both generated configs, since it is what the rule rests on.

**3. Is anything long-lived regenerated per run?** No — the class is clean. It had no automated backstop, which was the real risk; it has one now.

**4. Does an external private root reach the OS trust store?** **It did not.** That is finding (c), and four further defects in the same path.

## The three live bugs, fixed

**(a) The HTTPS redirect caught `service/secureboot/`.** `BootMenu` `imgfetch`es `MOK.der` and chains `mmx64.efi` / `arm64-efi/mmaa64.efi` out of that directory — iPXE fetches them itself, not FOS. On an `httpproto=https` / `netbootproto=http` install, Secure Boot enrolment was being redirected onto an HTTPS iPXE cannot validate. Nothing appears in the web server log; it surfaces at a PXE machine as a boot that stops.

**(b) nginx had no `ca.cert.der` exemption.** Apache has had one since GH-529. On nginx the `location /` 308 caught it, so fetching the CA required already trusting the CA — the exact chicken-and-egg the exemption exists to break.

**(c) An externally-supplied root never reached the OS trust store.** `--ca-root`/`--web-ca-root` land in `$extcaroot`/`$webExtCARoot`; `validateExternalCA` writes them into the chain file and, by its own comment, deliberately never assigns `$rootCAPem`. Root resolution has no branch consulting either variable and runs *before* the external-CA branch is reached. So the anchor was FOG's own root while the vhost served the admin's chain, and every server-side HTTPS call to itself still failed to verify — silently unfixed on the installs whose admins had thought hardest about certificates.

`$rootCAPem` is deliberately **not** repointed: it signs the fog-client communication leaf and every node certificate, and `--ca-root` supplies a certificate with no private key. The anchor is now a fingerprint-deduplicated bundle of FOG's root plus the root the served chain actually terminates in. On a FOG-issued install they are the same certificate reached two ways and it collapses to one.

Four defects found in that same path, each of which would have hidden the fix:

- the root was selected from a chain **by position**, and the writers disagree on order (generated CA and node signer append the root; the external-CA import writes it first), so a node of an external-CA master anchored an *intermediate*;
- the anchor was re-encoded with a single `openssl x509 -in`, which reads only the **first** certificate of a bundle and drops the rest with no error;
- on a node, `writeUpdateFile` runs *before* the certificate request, so the chain path was never persisted and later runs anchored out of the wrong file;
- `_createWebLeaf()`'s post-issue check used `-CAfile $rootCAPem`, so it failed on **every** external-CA install and printed a warning telling the admin to widen `--internal-domain` and `rm -rf` the Web zone — advice unrelated to their configuration, one half of which destroys a working PKI.

That last one now uses **`-trusted`, not `-CAfile`**: `-CAfile` adds to the default trust locations rather than replacing them, and FOG puts its own CA in the host store by default, so a `-CAfile` check can answer "verified" out of the system store instead of out of the file it was handed. Verified in both directions against a two-CA fixture.

Also: `--web-ca-cert`/`--web-ca-key`/`--web-ca-root` were not persisted in `.fogsettings`, unlike the `--ca-*` trio they mirror. And `_createCommLeaf()`'s early return kept any existing `.srvpublic.crt` with no modulus check, while the adopt branch right below it does exactly that check for a stated reason — a mismatched drop-in locks out every registered fog-client at once, surfacing per host as a failed check-in with nothing naming either file.

## Two things Phase 2 has to carry, neither of which is in #1116 or #1119

**HSTS is emitted unconditionally.** `Strict-Transport-Security max-age=15768000` goes onto the nginx `:443` server in *both* arms — including when `httpproto=http`. Apache emits none. HSTS does client-side, stickily, for six months what the redirect does server-side, and **turning a setting off does not undo it**. When #1119 introduces `httpsRedirect`, HSTS has to move to that key; the already-shipped unconditional emission needs a decision of its own.

**`_resolveNetbootProto` inverts under the new default.** It drops to HTTP only when `httpproto == https` *and* neither `externalca` nor `caCreated` is set. `caCreated` is persisted, so it is `yes` on every re-run of an existing server — meaning once `httpproto` defaults to `https`, every upgraded install resolves `netbootproto=https`, which is precisely the case that cannot work on a private CA. #1116's model replaces this function outright; it must not merely be tweaked.

Plus: flipping `installfog.sh:695` is **not sufficient** — `input.sh` prompts `[y/N]` and its empty arm catches `-y`, so both independently force HTTP on a fresh install.

## Tests

`tests/run-all.sh` is 35 green. Three new harnesses, each verified to **fail** against the pre-fix code rather than being tautologies:

- `tests/trust-anchor.test.sh` — generated two-CA fixture. Fails previously on the external-CA master and the root-first chain; passes for the node case both before and after, which is the honest split.
- `tests/pki-idempotence.test.sh` — runs the PKI path twice over 16 long-lived artefacts. Re-verified by reintroducing the historic `[[ ! -x $sslpubcert ]]` guard, which it catches. Also proves the `.webLeaf.sans` stamp does the work: renaming the server *must* re-issue the leaf and must not disturb anything above it.
- `tests/vhost-netboot-exclusion.test.sh` — asserts on the generator, not a running web server (rendering the real thing means calling `createSSLCA()`, which mints a PKI and restarts services — the same trade-off as `fos`'s `tests/checks/*-config.sh`). Also pins the measured finding that nginx's redirect must stay a `location /` and never a server-level `return`.

One unrelated repair was needed to get there: `run-all.sh` invoked `*.test.sh` with `sh`, but they all need bash. That worked only where `/bin/sh` *is* bash; on Debian/Ubuntu it is dash, and the pre-existing `secureboot-authvars.test.sh` died on "Bad substitution" before its first assertion — reporting as a failing test rather than a mis-invoked one.

`bash -n` clean on both `bin/installfog.sh` and `lib/common/functions.sh`.

## Not in this PR

Everything #1119 owns: splitting `httpproto` into `httpsRedirect`/`publicWebCert`/`rebuildIpxeWithMyCA`, flipping the default, `--install-mode`, and re-keying `functions.sh:1630/1701/1728` onto `$netbootproto`. `claude/decouple-secureboot-httpproto` is untouched.

Sub-CA delegation of the FOG root is designed and documented but **not wired up**. Most of the machinery already exists — `validateExternalCA`'s `flat` zone imports into the root zone and is dead code today — but turning it on changes what every fog-client pins, which is a migration rather than a flag. It belongs with #1121.

## Note on closing #1118

`Closes #1118` is **inert** on this PR. GitHub only honours the keyword for merges into the repository's default branch, and this targets `working-1.6` — #1043 merged with `Closes #1117` in its body and GitHub linked nothing. #1118 needs closing by hand after merge, as #1117 was.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtAqkznJ3qnh166rx7Adhq)_