### PR TITLE
Say 7.4 in the docblocks, which is what FOG has enforced for years

### DIFF
--- a/bin/schema-manifest.php
+++ b/bin/schema-manifest.php
@@ -4,7 +4,7 @@
  * Generates and diffs the expected-structure manifest used by
  * SchemaReconciler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaManifest
  * @package  FOGProject

--- a/bin/schema-reference-1.5.php
+++ b/bin/schema-reference-1.5.php
@@ -13,7 +13,7 @@
  *
  * Consumed by SchemaReconciler::reconcile().
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaExpected
  * @package  FOGProject

--- a/packages/service/lib/service_lib.php
+++ b/packages/service/lib/service_lib.php
@@ -2,7 +2,7 @@
 /**
  * Service library
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Service_Lib
  * @package  FOGProject

--- a/packages/web/api/index.php
+++ b/packages/web/api/index.php
@@ -2,7 +2,7 @@
 /**
  * Index/handler for api subsystem.
  *
- * PHP Version 7.4
+ * PHP version 7.4+
  *
  * @category APIHandler
  * @package  FOGProject

--- a/packages/web/client/download.php
+++ b/packages/web/client/download.php
@@ -2,7 +2,7 @@
 /**
  * Downloads fog client and utilities files.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Download
  * @package  FOGProject

--- a/packages/web/client/index.php
+++ b/packages/web/client/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to client/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -13,7 +13,7 @@
  *
  * Consumed by SchemaReconciler::reconcile().
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaExpected
  * @package  FOGProject

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -2,7 +2,7 @@
 /**
  * Schema layout for creating the database.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/commons/text.php
+++ b/packages/web/commons/text.php
@@ -10,7 +10,7 @@
  * then be translated just the one time for all the languages.
  * Then the element Host or Printer could be translated later.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/client/autologout.class.php
+++ b/packages/web/lib/client/autologout.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles auto log information as requested.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AutoLogout
  * @package  FOGProject

--- a/packages/web/lib/client/displaymanager.class.php
+++ b/packages/web/lib/client/displaymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles display manager
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DisplayManager
  * @package  FOGProject

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Base element for client services
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGClient
  * @package  FOGProject

--- a/packages/web/lib/client/hostnamechanger.class.php
+++ b/packages/web/lib/client/hostnamechanger.class.php
@@ -3,7 +3,7 @@
  * Sends the client with the hostname and domain
  * information needed to perform the client actions.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostnameChanger
  * @package  FOGProject

--- a/packages/web/lib/client/index.php
+++ b/packages/web/lib/client/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/client/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/client/jobs.class.php
+++ b/packages/web/lib/client/jobs.class.php
@@ -2,7 +2,7 @@
 /**
  * Tells the client if there's a task waiting for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Jobs
  * @package  FOGProject

--- a/packages/web/lib/client/pm.class.php
+++ b/packages/web/lib/client/pm.class.php
@@ -2,7 +2,7 @@
 /**
  * Powermanagement Client information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Powermanagement
  * @package  FOGProject

--- a/packages/web/lib/client/printerclient.class.php
+++ b/packages/web/lib/client/printerclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Sends the printer information for the FOG Client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/lib/client/registerclient.class.php
+++ b/packages/web/lib/client/registerclient.class.php
@@ -4,7 +4,7 @@
  * If using the new client can also register new hosts
  * into a pending status.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RegisterClient
  * @package  FOGProject

--- a/packages/web/lib/client/servicemodule.class.php
+++ b/packages/web/lib/client/servicemodule.class.php
@@ -2,7 +2,7 @@
 /**
  * The service module checks
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceModule
  * @package  FOGProject

--- a/packages/web/lib/client/snapinclient.class.php
+++ b/packages/web/lib/client/snapinclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles snapins for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinClient
  * @package  FOGProject

--- a/packages/web/lib/client/usertrack.class.php
+++ b/packages/web/lib/client/usertrack.class.php
@@ -2,7 +2,7 @@
 /**
  * Logs the user who logged in
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrack
  * @package  FOGProject

--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Database Manager Handles communication from fog to db class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This is what communicates with fog to the db class.
  *

--- a/packages/web/lib/db/index.php
+++ b/packages/web/lib/db/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/db/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -2,7 +2,7 @@
 /**
  * PDODB, the database connector.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This is what communicates between FOG and the Database.
  *

--- a/packages/web/lib/events/hostlist.event.php
+++ b/packages/web/lib/events/hostlist.event.php
@@ -2,7 +2,7 @@
 /**
  * Host list event
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostList_Event
  * @package  FOGProject

--- a/packages/web/lib/events/index.php
+++ b/packages/web/lib/events/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/events/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -2,7 +2,7 @@
 /**
  * Authorization service — native role-based permission checks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Authorization
  * @package  FOGProject

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2,7 +2,7 @@
 /**
  * Boot menu for the fog pxe system
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Bootmenu
  * @package  FOGProject

--- a/packages/web/lib/fog/csrf.class.php
+++ b/packages/web/lib/fog/csrf.class.php
@@ -2,7 +2,7 @@
 /**
  * CSRF, hopefully more secure handling centralized.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * For setting/checking CSRF tokens.
  *

--- a/packages/web/lib/fog/dmikey.class.php
+++ b/packages/web/lib/fog/dmikey.class.php
@@ -2,7 +2,7 @@
 /**
  * DMI Key tracker.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category DMIKey
  * @package  FOGProject

--- a/packages/web/lib/fog/dmikeymanager.class.php
+++ b/packages/web/lib/fog/dmikeymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * DMI Key handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DMIKeyManager
  * @package  FOGProject

--- a/packages/web/lib/fog/event.class.php
+++ b/packages/web/lib/fog/event.class.php
@@ -4,7 +4,7 @@
  * Because of the similarities of use for events and hooks
  * the event class here is the hook base model as well.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Event
  * @package  FOGProject

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -3,7 +3,7 @@
  * EventManager handles registering and loading
  * events and hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category EventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/filedeletequeue.class.php
+++ b/packages/web/lib/fog/filedeletequeue.class.php
@@ -2,7 +2,7 @@
 /**
  * File Delete Queue.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category FileDeleteQueue
  * @package  FOGProject

--- a/packages/web/lib/fog/filedeletequeuemanager.class.php
+++ b/packages/web/lib/fog/filedeletequeuemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * File Delete Queue handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FileDeleteQueueManager
  * @package  FOGProject

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2,7 +2,7 @@
 /**
  * FOGBase, the base class for pretty much all of fog.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This gives all the rest of the classes a common frame to work from.
  *

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -2,7 +2,7 @@
 /**
  * FOGController, individual SQL getters/setters.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * Gets and sets data for an individual object.
  * Generates the SQL Statements more specifically.

--- a/packages/web/lib/fog/fogcore.class.php
+++ b/packages/web/lib/fog/fogcore.class.php
@@ -2,7 +2,7 @@
 /**
  * The core elements accessible for all else
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGCore
  * @package  FOGProject

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -2,7 +2,7 @@
 /**
  * The cron validation
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGCron
  * @package  FOGProject

--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles FTP connections and operations for FOG
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGFTP
  * @package  FOGProject

--- a/packages/web/lib/fog/foglogpaths.class.php
+++ b/packages/web/lib/fog/foglogpaths.class.php
@@ -2,7 +2,7 @@
 /**
  * The one place that knows which directories hold FOG's logs.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGLogPaths
  * @package  FOGProject

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -2,7 +2,7 @@
 /**
  * FOG Manager Controller, main object mass getter.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGManagerController
  * @package  FOGProject

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -3,7 +3,7 @@
  * Presents many defaults for the pages and is
  * the calling point by all other page items.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGPage
  * @package  FOGProject

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manages and presents the page items
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGPageManager
  * @package  FOGProject

--- a/packages/web/lib/fog/fogrollingurl.class.php
+++ b/packages/web/lib/fog/fogrollingurl.class.php
@@ -2,7 +2,7 @@
 /**
  * The request for rolling urls.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGRollingURL
  * @package  FOGProject

--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles SSH connections and operations for FOG
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGSSH
  * @package  FOGProject

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -2,7 +2,7 @@
 /**
  * Processes URL requests for our needs.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGURLRequests
  * @package  FOGProject

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -2,7 +2,7 @@
 /**
  * Main class for group objects.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Group
  * @package  FOGProject

--- a/packages/web/lib/fog/groupassociation.class.php
+++ b/packages/web/lib/fog/groupassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Group association between host -> group links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/groupassociationmanager.class.php
+++ b/packages/web/lib/fog/groupassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group association manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/groupmanager.class.php
+++ b/packages/web/lib/fog/groupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/history.class.php
+++ b/packages/web/lib/fog/history.class.php
@@ -2,7 +2,7 @@
 /**
  * Stores any actions to the database.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category History
  * @package  FOGProject

--- a/packages/web/lib/fog/historymanager.class.php
+++ b/packages/web/lib/fog/historymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * History manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HistoryManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hook.class.php
+++ b/packages/web/lib/fog/hook.class.php
@@ -7,7 +7,7 @@
  *
  * Most of the accessible elements are handled from the event class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hook
  * @package  FOGProject

--- a/packages/web/lib/fog/hookevent.class.php
+++ b/packages/web/lib/fog/hookevent.class.php
@@ -2,7 +2,7 @@
 /**
  * Hook event tracker.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HookEvent
  * @package  FOGProject

--- a/packages/web/lib/fog/hookeventmanager.class.php
+++ b/packages/web/lib/fog/hookeventmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Hook Event handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookEventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -3,7 +3,7 @@
  * HookManager handles registering and loading
  * events and hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookManager
  * @package  FOGProject

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -2,7 +2,7 @@
 /**
  * The host object (main item FOG deals with
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Host
  * @package  FOGProject

--- a/packages/web/lib/fog/hostautologout.class.php
+++ b/packages/web/lib/fog/hostautologout.class.php
@@ -2,7 +2,7 @@
 /**
  * Presents the client with auto logout info.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostAutoLogout
  * @package  FOGProject

--- a/packages/web/lib/fog/hostautologoutmanager.class.php
+++ b/packages/web/lib/fog/hostautologoutmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Host auto logout manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostAutoLogoutManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hostmanager.class.php
+++ b/packages/web/lib/fog/hostmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for Hosts.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HostManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hostscreensetting.class.php
+++ b/packages/web/lib/fog/hostscreensetting.class.php
@@ -2,7 +2,7 @@
 /**
  * Host screen settings class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostScreenSetting
  * @package  FOGProject

--- a/packages/web/lib/fog/hostscreensettingmanager.class.php
+++ b/packages/web/lib/fog/hostscreensettingmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Host screen settings manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostScreenSettingManager
  * @package  FOGProject

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -2,7 +2,7 @@
 /**
  * The image object
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Image
  * @package  FOGProject

--- a/packages/web/lib/fog/imageassociation.class.php
+++ b/packages/web/lib/fog/imageassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The image storage group association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/imageassociationmanager.class.php
+++ b/packages/web/lib/fog/imageassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image association manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagemanager.class.php
+++ b/packages/web/lib/fog/imagemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagepartitiontype.class.php
+++ b/packages/web/lib/fog/imagepartitiontype.class.php
@@ -2,7 +2,7 @@
 /**
  * Image partition type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagePartitionType
  * @package  FOGProject

--- a/packages/web/lib/fog/imagepartitiontypemanager.class.php
+++ b/packages/web/lib/fog/imagepartitiontypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image partition type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagePartitionTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagetype.class.php
+++ b/packages/web/lib/fog/imagetype.class.php
@@ -2,7 +2,7 @@
 /**
  * The image type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageType
  * @package  FOGProject

--- a/packages/web/lib/fog/imagetypemanager.class.php
+++ b/packages/web/lib/fog/imagetypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imaginglog.class.php
+++ b/packages/web/lib/fog/imaginglog.class.php
@@ -2,7 +2,7 @@
 /**
  * The imaging log class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagingLog
  * @package  FOGProject

--- a/packages/web/lib/fog/imaginglogmanager.class.php
+++ b/packages/web/lib/fog/imaginglogmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The imaging log manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagingLogManager
  * @package  FOGProject

--- a/packages/web/lib/fog/index.php
+++ b/packages/web/lib/fog/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/fog/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -2,7 +2,7 @@
 /**
  * The inventory class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Inventory
  * @package  FOGProject

--- a/packages/web/lib/fog/inventorymanager.class.php
+++ b/packages/web/lib/fog/inventorymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The inventory manaager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category InventoryManager
  * @package  FOGProject

--- a/packages/web/lib/fog/ipxe.class.php
+++ b/packages/web/lib/fog/ipxe.class.php
@@ -2,7 +2,7 @@
 /**
  * The ipxe class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Ipxe
  * @package  FOGProject

--- a/packages/web/lib/fog/ipxemanager.class.php
+++ b/packages/web/lib/fog/ipxemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The ipxe manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category IpxeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/keysequence.class.php
+++ b/packages/web/lib/fog/keysequence.class.php
@@ -2,7 +2,7 @@
 /**
  * The key sequence class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KeySequence
  * @package  FOGProject

--- a/packages/web/lib/fog/keysequencemanager.class.php
+++ b/packages/web/lib/fog/keysequencemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The key sequence manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KeySequenceManager
  * @package  FOGProject

--- a/packages/web/lib/fog/loadglobals.class.php
+++ b/packages/web/lib/fog/loadglobals.class.php
@@ -2,7 +2,7 @@
 /**
  * Loads our global values
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LoadGlobals
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -2,7 +2,7 @@
 /**
  * A mac address verifier and getter.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddress
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddressassociation.class.php
+++ b/packages/web/lib/fog/macaddressassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * MAC Address associations
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddressAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddressassociationmanager.class.php
+++ b/packages/web/lib/fog/macaddressassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * MAC association manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddressAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/module.class.php
+++ b/packages/web/lib/fog/module.class.php
@@ -2,7 +2,7 @@
 /**
  * The module class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Module
  * @package  FOGProject

--- a/packages/web/lib/fog/moduleassociation.class.php
+++ b/packages/web/lib/fog/moduleassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The module association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/moduleassociationmanager.class.php
+++ b/packages/web/lib/fog/moduleassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Module association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/modulemanager.class.php
+++ b/packages/web/lib/fog/modulemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The module manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleManager
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsession.class.php
+++ b/packages/web/lib/fog/multicastsession.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the session in db.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSession
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionassociation.class.php
+++ b/packages/web/lib/fog/multicastsessionassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionassociationmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Multicast session manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionManager
  * @package  FOGProject

--- a/packages/web/lib/fog/nodefailure.class.php
+++ b/packages/web/lib/fog/nodefailure.class.php
@@ -2,7 +2,7 @@
 /**
  * The node failure class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NodeFailure
  * @package  FOGProject

--- a/packages/web/lib/fog/nodefailuremanager.class.php
+++ b/packages/web/lib/fog/nodefailuremanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The node failure manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NodeFailureManager
  * @package  FOGProject

--- a/packages/web/lib/fog/notifyevent.class.php
+++ b/packages/web/lib/fog/notifyevent.class.php
@@ -2,7 +2,7 @@
 /**
  * Notify event tracker.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NotifyEvent
  * @package  FOGProject

--- a/packages/web/lib/fog/notifyeventmanager.class.php
+++ b/packages/web/lib/fog/notifyeventmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Notify Event handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NotifyEventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -2,7 +2,7 @@
 /**
  * OpenAPI description of the FOG REST API, generated from FOG's own metadata.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OpenAPI
  * @package  FOGProject

--- a/packages/web/lib/fog/os.class.php
+++ b/packages/web/lib/fog/os.class.php
@@ -2,7 +2,7 @@
 /**
  * The os class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OS
  * @package  FOGProject

--- a/packages/web/lib/fog/osmanager.class.php
+++ b/packages/web/lib/fog/osmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The os manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OSManager
  * @package  FOGProject

--- a/packages/web/lib/fog/oui.class.php
+++ b/packages/web/lib/fog/oui.class.php
@@ -2,7 +2,7 @@
 /**
  * The oui class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUI
  * @package  FOGProject

--- a/packages/web/lib/fog/ouimanager.class.php
+++ b/packages/web/lib/fog/ouimanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The oui manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUIManager
  * @package  FOGProject

--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -2,7 +2,7 @@
 /**
  * The page display/modifier
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Page
  * @package  FOGProject

--- a/packages/web/lib/fog/ping.class.php
+++ b/packages/web/lib/fog/ping.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles pinging hosts.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Ping
  * @package  FOGProject

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -2,7 +2,7 @@
 /**
  * Plugin class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Plugin
  * @package  FOGProject

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Plugin manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginManager
  * @package  FOGProject

--- a/packages/web/lib/fog/plugintask.class.php
+++ b/packages/web/lib/fog/plugintask.class.php
@@ -2,7 +2,7 @@
 /**
  * Base class for background work a plugin declares.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginTask
  * @package  FOGProject

--- a/packages/web/lib/fog/powermanagement.class.php
+++ b/packages/web/lib/fog/powermanagement.class.php
@@ -2,7 +2,7 @@
 /**
  * PowerManagement class handler
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PowerManagement
  * @package  FOGProject

--- a/packages/web/lib/fog/powermanagementmanager.class.php
+++ b/packages/web/lib/fog/powermanagementmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Powermanagement manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PowerManagementManager
  * @package  FOGProject

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -2,7 +2,7 @@
 /**
  * The printer class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Printer
  * @package  FOGProject

--- a/packages/web/lib/fog/printerassociation.class.php
+++ b/packages/web/lib/fog/printerassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The printer association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/printerassociationmanager.class.php
+++ b/packages/web/lib/fog/printerassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Printer association manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/printermanager.class.php
+++ b/packages/web/lib/fog/printermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/pxemenuoptions.class.php
+++ b/packages/web/lib/fog/pxemenuoptions.class.php
@@ -2,7 +2,7 @@
 /**
  * Pxe menu items class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PXEMenuOptions
  * @package  FOGProject

--- a/packages/web/lib/fog/pxemenuoptionsmanager.class.php
+++ b/packages/web/lib/fog/pxemenuoptionsmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Pxe menu items manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PXEMenuOptionsManager
  * @package  FOGProject

--- a/packages/web/lib/fog/role.class.php
+++ b/packages/web/lib/fog/role.class.php
@@ -2,7 +2,7 @@
 /**
  * Role — native role-based access control.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Role
  * @package  FOGProject

--- a/packages/web/lib/fog/rolemanager.class.php
+++ b/packages/web/lib/fog/rolemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Role manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleManager
  * @package  FOGProject

--- a/packages/web/lib/fog/rolepermission.class.php
+++ b/packages/web/lib/fog/rolepermission.class.php
@@ -2,7 +2,7 @@
 /**
  * Permission granted to a role.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RolePermission
  * @package  FOGProject

--- a/packages/web/lib/fog/rolepermissionmanager.class.php
+++ b/packages/web/lib/fog/rolepermissionmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Role permission manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RolePermissionManager
  * @package  FOGProject

--- a/packages/web/lib/fog/roleuserassociation.class.php
+++ b/packages/web/lib/fog/roleuserassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Role association between user -> role links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleUserAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/roleuserassociationmanager.class.php
+++ b/packages/web/lib/fog/roleuserassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Role user association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleUserAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/roleusergroupassociation.class.php
+++ b/packages/web/lib/fog/roleusergroupassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Role association between user group -> role links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleUserGroupAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/roleusergroupassociationmanager.class.php
+++ b/packages/web/lib/fog/roleusergroupassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Role user group association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleUserGroupAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/scheduledtask.class.php
+++ b/packages/web/lib/fog/scheduledtask.class.php
@@ -2,7 +2,7 @@
 /**
  * Scheduled task class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ScheduledTask
  * @package  FOGProject

--- a/packages/web/lib/fog/scheduledtaskmanager.class.php
+++ b/packages/web/lib/fog/scheduledtaskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Scheduled task manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ScheduledTaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the database insert/export
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Schema
  * @package  FOGProject

--- a/packages/web/lib/fog/schemamanager.class.php
+++ b/packages/web/lib/fog/schemamanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Schema manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaManager
  * @package  FOGProject

--- a/packages/web/lib/fog/schemareconciler.class.php
+++ b/packages/web/lib/fog/schemareconciler.class.php
@@ -2,7 +2,7 @@
 /**
  * Repairs a database whose structure has fallen behind this release.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaReconciler
  * @package  FOGProject

--- a/packages/web/lib/fog/setting.class.php
+++ b/packages/web/lib/fog/setting.class.php
@@ -2,7 +2,7 @@
 /**
  * The global settings class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Setting
  * @package  FOGProject

--- a/packages/web/lib/fog/settingmanager.class.php
+++ b/packages/web/lib/fog/settingmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The global settings manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SettingManager
  * @package  FOGProject

--- a/packages/web/lib/fog/site.class.php
+++ b/packages/web/lib/fog/site.class.php
@@ -2,7 +2,7 @@
 /**
  * A site: a named group of hosts, users, groups and user groups.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Site
  * @package  FOGProject

--- a/packages/web/lib/fog/sitegroupmember.class.php
+++ b/packages/web/lib/fog/sitegroupmember.class.php
@@ -2,7 +2,7 @@
 /**
  * Membership association between site -> host group links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteGroupMember
  * @package  FOGProject

--- a/packages/web/lib/fog/sitegroupmembermanager.class.php
+++ b/packages/web/lib/fog/sitegroupmembermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * SiteGroupMember manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteGroupMemberManager
  * @package  FOGProject

--- a/packages/web/lib/fog/sitehostmember.class.php
+++ b/packages/web/lib/fog/sitehostmember.class.php
@@ -2,7 +2,7 @@
 /**
  * Membership association between site -> host links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteHostMember
  * @package  FOGProject

--- a/packages/web/lib/fog/sitehostmembermanager.class.php
+++ b/packages/web/lib/fog/sitehostmembermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * SiteHostMember manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteHostMemberManager
  * @package  FOGProject

--- a/packages/web/lib/fog/sitemanager.class.php
+++ b/packages/web/lib/fog/sitemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Site manager.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteManager
  * @package  FOGProject

--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -2,7 +2,7 @@
 /**
  * Resolves whether an object is inside a user's site scope.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteScope
  * @package  FOGProject

--- a/packages/web/lib/fog/siteusergroupmember.class.php
+++ b/packages/web/lib/fog/siteusergroupmember.class.php
@@ -2,7 +2,7 @@
 /**
  * Membership association between site -> user group links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteUserGroupMember
  * @package  FOGProject

--- a/packages/web/lib/fog/siteusergroupmembermanager.class.php
+++ b/packages/web/lib/fog/siteusergroupmembermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * SiteUserGroupMember manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteUserGroupMemberManager
  * @package  FOGProject

--- a/packages/web/lib/fog/siteusermember.class.php
+++ b/packages/web/lib/fog/siteusermember.class.php
@@ -2,7 +2,7 @@
 /**
  * Membership association between site -> user links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteUserMember
  * @package  FOGProject

--- a/packages/web/lib/fog/siteusermembermanager.class.php
+++ b/packages/web/lib/fog/siteusermembermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * SiteUserMember manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteUserMemberManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapin.class.php
+++ b/packages/web/lib/fog/snapin.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin object.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinassociation.class.php
+++ b/packages/web/lib/fog/snapinassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinassociationmanager.class.php
+++ b/packages/web/lib/fog/snapinassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapingroupassociation.class.php
+++ b/packages/web/lib/fog/snapingroupassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin group association handling.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinGroupAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/snapingroupassociationmanager.class.php
+++ b/packages/web/lib/fog/snapingroupassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin group association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinGroupAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinjob.class.php
+++ b/packages/web/lib/fog/snapinjob.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin job handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinJob
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinjobmanager.class.php
+++ b/packages/web/lib/fog/snapinjobmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin job handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinJob
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinmanager.class.php
+++ b/packages/web/lib/fog/snapinmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinsaveexception.class.php
+++ b/packages/web/lib/fog/snapinsaveexception.class.php
@@ -6,7 +6,7 @@
  * RuntimeExceptions (SSH/SFTP), which the UI's addPost preserves as 400
  * for backwards compatibility while the API maps to 500.
  *
- * PHP version 7.4
+ * PHP version 7.4+
  *
  * @category SnapinSaveException
  * @package  FOGProject

--- a/packages/web/lib/fog/snapintask.class.php
+++ b/packages/web/lib/fog/snapintask.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin task class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinTask
  * @package  FOGProject

--- a/packages/web/lib/fog/snapintaskmanager.class.php
+++ b/packages/web/lib/fog/snapintaskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin Task Manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinTaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage Group object
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageGroup
  * @package  FOGProject

--- a/packages/web/lib/fog/storagegroupmanager.class.php
+++ b/packages/web/lib/fog/storagegroupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage Group Manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageGroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage node handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageNode
  * @package  FOGProject

--- a/packages/web/lib/fog/storagenodemanager.class.php
+++ b/packages/web/lib/fog/storagenodemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage node manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageNodeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -2,7 +2,7 @@
 /**
  * System, the basic system layout.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * This just presents the system variables
  *

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -2,7 +2,7 @@
 /**
  * Task handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Task
  * @package  FOGProject

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -2,7 +2,7 @@
 /**
  * Task log class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskLog
  * @package  FOGProject

--- a/packages/web/lib/fog/tasklogmanager.class.php
+++ b/packages/web/lib/fog/tasklogmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task log manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskLogManager
  * @package  FOGProject

--- a/packages/web/lib/fog/taskmanager.class.php
+++ b/packages/web/lib/fog/taskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -2,7 +2,7 @@
 /**
  * The task state class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskState
  * @package  FOGProject

--- a/packages/web/lib/fog/taskstatemanager.class.php
+++ b/packages/web/lib/fog/taskstatemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The task state manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskStateManager
  * @package  FOGProject

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -2,7 +2,7 @@
 /**
  * Task type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskType
  * @package  FOGProject

--- a/packages/web/lib/fog/tasktypemanager.class.php
+++ b/packages/web/lib/fog/tasktypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/timer.class.php
+++ b/packages/web/lib/fog/timer.class.php
@@ -3,7 +3,7 @@
  * Creates the timer item so we know when
  * something is supposed to occur.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Timer
  * @package  FOGProject

--- a/packages/web/lib/fog/uploadexception.class.php
+++ b/packages/web/lib/fog/uploadexception.class.php
@@ -2,7 +2,7 @@
 /**
  * Upload exception handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UploadException
  * @package  FOGProject

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -2,7 +2,7 @@
 /**
  * Handler of the user as authenticated
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category User
  * @package  FOGProject

--- a/packages/web/lib/fog/userauth.class.php
+++ b/packages/web/lib/fog/userauth.class.php
@@ -2,7 +2,7 @@
 /**
  * Handler of the user as authenticated
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserAuth
  * @package  FOGProject

--- a/packages/web/lib/fog/userauthmanager.class.php
+++ b/packages/web/lib/fog/userauthmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User auth manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserAuthManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usergroup.class.php
+++ b/packages/web/lib/fog/usergroup.class.php
@@ -2,7 +2,7 @@
 /**
  * UserGroup — a named group of users for role assignment.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserGroup
  * @package  FOGProject

--- a/packages/web/lib/fog/usergroupmanager.class.php
+++ b/packages/web/lib/fog/usergroupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User group manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserGroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usergroupmember.class.php
+++ b/packages/web/lib/fog/usergroupmember.class.php
@@ -2,7 +2,7 @@
 /**
  * Membership association between user group -> user links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserGroupMember
  * @package  FOGProject

--- a/packages/web/lib/fog/usergroupmembermanager.class.php
+++ b/packages/web/lib/fog/usergroupmembermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User group member manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserGroupMemberManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usermanager.class.php
+++ b/packages/web/lib/fog/usermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usertracking.class.php
+++ b/packages/web/lib/fog/usertracking.class.php
@@ -2,7 +2,7 @@
 /**
  * UserTracking handles tracking users from client to client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTracking
  * @package  FOGProject

--- a/packages/web/lib/fog/usertrackingmanager.class.php
+++ b/packages/web/lib/fog/usertrackingmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * UserTrackingManager handles tracking users from client to client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrackingManager
  * @package  FOGProject

--- a/packages/web/lib/fog/wakeonlan.class.php
+++ b/packages/web/lib/fog/wakeonlan.class.php
@@ -2,7 +2,7 @@
 /**
  * Wake on lan management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WakeOnLan
  * @package  FOGProject

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * How to edit the boot menu via hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category BootItem
  * @package  FOGProject

--- a/packages/web/lib/hooks/boottask.hook.php
+++ b/packages/web/lib/hooks/boottask.hook.php
@@ -2,7 +2,7 @@
 /**
  * Alters the boot task to make a custom entry.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category BootTask
  * @package  FOGProject

--- a/packages/web/lib/hooks/changehostname.hook.php
+++ b/packages/web/lib/hooks/changehostname.hook.php
@@ -2,7 +2,7 @@
 /**
  * Change host name hook.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ChangeHostname
  * @package  FOGProject

--- a/packages/web/lib/hooks/hookdebugger.hook.php
+++ b/packages/web/lib/hooks/hookdebugger.hook.php
@@ -2,7 +2,7 @@
 /**
  * Prints all the hooks so we can debug
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookDebugger
  * @package  FOGProject

--- a/packages/web/lib/hooks/hostaddvnclink.hook.php
+++ b/packages/web/lib/hooks/hostaddvnclink.hook.php
@@ -2,7 +2,7 @@
 /**
  * Add host VNC link.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Add VNC Link
  * @package  FOGProject

--- a/packages/web/lib/hooks/index.php
+++ b/packages/web/lib/hooks/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/hooks/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/hooks/logviewerhook.hook.php
+++ b/packages/web/lib/hooks/logviewerhook.hook.php
@@ -10,7 +10,7 @@
  * Also the file will need to be readable by everybody:
  * chmod +r <filename>
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LogViewerHook
  * @package  FOGProject

--- a/packages/web/lib/hooks/mainmenudata.hook.php
+++ b/packages/web/lib/hooks/mainmenudata.hook.php
@@ -2,7 +2,7 @@
 /**
  * Main menu hook changer.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MainMenuData
  * @package  FOGProject

--- a/packages/web/lib/hooks/setsnapintaskstate.hook.php
+++ b/packages/web/lib/hooks/setsnapintaskstate.hook.php
@@ -2,7 +2,7 @@
 /**
  * Sets snapin task states
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SetSnapinTaskState
  * @package  FOGProject

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -2,7 +2,7 @@
 /**
  * Sub menu hook changer.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SubMenuData
  * @package  FOGProject

--- a/packages/web/lib/hooks/template.hook.php
+++ b/packages/web/lib/hooks/template.hook.php
@@ -2,7 +2,7 @@
 /**
  * Template for others to work from.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Template
  * @package  FOGProject

--- a/packages/web/lib/index.php
+++ b/packages/web/lib/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/pages/UserGroupManagement.page.php
+++ b/packages/web/lib/pages/UserGroupManagement.page.php
@@ -2,7 +2,7 @@
 /**
  * User group management page — native role-based access control.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserGroupManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/apidocumentation.page.php
+++ b/packages/web/lib/pages/apidocumentation.page.php
@@ -2,7 +2,7 @@
 /**
  * API Documentation Page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * Renders this server's own OpenAPI description, with a working try-it
  * console.

--- a/packages/web/lib/pages/clientmanagement.page.php
+++ b/packages/web/lib/pages/clientmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Client Management Page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * Presents the client page where users can download the FOG Client and
  * related utilities as needed.

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -2,7 +2,7 @@
 /**
  * Presents the home/dashboard page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DashboardPage
  * @package  FOGProject

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -2,7 +2,7 @@
 /**
  * The FOG Configuration Page display.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGConfigurationPage
  * @package  FOGProject

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Group management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * The group represented to the GUI
  *

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Host management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * The host represented to the GUI
  *

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Image management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/index.php
+++ b/packages/web/lib/pages/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/pages/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/pages/ipxemanagement.page.php
+++ b/packages/web/lib/pages/ipxemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * The Bootmenu Management Page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category IpxeManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/modulemanagement.page.php
+++ b/packages/web/lib/pages/modulemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Module management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * The module represented to the GUI
  *

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Plugin management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/printermanagement.page.php
+++ b/packages/web/lib/pages/printermanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Printer management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -2,7 +2,7 @@
 /**
  * Processes the current login.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ProcessLogin
  * @package  FOGProject

--- a/packages/web/lib/pages/reportmanagement.page.php
+++ b/packages/web/lib/pages/reportmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Displays 'reports' for the admins.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ReportManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Role management page — native role-based access control.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RoleManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -2,7 +2,7 @@
 /**
  * Handles the display of schema and schema updating in general.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaUpdaterPage
  * @package  FOGProject

--- a/packages/web/lib/pages/serverinfo.page.php
+++ b/packages/web/lib/pages/serverinfo.page.php
@@ -2,7 +2,7 @@
 /**
  * Presents server information when clicked.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServerInfo
  * @package  FOGProject

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -3,7 +3,7 @@
  * Configure global level module/services.
  * These are things like hostname changer, display, etc...
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceConfigurationPage
  * @package  FOGProject

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Site management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Snapin management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Displays the storage group information.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageGroupManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Displays the storage node information.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageNodeManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * Displays tasks to the user.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskManagement
  * @package  FOGProject

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -2,7 +2,7 @@
 /**
  * User management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserManagement
  * @package  FOGProject

--- a/packages/web/lib/reg-task/blame.class.php
+++ b/packages/web/lib/reg-task/blame.class.php
@@ -3,7 +3,7 @@
  * If a node fails with a host we write the information
  * into the db using this script.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Blame
  * @package  FOGProject

--- a/packages/web/lib/reg-task/index.php
+++ b/packages/web/lib/reg-task/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/reg-task/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -2,7 +2,7 @@
 /**
  * Performs host registration
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Registration
  * @package  FOGProject

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -2,7 +2,7 @@
 /**
  * The tasking element base class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskingElement
  * @package  FOGProject

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -2,7 +2,7 @@
 /**
  * The queue handling system for FOG's checkin/checkout processes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskQueue
  * @package  FOGProject

--- a/packages/web/lib/reports/file_deleter.report.php
+++ b/packages/web/lib/reports/file_deleter.report.php
@@ -2,7 +2,7 @@
 /**
  * File Deleter report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category File_Deleter
  * @package  FOGProject

--- a/packages/web/lib/reports/history_report.report.php
+++ b/packages/web/lib/reports/history_report.report.php
@@ -2,7 +2,7 @@
 /**
  * Prints the history of all items.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category History_Report
  * @package  FOGProject

--- a/packages/web/lib/reports/host_list.report.php
+++ b/packages/web/lib/reports/host_list.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports hosts within.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Host_List
  * @package  FOGProject

--- a/packages/web/lib/reports/hosts_and_users.report.php
+++ b/packages/web/lib/reports/hosts_and_users.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports hosts and the users within.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hosts_And_Users
  * @package  FOGProject

--- a/packages/web/lib/reports/imaging_log.report.php
+++ b/packages/web/lib/reports/imaging_log.report.php
@@ -2,7 +2,7 @@
 /**
  * Imaging Log report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Imaging_Log
  * @package  FOGProject

--- a/packages/web/lib/reports/inventory_report.report.php
+++ b/packages/web/lib/reports/inventory_report.report.php
@@ -2,7 +2,7 @@
 /**
  * Prints the inventory of all items.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Inventory_Report
  * @package  FOGProject

--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -2,7 +2,7 @@
 /**
  * Pending MAC report.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Pending_MAC_List
  * @package  FOGProject

--- a/packages/web/lib/reports/product_keys.report.php
+++ b/packages/web/lib/reports/product_keys.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports Host product keys
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ProductKeys
  * @package  FOGProject

--- a/packages/web/lib/reports/snapin_list.report.php
+++ b/packages/web/lib/reports/snapin_list.report.php
@@ -2,7 +2,7 @@
 /**
  * Snapin List report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Snapin_List
  * @package  FOGProject

--- a/packages/web/lib/router/altorouter.class.php
+++ b/packages/web/lib/router/altorouter.class.php
@@ -4,7 +4,7 @@
  * Based on klein.php and uses elements of Sinatra for regex
  * matching for routes.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AltoRouter
  * @package  AltoRouter

--- a/packages/web/lib/router/altotransformer.class.php
+++ b/packages/web/lib/router/altotransformer.class.php
@@ -2,7 +2,7 @@
 /**
  * Interface to create AltoTransformer
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AltoTransformer
  * @package  AltoRouter

--- a/packages/web/lib/router/httpresponsecodes.class.php
+++ b/packages/web/lib/router/httpresponsecodes.class.php
@@ -2,7 +2,7 @@
 /**
  * Builds the response codes.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HTTPResponseCodes
  * @package  FOGProject

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2,7 +2,7 @@
 /**
  * Creates our routes for api configuration.
  *
- * PHP Version 7.4
+ * PHP version 7.4+
  *
  * @category Route
  * @package  FOGProject

--- a/packages/web/lib/service/filedeleter.class.php
+++ b/packages/web/lib/service/filedeleter.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles file deletetion queued tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FileDeleter
  * @package  FOGProject

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the fog linux services
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGService
  * @package  FOGProject

--- a/packages/web/lib/service/imagereplicator.class.php
+++ b/packages/web/lib/service/imagereplicator.class.php
@@ -2,7 +2,7 @@
 /**
  * Replication service for images
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageReplicator
  * @package  FOGProject

--- a/packages/web/lib/service/imagesize.class.php
+++ b/packages/web/lib/service/imagesize.class.php
@@ -2,7 +2,7 @@
 /**
  * Image size service for images.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageSize
  * @package  FOGProject

--- a/packages/web/lib/service/index.php
+++ b/packages/web/lib/service/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/service/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast manager service
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastManager
  * @package  FOGProject

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -2,7 +2,7 @@
 /**
  * Multicast task generator/finder
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastTask
  * @package  FOGProject

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -3,7 +3,7 @@
  * Gets the current ping code of each host and
  * updates the hosts related to them.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PingHosts
  * @package  FOGProject

--- a/packages/web/lib/service/pluginrunner.class.php
+++ b/packages/web/lib/service/pluginrunner.class.php
@@ -2,7 +2,7 @@
 /**
  * Runs background work declared by installed, active plugins.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginRunner
  * @package  FOGProject

--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -2,7 +2,7 @@
 /**
  * Hashing service for snapins
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinHash
  * @package  FOGProject

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -2,7 +2,7 @@
 /**
  * Replication service for snapins
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinReplicator
  * @package  FOGProject

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles scheduled tasks and performs other "ondemand" related tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskSchedule
  * @package  FOGProject

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -2,7 +2,7 @@
 /**
  * Backs up the db for us
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Backup_DB
  * @package  FOGProject

--- a/packages/web/maintenance/check_node_exists.php
+++ b/packages/web/maintenance/check_node_exists.php
@@ -2,7 +2,7 @@
 /**
  * Check if the node exists and return it
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_Node_Exists
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Check if the node exists and return it
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_Node_Exists
  * @package  FOGProject

--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -2,7 +2,7 @@
 /**
  * Creates or updates nodes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Create_Update_Node
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Creates or updates nodes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Create_Update_Node
  * @package  FOGProject

--- a/packages/web/service/Post_Stage2.php
+++ b/packages/web/service/Post_Stage2.php
@@ -2,7 +2,7 @@
 /**
  * Check out upload task.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Upload_Complete
  * @package  FOGProject

--- a/packages/web/service/Post_Stage3.php
+++ b/packages/web/service/Post_Stage3.php
@@ -2,7 +2,7 @@
 /**
  * Check out download task.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Download_Complete
  * @package  FOGProject

--- a/packages/web/service/Post_Wipe.php
+++ b/packages/web/service/Post_Wipe.php
@@ -2,7 +2,7 @@
 /**
  * Check out other tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Other_Complete
  * @package  FOGProject

--- a/packages/web/service/Pre_Stage1.php
+++ b/packages/web/service/Pre_Stage1.php
@@ -2,7 +2,7 @@
 /**
  * Check in tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_In
  * @package  FOGProject

--- a/packages/web/service/PrinterManager.php
+++ b/packages/web/service/PrinterManager.php
@@ -2,7 +2,7 @@
 /**
  * Printer client script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/service/Printers.php
+++ b/packages/web/service/Printers.php
@@ -2,7 +2,7 @@
 /**
  * Printer client script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/service/Test.php
+++ b/packages/web/service/Test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the client stuff
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Test
  * @package  FOGProject

--- a/packages/web/service/alo-bg.php
+++ b/packages/web/service/alo-bg.php
@@ -3,7 +3,7 @@
  * Legacy client only, gives the background image
  * to use.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ALO-BG
  * @package  FOGProject

--- a/packages/web/service/auto.register.php
+++ b/packages/web/service/auto.register.php
@@ -2,7 +2,7 @@
 /**
  * FOG Registration passthru
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Registration
  * @package  FOGProject

--- a/packages/web/service/autologout.php
+++ b/packages/web/service/autologout.php
@@ -2,7 +2,7 @@
 /**
  * Autologout information client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Autologout
  * @package  FOGProject

--- a/packages/web/service/blame.php
+++ b/packages/web/service/blame.php
@@ -2,7 +2,7 @@
 /**
  * Sets the blame of a storage node thats problematic.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Blame
  * @package  FOGProject

--- a/packages/web/service/capone.php
+++ b/packages/web/service/capone.php
@@ -2,7 +2,7 @@
 /**
  * Capone within init's calls this script.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Capone
  * @package  FOGProject

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -2,7 +2,7 @@
 /**
  * Checks credentials for init based calls
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category CheckCredentials
  * @package  FOGProject

--- a/packages/web/service/displaymanager.php
+++ b/packages/web/service/displaymanager.php
@@ -2,7 +2,7 @@
 /**
  * Display sender for the clients
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DisplayManager
  * @package  FOGProject

--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -6,7 +6,7 @@
  * If the client update is disabled, it should return 0.0.0
  * as all clients use a numerical system of which 0.0.0 is below.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getversion
  * @package  FOGProject

--- a/packages/web/service/greenfog.php
+++ b/packages/web/service/greenfog.php
@@ -2,7 +2,7 @@
 /**
  * Green fog script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GreenFog
  * @package  FOGProject

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all groups in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Grouplisting
  * @package  FOGProject

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -2,7 +2,7 @@
 /**
  * Hostinfo returns the host information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostinfo
  * @package  FOGProject

--- a/packages/web/service/hostname.php
+++ b/packages/web/service/hostname.php
@@ -3,7 +3,7 @@
  * This is used by the client to determine
  * domain joining and changing hostname.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostname
  * @package  FOGProject

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -3,7 +3,7 @@
  * Hostname loop simply checks the host doesn't
  * already exist.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostnameloop
  * @package  FOGProject

--- a/packages/web/service/imagelisting.php
+++ b/packages/web/service/imagelisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all images in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Imagelisting
  * @package  FOGProject

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -2,7 +2,7 @@
 /**
  * Inventory, stores the host inventory.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Inventory
  * @package  FOGProject

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -2,7 +2,7 @@
 /**
  * This presents the advanced menu
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Advanced
  * @package  FOGProject

--- a/packages/web/service/ipxe/boot.php
+++ b/packages/web/service/ipxe/boot.php
@@ -2,7 +2,7 @@
 /**
  * Boot page for pxe/iPXE
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Boot
  * @package  FOGProject

--- a/packages/web/service/ipxe/index.php
+++ b/packages/web/service/ipxe/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to service/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/service/jobs.php
+++ b/packages/web/service/jobs.php
@@ -2,7 +2,7 @@
 /**
  * Checks for any jobs for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Jobs
  * @package  FOGProject

--- a/packages/web/service/locationcheck.php
+++ b/packages/web/service/locationcheck.php
@@ -3,7 +3,7 @@
  * Used for the location plugin and only checks if it is enabled
  * or not.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Locationcheck
  * @package  FOGProject

--- a/packages/web/service/locationlisting.php
+++ b/packages/web/service/locationlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all locations in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Locationlisting
  * @package  FOGProject

--- a/packages/web/service/man.hostexists.php
+++ b/packages/web/service/man.hostexists.php
@@ -2,7 +2,7 @@
 /**
  * Checks if the host exists.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostexists
  * @package  FOGProject

--- a/packages/web/service/mc_checkin.php
+++ b/packages/web/service/mc_checkin.php
@@ -2,7 +2,7 @@
 /**
  * Multicast check in
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Multicast_Checkin
  * @package  FOGProject

--- a/packages/web/service/nodecert.php
+++ b/packages/web/service/nodecert.php
@@ -2,7 +2,7 @@
 /**
  * Issues web and code-signing certificates to registered storage nodes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NodeCert
  * @package  FOGProject

--- a/packages/web/service/oucheck.php
+++ b/packages/web/service/oucheck.php
@@ -3,7 +3,7 @@
  * Used for the ou plugin and only checks if it is enabled
  * or not.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUcheck
  * @package  FOGProject

--- a/packages/web/service/oulisting.php
+++ b/packages/web/service/oulisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all ous in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUlisting
  * @package  FOGProject

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all printers in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Printerlisting
  * @package  FOGProject

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -2,7 +2,7 @@
 /**
  * Updates the progress information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Progress
  * @package  FOGProject

--- a/packages/web/service/register.php
+++ b/packages/web/service/register.php
@@ -4,7 +4,7 @@
  * host register information.  Particularly
  * useful for adding additional mac addresses.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Register
  * @package  FOGProject

--- a/packages/web/service/servicemodule-active.php
+++ b/packages/web/service/servicemodule-active.php
@@ -3,7 +3,7 @@
  * Legacy client uses this to find out
  * if the module checked is usable.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceModule_Active
  * @package  FOGProject

--- a/packages/web/service/snapcheck.php
+++ b/packages/web/service/snapcheck.php
@@ -2,7 +2,7 @@
 /**
  * Checks the snapin.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinCheck
  * @package  FOGProject

--- a/packages/web/service/snapinlisting.php
+++ b/packages/web/service/snapinlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all snapins in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapinlisting
  * @package  FOGProject

--- a/packages/web/service/snapins.checkin.php
+++ b/packages/web/service/snapins.checkin.php
@@ -2,7 +2,7 @@
 /**
  * Snapin client checkin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin_Checkin
  * @package  FOGProject

--- a/packages/web/service/snapins.file.php
+++ b/packages/web/service/snapins.file.php
@@ -2,7 +2,7 @@
 /**
  * Snapin client file download
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin_File
  * @package  FOGProject

--- a/packages/web/service/updates.php
+++ b/packages/web/service/updates.php
@@ -2,7 +2,7 @@
 /**
  * Legacy client handles module updates
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Updates
  * @package  FOGProject

--- a/packages/web/service/usercleanup-users.php
+++ b/packages/web/service/usercleanup-users.php
@@ -2,7 +2,7 @@
 /**
  * Cleans up users ony good for Windows XP
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Usercleanup_Users
  * @package  FOGProject

--- a/packages/web/service/usertracking.report.php
+++ b/packages/web/service/usertracking.report.php
@@ -2,7 +2,7 @@
 /**
  * Tracks users logging in and out
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrack
  * @package  FOGProject

--- a/packages/web/status/bandwidth.php
+++ b/packages/web/status/bandwidth.php
@@ -5,7 +5,7 @@
  * If interface cannot be found it will try to get it more
  * directly from within linux.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Bandwidth
  * @package  FOGProject

--- a/packages/web/status/dbrunning.php
+++ b/packages/web/status/dbrunning.php
@@ -2,7 +2,7 @@
 /**
  * Checks the database is running
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Dbrunning
  * @package  FOGProject

--- a/packages/web/status/freespace.php
+++ b/packages/web/status/freespace.php
@@ -2,7 +2,7 @@
 /**
  * Gets free space of disk/partition holding images from server
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Freespace
  * @package  FOGProject

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -2,7 +2,7 @@
 /**
  * Get's files stored as requested
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getfiles
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's files stored as requested
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getfiles
  * @package  FOGProject

--- a/packages/web/status/gethash.php
+++ b/packages/web/status/gethash.php
@@ -2,7 +2,7 @@
 /**
  * Get's hash of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's hash of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject

--- a/packages/web/status/getsize.php
+++ b/packages/web/status/getsize.php
@@ -2,7 +2,7 @@
 /**
  * Get's size of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's size of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject

--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -2,7 +2,7 @@
 /**
  * Hostgetkey returns the host token for hostinfo getting
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostgetkey
  * @package  FOGProject

--- a/packages/web/status/hw.php
+++ b/packages/web/status/hw.php
@@ -2,7 +2,7 @@
 /**
  * Presents Hardware/Software information of the server.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HardwareInfo
  * @package  FOGProject

--- a/packages/web/status/index.php
+++ b/packages/web/status/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to status/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/status/kernelvers.php
+++ b/packages/web/status/kernelvers.php
@@ -2,7 +2,7 @@
 /**
  * Presents the FOG Kernels version that the clients will use.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KernelVersion
  * @package  FOGProject

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -2,7 +2,7 @@
 /**
  * Logtoview handles reading files
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Logtoview
  * @package  FOGProject

--- a/packages/web/status/mainversion.php
+++ b/packages/web/status/mainversion.php
@@ -2,7 +2,7 @@
 /**
  * Gets version information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Mainversion
  * @package  FOGProject

--- a/packages/web/status/newtoken.php
+++ b/packages/web/status/newtoken.php
@@ -2,7 +2,7 @@
 /**
  * Generates a new token on ajax request.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NewToken
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Generates a new token on ajax request.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NewToken
  * @package  FOGProject

--- a/tests/php-version-docblocks.test.php
+++ b/tests/php-version-docblocks.test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * The `PHP version` line in file docblocks must match the version FOG enforces.
+ *
+ * 304 files said "PHP version 5" -- inherited from the era when that was true
+ * and never revisited, while Initiator::_verCheck() has required 7.4 for
+ * years. Nothing breaks, which is exactly why it sat there: the only readers
+ * are contributors, who were being told the wrong floor by every file they
+ * opened.
+ *
+ * The floor is read out of _verCheck() rather than hardcoded here, so raising
+ * it fails this test until the docblocks follow. That is the point -- the next
+ * bump should not be able to leave 300 files lying again.
+ *
+ * vendor/ is exempt: third-party packages state their own requirements.
+ *
+ * Usage: php tests/php-version-docblocks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+// The enforced floor, taken from the check that actually rejects a request.
+$init = (string) @file_get_contents('packages/web/commons/init.php');
+if (!preg_match("/version_compare\(phpversion\(\), '([0-9.]+)', '<'\)/", $init, $m)) {
+    fwrite(STDERR, "FAIL: cannot find the version floor in Initiator::_verCheck()\n");
+    exit(1);
+}
+$floor = $m[1];
+$expected = "PHP version $floor+";
+
+$files = explode("\n", trim((string) shell_exec('git ls-files "*.php"')));
+$fails = [];
+foreach ($files as $file) {
+    if ('' === $file || 0 === strpos($file, 'packages/web/vendor/')) {
+        continue;
+    }
+    $n = 0;
+    foreach (explode("\n", (string) @file_get_contents($file)) as $i => $line) {
+        // Only the docblock form: " * PHP version X". Prose that happens to
+        // begin that way (mysqldump's "PHP version of ... cli") is not a
+        // version claim and must not be rewritten into one.
+        if (!preg_match('/^\s*\*\s*PHP [Vv]ersion\s+[0-9]/', $line)) {
+            continue;
+        }
+        ++$n;
+        if (trim(preg_replace('/^\s*\*\s*/', '', $line)) !== $expected) {
+            $fails[] = "$file:" . ($i + 1) . ' says "'
+                . trim(preg_replace('/^\s*\*\s*/', '', $line))
+                . "\", but FOG enforces $floor -- expected \"$expected\"";
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " docblock(s) state the wrong PHP floor:\n");
+    foreach (array_slice($fails, 0, 20) as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    if (count($fails) > 20) {
+        fwrite(STDERR, '  ... and ' . (count($fails) - 20) . " more\n");
+    }
+    exit(1);
+}
+
+echo "ok: every PHP version docblock states the enforced floor ($floor)\n";
+exit(0);


### PR DESCRIPTION
304 files opened with `* PHP version 5`. `Initiator::_verCheck()` has thrown below 7.4 for years, `CONTRIBUTING.md` says "Target **PHP 7.4+**", and `CLAUDE.md` says 7.4+ — only the file headers were still describing the 1.x era.

Nothing breaks, which is why it survived: the only readers are contributors, and every file they opened told them the wrong floor.

## The change

310 lines across 304 files, plus three that already said 7.4 in two other spellings, normalized to the `PHP version 7.4+` form the newest files use.

| Before | Lines |
|---|---:|
| `* PHP version 5` | 288 |
| `* PHP Version 5` | 19 |
| `* PHP Version 7.4` | 2 |
| `* PHP version 7.4` | 1 |
| **After: `* PHP version 7.4+`** | **313** |

## It is comment text only

Token streams with comments and whitespace stripped are **byte-identical to HEAD in all 304 files** — checked with `token_get_all()`, not by eye. That is the whole safety argument for a diff this wide, so it is worth stating as a result rather than an intention.

`packages/web/vendor/` is untouched; third-party packages state their own requirements.

## Gate

`tests/php-version-docblocks.test.php` reads the floor out of `_verCheck()` rather than hardcoding it:

```php
preg_match("/version_compare\(phpversion\(\), '([0-9.]+)', '<'\)/", $init, $m);
```

So a future floor bump fails this test until the docblocks follow — the next bump should not be able to leave 300 files lying again. It matches only the docblock form, so prose like `mysqldump.class.php`'s *"PHP version of mysqldump cli that comes with MySQL"* is not mistaken for a version claim.

Verified failing when one file is reverted, passing when restored. `sh tests/run-all.sh` → **37 passed, 0 failed**.

## Why now

Prompted by #1125: `firebase/php-jwt` dropped 7.4 support, which raised the question of what FOG actually requires. **The floor stays 7.4** — this only makes the tree say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR