### PR TITLE
Say 7.4 in the docblocks, which is what FOG has enforced for years

### DIFF
--- a/packages/service/lib/service_lib.php
+++ b/packages/service/lib/service_lib.php
@@ -2,7 +2,7 @@
 /**
  * Service library
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Service_Lib
  * @package  FOGProject

--- a/packages/web/api/index.php
+++ b/packages/web/api/index.php
@@ -2,7 +2,7 @@
 /**
  * Index/handler for api subsystem.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category APIHandler
  * @package  FOGProject

--- a/packages/web/client/download.php
+++ b/packages/web/client/download.php
@@ -2,7 +2,7 @@
 /**
  * Downloads fog client and utilitie files.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Download
  * @package  FOGProject

--- a/packages/web/client/index.php
+++ b/packages/web/client/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to client/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/commons/index.php
+++ b/packages/web/commons/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to commons/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -2,7 +2,7 @@
 /**
  * Schema layout for creating the database.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/commons/text.php
+++ b/packages/web/commons/text.php
@@ -10,7 +10,7 @@
  * then be translated just the one time for all the languages.
  * Then the element Host or Printer could be translated later.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/index.php
+++ b/packages/web/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/client/alobg.class.php
+++ b/packages/web/lib/client/alobg.class.php
@@ -3,7 +3,7 @@
  * Sends the auto logout background image
  * NOTE: Only used on legacy client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ALOGB
  * @package  FOGProject

--- a/packages/web/lib/client/autologout.class.php
+++ b/packages/web/lib/client/autologout.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles auto log information as requested.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AutoLogout
  * @package  FOGProject

--- a/packages/web/lib/client/directorycleanup.class.php
+++ b/packages/web/lib/client/directorycleanup.class.php
@@ -2,7 +2,7 @@
 /**
  * Cleans directories but only for legacy client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DirectoryCleanup
  * @package  FOGProject

--- a/packages/web/lib/client/displaymanager.class.php
+++ b/packages/web/lib/client/displaymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles display manager
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DisplayManager
  * @package  FOGProject

--- a/packages/web/lib/client/fogclient.class.php
+++ b/packages/web/lib/client/fogclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Base element for client services
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGClient
  * @package  FOGProject

--- a/packages/web/lib/client/fogclientsend.class.php
+++ b/packages/web/lib/client/fogclientsend.class.php
@@ -2,7 +2,7 @@
 /**
  * A basic interface to define how client classes should operate
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGClientSend
  * @package  FOGProject

--- a/packages/web/lib/client/gf.class.php
+++ b/packages/web/lib/client/gf.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles GreenFog, now only for legacy client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Greenfog
  * @package  FOGProject

--- a/packages/web/lib/client/hostnamechanger.class.php
+++ b/packages/web/lib/client/hostnamechanger.class.php
@@ -3,7 +3,7 @@
  * Sends the client with the hostname and domain
  * information needed to perform the client actions.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostnameChanger
  * @package  FOGProject

--- a/packages/web/lib/client/index.php
+++ b/packages/web/lib/client/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/client/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/client/jobs.class.php
+++ b/packages/web/lib/client/jobs.class.php
@@ -2,7 +2,7 @@
 /**
  * Tells the client if there's a task waiting for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Jobs
  * @package  FOGProject

--- a/packages/web/lib/client/pm.class.php
+++ b/packages/web/lib/client/pm.class.php
@@ -2,7 +2,7 @@
 /**
  * Powermanagement Client information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Powermanagement
  * @package  FOGProject

--- a/packages/web/lib/client/printerclient.class.php
+++ b/packages/web/lib/client/printerclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Sends the printer information for the FOG Client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/lib/client/registerclient.class.php
+++ b/packages/web/lib/client/registerclient.class.php
@@ -4,7 +4,7 @@
  * If using the new client can also register new hosts
  * into a pending status.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RegisterClient
  * @package  FOGProject

--- a/packages/web/lib/client/servicemodule.class.php
+++ b/packages/web/lib/client/servicemodule.class.php
@@ -2,7 +2,7 @@
 /**
  * The service module checks
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceModule
  * @package  FOGProject

--- a/packages/web/lib/client/snapinclient.class.php
+++ b/packages/web/lib/client/snapinclient.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles snapins for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinClient
  * @package  FOGProject

--- a/packages/web/lib/client/updateclient.class.php
+++ b/packages/web/lib/client/updateclient.class.php
@@ -3,7 +3,7 @@
  * Updates client files
  * NOTE: Only for legacy client relations
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UpdateClient
  * @package  FOGProject

--- a/packages/web/lib/client/usercleaner.class.php
+++ b/packages/web/lib/client/usercleaner.class.php
@@ -2,7 +2,7 @@
 /**
  * Legacy client use only just returns the users to cleanup
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserCleaner
  * @package  FOGProject

--- a/packages/web/lib/client/usertrack.class.php
+++ b/packages/web/lib/client/usertrack.class.php
@@ -2,7 +2,7 @@
 /**
  * Logs the user who logged in
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrack
  * @package  FOGProject

--- a/packages/web/lib/db/databasemanager.class.php
+++ b/packages/web/lib/db/databasemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Database Manager Handles communication from fog to db class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This is what communicates with fog to the db class.
  *

--- a/packages/web/lib/db/index.php
+++ b/packages/web/lib/db/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/db/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/db/mysqldump.class.php
+++ b/packages/web/lib/db/mysqldump.class.php
@@ -2,7 +2,7 @@
 /**
  * Mysqldump File Doc Comment
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Library
  * @package  Ifsnop\Mysqldump

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -2,7 +2,7 @@
 /**
  * PDODB, the database connector.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This is what communicates between FOG and the Database.
  *

--- a/packages/web/lib/events/hostlist.event.php
+++ b/packages/web/lib/events/hostlist.event.php
@@ -2,7 +2,7 @@
 /**
  * Host list event
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostList_Event
  * @package  FOGProject

--- a/packages/web/lib/events/index.php
+++ b/packages/web/lib/events/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/events/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -2,7 +2,7 @@
 /**
  * Boot menu for the fog pxe system
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Bootmenu
  * @package  FOGProject

--- a/packages/web/lib/fog/clientupdater.class.php
+++ b/packages/web/lib/fog/clientupdater.class.php
@@ -2,7 +2,7 @@
 /**
  * Deals with the client updater files
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ClientUpdater
  * @package  FOGProject

--- a/packages/web/lib/fog/clientupdatermanager.class.php
+++ b/packages/web/lib/fog/clientupdatermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Client Update Manager handles the mass client update stuff.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ClientUpdaterManager
  * @package  FOGProject

--- a/packages/web/lib/fog/csrf.class.php
+++ b/packages/web/lib/fog/csrf.class.php
@@ -2,7 +2,7 @@
 /**
  * CSRF, hopefully more secure handling centralized.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * For setting/checking CSRF tokens.
  *

--- a/packages/web/lib/fog/dircleaner.class.php
+++ b/packages/web/lib/fog/dircleaner.class.php
@@ -2,7 +2,7 @@
 /**
  * Dir Cleaner handles directory cleanup
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DirCleaner
  * @package  FOGProject

--- a/packages/web/lib/fog/dircleanermanager.class.php
+++ b/packages/web/lib/fog/dircleanermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Directory Cleaner Manager deals with mass Dir Cleaner items.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DirCleanerManager
  * @package  FOGProject

--- a/packages/web/lib/fog/event.class.php
+++ b/packages/web/lib/fog/event.class.php
@@ -4,7 +4,7 @@
  * Because of the similarities of use for events and hooks
  * the event class here is the hook base model as well.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Event
  * @package  FOGProject

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -3,7 +3,7 @@
  * EventManager handles registering and loading
  * events and hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category EventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2,7 +2,7 @@
 /**
  * FOGBase, the base class for pretty much all of fog.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This gives all the rest of the classes a common frame to work from.
  *

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -2,7 +2,7 @@
 /**
  * FOGController, individual SQL getters/setters.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * Gets and sets data for an individual object.
  * Generates the SQL Statements more specifically.

--- a/packages/web/lib/fog/fogcore.class.php
+++ b/packages/web/lib/fog/fogcore.class.php
@@ -2,7 +2,7 @@
 /**
  * The core elements accessible for all else
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGCore
  * @package  FOGProject

--- a/packages/web/lib/fog/fogcron.class.php
+++ b/packages/web/lib/fog/fogcron.class.php
@@ -2,7 +2,7 @@
 /**
  * The cron validation
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGCron
  * @package  FOGProject

--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles FTP connections and operations for FOG
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGFTP
  * @package  FOGProject

--- a/packages/web/lib/fog/foggetset.class.php
+++ b/packages/web/lib/fog/foggetset.class.php
@@ -2,7 +2,7 @@
 /**
  * Get/set container for other elements
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGGetSet
  * @package  FOGProject

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -2,7 +2,7 @@
 /**
  * FOG Manager Controller, main object mass getter.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGManagerController
  * @package  FOGProject

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -3,7 +3,7 @@
  * Presents many defaults for the pages and is
  * the calling point by all other page items.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGPage
  * @package  FOGProject

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manages and presents the page items
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGPageManager
  * @package  FOGProject

--- a/packages/web/lib/fog/fogrollingurl.class.php
+++ b/packages/web/lib/fog/fogrollingurl.class.php
@@ -2,7 +2,7 @@
 /**
  * The request for rolling urls.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGRollingURL
  * @package  FOGProject

--- a/packages/web/lib/fog/fogsubmenu.class.php
+++ b/packages/web/lib/fog/fogsubmenu.class.php
@@ -2,7 +2,7 @@
 /**
  * FOGSubMenu.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * This file enables side menus and notes.
  *

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -2,7 +2,7 @@
 /**
  * Processes URL requests for our needs.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGURLRequests
  * @package  FOGProject

--- a/packages/web/lib/fog/greenfog.class.php
+++ b/packages/web/lib/fog/greenfog.class.php
@@ -2,7 +2,7 @@
 /**
  * GreenFog handler, specific to legacy client now.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GreenFog
  * @package  FOGProject

--- a/packages/web/lib/fog/greenfogmanager.class.php
+++ b/packages/web/lib/fog/greenfogmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Green fog manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GreenFogManager
  * @package  FOGProject

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -2,7 +2,7 @@
 /**
  * Main class for group objects.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Group
  * @package  FOGProject

--- a/packages/web/lib/fog/groupassociation.class.php
+++ b/packages/web/lib/fog/groupassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Group association between host -> group links.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/groupassociationmanager.class.php
+++ b/packages/web/lib/fog/groupassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group association manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/groupmanager.class.php
+++ b/packages/web/lib/fog/groupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/history.class.php
+++ b/packages/web/lib/fog/history.class.php
@@ -2,7 +2,7 @@
 /**
  * Stores any actions to the database.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category History
  * @package  FOGProject

--- a/packages/web/lib/fog/historymanager.class.php
+++ b/packages/web/lib/fog/historymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * History manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HistoryManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hook.class.php
+++ b/packages/web/lib/fog/hook.class.php
@@ -7,7 +7,7 @@
  *
  * Most of the accessible elements are handled from the event class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hook
  * @package  FOGProject

--- a/packages/web/lib/fog/hookevent.class.php
+++ b/packages/web/lib/fog/hookevent.class.php
@@ -2,7 +2,7 @@
 /**
  * Hook event tracker.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HookEvent
  * @package  FOGProject

--- a/packages/web/lib/fog/hookeventmanager.class.php
+++ b/packages/web/lib/fog/hookeventmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Hook Event handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookEventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -3,7 +3,7 @@
  * HookManager handles registering and loading
  * events and hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookManager
  * @package  FOGProject

--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -2,7 +2,7 @@
 /**
  * The host object (main item FOG deals with
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Host
  * @package  FOGProject

--- a/packages/web/lib/fog/hostautologout.class.php
+++ b/packages/web/lib/fog/hostautologout.class.php
@@ -2,7 +2,7 @@
 /**
  * Presents the client with auto logout info.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostAutoLogout
  * @package  FOGProject

--- a/packages/web/lib/fog/hostautologoutmanager.class.php
+++ b/packages/web/lib/fog/hostautologoutmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Host auto logout manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostAutoLogoutManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hostmanager.class.php
+++ b/packages/web/lib/fog/hostmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for Hosts.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HostManager
  * @package  FOGProject

--- a/packages/web/lib/fog/hostscreensetting.class.php
+++ b/packages/web/lib/fog/hostscreensetting.class.php
@@ -2,7 +2,7 @@
 /**
  * Host screen settings class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostScreenSetting
  * @package  FOGProject

--- a/packages/web/lib/fog/hostscreensettingmanager.class.php
+++ b/packages/web/lib/fog/hostscreensettingmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Host screen settings manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostScreenSettingManager
  * @package  FOGProject

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -2,7 +2,7 @@
 /**
  * The image object
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Image
  * @package  FOGProject

--- a/packages/web/lib/fog/imageassociation.class.php
+++ b/packages/web/lib/fog/imageassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The image storage group association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/imageassociationmanager.class.php
+++ b/packages/web/lib/fog/imageassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image association manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagemanager.class.php
+++ b/packages/web/lib/fog/imagemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagepartitiontype.class.php
+++ b/packages/web/lib/fog/imagepartitiontype.class.php
@@ -2,7 +2,7 @@
 /**
  * Image partition type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagePartitionType
  * @package  FOGProject

--- a/packages/web/lib/fog/imagepartitiontypemanager.class.php
+++ b/packages/web/lib/fog/imagepartitiontypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image partition type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagePartitionTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imagetype.class.php
+++ b/packages/web/lib/fog/imagetype.class.php
@@ -2,7 +2,7 @@
 /**
  * The image type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageType
  * @package  FOGProject

--- a/packages/web/lib/fog/imagetypemanager.class.php
+++ b/packages/web/lib/fog/imagetypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Image type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/imaginglog.class.php
+++ b/packages/web/lib/fog/imaginglog.class.php
@@ -2,7 +2,7 @@
 /**
  * The imaging log class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagingLog
  * @package  FOGProject

--- a/packages/web/lib/fog/imaginglogmanager.class.php
+++ b/packages/web/lib/fog/imaginglogmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The imaging log manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImagingLogManager
  * @package  FOGProject

--- a/packages/web/lib/fog/index.php
+++ b/packages/web/lib/fog/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/fog/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  *

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -2,7 +2,7 @@
 /**
  * The inventory class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Inventory
  * @package  FOGProject

--- a/packages/web/lib/fog/inventorymanager.class.php
+++ b/packages/web/lib/fog/inventorymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The inventory manaager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category InventoryManager
  * @package  FOGProject

--- a/packages/web/lib/fog/ipxe.class.php
+++ b/packages/web/lib/fog/ipxe.class.php
@@ -2,7 +2,7 @@
 /**
  * The ipxe class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Ipxe
  * @package  FOGProject

--- a/packages/web/lib/fog/ipxemanager.class.php
+++ b/packages/web/lib/fog/ipxemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The ipxe manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category IpxeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/keysequence.class.php
+++ b/packages/web/lib/fog/keysequence.class.php
@@ -2,7 +2,7 @@
 /**
  * The key sequence class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KeySequence
  * @package  FOGProject

--- a/packages/web/lib/fog/keysequencemanager.class.php
+++ b/packages/web/lib/fog/keysequencemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The key sequence manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KeySequenceManager
  * @package  FOGProject

--- a/packages/web/lib/fog/loadglobals.class.php
+++ b/packages/web/lib/fog/loadglobals.class.php
@@ -2,7 +2,7 @@
 /**
  * Loads our global values
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LoadGlobals
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddress.class.php
+++ b/packages/web/lib/fog/macaddress.class.php
@@ -2,7 +2,7 @@
 /**
  * A mac address verifier and getter.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddress
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddressassociation.class.php
+++ b/packages/web/lib/fog/macaddressassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * MAC Address associations
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddressAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/macaddressassociationmanager.class.php
+++ b/packages/web/lib/fog/macaddressassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * MAC association manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MACAddressAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/module.class.php
+++ b/packages/web/lib/fog/module.class.php
@@ -2,7 +2,7 @@
 /**
  * The module class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Module
  * @package  FOGProject

--- a/packages/web/lib/fog/moduleassociation.class.php
+++ b/packages/web/lib/fog/moduleassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The module association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/moduleassociationmanager.class.php
+++ b/packages/web/lib/fog/moduleassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Module association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/modulemanager.class.php
+++ b/packages/web/lib/fog/modulemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The module manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ModuleManager
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsession.class.php
+++ b/packages/web/lib/fog/multicastsession.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the session in db.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSession
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionassociation.class.php
+++ b/packages/web/lib/fog/multicastsessionassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionassociationmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/multicastsessionmanager.class.php
+++ b/packages/web/lib/fog/multicastsessionmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Multicast session manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastSessionManager
  * @package  FOGProject

--- a/packages/web/lib/fog/nodefailure.class.php
+++ b/packages/web/lib/fog/nodefailure.class.php
@@ -2,7 +2,7 @@
 /**
  * The node failure class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NodeFailure
  * @package  FOGProject

--- a/packages/web/lib/fog/nodefailuremanager.class.php
+++ b/packages/web/lib/fog/nodefailuremanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The node failure manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NodeFailureManager
  * @package  FOGProject

--- a/packages/web/lib/fog/notifyevent.class.php
+++ b/packages/web/lib/fog/notifyevent.class.php
@@ -2,7 +2,7 @@
 /**
  * Notify event tracker.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NotifyEvent
  * @package  FOGProject

--- a/packages/web/lib/fog/notifyeventmanager.class.php
+++ b/packages/web/lib/fog/notifyeventmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Notify Event handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category NotifyEventManager
  * @package  FOGProject

--- a/packages/web/lib/fog/os.class.php
+++ b/packages/web/lib/fog/os.class.php
@@ -2,7 +2,7 @@
 /**
  * The os class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OS
  * @package  FOGProject

--- a/packages/web/lib/fog/osmanager.class.php
+++ b/packages/web/lib/fog/osmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The os manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OSManager
  * @package  FOGProject

--- a/packages/web/lib/fog/oui.class.php
+++ b/packages/web/lib/fog/oui.class.php
@@ -2,7 +2,7 @@
 /**
  * The oui class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUI
  * @package  FOGProject

--- a/packages/web/lib/fog/ouimanager.class.php
+++ b/packages/web/lib/fog/ouimanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The oui manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category OUIManager
  * @package  FOGProject

--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -2,7 +2,7 @@
 /**
  * The page display/modifier
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Page
  * @package  FOGProject

--- a/packages/web/lib/fog/ping.class.php
+++ b/packages/web/lib/fog/ping.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles pinging hosts.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Ping
  * @package  FOGProject

--- a/packages/web/lib/fog/plugin.class.php
+++ b/packages/web/lib/fog/plugin.class.php
@@ -2,7 +2,7 @@
 /**
  * Plugin class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Plugin
  * @package  FOGProject

--- a/packages/web/lib/fog/pluginmanager.class.php
+++ b/packages/web/lib/fog/pluginmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Plugin manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginManager
  * @package  FOGProject

--- a/packages/web/lib/fog/powermanagement.class.php
+++ b/packages/web/lib/fog/powermanagement.class.php
@@ -2,7 +2,7 @@
 /**
  * PowerManagement class handler
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PowerManagement
  * @package  FOGProject

--- a/packages/web/lib/fog/powermanagementmanager.class.php
+++ b/packages/web/lib/fog/powermanagementmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Powermanagement manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PowerManagementManager
  * @package  FOGProject

--- a/packages/web/lib/fog/printer.class.php
+++ b/packages/web/lib/fog/printer.class.php
@@ -2,7 +2,7 @@
 /**
  * The printer class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Printer
  * @package  FOGProject

--- a/packages/web/lib/fog/printerassociation.class.php
+++ b/packages/web/lib/fog/printerassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The printer association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/printerassociationmanager.class.php
+++ b/packages/web/lib/fog/printerassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Printer association manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/printermanager.class.php
+++ b/packages/web/lib/fog/printermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Group manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/pxemenuoptions.class.php
+++ b/packages/web/lib/fog/pxemenuoptions.class.php
@@ -2,7 +2,7 @@
 /**
  * Pxe menu items class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PXEMenuOptions
  * @package  FOGProject

--- a/packages/web/lib/fog/pxemenuoptionsmanager.class.php
+++ b/packages/web/lib/fog/pxemenuoptionsmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Pxe menu items manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PXEMenuOptionsManager
  * @package  FOGProject

--- a/packages/web/lib/fog/reportmaker.class.php
+++ b/packages/web/lib/fog/reportmaker.class.php
@@ -2,7 +2,7 @@
 /**
  * Group manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ReportMaker
  * @package  FOGProject

--- a/packages/web/lib/fog/scheduledtask.class.php
+++ b/packages/web/lib/fog/scheduledtask.class.php
@@ -2,7 +2,7 @@
 /**
  * Scheduled task class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ScheduledTask
  * @package  FOGProject

--- a/packages/web/lib/fog/scheduledtaskmanager.class.php
+++ b/packages/web/lib/fog/scheduledtaskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Scheduled task manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ScheduledTaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the database insert/export
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Schema
  * @package  FOGProject

--- a/packages/web/lib/fog/schemamanager.class.php
+++ b/packages/web/lib/fog/schemamanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Schema manager class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaManager
  * @package  FOGProject

--- a/packages/web/lib/fog/service.class.php
+++ b/packages/web/lib/fog/service.class.php
@@ -2,7 +2,7 @@
 /**
  * The service/global settings class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Service
  * @package  FOGProject

--- a/packages/web/lib/fog/servicemanager.class.php
+++ b/packages/web/lib/fog/servicemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The service/global settings manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapin.class.php
+++ b/packages/web/lib/fog/snapin.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin object.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinassociation.class.php
+++ b/packages/web/lib/fog/snapinassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin association class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinassociationmanager.class.php
+++ b/packages/web/lib/fog/snapinassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapingroupassociation.class.php
+++ b/packages/web/lib/fog/snapingroupassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin group association handling.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinGroupAssociation
  * @package  FOGProject

--- a/packages/web/lib/fog/snapingroupassociationmanager.class.php
+++ b/packages/web/lib/fog/snapingroupassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin group association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinGroupAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinjob.class.php
+++ b/packages/web/lib/fog/snapinjob.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin job handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinJob
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinjobmanager.class.php
+++ b/packages/web/lib/fog/snapinjobmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin job handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinJob
  * @package  FOGProject

--- a/packages/web/lib/fog/snapinmanager.class.php
+++ b/packages/web/lib/fog/snapinmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin manager mass management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinManager
  * @package  FOGProject

--- a/packages/web/lib/fog/snapintask.class.php
+++ b/packages/web/lib/fog/snapintask.class.php
@@ -2,7 +2,7 @@
 /**
  * The snapin task class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinTask
  * @package  FOGProject

--- a/packages/web/lib/fog/snapintaskmanager.class.php
+++ b/packages/web/lib/fog/snapintaskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin Task Manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinTaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage Group object
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageGroup
  * @package  FOGProject

--- a/packages/web/lib/fog/storagegroupmanager.class.php
+++ b/packages/web/lib/fog/storagegroupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage Group Manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageGroupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage node handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageNode
  * @package  FOGProject

--- a/packages/web/lib/fog/storagenodemanager.class.php
+++ b/packages/web/lib/fog/storagenodemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Storage node manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageNodeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -2,7 +2,7 @@
 /**
  * System, the basic system layout.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * This just presents the system variables
  *

--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -2,7 +2,7 @@
 /**
  * Task handler class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Task
  * @package  FOGProject

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -2,7 +2,7 @@
 /**
  * Task log class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskLog
  * @package  FOGProject

--- a/packages/web/lib/fog/tasklogmanager.class.php
+++ b/packages/web/lib/fog/tasklogmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task log manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskLogManager
  * @package  FOGProject

--- a/packages/web/lib/fog/taskmanager.class.php
+++ b/packages/web/lib/fog/taskmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskManager
  * @package  FOGProject

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -2,7 +2,7 @@
 /**
  * The task state class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskState
  * @package  FOGProject

--- a/packages/web/lib/fog/taskstatemanager.class.php
+++ b/packages/web/lib/fog/taskstatemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The task state manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskStateManager
  * @package  FOGProject

--- a/packages/web/lib/fog/tasktype.class.php
+++ b/packages/web/lib/fog/tasktype.class.php
@@ -2,7 +2,7 @@
 /**
  * Task type class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskType
  * @package  FOGProject

--- a/packages/web/lib/fog/tasktypemanager.class.php
+++ b/packages/web/lib/fog/tasktypemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Task type manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskTypeManager
  * @package  FOGProject

--- a/packages/web/lib/fog/timer.class.php
+++ b/packages/web/lib/fog/timer.class.php
@@ -3,7 +3,7 @@
  * Creates the timer item so we know when
  * something is supposed to occur.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Timer
  * @package  FOGProject

--- a/packages/web/lib/fog/uploadexception.class.php
+++ b/packages/web/lib/fog/uploadexception.class.php
@@ -2,7 +2,7 @@
 /**
  * Upload exception handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UploadException
  * @package  FOGProject

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -2,7 +2,7 @@
 /**
  * Handler of the user as authenticated
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category User
  * @package  FOGProject

--- a/packages/web/lib/fog/usercleanup.class.php
+++ b/packages/web/lib/fog/usercleanup.class.php
@@ -2,7 +2,7 @@
 /**
  * User cleanup class used for legacy client.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserCleanup
  * @package  FOGProject

--- a/packages/web/lib/fog/usercleanupmanager.class.php
+++ b/packages/web/lib/fog/usercleanupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User cleanup manager class used for legacy client.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserCleanupManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usermanager.class.php
+++ b/packages/web/lib/fog/usermanager.class.php
@@ -2,7 +2,7 @@
 /**
  * User manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserManager
  * @package  FOGProject

--- a/packages/web/lib/fog/usertracking.class.php
+++ b/packages/web/lib/fog/usertracking.class.php
@@ -2,7 +2,7 @@
 /**
  * UserTracking handles tracking users from client to client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTracking
  * @package  FOGProject

--- a/packages/web/lib/fog/usertrackingmanager.class.php
+++ b/packages/web/lib/fog/usertrackingmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * UserTrackingManager handles tracking users from client to client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrackingManager
  * @package  FOGProject

--- a/packages/web/lib/fog/virus.class.php
+++ b/packages/web/lib/fog/virus.class.php
@@ -2,7 +2,7 @@
 /**
  * Virus handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Virus
  * @package  FOGProject

--- a/packages/web/lib/fog/virusmanager.class.php
+++ b/packages/web/lib/fog/virusmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Virus manager handler class (informative).
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category VirusManager
  * @package  FOGProject

--- a/packages/web/lib/fog/wakeonlan.class.php
+++ b/packages/web/lib/fog/wakeonlan.class.php
@@ -2,7 +2,7 @@
 /**
  * Wake on lan management class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WakeOnLan
  * @package  FOGProject

--- a/packages/web/lib/hooks/addhostmodel.hook.php
+++ b/packages/web/lib/hooks/addhostmodel.hook.php
@@ -2,7 +2,7 @@
 /**
  * Add' the host model to the list.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddHostModel
  * @package  FOGProject

--- a/packages/web/lib/hooks/addhostserial.hook.php
+++ b/packages/web/lib/hooks/addhostserial.hook.php
@@ -2,7 +2,7 @@
 /**
  * The host serial hook.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddHostSerial
  * @package  FOGProject

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * How to edit the boot menu via hooks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category BootItem
  * @package  FOGProject

--- a/packages/web/lib/hooks/boottask.hook.php
+++ b/packages/web/lib/hooks/boottask.hook.php
@@ -2,7 +2,7 @@
 /**
  * Alters the boot task to make a custom entry.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category BootTask
  * @package  FOGProject

--- a/packages/web/lib/hooks/changehostname.hook.php
+++ b/packages/web/lib/hooks/changehostname.hook.php
@@ -2,7 +2,7 @@
 /**
  * Change host name hook.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ChangeHostname
  * @package  FOGProject

--- a/packages/web/lib/hooks/changetableheader.hook.php
+++ b/packages/web/lib/hooks/changetableheader.hook.php
@@ -2,7 +2,7 @@
 /**
  * Changes the table header
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ChangeTableHeader
  * @package  FOGProject

--- a/packages/web/lib/hooks/hookdebugger.hook.php
+++ b/packages/web/lib/hooks/hookdebugger.hook.php
@@ -2,7 +2,7 @@
 /**
  * Prints all the hooks so we can debug
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HookDebugger
  * @package  FOGProject

--- a/packages/web/lib/hooks/hostvnclink.hook.php
+++ b/packages/web/lib/hooks/hostvnclink.hook.php
@@ -2,7 +2,7 @@
 /**
  * Displays the vnc link on hosts.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HostVNCLink
  * @package  FOGProject

--- a/packages/web/lib/hooks/index.php
+++ b/packages/web/lib/hooks/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/hooks/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/hooks/logviewerhook.hook.php
+++ b/packages/web/lib/hooks/logviewerhook.hook.php
@@ -10,7 +10,7 @@
  * Also the file will need to be readable by everybody:
  * chmod +r <filename>
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LogViewerHook
  * @package  FOGProject

--- a/packages/web/lib/hooks/mainmenudata.hook.php
+++ b/packages/web/lib/hooks/mainmenudata.hook.php
@@ -2,7 +2,7 @@
 /**
  * Main menu hook changer.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MainMenuData
  * @package  FOGProject

--- a/packages/web/lib/hooks/removeipaddresscolumn.hook.php
+++ b/packages/web/lib/hooks/removeipaddresscolumn.hook.php
@@ -2,7 +2,7 @@
 /**
  * Remove the ip column from host list.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RemoveIPAddressColumn
  * @package  FOGProject

--- a/packages/web/lib/hooks/setsnapintaskstate.hook.php
+++ b/packages/web/lib/hooks/setsnapintaskstate.hook.php
@@ -2,7 +2,7 @@
 /**
  * Sets snapin task states
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SetSnapinTaskState
  * @package  FOGProject

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -2,7 +2,7 @@
 /**
  * Sub menu hook changer.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SubMenuData
  * @package  FOGProject

--- a/packages/web/lib/hooks/template.hook.php
+++ b/packages/web/lib/hooks/template.hook.php
@@ -2,7 +2,7 @@
 /**
  * Template for others to work from.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Template
  * @package  FOGProject

--- a/packages/web/lib/index.php
+++ b/packages/web/lib/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/pages/clientmanagementpage.class.php
+++ b/packages/web/lib/pages/clientmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Client Management Page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * Presents the client page where users can download the FOG Client and
  * related utilities as needed.

--- a/packages/web/lib/pages/dashboardpage.class.php
+++ b/packages/web/lib/pages/dashboardpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Presents the home/dashboard page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DashboardPage
  * @package  FOGProject

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -2,7 +2,7 @@
 /**
  * The FOG Configuration Page display.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGConfigurationPage
  * @package  FOGProject

--- a/packages/web/lib/pages/groupmanagementpage.class.php
+++ b/packages/web/lib/pages/groupmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Group management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GroupManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/hostmanagementpage.class.php
+++ b/packages/web/lib/pages/hostmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Host management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * The host represented to the GUI
  *

--- a/packages/web/lib/pages/imagemanagementpage.class.php
+++ b/packages/web/lib/pages/imagemanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Image management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/index.php
+++ b/packages/web/lib/pages/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/pages/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/pages/pluginmanagementpage.class.php
+++ b/packages/web/lib/pages/pluginmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Plugin management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PluginManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/printermanagementpage.class.php
+++ b/packages/web/lib/pages/printermanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Printer management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/processlogin.class.php
+++ b/packages/web/lib/pages/processlogin.class.php
@@ -2,7 +2,7 @@
 /**
  * Processes the current login.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ProcessLogin
  * @package  FOGProject

--- a/packages/web/lib/pages/reportmanagementpage.class.php
+++ b/packages/web/lib/pages/reportmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Displays 'reports' for the admins.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ReportManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/schemaupdaterpage.class.php
+++ b/packages/web/lib/pages/schemaupdaterpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the display of schema and schema updating in general.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SchemaUpdaterPage
  * @package  FOGProject

--- a/packages/web/lib/pages/serverinfo.class.php
+++ b/packages/web/lib/pages/serverinfo.class.php
@@ -2,7 +2,7 @@
 /**
  * Presents server information when clicked.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServerInfo
  * @package  FOGProject

--- a/packages/web/lib/pages/serviceconfigurationpage.class.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.class.php
@@ -3,7 +3,7 @@
  * Configure global level module/services.
  * These are things like hostname changer, display, etc...
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceConfigurationPage
  * @package  FOGProject

--- a/packages/web/lib/pages/snapinmanagementpage.class.php
+++ b/packages/web/lib/pages/snapinmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Snapin management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Displays the storage group.node information.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category StorageManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/taskmanagementpage.class.php
+++ b/packages/web/lib/pages/taskmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Displays tasks to the user.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskManagementPage
  * @package  FOGProject

--- a/packages/web/lib/pages/usermanagementpage.class.php
+++ b/packages/web/lib/pages/usermanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * User management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrol.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrol.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControl
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociation.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlAssociation
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolrule.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolrule.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlRule
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociation.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlRuleAssociation
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlRuleAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlRuleManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/config/plugin.config.php
+++ b/packages/web/lib/plugins/accesscontrol/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Access control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Access_Control
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/accesscontrolindexdiv.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/accesscontrolindexdiv.hook.php
@@ -2,7 +2,7 @@
 /**
  * Changes access control index div data.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AccessControlIndexDiv
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontrolapi.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontrolapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects access control stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddAccessControlAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontrolmenuitem.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontrolmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the Access control menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddAccessControlMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontroltype.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontroltype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the access control report type.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddAccessControlType
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontroluser.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/addaccesscontroluser.hook.php
@@ -2,7 +2,7 @@
 /**
  * Modifies Access control Users.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddAccessControlUser
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/hooks/delaccesscontrolmenuitem.hook.php
+++ b/packages/web/lib/plugins/accesscontrol/hooks/delaccesscontrolmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the Access control menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddAccessControlMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
+++ b/packages/web/lib/plugins/accesscontrol/pages/accesscontrolmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Access Control plugin
  *
- * PHP version 7
+ * PHP version 7.4+
  *
  * @category AccessControlManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/class/capone.class.php
+++ b/packages/web/lib/plugins/capone/class/capone.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the database for Capone plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Capone
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/class/caponemanager.class.php
+++ b/packages/web/lib/plugins/capone/class/caponemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for Capone
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category CaponeManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/config/plugin.config.php
+++ b/packages/web/lib/plugins/capone/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/hooks/addbootmenuitem.hook.php
+++ b/packages/web/lib/plugins/capone/hooks/addbootmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Creates the capone menu item.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AddBootMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/hooks/addcaponeapi.hook.php
+++ b/packages/web/lib/plugins/capone/hooks/addcaponeapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects capone stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddCaponeAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/capone/reg-task/caponetasking.class.php
+++ b/packages/web/lib/plugins/capone/reg-task/caponetasking.class.php
@@ -2,7 +2,7 @@
 /**
  * This is only used for capone plugin.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category CaponeTasking
  * @package  FOGProject

--- a/packages/web/lib/plugins/example/class/example.class.php
+++ b/packages/web/lib/plugins/example/class/example.class.php
@@ -2,7 +2,7 @@
 /**
  * Example class builder for plugins
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Example
  * @package  FOGProject

--- a/packages/web/lib/plugins/example/class/examplemanager.class.php
+++ b/packages/web/lib/plugins/example/class/examplemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The example mass manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ExampleManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/example/config/plugin.config.php
+++ b/packages/web/lib/plugins/example/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/class/fileintegrity.class.php
+++ b/packages/web/lib/plugins/fileintegrity/class/fileintegrity.class.php
@@ -2,7 +2,7 @@
 /**
  * Fileintegrity class handling file integrity.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FileIntegrity
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/class/fileintegritymanager.class.php
+++ b/packages/web/lib/plugins/fileintegrity/class/fileintegritymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * FileIntegrity Manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FileIntegrityManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/config/plugin.config.php
+++ b/packages/web/lib/plugins/fileintegrity/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/hooks/addfileintegrityapi.hook.php
+++ b/packages/web/lib/plugins/fileintegrity/hooks/addfileintegrityapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects fileintegrity stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddFileintegrityAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/hooks/addfileintegritymenuitem.hook.php
+++ b/packages/web/lib/plugins/fileintegrity/hooks/addfileintegritymenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * The fileintegiry menu item hook
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddFileIntegrityMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/hooks/addfileintegritytype.hook.php
+++ b/packages/web/lib/plugins/fileintegrity/hooks/addfileintegritytype.hook.php
@@ -2,7 +2,7 @@
 /**
  * The fileintegiry type hook
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddFileIntegrityType
  * @package  FOGProject

--- a/packages/web/lib/plugins/fileintegrity/pages/fileintegritymanagementpage.class.php
+++ b/packages/web/lib/plugins/fileintegrity/pages/fileintegritymanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * FileIntegrityManagementPage
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FileIntegrityManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/index.php
+++ b/packages/web/lib/plugins/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/plugins/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/class/ldap.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldap.class.php
@@ -2,7 +2,7 @@
 /**
  * LDAP Authentication plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LDAP
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * LDAPManager
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LDAPManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/config/plugin.config.php
+++ b/packages/web/lib/plugins/ldap/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/hooks/addldapapi.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/addldapapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects ldap stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLDAPAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/hooks/addldapmenuitem.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/addldapmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the menu item for this plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLDAPMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/hooks/addldaptype.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/addldaptype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the ldap type to the reports/exports items
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLDAPType
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
+++ b/packages/web/lib/plugins/ldap/hooks/ldappluginhook.hook.php
@@ -2,7 +2,7 @@
 /**
  * LDAPPluginHook enables our checks as required
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LDAPPluginHook
  * @package  FOGProject

--- a/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
+++ b/packages/web/lib/plugins/ldap/pages/ldapmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * The ldap management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LDAPPluginHook
  * @package  FOGProject
@@ -15,7 +15,7 @@
 /**
  * The ldap management page
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LDAPPluginHook
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/class/location.class.php
+++ b/packages/web/lib/plugins/location/class/location.class.php
@@ -2,7 +2,7 @@
 /**
  * The location class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Location
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/class/locationassociation.class.php
+++ b/packages/web/lib/plugins/location/class/locationassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The association between hosts and locations.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LocationAssociation
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Location association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LocationAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/class/locationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Location manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LocationManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/config/plugin.config.php
+++ b/packages/web/lib/plugins/location/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationapi.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects location stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationgroup.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationgroup.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the location choice to groups.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationGroup
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationhost.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationhost.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the location choice to host.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationHost
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationmenuitem.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the location menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationtasks.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationtasks.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the location stuff to task page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationTasks
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addlocationtype.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addlocationtype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the location report type.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationType
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/addserviceconfiguration.hook.php
+++ b/packages/web/lib/plugins/location/hooks/addserviceconfiguration.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds service configuration with locations.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddServiceConfiguration
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/hooks/changeitems.hook.php
+++ b/packages/web/lib/plugins/location/hooks/changeitems.hook.php
@@ -2,7 +2,7 @@
 /**
  * Changes the elements we need.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ChangeItems
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
+++ b/packages/web/lib/plugins/location/pages/locationmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Location management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LocationManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/location/reports/location_report.report.php
+++ b/packages/web/lib/plugins/location/reports/location_report.report.php
@@ -2,7 +2,7 @@
 /**
  * Test report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Location_Report
  * @package  FOGProject

--- a/packages/web/lib/plugins/persistentgroups/class/persistentgroups.class.php
+++ b/packages/web/lib/plugins/persistentgroups/class/persistentgroups.class.php
@@ -2,7 +2,7 @@
 /**
  * Persistent group class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PersistentGroups
  * @package  FOGProject

--- a/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
+++ b/packages/web/lib/plugins/persistentgroups/class/persistentgroupsmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Enables persistent groups.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PersistentGroupsManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/persistentgroups/config/plugin.config.php
+++ b/packages/web/lib/plugins/persistentgroups/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/class/pushbullet.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbullet.class.php
@@ -2,7 +2,7 @@
 /**
  * The pushbullet database and object definer
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Pushbullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletexception.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletexception.class.php
@@ -2,7 +2,7 @@
 /**
  * Exception class for pushbullet
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category PushbulletException
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletextends.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletextends.class.php
@@ -4,7 +4,7 @@
  *
  * Extends the pushbullet elements into the event class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PushbulletExtends
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/class/pushbullethandler.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbullethandler.class.php
@@ -2,7 +2,7 @@
 /**
  * Pushbullet handler
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PushbulletHandler
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for pushbullet
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category PushbulletManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/config/plugin.config.php
+++ b/packages/web/lib/plugins/pushbullet/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/events/imagecomplete_pushbullet.event.php
+++ b/packages/web/lib/plugins/pushbullet/events/imagecomplete_pushbullet.event.php
@@ -2,7 +2,7 @@
 /**
  * Pushes notification on image completion.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageComplete_PushBullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/events/imagefail_pushbullet.event.php
+++ b/packages/web/lib/plugins/pushbullet/events/imagefail_pushbullet.event.php
@@ -2,7 +2,7 @@
 /**
  * Pushes notification on imaging failure.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageFail_PushBullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/events/loginfailure_pushbullet.event.php
+++ b/packages/web/lib/plugins/pushbullet/events/loginfailure_pushbullet.event.php
@@ -2,7 +2,7 @@
 /**
  * Pushes notification on login failure.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LogonFailure_PushBullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/events/snapincomplete_pushbullet.event.php
+++ b/packages/web/lib/plugins/pushbullet/events/snapincomplete_pushbullet.event.php
@@ -2,7 +2,7 @@
 /**
  * Pushes notification on snapin completion.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinComplete_PushBullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/events/snapintaskcomplete_pushbullet.event.php
+++ b/packages/web/lib/plugins/pushbullet/events/snapintaskcomplete_pushbullet.event.php
@@ -2,7 +2,7 @@
 /**
  * Pushes notification on image completion.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageComplete_PushBullet
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/hooks/addpushbulletmenuitem.hook.php
+++ b/packages/web/lib/plugins/pushbullet/hooks/addpushbulletmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the pushbullet menu item to the menu.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddPushbulletMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
+++ b/packages/web/lib/plugins/pushbullet/pages/pushbulletmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Page presenter for pushbullet plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PushbulletManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -2,7 +2,7 @@
 /**
  * Site Control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Site
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/sitehostassociation.class.php
+++ b/packages/web/lib/plugins/site/class/sitehostassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteHostAssoc
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteHostAssocManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/sitemanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitemanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/siteuserassociation.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteAssoc
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteAssocManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/siteuserrestriction.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserrestriction.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 7
+ * PHP version 7.4+
  *
  * @category SiteUserRestriction
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteAssocManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/config/plugin.config.php
+++ b/packages/web/lib/plugins/site/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Access control plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Access_Control
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsiteapi.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsiteapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects access control stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsitefiltersearch.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitefiltersearch.hook.php
@@ -2,7 +2,7 @@
 /**
  * Modifies Site filter searches.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteFilterSearch
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsitegroup.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitegroup.hook.php
@@ -2,7 +2,7 @@
 /**
  * Associate host of a group to a Site.
  *
- * PHP version 7
+ * PHP version 7.4+
  *
  * @category AddSiteGroup
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitehost.hook.php
@@ -2,7 +2,7 @@
 /**
  * Associate Hosts to a Site.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteHost
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsitemenuitem.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitemenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the Site menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsitetype.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitetype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the site report type.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteType
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/hooks/addsiteuser.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsiteuser.hook.php
@@ -2,7 +2,7 @@
 /**
  * Associate Users to a Site.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSiteUSer
  * @package  FOGProject

--- a/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
+++ b/packages/web/lib/plugins/site/pages/sitemanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Site plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SiteManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/class/slackmanager.class.php
+++ b/packages/web/lib/plugins/slack/class/slackmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Slack manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SlackManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/config/plugin.config.php
+++ b/packages/web/lib/plugins/slack/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Slack plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/events/imagecomplete_slack.event.php
+++ b/packages/web/lib/plugins/slack/events/imagecomplete_slack.event.php
@@ -2,7 +2,7 @@
 /**
  * The event to call when Images are complete
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageComplete_Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/events/imagefail_slack.event.php
+++ b/packages/web/lib/plugins/slack/events/imagefail_slack.event.php
@@ -2,7 +2,7 @@
 /**
  * The event to call when imaging task fails
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageFail_Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/events/loginfailure_slack.event.php
+++ b/packages/web/lib/plugins/slack/events/loginfailure_slack.event.php
@@ -3,7 +3,7 @@
  * The event to call to slack plugin on login
  * failure
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category LoginFailure_Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/events/snapincomplete_slack.event.php
+++ b/packages/web/lib/plugins/slack/events/snapincomplete_slack.event.php
@@ -2,7 +2,7 @@
 /**
  * The event to call when snapin completes
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinComplete_Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/events/snapintaskcomplete_slack.event.php
+++ b/packages/web/lib/plugins/slack/events/snapintaskcomplete_slack.event.php
@@ -2,7 +2,7 @@
 /**
  * Sends notification when snapin task completes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinTaskComplete_Slack
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/hooks/addslackmenuitem.hook.php
+++ b/packages/web/lib/plugins/slack/hooks/addslackmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Add slack menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSlackMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/hooks/removeslackitem.hook.php
+++ b/packages/web/lib/plugins/slack/hooks/removeslackitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Removes slack account.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category RemoveSlackItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
+++ b/packages/web/lib/plugins/slack/pages/slackmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Slack page edit/add.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category SlackManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/class/subnetgroup.class.php
+++ b/packages/web/lib/plugins/subnetgroup/class/subnetgroup.class.php
@@ -2,7 +2,7 @@
 /**
  * Subnetgroup Class handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Subnetgroup
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
+++ b/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for subnetgroup
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category SubnetgroupManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/config/plugin.config.php
+++ b/packages/web/lib/plugins/subnetgroup/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgroupapi.hook.php
+++ b/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgroupapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects subnetgroup stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSubnetGroupAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgrouphost.hook.php
+++ b/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgrouphost.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the subnetgroup host to group.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSubnetGroupHost
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgroupmenuitem.hook.php
+++ b/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgroupmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the subnetgroup menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSubnetgroupMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgrouptype.hook.php
+++ b/packages/web/lib/plugins/subnetgroup/hooks/addsubnetgrouptype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds SubnetGroup type for export.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddSubnetGroupType
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/hooks/removesubnetgroupgroup.hook.php
+++ b/packages/web/lib/plugins/subnetgroup/hooks/removesubnetgroupgroup.hook.php
@@ -2,7 +2,7 @@
 /**
  * Remove the subnetgroup group.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddLocationHost
  * @package  FOGProject

--- a/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
+++ b/packages/web/lib/plugins/subnetgroup/pages/subnetgroupmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * The subnetgroup page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SubnetGroupManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/class/taskstateedit.class.php
+++ b/packages/web/lib/plugins/taskstateedit/class/taskstateedit.class.php
@@ -2,7 +2,7 @@
 /**
  * Taskstateeedit Class Handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Taskstateedit
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/class/taskstateeditmanager.class.php
+++ b/packages/web/lib/plugins/taskstateedit/class/taskstateeditmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * TaskstateeditManager
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskstateeditManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/config/plugin.config.php
+++ b/packages/web/lib/plugins/taskstateedit/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Task State Edit plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskStateEdit
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/hooks/addtaskstateeditmenuitem.hook.php
+++ b/packages/web/lib/plugins/taskstateedit/hooks/addtaskstateeditmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds task state edit menu item.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AddTaskstateeditMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/hooks/addtaskstatetype.hook.php
+++ b/packages/web/lib/plugins/taskstateedit/hooks/addtaskstatetype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds task state type report.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AddTaskStateType
  * @package  FOGProject

--- a/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/taskstateedit/pages/taskstateeditmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Task state edit page.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category TaskstateeditManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/class/tasktypeedit.class.php
+++ b/packages/web/lib/plugins/tasktypeedit/class/tasktypeedit.class.php
@@ -2,7 +2,7 @@
 /**
  * Tasktypeedit Class Handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Tasktypeedit
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/class/tasktypeeditmanager.class.php
+++ b/packages/web/lib/plugins/tasktypeedit/class/tasktypeeditmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * TasktypeeditManager
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskypeeditManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/config/plugin.config.php
+++ b/packages/web/lib/plugins/tasktypeedit/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Task Type Edit plugin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskTypeEdit
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/hooks/addtasktypeeditmenuitem.hook.php
+++ b/packages/web/lib/plugins/tasktypeedit/hooks/addtasktypeeditmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds task type edit menu item.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AddTasktypeeditMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/hooks/addtasktypetype.hook.php
+++ b/packages/web/lib/plugins/tasktypeedit/hooks/addtasktypetype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Add task type type reporter.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AddTaskTypeType
  * @package  FOGProject

--- a/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
+++ b/packages/web/lib/plugins/tasktypeedit/pages/tasktypeeditmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Task type edit page.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category TasktypeeditManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/class/windowskey.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskey.class.php
@@ -2,7 +2,7 @@
 /**
  * The Windows Keys class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WindowsKey
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/class/windowskeyassociation.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeyassociation.class.php
@@ -2,7 +2,7 @@
 /**
  * The association between images and windows keys.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WindowsKeyAssociation
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Windows keys association manager class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WindowsKeyAssociationManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Windows Key manager mass management class
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WindowsKeyManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/config/plugin.config.php
+++ b/packages/web/lib/plugins/windowskey/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/hooks/addwindowskeyapi.hook.php
+++ b/packages/web/lib/plugins/windowskey/hooks/addwindowskeyapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects windows key stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWindowskeyAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/hooks/addwindowskeyimage.hook.php
+++ b/packages/web/lib/plugins/windowskey/hooks/addwindowskeyimage.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the windows keys choice to image.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWindowsKeyImage
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/hooks/addwindowskeymenuitem.hook.php
+++ b/packages/web/lib/plugins/windowskey/hooks/addwindowskeymenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the windows keys menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWindowsKeyMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/hooks/changehostkey.hook.php
+++ b/packages/web/lib/plugins/windowskey/hooks/changehostkey.hook.php
@@ -3,7 +3,7 @@
  * Adds the windows key in the image to the host on
  * deploy completion.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ChangeHostKey
  * @package  FOGProject

--- a/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
+++ b/packages/web/lib/plugins/windowskey/pages/windowskeymanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * Windows Keys management page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WindowsKeyManagementPage
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/class/wolbroadcast.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/class/wolbroadcast.class.php
@@ -2,7 +2,7 @@
 /**
  * Wolbroadcast Class handler.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Wolbroadcast
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/class/wolbroadcastmanager.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/class/wolbroadcastmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * Manager class for wolbroadcast
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category WolbroadcastManager
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/config/plugin.config.php
+++ b/packages/web/lib/plugins/wolbroadcast/config/plugin.config.php
@@ -2,7 +2,7 @@
 /**
  * Plugin configuration file.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Config
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/hooks/addbroadcastaddresses.hook.php
+++ b/packages/web/lib/plugins/wolbroadcast/hooks/addbroadcastaddresses.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds Broadcast addresses to wol info.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddBroadCastAddresses
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/hooks/addwolbroadcastapi.hook.php
+++ b/packages/web/lib/plugins/wolbroadcast/hooks/addwolbroadcastapi.hook.php
@@ -2,7 +2,7 @@
 /**
  * Injects wol broadcast stuff into the api system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWOLBroadcastAPI
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/hooks/addwolbroadcasttype.hook.php
+++ b/packages/web/lib/plugins/wolbroadcast/hooks/addwolbroadcasttype.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds Broadcast type for export.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWOLBroadcastType
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/hooks/addwolmenuitem.hook.php
+++ b/packages/web/lib/plugins/wolbroadcast/hooks/addwolmenuitem.hook.php
@@ -2,7 +2,7 @@
 /**
  * Adds the wol menu item.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category AddWOLMenuItem
  * @package  FOGProject

--- a/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/pages/wolbroadcastmanagementpage.class.php
@@ -2,7 +2,7 @@
 /**
  * The wol broadcast page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category WOLBroadcastManagementPage
  * @package  FOGProject

--- a/packages/web/lib/reg-task/blame.class.php
+++ b/packages/web/lib/reg-task/blame.class.php
@@ -3,7 +3,7 @@
  * If a node fails with a host we write the information
  * into the db using this script.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Blame
  * @package  FOGProject

--- a/packages/web/lib/reg-task/index.php
+++ b/packages/web/lib/reg-task/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/reg-task/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -2,7 +2,7 @@
 /**
  * Performs host registration
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Registration
  * @package  FOGProject

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -2,7 +2,7 @@
 /**
  * The tasking element base class.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskingElement
  * @package  FOGProject

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -2,7 +2,7 @@
 /**
  * The queue handling system for FOG's checkin/checkout processes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskQueue
  * @package  FOGProject

--- a/packages/web/lib/reports/equipment_loan.report.php
+++ b/packages/web/lib/reports/equipment_loan.report.php
@@ -2,7 +2,7 @@
 /**
  * Prints equipment loan.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Equipment_Loan
  * @package  FOGProject

--- a/packages/web/lib/reports/history_report.report.php
+++ b/packages/web/lib/reports/history_report.report.php
@@ -2,7 +2,7 @@
 /**
  * Prints the history of all items.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category History_Report
  * @package  FOGProject

--- a/packages/web/lib/reports/host_list.report.php
+++ b/packages/web/lib/reports/host_list.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports hosts within.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Host_List
  * @package  FOGProject

--- a/packages/web/lib/reports/hosts_and_users.report.php
+++ b/packages/web/lib/reports/hosts_and_users.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports hosts and the users within.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hosts_And_Users
  * @package  FOGProject

--- a/packages/web/lib/reports/imaging_log.report.php
+++ b/packages/web/lib/reports/imaging_log.report.php
@@ -2,7 +2,7 @@
 /**
  * Imaging Log report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Imaging_Log
  * @package  FOGProject

--- a/packages/web/lib/reports/inventory_report.report.php
+++ b/packages/web/lib/reports/inventory_report.report.php
@@ -2,7 +2,7 @@
 /**
  * Prints the inventory of all items.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Inventory_Report
  * @package  FOGProject

--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -2,7 +2,7 @@
 /**
  * Pending MAC report.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Pending_MAC_List
  * @package  FOGProject

--- a/packages/web/lib/reports/product_keys.report.php
+++ b/packages/web/lib/reports/product_keys.report.php
@@ -2,7 +2,7 @@
 /**
  * Reports Host product keys
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ProductKeys
  * @package  FOGProject

--- a/packages/web/lib/reports/snapin_log.report.php
+++ b/packages/web/lib/reports/snapin_log.report.php
@@ -2,7 +2,7 @@
 /**
  * Snapin Log report
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Snapin_Log
  * @package  FOGProject

--- a/packages/web/lib/reports/user_tracking.report.php
+++ b/packages/web/lib/reports/user_tracking.report.php
@@ -2,7 +2,7 @@
 /**
  * User tracking report.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category User_Tracking
  * @package  FOGProject

--- a/packages/web/lib/reports/virus_history.report.php
+++ b/packages/web/lib/reports/virus_history.report.php
@@ -2,7 +2,7 @@
 /**
  * Virus report.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Virus_History
  * @package  FOGProject

--- a/packages/web/lib/router/altorouter.class.php
+++ b/packages/web/lib/router/altorouter.class.php
@@ -4,7 +4,7 @@
  * Based on klein.php and uses elements of Sinatra for regex
  * matching for routes.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AltoRouter
  * @package  AltoRouter

--- a/packages/web/lib/router/altotransformer.class.php
+++ b/packages/web/lib/router/altotransformer.class.php
@@ -2,7 +2,7 @@
 /**
  * Interface to create AltoTransformer
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category AltoTransformer
  * @package  AltoRouter

--- a/packages/web/lib/router/httpresponsecodes.class.php
+++ b/packages/web/lib/router/httpresponsecodes.class.php
@@ -2,7 +2,7 @@
 /**
  * Builds the response codes.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category HTTPResponseCodes
  * @package  FOGProject

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2,7 +2,7 @@
 /**
  * Creates our routes for api configuration.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category Route
  * @package  FOGProject

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles the fog linux services
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category FOGService
  * @package  FOGProject

--- a/packages/web/lib/service/imagereplicator.class.php
+++ b/packages/web/lib/service/imagereplicator.class.php
@@ -2,7 +2,7 @@
 /**
  * Replication service for images
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageReplicator
  * @package  FOGProject

--- a/packages/web/lib/service/imagesize.class.php
+++ b/packages/web/lib/service/imagesize.class.php
@@ -2,7 +2,7 @@
 /**
  * Image size service for images.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ImageSize
  * @package  FOGProject

--- a/packages/web/lib/service/index.php
+++ b/packages/web/lib/service/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to lib/service/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -2,7 +2,7 @@
 /**
  * The multicast manager service
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastManager
  * @package  FOGProject

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -2,7 +2,7 @@
 /**
  * Multicast task generator/finder
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category MulticastTask
  * @package  FOGProject

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -3,7 +3,7 @@
  * Gets the current ping code of each host and
  * updates the hosts related to them.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PingHosts
  * @package  FOGProject

--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -2,7 +2,7 @@
 /**
  * Hashing service for snapins
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinHash
  * @package  FOGProject

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -2,7 +2,7 @@
 /**
  * Replication service for snapins
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinReplicator
  * @package  FOGProject

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -2,7 +2,7 @@
 /**
  * Handles scheduled tasks and performs other "ondemand" related tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category TaskSchedule
  * @package  FOGProject

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -2,7 +2,7 @@
 /**
  * Backs up the db for us
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Backup_DB
  * @package  FOGProject

--- a/packages/web/maintenance/check_node_exists.php
+++ b/packages/web/maintenance/check_node_exists.php
@@ -2,7 +2,7 @@
 /**
  * Check if the node exists and return it
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_Node_Exists
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Check if the node exists and return it
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_Node_Exists
  * @package  FOGProject

--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -2,7 +2,7 @@
 /**
  * Creates or updates nodes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Create_Update_Node
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Creates or updates nodes.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Create_Update_Node
  * @package  FOGProject

--- a/packages/web/management/export.php
+++ b/packages/web/management/export.php
@@ -2,7 +2,7 @@
 /**
  * Handles exporting of csv, pdf, or DB after verification
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Export
  * @package  FOGProject

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -2,7 +2,7 @@
 /**
  * The main index presenter
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Index_Page
  * @package  FOGProject

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 /**
  * Presents the page the same to all.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Index
  * @package  FOGProject

--- a/packages/web/service/Post_Stage2.php
+++ b/packages/web/service/Post_Stage2.php
@@ -2,7 +2,7 @@
 /**
  * Check out upload task.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Upload_Complete
  * @package  FOGProject

--- a/packages/web/service/Post_Stage3.php
+++ b/packages/web/service/Post_Stage3.php
@@ -2,7 +2,7 @@
 /**
  * Check out download task.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Download_Complete
  * @package  FOGProject

--- a/packages/web/service/Post_Wipe.php
+++ b/packages/web/service/Post_Wipe.php
@@ -2,7 +2,7 @@
 /**
  * Check out other tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Other_Complete
  * @package  FOGProject

--- a/packages/web/service/Pre_Stage1.php
+++ b/packages/web/service/Pre_Stage1.php
@@ -2,7 +2,7 @@
 /**
  * Check in tasks.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Check_In
  * @package  FOGProject

--- a/packages/web/service/PrinterManager.php
+++ b/packages/web/service/PrinterManager.php
@@ -2,7 +2,7 @@
 /**
  * Printer client script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/service/Printers.php
+++ b/packages/web/service/Printers.php
@@ -2,7 +2,7 @@
 /**
  * Printer client script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category PrinterClient
  * @package  FOGProject

--- a/packages/web/service/alo-bg.php
+++ b/packages/web/service/alo-bg.php
@@ -3,7 +3,7 @@
  * Legacy client only, gives the background image
  * to use.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ALO-BG
  * @package  FOGProject

--- a/packages/web/service/auto.register.php
+++ b/packages/web/service/auto.register.php
@@ -2,7 +2,7 @@
 /**
  * FOG Registration passthru
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Registration
  * @package  FOGProject

--- a/packages/web/service/autologout.php
+++ b/packages/web/service/autologout.php
@@ -2,7 +2,7 @@
 /**
  * Autologout information client
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Autologout
  * @package  FOGProject

--- a/packages/web/service/av.php
+++ b/packages/web/service/av.php
@@ -2,7 +2,7 @@
 /**
  * Antivirus handler
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Antivirus
  * @package  FOGProject

--- a/packages/web/service/blame.php
+++ b/packages/web/service/blame.php
@@ -2,7 +2,7 @@
 /**
  * Sets the blame of a storage node that's problematic.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Blame
  * @package  FOGProject

--- a/packages/web/service/capone.php
+++ b/packages/web/service/capone.php
@@ -2,7 +2,7 @@
 /**
  * Capone within init's calls this script.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Capone
  * @package  FOGProject

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -2,7 +2,7 @@
 /**
  * Checks credentials for init based calls
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category CheckCredentials
  * @package  FOGProject

--- a/packages/web/service/displaymanager.php
+++ b/packages/web/service/displaymanager.php
@@ -2,7 +2,7 @@
 /**
  * Display sender for the clients
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category DisplayManager
  * @package  FOGProject

--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -6,7 +6,7 @@
  * If the client update is disabled, it should return 0.0.0
  * as all clients use a numerical system of which 0.0.0 is below.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getversion
  * @package  FOGProject

--- a/packages/web/service/greenfog.php
+++ b/packages/web/service/greenfog.php
@@ -2,7 +2,7 @@
 /**
  * Green fog script
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category GreenFog
  * @package  FOGProject

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all groups in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Grouplisting
  * @package  FOGProject

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -2,7 +2,7 @@
 /**
  * Hostinfo returns the host information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostinfo
  * @package  FOGProject

--- a/packages/web/service/hostname.php
+++ b/packages/web/service/hostname.php
@@ -3,7 +3,7 @@
  * This is used by the client to determine
  * domain joining and changing hostname.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostname
  * @package  FOGProject

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -3,7 +3,7 @@
  * Hostname loop simply checks the host doesn't
  * already exist.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostnameloop
  * @package  FOGProject

--- a/packages/web/service/imagelisting.php
+++ b/packages/web/service/imagelisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all images in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Imagelisting
  * @package  FOGProject

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -2,7 +2,7 @@
 /**
  * Inventory, stores the host inventory.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Inventory
  * @package  FOGProject

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -2,7 +2,7 @@
 /**
  * This presents the advanced menu
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Advanced
  * @package  FOGProject

--- a/packages/web/service/ipxe/boot.php
+++ b/packages/web/service/ipxe/boot.php
@@ -2,7 +2,7 @@
 /**
  * Boot page for pxe/iPXE
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Boot
  * @package  FOGProject

--- a/packages/web/service/ipxe/index.php
+++ b/packages/web/service/ipxe/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to service/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/service/jobs.php
+++ b/packages/web/service/jobs.php
@@ -2,7 +2,7 @@
 /**
  * Checks for any jobs for the host
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Jobs
  * @package  FOGProject

--- a/packages/web/service/locationcheck.php
+++ b/packages/web/service/locationcheck.php
@@ -3,7 +3,7 @@
  * Used for the location plugin and only checks if it is enabled
  * or not.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Locationcheck
  * @package  FOGProject

--- a/packages/web/service/locationlisting.php
+++ b/packages/web/service/locationlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all locations in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Locationlisting
  * @package  FOGProject

--- a/packages/web/service/man.hostexists.php
+++ b/packages/web/service/man.hostexists.php
@@ -2,7 +2,7 @@
 /**
  * Checks if the host exists.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostexists
  * @package  FOGProject

--- a/packages/web/service/mc_checkin.php
+++ b/packages/web/service/mc_checkin.php
@@ -2,7 +2,7 @@
 /**
  * Multicast check in
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Multicast_Checkin
  * @package  FOGProject

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all printers in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Printerlisting
  * @package  FOGProject

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -2,7 +2,7 @@
 /**
  * Updates the progress information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Progress
  * @package  FOGProject

--- a/packages/web/service/register.php
+++ b/packages/web/service/register.php
@@ -4,7 +4,7 @@
  * host register information.  Particularly
  * useful for adding additional mac addresses.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Register
  * @package  FOGProject

--- a/packages/web/service/servicemodule-active.php
+++ b/packages/web/service/servicemodule-active.php
@@ -3,7 +3,7 @@
  * Legacy client uses this to find out
  * if the module checked is usable.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category ServiceModule_Active
  * @package  FOGProject

--- a/packages/web/service/snapcheck.php
+++ b/packages/web/service/snapcheck.php
@@ -2,7 +2,7 @@
 /**
  * Checks the snapin.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category SnapinCheck
  * @package  FOGProject

--- a/packages/web/service/snapinlisting.php
+++ b/packages/web/service/snapinlisting.php
@@ -2,7 +2,7 @@
 /**
  * Returns a listing of all snapins in the system.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapinlisting
  * @package  FOGProject

--- a/packages/web/service/snapins.checkin.php
+++ b/packages/web/service/snapins.checkin.php
@@ -2,7 +2,7 @@
 /**
  * Snapin client checkin
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin_Checkin
  * @package  FOGProject

--- a/packages/web/service/snapins.file.php
+++ b/packages/web/service/snapins.file.php
@@ -2,7 +2,7 @@
 /**
  * Snapin client file download
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Snapin_File
  * @package  FOGProject

--- a/packages/web/service/updates.php
+++ b/packages/web/service/updates.php
@@ -2,7 +2,7 @@
 /**
  * Legacy client handles module updates
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Updates
  * @package  FOGProject

--- a/packages/web/service/usercleanup-users.php
+++ b/packages/web/service/usercleanup-users.php
@@ -2,7 +2,7 @@
 /**
  * Cleans up users; only good for Windows XP
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Usercleanup_Users
  * @package  FOGProject

--- a/packages/web/service/usertracking.report.php
+++ b/packages/web/service/usertracking.report.php
@@ -2,7 +2,7 @@
 /**
  * Tracks users logging in and out
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category UserTrack
  * @package  FOGProject

--- a/packages/web/status/bandwidth.php
+++ b/packages/web/status/bandwidth.php
@@ -5,7 +5,7 @@
  * If interface cannot be found it will try to get it more
  * directly from within linux.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Bandwidth
  * @package  FOGProject

--- a/packages/web/status/dbrunning.php
+++ b/packages/web/status/dbrunning.php
@@ -2,7 +2,7 @@
 /**
  * Checks the database is running
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Dbrunning
  * @package  FOGProject

--- a/packages/web/status/freespace.php
+++ b/packages/web/status/freespace.php
@@ -2,7 +2,7 @@
 /**
  * Gets free space of disk/partition holding images from server
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Freespace
  * @package  FOGProject

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -2,7 +2,7 @@
 /**
  * Get's files stored as requested
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getfiles
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's files stored as requested
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getfiles
  * @package  FOGProject

--- a/packages/web/status/gethash.php
+++ b/packages/web/status/gethash.php
@@ -2,7 +2,7 @@
 /**
  * Get's hash of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's hash of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject

--- a/packages/web/status/getservertime.php
+++ b/packages/web/status/getservertime.php
@@ -2,7 +2,7 @@
 /**
  * Returns the server time
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Getservertime
  * @package  FOGProject

--- a/packages/web/status/getsize.php
+++ b/packages/web/status/getsize.php
@@ -2,7 +2,7 @@
 /**
  * Get's size of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Get's size of file passed.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Gethash
  * @package  FOGProject

--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -2,7 +2,7 @@
 /**
  * Hostgetkey returns the host token for hostinfo getting
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Hostgetkey
  * @package  FOGProject

--- a/packages/web/status/hw.php
+++ b/packages/web/status/hw.php
@@ -2,7 +2,7 @@
 /**
  * Presents Hardware/Software information of the server.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category HardwareInfo
  * @package  FOGProject

--- a/packages/web/status/index.php
+++ b/packages/web/status/index.php
@@ -2,7 +2,7 @@
 /**
  * Redirects calls to status/index.php to main page.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Redirect
  * @package  FOGProject

--- a/packages/web/status/kernelvers.php
+++ b/packages/web/status/kernelvers.php
@@ -2,7 +2,7 @@
 /**
  * Presents the FOG Kernels version that the clients will use.
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category KernelVersion
  * @package  FOGProject

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -2,7 +2,7 @@
 /**
  * Logtoview handles reading files
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Logtoview
  * @package  FOGProject

--- a/packages/web/status/mainversion.php
+++ b/packages/web/status/mainversion.php
@@ -2,7 +2,7 @@
 /**
  * Gets version information
  *
- * PHP version 5
+ * PHP version 7.4+
  *
  * @category Mainversion
  * @package  FOGProject

--- a/packages/web/status/newtoken.php
+++ b/packages/web/status/newtoken.php
@@ -2,7 +2,7 @@
 /**
  * Generates a new token on ajax request.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NewToken
  * @package  FOGProject
@@ -13,7 +13,7 @@
 /**
  * Generates a new token on ajax request.
  *
- * PHP Version 5
+ * PHP version 7.4+
  *
  * @category NewToken
  * @package  FOGProject

--- a/tests/php-version-docblocks.test.php
+++ b/tests/php-version-docblocks.test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * The `PHP version` line in file docblocks must match the version FOG enforces.
+ *
+ * 304 files said "PHP version 5" -- inherited from the era when that was true
+ * and never revisited, while Initiator::_verCheck() has required 7.4 for
+ * years. Nothing breaks, which is exactly why it sat there: the only readers
+ * are contributors, who were being told the wrong floor by every file they
+ * opened.
+ *
+ * The floor is read out of _verCheck() rather than hardcoded here, so raising
+ * it fails this test until the docblocks follow. That is the point -- the next
+ * bump should not be able to leave 300 files lying again.
+ *
+ * vendor/ is exempt: third-party packages state their own requirements.
+ *
+ * Usage: php tests/php-version-docblocks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+// The enforced floor, taken from the check that actually rejects a request.
+$init = (string) @file_get_contents('packages/web/commons/init.php');
+if (!preg_match("/version_compare\(phpversion\(\), '([0-9.]+)', '<'\)/", $init, $m)) {
+    fwrite(STDERR, "FAIL: cannot find the version floor in Initiator::_verCheck()\n");
+    exit(1);
+}
+$floor = $m[1];
+$expected = "PHP version $floor+";
+
+$files = explode("\n", trim((string) shell_exec('git ls-files "*.php"')));
+$fails = [];
+foreach ($files as $file) {
+    if ('' === $file || 0 === strpos($file, 'packages/web/vendor/')) {
+        continue;
+    }
+    $n = 0;
+    foreach (explode("\n", (string) @file_get_contents($file)) as $i => $line) {
+        // Only the docblock form: " * PHP version X". Prose that happens to
+        // begin that way (mysqldump's "PHP version of ... cli") is not a
+        // version claim and must not be rewritten into one.
+        if (!preg_match('/^\s*\*\s*PHP [Vv]ersion\s+[0-9]/', $line)) {
+            continue;
+        }
+        ++$n;
+        if (trim(preg_replace('/^\s*\*\s*/', '', $line)) !== $expected) {
+            $fails[] = "$file:" . ($i + 1) . ' says "'
+                . trim(preg_replace('/^\s*\*\s*/', '', $line))
+                . "\", but FOG enforces $floor -- expected \"$expected\"";
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " docblock(s) state the wrong PHP floor:\n");
+    foreach (array_slice($fails, 0, 20) as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    if (count($fails) > 20) {
+        fwrite(STDERR, '  ... and ' . (count($fails) - 20) . " more\n");
+    }
+    exit(1);
+}
+
+echo "ok: every PHP version docblock states the enforced floor ($floor)\n";
+exit(0);


### PR DESCRIPTION
Port of the `working-1.6` sweep in #1126. The drift is worse here.

**427 files** opened with `* PHP version 5`, while `Initiator::_verCheck()` has thrown below 7.4 for years and `CONTRIBUTING.md` says "Target **PHP 7.4+**". Only the file headers were still describing the 1.x era.

## The change

430 lines across 423 files, including three that said `* PHP version 7` without the minor, normalized to `* PHP version 7.4+`.

| Before | Lines |
|---|---:|
| `* PHP version 5` | 394 |
| `* PHP Version 5` | 33 |
| `* PHP version 7` | 3 |
| **After: `* PHP version 7.4+`** | **430** |

## It is comment text only

Token streams with comments and whitespace stripped are **byte-identical to HEAD in all 423 files** — checked with `token_get_all()`, not by eye. That is the entire safety argument for a diff this wide.

## Gate

`tests/php-version-docblocks.test.php` reads the floor out of `_verCheck()` rather than hardcoding it, so a future floor bump fails this test until the docblocks follow. All six `tests/*.test.php` pass on this branch.

**The floor stays 7.4** — this only makes the tree say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR