### PR TITLE
Phase 2.1a: let a plugin ship its own Composer dependencies

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -124,10 +124,12 @@ The running example, `helloworld`, manages a trivial entity with a `name` and a
 │   ├── addhelloworldmenuitem.hook.php # menu entry + search/objects
 │   ├── addhelloworldjs.hook.php       # JS injection
 │   └── addhelloworldapi.hook.php      # REST API exposure
-└── js/
-    ├── fog.helloworld.list.js
-    ├── fog.helloworld.add.js
-    └── fog.helloworld.edit.js
+├── js/
+│   ├── fog.helloworld.list.js
+│   ├── fog.helloworld.add.js
+│   └── fog.helloworld.edit.js
+└── vendor/                        # optional — Composer dependencies, see 7b
+    └── autoload.php
 ```
 
 The directory name **is** the plugin's machine name and routing `node`. Keep it
@@ -514,6 +516,58 @@ Two things to know:
 earliest they could be reviewed for removal is 1.7, with at least one minor
 release of notice before it happens. Adopting `FOG\` names now costs nothing and
 removes the question later.
+
+## 7b. Composer dependencies
+
+Your plugin may ship its own `vendor/`. Put it beside `config/`, exactly where
+`composer install` leaves it, and FOG registers it at boot:
+
+```
+<root>/helloworld/
+├── composer.json
+├── vendor/
+│   └── autoload.php               # FOG requires this if it is present
+├── config/
+...
+```
+
+Nothing else is needed — no hook, no manifest entry. Run `composer install` in
+your plugin directory, ship the resulting `vendor/` inside the archive, and
+your packages are autoloadable everywhere your plugin's PHP runs.
+
+Two rules make that safe.
+
+**Core wins.** Plugin loaders are registered last, after core's own Composer
+loader and after FOG's class map. A name core can resolve is resolved by core,
+whatever your `vendor/` contains.
+
+**One copy of a package, project-wide.** A plugin whose `vendor/` claims a
+namespace or class name already provided by core — or by a plugin that loaded
+earlier — is **refused**: its loader is unregistered and a line explaining why
+goes to the PHP error log. Only that plugin's vendored classes stop resolving;
+the rest of it, and the rest of FOG, keep working.
+
+This is not tidiness. Two plugins vendoring different majors of one package
+both declare the same class names, and whichever registered first wins — the
+other silently runs against a version it was never tested against. For an
+authentication or crypto library that is a security bug, so FOG makes it a
+loud failure instead.
+
+**What core provides, depend on rather than vendor:**
+
+| Package | Since | For |
+|---|---|---|
+| `firebase/php-jwt` | 1.6.0 | JWT decode and JWKS parsing |
+
+Declare it in your `composer.json` as usual and mark it `"replace"`-free — just
+do not commit your own copy into `vendor/`. If you need a version core does not
+ship, raise it with the project rather than working around it; a second copy is
+exactly what the refusal is there to stop.
+
+**Caveat.** Composer's `files` autoload runs the moment the file is required,
+so a package with side effects at load time may have executed before a refusal
+takes effect. Keep boot-time side effects out of vendored code you expect FOG
+to load.
 
 ## 8. Security & output conventions
 

--- a/docs/refactor-phase2-plan.md
+++ b/docs/refactor-phase2-plan.md
@@ -269,7 +269,7 @@ podman run --rm -v .../vendor:/src:ro php:7.4-cli ...   # 17 files, 0 lint failu
 sh tests/run-all.sh
 ```
 
-### PR 2.1a — let a plugin have its own `vendor/`
+### PR 2.1a — let a plugin have its own `vendor/` ✅ DONE
 
 Closes G4 properly rather than working around it. Core loads
 `<plugin>/vendor/autoload.php` when present, mirroring the six lines it
@@ -280,10 +280,19 @@ refused and logged, not silently first-wins.
 Independent of OIDC — every plugin author benefits, and it is the honest
 answer to "why can't my plugin use Composer".
 
+Landed as `Initiator::_registerPluginAutoloaders()`, called last in the
+constructor so plugin loaders sit behind core's Composer loader, the FOG class
+map and the built-in resolver. That ordering is the real protection: even with
+the collision check wrong, core answers first for any name it can serve.
+Documented for plugin authors in `docs/plugin-development.md` §7b.
+
 ```bash
 php tests/plugin-vendor-autoload.test.php
-# fixture plugin with its own vendor/ resolves its class
-# second fixture vendoring a conflicting version is REFUSED, not silently shadowed
+# four fixture plugins in a throwaway FOG_PLUGIN_DIR:
+#   its own vendor/ resolves; a second claiming the same namespace is REFUSED;
+#   one vendoring a package CORE provides is refused and core's copy wins;
+#   one with no vendor/ is silent
+# verified failing both with the call removed and with the check neutered
 ```
 
 ### PR 2.2 — the extension point (this is the phase's real deliverable)

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -164,6 +164,9 @@ class Initiator
         spl_autoload_register([self::class, 'autoload']);
         spl_autoload_register();
 
+        // Last in the chain on purpose -- see the method.
+        self::_registerPluginAutoloaders();
+
         /*
          * Start a session only when there is one to resume or something has
          * asked for one.
@@ -323,6 +326,178 @@ class Initiator
             }
         }
         return false;
+    }
+
+    /**
+     * Let a plugin ship its own Composer dependencies.
+     *
+     * ADR 0009 left this out, and the Phase 2 plan first read that absence as
+     * "plugins cannot use Composer". They can: an autoloader is an
+     * spl_autoload_register callback and several coexist in one process, so a
+     * plugin could always have required its own vendor/autoload.php from a
+     * file body FOG already includes. What was missing is core doing it in a
+     * defined order, with a defined answer when two of them disagree.
+     *
+     * Registered LAST, after core's Composer loader (file scope, above),
+     * Initiator::autoload() and the built-in resolver. That ordering is the
+     * real protection: even if the collision check below were wrong, core
+     * still answers first for any name it can serve, so a plugin's vendor
+     * copy cannot displace a class core provides.
+     *
+     * The collision check is what makes shipping a dependency in core mean
+     * something. Two plugins vendoring different majors of one package both
+     * declare the same class names, and whichever registered first wins --
+     * the other then runs against a version it was never tested against, with
+     * nothing said. For a JWT library that is a security bug rather than an
+     * inconvenience, which is why core ships firebase/php-jwt and a plugin is
+     * expected to depend on it instead of carrying its own.
+     *
+     * A refused plugin is unregistered, not fatal: the rest of FOG, and the
+     * plugin's own PHP, keep working. Only its vendored classes stop
+     * resolving, which is the visible failure the silent version-skew was not.
+     *
+     * Caveat worth knowing: Composer's `files` autoload runs at require time,
+     * so a refused plugin may already have executed those before we could
+     * unregister it. Preventing that would mean parsing the vendor tree
+     * instead of loading it, which buys less than it costs.
+     *
+     * @return void
+     */
+    private static function _registerPluginAutoloaders(): void
+    {
+        if (!class_exists('\Composer\Autoload\ClassLoader', false)) {
+            // No core vendor/ -- an install predating Phase 0, or a checkout
+            // that never ran composer install. Nothing to register against.
+            return;
+        }
+        $claimed = [];
+        foreach (self::_composerLoaders() as $loader) {
+            foreach (self::_claimsOf($loader) as $claim) {
+                $claimed[$claim] = 'FOG core';
+            }
+        }
+        foreach (self::_pluginVendorAutoloads() as $plugin => $file) {
+            $loader = require $file;
+            if (!$loader instanceof \Composer\Autoload\ClassLoader) {
+                error_log(
+                    sprintf(
+                        'FOG plugin autoloader: %s did not return a Composer '
+                        . 'ClassLoader. Regenerate it with `composer install`.',
+                        $file
+                    )
+                );
+                continue;
+            }
+            $claims = self::_claimsOf($loader);
+            $conflicts = array_intersect($claims, array_keys($claimed));
+            if (count($conflicts) > 0) {
+                $loader->unregister();
+                $first = reset($conflicts);
+                error_log(
+                    sprintf(
+                        'FOG plugin autoloader: refusing %s -- it vendors %s, '
+                        . 'already provided by %s (%d name(s) in common). Two '
+                        . 'copies of one package resolve to whichever loaded '
+                        . 'first, silently. Depend on the provided copy, or '
+                        . 'raise it with the FOG project if core should ship '
+                        . 'a different version.',
+                        $file,
+                        preg_replace('#^(ns|class):#', '', (string) $first),
+                        $claimed[$first],
+                        count($conflicts)
+                    )
+                );
+                continue;
+            }
+            foreach ($claims as $claim) {
+                $claimed[$claim] = $plugin;
+            }
+        }
+    }
+
+    /**
+     * Every Composer ClassLoader currently in the autoload chain.
+     *
+     * Read out of spl_autoload_functions() rather than tracked in a property,
+     * so it sees core's loader however it got there -- including on a tree
+     * where something else required vendor/autoload.php first.
+     *
+     * @return \Composer\Autoload\ClassLoader[]
+     */
+    private static function _composerLoaders(): array
+    {
+        $loaders = [];
+        foreach ((array) spl_autoload_functions() as $fn) {
+            if (is_array($fn)
+                && isset($fn[0])
+                && $fn[0] instanceof \Composer\Autoload\ClassLoader
+            ) {
+                $loaders[] = $fn[0];
+            }
+        }
+        return $loaders;
+    }
+
+    /**
+     * The class names a loader claims, as comparable strings.
+     *
+     * Namespace prefixes and classmap entries both, because a package can be
+     * autoloaded either way -- PSR-4 for the normal case, a classmap for one
+     * that predates it. `optimize-autoloader` adds a classmap without
+     * dropping the prefixes, so an optimised tree is caught by either.
+     *
+     * @param \Composer\Autoload\ClassLoader $loader The loader to inspect.
+     *
+     * @return string[]
+     */
+    private static function _claimsOf($loader): array
+    {
+        $claims = [];
+        foreach (array_keys($loader->getPrefixesPsr4()) as $ns) {
+            $claims[] = 'ns:' . strtolower($ns);
+        }
+        foreach (array_keys($loader->getPrefixes()) as $ns) {
+            $claims[] = 'ns:' . strtolower($ns);
+        }
+        foreach (array_keys($loader->getClassMap()) as $class) {
+            $claims[] = 'class:' . strtolower($class);
+        }
+        return array_values(array_unique($claims));
+    }
+
+    /**
+     * Plugin name => its vendor/autoload.php, for every plugin that has one.
+     *
+     * Both plugin roots, one level deep: a plugin is a directory, its
+     * dependencies are vendor/ inside it. Sorted so the order two plugins are
+     * offered in is a property of their names rather than of readdir -- the
+     * same per-install nondeterminism the class map had before core-wins.
+     *
+     * @return array<string,string>
+     */
+    private static function _pluginVendorAutoloads(): array
+    {
+        $found = [];
+        $roots = [rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins'];
+        if (defined('FOG_PLUGIN_DIR') && FOG_PLUGIN_DIR) {
+            $roots[] = rtrim(FOG_PLUGIN_DIR, DS);
+        }
+        foreach ($roots as $root) {
+            if (!is_dir($root)) {
+                continue;
+            }
+            foreach ((array) scandir($root) as $entry) {
+                if ('.' === $entry || '..' === $entry) {
+                    continue;
+                }
+                $file = $root . DS . $entry . DS . 'vendor' . DS . 'autoload.php';
+                if (is_readable($file)) {
+                    $found[$entry] = $file;
+                }
+            }
+        }
+        ksort($found);
+        return $found;
     }
 
     /**

--- a/tests/plugin-vendor-autoload.test.php
+++ b/tests/plugin-vendor-autoload.test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * A plugin may ship its own Composer dependencies -- unless they collide.
+ *
+ * Boots the real Initiator against a throwaway FOG_PLUGIN_DIR holding four
+ * fixture plugins, then asks the autoload chain real questions. Like
+ * autoload.test.php this needs no database: the constructor only registers
+ * autoloaders, and startInit() -- the part that wants MySQL -- is never
+ * called.
+ *
+ * Four properties, and the last two are the ones that matter:
+ *
+ *   1. A plugin with vendor/ gets its classes.
+ *   2. A plugin without one still works. (It is the normal case; every
+ *      bundled plugin today has no vendor/ at all.)
+ *   3. A second plugin claiming a namespace the first already claimed is
+ *      REFUSED, not silently shadowed. Two copies of one package otherwise
+ *      resolve to whichever registered first, which is readdir order.
+ *   4. A plugin vendoring a package CORE provides is refused, and core's
+ *      copy is what resolves. This is what makes "core ships php-jwt and you
+ *      depend on it" a guarantee rather than a request.
+ *
+ * Usage: php tests/plugin-vendor-autoload.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+if (!is_readable($web . '/vendor/autoload.php')) {
+    echo "skip: no core vendor/ in this tree\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------- fixtures
+
+$tmp = sys_get_temp_dir() . '/fog-plugin-vendor-' . getmypid();
+$plugins = $tmp . '/plugins';
+
+$rmrf = function ($dir) use (&$rmrf) {
+    if (!is_dir($dir)) {
+        return;
+    }
+    foreach (array_diff((array) scandir($dir), ['.', '..']) as $e) {
+        $p = "$dir/$e";
+        is_dir($p) ? $rmrf($p) : unlink($p);
+    }
+    rmdir($dir);
+};
+$rmrf($tmp);
+
+/**
+ * Write one fixture plugin: a vendor/autoload.php that registers a PSR-4
+ * namespace, plus the class file it points at. This is the shape Composer
+ * generates -- construct a ClassLoader, register it, return it -- with the
+ * generated init class left out because nothing here depends on it.
+ */
+$fixture = function (string $name, string $ns, string $class) use ($plugins) {
+    $dir = "$plugins/$name";
+    @mkdir("$dir/vendor", 0777, true);
+    @mkdir("$dir/src", 0777, true);
+    $nsEsc = str_replace('\\', '\\\\', $ns);
+    file_put_contents(
+        "$dir/vendor/autoload.php",
+        "<?php\n"
+        . "\$loader = new \\Composer\\Autoload\\ClassLoader();\n"
+        . "\$loader->setPsr4('$nsEsc\\\\', __DIR__ . '/../src');\n"
+        . "\$loader->register();\n"
+        . "return \$loader;\n"
+    );
+    file_put_contents(
+        "$dir/src/$class.php",
+        "<?php\nnamespace $ns;\nclass $class { public static function who() { return '$name'; } }\n"
+    );
+};
+
+// 1+3: two plugins claiming the same namespace. "aaa" sorts first, so it is
+//      the one that should win; "zzz" must be refused.
+$fixture('aaa-first', 'AcmeShared', 'Thing');
+$fixture('zzz-second', 'AcmeShared', 'Other');
+// 4: a plugin vendoring a package core already provides.
+$fixture('ccc-conflicts-core', 'Firebase\\JWT', 'JWT');
+// 2: a plugin with no vendor/ at all.
+@mkdir("$plugins/ddd-plain/src", 0777, true);
+
+// ------------------------------------------------------------------- boot
+
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $plugins);
+@mkdir(FOG_CACHE_DIR, 0777, true);
+@mkdir(FOG_LOG_DIR, 0777, true);
+
+// Keep the refusal messages out of the test's own output; they are expected,
+// and one of them is asserted on below.
+$errLog = $tmp . '/php-error.log';
+ini_set('error_log', $errLog);
+
+require $web . '/commons/init.php';
+new Initiator();
+
+// ----------------------------------------------------------------- checks
+
+$fails = [];
+
+// 1. The first plugin's vendored class resolves.
+if (!class_exists('AcmeShared\Thing')) {
+    $fails[] = 'a plugin with its own vendor/autoload.php did not get its'
+        . ' classes -- AcmeShared\Thing does not resolve';
+} elseif ('aaa-first' !== AcmeShared\Thing::who()) {
+    $fails[] = 'AcmeShared\Thing resolved to the wrong plugin: '
+        . AcmeShared\Thing::who();
+}
+
+// 3. The colliding plugin was refused, so its own class is unreachable.
+if (class_exists('AcmeShared\Other')) {
+    $fails[] = 'a second plugin claiming an already-claimed namespace was'
+        . ' registered anyway -- AcmeShared\Other resolves, so two copies of'
+        . ' one package are live and load order decides which';
+}
+
+// 4. Core still owns what core provides.
+if (!class_exists('Firebase\JWT\JWT')) {
+    $fails[] = "core's own vendored Firebase\\JWT\\JWT stopped resolving";
+} else {
+    $file = (new ReflectionClass('Firebase\JWT\JWT'))->getFileName();
+    if (false !== strpos($file, 'ccc-conflicts-core')) {
+        $fails[] = "a plugin's vendored copy displaced core's: Firebase\\JWT"
+            . "\\JWT loaded from $file";
+    }
+}
+
+// The refusals must be reported. A silent refusal is the same class of
+// problem as a silent shadow -- the plugin author has no way to find out.
+$log = is_readable($errLog) ? (string) file_get_contents($errLog) : '';
+foreach (['zzz-second', 'ccc-conflicts-core'] as $refused) {
+    if (false === strpos($log, $refused)) {
+        $fails[] = "refusing $refused was not logged, so a plugin author has"
+            . ' no way to learn why their dependency stopped resolving';
+    }
+}
+
+// 2. A plugin with no vendor/ is not an error.
+if (false !== strpos($log, 'ddd-plain')) {
+    $fails[] = 'a plugin with no vendor/ produced a log line; that is the'
+        . ' normal case and must be silent';
+}
+
+$rmrf($tmp);
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: plugins may vendor their own dependencies, collisions are refused\n";
+exit(0);


### PR DESCRIPTION
Closes the G4 gap properly rather than working around it, and it is useful on its own — every plugin author benefits, independent of OIDC.

## What was actually missing

ADR 0009 left this out, and the Phase 2 plan first read that absence as *"plugins cannot use Composer"*. They can. An autoloader is an `spl_autoload_register` callback and several coexist in one process, so a plugin could always have required its own `vendor/autoload.php` from a file body FOG already includes.

What was missing is **core doing it in a defined order, with a defined answer when two of them disagree.**

## The change

`Initiator` now registers `<plugin>/vendor/autoload.php` for every plugin that has one, across both plugin roots, sorted by name so the order is a property of the names rather than of readdir. No hook, no manifest entry — drop `vendor/` in the plugin directory and it loads.

**Registered last**, after core's Composer loader, `Initiator::autoload()` and the built-in resolver. That ordering is the real protection: even if the collision check below were wrong, core still answers first for any name it can serve, so a plugin's vendored copy cannot displace a class core provides. (The test proves this independently — with the collision check neutered, `Firebase\JWT\JWT` *still* resolves from core.)

## The collision check, and why it is not tidiness

Two plugins vendoring different majors of one package both declare the same class names, and whichever registered first wins. The other then runs against a version it was never tested against, with nothing said. For the JWT library added in #1125 that is a security bug rather than an inconvenience.

A plugin claiming a namespace or class name already provided is now **unregistered and the reason logged**. Only its vendored classes stop resolving — the plugin's own PHP, and the rest of FOG, keep working. A visible failure instead of a silent wrong version.

Claims are compared as namespace prefixes (PSR-4 and PSR-0) *and* classmap keys, because a package can be autoloaded either way, and `optimize-autoloader` adds a classmap without dropping the prefixes.

**Known caveat, documented rather than worked around:** Composer's `files` autoload runs at require time, so a refused plugin may already have executed those. Preventing it would mean parsing the vendor tree instead of loading it, which buys less than it costs.

## Gate

`tests/plugin-vendor-autoload.test.php` boots the real `Initiator` against four fixture plugins in a throwaway `FOG_PLUGIN_DIR` — no database, same trick as `autoload.test.php`:

| Fixture | Asserted |
|---|---|
| `aaa-first` vendors `AcmeShared\` | its class resolves |
| `zzz-second` vendors `AcmeShared\` too | **refused** — `AcmeShared\Other` must not resolve |
| `ccc-conflicts-core` vendors `Firebase\JWT\` | **refused** — and `Firebase\JWT\JWT` still loads from core's file |
| `ddd-plain`, no `vendor/` | works, and logs nothing |

Both refusals must appear in the error log: a silent refusal is the same class of problem as a silent shadow, since the author has no way to find out.

Verified failing **both** with the registration call removed and with the collision check neutered. `sh tests/run-all.sh` → **38 passed, 0 failed**.

## Docs

`docs/plugin-development.md` gains §7b for plugin authors — the layout, the two rules, and the table of what core provides and should be depended on rather than vendored (`firebase/php-jwt` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR