### PR TITLE
Let the prefix gate see a file before it is tracked

### DIFF
--- a/bin/prefix-global-classes.php
+++ b/bin/prefix-global-classes.php
@@ -70,8 +70,18 @@ function collectFiles($root, array $paths)
             $candidates[] = $p;
         }
     } else {
+        // --cached --others --exclude-standard, not a bare ls-files: a file
+        // that is written but not yet `git add`ed is exactly the one being
+        // checked, and a bare listing cannot see it. That gap let a new test
+        // file ship a bare ReflectionClass -- green locally, red the moment
+        // the merge made it tracked. --exclude-standard keeps .gitignore
+        // honoured, so vendor/ and lib/plugins stay out.
         $out = [];
-        exec('git -C ' . escapeshellarg($root) . ' ls-files', $out);
+        exec(
+            'git -C ' . escapeshellarg($root)
+            . ' ls-files --cached --others --exclude-standard',
+            $out
+        );
         foreach ($out as $rel) {
             $candidates[] = $root . DIRECTORY_SEPARATOR . $rel;
         }

--- a/tests/plugin-vendor-autoload.test.php
+++ b/tests/plugin-vendor-autoload.test.php
@@ -123,7 +123,7 @@ if (class_exists('AcmeShared\Other')) {
 if (!class_exists('Firebase\JWT\JWT')) {
     $fails[] = "core's own vendored Firebase\\JWT\\JWT stopped resolving";
 } else {
-    $file = (new ReflectionClass('Firebase\JWT\JWT'))->getFileName();
+    $file = (new \ReflectionClass('Firebase\JWT\JWT'))->getFileName();
     if (false !== strpos($file, 'ccc-conflicts-core')) {
         $fails[] = "a plugin's vendored copy displaced core's: Firebase\\JWT"
             . "\\JWT loaded from $file";


### PR DESCRIPTION
**`working-1.6` is currently red.** Merging #1128 turned it: `tests/plugin-vendor-autoload.test.php` used a bare `ReflectionClass`, which `global-class-prefix.test.php` exists to catch — and did not.

## Why the gate missed it

`bin/prefix-global-classes.php` builds its candidate list with `git ls-files`, which reports **tracked files only**. A file that has been written but not yet `git add`ed — exactly the file under review — is invisible to it.

So the gate passed on the branch, and failed the moment the merge made the file tracked. It was reporting on the previous commit's tree while appearing to report on the working one, which is the worst shape a check can have: green when it should be red, and only for new files.

## The fix

```diff
-exec('git -C ' . escapeshellarg($root) . ' ls-files', $out);
+exec(
+    'git -C ' . escapeshellarg($root)
+    . ' ls-files --cached --others --exclude-standard',
+    $out
+);
```

`--others` adds untracked files; `--exclude-standard` keeps `.gitignore` honoured, so `vendor/` and `lib/plugins` stay out exactly as before.

Plus the one-character fix to the offending line.

## Verification

`sh tests/run-all.sh` → **38 passed, 0 failed**, where `working-1.6` at `e690939e3` gives 37 passed / 1 failed. Confirmed the scanner now sees an untracked file by adding one with a bare `DateTime` and watching it fail before it was ever staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR