### PR TITLE
Phase 2.2: the plugin extension point — routes, session-less nodes, login buttons

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -569,6 +569,78 @@ so a package with side effects at load time may have executed before a refusal
 takes effect. Keep boot-time side effects out of vendored code you expect FOG
 to load.
 
+## 7c. Authentication extension points
+
+Three seams a plugin can use to add a way of signing in. Each is gated, and in
+every case **declaring nothing means denied** — none of them is a way to make
+something reachable by accident.
+
+### A route — `API_PLUGIN_ROUTES`
+
+```php
+self::$HookManager->register('API_PLUGIN_ROUTES', function ($args) {
+    $args['routes'][] = [
+        'name'       => 'oidcCallback',           // bare identifier
+        'method'     => 'GET',
+        'path'       => '/ext/oidc/callback',     // must be under /ext/
+        'handler'    => ['FOG\OidcRoutes', 'callback'],
+        'auth'       => 'public',                 // default 'required'
+    ];
+    $args['routes'][] = [
+        'name'       => 'oidcConfig',
+        'method'     => 'POST',
+        'path'       => '/ext/oidc/config',
+        'handler'    => ['FOG\OidcRoutes', 'saveConfig'],
+        'permission' => 'oidc.edit',              // required when not public
+    ];
+});
+```
+
+| Rule | Why |
+|---|---|
+| Path must start with `/ext/` | Core mints new top-level paths from its API class list, so today's free path is not tomorrow's. Under `/ext/` the two namespaces cannot meet |
+| Route name is registered as `ext:<name>` | The name is what the permission layer keys on; without a prefix a route called `status` would inherit core's "no check" |
+| `auth` is `'public'` only when it is exactly that string | A typo, or a truthy value someone thought meant "needs auth", must not open a route |
+| A public route must be a literal path | The unauthenticated test is an exact string match, so a path with `[i:id]` in it cannot be expressed there |
+| No `permission` and not public → **403**, not 404 | The route still registers, so you get a log line telling you what to declare instead of a silent miss |
+
+Registered after every core route, so a core path always matches first.
+
+### A session-less page node — `PAGE_EXEMPT_NODES`
+
+Every page node is permission-checked. That is right for a settings page and
+impossible for the page a visitor reaches *before* they have a session.
+
+```php
+self::$HookManager->register('PAGE_EXEMPT_NODES', function ($args) {
+    $args['nodes'][] = 'oidcstart';
+});
+```
+
+You may only exempt a node **nothing else owns**. A node that is in the
+permission registry — core's or another plugin's — is refused, because
+"exempt" and "check this permission" are contradictory instructions about the
+same node and the permissive one would win. Give the pre-authentication page a
+node of its own.
+
+### A login button — `LOGIN_PAGE_PROVIDERS`
+
+```php
+self::$HookManager->register('LOGIN_PAGE_PROVIDERS', function ($args) {
+    $args['providers'][] = [
+        'label' => _('Sign in with Acme'),
+        'url'   => '/fog/ext/oidc/start',
+        'icon'  => 'fa fa-key',
+    ];
+});
+```
+
+The start URL must be a **site-absolute path** or an **`https://` URL**.
+`javascript:`, `data:`, protocol-relative `//host` and plain `http://` are all
+refused — this is the one page every unauthenticated visitor sees. Label and
+icon are escaped; the icon is additionally restricted to plain class
+characters.
+
 ## 8. Security & output conventions
 
 - **Output:** wrap every user‑controlled value with `Initiator::e($value)` when

--- a/docs/refactor-phase2-plan.md
+++ b/docs/refactor-phase2-plan.md
@@ -295,7 +295,7 @@ php tests/plugin-vendor-autoload.test.php
 # verified failing both with the call removed and with the check neutered
 ```
 
-### PR 2.2 — the extension point (this is the phase's real deliverable)
+### PR 2.2 — the extension point (this is the phase's real deliverable) ✅ DONE
 
 Three seams, each closing one gap, each independently useful:
 
@@ -309,9 +309,40 @@ Three seams, each closing one gap, each independently useful:
 - **G3** — a `LOGIN_PAGE_PROVIDERS` hook contributing a button (label, icon,
   start URL) to the login form.
 
-Gate: a fixture plugin in `tests/` registers a route, an exempt node and a
-button, and the test asserts all three take effect — and, crucially, that a
-plugin route which did **not** declare itself session-less is still gated.
+Landed with a fourth thing the plan did not anticipate, and which turned out
+to matter more than any of the three: `resolveApiPermission()` **already**
+returned `null` — no check — for a route name it did not recognise, described
+in a comment as matching the unregistered-page stance that had since been
+tightened everywhere else. Harmless while nothing could add a route; an open
+default the moment something could. Flipped to deny first, in its own commit,
+after verifying all 29 core route names are mapped.
+
+The seam then enforces, rather than trusts:
+
+- Plugin routes live under a reserved `/ext/` mount point, so a plugin path and
+  a core path cannot collide — which also means declaring one public can never
+  open a core path by exact-match coincidence. Not `/plugin/`: that is already
+  an API class.
+- Route names are registered as `ext:<name>`, because the name is what the
+  permission layer keys on and an unprefixed `status` would inherit core's
+  "no check".
+- A route declaring no permission is registered but not declared, so it answers
+  403 with a diagnostic instead of 404 with silence.
+- `EXEMPT_NODES` stays a `const`; plugin entries merge on top and a node in the
+  permission registry is refused, so this cannot be used to turn the gate off
+  on `host`.
+- Login-button start URLs must be site-absolute or `https://`.
+
+Gate: `tests/plugin-extension-points.test.php`, driving all three seams with a
+stub hook manager and no database.
+
+```bash
+php tests/plugin-extension-points.test.php
+# 8 route fixtures, incl. one declaring nothing (must be DENIED), one with a
+# misspelt auth, one at /system/export, one with ../ in the path
+# verified failing with: any-truthy auth accepted; the /ext/ check removed;
+# the exempt-node registry guard removed; the provider URL check removed
+```
 
 ```bash
 php tests/plugin-extension-points.test.php

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -250,6 +250,27 @@ class Authorization extends FOGBase
      */
     private static $_unmappedLogged = [];
     /**
+     * Permissions declared by plugin-contributed routes, name => permission.
+     *
+     * A null value means "no permission check", and Route only ever passes
+     * null for a route it also declared public -- an unauthenticated caller
+     * has no permissions to check, so demanding one would deny every request
+     * including the ones the route exists to serve.
+     *
+     * Populated in Route::defineRoutes(), which is the one place a route and
+     * its permission are decided together. A route absent from here reaches
+     * the unmapped branch of resolveApiPermission() and is denied.
+     *
+     * @var array
+     */
+    private static $_declaredRoutePermissions = [];
+    /**
+     * Exempt nodes after the plugin hook, or null before it has fired.
+     *
+     * @var array|null
+     */
+    private static $_exemptNodes = null;
+    /**
      * The permission registry: registry node => list of valid actions.
      *
      * Plugins can add their own nodes/actions through the
@@ -451,7 +472,7 @@ class Authorization extends FOGBase
         if (isset($globals[$sub])) {
             return $globals[$sub];
         }
-        if ('' === $node || in_array($node, self::EXEMPT_NODES, true)) {
+        if ('' === $node || in_array($node, self::exemptNodes(), true)) {
             return null;
         }
         $aliases = self::NODE_ALIASES;
@@ -582,11 +603,104 @@ class Authorization extends FOGBase
      *
      * @return string|null the required permission, null = no check
      */
+    /**
+     * Page nodes that are never permission-checked, core's plus any a plugin
+     * has contributed.
+     *
+     * Closes ADR 0009's second gap. EXEMPT_NODES is a const, so a plugin
+     * could not append to it, and every page a plugin adds is therefore
+     * permission-checked -- correct for a settings page, impossible for the
+     * one page an authentication provider needs: the surface a visitor
+     * reaches BEFORE they have a session.
+     *
+     * The const stays exactly as it was, so "what does core exempt" is still
+     * answerable by reading one array. Plugin entries are merged on top here.
+     *
+     * A plugin may only exempt a node nothing else owns. Exempting a node
+     * that is in the permission registry -- core's or another plugin's --
+     * is refused, because the two are contradictory instructions about the
+     * same node and the permissive one would win. That check is what stops
+     * this being a way to turn the gate off on 'host'.
+     *
+     * @return array
+     */
+    public static function exemptNodes()
+    {
+        if (null !== self::$_exemptNodes) {
+            return self::$_exemptNodes;
+        }
+        $nodes = self::EXEMPT_NODES;
+        $extra = [];
+        if (self::$HookManager) {
+            self::$HookManager->processEvent(
+                'PAGE_EXEMPT_NODES',
+                ['nodes' => &$extra]
+            );
+        }
+        $registry = self::registry();
+        foreach ((array)$extra as $node) {
+            $node = strtolower(trim((string)$node));
+            if ('' === $node || in_array($node, $nodes, true)) {
+                continue;
+            }
+            if (isset($registry[$node]) || isset(self::NODE_ALIASES[$node])) {
+                error_log(
+                    sprintf(
+                        'FOG exempt node: refusing "%s" -- it is a registered '
+                        . 'permission node, so exempting it would silently '
+                        . 'turn off a check something else asked for. Use a '
+                        . 'node of its own for the pre-authentication page.',
+                        $node
+                    )
+                );
+                continue;
+            }
+            $nodes[] = $node;
+        }
+        return self::$_exemptNodes = array_values(array_unique($nodes));
+    }
+    /**
+     * Record the permission a plugin-contributed route requires.
+     *
+     * Called by Route::defineRoutes() for each validated plugin route. A
+     * route that declared nothing is simply never registered here, which is
+     * what makes "declares nothing" mean "denied" rather than "allowed".
+     *
+     * @param string      $routeName  The prefixed route name Route registered.
+     * @param string|null $permission The permission, or null for a public route.
+     *
+     * @return void
+     */
+    public static function declareRoutePermission($routeName, $permission)
+    {
+        $routeName = (string)$routeName;
+        if ('' === $routeName
+            || array_key_exists($routeName, self::API_ROUTE_PERMISSIONS)
+            || isset(self::API_ROUTE_ACTIONS[$routeName])
+        ) {
+            // Never let a declaration land on a core route's name.
+            return;
+        }
+        if (null !== $permission
+            && (!is_string($permission) || '' === $permission)
+        ) {
+            return;
+        }
+        self::$_declaredRoutePermissions[$routeName] = $permission;
+    }
     public static function resolveApiPermission($routeName, $class = '')
     {
         $routeName = (string)$routeName;
         if (array_key_exists($routeName, self::API_ROUTE_PERMISSIONS)) {
             return self::API_ROUTE_PERMISSIONS[$routeName];
+        }
+        // Core's table is consulted first on purpose: a plugin cannot
+        // redeclare the permission of a core route even if it manages to
+        // register a route under the same name. Route stamps its own prefix
+        // on plugin names so that should be impossible, and this makes it
+        // impossible twice.
+        if (array_key_exists($routeName, self::$_declaredRoutePermissions)) {
+            return self::$_declaredRoutePermissions[$routeName];
         }
         if (!isset(self::API_ROUTE_ACTIONS[$routeName])) {
             // A route name nothing claims. This used to return null, which

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -589,9 +589,41 @@ class Authorization extends FOGBase
             return self::API_ROUTE_PERMISSIONS[$routeName];
         }
         if (!isset(self::API_ROUTE_ACTIONS[$routeName])) {
-            // Unknown route (plugin-added): allow, matching the
-            // unregistered-page compatibility stance.
-            return null;
+            // A route name nothing claims. This used to return null, which
+            // means "no check", on the grounds that it matched the
+            // unregistered-page compatibility stance -- but that stance was
+            // tightened below and in resolvePagePermission(), leaving this
+            // the last allow-by-default in the file.
+            //
+            // It was very nearly harmless while it lasted, because nothing
+            // could add a route: defineRoutes() is core-only and all 29 of
+            // its route names are listed in API_ROUTE_ACTIONS or
+            // API_ROUTE_PERMISSIONS, so this branch was unreachable on a
+            // stock install. The plugin route seam is what makes it
+            // reachable, and an "open unless declared" default is exactly
+            // the wrong way round for a seam whose whole job is letting
+            // third-party code answer a URL.
+            //
+            // Deny the same way the class branch below does: require a
+            // permission no role can be granted, so an administrator keeps
+            // working and a restricted role does not get a free pass. A
+            // plugin route declares its permission when it registers (see
+            // Route::pluginRoutes), and that declaration is what lands in
+            // API_ROUTE_PERMISSIONS' plugin-supplied counterpart, so a
+            // route reaching here declared nothing.
+            if (!isset(self::$_unmappedLogged['route:' . $routeName])) {
+                self::$_unmappedLogged['route:' . $routeName] = true;
+                error_log(
+                    sprintf(
+                        '%s: %s. %s',
+                        _('API route is not mapped to a permission'),
+                        $routeName,
+                        _('Only administrators may use it until the plugin '
+                            . 'declares a permission for the route.')
+                    )
+                );
+            }
+            return 'unmapped.route.' . $routeName;
         }
         $class = strtolower(trim((string)$class));
         $entity = self::API_CLASS_ENTITIES[$class] ?? self::_pluginEntity($class);

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -300,9 +300,92 @@ class ProcessLogin extends FOGPage
             true
         );
         echo '</form>';
+        echo self::loginProviders();
         echo '</div>';
         echo '</div>';
         echo '</div>';
+    }
+    /**
+     * "Sign in with ..." buttons contributed by authentication plugins.
+     *
+     * Closes ADR 0009's third gap. This page fired exactly two hooks --
+     * USER_TYPE_HOOK before the credential check and LoginSuccess after it --
+     * and neither contributes markup, so a provider had nowhere to put a
+     * button. Password login is the only thing a visitor could ever be
+     * offered.
+     *
+     * A provider supplies a label, a start URL and optionally an icon class:
+     *
+     *   $providers[] = [
+     *       'label' => _('Sign in with Acme'),
+     *       'url'   => '/fog/ext/oidc/start',
+     *       'icon'  => 'fa fa-key'
+     *   ];
+     *
+     * The URL is the only part with teeth, and it is checked rather than
+     * trusted: a same-origin absolute path, or an https:// URL, and nothing
+     * else. Without that, a plugin -- or anything that can register a hook --
+     * could put a javascript: or data: URI on the one page every
+     * unauthenticated visitor sees. http:// is refused too: an authentication
+     * handshake that starts in clear text is not one worth starting.
+     *
+     * Everything rendered goes through Initiator::e(), including the icon
+     * class, which is attacker-supplied markup as much as the label is.
+     *
+     * @return string
+     */
+    public static function loginProviders()
+    {
+        $providers = [];
+        if (self::$HookManager) {
+            self::$HookManager->processEvent(
+                'LOGIN_PAGE_PROVIDERS',
+                ['providers' => &$providers]
+            );
+        }
+        $buttons = [];
+        foreach ((array)$providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+            $label = isset($provider['label']) ? trim((string)$provider['label']) : '';
+            $url = isset($provider['url']) ? trim((string)$provider['url']) : '';
+            $icon = isset($provider['icon']) ? trim((string)$provider['icon']) : '';
+            if ('' === $label || '' === $url) {
+                continue;
+            }
+            // A path must be site-absolute and must not be protocol-relative
+            // ("//evil.example" is a URL, not a path). Anything else has to
+            // spell out https.
+            $sameOrigin = 0 === strpos($url, '/') && 0 !== strpos($url, '//');
+            if (!$sameOrigin && 0 !== stripos($url, 'https://')) {
+                error_log(
+                    sprintf(
+                        'FOG login provider: refusing "%s" -- a start URL must '
+                        . 'be a site-absolute path or an https:// URL.',
+                        $label
+                    )
+                );
+                continue;
+            }
+            if (!preg_match('#^[A-Za-z0-9 _-]*$#', $icon)) {
+                $icon = '';
+            }
+            $buttons[] = '<a class="btn btn-outline-secondary w-100 mb-2"'
+                . ' href="' . \Initiator::e($url) . '">'
+                . ('' === $icon
+                    ? ''
+                    : '<span class="' . \Initiator::e($icon) . ' me-2"></span>')
+                . \Initiator::e($label)
+                . '</a>';
+        }
+        if (0 === count($buttons)) {
+            return '';
+        }
+        return '<div class="text-center text-muted my-3">'
+            . \Initiator::e(_('or'))
+            . '</div>'
+            . implode('', $buttons);
     }
 }
 

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -45,6 +45,41 @@ class Route extends FOGBase
      */
     private static $_webrootbase = '/fog/';
     /**
+     * Where a plugin-contributed route must live.
+     *
+     * A reserved mount point rather than "anywhere core is not currently
+     * using" (ADR 0009, Phase 2). Core mints new top-level paths from
+     * $validClasses, so today's free path is not tomorrow's, and a plugin
+     * route that silently started shadowing -- or worse, being shadowed by --
+     * a core one on upgrade would be a very quiet failure. Under /ext/ the
+     * two namespaces cannot meet, which also means declaring a plugin route
+     * public can never open a core path by exact-match coincidence.
+     *
+     * 'ext' and not 'plugin': 'plugin' is already an API class, so /plugin/
+     * belongs to core's CRUD routes for it.
+     *
+     * @var string
+     */
+    const PLUGIN_ROUTE_PREFIX = '/ext/';
+    /**
+     * Prefix stamped on a plugin route's name before it is registered.
+     *
+     * The route NAME is what resolveApiPermission() keys on, so an
+     * unprefixed plugin name could land on a core mapping: a route called
+     * 'status' would inherit API_ROUTE_PERMISSIONS['status'] = null and skip
+     * the permission check entirely. Core owns the namespace; plugins get
+     * their own.
+     *
+     * @var string
+     */
+    const PLUGIN_ROUTE_NAME_PREFIX = 'ext:';
+    /**
+     * Validated plugin routes, or null before the hook has been fired.
+     *
+     * @var array|null
+     */
+    private static $_pluginRoutes = null;
+    /**
      * AltoRouter object container.
      *
      * @var AltoRouter
@@ -489,6 +524,25 @@ class Route extends FOGBase
             // renamed OpenAPI. Same handler, same document.
             $webrootbase . 'swagger.json'
         ];
+        /**
+         * A plugin may declare one of its /ext/ routes reachable without API
+         * auth -- an IdP redirecting a browser back to a callback carries no
+         * token and no session, so the request must be answerable before
+         * either exists. Only an exact literal path can be declared this way
+         * (see _validatePluginRoute), matching how the /system endpoints are
+         * handled rather than the parent-path rule the wildcard routes use.
+         *
+         * Being unauthenticated here does NOT mean unguarded: the handler
+         * still runs behind whatever it checks for itself, and the route
+         * carries no permission, so nothing in FOG's data is reachable
+         * through it that the plugin did not deliberately expose.
+         */
+        foreach (self::pluginRoutes() as $pluginRoute) {
+            if ('public' !== $pluginRoute['auth']) {
+                continue;
+            }
+            $unauthexact[] = $webrootbase . ltrim($pluginRoute['path'], '/');
+        }
         $requripath = strtok((string)self::$requesturi, '?');
         $requribase = dirname($requripath);
         $isunauth = in_array($requribase, $unauthprefixes)
@@ -786,6 +840,147 @@ class Route extends FOGBase
         return $whereItems;
     }
     /**
+     * Routes contributed by plugins, validated and normalised.
+     *
+     * Closes ADR 0009's first gap: every plugin-facing router hook until now
+     * mutated a CLASS LIST, so a plugin could add a resource but never a
+     * path. An OIDC callback is not a CRUD shape on any class, and neither is
+     * most of what a provider needs.
+     *
+     * Fired once and memoised, because the answer is needed twice and in two
+     * different phases -- before authentication, to know which paths are
+     * declared public, and again at defineRoutes() to register them.
+     *
+     * Shape of an entry, as a plugin supplies it:
+     *
+     *   [
+     *     'name'       => 'oidcCallback',
+     *     'method'     => 'GET',                     // default GET
+     *     'path'       => '/ext/oidc/callback',      // must be under /ext/
+     *     'handler'    => [OidcRoutes::class, 'callback'],
+     *     'auth'       => 'public',                  // default 'required'
+     *     'permission' => 'oidc.view'                // when auth is required
+     *   ]
+     *
+     * Everything about the validation below fails closed. A malformed entry
+     * is dropped, an unrecognised 'auth' becomes 'required', and a route that
+     * declares no permission is still registered but resolves to a
+     * permission no role can hold (see Authorization::resolveApiPermission),
+     * so it answers 403 with a log line naming the fix rather than 404 with
+     * nothing. Silence is the one outcome not on offer.
+     *
+     * @return array
+     */
+    public static function pluginRoutes()
+    {
+        if (self::$_pluginRoutes !== null) {
+            return self::$_pluginRoutes;
+        }
+        $declared = [];
+        self::$HookManager->processEvent(
+            'API_PLUGIN_ROUTES',
+            ['routes' => &$declared]
+        );
+        $routes = [];
+        $seen = [];
+        foreach ((array)$declared as $entry) {
+            $route = self::_validatePluginRoute((array)$entry, $seen);
+            if ($route === null) {
+                continue;
+            }
+            $seen[$route['name']] = true;
+            $routes[] = $route;
+        }
+        self::$_pluginRoutes = $routes;
+        return self::$_pluginRoutes;
+    }
+    /**
+     * Check one plugin route declaration, or reject it.
+     *
+     * @param array $entry The declaration as the plugin supplied it.
+     * @param array $seen  Names already taken, as name => true.
+     *
+     * @return array|null The normalised route, or null to drop it.
+     */
+    private static function _validatePluginRoute(array $entry, array $seen)
+    {
+        $reject = function ($why) use ($entry) {
+            error_log(
+                sprintf(
+                    'FOG plugin route: ignoring %s -- %s',
+                    isset($entry['path']) && is_string($entry['path'])
+                        ? $entry['path']
+                        : '(no path)',
+                    $why
+                )
+            );
+            return null;
+        };
+        $name = isset($entry['name']) ? (string)$entry['name'] : '';
+        $path = isset($entry['path']) ? (string)$entry['path'] : '';
+        if ('' === $name || !preg_match('#^[A-Za-z][A-Za-z0-9_]*$#', $name)) {
+            return $reject('the name must be a bare identifier');
+        }
+        $name = self::PLUGIN_ROUTE_NAME_PREFIX . $name;
+        if (isset($seen[$name])) {
+            return $reject(sprintf('another plugin already registered %s', $name));
+        }
+        if (0 !== strpos($path, self::PLUGIN_ROUTE_PREFIX)
+            || false !== strpos($path, '..')
+        ) {
+            return $reject(
+                sprintf('a plugin route must live under %s', self::PLUGIN_ROUTE_PREFIX)
+            );
+        }
+        if (!isset($entry['handler']) || !is_callable($entry['handler'])) {
+            return $reject('the handler is not callable');
+        }
+        $method = strtoupper(
+            isset($entry['method']) ? (string)$entry['method'] : 'GET'
+        );
+        if (!preg_match('#^(GET|POST|PUT|PATCH|DELETE|HEAD)(\|(GET|POST|PUT|PATCH|DELETE|HEAD))*$#', $method)) {
+            return $reject(sprintf('unsupported method %s', $method));
+        }
+        // Anything but the exact string 'public' is 'required'. A typo must
+        // not open a route, and neither must a truthy value someone thought
+        // meant "needs auth".
+        $auth = (isset($entry['auth']) && 'public' === $entry['auth'])
+            ? 'public'
+            : 'required';
+        if ('public' === $auth && false !== strpos($path, '[')) {
+            // The unauthenticated test is an exact string comparison against
+            // the request URI, so a path with router parameters in it cannot
+            // be matched there -- it would be declared public and then still
+            // demand auth, which is worse than refusing.
+            error_log(
+                sprintf(
+                    'FOG plugin route: %s cannot be public because it has URL '
+                    . 'parameters; treating it as authenticated. Split the '
+                    . 'literal part into its own route if it must be reachable '
+                    . 'before login.',
+                    $path
+                )
+            );
+            $auth = 'required';
+        }
+        $permission = null;
+        if ('required' === $auth
+            && isset($entry['permission'])
+            && is_string($entry['permission'])
+            && '' !== $entry['permission']
+        ) {
+            $permission = $entry['permission'];
+        }
+        return [
+            'name' => $name,
+            'method' => $method,
+            'path' => $path,
+            'handler' => $entry['handler'],
+            'auth' => $auth,
+            'permission' => $permission,
+        ];
+    }
+    /**
      * Defines our standard routes.
      *
      * @return void
@@ -928,6 +1123,42 @@ class Route extends FOGBase
             [__CLASS__, 'delete'],
             'delete'
         );
+        /**
+         * Plugin routes go on LAST, so a core path always matches first --
+         * AltoRouter returns the first route that matches, and the /ext/
+         * mount point means the two sets cannot overlap anyway. Belt and
+         * braces on purpose: this is a seam that lets third-party code answer
+         * a URL, and it should be safe for two independent reasons.
+         *
+         * The permission each declares is handed to Authorization here rather
+         * than read from the route later, so there is exactly one moment at
+         * which a route and its permission are decided together.
+         */
+        foreach (self::pluginRoutes() as $route) {
+            self::$router->map(
+                $route['method'],
+                $route['path'],
+                $route['handler'],
+                $route['name']
+            );
+            if ('public' === $route['auth']) {
+                // Declared public: no permission, because there is no
+                // authenticated user to hold one.
+                Authorization::declareRoutePermission($route['name'], null);
+            } elseif (null !== $route['permission']) {
+                Authorization::declareRoutePermission(
+                    $route['name'],
+                    $route['permission']
+                );
+            }
+            // No third branch, and the absence is the point. A route that
+            // declared no permission is registered but NOT declared here, so
+            // resolveApiPermission() finds nothing and denies it. Passing null
+            // through instead would read as "public" and hand an undeclared
+            // route a free pass -- which is precisely the inversion this seam
+            // must not have, and is what the gate test caught when this code
+            // did exactly that.
+        }
     }
     /**
      * Sets the matches variable

--- a/tests/plugin-extension-points.test.php
+++ b/tests/plugin-extension-points.test.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * The three plugin extension points, and the gates on each.
+ *
+ * G1 a route, G2 a session-less page node, G3 a login-page button. A plugin
+ * could contribute none of them before Phase 2, which is why an OIDC provider
+ * could not be a plugin at all.
+ *
+ * The headline is G1: a plugin may contribute a route, but not an ungated one.
+ *
+ * This is the check the Phase 2 plan asks to be done by hand before the seam
+ * is accepted, written down so it is done every time instead: PR 2.2 puts a
+ * new way to reach PHP into the plugin system, and Phase 1 spent real effort
+ * closing exactly that shape of hole. The claim that would hurt most if false
+ * is "a plugin-contributed route can be gated as safely as a core route", so
+ * the fixture that matters most here is the one that declares nothing.
+ *
+ * No database: Route::pluginRoutes() only fires a hook and validates what
+ * comes back, and the branches of Authorization::resolveApiPermission() this
+ * exercises return before touching the registry. The hook manager is a stub
+ * injected by reflection, which is also the only way to drive the seam
+ * without booting the whole application.
+ *
+ * Usage: php tests/plugin-extension-points.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$tmp = sys_get_temp_dir() . '/fog-plugin-route-' . getmypid();
+@mkdir($tmp . '/cache', 0777, true);
+@mkdir($tmp . '/log', 0777, true);
+@mkdir($tmp . '/plugins', 0777, true);
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+$errLog = $tmp . '/php-error.log';
+ini_set('error_log', $errLog);
+
+require $web . '/commons/init.php';
+new Initiator();
+
+$fails = [];
+
+/**
+ * Stands in for HookManager. Hands back whatever declarations the current
+ * case is testing; the routes element arrives by reference, exactly as the
+ * real manager passes it.
+ */
+class StubHookManager
+{
+    public $routes = [];
+
+    public $exemptNodes = [];
+    public $providers = [];
+
+    public function processEvent($event, $arguments = [])
+    {
+        if ('API_PLUGIN_ROUTES' === $event && isset($arguments['routes'])) {
+            $arguments['routes'] = $this->routes;
+        }
+        if ('PAGE_EXEMPT_NODES' === $event && isset($arguments['nodes'])) {
+            $arguments['nodes'] = $this->exemptNodes;
+        }
+        if ('LOGIN_PAGE_PROVIDERS' === $event && isset($arguments['providers'])) {
+            $arguments['providers'] = $this->providers;
+        }
+    }
+}
+
+$stub = new StubHookManager();
+$hook = new \ReflectionProperty('FOG\FOGBase', 'HookManager');
+$hook->setAccessible(true);
+$hook->setValue(null, $stub);
+
+$cache = new \ReflectionProperty('FOG\Route', '_pluginRoutes');
+$cache->setAccessible(true);
+
+/**
+ * Declare a set of routes and get back what the router would register.
+ *
+ * @param array $routes Declarations as a plugin would supply them.
+ *
+ * @return array Normalised routes, keyed by their registered name.
+ */
+$offer = function (array $routes) use ($stub, $cache) {
+    $stub->routes = $routes;
+    $cache->setValue(null, null);
+    $out = [];
+    foreach (\FOG\Route::pluginRoutes() as $r) {
+        $out[$r['name']] = $r;
+    }
+    return $out;
+};
+
+// ---------------------------------------------------------- the mount point
+
+if ('/ext/' !== \FOG\Route::PLUGIN_ROUTE_PREFIX) {
+    $fails[] = 'the plugin route prefix moved; the rest of this test, and the'
+        . ' guarantee that plugin paths cannot collide with core ones, is'
+        . ' written around /ext/';
+}
+$classes = new \ReflectionProperty('FOG\Route', 'validClasses');
+$classes->setAccessible(true);
+$valid = array_map('strtolower', (array) $classes->getValue());
+if (in_array(trim(\FOG\Route::PLUGIN_ROUTE_PREFIX, '/'), $valid, true)) {
+    $fails[] = 'an API class is now named after the plugin route mount point,'
+        . ' so core CRUD routes and plugin routes share a path prefix -- the'
+        . ' collision the reserved mount point exists to prevent';
+}
+
+// ------------------------------------------------------------- the fixtures
+
+$got = $offer([
+    // Declares nothing beyond the minimum. THE case: it must be registered
+    // (so it answers 403 with a diagnostic, not 404 with silence) and it must
+    // resolve to a permission no role can hold.
+    [
+        'name' => 'silent',
+        'path' => '/ext/demo/silent',
+        'handler' => 'strlen',
+    ],
+    // Properly declared, authenticated.
+    [
+        'name' => 'guarded',
+        'path' => '/ext/demo/guarded',
+        'method' => 'post',
+        'handler' => 'strlen',
+        'permission' => 'demo.edit',
+    ],
+    // Properly declared, deliberately public -- an IdP callback shape.
+    [
+        'name' => 'callback',
+        'path' => '/ext/demo/callback',
+        'handler' => 'strlen',
+        'auth' => 'public',
+    ],
+    // Public, but with URL parameters, which the exact-match unauth test
+    // cannot express. Must fall back to authenticated rather than pretend.
+    [
+        'name' => 'paramPublic',
+        'path' => '/ext/demo/[i:id]',
+        'handler' => 'strlen',
+        'auth' => 'public',
+    ],
+    // 'auth' misspelt. Must NOT be read as anything but 'required'.
+    [
+        'name' => 'typo',
+        'path' => '/ext/demo/typo',
+        'handler' => 'strlen',
+        'auth' => true,
+    ],
+    // Outside the mount point. Dropped.
+    [
+        'name' => 'escapee',
+        'path' => '/system/export',
+        'handler' => 'strlen',
+        'auth' => 'public',
+    ],
+    // Traversal in the path. Dropped.
+    [
+        'name' => 'traversal',
+        'path' => '/ext/../system/export',
+        'handler' => 'strlen',
+        'auth' => 'public',
+    ],
+    // Handler that is not callable. Dropped.
+    [
+        'name' => 'broken',
+        'path' => '/ext/demo/broken',
+        'handler' => 'no_such_function_anywhere',
+    ],
+]);
+
+$expectDropped = ['ext:escapee', 'ext:traversal', 'ext:broken'];
+foreach ($expectDropped as $name) {
+    if (isset($got[$name])) {
+        $fails[] = "$name should have been rejected but was registered at "
+            . $got[$name]['path'];
+    }
+}
+foreach (['ext:silent', 'ext:guarded', 'ext:callback'] as $name) {
+    if (!isset($got[$name])) {
+        $fails[] = "$name should have been registered and was not";
+    }
+}
+if (isset($got['ext:guarded']) && 'POST' !== $got['ext:guarded']['method']) {
+    $fails[] = 'method was not normalised to upper case';
+}
+foreach (['ext:silent', 'ext:typo', 'ext:paramPublic'] as $name) {
+    if (isset($got[$name]) && 'required' !== $got[$name]['auth']) {
+        $fails[] = "$name is not authenticated; anything but the exact string"
+            . " 'public' must mean authenticated";
+    }
+}
+if (isset($got['ext:callback']) && 'public' !== $got['ext:callback']['auth']) {
+    $fails[] = 'a correctly declared public route was not treated as public,'
+        . ' so a callback that cannot carry credentials is unreachable';
+}
+
+// ------------------------------------------------- what the router enforces
+
+// Registration is where a route and its permission are decided together, so
+// replay that step and then ask Authorization the question the dispatcher asks.
+foreach ($got as $r) {
+    if ('public' === $r['auth']) {
+        \FOG\Authorization::declareRoutePermission($r['name'], null);
+    } elseif (null !== $r['permission']) {
+        \FOG\Authorization::declareRoutePermission($r['name'], $r['permission']);
+    }
+}
+
+$resolved = function ($name) {
+    return \FOG\Authorization::resolveApiPermission($name, '');
+};
+
+// THE assertion. A route that declared no permission must not be allowed.
+$silent = $resolved('ext:silent');
+if (null === $silent) {
+    $fails[] = 'a plugin route that declared no permission resolves to NO'
+        . ' CHECK. The seam is inverted: open unless declared. This is the'
+        . ' failure the whole design is arranged to prevent.';
+} elseif (0 !== strpos((string) $silent, 'unmapped.')) {
+    $fails[] = 'a plugin route that declared no permission resolved to '
+        . var_export($silent, true) . ', expected an unmapped.* permission'
+        . ' that no role can be granted';
+}
+// The same, for a name never offered at all.
+if (null === $resolved('ext:neverHeardOf')) {
+    $fails[] = 'an unknown route name resolves to NO CHECK';
+}
+if ('demo.edit' !== $resolved('ext:guarded')) {
+    $fails[] = 'a declared permission did not survive registration: got '
+        . var_export($resolved('ext:guarded'), true);
+}
+if (null !== $resolved('ext:callback')) {
+    $fails[] = 'a public route demands a permission, so the unauthenticated'
+        . ' caller it exists for can never satisfy it';
+}
+
+// A plugin must not be able to redeclare a core route's permission.
+\FOG\Authorization::declareRoutePermission('status', 'demo.edit');
+if (null !== $resolved('status')) {
+    $fails[] = "a plugin overwrote a core route's permission";
+}
+\FOG\Authorization::declareRoutePermission('list', null);
+if (null === $resolved('list')) {
+    $fails[] = 'a plugin turned off the permission check on core\'s list route';
+}
+
+// Every rejection must be explained. A dropped route is otherwise a 404 with
+// no cause, which is the hardest possible thing for a plugin author to debug.
+$log = is_readable($errLog) ? (string) file_get_contents($errLog) : '';
+foreach (['/system/export', '/ext/demo/broken', '/ext/demo/[i:id]'] as $needle) {
+    if (false === strpos($log, $needle)) {
+        $fails[] = "rejecting $needle was not logged";
+    }
+}
+
+// ------------------------------------------------------ G2: exempt nodes
+
+$stub->exemptNodes = [
+    'oidcstart',        // a node of its own -- allowed
+    'host',             // a registered core node -- must be refused
+    'about',            // a NODE_ALIASES key -- must be refused
+    '  OidcStart  ',    // same as the first once trimmed and lowered
+    '',                 // noise
+];
+$exemptCache = new \ReflectionProperty('FOG\Authorization', '_exemptNodes');
+$exemptCache->setAccessible(true);
+$exemptCache->setValue(null, null);
+$exempt = \FOG\Authorization::exemptNodes();
+
+foreach (\FOG\Authorization::EXEMPT_NODES as $core) {
+    if (!in_array($core, $exempt, true)) {
+        $fails[] = "core exempt node $core was lost when plugin entries were"
+            . ' merged';
+    }
+}
+if (!in_array('oidcstart', $exempt, true)) {
+    $fails[] = 'a plugin could not exempt a node of its own, so an'
+        . ' authentication provider still has nowhere to put a pre-login page';
+}
+if (in_array('host', $exempt, true)) {
+    $fails[] = 'a plugin exempted "host" -- the permission check on every host'
+        . ' page can be switched off by any registered hook';
+}
+if (in_array('about', $exempt, true)) {
+    $fails[] = 'a plugin exempted an aliased core node';
+}
+if (count($exempt) !== count(array_unique($exempt))) {
+    $fails[] = 'exemptNodes() returned duplicates';
+}
+
+// ------------------------------------------------- G3: login page providers
+
+$stub->providers = [
+    ['label' => 'Sign in with Acme', 'url' => '/fog/ext/oidc/start', 'icon' => 'fa fa-key'],
+    ['label' => 'Remote IdP', 'url' => 'https://idp.example/start'],
+    ['label' => 'XSS', 'url' => 'javascript:alert(1)'],
+    ['label' => 'Data URI', 'url' => 'data:text/html;base64,PHNjcmlwdD4='],
+    ['label' => 'Cleartext', 'url' => 'http://idp.example/start'],
+    ['label' => 'Protocol relative', 'url' => '//evil.example/start'],
+    ['label' => '<img src=x onerror=alert(1)>', 'url' => '/fog/ext/ok'],
+    ['label' => 'Bad icon', 'url' => '/fog/ext/ok2', 'icon' => '" onmouseover="alert(1)'],
+];
+$html = \FOG\ProcessLogin::loginProviders();
+
+foreach (['javascript:', 'data:text/html', 'http://idp.example', '//evil.example'] as $bad) {
+    if (false !== strpos($html, $bad)) {
+        $fails[] = "a login provider URL of $bad was rendered on the one page"
+            . ' every unauthenticated visitor sees';
+    }
+}
+if (false === strpos($html, '/fog/ext/oidc/start')
+    || false === strpos($html, 'https://idp.example/start')
+) {
+    $fails[] = 'a legitimate provider button was not rendered';
+}
+if (false !== strpos($html, '<img src=x')
+    || false !== strpos($html, 'onmouseover=')
+) {
+    $fails[] = 'provider-supplied markup reached the page unescaped';
+}
+$stub->providers = [];
+if ('' !== \FOG\ProcessLogin::loginProviders()) {
+    $fails[] = 'the login form grew a divider with no providers behind it';
+}
+
+$rmrf = function ($dir) use (&$rmrf) {
+    if (!is_dir($dir)) {
+        return;
+    }
+    foreach (array_diff((array) scandir($dir), ['.', '..']) as $e) {
+        $p = "$dir/$e";
+        is_dir($p) ? $rmrf($p) : unlink($p);
+    }
+    rmdir($dir);
+};
+$rmrf($tmp);
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: routes, exempt nodes and login buttons are all gated\n";
+exit(0);


### PR DESCRIPTION
The phase's real deliverable: the three seams that let an authentication provider be a plugin at all. Three commits, each independently reviewable.

It also fixes a fourth thing the plan did not anticipate, and which turned out to matter more than any of the three.

---

## The one that was already there

`Authorization::resolveApiPermission()` returned `null` — **no check** — for any route name it did not recognise:

```php
if (!isset(self::API_ROUTE_ACTIONS[$routeName])) {
    // Unknown route (plugin-added): allow, matching the
    // unregistered-page compatibility stance.
    return null;
}
```

That comment was describing a stance which had since been tightened in both other places: `resolvePagePermission()` denies an unmapped page node, and the class branch immediately below denies an unmapped API class. This was the last allow-by-default in the file.

It was nearly harmless while it lasted, because **nothing could add a route**. I verified that rather than assuming it: extracting all 29 route names from `defineRoutes()` and diffing against `API_ROUTE_ACTIONS` + `API_ROUTE_PERMISSIONS` gives **zero unknown**, so the branch was unreachable on a stock install — which is also why flipping it breaks nothing.

The seam below is exactly what would have made it reachable. Flipped first, in its own commit.

---

## G1 — a plugin may contribute a route

`API_PLUGIN_ROUTES`. Four choices make it safe rather than merely possible:

| Choice | Why |
|---|---|
| Routes live under a reserved **`/ext/`** mount point | Core mints new top-level paths from `$validClasses`, so today's free path is not tomorrow's. A route that quietly started shadowing a core one on upgrade would be a very quiet failure. It also means declaring a plugin route public can never open a core path by exact-match coincidence. `/ext/` and not `/plugin/` — `plugin` is already an API class |
| Names register as **`ext:<name>`** | The name is what the permission layer keys on. An unprefixed route called `status` would inherit `API_ROUTE_PERMISSIONS['status'] = null` and skip the check entirely |
| `auth` is public **only** when it is exactly `'public'`, and only for a literal path | A typo must not open a route. And the unauthenticated test is an exact string comparison, so a path with `[i:id]` cannot be expressed there — it is downgraded to authenticated rather than silently pretending |
| No permission declared → registered, **not declared** → 403 | A log line naming the fix, rather than 404 with nothing |

Registered after every core route, so a core path always matches first — belt and braces alongside the mount point.

**The gate test earned its keep here.** The first version of this commit passed `null` through for an undeclared route, which reads as "public" and would have handed every undeclared plugin route a free pass — precisely the inversion the design exists to prevent. The test written to look for it found it:

> `a plugin route that declared no permission resolves to NO CHECK. The seam is inverted: open unless declared.`

There is now no third branch in that code, and a comment saying the absence is load-bearing.

## G2 — a plugin may declare a session-less page node

`PAGE_EXEMPT_NODES`. `EXEMPT_NODES` stays a `const`, so "what does core exempt" is still one array to read; plugin entries merge on top.

A plugin may only exempt a node **nothing else owns**. A node in the permission registry — core's or another plugin's — is refused, because *exempt* and *check this permission* are contradictory instructions about one node and the permissive one would win. That check is what stops this being a way to turn the gate off on `host`.

## G3 — a plugin may put a button on the login page

`LOGIN_PAGE_PROVIDERS`. The start URL must be a site-absolute path or an `https://` URL. `javascript:`, `data:`, protocol-relative `//host` and plain `http://` are all refused — this is the one page every unauthenticated visitor sees. Label and icon are escaped, and the icon is additionally restricted to plain class characters since it lands inside an attribute.

Nothing renders when no provider registers, so a stock login page is unchanged rather than growing an empty divider.

---

## Gate

`tests/plugin-extension-points.test.php` drives all three seams with a stub hook manager and **no database** — `pluginRoutes()` only fires a hook and validates, and the `resolveApiPermission()` branches it exercises return before touching the registry.

Eight route fixtures, including one declaring nothing (the headline case), one with a misspelt `auth`, one at `/system/export`, and one with `../` in its path. Plus exempt-node and provider-URL fixtures.

Verified failing with each guard removed in turn:

| Guard removed | Test says |
|---|---|
| `auth` accepts any truthy value | `ext:typo is not authenticated` |
| the `/ext/` prefix check | `ext:escapee should have been rejected but was registered at /system/export` |
| the exempt-node registry guard | `a plugin exempted "host"` |
| the provider URL check | `a login provider URL of javascript: was rendered` |

`sh tests/run-all.sh` → **39 passed, 0 failed**.

## Docs

`docs/plugin-development.md` §7c covers all three seams with worked examples and the rule common to them: **declaring nothing means denied**.

## Deviation from the plan worth flagging

The plan's example callback path was `/oidc/callback`. It is `/ext/oidc/callback` here, for the collision reason above. An IdP redirect URI is configured once, so the extra segment costs nothing and buys a namespace that provably cannot meet core's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR