### PR TITLE
Record how a session was established, not just who owns it

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -641,6 +641,33 @@ refused — this is the one page every unauthenticated visitor sees. Label and
 icon are escaped; the icon is additionally restricted to plain class
 characters.
 
+### Turning a proven identity into a session — `establishSession($source)`
+
+Once your callback has proven who somebody is, hand the identity to FOG and
+**say how you proved it**:
+
+```php
+$user = self::getClass('User', $uid);
+$user->establishSession('oidc');
+```
+
+`$source` names the mechanism, not the account. It is recorded in the login
+history entry and kept in the session, where `User::sessionAuthSource()` reads
+it back. Two things need it: an audit that can distinguish an identity-provider
+sign-in from a local password one, and the break-glass rule that local password
+login keeps working when a provider is down — which has to be able to count
+sessions by how they were made.
+
+It is deliberately **not** the same thing as `users.uAuthSource`. That column is
+a property of the *account* and says which directory owns it; `$source` is a
+property of *this request*. An account owned by LDAP can still be signed in by
+something else, and that is exactly the case worth being able to see.
+
+Use a plain lowercase slug, up to 32 characters of `a-z0-9_-` starting
+alphanumeric — normally just your plugin's name. Anything else is recorded as
+`unknown` rather than passed through, because the value reaches an audit trail.
+Omitting the argument means `password`, so existing callers are unchanged.
+
 ## 8. Security & output conventions
 
 - **Output:** wrap every user‑controlled value with `Initiator::e($value)` when

--- a/docs/refactor-phase2-plan.md
+++ b/docs/refactor-phase2-plan.md
@@ -349,14 +349,43 @@ php tests/plugin-extension-points.test.php
 sh tests/run-all.sh
 ```
 
-### PR 2.3 — `establishSession()` grows a provenance argument
+### PR 2.3 — `establishSession()` grows a provenance argument ✅ DONE
 
 An IdP-established session must be distinguishable from a password one, for
 audit and for break-glass. Extends the login history entry and the session
 with the auth source. No behaviour change for the password path.
 
+Landed as `establishSession($source = self::AUTH_SOURCE_PASSWORD)`, writing
+`$_SESSION['FOG_AUTH_SOURCE']` and appending `(<source>)` to the history
+entry. Two things the plan did not spell out and that the implementation
+had to settle:
+
+- **The value is normalised, not trusted.** A provider plugin supplies it and
+  it lands in an audit trail, so anything that is not a plain slug
+  (`^[a-z0-9][a-z0-9_-]{0,31}$`, case-folded and trimmed) is recorded as
+  `unknown` rather than passed through. The normalisation is a separate
+  public static — `User::normalizeAuthSource()` — purely so it can be tested
+  without a database; `establishSession()` itself writes a history row and
+  cannot be exercised DB-free.
+- **`logout()` needs no line of its own,** and the gate pins why rather than
+  adding a redundant-looking one: `session_unset()` empties `$_SESSION`
+  wholesale, so this key and every future one are cleared without anyone
+  remembering to. If that ever becomes a selective unset, provenance would
+  survive a logout and describe the *next* session — so the test fails on
+  the wholesale clear disappearing.
+
+Worth restating because it is the distinction the whole PR rests on:
+`users.uAuthSource` is a property of the **account** (which directory owns
+it), `$_SESSION['FOG_AUTH_SOURCE']` is a property of the **request** (what
+proved it this time). Break-glass in 2.5 needs the second one.
+
 ```bash
 grep -n 'function establishSession' -A5 packages/web/lib/fog/user.class.php
+php tests/session-provenance.test.php
+# 13 normaliser cases + the 32-char boundary; static pins on the session
+# stamp, on validatePw() still taking the default, and on logout()'s
+# wholesale clear
+# verified failing with: normalizeAuthSource() bypassed in establishSession()
 php tests/ipxe-auth-no-session.test.php
 ```
 

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -25,6 +25,26 @@ class User extends FOGController
 {
     const PATTERN = '/(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[\w0-9][\w0-9\s\-\.]*[\w0-9]$/i';
     /**
+     * A session established by presenting a local password.
+     *
+     * The default, and the one that must never stop working: break-glass
+     * depends on password login remaining reachable when an identity
+     * provider is not.
+     *
+     * @var string
+     */
+    const AUTH_SOURCE_PASSWORD = 'password';
+    /**
+     * A session whose provenance was supplied but unusable.
+     *
+     * Recorded rather than guessed. A provider handing over something that
+     * is not a plain slug is a bug in that provider, and "unknown" is the
+     * honest entry in an audit trail.
+     *
+     * @var string
+     */
+    const AUTH_SOURCE_UNKNOWN = 'unknown';
+    /**
      * The users table
      *
      * @var string
@@ -264,19 +284,75 @@ class User extends FOGController
         return $this;
     }
     /**
+     * How this session was established, or '' when there is no session.
+     *
+     * Read this rather than users.uAuthSource when the question is about the
+     * REQUEST. uAuthSource is a property of the ACCOUNT -- where its identity
+     * lives -- and the two genuinely differ: an account homed in LDAP or an
+     * IdP can still be carrying a local password, and the point of asking is
+     * usually to find out which of the two got someone in just now.
+     *
+     * @return string
+     */
+    public static function sessionAuthSource()
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            return '';
+        }
+        return (string)($_SESSION['FOG_AUTH_SOURCE'] ?? '');
+    }
+    /**
+     * Reduce a caller-supplied auth source to something safe to record.
+     *
+     * Normalised, not trusted: the value reaches the history table and a
+     * session key, and a provider plugin supplies it. Anything that is not a
+     * plain slug is recorded as unknown rather than passed through, because
+     * "we do not know how this session was made" is a fact worth keeping and
+     * is safer than storing whatever was handed over.
+     *
+     * Public so it can be exercised without a database; nothing else calls it.
+     *
+     * @param string $source The value as supplied.
+     *
+     * @return string
+     */
+    public static function normalizeAuthSource($source)
+    {
+        $source = strtolower(trim((string)$source));
+        if (!preg_match('#^[a-z0-9][a-z0-9_-]{0,31}$#', $source)) {
+            return self::AUTH_SOURCE_UNKNOWN;
+        }
+        return $source;
+    }
+    /**
      * Turns an already-proven identity into a logged-in browser session.
      *
      * The other half of the authenticate() split. Everything here needs a
      * session to exist and a browser to carry it, so nothing here may run
      * for the iPXE callers.
      *
+     * $source records WHICH mechanism proved the identity, and it exists for
+     * two later jobs rather than for its own sake. Audit: "logged in" in the
+     * history table cannot presently distinguish a password from an identity
+     * provider, so an install adopting SSO loses the ability to answer how
+     * someone got in. Break-glass: an IdP outage must leave local password
+     * login working, and the checks that guarantee that need to be able to
+     * count sessions by how they were made, not by what the account looks
+     * like.
+     *
+     * Defaults to 'password' so every existing caller -- validatePw() and
+     * whatever third-party code calls it -- keeps the meaning it already had.
+     *
+     * @param string $source Slug naming the mechanism, e.g. 'password', 'oidc'.
+     *
      * @return self
      */
-    public function establishSession()
+    public function establishSession($source = self::AUTH_SOURCE_PASSWORD)
     {
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }
+        $source = self::normalizeAuthSource($source);
         if (self::$FOGUser->isValid()) {
             $type = self::$FOGUser->get('type');
             self::$HookManager->processEvent(
@@ -290,11 +366,13 @@ class User extends FOGController
                 ->set('type', $type);
         }
         $_SESSION['FOG_USER'] = $this->get('id');
+        $_SESSION['FOG_AUTH_SOURCE'] = $source;
         self::log(
             sprintf(
-                '%s %s.',
+                '%s %s (%s).',
                 $this->get('name'),
-                _('user successfully logged in')
+                _('user successfully logged in'),
+                $source
             ),
             0,
             0,

--- a/tests/session-provenance.test.php
+++ b/tests/session-provenance.test.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * A session must record HOW it was established, not just who owns it.
+ *
+ * Phase 2 PR 2.3. Today every logged-in session looks identical: $_SESSION
+ * holds FOG_USER and nothing else, and the history row says "user
+ * successfully logged in" whatever proved the credential. Once an identity
+ * provider can establish a session that is no longer good enough, for two
+ * reasons that are worth stating separately:
+ *
+ *   Audit -- an install that adopts SSO otherwise loses the ability to
+ *   answer "did this person come in through the IdP or through a local
+ *   password?", which is precisely the question asked after an incident.
+ *
+ *   Break-glass -- an IdP outage must leave local password login working,
+ *   and the checks that will guarantee that (PR 2.5) need to count sessions
+ *   by how they were MADE. They cannot use users.uAuthSource for this:
+ *   uAuthSource is a property of the ACCOUNT and says which directory owns
+ *   it, while provenance is a property of the REQUEST. An LDAP-sourced
+ *   account reaching a break-glass path still made this particular session
+ *   somehow, and that is the fact being recorded here.
+ *
+ * The behavioural half of establishSession() cannot be exercised without a
+ * database -- it writes a history row and runs the logged-in bookkeeping --
+ * so the pure part was pulled out into User::normalizeAuthSource() and is
+ * tested for real below. The rest is pinned statically.
+ *
+ * Usage: php tests/session-provenance.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$userFile = 'packages/web/lib/fog/user.class.php';
+
+/**
+ * Source text of one method, comments and whitespace stripped.
+ *
+ * Comments go first so the explanatory prose above each method -- which
+ * names every symbol this test searches for -- cannot satisfy the search
+ * on its own. The same trap as the browser-less session gate.
+ *
+ * @param string $file   path to read
+ * @param string $method method name to find
+ *
+ * @return string|null code of the body, or null if not found
+ */
+function methodSource($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        $depth = 0;
+        $src = '';
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (is_array($c)
+                && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+            ) {
+                continue;
+            }
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return $src;
+                    }
+                } elseif (';' === $c && !$started) {
+                    return null;
+                }
+            }
+            if ($started) {
+                $src .= is_array($c) ? $c[1] : $c;
+            }
+        }
+        return $src;
+    }
+    return null;
+}
+
+// 1. establishSession() stamps the session with the provenance, and does it
+//    through the normaliser rather than with whatever it was handed.
+$body = methodSource($userFile, 'establishSession');
+if (null === $body) {
+    $fails[] = 'User::establishSession() is missing';
+} else {
+    if (false === strpos($body, "\$_SESSION['FOG_AUTH_SOURCE']")) {
+        $fails[] = "User::establishSession() does not set"
+            . " \$_SESSION['FOG_AUTH_SOURCE'] -- a session established by an"
+            . " identity provider would be indistinguishable from a password"
+            . ' one';
+    }
+    if (false === strpos($body, 'normalizeAuthSource')) {
+        $fails[] = 'User::establishSession() does not pass its $source'
+            . ' through normalizeAuthSource(); the value reaches the history'
+            . ' table and a session key and a plugin supplies it';
+    }
+}
+
+// 2. validatePw() must still call establishSession() with no argument. That
+//    default is the whole no-behaviour-change claim for the password path:
+//    every existing caller keeps the meaning it already had.
+$pw = methodSource($userFile, 'validatePw');
+if (null !== $pw && false === strpos($pw, 'establishSession()')) {
+    $fails[] = 'User::validatePw() no longer calls establishSession() with'
+        . ' no argument -- the password path must keep taking the default';
+}
+
+/*
+ * 3. logout() needs no FOG_AUTH_SOURCE line of its own, and this is why:
+ *    session_unset() empties $_SESSION wholesale, so every key added here
+ *    or by a future provider is cleared without anyone remembering to. If
+ *    that ever becomes a selective unset, provenance would survive a logout
+ *    and describe the NEXT session -- so pin the wholesale clear rather
+ *    than adding a line that looks redundant today.
+ */
+$out = methodSource($userFile, 'logout');
+if (null !== $out
+    && false === strpos($out, 'session_unset')
+    && false === strpos($out, 'FOG_AUTH_SOURCE')
+) {
+    $fails[] = 'User::logout() no longer clears the session wholesale with'
+        . ' session_unset(); FOG_AUTH_SOURCE would outlive the session that'
+        . ' set it';
+}
+
+/*
+ * 4. The normaliser, for real. Booting the autoloader is enough to reach it
+ *    -- Initiator's constructor only registers the autoloader, and this is
+ *    a pure static method, so no database is involved. FOG_CACHE_DIR and
+ *    friends are redirected into a throwaway directory first; see the long
+ *    note in tests/autoload.test.php for why that line must never become
+ *    conditional.
+ */
+$tmp = sys_get_temp_dir() . '/fog-provenance-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        foreach (glob($tmp . '/*/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        foreach (glob($tmp . '/*') ?: [] as $d) {
+            @rmdir($d);
+        }
+        @rmdir($tmp);
+    }
+);
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+require_once $root . '/packages/web/commons/init.php';
+new Initiator();
+
+$cases = [
+    // As supplied           => as recorded
+    'password'               => 'password',
+    'oidc'                   => 'oidc',
+    'OIDC'                   => 'oidc',
+    '  saml  '               => 'saml',
+    'azure-ad'               => 'azure-ad',
+    'my_provider2'           => 'my_provider2',
+    // Refused: not a plain slug. Recorded as unknown rather than passed
+    // through, because this string reaches an audit trail.
+    ''                       => 'unknown',
+    '-leading'               => 'unknown',
+    'has space'              => 'unknown',
+    "new\nline"              => 'unknown',
+    'quote"inject'           => 'unknown',
+    '<script>'               => 'unknown',
+    str_repeat('a', 33)      => 'unknown',
+];
+foreach ($cases as $in => $want) {
+    $got = \FOG\User::normalizeAuthSource($in);
+    if ($got !== $want) {
+        $fails[] = sprintf(
+            'User::normalizeAuthSource(%s) returned %s, expected %s',
+            var_export($in, true),
+            var_export($got, true),
+            var_export($want, true)
+        );
+    }
+}
+
+// 32 characters is the boundary, and it is on the allowed side of it.
+if ('unknown' === \FOG\User::normalizeAuthSource(str_repeat('a', 32))) {
+    $fails[] = 'User::normalizeAuthSource() rejects a 32-character slug;'
+        . ' the documented limit is 32, not 31';
+}
+
+// 5. No session, no provenance -- and no notice for reading a key that is
+//    not there. Every caller of this reads it on requests that may have no
+//    session at all.
+if ('' !== \FOG\User::sessionAuthSource()) {
+    $fails[] = 'User::sessionAuthSource() returned a value with no active'
+        . ' session';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: sessions record how they were established\n";
+exit(0);


### PR DESCRIPTION
Phase 2, PR 2.3. Small and additive; the password path is byte-for-byte unchanged in behaviour.

## The problem

Every logged-in session looks identical. `$_SESSION` carries `FOG_USER` and nothing else, and the history row says *"user successfully logged in"* whatever proved the credential. That is fine while a password is the only way in. It stops being fine the moment an identity provider can establish a session, for two separate reasons:

- **Audit** — an install that adopts SSO otherwise loses the ability to answer *"did this person come in through the IdP, or through a local password?"*, which is exactly the question asked after an incident.
- **Break-glass** (PR 2.5) — an IdP outage must leave local password login working, and the checks that will guarantee that need to count sessions by **how they were made**.

`users.uAuthSource` cannot answer either. It is a property of the **account** — which directory owns it — while provenance is a property of the **request**. An LDAP-sourced account reaching a break-glass path still made *this particular session* somehow, and that is the fact worth recording.

## The change

`establishSession()` takes a `$source`, defaulting to `User::AUTH_SOURCE_PASSWORD`, so `validatePw()` and any third-party caller keep the meaning they already had:

```php
public function establishSession($source = self::AUTH_SOURCE_PASSWORD)
```

It is stamped into `$_SESSION['FOG_AUTH_SOURCE']`, read back by the new `User::sessionAuthSource()`, and appended to the login history entry (`… user successfully logged in (oidc).`).

Two things the plan did not spell out and the implementation had to settle:

**The value is normalised, not trusted.** A provider plugin supplies it and it lands in an audit trail, so anything that is not a plain slug (`^[a-z0-9][a-z0-9_-]{0,31}$`, trimmed and case-folded) is recorded as `unknown` rather than passed through. That normalisation is a separate public static, `User::normalizeAuthSource()`, purely so it can be tested without a database — `establishSession()` itself writes a history row and cannot be exercised DB-free.

**`logout()` needs no line of its own.** `session_unset()` empties `$_SESSION` wholesale, so this key and every future one are cleared without anyone remembering to. The gate pins *that* rather than adding a redundant-looking unset: if it ever became a selective unset, provenance would survive a logout and describe the **next** session.

## Verification

`tests/session-provenance.test.php` — new, and half of it is a real behavioural test rather than a source parse. It boots the autoloader (no DB, same harness note as `tests/autoload.test.php`) and runs the normaliser over 13 cases plus the 32-character boundary; the rest is pinned statically: the session stamp, `establishSession()` going through the normaliser, `validatePw()` still calling it with no argument, and `logout()`'s wholesale clear.

Verified failing by bypassing `normalizeAuthSource()` in `establishSession()`:

```
FAIL: 1 problem(s):
  - User::establishSession() does not pass its $source through normalizeAuthSource(); …
```

`sh tests/run-all.sh` → **40 passed, 0 failed**.

## Docs

`docs/plugin-development.md` §7c gains a fourth subsection — how a provider plugin hands a proven identity over, and the account-vs-request distinction spelled out so nobody reaches for `uAuthSource`. `docs/refactor-phase2-plan.md` marks 2.3 done with both findings above.

## Downstream

None. No route, no class-list change, no schema change, no OpenAPI change.