### PR TITLE
Verify TLS on outbound requests, and keep the session off third-party hosts

### DIFF
--- a/docs/refactor-phase2-plan.md
+++ b/docs/refactor-phase2-plan.md
@@ -404,14 +404,16 @@ anybody in yet.
 
 Three findings from building it, all worth carrying into 2.4b:
 
-- **`FOGURLRequests` cannot be used for the token exchange.** It sets
-  `CURLOPT_SSL_VERIFYPEER => false` and `VERIFYHOST => false` as defaults
-  (`fogurlrequests.class.php:79-80`, `:160-161`) — correct for reaching a
-  storage node with a self-signed certificate, and disqualifying here, where
-  TLS to the provider *is* the security model. 2.4b brings its own fetch that
-  turns verification on explicitly and fails closed, rather than passing an
-  override into a class whose default is "do not verify": one refactor of
-  those defaults and the plugin stops verifying with no error.
+- **`FOGURLRequests` could not be used for the token exchange — so it was
+  fixed instead.** It defaulted `CURLOPT_SSL_VERIFYPEER` and `VERIFYHOST` to
+  false for *every* request, which is correct for reaching a storage node by
+  bare IP with a self-signed certificate and disqualifying for an OIDC token
+  exchange, where TLS to the provider *is* the security model. Rather than
+  give the plugin a private HTTP client, the class now verifies by default
+  and exempts only hosts this install owns — decided by the URL's host, so a
+  new caller cannot inherit the exemption by not thinking about it. It also
+  stopped attaching the signed-in administrator's session cookie and CSRF
+  token to third-party requests. 2.4b uses `FOGURLRequests` directly.
 - **`/ext/…` routes get no session.** `api/index.php` does not define
   `FOG_WANTS_SESSION`, and a visitor clicking the login button has no cookie
   yet, so the #1113 gate correctly declines to start one. The `state`, `nonce`

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -71,13 +71,41 @@ class FOGURLRequests extends FOGBase
      */
     private $_response = [];
     /**
+     * The TLS options used for a FOG-owned host, and only for one.
+     *
+     * A storage node presents whatever certificate the installer generated
+     * for it -- self-signed, or signed by the CA this server minted -- and it
+     * is addressed by bare IP, so no certificate could name it correctly
+     * anyway. fogservice.class.php retries a failed http size/hash fetch over
+     * https precisely because "we don't know about the storage node setup".
+     * Verification there would break replication on every install and buy
+     * nothing: the node's address came out of this server's own database.
+     *
+     * Applied by host, not by caller, so a new caller cannot inherit it by
+     * accident. See _isFogHost().
+     *
+     * @var array
+     */
+    const NODE_TLS_OPTIONS = [
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => 0,
+    ];
+    /**
      * Curl options to all url requests.
+     *
+     * Verification is ON. It used to be off for every request this class
+     * made, which was written for the storage-node traffic above and then
+     * silently applied to everything else -- the GitHub kernel/init listing,
+     * the fogproject.org version check, the kernel download itself. Those all
+     * present ordinary publicly-signed certificates, so there was nothing to
+     * gain and a machine-in-the-middle to lose, and the failure mode is
+     * invisible: a substituted response looks exactly like a real one.
      *
      * @var array
      */
     public $options = [
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_SSL_VERIFYHOST => false,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
         CURLOPT_RETURNTRANSFER => true,
     ];
     /**
@@ -157,8 +185,10 @@ class FOGURLRequests extends FOGBase
     private function _baseOptions()
     {
         return [
-            CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSL_VERIFYHOST => false,
+            // Verification on; see the $options docblock. The exemption for
+            // FOG's own nodes is applied per URL in _getOptions().
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_CONNECTTIMEOUT => $this->_conntimeout,
             CURLOPT_TIMEOUT => $this->_timeout,
@@ -432,7 +462,24 @@ class FOGURLRequests extends FOGBase
                 'FOG_PROXY_USERNAME'
             ]
         );
-        $IPs = Route::getIds('storagenode', ['isEnabled' => [1]], 'ip') ?: [];
+        /**
+         * Every host this install owns: its storage nodes, and itself.
+         *
+         * Not filtered on isEnabled any more. It used to be, because the only
+         * consumer was the proxy bypass and a disabled node is not fetched
+         * from -- but the TLS exemption below reads the same list, and the
+         * storage node management page tests a node's availability while the
+         * admin is still creating it. A node absent from this list gets its
+         * certificate verified, which for a node addressed by bare IP means
+         * it is unreachable.
+         *
+         * The FOG server itself is included because several of these requests
+         * are this server calling its own status endpoints, and its
+         * certificate is the installer's self-signed one.
+         */
+        $IPs = Route::getIds('storagenode', [], 'ip') ?: [];
+        $IPs[] = self::getSetting('FOG_WEB_HOST');
+        $IPs = array_merge($IPs, ['127.0.0.1', '::1', 'localhost']);
         $options = [];
         if ($ip) {
             $options[CURLOPT_PROXYAUTH] = CURLAUTH_BASIC;
@@ -447,10 +494,63 @@ class FOGURLRequests extends FOGBase
             }
         }
 
+        /**
+         * A set of hosts, not a regex.
+         *
+         * This used to be '#' . implode('|', $IPs) . '#i' matched against the
+         * whole URL, which has two problems. It is unanchored and the dots
+         * are unescaped, so a node at 10.0.0.5 also "matches"
+         * https://example.com/?ref=10x0x0x5 -- tolerable when the only
+         * consequence was skipping a proxy, and not tolerable now that the
+         * same answer decides whether a certificate is checked. And with no
+         * enabled storage nodes implode() returned '', giving the pattern
+         * '##i', which matches every URL -- so the proxy was silently never
+         * applied on an install that had none.
+         */
         return [
-            'pattern' => sprintf('#%s#i', implode('|', $IPs)),
+            'hosts' => array_values(
+                array_unique(
+                    array_filter(
+                        array_map(
+                            function ($host) {
+                                return strtolower(trim((string)$host));
+                            },
+                            $IPs
+                        ),
+                        'strlen'
+                    )
+                )
+            ),
             'options' => $options,
         ];
+    }
+    /**
+     * Whether a URL addresses a host this FOG install owns.
+     *
+     * The host is compared whole and exactly, because this answer decides
+     * whether the connection's certificate is verified. Substring or pattern
+     * matching would let an attacker-chosen URL that merely CONTAINS a node
+     * address opt itself out of verification.
+     *
+     * Public and static so it can be exercised directly: it needs no
+     * database, and the cases that matter are the ones that must NOT match.
+     *
+     * @param string $url   the URL about to be requested
+     * @param array  $hosts the hosts this install owns, already lowercased
+     *
+     * @return bool
+     */
+    public static function isFogHost($url, array $hosts)
+    {
+        $host = parse_url((string)$url, PHP_URL_HOST);
+        if (!is_string($host) || '' === $host) {
+            return false;
+        }
+        // parse_url keeps the brackets on an IPv6 literal; the stored value
+        // has none.
+        $host = strtolower(trim($host, '[]'));
+
+        return in_array($host, $hosts, true);
     }
     /**
      * Get options of the request and whole.
@@ -468,6 +568,7 @@ class FOGURLRequests extends FOGBase
             $options[CURLOPT_MAXREDIRS] = 5;
         }
         $url = $this->_validUrl($request->url);
+        $isFogHost = self::isFogHost($url, (array)($this->_proxy['hosts'] ?? []));
         if ($request->options) {
             $options = $request->options + $options;
         }
@@ -478,9 +579,38 @@ class FOGURLRequests extends FOGBase
         }
         if ($this->_headers) {
             $options[CURLOPT_HEADER] = 0;
-            $options[CURLOPT_HTTPHEADER] = (array)$this->_headers;
+            /*
+             * The CSRF token goes to FOG's own hosts only. process() adds it
+             * so that a status endpoint on a storage node accepts the POST;
+             * on any other host it is a credential handed to a third party
+             * for no purpose. Same reasoning as the cookie below.
+             */
+            $options[CURLOPT_HTTPHEADER] = $isFogHost
+                ? (array)$this->_headers
+                : array_values(
+                    array_filter(
+                        (array)$this->_headers,
+                        function ($header) {
+                            return 0 !== stripos(
+                                (string)$header,
+                                'X-CSRF-Token:'
+                            );
+                        }
+                    )
+                );
         }
-        if (!isset($options[CURLOPT_COOKIE])) {
+        /*
+         * The session cookie goes to FOG's own hosts only.
+         *
+         * This used to be sent on every request this class made, which meant
+         * the signed-in administrator's PHP session id was handed to
+         * api.github.com on every kernel listing and to fogproject.org on
+         * every version check. It is here because a node's status endpoint
+         * needs the caller's session to authorise the request -- that is a
+         * reason to send it to a node, and not a reason to send it anywhere
+         * else.
+         */
+        if ($isFogHost && !isset($options[CURLOPT_COOKIE])) {
             $options[CURLOPT_COOKIE] = session_name() . '=' . session_id();
         }
         if ($available) {
@@ -495,9 +625,22 @@ class FOGURLRequests extends FOGBase
             $options[CURLOPT_HEADER] = true;
             $options[CURLOPT_NOSIGNAL] = true;
         }
-        if ($this->_proxy['options']
-            && !preg_match($this->_proxy['pattern'], $url)
+        /*
+         * The TLS exemption for FOG's own nodes. Applied here rather than in
+         * the defaults so it is decided by the URL: a caller cannot acquire
+         * it by not thinking about it, which is how every request this class
+         * made ended up unverified in the first place.
+         *
+         * Skipped when the caller named CURLOPT_SSL_VERIFYPEER itself --
+         * $request->options already wins over $this->options above, and an
+         * explicit choice must not be overwritten by an implicit one.
+         */
+        if ($isFogHost
+            && !isset($request->options[CURLOPT_SSL_VERIFYPEER])
         ) {
+            $options = self::NODE_TLS_OPTIONS + $options;
+        }
+        if ($this->_proxy['options'] && !$isFogHost) {
             $options = $this->_proxy['options'] + $options;
         }
 

--- a/tests/url-requests-tls.test.php
+++ b/tests/url-requests-tls.test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * FOGURLRequests must verify TLS, and must not leak the session off-site.
+ *
+ * This class makes every outbound HTTP request the web tier makes: the
+ * GitHub kernel and init listings, the kernel download itself, the
+ * fogproject.org version check, and the storage-node status endpoints. It
+ * used to treat all of those the same way, with two consequences that were
+ * written for the last of them and silently applied to the rest:
+ *
+ *   1. CURLOPT_SSL_VERIFYPEER and VERIFYHOST were false for everything. A
+ *      storage node is addressed by bare IP and presents a self-signed
+ *      certificate, so verification genuinely cannot work there -- but
+ *      api.github.com and fogproject.org present ordinary publicly-signed
+ *      certificates, and there the setting bought nothing and cost the
+ *      ability to notice a substituted response. Downloading a kernel is
+ *      the sharpest case: the file lands on disk and is booted by every
+ *      machine that images afterwards.
+ *   2. The signed-in administrator's PHP session id (and the CSRF token)
+ *      were attached to every request. They are there so a node's status
+ *      endpoint can authorise the call; sending them to a third party is a
+ *      credential handed over for no purpose.
+ *
+ * Both are now decided by the URL's host rather than by the caller, so a
+ * new caller cannot inherit either by not thinking about it. That decision
+ * is the thing under test.
+ *
+ * The host matcher runs for real: it is a pure static, so it needs no
+ * database. The wiring around it is pinned by source inspection, because
+ * observing it needs a live curl handle and a populated storage node table.
+ *
+ * Usage: php tests/url-requests-tls.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$file = 'packages/web/lib/fog/fogurlrequests.class.php';
+$src = (string)file_get_contents($file);
+
+/*
+ * 1. The host matcher, for real.
+ *
+ * The cases that matter are the ones that must NOT match. The previous
+ * implementation was an unanchored regex of unescaped IPs matched against
+ * the whole URL, so a URL merely CONTAINING a node's address matched it --
+ * harmless while the answer only chose whether to use a proxy, and not
+ * harmless now that it decides whether a certificate is checked.
+ */
+preg_match('#public static function isFogHost.*?\n    \}#s', $src, $m);
+if (empty($m)) {
+    $fails[] = 'FOGURLRequests::isFogHost() is gone; the TLS exemption and'
+        . ' the session-forwarding decision both key off it';
+} else {
+    eval(
+        'function fogHostProbe($url, array $hosts) '
+        . substr($m[0], strpos($m[0], '{'))
+    );
+    $hosts = [
+        '10.0.0.5',
+        'node.example.lan',
+        '127.0.0.1',
+        '::1',
+        'fogserver.example.lan'
+    ];
+    $cases = [
+        // Ours: exempt from verification, and allowed the session cookie.
+        ['https://10.0.0.5/fog/status/getsize.php', true],
+        ['http://10.0.0.5/fog/status/getfiles.php?path=/images', true],
+        ['https://NODE.EXAMPLE.LAN/fog/', true],
+        ['https://[::1]/fog/', true],
+        // Not ours.
+        ['https://api.github.com/repos/FOGProject/fos/releases', false],
+        ['https://fogproject.org/version/index.php', false],
+        // The substring cases the old regex got wrong.
+        ['https://example.com/?ref=10.0.0.5', false],
+        ['https://10.0.0.5.evil.com/', false],
+        ['https://node.example.lan.evil.com/', false],
+        ['https://10.0.0.50/', false],
+        // Nothing to match on must not match.
+        ['not a url', false],
+        ['', false]
+    ];
+    foreach ($cases as $case) {
+        list($url, $want) = $case;
+        $got = fogHostProbe($url, $hosts);
+        if ($got !== $want) {
+            $fails[] = sprintf(
+                'isFogHost(%s) returned %s, expected %s',
+                var_export($url, true),
+                var_export($got, true),
+                var_export($want, true)
+            );
+        }
+    }
+}
+
+/*
+ * 2. Verification is the default. Both places that build the shared option
+ *    set have to say so -- the property and _baseOptions() -- because the
+ *    constructor replaces one with the other and a disagreement between
+ *    them would be invisible.
+ */
+$verifyOff = preg_match_all(
+    '#CURLOPT_SSL_VERIFYPEER\s*=>\s*(false|0)\b#',
+    $src,
+    $offs
+);
+$exemption = '';
+if (preg_match('#const NODE_TLS_OPTIONS = \[.*?\];#s', $src, $m)) {
+    $exemption = $m[0];
+}
+if ('' === $exemption) {
+    $fails[] = 'FOGURLRequests::NODE_TLS_OPTIONS is gone; the exemption for'
+        . " FOG's own nodes has to be one named thing, not a value repeated"
+        . ' wherever somebody needed it';
+} else {
+    $offInExemption = preg_match_all(
+        '#CURLOPT_SSL_VERIFYPEER\s*=>\s*(false|0)\b#',
+        $exemption
+    );
+    if ($verifyOff !== $offInExemption) {
+        $fails[] = sprintf(
+            'CURLOPT_SSL_VERIFYPEER is disabled in %d place(s) outside'
+            . ' NODE_TLS_OPTIONS; verification must be off only for a host'
+            . ' this install owns',
+            $verifyOff - $offInExemption
+        );
+    }
+}
+if (2 !== preg_match_all('#CURLOPT_SSL_VERIFYPEER\s*=>\s*true#', $src)) {
+    $fails[] = 'the shared option set no longer defaults'
+        . ' CURLOPT_SSL_VERIFYPEER to true in both the property and'
+        . ' _baseOptions()';
+}
+
+/*
+ * 3. The exemption and the session forwarding are conditioned on the host.
+ *    Checked by shape rather than by value: what must not come back is an
+ *    unconditional cookie line, which is what shipped.
+ */
+if (!preg_match(
+    '#if \(\$isFogHost\s*\n\s*&& !isset\(\$request->options\[CURLOPT_SSL_VERIFYPEER\]\)#',
+    $src
+)) {
+    $fails[] = 'the TLS exemption is no longer gated on $isFogHost, or no'
+        . ' longer yields to a caller that named CURLOPT_SSL_VERIFYPEER'
+        . ' itself';
+}
+if (!preg_match(
+    '#if \(\$isFogHost && !isset\(\$options\[CURLOPT_COOKIE\]\)\) \{\s*\n\s*\$options\[CURLOPT_COOKIE\]#',
+    $src
+)) {
+    $fails[] = "the session cookie is no longer gated on \$isFogHost; the"
+        . " signed-in administrator's session id would be sent to every"
+        . ' third-party host this class fetches from';
+}
+if (false === strpos($src, 'X-CSRF-Token:')) {
+    $fails[] = 'the CSRF token is no longer filtered out for third-party'
+        . ' hosts';
+}
+
+/*
+ * 4. Nothing may go back to matching the URL with a regex. The proxy bypass
+ *    and the TLS exemption now share one answer, so a pattern loose enough
+ *    for the first is a hole in the second.
+ */
+if (preg_match('#preg_match\(\$this->_proxy#', $src)) {
+    $fails[] = 'the proxy bypass matches the URL against a pattern again;'
+        . ' it shares its answer with the TLS exemption, so the comparison'
+        . ' has to be a whole-host one';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: outbound requests verify TLS and keep the session at home\n";
+exit(0);


### PR DESCRIPTION
`FOGURLRequests` makes **every** outbound HTTP request the web tier makes — the GitHub kernel/init listings, the kernel download itself, the fogproject.org version check, and the storage-node status endpoints. It treated all of them identically, in two ways that were written for the last of those and then silently applied to the rest.

## 1. TLS verification was off for everything

```php
public $options = [
    CURLOPT_SSL_VERIFYPEER => false,
    CURLOPT_SSL_VERIFYHOST => false,
    ...
```

That is genuinely necessary for a storage node: it's addressed by bare IP and presents whatever certificate the installer generated, which is why `fogservice.class.php` retries a failed size fetch over https with the comment *"we should re-try HTTPS because we don't know about the storage node setup"*.

It is not necessary for `api.github.com` or `fogproject.org`, which present ordinary publicly-signed certificates. There it bought nothing and cost the ability to notice a substituted response. **The kernel download is the sharpest case** — the file lands on disk and is then booted by every machine that images afterwards.

## 2. The admin's session went to every host

`CURLOPT_COOKIE` was set unconditionally to `session_name()=session_id()`, and `process()` appends an `X-CSRF-Token` header. Both exist so a node's status endpoint can authorise the call. Sending them to `api.github.com` on every kernel listing is a credential handed to a third party for no purpose.

## The fix: decide by host, not by caller

Both are now conditioned on the URL's host, so a new caller cannot acquire either by not thinking about it — which is exactly how every request this class made came to be unverified.

- Verification defaults **on** in both places that build the shared option set.
- The exemption is one named constant, `NODE_TLS_OPTIONS`, applied only when `isFogHost()` says the host is one this install owns: a storage node, this server (`FOG_WEB_HOST`), or loopback.
- Storage nodes are no longer filtered on `isEnabled` — the storage node page tests a node's availability while the admin is still creating it, and a node missing from the list would have its certificate verified, which for a bare IP means unreachable.
- A caller that names `CURLOPT_SSL_VERIFYPEER` itself still wins.

### The host test is a whole-host comparison, not the regex it replaces

The old one was `'#' . implode('|', $IPs) . '#i'` matched against the entire URL — unanchored, dots unescaped. A node at `10.0.0.5` therefore also "matched" `https://example.com/?ref=10.0.0.5`. Tolerable while the only consequence was skipping a proxy; not tolerable now that the same answer decides whether a certificate is checked.

It also fixes a live bug in the proxy path: with no enabled storage nodes, `implode()` returned `''`, giving the pattern `'##i'` — which matches every URL, so **the proxy was silently never applied** on an install that had none.

## Behaviour change worth stating

An install whose outbound traffic is TLS-intercepted by a corporate proxy will now fail to fetch the kernel list and the version check until that proxy's CA is trusted by the OS. That's the correct outcome and the normal fix, but it is a visible change and someone will hit it.

Storage-node traffic is unaffected — that's the whole point of the exemption.

## Verification

`tests/url-requests-tls.test.php` runs the host matcher **for real** (it's a pure static, so no database) over 12 cases, including the substring ones the old regex got wrong, and pins the wiring by shape.

Verified failing by two mutations:

```
# verification turned back off in _baseOptions()
FAIL: 2 problem(s):
  - CURLOPT_SSL_VERIFYPEER is disabled in 1 place(s) outside NODE_TLS_OPTIONS; ...
  - the shared option set no longer defaults CURLOPT_SSL_VERIFYPEER to true ...

# session cookie un-gated
FAIL: 1 problem(s):
  - the session cookie is no longer gated on $isFogHost; the signed-in
    administrator's session id would be sent to every third-party host ...
```

`sh tests/run-all.sh` → **41 passed, 0 failed**.

## Context

Found while building the OIDC plugin, which needs a verified fetch for the token exchange. Rather than give the plugin a private HTTP client, the shared one is now correct — so the Phase 2 plan note that said 2.4b would bring its own is updated to say it uses this one.

## Downstream

None. No route change, no class-list change, no schema change.