### PR TITLE
Verify TLS on outbound requests, and keep the session off third-party hosts

### DIFF
--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -68,13 +68,39 @@ class FOGURLRequests extends FOGBase
      */
     private $_response = array();
     /**
+     * The TLS options used for a FOG-owned host, and only for one.
+     *
+     * A storage node presents whatever certificate the installer generated
+     * for it -- self-signed, or signed by the CA this server minted -- and it
+     * is addressed by bare IP, so no certificate could name it correctly
+     * anyway. Verification there would break replication on every install and
+     * buy nothing: the node's address came out of this server's own database.
+     *
+     * Applied by host, not by caller, so a new caller cannot inherit it by
+     * accident. See isFogHost().
+     *
+     * @var array
+     */
+    const NODE_TLS_OPTIONS = array(
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => 0,
+    );
+    /**
      * Curl options to all url requests.
+     *
+     * Verification is ON. It used to be off for every request this class
+     * made, which was written for the storage-node traffic above and then
+     * silently applied to everything else -- the GitHub kernel/init listing,
+     * the fogproject.org version check, the kernel download itself. Those all
+     * present ordinary publicly-signed certificates, so there was nothing to
+     * gain and a machine-in-the-middle to lose, and the failure mode is
+     * invisible: a substituted response looks exactly like a real one.
      *
      * @var array
      */
     public $options = array(
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_SSL_VERIFYHOST => false,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
         CURLOPT_RETURNTRANSFER => true,
     );
     /**
@@ -150,9 +176,11 @@ class FOGURLRequests extends FOGBase
     {
         $this->_windowSize = 20;
         $this->_callback = '';
+        // Same defaults as the property; the exemption for FOG's own nodes
+        // is applied per URL in _getOptions().
         $this->options = array(
-            CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSL_VERIFYHOST => false,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_RETURNTRANSFER => true,
         );
         $this->_response = array();
@@ -453,12 +481,95 @@ class FOGURLRequests extends FOGBase
             $options[CURLOPT_POST] = 1;
             $options[CURLOPT_POSTFIELDS] = $request->postData;
         }
+        /**
+         * Every host this install owns: its storage nodes, and itself.
+         *
+         * The FOG server is included because several of these requests are
+         * this server calling its own status endpoints, and its certificate
+         * is the installer's self-signed one.
+         *
+         * Note the 'ip' argument. This read used to be
+         * getSubObjectIDs('StorageNode', array('isEnabled' => 1)) with no
+         * field, and getSubObjectIDs() defaults $getField to 'id' -- so the
+         * list it produced was storage node IDs, not addresses, and the
+         * pattern below was matching '#1|2|5#' against the whole URL. The
+         * only consequence was a proxy that was applied essentially never
+         * (any URL containing one of those digits looked like a node), which
+         * is why nobody noticed. It is not survivable now that the same
+         * answer decides whether a certificate is verified.
+         *
+         * isEnabled is no longer filtered on either: a node an admin is
+         * still creating is contacted by the storage node page, and a node
+         * absent from this list gets its certificate verified, which for a
+         * node addressed by bare IP means it is unreachable.
+         */
+        $hosts = self::getSubObjectIDs('StorageNode', array(), 'ip');
+        $hosts[] = self::getSetting('FOG_WEB_HOST');
+        $hosts = array_merge($hosts, array('127.0.0.1', '::1', 'localhost'));
+        $hosts = array_values(
+            array_unique(
+                array_filter(
+                    array_map(
+                        function ($host) {
+                            return strtolower(trim((string)$host));
+                        },
+                        $hosts
+                    ),
+                    'strlen'
+                )
+            )
+        );
+        $isFogHost = self::isFogHost($url, $hosts);
         if ($headers) {
             $options[CURLOPT_HEADER] = 0;
-            $options[CURLOPT_HTTPHEADER] = (array)$headers;
+            /*
+             * The CSRF token goes to FOG's own hosts only. It is added so
+             * that a status endpoint on a storage node accepts the POST; on
+             * any other host it is a credential handed to a third party for
+             * no purpose. Same reasoning as the cookie below.
+             */
+            $options[CURLOPT_HTTPHEADER] = $isFogHost
+                ? (array)$headers
+                : array_values(
+                    array_filter(
+                        (array)$headers,
+                        function ($header) {
+                            return 0 !== stripos(
+                                (string)$header,
+                                'X-CSRF-Token:'
+                            );
+                        }
+                    )
+                );
         }
-        if (!isset($options[CURLOPT_COOKIE])) {
+        /*
+         * The session cookie goes to FOG's own hosts only.
+         *
+         * This used to be sent on every request this class made, which meant
+         * the signed-in administrator's PHP session id was handed to
+         * api.github.com on every kernel listing and to fogproject.org on
+         * every version check. It is here because a node's status endpoint
+         * needs the caller's session to authorise the request -- that is a
+         * reason to send it to a node, and not a reason to send it anywhere
+         * else.
+         */
+        if ($isFogHost && !isset($options[CURLOPT_COOKIE])) {
             $options[CURLOPT_COOKIE] = session_name() . '=' . session_id();
+        }
+        /*
+         * The TLS exemption for FOG's own nodes. Applied here rather than in
+         * the defaults so it is decided by the URL: a caller cannot acquire
+         * it by not thinking about it, which is how every request this class
+         * made ended up unverified in the first place.
+         *
+         * Skipped when the caller named CURLOPT_SSL_VERIFYPEER itself --
+         * $request->options already wins over $this->options above, and an
+         * explicit choice must not be overwritten by an implicit one.
+         */
+        if ($isFogHost
+            && !isset($request->options[CURLOPT_SSL_VERIFYPEER])
+        ) {
+            $options = self::NODE_TLS_OPTIONS + $options;
         }
         list($ip, $password, $port, $username) = self::getSubObjectIDs(
             'Service',
@@ -477,12 +588,7 @@ class FOGURLRequests extends FOGBase
             false,
             false
         );
-        $IPs = self::getSubObjectIDs('StorageNode', array('isEnabled' => 1));
-        $pat = sprintf(
-            '#%s#i',
-            implode('|', $IPs)
-        );
-        if (!preg_match($pat, $url)) {
+        if (!$isFogHost) {
             if ($ip) {
                 $options[CURLOPT_PROXYAUTH] = CURLAUTH_BASIC;
                 $options[CURLOPT_PROXYPORT] = $port;
@@ -498,6 +604,36 @@ class FOGURLRequests extends FOGBase
         }
 
         return $options;
+    }
+    /**
+     * Whether a URL addresses a host this FOG install owns.
+     *
+     * The host is compared whole and exactly, because this answer decides
+     * whether the connection's certificate is verified. Substring or pattern
+     * matching would let an attacker-chosen URL that merely CONTAINS a node
+     * address opt itself out of verification -- which is what the regex this
+     * replaces did: unanchored, with the dots unescaped, so a node at
+     * 10.0.0.5 also matched https://example.com/?ref=10.0.0.5.
+     *
+     * Public and static so it can be exercised directly: it needs no
+     * database, and the cases that matter are the ones that must NOT match.
+     *
+     * @param string $url   the URL about to be requested
+     * @param array  $hosts the hosts this install owns, already lowercased
+     *
+     * @return bool
+     */
+    public static function isFogHost($url, array $hosts)
+    {
+        $host = parse_url((string)$url, PHP_URL_HOST);
+        if (!is_string($host) || '' === $host) {
+            return false;
+        }
+        // parse_url keeps the brackets on an IPv6 literal; the stored value
+        // has none.
+        $host = strtolower(trim($host, '[]'));
+
+        return in_array($host, $hosts, true);
     }
     /**
      * Function simply ensures the url is valid.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -53,7 +53,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.5.10.2277');
+        define('FOG_VERSION', '1.5.10.2278');
         define('FOG_SCHEMA', 279);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');

--- a/tests/url-requests-tls.test.php
+++ b/tests/url-requests-tls.test.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * FOGURLRequests must verify TLS, and must not leak the session off-site.
+ *
+ * This class makes every outbound HTTP request the web tier makes: the
+ * GitHub kernel and init listings, the kernel download itself, the
+ * fogproject.org version check, and the storage-node status endpoints. It
+ * used to treat all of those the same way, with two consequences that were
+ * written for the last of them and silently applied to the rest:
+ *
+ *   1. CURLOPT_SSL_VERIFYPEER and VERIFYHOST were false for everything. A
+ *      storage node is addressed by bare IP and presents a self-signed
+ *      certificate, so verification genuinely cannot work there -- but
+ *      api.github.com and fogproject.org present ordinary publicly-signed
+ *      certificates, and there the setting bought nothing and cost the
+ *      ability to notice a substituted response. Downloading a kernel is
+ *      the sharpest case: the file lands on disk and is booted by every
+ *      machine that images afterwards.
+ *   2. The signed-in administrator's PHP session id (and the CSRF token)
+ *      were attached to every request. They are there so a node's status
+ *      endpoint can authorise the call; sending them to a third party is a
+ *      credential handed over for no purpose.
+ *
+ * Both are now decided by the URL's host rather than by the caller, so a
+ * new caller cannot inherit either by not thinking about it. That decision
+ * is the thing under test.
+ *
+ * The host matcher runs for real: it is a pure static, so it needs no
+ * database. The wiring around it is pinned by source inspection, because
+ * observing it needs a live curl handle and a populated storage node table.
+ *
+ * Usage: php tests/url-requests-tls.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$file = 'packages/web/lib/fog/fogurlrequests.class.php';
+$src = (string)file_get_contents($file);
+
+/*
+ * 1. The host matcher, for real.
+ *
+ * The cases that matter are the ones that must NOT match. The previous
+ * implementation was an unanchored regex of unescaped IPs matched against
+ * the whole URL, so a URL merely CONTAINING a node's address matched it --
+ * harmless while the answer only chose whether to use a proxy, and not
+ * harmless now that it decides whether a certificate is checked.
+ */
+preg_match('#public static function isFogHost.*?\n    \}#s', $src, $m);
+if (empty($m)) {
+    $fails[] = 'FOGURLRequests::isFogHost() is gone; the TLS exemption and'
+        . ' the session-forwarding decision both key off it';
+} else {
+    eval(
+        'function fogHostProbe($url, array $hosts) '
+        . substr($m[0], strpos($m[0], '{'))
+    );
+    $hosts = [
+        '10.0.0.5',
+        'node.example.lan',
+        '127.0.0.1',
+        '::1',
+        'fogserver.example.lan'
+    ];
+    $cases = [
+        // Ours: exempt from verification, and allowed the session cookie.
+        ['https://10.0.0.5/fog/status/getsize.php', true],
+        ['http://10.0.0.5/fog/status/getfiles.php?path=/images', true],
+        ['https://NODE.EXAMPLE.LAN/fog/', true],
+        ['https://[::1]/fog/', true],
+        // Not ours.
+        ['https://api.github.com/repos/FOGProject/fos/releases', false],
+        ['https://fogproject.org/version/index.php', false],
+        // The substring cases the old regex got wrong.
+        ['https://example.com/?ref=10.0.0.5', false],
+        ['https://10.0.0.5.evil.com/', false],
+        ['https://node.example.lan.evil.com/', false],
+        ['https://10.0.0.50/', false],
+        // Nothing to match on must not match.
+        ['not a url', false],
+        ['', false]
+    ];
+    foreach ($cases as $case) {
+        list($url, $want) = $case;
+        $got = fogHostProbe($url, $hosts);
+        if ($got !== $want) {
+            $fails[] = sprintf(
+                'isFogHost(%s) returned %s, expected %s',
+                var_export($url, true),
+                var_export($got, true),
+                var_export($want, true)
+            );
+        }
+    }
+}
+
+/*
+ * 2. Verification is the default. Both places that build the shared option
+ *    set have to say so -- the property and _baseOptions() -- because the
+ *    constructor replaces one with the other and a disagreement between
+ *    them would be invisible.
+ */
+$verifyOff = preg_match_all(
+    '#CURLOPT_SSL_VERIFYPEER\s*=>\s*(false|0)\b#',
+    $src,
+    $offs
+);
+$exemption = '';
+// Either array syntax: working-1.6 writes [], dev-branch writes array().
+if (preg_match('#const NODE_TLS_OPTIONS = (?:\[|array\().*?;#s', $src, $m)) {
+    $exemption = $m[0];
+}
+if ('' === $exemption) {
+    $fails[] = 'FOGURLRequests::NODE_TLS_OPTIONS is gone; the exemption for'
+        . " FOG's own nodes has to be one named thing, not a value repeated"
+        . ' wherever somebody needed it';
+} else {
+    $offInExemption = preg_match_all(
+        '#CURLOPT_SSL_VERIFYPEER\s*=>\s*(false|0)\b#',
+        $exemption
+    );
+    if ($verifyOff !== $offInExemption) {
+        $fails[] = sprintf(
+            'CURLOPT_SSL_VERIFYPEER is disabled in %d place(s) outside'
+            . ' NODE_TLS_OPTIONS; verification must be off only for a host'
+            . ' this install owns',
+            $verifyOff - $offInExemption
+        );
+    }
+}
+if (2 !== preg_match_all('#CURLOPT_SSL_VERIFYPEER\s*=>\s*true#', $src)) {
+    $fails[] = 'the shared option set no longer defaults'
+        . ' CURLOPT_SSL_VERIFYPEER to true in both the property and the'
+        . ' __destruct() reset';
+}
+
+/*
+ * 3. The exemption and the session forwarding are conditioned on the host.
+ *    Checked by shape rather than by value: what must not come back is an
+ *    unconditional cookie line, which is what shipped.
+ */
+if (!preg_match(
+    '#if \(\$isFogHost\s*\n\s*&& !isset\(\$request->options\[CURLOPT_SSL_VERIFYPEER\]\)#',
+    $src
+)) {
+    $fails[] = 'the TLS exemption is no longer gated on $isFogHost, or no'
+        . ' longer yields to a caller that named CURLOPT_SSL_VERIFYPEER'
+        . ' itself';
+}
+if (!preg_match(
+    '#if \(\$isFogHost && !isset\(\$options\[CURLOPT_COOKIE\]\)\) \{\s*\n\s*\$options\[CURLOPT_COOKIE\]#',
+    $src
+)) {
+    $fails[] = "the session cookie is no longer gated on \$isFogHost; the"
+        . " signed-in administrator's session id would be sent to every"
+        . ' third-party host this class fetches from';
+}
+if (false === strpos($src, 'X-CSRF-Token:')) {
+    $fails[] = 'the CSRF token is no longer filtered out for third-party'
+        . ' hosts';
+}
+
+/*
+ * 4. Nothing may go back to matching the URL with a regex. The proxy bypass
+ *    and the TLS exemption now share one answer, so a pattern loose enough
+ *    for the first is a hole in the second.
+ */
+if (preg_match('#preg_match\(\$pat, \$url\)#', $src)) {
+    $fails[] = 'the proxy bypass matches the URL against a pattern again;'
+        . ' it shares its answer with the TLS exemption, so the comparison'
+        . ' has to be a whole-host one';
+}
+/*
+ * 5. The node list must be ADDRESSES. getSubObjectIDs() defaults its field
+ *    to 'id', and this call used to take that default -- so the list was
+ *    storage node IDs and the pattern above was matching '#1|2|5#' against
+ *    the whole URL. Survivable while it only chose a proxy (which it
+ *    therefore applied essentially never, unnoticed); not survivable now
+ *    that the same answer decides whether a certificate is verified.
+ */
+if (!preg_match(
+    "#getSubObjectIDs\('StorageNode', array\(\), 'ip'\)#",
+    $src
+)) {
+    $fails[] = "the storage node list is not read with the 'ip' field;"
+        . " getSubObjectIDs() defaults to 'id', which would make the host"
+        . ' comparison a list of row ids';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: outbound requests verify TLS and keep the session at home\n";
+exit(0);


### PR DESCRIPTION
Port of **#1132** (working-1.6). Same two problems, same fix, adapted to this branch's shape — plus **one extra bug that only exists here**.

## The two shared problems

`FOGURLRequests` makes every outbound HTTP request the web tier makes: the GitHub kernel/init listings, the kernel download itself, the fogproject.org version check, and the storage-node status endpoints.

**TLS verification was off for everything.** Necessary for a storage node — addressed by bare IP, presenting whatever certificate the installer generated. Not necessary for `api.github.com` or `fogproject.org`, which present ordinary publicly-signed certificates; there it bought nothing and cost the ability to notice a substituted response. The kernel download is the sharpest case: the file lands on disk and is booted by every machine that images afterwards.

**The admin's session went to every host.** `CURLOPT_COOKIE` was set unconditionally to `session_name()=session_id()`, and the `X-CSRF-Token` header rode along. Both exist so a node's status endpoint can authorise the call; sending them to a third party is a credential handed over for no purpose.

Both are now decided by the URL's **host**, not by the caller — so a new caller cannot acquire either by not thinking about it, which is how every request came to be unverified. The exemption is one named constant, `NODE_TLS_OPTIONS`, applied only when `isFogHost()` says the host is a storage node, this server, or loopback. A caller that names `CURLOPT_SSL_VERIFYPEER` itself still wins.

## The extra bug — why this isn't a straight copy

The node list was read as:

```php
$IPs = self::getSubObjectIDs('StorageNode', array('isEnabled' => 1));
```

with **no field argument**, and `getSubObjectIDs()` defaults `$getField` to `'id'`. So `$IPs` was storage node **row ids**, and the pattern built from it was `#1|2|5#` matched against the whole URL.

The only consequence was a proxy applied essentially never — any URL containing one of those digits looked like a node — which is why it went unnoticed. It is not survivable once the same answer decides whether a certificate is checked. The read now asks for `'ip'`, and the gate pins that it does.

(working-1.6 doesn't have this half: its equivalent already passed `'ip'`.)

The comparison is a whole-host one rather than a pattern for the same reason. Even with real addresses, `'#' . implode('|', $IPs) . '#i'` is unanchored with the dots unescaped — a node at `10.0.0.5` also matched `https://example.com/?ref=10.0.0.5`.

## Behaviour change worth stating

An install whose outbound traffic is TLS-intercepted by a corporate proxy will now fail to fetch the kernel list and the version check until that proxy's CA is trusted by the OS. That's the correct outcome and the normal fix, but it's a **visible change on a patch line** and someone will hit it.

Storage-node traffic is unaffected — that's the point of the exemption.

## Verification

`tests/url-requests-tls.test.php` runs the host matcher for real (a pure static, so no database) over 12 cases including the substring ones the old regex got wrong, and pins the wiring by shape.

Verified failing by two mutations:

```
FAIL: 2 problem(s):
  - the session cookie is no longer gated on $isFogHost; the signed-in
    administrator's session id would be sent to every third-party host ...
  - the storage node list is not read with the 'ip' field; getSubObjectIDs()
    defaults to 'id', which would make the host comparison a list of row ids
```

All 7 tests in `tests/` pass.

## Downstream

None. No route change, no class-list change, no schema change.