### PR TITLE
Keep one way in that does not depend on the identity provider

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -1111,9 +1111,27 @@ class Authorization extends FOGBase
      *                         list of specific groups.
      * - 'removeGroups'     => [groupID, ...] groups about to be deleted —
      *                         their memberships and role assignments vanish.
+     * - 'localOnly'        => true count only administrators who can
+     *                         authenticate without an external identity
+     *                         provider (see below).
+     * - 'authSources'      => [userID => 'source'] proposed users.uAuthSource
+     *                         values, '' meaning local. Only consulted under
+     *                         'localOnly'.
      *
      * A user is an effective administrator when they hold '*', counting
      * roles reached both directly and through any group they belong to.
+     *
+     * Under 'localOnly' they must also carry an empty users.uAuthSource.
+     * That column makes an account unable to log in with a local password
+     * (see User::passwordValidate()), so an install whose every
+     * administrator carries one has no way in at all while its directory is
+     * unreachable. This is the question the break-glass guards ask; every
+     * other caller wants the plain one.
+     *
+     * A fog-user-token deliberately does NOT count. It reaches the API and
+     * not the UI, and it is a bearer secret that can be rotated, revoked or
+     * simply lost -- an install whose only remaining way in is a token
+     * somebody may no longer have is not one this guard should call safe.
      *
      * @param array $changes the proposed changes (see above)
      *
@@ -1138,6 +1156,9 @@ class Authorization extends FOGBase
             (array)($changes['excludeUsers'] ?? [])
         );
         $users = array_diff($allUsers, $special, $exclude);
+        if (!empty($changes['localOnly'])) {
+            $users = array_diff($users, self::_externalUsers($changes));
+        }
         // Direct membership as roleID => [userIDs].
         $membership = [];
         $rows = self::$DB
@@ -1246,6 +1267,109 @@ class Authorization extends FOGBase
         return false;
     }
     /**
+     * The user ids whose identity is owned by an external provider, after
+     * applying any proposed users.uAuthSource changes.
+     *
+     * Reads the column directly rather than going through Route::getIds()
+     * for the reason rolesHolding() does: an auth source is an opaque
+     * plugin-chosen string, and the query builder rewrites '*' and '+' in a
+     * scalar filter value into a SQL LIKE wildcard. This is a query whose
+     * wrong answer unlocks -- or bricks -- the install, so it owns its SQL.
+     *
+     * @param array $changes the proposed changes; 'authSources' is honoured
+     *
+     * @return array user ids
+     */
+    private static function _externalUsers($changes = [])
+    {
+        $rows = self::$DB
+            ->query('SELECT `uID`, `uAuthSource` FROM `users`')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        $stored = [];
+        foreach ((array)$rows as $row) {
+            $stored[(int)$row['uID']] = (string)$row['uAuthSource'];
+        }
+        return self::externalUsersGiven(
+            $stored,
+            (array)($changes['authSources'] ?? [])
+        );
+    }
+    /**
+     * Which of these accounts an external provider would own.
+     *
+     * The decision half of _externalUsers(), split out because it is the
+     * part with rules in it and the only part testable without a database:
+     * a proposed source REPLACES the stored one rather than adding to it,
+     * and an empty (or whitespace) source means local. Getting either
+     * backwards would make the break-glass guards answer confidently and
+     * wrongly, in the direction that locks an install out.
+     *
+     * @param array $stored   userID => stored users.uAuthSource
+     * @param array $proposed userID => proposed users.uAuthSource
+     *
+     * @return array user ids
+     */
+    public static function externalUsersGiven(array $stored, array $proposed)
+    {
+        foreach ($proposed as $uid => $source) {
+            $stored[(int)$uid] = (string)$source;
+        }
+        $external = [];
+        foreach ($stored as $uid => $source) {
+            if ('' !== trim((string)$source)) {
+                $external[] = (int)$uid;
+            }
+        }
+        return $external;
+    }
+    /**
+     * Is there an administrator who can sign in without a directory?
+     *
+     * @param array $changes the proposed changes (see adminExistsGiven())
+     *
+     * @return bool
+     */
+    public static function localAdminExists($changes = [])
+    {
+        $changes['localOnly'] = true;
+        return self::adminExistsGiven($changes);
+    }
+    /**
+     * Refuses a change that would leave nobody able to administer FOG
+     * without its directory.
+     *
+     * PRESERVES rather than REQUIRES, and the difference matters: it only
+     * refuses when a locally-authenticating administrator exists right now.
+     * An install that has deliberately moved every administrator to a
+     * directory has nothing left for this to protect, and refusing its
+     * operations would brick it to defend a property it already gave up.
+     *
+     * So the rule is "do not be the operation that removes the last one",
+     * which is the same standing property assertAdminRemainsAfterDelete()
+     * holds for administrators in general.
+     *
+     * @param array $changes the proposed changes (see adminExistsGiven())
+     *
+     * @throws Exception when the last local administrator would be lost
+     * @return void
+     */
+    public static function assertLocalAdminRemains($changes = [])
+    {
+        if (!self::localAdminExists()) {
+            return;
+        }
+        if (self::localAdminExists($changes)) {
+            return;
+        }
+        throw new \Exception(
+            _(
+                'This would leave no account able to administer FOG without '
+                . 'its identity provider.'
+            )
+        );
+    }
+    /**
      * Builds the adminExistsGiven() change map for deleting rows of an
      * RBAC-relevant class, then refuses the delete if it would leave the
      * install with no effective administrator.
@@ -1279,6 +1403,13 @@ class Authorization extends FOGBase
         switch (strtolower((string)$classname)) {
             case 'user':
                 $changes = ['excludeUsers' => $ids];
+                // Deleting an administrator can also be what takes away the
+                // last account able to sign in without the directory, and
+                // the check below would not notice: it counts every
+                // administrator, so an install left with nothing but
+                // directory-sourced admins passes it while being one
+                // outage away from locked out.
+                self::assertLocalAdminRemains($changes);
                 break;
             case 'role':
                 $changes = ['removeRoles' => $ids];

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -709,6 +709,7 @@ class User extends FOGController
      */
     public function save()
     {
+        $this->_assertAuthSourceKeepsBreakGlass();
         // Captured before the save, because that is what stamps the id on.
         $isNew = (int)$this->get('id') < 1;
         // Propagate a failed write rather than reporting success; the
@@ -724,6 +725,62 @@ class User extends FOGController
             ->assocSetter('RoleUser', 'role')
             ->assocSetter('UserGroupMember', 'usergroup', true)
             ->load();
+    }
+    /**
+     * Refuses to hand the last local administrator to a directory.
+     *
+     * Writing users.uAuthSource takes local password login away from the
+     * account it is written to (see passwordValidate() above). Doing that to
+     * the last administrator who still has one leaves the install reachable
+     * only while its identity provider is: an outage, an expired client
+     * secret or a mistyped issuer then locks everybody out of their own
+     * server, with no way back in that does not involve the database.
+     *
+     * It sits on save() rather than on each caller because there are three
+     * ways to get here and they have nothing in common: a REST
+     * PUT /fog/user/{id} (uAuthSource is an ordinary field and is not in
+     * Route::$serverOwnedFields), a plugin's own set()/save(), and the CSV
+     * import. Guarding the write is what makes it a standing property
+     * instead of something each new caller has to remember. Delete is
+     * covered separately, by Authorization::assertAdminRemainsAfterDelete().
+     *
+     * Neither bundled auth plugin can reach this: LDAP returns early for an
+     * account that exists and is not already its own, and OIDC stamps only
+     * accounts it created itself. It is the deliberate administrative paths
+     * that were open.
+     *
+     * @throws Exception when the last local administrator would be lost
+     * @return void
+     */
+    private function _assertAuthSourceKeepsBreakGlass()
+    {
+        $id = (int)$this->get('id');
+        /*
+         * A row with no id yet is a new account, which cannot take a login
+         * away from anybody. It cannot quietly become an update either:
+         * users.uName carries a plain KEY and not a UNIQUE one, so there is
+         * no INSERT ... ON DUPLICATE KEY UPDATE by name to ride in on, and
+         * the CSV import refuses a name that already exists before it gets
+         * this far.
+         */
+        if ($id < 1 || !$this->isDirty('authsource')) {
+            return;
+        }
+        $pending = trim((string)$this->get('authsource'));
+        // Clearing it only ever gives an account its password back.
+        if ('' === $pending) {
+            return;
+        }
+        /*
+         * No need to read the stored value to spot a no-op: an account that
+         * is already external stays external under the simulated change, so
+         * the answer is the same with and without it and the assertion
+         * passes. That covers a round-tripping PUT and a re-stamp from one
+         * provider to another without a second query.
+         */
+        Authorization::assertLocalAdminRemains(
+            ['authSources' => [$id => $pending]]
+        );
     }
     /**
      * Adds roles to the user.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7839,6 +7839,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7836,6 +7836,9 @@ msgstr " | This is not the primary group"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8019,6 +8019,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7840,6 +7840,9 @@ msgstr "Dies ist nicht die primäre Gruppe"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7838,6 +7838,9 @@ msgstr " | Cela ne veut pas le groupe principal"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -7542,6 +7542,9 @@ msgstr "Questo non è il gruppo primario"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -7470,6 +7470,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6657,6 +6657,9 @@ msgstr ""
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7837,6 +7837,9 @@ msgstr " | Este não é o grupo primário"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7837,6 +7837,9 @@ msgstr "|这不是主要组"
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
 
+msgid "This would leave no account able to administer FOG without its identity provider."
+msgstr ""
+
 msgid "This would leave no account able to administer FOG."
 msgstr ""
 

--- a/tests/break-glass-auth-sources.test.php
+++ b/tests/break-glass-auth-sources.test.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * An identity provider outage must never lock an install out of itself.
+ *
+ * Phase 2 PR 2.5. FOG can now be signed into by an external provider, and
+ * users.uAuthSource is what says an account belongs to one. That column has
+ * a second effect people do not expect: it makes the account unable to log
+ * in with a local password at all (User::passwordValidate()). So an install
+ * whose every administrator carries one is reachable only while its
+ * directory is -- and an expired client secret, a mistyped issuer or a dead
+ * DC then locks everybody out of their own server, with no way back that
+ * does not involve the database.
+ *
+ * Three properties, and they fail differently:
+ *
+ *   1. Local password login cannot be turned off. Not a setting with a
+ *      scary label -- no setting at all. This one is true today and the
+ *      risk is that somebody adds the setting later meaning well.
+ *   2. No single operation may remove the last administrator who can sign
+ *      in without the directory. Two operations can: writing uAuthSource
+ *      onto them, and deleting them.
+ *   3. The guard PRESERVES, it does not REQUIRE. An install that has
+ *      deliberately moved every administrator to a directory has nothing
+ *      left to protect, and a guard that started refusing its operations
+ *      would brick it to defend a property it already gave up.
+ *
+ * Most of this needs a database -- counting administrators means reading
+ * four tables -- so the decision half was split into
+ * Authorization::externalUsersGiven() and is run for real below. The rest
+ * is pinned by inspecting what the code does, which is enough: every one of
+ * these regresses silently, with a working login and no error anywhere.
+ *
+ * Usage: php tests/break-glass-auth-sources.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$userFile = 'packages/web/lib/fog/user.class.php';
+$authFile = 'packages/web/lib/fog/authorization.class.php';
+
+/**
+ * Source text of one method, comments and whitespace stripped.
+ *
+ * Comments go first so the explanatory prose above each method -- which
+ * names every symbol this test searches for -- cannot satisfy the search on
+ * its own.
+ *
+ * @param string $file   path to read
+ * @param string $method method name to find
+ *
+ * @return string|null code of the body, or null if not found
+ */
+function methodSource($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        $depth = 0;
+        $src = '';
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (is_array($c)
+                && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+            ) {
+                continue;
+            }
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return preg_replace('#\s+#', '', $src);
+                    }
+                }
+            }
+            if ($started) {
+                $src .= is_array($c) ? $c[1] : $c;
+            }
+        }
+        return preg_replace('#\s+#', '', $src);
+    }
+    return null;
+}
+
+/*
+ * 1. Local password login is not configurable.
+ *
+ * The whole break-glass position rests on there being no way to switch the
+ * local path off, so the test is the absence of one: passwordValidate()
+ * must consult no setting at all. A FOG_DISABLE_LOCAL_LOGIN added later
+ * with the best of intentions is exactly the change that would make an IdP
+ * outage unrecoverable, and it would look reasonable in review.
+ */
+$validate = methodSource($userFile, 'passwordValidate');
+if (null === $validate) {
+    $fails[] = 'User::passwordValidate() is missing';
+} else {
+    if (false !== strpos($validate, 'getSetting(')) {
+        $fails[] = 'User::passwordValidate() now reads a setting; local'
+            . ' password login must not be something an install can turn'
+            . ' off, or an identity provider outage has no way back in';
+    }
+    /*
+     * The other half of the same property: an account WITH an auth source
+     * must still be refused a local password, which is what makes a
+     * leftover shadow row harmless when the plugin is gone.
+     *
+     * Both the test and what it is computed FROM. Pinning only the test
+     * leaves $isExternal free to be hardcoded false somewhere above it,
+     * which reads as a tidy-up and turns every abandoned shadow row back
+     * into a login against whatever hash it still carries.
+     */
+    $isExternal = "\$isExternal=(''!==trim((string)\$tmpUser->get("
+        . "'authsource')))";
+    if (false === strpos($validate, $isExternal)) {
+        $fails[] = 'User::passwordValidate() no longer derives $isExternal'
+            . ' from the stored auth source';
+    }
+    if (false === strpos($validate, '$isExternal&&true!==$authenticated')) {
+        $fails[] = 'User::passwordValidate() no longer refuses a local'
+            . ' credential for an externally-sourced account; a leftover'
+            . ' row from an uninstalled auth plugin becomes a login';
+    }
+}
+
+/*
+ * 2a. Writing uAuthSource is guarded, and guarded on save().
+ *
+ * There are three ways to write that column and they have nothing in
+ * common: a REST PUT /fog/user/{id} (it is an ordinary field and not in
+ * Route::$serverOwnedFields), a plugin's own set()/save(), and the CSV
+ * import. Guarding save() is what makes it a standing property rather than
+ * something each new caller has to remember.
+ */
+$save = methodSource($userFile, 'save');
+if (null === $save) {
+    $fails[] = 'User::save() is missing';
+} elseif (false === strpos($save, '_assertAuthSourceKeepsBreakGlass()')) {
+    $fails[] = 'User::save() no longer checks the auth source write; a PUT,'
+        . ' a plugin or a CSV import could hand the last local'
+        . ' administrator to a directory';
+}
+
+$guard = methodSource($userFile, '_assertAuthSourceKeepsBreakGlass');
+if (null === $guard) {
+    $fails[] = 'User::_assertAuthSourceKeepsBreakGlass() is missing';
+} else {
+    if (false === strpos($guard, 'Authorization::assertLocalAdminRemains')) {
+        $fails[] = 'User::_assertAuthSourceKeepsBreakGlass() no longer asks'
+            . ' whether a locally-authenticating administrator would remain';
+    }
+    if (false === strpos($guard, "'authSources'=>[\$id=>\$pending]")) {
+        $fails[] = 'User::_assertAuthSourceKeepsBreakGlass() no longer'
+            . ' simulates the pending value; asking about the state already'
+            . ' stored answers a question nobody asked';
+    }
+    /*
+     * Clearing the column only ever gives an account its password back, and
+     * refusing that would be the guard preventing the very recovery it
+     * exists to protect.
+     */
+    $clearAt = strpos($guard, "if(''===\$pending){return;}");
+    $assertAt = strpos($guard, 'assertLocalAdminRemains');
+    if (false === $clearAt) {
+        $fails[] = 'User::_assertAuthSourceKeepsBreakGlass() no longer lets'
+            . ' an auth source be cleared; that is the recovery path itself';
+    } elseif (false !== $assertAt && $clearAt > $assertAt) {
+        $fails[] = 'User::_assertAuthSourceKeepsBreakGlass() asserts before'
+            . ' letting a clear through, so removing an auth source could be'
+            . ' refused';
+    }
+}
+
+/*
+ * 2b. Deleting an administrator is guarded too.
+ *
+ * Without this half the other one is theater: converting the last local
+ * administrator is refused while deleting the same account is not, and both
+ * leave the install in the identical state.
+ */
+$assertDelete = methodSource($authFile, 'assertAdminRemainsAfterDelete');
+if (null === $assertDelete) {
+    $fails[] = 'Authorization::assertAdminRemainsAfterDelete() is missing';
+} elseif (false === strpos($assertDelete, 'assertLocalAdminRemains(')) {
+    $fails[] = 'Authorization::assertAdminRemainsAfterDelete() no longer'
+        . ' checks the local administrator count; it counts every'
+        . ' administrator, so deleting the last one who can sign in without'
+        . ' the directory passes it';
+}
+
+/*
+ * 3. The guard preserves rather than requires.
+ *
+ * The early return has to come FIRST. An install with no local
+ * administrator today has nothing for this to protect, and a guard that
+ * refused its operations anyway would be defending a property that install
+ * already gave up -- while making it unable to tidy up its own accounts.
+ */
+$assertLocal = methodSource($authFile, 'assertLocalAdminRemains');
+if (null === $assertLocal) {
+    $fails[] = 'Authorization::assertLocalAdminRemains() is missing';
+} else {
+    $bailAt = strpos($assertLocal, 'if(!self::localAdminExists()){return;}');
+    $throwAt = strpos($assertLocal, 'thrownew');
+    if (false === $bailAt) {
+        $fails[] = 'Authorization::assertLocalAdminRemains() no longer'
+            . ' returns early when no local administrator exists; an install'
+            . ' that has already gone all-directory would be unable to'
+            . ' delete or convert anything';
+    } elseif (false === $throwAt || $bailAt > $throwAt) {
+        $fails[] = 'Authorization::assertLocalAdminRemains() can throw before'
+            . ' establishing that there was anything to preserve';
+    }
+}
+
+/*
+ * The auth-source read owns its SQL, for the reason rolesHolding() does: an
+ * auth source is an opaque plugin-chosen string, and '*' or '+' in a scalar
+ * filter value becomes a SQL LIKE wildcard in the query builder. Here that
+ * would mean every account reading as external -- and the guard then
+ * refusing every delete on a perfectly healthy install.
+ */
+$external = methodSource($authFile, '_externalUsers');
+if (null === $external) {
+    $fails[] = 'Authorization::_externalUsers() is missing';
+} else {
+    if (false !== strpos($external, 'Route::getIds')) {
+        $fails[] = 'Authorization::_externalUsers() reads the auth source'
+            . " through Route::getIds(); '*' and '+' in a filter value become"
+            . ' SQL LIKE wildcards, and an auth source is an opaque'
+            . ' plugin-chosen string';
+    }
+    /*
+     * The SELECT itself, not merely a mention of the column. Narrowing the
+     * query while leaving $row['uAuthSource'] in the loop below reads as a
+     * tidy-up and leaves every account looking local, so localAdminExists()
+     * answers exactly what adminExistsGiven() does and the guard silently
+     * never fires again.
+     */
+    if (false === strpos($external, ',`uAuthSource`FROM`users`')) {
+        $fails[] = 'Authorization::_externalUsers() no longer SELECTs'
+            . ' users.uAuthSource; every account would read as local and the'
+            . ' guard would never refuse anything';
+    }
+}
+
+/*
+ * 4. The classifier, for real. Booting the autoloader is enough to reach it
+ *    -- Initiator's constructor only registers the autoloader, and this is a
+ *    pure static method, so no database is involved. FOG_CACHE_DIR and
+ *    friends are redirected into a throwaway directory first; see the long
+ *    note in tests/autoload.test.php for why that line must never become
+ *    conditional.
+ */
+$tmp = sys_get_temp_dir() . '/fog-breakglass-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        foreach (glob($tmp . '/*/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        foreach (glob($tmp . '/*') ?: [] as $d) {
+            @rmdir($d);
+        }
+        @rmdir($tmp);
+    }
+);
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+require_once $root . '/packages/web/commons/init.php';
+new Initiator();
+
+$cases = [
+    'nobody is external' => [
+        [1 => '', 2 => '', 3 => ''],
+        [],
+        []
+    ],
+    'a stored source makes an account external' => [
+        [1 => '', 2 => 'ldap', 3 => ''],
+        [],
+        [2]
+    ],
+    // Whitespace is not an auth source. A column padded by a hand-written
+    // UPDATE would otherwise read as external and take that account out of
+    // the count that decides whether anyone can still get in.
+    'whitespace is local' => [
+        [1 => '   ', 2 => "\t", 3 => ''],
+        [],
+        []
+    ],
+    // The proposed value REPLACES the stored one. Merging instead would
+    // make a conversion invisible, which is the direction that locks the
+    // install out.
+    'a proposal converts a local account' => [
+        [1 => '', 2 => ''],
+        [1 => 'oidc'],
+        [1]
+    ],
+    // And the other way: a proposal that clears the column has to be able
+    // to bring an account back, or the guard could never see a recovery.
+    'a proposal can clear a stored source' => [
+        [1 => 'ldap', 2 => ''],
+        [1 => ''],
+        []
+    ],
+    'a proposal for an unknown id still counts' => [
+        [1 => ''],
+        [7 => 'saml'],
+        [7]
+    ],
+    // Ids arrive as strings from PDO and as int keys from a change map;
+    // the answer is compared with array_diff() against integer user ids, so
+    // a string '2' here would silently fail to exclude user 2.
+    'ids come back as integers' => [
+        ['2' => 'ldap'],
+        [],
+        [2]
+    ],
+];
+foreach ($cases as $label => $case) {
+    list($stored, $proposed, $want) = $case;
+    $got = \FOG\Authorization::externalUsersGiven($stored, $proposed);
+    sort($got);
+    sort($want);
+    if ($got !== $want) {
+        $fails[] = sprintf(
+            'externalUsersGiven, %s: got %s, expected %s',
+            $label,
+            var_export($got, true),
+            var_export($want, true)
+        );
+    }
+    foreach ($got as $id) {
+        if (!is_int($id)) {
+            $fails[] = sprintf(
+                'externalUsersGiven, %s: returned %s, not an int',
+                $label,
+                var_export($id, true)
+            );
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo '  - ' . $f . "\n";
+    }
+    exit(1);
+}
+echo "ok: an identity provider outage cannot lock the install out\n";
+exit(0);


### PR DESCRIPTION
PR 2.5 of Phase 2. Depends on nothing; closes the hole 2.4 opened.

## The problem

FOG can now be signed into by an external provider, and `users.uAuthSource` is what says an account belongs to one. That column has a second effect people do not expect: **it makes the account unable to log in with a local password at all** (`User::passwordValidate()`).

So an install whose every administrator carries one is reachable only while its directory is. An expired client secret, a mistyped issuer or a dead DC then locks everybody out of their own server, with no way back that does not involve the database.

Two operations can take the last such administrator away. Neither was guarded.

| Operation | Why it was open |
|---|---|
| Writing `uAuthSource` onto them | `PUT /fog/user/{id}` — it is an ordinary `$databaseFields` key and `Route::$serverOwnedFields['user']` lists only `token`. Also reachable from a plugin's `set()`/`save()` and from the CSV import. |
| Deleting them | `assertAdminRemainsAfterDelete()` counts *every* administrator, so an install left with nothing but directory-sourced admins passed it while being one outage away from locked out. |

Both halves are needed. Guarding only the conversion is theater — deleting the same account leaves the identical state.

## The shape

`adminExistsGiven()` — the simulator every other lockout guard already goes through — gains two change keys:

- `localOnly` — count only administrators whose `uAuthSource` is empty.
- `authSources` — proposed `uAuthSource` values, so a conversion can be asked about before it is written.

Then `localAdminExists()` and `assertLocalAdminRemains()` on top, called from `User::save()` (via a new private `_assertAuthSourceKeepsBreakGlass()`) and from `assertAdminRemainsAfterDelete()`'s `user` case.

Guarding `save()` rather than each caller is what makes it a standing property instead of something each new caller has to remember. Neither bundled auth plugin can reach it, incidentally: LDAP returns early for an account that exists and is not already its own, and OIDC stamps only accounts it created itself. It was the deliberate administrative paths that were open.

## Two decisions worth stating

**It preserves, it does not require.** `assertLocalAdminRemains()` refuses only when a locally-authenticating administrator exists *right now*. An install that has deliberately moved everybody to a directory has nothing left for this to protect, and refusing its operations would brick it to defend a property it already gave up. The rule is "do not be the operation that removes the last one" — the same standing property `assertAdminRemainsAfterDelete()` already holds for administrators in general.

**A `fog-user-token` does not count as a way in.** It reaches the API and not the UI, and it is a bearer secret that can be rotated, revoked or simply lost. An install whose only remaining way in is a token somebody may no longer have is not one this guard should call safe. Worth knowing it *is* a second, weaker path: token auth never touches a password or `authsource` (`route.class.php:1312`). API **basic** auth is not such a path — `passwordValidate()` fires `USER_LOGGING_IN` and applies the same external gate as the browser.

## The third property needed no code

Nothing in FOG can disable local password login — `passwordValidate()` reads no setting at all. The test is what keeps that true. A `FOG_DISABLE_LOCAL_LOGIN` added later with the best of intentions is exactly the change that would make an outage unrecoverable, and it would look reasonable in review.

## Behavior change

An install with one local admin and five directory admins can no longer delete that local account, or convert it. That is the point, and it is visible. The escape is to give another administrator a local password first.

## Verification

`sh tests/run-all.sh` — **42 passed, 0 failed**. `php-cs-fixer --rules=@PSR2 --dry-run` clean over 478 files in `packages/web` and 38 in `tests`.

`tests/break-glass-auth-sources.test.php` runs `Authorization::externalUsersGiven()` for real over seven cases — including that a proposal *replaces* rather than merges, that whitespace is local, and that ids come back as `int` (they are compared with `array_diff()` against integer user ids, so a string `'2'` would silently fail to exclude user 2). The rest is pinned by inspection, because every one of these regresses silently with a working login and no error anywhere.

Every gate was verified by breaking it and watching the test fail. **Two were too weak on the first pass** and were tightened until the mutation was caught: one pinned the *use* of `$isExternal` but not what it was computed from (so `$isExternal = false;` slipped through), the other a *mention* of `uAuthSource` rather than the `SELECT` (so narrowing the query while leaving `$row['uAuthSource']` in the loop slipped through — which would make every account read as local and the guard never fire again).

Not live-tested against a running install; the guards need a populated `users`/`roleUserAssoc` to exercise, which comes with 2.6's lab pass.

## Downstream

None. No route class added or removed, no schema change, no `globalSettings` row.