### PR TITLE
Run the test suite on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+# A pull_request trigger can only fire from the repository the PR is opened
+# against, so this stub has to live here even though every other fogproject
+# workflow lives in FOGProject/fog-workflows. It is deliberately six lines:
+# all of the logic is in the reusable workflow, so fixing the runner does not
+# mean editing this file on three branches.
+#
+# For pull_request events GitHub reads workflows from the merge of head into
+# base, so one copy on each BASE branch (working-1.6, dev-branch, stable)
+# covers every PR opened against it -- the contributor's branch needs
+# nothing.
+#
+# Not a push trigger, and not because of caution: the runaway that put ~30
+# commits on dev-branch in 20 minutes happened because the triggered
+# workflow pushed a commit back here. This one only reads.
+
+on:
+  pull_request:
+
+jobs:
+  suite:
+    uses: FOGProject/fog-workflows/.github/workflows/fogproject-tests.yml@main


### PR DESCRIPTION
Pairs with FOGProject/fog-workflows#15, which holds the runner. **Merge that one first** — this stub calls it by path, so until it exists on `fog-workflows@main` this workflow fails to resolve.

## Why

The 43 tests in `tests/` have never run anywhere but a developer's terminal. `fog-workflows` holds all of this repository's CI and every workflow there is `schedule:` or `workflow_dispatch:` — there is no `pull_request` trigger in either repo and nothing references `tests/`. Every gate written across the Phase 0–3 modernization is therefore advisory, including the ones that were mutation-verified specifically so they would not be.

## Why a stub here rather than everything in `fog-workflows`

A `pull_request` trigger can only fire from the repository the PR is opened against. Everything else lives in the reusable workflow, so this file should not need editing again — which matters, because for `pull_request` events GitHub reads workflows from head merged into base, so **one copy per base branch** is needed:

| Base branch | Status |
|---|---|
| `working-1.6` | this PR |
| `dev-branch` | needs the same file |
| `stable` | needs the same file |

A contributor's own branch needs nothing.

## Not the push-trigger incident

That runaway happened because the triggered workflow pushed a commit back here, which re-fired the stub. The reusable workflow writes nothing and has no token beyond the caller's read-only `GITHUB_TOKEN`. It is also `pull_request`, not `push`.

## Verification

Ran the suite in a real `php:7.4-cli` container: 43 passed, 0 failed with `git` and the `gettext` extension present, and 7 failures without them — which is why the runner declares both. Same 43/43 on 8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR