### PR TITLE
Inherit site scope from a role or a user group

### DIFF
--- a/bin/schema-manifest.php
+++ b/bin/schema-manifest.php
@@ -211,7 +211,12 @@ if ($cmd === 'generate') {
         . " *\n"
         . " * Consumed by SchemaReconciler::reconcile().\n"
         . " *\n"
-        . " * PHP version 5\n"
+        // The enforced floor, not the historic boilerplate. The 727-file
+        // sweep off "PHP version 5" fixed the manifest but not the generator
+        // that writes it, so the next regeneration silently reverted the file
+        // and failed tests/php-version-docblocks.test.php -- a generated
+        // artifact drifting back because only its output was corrected.
+        . " * PHP version 7.4+\n"
         . " *\n"
         . " * @category SchemaExpected\n"
         . " * @package  FOGProject\n"

--- a/docs/adr/0006-site-object-scope-boundary.md
+++ b/docs/adr/0006-site-object-scope-boundary.md
@@ -85,3 +85,66 @@ client could flip it and escape filtering; `$apiRequest` cannot be spoofed.
   get an off record count — never out-of-scope data, only a wrong total.
 - Unrestricted users (implicit admins, `*` holders) are unaffected; the
   boundary only ever narrows a user who already holds a restricting role.
+
+## Amendment — scope is inherited from a role or a user group (schema 335)
+
+This ADR describes assignment as explicit and per-user, and for the plugin it
+was. Core keeps that as the base case and adds two ways a site can reach a user
+without naming them.
+
+### Grant is a different relation from membership
+
+`siteUserGroupMembers` and `siteUserGroupGrants` hold the same two ids in the
+same order and answer opposite questions:
+
+| | Means |
+|---|---|
+| **Member** | this user group **is in** the site — one of the objects it contains, visible and editable to that site's admins |
+| **Grant** | members of this user group **get** the site — holding it is what puts you in scope |
+
+They are separate tables because overloading one would cost the ability to grant
+somebody access to a site without also making the group they arrived through an
+editable object inside it, and it would never fail loudly — it would quietly
+widen what site-scoped admins can reach. Roles have no membership sense, so
+`siteRoleGrants` has no counterpart.
+
+### Four arms, in one place
+
+`SiteScope::userSiteIDs()` remains the only answer to "which sites is this user
+in". It now unions four reachability paths: direct membership, a grant to a user
+group the user is in, and a grant to a role — held directly, or held through a
+user group.
+
+The fourth exists because `Authorization::getPermissions()` already grants
+permissions along both role paths. A role that granted its site only when
+assigned directly would produce a user holding the permission to edit hosts and
+no hosts to edit.
+
+`UNION`, not `UNION ALL`: the result is a set, so "most open wins" is true by
+construction rather than by a precedence rule. The consequence that matters is
+that inheritance can only ever **add** sites — no arrangement of grants takes
+away a site a direct membership already gave, so no user on any install loses
+access.
+
+### `isUnscoped()` asks over the same SQL
+
+Not tidiness. Its original query read direct membership only, so granting a role
+the **catch-all** site would have put the catch-all's id in the user's list while
+leaving `isUnscoped()` false — and because catch-all membership short-circuits
+above the per-site query, the user would have been scoped to the one site that
+means "no restriction", and seen nothing. Single-sourcing the SQL makes the two
+answers unable to disagree.
+
+### Consequences
+
+- Deleting a role or a user group clears its grants, and deleting a site clears
+  both grant lists. A grant row surviving its subject is worse than a stale
+  membership row: AUTO_INCREMENT ids are reused, so it can put every holder of
+  an unrelated new role into the site the old one granted.
+- The grant classes are not in `Route::$validClasses`, matching the four
+  membership classes. `Route::getIds()` does not need it, and adding them would
+  be two new REST resources — an access-control surface, and a separate
+  decision.
+- Nothing changes on upgrade day. Both tables start empty, three of the four
+  arms return nothing, and `userSiteIDs()` answers exactly what it answered
+  before until an administrator creates a grant.

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -637,6 +637,15 @@ return [
                 'shmHostID' => 'int(11) NOT NULL',
             ],
         ],
+        'siteRoleGrants' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteRoleGrants` ( `srgID` int(11) NOT NULL AUTO_INCREMENT, `srgName` varchar(60) NOT NULL DEFAULT \'\', `srgSiteID` int(11) NOT NULL, `srgRoleID` int(11) NOT NULL, PRIMARY KEY (`srgID`), UNIQUE KEY `srgSiteRole` (`srgSiteID`,`srgRoleID`), KEY `srgRoleID` (`srgRoleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'srgID' => 'int(11) NOT NULL',
+                'srgName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'srgSiteID' => 'int(11) NOT NULL',
+                'srgRoleID' => 'int(11) NOT NULL',
+            ],
+        ],
         'sites' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `sites` ( `siteID` int(11) NOT NULL AUTO_INCREMENT, `siteName` varchar(255) NOT NULL, `siteDesc` longtext NOT NULL, `siteCatchAll` tinyint(1) unsigned DEFAULT NULL, PRIMARY KEY (`siteID`), UNIQUE KEY `siteName` (`siteName`), UNIQUE KEY `siteCatchAll` (`siteCatchAll`), CONSTRAINT `siteCatchAllIsOneOrNull` CHECK (`siteCatchAll` = 1) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
@@ -644,6 +653,15 @@ return [
                 'siteName' => 'varchar(255) NOT NULL',
                 'siteDesc' => 'longtext NOT NULL',
                 'siteCatchAll' => 'tinyint(1) unsigned DEFAULT NULL',
+            ],
+        ],
+        'siteUserGroupGrants' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `siteUserGroupGrants` ( `suggID` int(11) NOT NULL AUTO_INCREMENT, `suggName` varchar(60) NOT NULL DEFAULT \'\', `suggSiteID` int(11) NOT NULL, `suggGroupID` int(11) NOT NULL, PRIMARY KEY (`suggID`), UNIQUE KEY `suggSiteGroup` (`suggSiteID`,`suggGroupID`), KEY `suggGroupID` (`suggGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'suggID' => 'int(11) NOT NULL',
+                'suggName' => 'varchar(60) NOT NULL DEFAULT \'\'',
+                'suggSiteID' => 'int(11) NOT NULL',
+                'suggGroupID' => 'int(11) NOT NULL',
             ],
         ],
         'siteUserGroupMembers' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5632,3 +5632,58 @@ $this->schema[] = [
         return true;
     },
 ];
+// 335
+$this->schema[] = [
+    // Site scope inherited from a role or a user group.
+    //
+    // Today a site is assigned one user at a time (`siteUserMembers`), so a
+    // fifty-person helpdesk covering two sites is a hundred rows kept by
+    // hand, and a new starter is out of scope until somebody remembers
+    // them. Both facts needed to fix that already exist -- the user is in a
+    // user group and holds a role -- and neither carries a site.
+    //
+    // GRANT, not MEMBER, and the two are not the same relation even though
+    // they hold the same two ids. `siteUserGroupMembers` means "this user
+    // group IS IN this site": it is one of the objects the site contains,
+    // and a site-scoped admin may see and edit it. `siteUserGroupGrants`
+    // means "members of this user group GET this site": holding it is what
+    // puts you in scope. Overloading one table for both would save a table
+    // and cost the ability to grant somebody access to a site without also
+    // making their group an editable object inside it -- which is the
+    // distinction sites exist to draw. It would also never fail loudly; it
+    // would just quietly widen what site-scoped admins can reach.
+    //
+    // Empty and unread at this step. Nothing queries these until
+    // SiteScope::userSiteIDs() grows its arms, so this is inert on any
+    // server that applies it.
+    //
+    // Shape copied from the four membership tables deliberately, `*Name`
+    // column included even though nothing reads it: Route::ids() orders by
+    // name and assocSetter() derives its column from the class name, so a
+    // table that departs from the pattern stops working with the shared
+    // association machinery.
+    //
+    // The UNIQUE covers every non-id column but the name. That is the case
+    // where FOGController::save()'s INSERT ... ON DUPLICATE KEY UPDATE has
+    // nothing to destroy -- it can only rewrite the row it matched on --
+    // rather than the silent-overwrite bug class the site tables above
+    // needed repair closures for.
+    "CREATE TABLE IF NOT EXISTS `siteRoleGrants` ("
+    . "`srgID` INT NOT NULL AUTO_INCREMENT,"
+    . "`srgName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`srgSiteID` INT NOT NULL,"
+    . "`srgRoleID` INT NOT NULL,"
+    . "PRIMARY KEY (`srgID`),"
+    . "UNIQUE KEY `srgSiteRole` (`srgSiteID`,`srgRoleID`),"
+    . "KEY `srgRoleID` (`srgRoleID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `siteUserGroupGrants` ("
+    . "`suggID` INT NOT NULL AUTO_INCREMENT,"
+    . "`suggName` VARCHAR(60) NOT NULL DEFAULT '',"
+    . "`suggSiteID` INT NOT NULL,"
+    . "`suggGroupID` INT NOT NULL,"
+    . "PRIMARY KEY (`suggID`),"
+    . "UNIQUE KEY `suggSiteGroup` (`suggSiteID`,`suggGroupID`),"
+    . "KEY `suggGroupID` (`suggGroupID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci ROW_FORMAT=DYNAMIC",
+];

--- a/packages/web/lib/fog/site.class.php
+++ b/packages/web/lib/fog/site.class.php
@@ -80,6 +80,13 @@ class Site extends FOGController
         'hosts',
         'groups',
         'usergroups',
+        // The grant side. `usergroups` above means "this user group is an
+        // OBJECT in this site"; `grantusergroups` means "members of this
+        // user group GET this site". Same pair of ids, opposite question,
+        // which is why they are separate tables and separate fields --
+        // see SiteUserGroupGrant.
+        'grantroles',
+        'grantusergroups',
         'catchall'
     ];
     /**
@@ -213,6 +220,60 @@ class Site extends FOGController
         return $this->addRemItem('usergroups', (array)$removeArray, 'diff');
     }
     /**
+     * Grant this site to a role.
+     *
+     * Everyone holding the role is in scope for this site, including
+     * through a user group that holds it -- SiteScope resolves both paths.
+     *
+     * @param array $addArray The roles to grant to.
+     *
+     * @return object
+     */
+    public function addGrantRole($addArray)
+    {
+        return $this->addRemItem('grantroles', (array)$addArray, 'merge');
+    }
+    /**
+     * Stop granting this site to a role.
+     *
+     * @param array $removeArray The roles to stop granting to.
+     *
+     * @return object
+     */
+    public function removeGrantRole($removeArray)
+    {
+        return $this->addRemItem('grantroles', (array)$removeArray, 'diff');
+    }
+    /**
+     * Grant this site to a user group.
+     *
+     * Not the same act as adding the user group to the site: that makes it
+     * an object the site contains, this puts its members in scope.
+     *
+     * @param array $addArray The user groups to grant to.
+     *
+     * @return object
+     */
+    public function addGrantUserGroup($addArray)
+    {
+        return $this->addRemItem('grantusergroups', (array)$addArray, 'merge');
+    }
+    /**
+     * Stop granting this site to a user group.
+     *
+     * @param array $removeArray The user groups to stop granting to.
+     *
+     * @return object
+     */
+    public function removeGrantUserGroup($removeArray)
+    {
+        return $this->addRemItem(
+            'grantusergroups',
+            (array)$removeArray,
+            'diff'
+        );
+    }
+    /**
      * Stores/updates the site.
      *
      * @return object
@@ -232,6 +293,8 @@ class Site extends FOGController
             ->assocSetter('SiteHostMember', 'host', true)
             ->assocSetter('SiteGroupMember', 'group', true)
             ->assocSetter('SiteUserGroupMember', 'usergroup', true)
+            ->assocSetter('SiteRoleGrant', 'grantrole', true)
+            ->assocSetter('SiteUserGroupGrant', 'grantusergroup', true)
             ->load();
     }
     /**
@@ -338,6 +401,36 @@ class Site extends FOGController
         $this->set(
             'usergroups',
             (array)Route::getIds('siteusergroupmember', $find, 'usergroupID')
+        );
+    }
+    /**
+     * Load the roles this site is granted to.
+     *
+     * @return void
+     */
+    protected function loadGrantroles()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'grantroles',
+            (array)Route::getIds('siterolegrant', $find, 'grantroleID')
+        );
+    }
+    /**
+     * Load the user groups this site is granted to.
+     *
+     * @return void
+     */
+    protected function loadGrantusergroups()
+    {
+        $find = ['siteID' => $this->get('id')];
+        $this->set(
+            'grantusergroups',
+            (array)Route::getIds(
+                'siteusergroupgrant',
+                $find,
+                'grantusergroupID'
+            )
         );
     }
     /**

--- a/packages/web/lib/fog/siterolegrant.class.php
+++ b/packages/web/lib/fog/siterolegrant.class.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Grant association between site -> role links.
+ *
+ * PHP version 7.4+
+ *
+ * @category SiteRoleGrant
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * Grant association between site -> role links.
+ *
+ * A GRANT, not a membership, and the difference is the reason this table
+ * exists rather than being folded into one of the four `site*Members`
+ * tables. A membership says an object IS IN a site and may be seen and
+ * edited by that site's admins. A grant says holders of this role GET this
+ * site -- it is what puts a user in scope in the first place. The two hold
+ * the same pair of ids and answer opposite questions.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives grants through this association the
+ * same way it drives membership through SiteUserMember.
+ *
+ * @category SiteRoleGrant
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteRoleGrant extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteRoleGrants';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'srgID',
+        'name' => 'srgName',
+        'siteID' => 'srgSiteID',
+        'roleID' => 'srgRoleID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'roleID'
+    ];
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteRoleGrant', 'SiteRoleGrant');

--- a/packages/web/lib/fog/siterolegrant.class.php
+++ b/packages/web/lib/fog/siterolegrant.class.php
@@ -50,7 +50,7 @@ class SiteRoleGrant extends FOGController
         'id' => 'srgID',
         'name' => 'srgName',
         'siteID' => 'srgSiteID',
-        'roleID' => 'srgRoleID'
+        'grantroleID' => 'srgRoleID'
     ];
     /**
      * The required fields.
@@ -59,7 +59,7 @@ class SiteRoleGrant extends FOGController
      */
     protected $databaseFieldsRequired = [
         'siteID',
-        'roleID'
+        'grantroleID'
     ];
 }
 

--- a/packages/web/lib/fog/siterolegrantmanager.class.php
+++ b/packages/web/lib/fog/siterolegrantmanager.class.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * SiteRoleGrant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category SiteRoleGrantManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * SiteRoleGrant manager class.
+ *
+ * @category SiteRoleGrantManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteRoleGrantManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteRoleGrants';
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteRoleGrantManager', 'SiteRoleGrantManager');

--- a/packages/web/lib/fog/sitescope.class.php
+++ b/packages/web/lib/fog/sitescope.class.php
@@ -259,27 +259,91 @@ class SiteScope extends FOGBase
     {
         $userID = (int)$userID;
         if (!array_key_exists($userID, self::$_catchAll)) {
+            // Asks the same reachability question userSiteIDs() asks, over
+            // the same SQL, rather than keeping a second copy of the arms.
+            // If these two ever disagreed the failure would be silent and
+            // backwards: granting a role the catch-all site would put its
+            // id in the user's list while leaving isUnscoped() false, so
+            // the user would be scoped to a site nothing is explicitly
+            // assigned to -- which is deny-all wearing the name of the
+            // site that means "no restriction".
             self::$_catchAll[$userID] = self::_count(
-                'SELECT COUNT(*) AS `cnt` FROM `siteUserMembers` `m` '
-                . 'INNER JOIN `sites` `s` ON `s`.`siteID` = `m`.`sumSiteID` '
-                . 'WHERE `m`.`sumUserID` = :uid '
-                . 'AND `s`.`siteCatchAll` IS NOT NULL',
-                ['uid' => $userID]
+                'SELECT COUNT(*) AS `cnt` FROM `sites` `s` '
+                . 'WHERE `s`.`siteCatchAll` IS NOT NULL '
+                . 'AND `s`.`siteID` IN (' . self::_reachableSitesSql() . ')',
+                self::_reachableSitesParams($userID)
             ) > 0;
         }
         return self::$_catchAll[$userID];
     }
     /**
+     * The SQL answering "which sites can this user reach, and how".
+     *
+     * Four arms, and the count is not arbitrary. A site reaches a user
+     * directly, through a user group, or through a role -- and a role
+     * itself reaches a user by two paths, assigned to them or assigned to
+     * a group they are in. Authorization::getPermissions() already grants
+     * permissions along both of those role paths, so a role that granted
+     * its site only when assigned directly would produce a user holding
+     * the permission to edit hosts and no hosts to edit.
+     *
+     * UNION rather than UNION ALL: the result is a set. That is what makes
+     * "most open wins" true by construction instead of by a precedence
+     * rule somebody has to remember, and it is why inheritance can only
+     * ever ADD sites -- no configuration of grants can take away a site a
+     * direct membership already gave.
+     *
+     * Separate placeholder names per arm because the layer binds by name,
+     * so one name reused across four arms binds once and leaves three
+     * unbound.
+     *
+     * @return string the SQL
+     */
+    private static function _reachableSitesSql()
+    {
+        return 'SELECT `sumSiteID` AS `siteID` FROM `siteUserMembers` '
+            . 'WHERE `sumUserID` = :uid '
+            . 'UNION '
+            . 'SELECT `suggSiteID` FROM `siteUserGroupGrants` '
+            . 'INNER JOIN `userGroupMembers` '
+            . 'ON `ugmGroupID` = `suggGroupID` '
+            . 'WHERE `ugmUserID` = :uidgroup '
+            . 'UNION '
+            . 'SELECT `srgSiteID` FROM `siteRoleGrants` '
+            . 'INNER JOIN `roleUserAssoc` ON `ruaRoleID` = `srgRoleID` '
+            . 'WHERE `ruaUserID` = :uidrole '
+            . 'UNION '
+            . 'SELECT `srgSiteID` FROM `siteRoleGrants` '
+            . 'INNER JOIN `roleUserGroupAssoc` ON `rugRoleID` = `srgRoleID` '
+            . 'INNER JOIN `userGroupMembers` ON `ugmGroupID` = `rugGroupID` '
+            . 'WHERE `ugmUserID` = :uidrolegroup';
+    }
+    /**
+     * The bindings _reachableSitesSql() expects.
+     *
+     * @param int $userID the acting user id
+     *
+     * @return array
+     */
+    private static function _reachableSitesParams($userID)
+    {
+        $userID = (int)$userID;
+        return [
+            'uid' => $userID,
+            'uidgroup' => $userID,
+            'uidrole' => $userID,
+            'uidrolegroup' => $userID
+        ];
+    }
+    /**
      * The site ids a user belongs to. Empty means deny-all, not allow-all.
      *
-     * Direct membership only, matching what the plugin enforced. This is
-     * deliberately the ONLY place that answers "which sites is this user
-     * in", so that inherited membership -- via a user group, or via a role
-     * -- is one more UNION arm here and not a second rule somewhere else.
-     * Both joins already exist (`userGroupMembers`, `roleUserAssoc`); what
-     * is missing is the site-side edge, and adding one is a schema step
-     * plus an arm in this query. Nothing else in this class changes,
-     * because everything downstream consumes the list this returns.
+     * Direct membership, plus membership inherited from a user group or a
+     * role. This is deliberately the ONLY place that answers "which sites
+     * is this user in", so each way of reaching a site is one more UNION
+     * arm in _reachableSitesSql() and not a second rule somewhere else.
+     * Nothing else in this class changes, because everything downstream
+     * consumes the list this returns.
      *
      * Note that inherited membership only ever ADDS sites. Union semantics
      * are what make "most open wins" true by construction rather than by a
@@ -298,15 +362,17 @@ class SiteScope extends FOGBase
         $ids = [];
         try {
             $res = self::$DB->query(
-                'SELECT `sumSiteID` FROM `siteUserMembers` '
-                . 'WHERE `sumUserID` = :uid',
+                self::_reachableSitesSql(),
                 [],
-                ['uid' => $userID]
+                self::_reachableSitesParams($userID)
             );
             if (false === $res->error) {
                 $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
                 foreach ((array)$rows as $row) {
-                    $ids[] = (int)$row['sumSiteID'];
+                    // Aliased to `siteID` by the first arm; a UNION takes
+                    // its column names from the leading SELECT, so the
+                    // three grant arms land under the same key.
+                    $ids[] = (int)$row['siteID'];
                 }
             }
         } catch (\Exception $e) {

--- a/packages/web/lib/fog/siteusergroupgrant.class.php
+++ b/packages/web/lib/fog/siteusergroupgrant.class.php
@@ -52,7 +52,7 @@ class SiteUserGroupGrant extends FOGController
         'id' => 'suggID',
         'name' => 'suggName',
         'siteID' => 'suggSiteID',
-        'usergroupID' => 'suggGroupID'
+        'grantusergroupID' => 'suggGroupID'
     ];
     /**
      * The required fields.
@@ -61,7 +61,7 @@ class SiteUserGroupGrant extends FOGController
      */
     protected $databaseFieldsRequired = [
         'siteID',
-        'usergroupID'
+        'grantusergroupID'
     ];
 }
 

--- a/packages/web/lib/fog/siteusergroupgrant.class.php
+++ b/packages/web/lib/fog/siteusergroupgrant.class.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Grant association between site -> user group links.
+ *
+ * PHP version 7.4+
+ *
+ * @category SiteUserGroupGrant
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * Grant association between site -> user group links.
+ *
+ * Not to be confused with SiteUserGroupMember, which holds the same two ids
+ * in the same order and means the opposite thing. That one says a user group
+ * IS IN a site -- it is one of the objects the site contains, visible and
+ * editable to that site's admins. This one says members of this user group
+ * GET this site, which is what puts them in scope at all.
+ *
+ * Keeping them apart is what allows granting somebody access to a site
+ * without also making the group they arrived through an object inside it.
+ *
+ * The friendly `siteID` key matches assocSetter's derivation from the Site
+ * class name, so a site's save() drives grants through this association the
+ * same way it drives membership through SiteUserGroupMember.
+ *
+ * @category SiteUserGroupGrant
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserGroupGrant extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'siteUserGroupGrants';
+    /**
+     * The table fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'suggID',
+        'name' => 'suggName',
+        'siteID' => 'suggSiteID',
+        'usergroupID' => 'suggGroupID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'siteID',
+        'usergroupID'
+    ];
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserGroupGrant', 'SiteUserGroupGrant');

--- a/packages/web/lib/fog/siteusergroupgrantmanager.class.php
+++ b/packages/web/lib/fog/siteusergroupgrantmanager.class.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * SiteUserGroupGrant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category SiteUserGroupGrantManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * SiteUserGroupGrant manager class.
+ *
+ * @category SiteUserGroupGrantManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SiteUserGroupGrantManager extends FOGManagerController
+{
+    /**
+     * The base table name.
+     *
+     * @var string
+     */
+    public $tablename = 'siteUserGroupGrants';
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\SiteUserGroupGrantManager', 'SiteUserGroupGrantManager');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 334);
+        define('FOG_SCHEMA', 335);
         define('FOG_BCACHE_VER', 283);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 335);
-        define('FOG_BCACHE_VER', 283);
+        define('FOG_BCACHE_VER', 284);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -440,6 +440,64 @@ class SiteManagement extends FOGPage
         $this->assocPost('addUserGroup', 'removeUserGroup');
     }
     /**
+     * Presents the roles this site is granted to.
+     *
+     * Separate from the four association tabs above because it answers the
+     * opposite question. Those say which objects the site CONTAINS; this
+     * says who the site is GIVEN TO -- everyone holding the role is in
+     * scope for it, including through a user group that holds the role.
+     *
+     * @return void
+     */
+    public function siteGrantRoles()
+    {
+        $this->renderAssocTab(
+            'site-grantrole',
+            _('Site Granted To Roles'),
+            _('Role Name'),
+            'role',
+            'btn btn-primary float-end',
+            '',
+            'role'
+        );
+    }
+    /**
+     * Updates the roles this site is granted to.
+     *
+     * @return void
+     */
+    public function siteGrantRolePost()
+    {
+        $this->assocPost('addGrantRole', 'removeGrantRole');
+    }
+    /**
+     * Presents the user groups this site is granted to.
+     *
+     * @return void
+     */
+    public function siteGrantUserGroups()
+    {
+        $this->renderAssocTab(
+            'site-grantusergroup',
+            _('Site Granted To User Groups'),
+            _('User Group Name'),
+            'usergroup',
+            'btn btn-primary float-end',
+            '',
+            'usergroup',
+            _('User Group')
+        );
+    }
+    /**
+     * Updates the user groups this site is granted to.
+     *
+     * @return void
+     */
+    public function siteGrantUserGroupPost()
+    {
+        $this->assocPost('addGrantUserGroup', 'removeGrantUserGroup');
+    }
+    /**
      * Edit existing item.
      *
      * @return void
@@ -491,6 +549,35 @@ class SiteManagement extends FOGPage
                 ]
             ]
         ];
+
+        // Grants sit in their own group rather than beside the four
+        // associations, because the two read alike and mean opposite
+        // things. "User Group Association" puts a user group IN this site
+        // as an object; "Granted To User Groups" puts its members in scope
+        // for it. Same picker, same list of names, and mixing them into one
+        // row of tabs is how somebody grants a site while meaning to
+        // catalogue one.
+        $tabData[] = [
+            'tabs' => [
+                'name' => _('Granted To'),
+                'tabData' => [
+                    [
+                        'name' => _('Roles'),
+                        'id' => 'site-grantrole',
+                        'generator' => function () {
+                            $this->siteGrantRoles();
+                        }
+                    ],
+                    [
+                        'name' => _('User Groups'),
+                        'id' => 'site-grantusergroup',
+                        'generator' => function () {
+                            $this->siteGrantUserGroups();
+                        }
+                    ]
+                ]
+            ]
+        ];
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -523,6 +610,12 @@ class SiteManagement extends FOGPage
                         break;
                     case 'site-usergroup':
                         $this->siteUserGroupPost();
+                        break;
+                    case 'site-grantrole':
+                        $this->siteGrantRolePost();
+                        break;
+                    case 'site-grantusergroup':
+                        $this->siteGrantUserGroupPost();
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;
@@ -614,6 +707,61 @@ class SiteManagement extends FOGPage
             '`userGroups`.`ugID`',
             '`siteUserGroupMembers`.`sugmUserGroupID`',
             '`siteUserGroupMembers`.`sugmSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+    /**
+     * Gets the list of roles this site is granted to.
+     *
+     * Its own endpoint rather than a flag on getRolesList, because the
+     * `association` column is what the tab ticks and it has to come from
+     * the GRANT table -- reusing the membership list here would tick boxes
+     * from the wrong relation.
+     *
+     * @return void
+     */
+    public function getGrantRolesList()
+    {
+        return $this->assocItemsList(
+            'role',
+            'siterolegrant',
+            'siteRoleGrants',
+            '`roles`.`rID`',
+            '`siteRoleGrants`.`srgRoleID`',
+            '`siteRoleGrants`.`srgSiteID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
+    }
+    /**
+     * Gets the list of user groups this site is granted to.
+     *
+     * Separate from getUserGroupsList() for the same reason, and the pair
+     * is the one place the two senses are most likely to be confused: same
+     * node, same names, different relation.
+     *
+     * @return void
+     */
+    public function getGrantUserGroupsList()
+    {
+        return $this->assocItemsList(
+            'usergroup',
+            'siteusergroupgrant',
+            'siteUserGroupGrants',
+            '`userGroups`.`ugID`',
+            '`siteUserGroupGrants`.`suggGroupID`',
+            '`siteUserGroupGrants`.`suggSiteID`',
             [
                 [
                     'db' => 'siteAssoc',

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -5390,7 +5390,13 @@ class Route extends FOGBase
                         'sitehostmember' => $findWhere,
                         'siteusermember' => $findWhere,
                         'sitegroupmember' => $findWhere,
-                        'siteusergroupmember' => $findWhere
+                        'siteusergroupmember' => $findWhere,
+                        // ...and the two grant lists. A grant naming a
+                        // site that no longer exists would keep putting
+                        // its holders "in scope" for an id that resolves
+                        // to nothing, which reads as deny-all.
+                        'siterolegrant' => $findWhere,
+                        'siteusergroupgrant' => $findWhere
                     ];
                     break;
                 default:
@@ -5421,6 +5427,26 @@ class Route extends FOGBase
                 $removeItems[$siteMemberTables[$classname]] = [
                     $classname . 'ID' => $itemIDs
                 ];
+            }
+
+            // The grant side of the same cleanup, and the same id-reuse
+            // hazard with a sharper edge: a grant row left behind by a
+            // deleted role can later put every holder of an unrelated NEW
+            // role into the site the old one granted. Membership leaks one
+            // object into a site; a stale grant leaks a whole population.
+            //
+            // Its own map rather than an entry in the one above because
+            // that one derives the column as "{$classname}ID", and these
+            // columns are grantroleID and grantusergroupID -- the "grant"
+            // prefix being what keeps them distinct from the membership
+            // sense of the same two ids.
+            $siteGrantTables = [
+                'role' => ['siterolegrant', 'grantroleID'],
+                'usergroup' => ['siteusergroupgrant', 'grantusergroupID']
+            ];
+            if (isset($siteGrantTables[$classname])) {
+                list($grantTable, $grantCol) = $siteGrantTables[$classname];
+                $removeItems[$grantTable] = [$grantCol => $itemIDs];
             }
 
             self::$HookManager->processEvent(

--- a/packages/web/management/js/fog/site/fog.site.edit.js
+++ b/packages/web/management/js/fog/site/fog.site.edit.js
@@ -38,6 +38,25 @@ $(function() {
     });
 
     // ---------------------------------------------------------------
+    // GRANTED TO TABS
+    // The opposite direction from the four above: those say which objects
+    // this site contains, these say who the site is given to. Same picker
+    // and the same list of names, so they get their own sub -- the
+    // `association` column has to come from the grant table or the tab
+    // ticks boxes from the wrong relation.
+    var siteGrantRolesTable = $.registerAssociationTab({
+        slug: 'site-grantrole',
+        item: 'role',
+        sub: 'getGrantRolesList'
+    });
+
+    var siteGrantUserGroupsTable = $.registerAssociationTab({
+        slug: 'site-grantusergroup',
+        item: 'usergroup',
+        sub: 'getGrantUserGroupsList'
+    });
+
+    // ---------------------------------------------------------------
     // CREATE AND ASSOCIATE
     // Each association tab can create the thing it associates without
     // leaving the page. These are grid tabs, so the modal posts additems[]
@@ -46,11 +65,18 @@ $(function() {
     $.registerCreateAndAssociate('site-user', siteUsersTable);
     $.registerCreateAndAssociate('site-group', siteGroupsTable);
     $.registerCreateAndAssociate('site-usergroup', siteUserGroupsTable);
+    $.registerCreateAndAssociate('site-grantrole', siteGrantRolesTable);
+    $.registerCreateAndAssociate(
+        'site-grantusergroup',
+        siteGrantUserGroupsTable
+    );
 
     if (Common.search && Common.search.length > 0) {
         siteHostsTable.search(Common.search).draw();
         siteUsersTable.search(Common.search).draw();
         siteGroupsTable.search(Common.search).draw();
         siteUserGroupsTable.search(Common.search).draw();
+        siteGrantRolesTable.search(Common.search).draw();
+        siteGrantUserGroupsTable.search(Common.search).draw();
     }
 });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2728,6 +2728,10 @@ msgstr "Standort aktualisiert"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Erstellt von"
+
 msgid "Grants"
 msgstr ""
 
@@ -6583,6 +6587,14 @@ msgstr "Drucker hinzufügen erfolgreich."
 #, fuzzy
 msgid "Site Description"
 msgstr "Site Beschreibung"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2730,6 +2730,10 @@ msgstr "Location Updated"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Created By"
+
 msgid "Grants"
 msgstr ""
 
@@ -6583,6 +6587,14 @@ msgstr "Printer already exists"
 #, fuzzy
 msgid "Site Description"
 msgstr "Printer Description"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Printer already exists"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Create New %s"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2785,6 +2785,10 @@ msgstr "información de LDAP actualizado!"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Creado"
+
 msgid "Grants"
 msgstr ""
 
@@ -6739,6 +6743,14 @@ msgstr "Impresora ya existe"
 #, fuzzy
 msgid "Site Description"
 msgstr "Descripción de la impresora"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Impresora ya existe"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Crear nuevo grupo"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2728,6 +2728,10 @@ msgstr "Standort aktualisiert"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Erstellt von"
+
 msgid "Grants"
 msgstr ""
 
@@ -6584,6 +6588,14 @@ msgstr "Drucker hinzufügen erfolgreich."
 #, fuzzy
 msgid "Site Description"
 msgstr "Site Beschreibung"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2732,6 +2732,10 @@ msgstr "Emplacement Mise à jour"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Créé par"
+
 msgid "Grants"
 msgstr ""
 
@@ -6585,6 +6589,14 @@ msgstr "Imprimante existe déjà"
 #, fuzzy
 msgid "Site Description"
 msgstr "Printer description"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Imprimante existe déjà"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Créer un nouveau %s"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2643,6 +2643,10 @@ msgstr "Posizione aggiornata!"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Creato da"
+
 msgid "Grants"
 msgstr ""
 
@@ -6349,6 +6353,14 @@ msgstr "Creazione stampante riuscita"
 
 msgid "Site Description"
 msgstr "Descrizione Sito"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Creazione stampante riuscita"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Crea nuovo %s"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2615,6 +2615,10 @@ msgstr "ロケーションを更新しました！"
 msgid "Got in line at"
 msgstr "キューに登録されました:"
 
+#, fuzzy
+msgid "Granted To"
+msgstr "ジョブ作成時刻"
+
 msgid "Grants"
 msgstr ""
 
@@ -6289,6 +6293,14 @@ msgstr "サイトを作成しました"
 
 msgid "Site Description"
 msgstr "サイトの説明"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "サイトを作成しました"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "新しいサブネットグループを作成しますか？"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2326,6 +2326,9 @@ msgstr ""
 msgid "Got in line at"
 msgstr ""
 
+msgid "Granted To"
+msgstr ""
+
 msgid "Grants"
 msgstr ""
 
@@ -5586,6 +5589,12 @@ msgid "Site Create Success"
 msgstr ""
 
 msgid "Site Description"
+msgstr ""
+
+msgid "Site Granted To Roles"
+msgstr ""
+
+msgid "Site Granted To User Groups"
 msgstr ""
 
 msgid "Site Group Associations"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2731,6 +2731,10 @@ msgstr "Localização Atualizado"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "Criado por"
+
 msgid "Grants"
 msgstr ""
 
@@ -6584,6 +6588,14 @@ msgstr "Impressora já existe"
 #, fuzzy
 msgid "Site Description"
 msgstr "Descrição Printer"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "Impressora já existe"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "Criar novo %s"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2731,6 +2731,10 @@ msgstr "更新位置"
 msgid "Got in line at"
 msgstr ""
 
+#, fuzzy
+msgid "Granted To"
+msgstr "由...制作"
+
 msgid "Grants"
 msgstr ""
 
@@ -6584,6 +6588,14 @@ msgstr "打印机已经存在"
 #, fuzzy
 msgid "Site Description"
 msgstr "打印机说明"
+
+#, fuzzy
+msgid "Site Granted To Roles"
+msgstr "打印机已经存在"
+
+#, fuzzy
+msgid "Site Granted To User Groups"
+msgstr "新建%s"
 
 #, fuzzy
 msgid "Site Group Associations"

--- a/tests/object-scope-enforcement.test.php
+++ b/tests/object-scope-enforcement.test.php
@@ -155,7 +155,7 @@ $scenario = function (
 ) use ($dbProp, $hookProp, $permProp) {
     $db = new FakeDB(
         function ($sql, $params) use ($tables) {
-            if (false !== strpos($sql, 'INNER JOIN `sites`')) {
+            if (false !== strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')) {
                 $uid = (int)$params['uid'];
                 $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
                 return ['cnt' => $hit ? 1 : 0];
@@ -167,7 +167,7 @@ $scenario = function (
                 $uid = (int)$params['uid'];
                 $out = [];
                 foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
-                    $out[] = ['sumSiteID' => $s];
+                    $out[] = ['siteID' => $s];
                 }
                 return $out;
             }

--- a/tests/site-scope-lists.test.php
+++ b/tests/site-scope-lists.test.php
@@ -114,7 +114,7 @@ $permProp->setAccessible(true);
 $scenario = function (array $tables, array $perms) use ($dbProp, $permProp) {
     $db = new FakeDB(
         function ($sql, $params) use ($tables) {
-            if (false !== strpos($sql, 'INNER JOIN `sites`')) {
+            if (false !== strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')) {
                 $uid = (int)$params['uid'];
                 $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
                 return ['cnt' => $hit ? 1 : 0];
@@ -126,7 +126,7 @@ $scenario = function (array $tables, array $perms) use ($dbProp, $permProp) {
                 $uid = (int)$params['uid'];
                 $out = [];
                 foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
-                    $out[] = ['sumSiteID' => $s];
+                    $out[] = ['siteID' => $s];
                 }
                 return $out;
             }

--- a/tests/site-scope.test.php
+++ b/tests/site-scope.test.php
@@ -154,8 +154,10 @@ $scenario = function (array $tables) use ($dbProp) {
     $db = new FakeDB(
         function ($sql, $params) use ($tables) {
             // Catch-all membership -- checked before the plain sites count
-            // because both mention `sites`.
-            if (false !== strpos($sql, 'INNER JOIN `sites`')) {
+            // because both mention `sites`, and before the membership arm
+            // because it now EMBEDS the membership union as a subquery
+            // (that is what makes a grant of the catch-all site work).
+            if (false !== strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')) {
                 if (isset($tables['catchAllThrows'])) {
                     throw new \Exception('no such table');
                 }
@@ -188,9 +190,19 @@ $scenario = function (array $tables) use ($dbProp) {
             }
             if (false !== strpos($sql, 'FROM `siteUserMembers` WHERE')) {
                 $uid = (int)$params['uid'];
+                // One query, four arms: `userSites` is what the direct arm
+                // contributes and `inheritedSites` is what the three grant
+                // arms contribute. Kept as separate fixture keys so a case
+                // can say "this user reaches the site ONLY by inheritance"
+                // and mean it. Deduped, because the SQL is UNION and not
+                // UNION ALL.
                 $out = [];
-                foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
-                    $out[] = ['sumSiteID' => $s];
+                $seen = array_values(array_unique(array_merge(
+                    (array)($tables['userSites'][$uid] ?? []),
+                    (array)($tables['inheritedSites'][$uid] ?? [])
+                )));
+                foreach ($seen as $s) {
+                    $out[] = ['siteID' => $s];
                 }
                 return $out;
             }
@@ -223,7 +235,7 @@ $scenario = function (array $tables) use ($dbProp) {
 $touchedMembership = function (FakeDB $db) {
     foreach ($db->log as $sql) {
         if (preg_match('/`site(Host|User|Group|UserGroup)Members`/', $sql)
-            && false === strpos($sql, 'INNER JOIN `sites`')
+            && false === strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')
         ) {
             return true;
         }
@@ -656,6 +668,153 @@ $otherUser = SiteScope::inScope('host', 5, 4);
 check(
     'catch-all user allowed, other user denied, same request',
     $catchAllUser === true && $otherUser === false,
+    $failures,
+    $checks
+);
+
+/*
+ * 12. Inherited membership. A site reaches a user directly, through a user
+ *     group, or through a role -- and a role reaches a user two ways, so
+ *     four arms. These cases prove the behaviour; case 13 pins the SQL,
+ *     because the fake answers one union query and cannot tell which arm
+ *     produced a row.
+ */
+$scenario(
+    [
+        'siteCount' => 2,
+        'userSites' => [7 => []],
+        'inheritedSites' => [7 => [2]],
+        'members' => [5],
+    ]
+);
+check(
+    'a user with no direct membership is scoped by inheritance alone',
+    SiteScope::inScope('host', 5, 7) === true,
+    $failures,
+    $checks
+);
+
+$scenario(
+    [
+        'siteCount' => 2,
+        'userSites' => [7 => []],
+        'inheritedSites' => [7 => [2]],
+        'members' => [],
+    ]
+);
+check(
+    'inheritance still denies an object outside the inherited site',
+    SiteScope::inScope('host', 5, 7) === false,
+    $failures,
+    $checks
+);
+
+// Union, not union all: the same site reached twice is one id. Anything
+// downstream doing in_array() would not notice, but filterInScope() and the
+// IN () it builds would carry the duplicate into SQL.
+$scenario(
+    [
+        'siteCount' => 2,
+        'userSites' => [7 => [2]],
+        'inheritedSites' => [7 => [2, 3]],
+        'members' => [5],
+    ]
+);
+check(
+    'a site reached both directly and by inheritance appears once',
+    SiteScope::userSiteIDs(7) === [2, 3],
+    $failures,
+    $checks
+);
+
+// The property that makes this separable from Phase 1: no arrangement of
+// grants can take a site away. Direct membership survives an empty
+// inheritance set.
+$scenario(
+    [
+        'siteCount' => 2,
+        'userSites' => [7 => [2]],
+        'inheritedSites' => [7 => []],
+        'members' => [5],
+    ]
+);
+check(
+    'inheritance never narrows: direct membership stands alone',
+    SiteScope::userSiteIDs(7) === [2],
+    $failures,
+    $checks
+);
+
+$scenario(['siteCount' => 2, 'userSites' => [7 => []], 'members' => [5]]);
+check(
+    'no membership and no grant is still deny-all',
+    SiteScope::inScope('host', 5, 7) === false,
+    $failures,
+    $checks
+);
+
+/*
+ * 13. The arms themselves. The fixtures above would pass against a query
+ *     that read one table, so the shape is pinned here: four arms, the
+ *     joins each one needs, and UNION rather than UNION ALL.
+ */
+$db = $scenario(['siteCount' => 2, 'userSites' => [7 => []], 'members' => []]);
+SiteScope::userSiteIDs(7);
+$armSql = '';
+foreach ($db->log as $sql) {
+    if (0 === strpos($sql, 'SELECT `sumSiteID` AS `siteID`')) {
+        $armSql = $sql;
+        break;
+    }
+}
+$flat = preg_replace('/\s+/', ' ', $armSql);
+foreach ([
+    'direct membership' => 'FROM `siteUserMembers` WHERE `sumUserID` = :uid',
+    'user group grant' => 'FROM `siteUserGroupGrants` INNER JOIN '
+        . '`userGroupMembers` ON `ugmGroupID` = `suggGroupID`',
+    'role grant, role held directly' => 'FROM `siteRoleGrants` INNER JOIN '
+        . '`roleUserAssoc` ON `ruaRoleID` = `srgRoleID`',
+    'role grant, role held via a user group' => 'INNER JOIN '
+        . '`roleUserGroupAssoc` ON `rugRoleID` = `srgRoleID` INNER JOIN '
+        . '`userGroupMembers` ON `ugmGroupID` = `rugGroupID`',
+] as $what => $fragment) {
+    check(
+        "userSiteIDs() carries the $what arm",
+        false !== strpos($flat, $fragment),
+        $failures,
+        $checks
+    );
+}
+check(
+    'the arms are UNION, not UNION ALL -- the result is a set',
+    3 === substr_count($flat, ' UNION ')
+    && false === strpos($flat, 'UNION ALL'),
+    $failures,
+    $checks
+);
+
+/*
+ * 13a. And isUnscoped() asks the SAME question, over the same SQL. If it
+ *      kept its own copy reading only direct membership, granting a role
+ *      the catch-all site would put the catch-all's id in the user's list
+ *      while leaving isUnscoped() false -- so the user would be scoped to
+ *      the one site that means "no restriction", and see nothing.
+ */
+$db = $scenario(['siteCount' => 2, 'catchAll' => [], 'userSites' => [7 => []], 'members' => []]);
+SiteScope::inScope('host', 5, 7);
+$catchAllSql = '';
+foreach ($db->log as $sql) {
+    if (false !== strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')) {
+        $catchAllSql = $sql;
+        break;
+    }
+}
+$flatCatch = preg_replace('/\s+/', ' ', $catchAllSql);
+check(
+    'the catch-all check embeds the same four arms',
+    false !== strpos($flatCatch, '`siteUserGroupGrants`')
+    && false !== strpos($flatCatch, '`siteRoleGrants`')
+    && 3 === substr_count($flatCatch, ' UNION '),
     $failures,
     $checks
 );


### PR DESCRIPTION
Builds the follow-up deferred out of Phase 1 on 2026-08-16. Plan is `docs/refactor-phase1-site-inheritance-plan.md`, committed as `c6b4b413e`.

Four commits rather than four stacked PRs — each is independently revertable and green, but stacking would have made each one wait on the previous merge.

## The problem

Site membership is assigned one user at a time, so a fifty-person helpdesk covering two sites is a hundred rows maintained by hand, and a new starter is out of scope until somebody remembers them. The user is already in a user group and already holds a role; neither carried a site.

## Grant is not membership

The one thing worth reading carefully. `siteUserGroupMembers` and the new `siteUserGroupGrants` hold **the same two ids in the same order** and answer opposite questions:

| | Means |
|---|---|
| **Member** | this user group **is in** the site — an object it contains, visible and editable to that site's admins |
| **Grant** | members of this user group **get** the site — holding it is what puts you in scope |

Separate tables because overloading one would cost the ability to grant access to a site without also making the granting group an editable object inside it — and it would never fail loudly, it would quietly widen what site-scoped admins can reach. Roles have no membership sense, so `siteRoleGrants` has no counterpart.

The UI keeps them apart too: grants are their own "Granted To" tab group, not a fifth and sixth entry beside the four associations. Same picker, same list of names — mixing them in one row is how somebody grants a site while meaning to catalogue one.

## Four arms, not three

`SiteScope::userSiteIDs()` stays the only answer to "which sites is this user in", and now unions: direct membership; a grant to a user group the user is in; a grant to a role held directly; a grant to a role held **through a user group**.

That fourth arm exists because `Authorization::getPermissions()` (`authorization.class.php:380-389`) already grants permissions along both role paths. A role that granted its site only when assigned directly would produce a user holding the permission to edit hosts and no hosts to edit.

`UNION`, not `UNION ALL` — the result is a set, so "most open wins" is true by construction. **Inheritance can only ever add sites.** No arrangement of grants takes away a site a direct membership already gave, so no user on any install loses access to anything. That property is what made this separable from Phase 1, whose risk was the opposite.

## The bug this would have shipped with

`isUnscoped()` read direct membership only. Granting a role the **catch-all** site would have put the catch-all's id in the user's list while leaving `isUnscoped()` false — and catch-all membership short-circuits *above* the per-site query, so the user would have been scoped to the one site that means "no restriction" and seen nothing. A grant that silently produces deny-all is the worst available failure. Both now ask over the same SQL, so they cannot disagree.

## Cascades

Deleting a role or a user group clears its grants; deleting a site clears both grant lists. Its own map rather than an entry in the membership one, which derives the column as `{$classname}ID`. Same AUTO_INCREMENT id-reuse hazard the membership map documents, but sharper: a grant row left behind by a deleted role can later put every holder of an unrelated **new** role into the site the old one granted. Membership leaks one object into a site; a stale grant leaks a whole population.

## Verification

```
sh tests/run-all.sh          # 43 passed, 0 failed
```

`tests/site-scope.test.php` goes 34 → 45 checks. Five are behavioural (inheritance alone scopes a user; it still denies outside the inherited site; a site reached twice appears once; direct membership survives an empty grant set; nothing anywhere is still deny-all) and six pin the SQL, because the fake answers one union query and cannot tell which arm produced a row.

**Mutation-verified** — each of these fails the test: dropping the role-via-usergroup arm; `UNION` → `UNION ALL`; reverting `isUnscoped()` to direct-only; dropping the `siteID` alias.

## Notes for review

- `schema-expected.php`'s two entries are **hand-written**, unusually. `schema-manifest.php generate` derives column types from `SHOW CREATE TABLE` against a live database, so a table no server has yet cannot enter the manifest that way — and `.githooks/pre-commit` refuses a commit whose `schema.php` builds a table the manifest lacks. Both mirror `siteUserMembers`, whose DDL these copy, so the next regeneration on a server that has applied 335 should be a no-op.
- Also fixed: `bin/schema-manifest.php` wrote `PHP version 5` into the docblock it generates, so regenerating reverted the file the 727-file sweep corrected and failed `tests/php-version-docblocks.test.php`. Regeneration is now byte-identical.
- The grant classes are **not** in `Route::$validClasses` — neither are the four membership classes. `Route::getIds()` doesn't need it, and adding them would be two new REST resources, which is an access-control surface and a separate decision.
- `FOG_SCHEMA` 334 → 335, `FOG_BCACHE_VER` 283 → 284 (`fog.site.edit.js` changed).

## Still to do

- The reverse-direction tabs on the Role and User Group pages — seeing a grant from the side an admin is usually looking at. Same data, other end.
- `fog-docs` `site-scoping.md`, which is a separate repo and a separate PR.
- Live verification on the lab server; this has not run against a real database yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR