### PR TITLE
Grant a site from the Role and User Group pages

### DIFF
--- a/packages/web/lib/fog/fogpagepost.class.php
+++ b/packages/web/lib/fog/fogpagepost.class.php
@@ -277,6 +277,69 @@ trait FOGPagePost
     }
 
     /**
+     * The same POST, written from the other end of the association.
+     *
+     * assocPost() calls a method on the page's own object. That only works
+     * when the page's class is the one the association table is keyed to --
+     * assocSetter() derives the column it diffs on from the OWNING class
+     * name, so `siteRoleGrants` can be driven from a Site and not from a
+     * Role, whichever end an administrator happens to be looking at.
+     *
+     * So this inverts it: for each id the tab submitted, load THAT object
+     * and call its add/remove with the page object's id. One table, one
+     * writer, two doors -- which is the property that keeps the two ends
+     * from drifting, and the reason every other association tab in FOG is
+     * editable from both.
+     *
+     * The caller is responsible for the permission check. A reverse tab is
+     * a second door onto somebody else's association, so it must take that
+     * association's permission and not merely the edit right that got the
+     * admin onto this page.
+     *
+     * @param string $ownerClass   class owning the association (e.g. 'Site')
+     * @param string $addMethod    its add method (e.g. 'addGrantRole')
+     * @param string $removeMethod its remove method (e.g. 'removeGrantRole')
+     *
+     * @return void
+     */
+    protected function assocPostInverse($ownerClass, $addMethod, $removeMethod)
+    {
+        self::checkAuthAndCSRF();
+        $subjectID = (int)$this->obj->get('id');
+        if ($subjectID < 1) {
+            return;
+        }
+        $method = '';
+        $items = [];
+        if (isset($_POST['confirmadd'])) {
+            $method = $addMethod;
+            $items = filter_input_array(
+                INPUT_POST,
+                ['additems' => ['flags' => FILTER_REQUIRE_ARRAY]]
+            );
+            $items = $items['additems'];
+        } elseif (isset($_POST['confirmdel'])) {
+            $method = $removeMethod;
+            $items = filter_input_array(
+                INPUT_POST,
+                ['remitems' => ['flags' => FILTER_REQUIRE_ARRAY]]
+            );
+            $items = $items['remitems'];
+        }
+        if ('' === $method) {
+            return;
+        }
+        foreach (self::positiveIntIds($items) as $ownerID) {
+            $owner = self::getClass($ownerClass, $ownerID);
+            if (!$owner->isValid()) {
+                continue;
+            }
+            $owner->{$method}([$subjectID]);
+            $owner->save();
+        }
+    }
+
+    /**
      * Handles a standard association add/remove POST: reads the additems /
      * remitems arrays and dispatches them to the object's add/remove methods.
      * When $orderMethod is supplied, also honours a snapinorder array (used by

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 335);
-        define('FOG_BCACHE_VER', 284);
+        define('FOG_BCACHE_VER', 285);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -629,7 +629,93 @@ class RoleManagement extends FOGPage
                 $this->roleUserGroups();
             }
         ];
+
+        // Sites granted. Hidden without site.view for the same reason the
+        // POST takes site.edit: this is a second door onto somebody else's
+        // association, and role.edit is not the right that opens it. An
+        // install using no sites has nothing to show here either.
+        if (Authorization::can('site.view')) {
+            $tabData[] = [
+                'name' => _('Site Grants'),
+                'id' => 'role-site',
+                'generator' => function () {
+                    $this->roleSites();
+                }
+            ];
+        }
         $this->renderEditTabs($tabData, $this->obj);
+    }
+    /**
+     * Present the sites this role grants.
+     *
+     * The other end of the Site page's "Granted To -> Roles" tab. Both
+     * write `siteRoleGrants`, so there is no second source of truth to
+     * drift -- the same reasoning every other association tab in FOG is
+     * editable from both ends for.
+     *
+     * @return void
+     */
+    public function roleSites()
+    {
+        $this->renderAssocTab(
+            'role-site',
+            _('Sites This Role Grants'),
+            _('Site Name'),
+            'site'
+        );
+    }
+    /**
+     * Update the sites this role grants.
+     *
+     * Two things are different from every other tab on this page.
+     *
+     * It writes through the Site, not through $this->obj: assocSetter()
+     * derives the column it diffs on from the owning class name, so the
+     * grant table is driven from a Site whichever end is being looked at.
+     *
+     * And it takes `site.edit` rather than riding in on the role.edit
+     * right that reached this POST. Granting a site to a role is not a
+     * change to the role -- it widens what everyone holding the role can
+     * see, INCLUDING the person making the change if they hold it. Without
+     * this gate, role.edit alone would be a route to widening your own
+     * scope, which the Site page itself does not hand out. Same reasoning
+     * as the LDAP plugin's group tabs, which gate on ldapgroup.edit.
+     *
+     * @return void
+     */
+    public function roleSitePost()
+    {
+        if (!Authorization::can('site.edit')) {
+            throw new \Exception(
+                _('You do not have permission to change site grants.')
+            );
+        }
+        $this->assocPostInverse('Site', 'addGrantRole', 'removeGrantRole');
+        // Who can see what just changed, and both answers are cached.
+        SiteScope::forgetCaches();
+    }
+    /**
+     * Gets the list of sites this role grants.
+     *
+     * @return void
+     */
+    public function getSitesList()
+    {
+        return $this->assocItemsList(
+            'site',
+            'siterolegrant',
+            'siteRoleGrants',
+            '`sites`.`siteID`',
+            '`siteRoleGrants`.`srgSiteID`',
+            '`siteRoleGrants`.`srgRoleID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
     }
     /**
      * Update the edit elements.
@@ -658,6 +744,9 @@ class RoleManagement extends FOGPage
                         break;
                     case 'role-usergroup':
                         $this->roleUserGroupPost();
+                        break;
+                    case 'role-site':
+                        $this->roleSitePost();
                 }
                 if (!$this->obj->save()) {
                     $serverFault = true;

--- a/packages/web/lib/pages/usergroupmanagement.page.php
+++ b/packages/web/lib/pages/usergroupmanagement.page.php
@@ -373,6 +373,20 @@ class UserGroupManagement extends FOGPage
             }
         ];
 
+        // Site grants -- the opposite direction from the tab above, hence
+        // the longer label. Hidden without site.view for the same reason
+        // the POST takes site.edit: this is a second door onto somebody
+        // else's association.
+        if (Authorization::can('site.view')) {
+            $tabData[] = [
+                'name' => _('Site Grants'),
+                'id' => 'usergroup-sitegrant',
+                'generator' => function () {
+                    $this->usergroupSiteGrants();
+                }
+            ];
+        }
+
         $this->renderEditTabs($tabData, $this->obj);
     }
     /**
@@ -393,6 +407,9 @@ class UserGroupManagement extends FOGPage
                 switch ($tab) {
                     case 'usergroup-site':
                         $this->usergroupSitePost();
+                        break;
+                    case 'usergroup-sitegrant':
+                        $this->usergroupSiteGrantPost();
                         break;
                     case 'usergroup-general':
                         $this->usergroupGeneralPost();
@@ -536,6 +553,79 @@ class UserGroupManagement extends FOGPage
     public function usergroupSitePost()
     {
         $this->siteTabPost('usergroup', $this->obj);
+    }
+
+    /**
+     * Presents the sites this user group grants to its members.
+     *
+     * Deliberately NOT the "Site" tab above, which sits two entries away
+     * and is the easiest thing on this page to confuse it with. That one
+     * says which site this user group BELONGS TO -- it is an object a
+     * site-scoped admin can see and edit. This one says which sites its
+     * MEMBERS GET. Same page, same word, opposite direction, which is why
+     * the labels and the box titles both spell it out rather than relying
+     * on the reader to hold the distinction.
+     *
+     * The other end of the Site page's "Granted To -> User Groups" tab.
+     * Both write `siteUserGroupGrants`.
+     *
+     * @return void
+     */
+    public function usergroupSiteGrants()
+    {
+        $this->renderAssocTab(
+            'usergroup-sitegrant',
+            _("Sites Granted To This User Group's Members"),
+            _('Site Name'),
+            'site'
+        );
+    }
+    /**
+     * Updates the sites this user group grants to its members.
+     *
+     * Written through the Site, and gated on site.edit rather than the
+     * usergroup.edit right that reached this POST -- granting a site to a
+     * user group widens what every member can see, including the person
+     * making the change if they are one. See RoleManagement::roleSitePost().
+     *
+     * @return void
+     */
+    public function usergroupSiteGrantPost()
+    {
+        if (!Authorization::can('site.edit')) {
+            throw new \Exception(
+                _('You do not have permission to change site grants.')
+            );
+        }
+        $this->assocPostInverse(
+            'Site',
+            'addGrantUserGroup',
+            'removeGrantUserGroup'
+        );
+        SiteScope::forgetCaches();
+    }
+    /**
+     * Gets the list of sites this user group grants.
+     *
+     * @return void
+     */
+    public function getSitesList()
+    {
+        return $this->assocItemsList(
+            'site',
+            'siteusergroupgrant',
+            'siteUserGroupGrants',
+            '`sites`.`siteID`',
+            '`siteUserGroupGrants`.`suggSiteID`',
+            '`siteUserGroupGrants`.`suggGroupID`',
+            [
+                [
+                    'db' => 'siteAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
+        );
     }
 }
 

--- a/packages/web/management/js/fog/role/fog.role.edit.js
+++ b/packages/web/management/js/fog/role/fog.role.edit.js
@@ -54,8 +54,25 @@ $(function() {
         sub: 'getUserGroupsList'
     });
 
+    // ---------------------------------------------------------------
+    // SITE GRANTS TAB
+    // The other end of the Site page's "Granted To -> Roles" tab; both
+    // write siteRoleGrants. Rendered only when the user holds site.view,
+    // so guard on the table existing rather than assuming the tab is here.
+    var roleSitesTable = null;
+    if ($('#role-site').length > 0) {
+        roleSitesTable = $.registerAssociationTab({
+            slug: 'role-site',
+            item: 'site',
+            sub: 'getSitesList'
+        });
+    }
+
     if (Common.search && Common.search.length > 0) {
         roleUsersTable.search(Common.search).draw();
         roleUserGroupsTable.search(Common.search).draw();
+        if (roleSitesTable) {
+            roleSitesTable.search(Common.search).draw();
+        }
     }
 });

--- a/packages/web/management/js/fog/usergroup/fog.usergroup.edit.js
+++ b/packages/web/management/js/fog/usergroup/fog.usergroup.edit.js
@@ -36,4 +36,22 @@ $(function() {
         send: 'site-send',
         node: 'site'
     });
+
+    // ---------------------------------------------------------------
+    // SITE GRANTS TAB
+    // Not the tab above. That one picks the site this user group BELONGS
+    // to; this one lists the sites its MEMBERS GET. Grid, not dropdown,
+    // because a user group can grant several. Rendered only when the user
+    // holds site.view, so guard on the table existing.
+    var ugSiteGrantsTable = null;
+    if ($('#usergroup-sitegrant').length > 0) {
+        ugSiteGrantsTable = $.registerAssociationTab({
+            slug: 'usergroup-sitegrant',
+            item: 'site',
+            sub: 'getSitesList'
+        });
+        if (Common.search && Common.search.length > 0) {
+            ugSiteGrantsTable.search(Common.search).draw();
+        }
+    }
 });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6597,6 +6597,10 @@ msgid "Site Granted To User Groups"
 msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Speicherknoten erstellt"
 
@@ -6643,6 +6647,13 @@ msgstr "Drucker aktualisiert!"
 #, fuzzy
 msgid "Sites"
 msgstr "Sites"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Neuen Schlüssel erstellen"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8650,6 +8661,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6597,6 +6597,10 @@ msgid "Site Granted To User Groups"
 msgstr "Create New %s"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Printer already exists"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Storage Node Created"
 
@@ -6643,6 +6647,13 @@ msgstr "Printer updated!"
 #, fuzzy
 msgid "Sites"
 msgstr "minutes"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Create New %s"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8648,6 +8659,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6753,6 +6753,10 @@ msgid "Site Granted To User Groups"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Impresora ya existe"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "nodo de almacenamiento"
 
@@ -6799,6 +6803,13 @@ msgstr "Impresora actualiza!"
 #, fuzzy
 msgid "Sites"
 msgstr "minutos"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Crear nuevo grupo"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8835,6 +8846,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6598,6 +6598,10 @@ msgid "Site Granted To User Groups"
 msgstr "Neuen Schlüssel erstellen"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Drucker hinzufügen erfolgreich."
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Speicherknoten erstellt"
 
@@ -6644,6 +6648,13 @@ msgstr "Drucker aktualisiert!"
 #, fuzzy
 msgid "Sites"
 msgstr "Sites"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Neuen Schlüssel erstellen"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8651,6 +8662,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6599,6 +6599,10 @@ msgid "Site Granted To User Groups"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Imprimante existe déjà"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Nœud de stockage Créé"
 
@@ -6645,6 +6649,13 @@ msgstr "Imprimante mis à jour!"
 #, fuzzy
 msgid "Sites"
 msgstr "minutes"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Créer un nouveau %s"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8650,6 +8661,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6363,6 +6363,10 @@ msgid "Site Granted To User Groups"
 msgstr "Crea nuovo %s"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Creazione stampante riuscita"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Storage Node Creato"
 
@@ -6407,6 +6411,13 @@ msgstr "aggiornato stampante!"
 
 msgid "Sites"
 msgstr "Siti"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Crea nuovo %s"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 msgid "Size"
 msgstr "Dimensione"
@@ -8325,6 +8336,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6303,6 +6303,10 @@ msgid "Site Granted To User Groups"
 msgstr "新しいサブネットグループを作成しますか？"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "サイト全般"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "グループの関連付け"
 
@@ -6343,6 +6347,13 @@ msgstr "サイトを更新しました！"
 
 msgid "Sites"
 msgstr "サイト"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "新しいサブネットグループを作成しますか？"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 msgid "Size"
 msgstr "サイズ"
@@ -8247,6 +8258,10 @@ msgstr ""
 
 #, fuzzy
 msgid "You do not have permission to change LDAP group associations."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
+msgid "You do not have permission to change site grants."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 msgid "You do not have permission to perform this action."
@@ -10710,9 +10725,6 @@ msgstr ""
 
 #~ msgid "Site Control Management"
 #~ msgstr "サイト制御管理"
-
-#~ msgid "Site General"
-#~ msgstr "サイト全般"
 
 #~ msgid "Snapin Args"
 #~ msgstr "スナップイン引数"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5597,6 +5597,9 @@ msgstr ""
 msgid "Site Granted To User Groups"
 msgstr ""
 
+msgid "Site Grants"
+msgstr ""
+
 msgid "Site Group Associations"
 msgstr ""
 
@@ -5631,6 +5634,12 @@ msgid "Site updated!"
 msgstr ""
 
 msgid "Sites"
+msgstr ""
+
+msgid "Sites Granted To This User Group's Members"
+msgstr ""
+
+msgid "Sites This Role Grants"
 msgstr ""
 
 msgid "Size"
@@ -7347,6 +7356,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6598,6 +6598,10 @@ msgid "Site Granted To User Groups"
 msgstr "Criar novo %s"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "Impressora já existe"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "Nó de Armazenamento Criado"
 
@@ -6644,6 +6648,13 @@ msgstr "Impressora atualizado!"
 #, fuzzy
 msgid "Sites"
 msgstr "minutos"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "Criar novo %s"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8649,6 +8660,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6598,6 +6598,10 @@ msgid "Site Granted To User Groups"
 msgstr "新建%s"
 
 #, fuzzy
+msgid "Site Grants"
+msgstr "打印机已经存在"
+
+#, fuzzy
 msgid "Site Group Associations"
 msgstr "存储节点创建"
 
@@ -6644,6 +6648,13 @@ msgstr "打印机更新！"
 #, fuzzy
 msgid "Sites"
 msgstr "分钟"
+
+#, fuzzy
+msgid "Sites Granted To This User Group's Members"
+msgstr "新建%s"
+
+msgid "Sites This Role Grants"
+msgstr ""
 
 #, fuzzy
 msgid "Size"
@@ -8649,6 +8660,9 @@ msgid "You do not have permission to access this page (%s required)."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change site grants."
 msgstr ""
 
 msgid "You do not have permission to perform this action."

--- a/tests/site-grant-reverse-tabs.test.php
+++ b/tests/site-grant-reverse-tabs.test.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * A reverse site-grant tab takes site permissions, not the page's own.
+ *
+ * The Role and User Group pages each carry a tab that writes
+ * `siteRoleGrants` / `siteUserGroupGrants` -- the other end of the Site
+ * page's "Granted To" tabs. Both ends writing one table is deliberate and is
+ * why every association tab in FOG is editable from both.
+ *
+ * What is NOT symmetric is the permission. Granting a site to a role is not
+ * a change to the role: it widens what everyone holding that role can see,
+ * INCLUDING the person making the change if they hold it. So `role.edit`
+ * alone must not open it -- that would be a route to widening your own
+ * scope, through a right the Site page itself does not hand out. The LDAP
+ * plugin's group tabs settled the same question the same way, gating on
+ * ldapgroup.edit rather than the page's own right.
+ *
+ * The failure this pins is silent and one line wide: drop the check, or move
+ * it after the write, and the tab keeps working perfectly for an
+ * administrator while quietly becoming a privilege-escalation path for a
+ * role-scoped one. Nothing errors, and the escalation looks exactly like
+ * ordinary use.
+ *
+ * Source-level: reads the method bodies rather than booting FOG, which needs
+ * a database and a session.
+ *
+ * Usage: php tests/site-grant-reverse-tabs.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$pages = $root . '/packages/web/lib/pages';
+$roleFile = $pages . '/rolemanagement.page.php';
+$ugFile = $pages . '/usergroupmanagement.page.php';
+$postFile = $root . '/packages/web/lib/fog/fogpagepost.class.php';
+
+foreach ([$roleFile, $ugFile, $postFile] as $needed) {
+    if (!is_readable($needed)) {
+        fwrite(STDERR, "FAIL: cannot read $needed\n");
+        exit(1);
+    }
+}
+
+/**
+ * A method body with comments stripped and whitespace flattened.
+ *
+ * Comments have to go: the prose above each of these methods names every
+ * symbol this test searches for, and would satisfy the search on its own.
+ *
+ * @param string $file   file to read
+ * @param string $method method name
+ *
+ * @return string|null code of the body, or null if not found
+ */
+function methodSource($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        $depth = 0;
+        $src = '';
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (is_array($c)
+                && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+            ) {
+                continue;
+            }
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return preg_replace('#\s+#', '', $src);
+                    }
+                }
+            }
+            if ($started) {
+                $src .= is_array($c) ? $c[1] : $c;
+            }
+        }
+        return preg_replace('#\s+#', '', $src);
+    }
+    return null;
+}
+
+$failures = [];
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $what the claim
+ * @param bool   $ok   whether it held
+ *
+ * @return void
+ */
+function check($what, $ok)
+{
+    global $failures, $checks;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+/*
+ * 1. Each POST handler demands site.edit, and demands it BEFORE it writes.
+ *
+ * Both halves matter. A check that runs after assocPostInverse() has already
+ * saved is not a check, and ordering is the half a substring search would
+ * miss -- so it is pinned by position.
+ */
+$posts = [
+    'RoleManagement::roleSitePost' => [$roleFile, 'roleSitePost'],
+    'UserGroupManagement::usergroupSiteGrantPost' => [
+        $ugFile,
+        'usergroupSiteGrantPost'
+    ]
+];
+
+foreach ($posts as $label => $where) {
+    list($file, $method) = $where;
+    $src = methodSource($file, $method);
+    if (null === $src) {
+        fwrite(STDERR, "FAIL: cannot find $label\n");
+        exit(1);
+    }
+    $gate = strpos($src, "Authorization::can('site.edit')");
+    $write = strpos($src, 'assocPostInverse');
+    check("$label requires site.edit", false !== $gate);
+    check("$label writes through assocPostInverse", false !== $write);
+    check(
+        "$label checks the permission BEFORE it writes",
+        false !== $gate && false !== $write && $gate < $write
+    );
+    // The page's own right must not be what opens this. If it ever reads
+    // role.edit or usergroup.edit here, the gate has been rewritten into
+    // the thing it exists to prevent.
+    check(
+        "$label does not gate on the page's own edit right",
+        false === strpos($src, "can('role.edit')")
+        && false === strpos($src, "can('usergroup.edit')")
+    );
+    // Scope answers are cached per user per request. A grant that changes
+    // who can see what and leaves the cache alone is correct only until
+    // somebody looks.
+    check(
+        "$label clears the scope cache",
+        false !== strpos($src, 'SiteScope::forgetCaches')
+    );
+}
+
+/*
+ * 2. The tabs are hidden without site.view.
+ *
+ * Not security on its own -- the POST gate above is what actually refuses --
+ * but a tab that renders and then refuses every save is a bug report, and an
+ * install using no sites has nothing to put in it.
+ */
+foreach ([
+    'RoleManagement' => [$roleFile, 'edit', 'role-site'],
+    'UserGroupManagement' => [$ugFile, 'edit', 'usergroup-sitegrant']
+] as $label => $where) {
+    list($file, $method, $tabId) = $where;
+    $src = methodSource($file, $method);
+    if (null === $src) {
+        fwrite(STDERR, "FAIL: cannot find $label::$method\n");
+        exit(1);
+    }
+    $view = strpos($src, "Authorization::can('site.view')");
+    $tab = strpos($src, "'" . $tabId . "'");
+    check("$label offers the $tabId tab", false !== $tab);
+    check(
+        "$label gates the $tabId tab on site.view",
+        false !== $view && false !== $tab && $view < $tab
+    );
+}
+
+/*
+ * 3. assocPostInverse writes through the OWNER, not the page object.
+ *
+ * That is the whole reason it exists: assocSetter() derives the column it
+ * diffs on from the owning class name, so `siteRoleGrants` can only be
+ * driven from a Site. An "optimization" back to $this->obj would write
+ * nothing and report success.
+ */
+$inverse = methodSource($postFile, 'assocPostInverse');
+if (null === $inverse) {
+    fwrite(STDERR, "FAIL: cannot find FOGPagePost::assocPostInverse\n");
+    exit(1);
+}
+check(
+    'assocPostInverse loads the owner class',
+    false !== strpos($inverse, 'self::getClass($ownerClass,$ownerID)')
+);
+check(
+    'assocPostInverse passes the page object id as the subject',
+    false !== strpos($inverse, '$owner->{$method}([$subjectID])')
+);
+check(
+    'assocPostInverse enforces CSRF and auth',
+    false !== strpos($inverse, 'self::checkAuthAndCSRF()')
+);
+// Ids arrive from a POST array. positiveIntIds() is what keeps a 0 or a
+// non-numeric out of a getClass() lookup that would otherwise load object 0.
+check(
+    'assocPostInverse normalizes the submitted ids',
+    false !== strpos($inverse, 'self::positiveIntIds($items)')
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Schema 335 (#1139) gave the Site page two "Granted To" tabs, so a site can name the roles and user groups whose holders fall inside it. That left the association editable from one end only: to find which sites a role grants, you had to open every site in turn.

This adds the other end. The Role page gains a **Site Grants** tab, the User Group page gains one of its own, and both edit exactly the rows the Site page's tabs write. Both ends writing the same table is how every other association in FOG works, and the LDAP plugin already gave the reason — there is no second source of truth to drift.

### The permission is not the page's own

Granting a site to a role is not a change to the role. It widens what every holder of that role can see, **including the person making the change** if they hold it. So `role.edit` alone must not open it — that would be a route to widening your own scope through a right the Site page itself does not hand out.

| | Tab renders | POST accepted |
|---|---|---|
| Role → Site Grants | `site.view` | `site.edit` |
| User Group → Site Grants | `site.view` | `site.edit` |

`addldapgrouptabs.hook.php` settled the same question the same way, gating on `ldapgroup.edit` rather than the page's right. An install with no sites configured sees neither tab.

### Why the write goes through a helper

New `FOGPagePost::assocPostInverse()` loads each **owner** and calls its add/remove method. That indirection is required, not stylistic: `assocSetter()` derives the column it diffs on from the owning class name (`fogcontroller.class.php:1390-1402`), so `siteRoleGrants` can only be driven from a `Site`. Writing from the `Role` object would diff the wrong column and report success.

Both handlers call `SiteScope::forgetCaches()` afterwards — the grant changes who can see what, and that answer is cached per user per request.

### Verification

`tests/site-grant-reverse-tabs.test.php` pins the access-control shape at source level, since booting these pages needs a database and a session. It asserts each POST demands `site.edit`, demands it **before** it writes, and never reads the page's own edit right; each tab is gated on `site.view`; and `assocPostInverse` keeps its CSRF check, its id normalization, and its owner-side write.

Ten mutations run against it, all ten caught:

```
CAUGHT  drop the site.edit gate on roleSitePost
CAUGHT  move the gate AFTER the write
CAUGHT  gate roleSitePost on role.edit instead
CAUGHT  stop clearing the scope cache
CAUGHT  write through the page object, not the owner
CAUGHT  trust the submitted ids
CAUGHT  ungate the role-site tab
CAUGHT  ungate the usergroup-sitegrant tab
CAUGHT  drop the site.edit gate on usergroupSiteGrantPost
CAUGHT  drop the CSRF/auth check
```

`sh tests/run-all.sh` → 44 passed, 0 failed.

`FOG_BCACHE_VER` 284 → 285 for the two edited JS files. No schema change — this writes the tables #1139 already created.

Still to do, not in this PR: the OIDC plugin's equivalent tab (`fog-plugins`, injected via `PLUGINS_INJECT_TABDATA` the way LDAP does), and the `fog-docs` page for site grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
