### PR TITLE
Ship the plugins from v1.6.6

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.5');
+        define('FOG_PLUGINS_VERSION', 'v1.6.6');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Bumps `FOG_PLUGINS_VERSION` to [v1.6.6](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.6).

The release that matters here is fog-plugins#10 — the OIDC provider-group tabs on the Role and User Group pages. They are the OIDC counterpart to the LDAP group tabs, and they gate on `oidcgroup.view` / `oidcgroup.edit` rather than `role.edit` / `usergroup.edit`, for the same reason #1141's site-grant tabs take Site permissions: granting a provider group to a role widens what every holder of that role receives at sign-in, so being able to edit roles is not by itself enough to hand that out.

No released plugin set carries them yet — `v1.6.5` predates them — so without this bump an install has the core-side reverse tabs from #1141 and no plugin equivalent.

Also in v1.6.6:

- fog-plugins#11 — the plugin suite now runs on every PR there, PHP 7.4 and 8.3, through `fog-workflows/.github/workflows/fog-plugins-tests.yml`. Verified green on fog-plugins#12.
- fog-plugins#12 — `.github/` is excluded from the release tarball. The installer untars that asset straight into `lib/plugins`, which the web server serves, so the workflow file would otherwise have shipped into every web root.

Asset sha256 `de86bb801c7339d5dfee150b19cd8ade502b912069eab292fbf6080bb6fbc5cf`, built with the repo's own `make-release.sh` (deterministic modes and mtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR