### PR TITLE
Stop reading a field name as proof it holds a foreign key

### DIFF
--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -67,6 +67,18 @@ abstract class FOGController extends FOGBase
      */
     protected $databaseFieldsRequired = [];
     /**
+     * Keys that end in "id" but do not hold a foreign key.
+     *
+     * save() infers "this is an integer id" from the key's name, which is
+     * right for all 95 real foreign keys in the tree and wrong for a string
+     * identifier that happens to end the same way -- an OIDC client id, a
+     * system UUID. The name is a proxy for the column's type, and the model
+     * is the only thing that knows the actual type, so it says so here.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = [];
+    /**
      * Additional elements unrelated to DB side directly for object.
      *
      * @var array
@@ -461,6 +473,14 @@ abstract class FOGController extends FOGBase
                 $required[$reqKeyNorm] = true;
             }
 
+            // The model's own list of keys that end in "id" without being a
+            // foreign key. Normalized the same way, so the branch below can
+            // ask about $key directly.
+            $notInt = [];
+            foreach ($this->databaseFieldsNotInt as $strKey) {
+                $notInt[$this->key($strKey)] = true;
+            }
+
             foreach ($this->databaseFields as $rawKey => $column) {
                 $key = $this->key($rawKey);
                 $column = trim($column);
@@ -484,8 +504,14 @@ abstract class FOGController extends FOGBase
                     $val = (int)$validId;
                 }
 
-                // Keys ending with "id" (case-insensitive)
-                elseif (strtolower(substr($key, -2)) === 'id') {
+                // Keys ending with "id" (case-insensitive), unless the model
+                // has said this one is a string. Without that exclusion a
+                // required string id throws "Required database field is
+                // empty" while holding a perfectly good value, and an
+                // optional one is silently rewritten to 0.
+                elseif (strtolower(substr($key, -2)) === 'id'
+                    && !isset($notInt[$key])
+                ) {
                     $isRequired = isset($required[$key]);
                     $isEmpty = ($val === null) || (is_string($val) && trim($val) === '');
 

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -81,6 +81,16 @@ class Inventory extends FOGController
         'hostID'
     ];
     /**
+     * Ends in "id" but is not one: iSystemUUID is varchar(255) holding the
+     * SMBIOS UUID. Without this, save() read the name as a foreign key and
+     * rewrote every UUID it stored to 0.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = [
+        'sysuuid'
+    ];
+    /**
      * Additional fields
      *
      * @var array

--- a/tests/databasefields-notint.test.php
+++ b/tests/databasefields-notint.test.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Every model key ending in "id" is either a real integer column or is
+ * declared a string.
+ *
+ * FOGController::save() infers "this is a foreign key" from the key's name
+ * ending in "id". That is right for the 95 genuine foreign keys in the tree
+ * and wrong for a string identifier spelled the same way, and the two failure
+ * modes differ:
+ *
+ *   required -> throws "Required database field is empty: <key>" while the
+ *               field holds a perfectly good value, so the object can never
+ *               be saved at all (OIDC's clientId, which is why this exists);
+ *   optional -> filter_var fails, the value is replaced with 0 and written,
+ *               so the real value is lost with no error anywhere
+ *               (Inventory's sysuuid -> iSystemUUID, a varchar(255)).
+ *
+ * The name is a proxy for the column's type, so this test checks the type
+ * itself. Column types come from commons/schema-expected.php, which is
+ * generated from the live schema -- so a model that gains such a field, or a
+ * column that changes type under a model, fails here rather than in the
+ * field.
+ *
+ * The check runs both ways on purpose. An entry in $databaseFieldsNotInt
+ * naming an integer column is also a failure: a stale exclusion turns the
+ * foreign-key validation off for a field that wants it, which is the same
+ * class of silent hole in the other direction.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = [];
+$checks = 0;
+
+/**
+ * Reads a bracketed PHP array literal assigned to a property.
+ *
+ * Deliberately textual: loading the models would need the autoloader, a
+ * database and a booted FOG. Comments are stripped through the tokenizer
+ * first so a commented-out entry cannot satisfy the test.
+ *
+ * @param string $src  the file's source
+ * @param string $prop the property name, without the dollar
+ *
+ * @return array|null the quoted strings found, or null if not declared
+ */
+function notIntArrayLiteral($src, $prop)
+{
+    $clean = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    $at = strpos($clean, '$' . $prop);
+    if ($at === false) {
+        return null;
+    }
+    $open = strpos($clean, '[', $at);
+    if ($open === false) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($clean);
+    for ($i = $open; $i < $len; $i++) {
+        if ($clean[$i] === '[') {
+            $depth++;
+        } elseif ($clean[$i] === ']') {
+            $depth--;
+            if ($depth === 0) {
+                $body = substr($clean, $open, $i - $open + 1);
+                preg_match_all('#[\'"]([^\'"]+)[\'"]#', $body, $m);
+                return $m[1];
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Reads the key => column pairs of a $databaseFields literal.
+ *
+ * @param string $src the file's source
+ *
+ * @return array key => column, empty when the model declares none
+ */
+function fieldMap($src)
+{
+    $clean = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    $at = strpos($clean, '$databaseFields');
+    if ($at === false) {
+        return [];
+    }
+    $open = strpos($clean, '[', $at);
+    if ($open === false) {
+        return [];
+    }
+    $depth = 0;
+    $len = strlen($clean);
+    for ($i = $open; $i < $len; $i++) {
+        if ($clean[$i] === '[') {
+            $depth++;
+        } elseif ($clean[$i] === ']') {
+            $depth--;
+            if ($depth === 0) {
+                $body = substr($clean, $open, $i - $open + 1);
+                preg_match_all(
+                    '#[\'"]([A-Za-z0-9_]+)[\'"]\s*=>\s*[\'"]([A-Za-z0-9_]+)[\'"]#',
+                    $body,
+                    $m
+                );
+                return array_combine($m[1], $m[2]);
+            }
+        }
+    }
+    return [];
+}
+
+/**
+ * Whether a column definition is an integer type.
+ *
+ * @param string $type the column definition from the manifest
+ *
+ * @return bool
+ */
+function isIntColumn($type)
+{
+    return (bool)preg_match('#^\s*(tiny|small|medium|big)?int\b#i', $type);
+}
+
+/*
+ * Genuine foreign keys whose COLUMN is mistyped, rather than string ids the
+ * model got wrong. taskLog.taskID is mediumtext while tasks.taskID is
+ * int(11) -- a schema wart, not a modelling one, and the values in it are
+ * numeric, so save() coercing them to int is the correct reading. Declaring
+ * them "not int" would state something untrue to quiet a test.
+ *
+ * Fixing the column is a migration and a FOG_SCHEMA bump, deliberately not
+ * bundled with this. Listed here so the wart is written down rather than
+ * silently tolerated by a looser rule.
+ */
+$textColumnedForeignKeys = [
+    'taskLog.taskID',
+];
+
+$manifest = require $web . '/commons/schema-expected.php';
+$tables = $manifest['tables'] ?? [];
+if (count($tables) < 1) {
+    $failures[] = 'schema-expected.php produced no tables';
+}
+
+// ---------------------------------------------------------------
+// 1. The base class still consults the model's list.
+// ---------------------------------------------------------------
+$controller = file_get_contents($web . '/lib/fog/fogcontroller.class.php');
+$squashed = preg_replace('#\s+#', '', $controller);
+
+$gate = 'protected$databaseFieldsNotInt=[];';
+$checks++;
+if (strpos($squashed, $gate) === false) {
+    $failures[] = 'FOGController no longer declares $databaseFieldsNotInt';
+}
+
+$build = 'foreach($this->databaseFieldsNotIntas$strKey){'
+    . '$notInt[$this->key($strKey)]=true;}';
+$checks++;
+if (strpos($squashed, $build) === false) {
+    $failures[] = 'FOGController::save() no longer builds the $notInt lookup';
+}
+
+$branch = "elseif(strtolower(substr(\$key,-2))==='id'&&!isset(\$notInt[\$key]))";
+$checks++;
+if (strpos($squashed, $branch) === false) {
+    $failures[] = 'the foreign-key branch no longer excludes $notInt keys';
+}
+
+// The lookup has to be built before the loop that reads it, or every model
+// silently loses the exclusion.
+$checks++;
+if (strpos($squashed, $build) !== false
+    && strpos($squashed, $branch) !== false
+    && strpos($squashed, $build) > strpos($squashed, $branch)
+) {
+    $failures[] = '$notInt is built after the branch that reads it';
+}
+
+// ---------------------------------------------------------------
+// 2. Every model's *id keys match their column's actual type.
+// ---------------------------------------------------------------
+$iter = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($web . '/lib')
+);
+foreach ($iter as $file) {
+    if (substr($file->getFilename(), -10) !== '.class.php') {
+        continue;
+    }
+    $src = file_get_contents($file->getPathname());
+    if (!preg_match('#\$databaseTable\s*=\s*[\'"]([A-Za-z0-9_]+)[\'"]#', $src, $t)) {
+        continue;
+    }
+    $table = $t[1];
+    if (!isset($tables[$table]['columns'])) {
+        // Plugin tables are not in the core manifest. The plugin repo's own
+        // suite covers those; skipping here beats guessing at their types.
+        continue;
+    }
+    $columns = $tables[$table]['columns'];
+    $fields = fieldMap($src);
+    $notInt = array_map('strtolower', (array)notIntArrayLiteral($src, 'databaseFieldsNotInt'));
+    $name = $file->getFilename();
+
+    foreach ($fields as $key => $column) {
+        if (strtolower($key) === 'id') {
+            continue;
+        }
+        if (strtolower(substr($key, -2)) !== 'id') {
+            continue;
+        }
+        if (!isset($columns[$column])) {
+            continue;
+        }
+        if (in_array($table . '.' . $column, $textColumnedForeignKeys, true)) {
+            continue;
+        }
+        $declared = in_array(strtolower($key), $notInt, true);
+        $isInt = isIntColumn($columns[$column]);
+        $checks++;
+        if (!$isInt && !$declared) {
+            $failures[] = sprintf(
+                '%s: %s -> %s is %s, not an integer, and is not in '
+                . '$databaseFieldsNotInt -- save() will reject it or '
+                . 'overwrite it with 0',
+                $name,
+                $key,
+                $column,
+                trim($columns[$column])
+            );
+        }
+        if ($isInt && $declared) {
+            $failures[] = sprintf(
+                '%s: %s -> %s IS an integer column but is listed in '
+                . '$databaseFieldsNotInt, so its foreign-key validation '
+                . 'is switched off for nothing',
+                $name,
+                $key,
+                $column
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// 3. The known casualty is actually declared.
+// ---------------------------------------------------------------
+$inventory = file_get_contents($web . '/lib/fog/inventory.class.php');
+$checks++;
+if (!in_array(
+    'sysuuid',
+    array_map('strtolower', (array)notIntArrayLiteral($inventory, 'databaseFieldsNotInt')),
+    true
+)) {
+    $failures[] = 'Inventory does not declare sysuuid in $databaseFieldsNotInt';
+}
+
+if (count($failures) > 0) {
+    echo "FAIL databasefields-notint (" . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS databasefields-notint ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
`FOGController::save()` decided a value was an integer id by looking at whether its key ends in `"id"`. That is right for the 95 genuine foreign keys in the tree and wrong for a string identifier spelled the same way — and it failed in two different directions.

**Required → cannot save at all.** `filter_var` refuses the string, and `save()` throws `Required database field is empty: <key>` about a field that is not empty:

```
[2026-08-17 14:49:30] OIDC ID:  Name: Test IdP has failed to save.
                      Error: Required database field is empty: clientId
```

An OpenID Connect client id is a string — `fog-web`, or a GUID on Entra — so **no OIDC provider could be created at all**, and the UI reported only the generic "Add provider failed!". Reproduced directly: `clientId => 'fog'` returns false, `clientId => '12345'` saves.

**Optional → silently written as 0.** The other branch replaces the value rather than throwing. `Inventory` maps `sysuuid` to `iSystemUUID`, a `varchar(255)` holding the SMBIOS UUID, so a system UUID could be stored as `0` with nothing logged. On my lab server:

```
iID  iSystemUUID
7    9a4a2795-763a-7345-8db1-255950c35eb0
8    0
9    2e650105-a84f-7947-a5b0-32119a0318c8
```

I have not traced which write produced row 8, so treat that as consistent-with rather than proven.

## The fix

The field name was standing in for the column's *type*, and the model is the only thing that knows the type — so the model says so. `$databaseFieldsNotInt` names the keys that end in "id" without being one, and `save()` skips the foreign-key branch for exactly those. Every other field behaves precisely as before.

Rejected alternatives:

- **Guess from the value's shape** (take the FK branch only when the value is numeric). Cheaper, still a guess, and it drops the check that currently catches a bad required FK — that value would then be written as a string into an integer column.
- **Rename the plugin's key** so it dodges the heuristic. Unblocks OIDC and leaves the `Inventory` half writing `0` over system UUIDs.

## The test

`tests/databasefields-notint.test.php` checks the claim against the column types in `commons/schema-expected.php` rather than against another name rule, so a model that gains such a field — or a column that changes type under a model — fails the suite instead of failing in the field. It runs both ways: listing an *integer* column in `$databaseFieldsNotInt` is also a failure, because a stale exclusion turns off foreign-key validation for a field that wants it. 77 checks; 7 mutations, all caught.

`taskLog.taskID` is carried as a documented exception in the test. It is a real foreign key whose column is `mediumtext` while `tasks.taskID` is `int(11)` — a schema wart, not a modelling one, and its values are numeric, so the existing coercion reads it correctly. Fixing the column is a migration and a `FOG_SCHEMA` bump, deliberately not bundled here.

## Downstream

The OIDC half ships separately in `fog-plugins` — the plugin cannot declare `clientId` until the base class understands the property. Merge order matters only in that the plugin change is inert without this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR