### PR TITLE
Ship the plugins from v1.6.7

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.6');
+        define('FOG_PLUGINS_VERSION', 'v1.6.7');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Bumps `FOG_PLUGINS_VERSION` to [v1.6.7](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.7), which carries FOGProject/fog-plugins#13 — the plugin half of #1153.

Both halves are needed for an OIDC provider to be creatable at all: #1153 stops `FOGController::save()` inferring a column's type from its key name, and fog-plugins#13 is the model declaring `clientId` a string. Until both are in place `save()` rejected a perfectly good client id as a malformed foreign key, so the provider-group tabs shipped in v1.6.6 had nothing to associate.

Asset sha256 `9c8884ab775f9bbe1f0cd1d9918bca704220268c43275923873f4093c5604890`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR