### PR TITLE
Make taskLog.taskID the integer it always held (schema 336)

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -758,10 +758,10 @@ return [
             ],
         ],
         'taskLog' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` mediumtext NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` int(11) NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, PRIMARY KEY (`id`), KEY `taskID` (`taskID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'id' => 'mediumint(9) NOT NULL',
-                'taskID' => 'mediumtext NOT NULL',
+                'taskID' => 'int(11) NOT NULL',
                 'taskStateID' => 'mediumint(9) NOT NULL',
                 'ip' => 'varchar(15) NOT NULL',
                 'createTime' => 'timestamp NOT NULL DEFAULT current_timestamp()',

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5687,3 +5687,71 @@ $this->schema[] = [
     . "KEY `suggGroupID` (`suggGroupID`)"
     . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
 ];
+// 336
+$this->schema[] = [
+    // taskLog.taskID becomes the integer it always held. GH-1155.
+    //
+    // It is a foreign key to `tasks`.`taskID`, an int(11), but the column
+    // was mediumtext. The values are numeric only because
+    // FOGController::save() coerces them on the way in -- a behaviour of the
+    // PHP layer, not a constraint of the database -- and three things follow
+    // from the type:
+    //
+    //   no index is possible without a prefix length, so the table has none
+    //     on taskID at all and "the log for task N" is a full scan that
+    //     adding an ordinary index cannot fix;
+    //   a join to `tasks` compares text to int, so MySQL converts per row
+    //     and could not use an index even if one existed;
+    //   under that conversion '60abc' = 60 is true, so a junk value matches
+    //     a real task.
+    //
+    // A closure, not a bare ALTER, for one reason: MySQL's own conversion
+    // turns a non-numeric value into 0 with nothing but a warning, and 0 is
+    // a task id that does not exist. Rows like that are unreadable either
+    // way, but they should be counted and named in the log rather than
+    // rewritten in silence -- an audit table quietly gaining rows that point
+    // at task zero is worse than one that says how many it could not read.
+    //
+    // Idempotent: if the column is already an integer there is nothing to
+    // do, so a re-run converges rather than failing on the second ALTER.
+    function () {
+        $type = self::$DB->query(
+            "SELECT LOWER(`DATA_TYPE`) AS `t` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() "
+            . "AND `TABLE_NAME` = 'taskLog' AND `COLUMN_NAME` = 'taskID' LIMIT 1"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        if (!is_array($type) || !isset($type['t'])) {
+            // No such table or column on this server; nothing to convert.
+            return true;
+        }
+        if (strpos((string)$type['t'], 'int') !== false) {
+            return true;
+        }
+        $bad = self::$DB->query(
+            "SELECT COUNT(*) AS `n` FROM `taskLog` WHERE `taskID` REGEXP '[^0-9]'"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        $n = (int)($bad['n'] ?? 0);
+        if ($n > 0) {
+            error_log(
+                sprintf(
+                    'FOG taskLog migration: %d row(s) held a non-numeric '
+                    . 'taskID and now read 0. They pointed at no task before '
+                    . 'the conversion either -- MySQL would have made the '
+                    . 'same change on its own, silently.',
+                    $n
+                )
+            );
+            self::$DB->query(
+                "UPDATE `taskLog` SET `taskID` = 0 WHERE `taskID` REGEXP '[^0-9]'"
+            );
+        }
+        self::$DB->query(
+            "ALTER TABLE `taskLog` MODIFY `taskID` INT(11) NOT NULL"
+        );
+        self::$DB->query(
+            "ALTER TABLE `taskLog` ADD KEY `taskID` (`taskID`)"
+        );
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 335);
+        define('FOG_SCHEMA', 336);
         define('FOG_BCACHE_VER', 285);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/tests/databasefields-notint.test.php
+++ b/tests/databasefields-notint.test.php
@@ -147,21 +147,6 @@ function isIntColumn($type)
     return (bool)preg_match('#^\s*(tiny|small|medium|big)?int\b#i', $type);
 }
 
-/*
- * Genuine foreign keys whose COLUMN is mistyped, rather than string ids the
- * model got wrong. taskLog.taskID is mediumtext while tasks.taskID is
- * int(11) -- a schema wart, not a modelling one, and the values in it are
- * numeric, so save() coercing them to int is the correct reading. Declaring
- * them "not int" would state something untrue to quiet a test.
- *
- * Fixing the column is a migration and a FOG_SCHEMA bump, deliberately not
- * bundled with this. Listed here so the wart is written down rather than
- * silently tolerated by a looser rule.
- */
-$textColumnedForeignKeys = [
-    'taskLog.taskID',
-];
-
 $manifest = require $web . '/commons/schema-expected.php';
 $tables = $manifest['tables'] ?? [];
 if (count($tables) < 1) {
@@ -236,9 +221,6 @@ foreach ($iter as $file) {
             continue;
         }
         if (!isset($columns[$column])) {
-            continue;
-        }
-        if (in_array($table . '.' . $column, $textColumnedForeignKeys, true)) {
             continue;
         }
         $declared = in_array(strtolower($key), $notInt, true);


### PR DESCRIPTION
Closes #1155.

`taskLog.taskID` is a foreign key to `tasks.taskID` (`int(11)`), but the column was `mediumtext`. Its values are numeric only because `FOGController::save()` coerces them on the way in — a behaviour of the PHP layer, not a constraint of the database — and three things follow from the type:

- **No index is possible** on a text column without a prefix length, so the table has none on `taskID` at all. "The log for task N" is a full scan, and adding an ordinary index cannot fix it.
- **Joins cannot use one either.** `taskLog.taskID = tasks.taskID` compares text to int, so MySQL converts per row.
- **Equality is loose** under that conversion: `'60abc' = 60` is true, so a junk value matches a real task.

Nothing in the tree reads `taskLog` by `taskID` today — it is written at `taskingelement.class.php:293` and never filtered on — so this closes a trap rather than fixing a symptom. The trap got sharper with #1153, which made "which fields hold integers" an explicit model declaration: `taskID` here is exactly the field that *looks* like it belongs in `$databaseFieldsNotInt`, and adding it would be a one-line change that reads as tidy while starting to write unvalidated strings into an unconstrained, unindexed column. That exception is now deleted from `tests/databasefields-notint.test.php` instead of documented in it, and the test's `taskLog.taskID` check is a real passing check (77 → 78).

### Why a closure and not a bare ALTER

MySQL's own conversion turns a non-numeric value into `0` with nothing but a warning, and `0` is a task id that does not exist. Those rows are unreadable either way, but an audit table quietly gaining rows that point at task zero is worse than one that says in the log how many it could not read — so the step counts them, writes an `error_log` line naming the count, and then converts. Idempotent: a column that is already an integer is left alone, so a re-run converges rather than failing on the second ALTER.

### Rehearsal

Run against a clone of the live `taskLog` carrying a deliberate `'60abc'` row:

```
before:  60 | 59 | 60abc
type detected: mediumtext
non-numeric: 1
after:   60 | 59 | 0
type now: int
indexes: PRIMARY(id), taskID(taskID)
```

The clone was dropped afterwards. The `TABLE_SCHEMA = DATABASE()` guard was checked separately against FOG's own connection shape — `pdodb.class.php:275` puts `dbname=` in the DSN, so `DATABASE()` resolves and the type check cannot silently no-op into an early return.

`commons/schema-expected.php` is updated in the same commit (column type and the new key), so `SchemaReconciler` and the manifest agree with the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR