### PR TITLE
Stop the fogstorage probe writing a string into an integer column

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -890,10 +890,25 @@ updateDB() {
     mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_STORAGENODE_MYSQLPASS', 'This setting defines the password the storage nodes should use to connect to the fog server.', \"$snmysqlstoragepass\", 'FOG Storage Nodes') ON DUPLICATE KEY UPDATE settingValue=\"$snmysqlstoragepass\"" $mysqldbname >>$error_log 2>&1
     errorStat $?
     dots "Granting access to fogstorage database user"
-    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog VALUES ( 0, '999test', 3, '127.0.0.1', NOW(), 'fog');" >/dev/null 2>&1
+    # The probe writes a throwaway row to find out whether fogstorage still
+    # holds INSERT; a failure here is read as "the grants need redoing", which
+    # is what sends the installer off to ask for the database root password.
+    #
+    # So the row has to be valid, and the marker cannot live in taskID. That
+    # column used to be mediumtext and took the literal '999test'; schema 336
+    # made it the int(11) it always held, and under STRICT_TRANS_TABLES -- the
+    # MariaDB default -- inserting a non-numeric string into it is error 1265,
+    # not a warning. The probe then failed on a server whose grants were
+    # perfectly correct, and every upgrade demanded a root password nobody
+    # needed to type. Reported on a 1.6 server at schema 336 while two nodes
+    # still on the old column type were unaffected.
+    #
+    # createdBy is varchar(30), so the marker goes there and the DELETE keys
+    # on it. taskID 0 points at no task, which is what a throwaway row should.
+    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog VALUES ( 0, 0, 3, '127.0.0.1', NOW(), 'fog-install-probe');" >/dev/null 2>&1
     connect_as_fogstorage=$?
     if [[ $connect_as_fogstorage -eq 0 ]]; then
-        mysql $sqloptionsuser --password="${snmysqlpass}" --execute="DELETE FROM $mysqldbname.taskLog WHERE taskID='999test' AND ip='127.0.0.1';" >/dev/null 2>&1
+        mysql $sqloptionsuser --password="${snmysqlpass}" --execute="DELETE FROM $mysqldbname.taskLog WHERE createdBy='fog-install-probe' AND ip='127.0.0.1';" >/dev/null 2>&1
         echo "Skipped"
         return
     fi


### PR DESCRIPTION
Regression from #1156, reported within the hour: an upgrade on a server at schema 336 now stops and asks for the database **root** password.

```
 * Granting access to fogstorage database user.................
   To improve the overall security the installer will restrict
   permissions for the *fogstorage* database user.
   Please provide the database *root* user password.
```

`backupDB`'s neighbour at `functions.sh:893` writes a throwaway row as `fogstorage` to find out whether that user still holds `INSERT`. A failure is read as "the grants need redoing", which is the branch that asks for root.

The row put the literal `'999test'` into `taskLog.taskID`. That was fine while the column was `mediumtext`. #1156 made it the `int(11)` it always held, and under `STRICT_TRANS_TABLES` — MariaDB's default, and what is set on the reporting server — a non-numeric string there is **error 1265, not a warning**:

```
ERROR 1265 (01000): Data truncated for column 'taskID' at row 1
```

So the probe failed on a server whose grants were entirely correct. Two storage nodes on the same estate did not prompt, because they have not applied 336 and their column is still text — which is exactly the shape of the report.

Measured on a live 1.6 server at schema 336, running each statement as `fogstorage`:

| statement | exit |
|---|---|
| old — `VALUES (0, '999test', 3, …)` | **1** |
| new — `VALUES (0, 0, 3, …, 'fog-install-probe')` | **0** |

The marker moves to `createdBy`, a `varchar(30)`, and the `DELETE` keys on it instead. `taskID 0` points at no task, which is what a throwaway row should. Keeping the marker in a text column also means the probe cannot be broken again by a column type it does not control.

**Not ported to `dev-branch`** — `taskLog.taskID` is still `mediumtext` there, so the original statement is correct on that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR