### PR TITLE
Make the storage node probe advisory, and make it measure something

### DIFF
--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -773,6 +773,15 @@ class FOGURLRequests extends FOGBase
     ) {
         $this->_reset();
         $output = [];
+        // Floor the timeout at a second. 1.5 carried this and 1.6 dropped it,
+        // which let a caller pass 0.1 and get a literal 100ms fsockopen --
+        // long enough for a loopback answer and not for a NAS on a switched
+        // network, so hosts that were merely unhurried came back "offline".
+        // A probe whose false-negative rate depends on switch latency is not
+        // measuring what it claims to.
+        if (!is_numeric($timeout) || $timeout < 1) {
+            $timeout = 1;
+        }
         // When no port is passed the probe falls back to the ssh port, so it
         // has to honour FOG_SSH_PORT the same way FOGSSH::connect() does.
         // Assuming 22 made every node look offline on installs that moved ssh

--- a/packages/web/lib/fog/storagegroup.class.php
+++ b/packages/web/lib/fog/storagegroup.class.php
@@ -258,6 +258,55 @@ class StorageGroup extends FOGController
         return array_sum($maxClients);
     }
     /**
+     * Picks a node without consulting the availability probe.
+     *
+     * The probe is a TCP connect to the node's ssh or web port. Neither says
+     * anything about whether the image share works, so it is useful for
+     * choosing BETWEEN nodes and must not be what decides an admin may not
+     * create a task at all. 1.5 fell back to min($nodes) here for exactly
+     * that reason; 1.6 threw instead, which turned an unprobeable node -- a
+     * NAS with ssh switched off is the common one -- into "No master nodes
+     * available" and no capture task (forums 18217).
+     *
+     * Unlike 1.5 this is not silent. A node picked here is a node FOG could
+     * not reach on either port, so the task may well fail later; saying so
+     * once, with the group and node named, is the difference between a
+     * puzzling failure and an obvious one.
+     *
+     * @param array  $ids    candidate node ids
+     * @param string $reason what the probe failed to find
+     *
+     * @return int|null the chosen node id
+     */
+    private function _fallbackNode($ids, $reason)
+    {
+        $ids = array_values(array_filter(array_map('intval', (array)$ids)));
+        if (count($ids) < 1) {
+            return null;
+        }
+        $chosen = min($ids);
+        // error_log, not self::error(). The latter writes only when its
+        // logging setting is switched on, and returns without printing
+        // anything at all on an ajax request -- which is how tasking runs.
+        // A warning nobody sees is the silence this exists to end, so it goes
+        // to the web server's log unconditionally.
+        error_log(
+            sprintf(
+                'FOG storage node availability: %s. Group %s (id %d); '
+                . 'node id %d chosen anyway. The probe is a reachability '
+                . 'test, not a test of the image share, so tasking '
+                . 'continues -- if the task fails, check that this node is '
+                . 'reachable.',
+                $reason,
+                $this->get('name'),
+                (int)$this->get('id'),
+                $chosen
+            )
+        );
+
+        return $chosen;
+    }
+    /**
      * Get's the groups master storage node
      *
      * @return object
@@ -285,7 +334,9 @@ class StorageGroup extends FOGController
         // third-party plugin may already read. Only the per-row fetch moves --
         // getItem() answers null for a node deleted between the list and the
         // fetch, where indiv() ended the response outright. Refs ADR 0011.
+        $masterIds = [];
         foreach ($StorageNodes->data as $StorageNode) {
+            $masterIds[] = (int)$StorageNode->id;
             $StorageNode = Route::getItem('storagenode', $StorageNode->id);
             if (!$StorageNode || !$StorageNode->online) {
                 continue;
@@ -296,7 +347,20 @@ class StorageGroup extends FOGController
             }
             unset($StorageNode);
         }
-        $StorageNode = empty($masternode) ? null : new StorageNode($masternode->id);
+        $masterId = empty($masternode) ? null : (int)$masternode->id;
+        if ($masterId === null) {
+            // Enabled masters first: an unreachable master is still the node
+            // this group is configured to capture to, so preferring it over
+            // an arbitrary member keeps the degraded answer the same shape as
+            // the healthy one.
+            $masterId = $this->_fallbackNode(
+                count($masterIds) > 0 ? $masterIds : $this->get($getter),
+                count($masterIds) > 0
+                    ? _('no enabled master node answered the probe')
+                    : _('the group has no enabled master node')
+            );
+        }
+        $StorageNode = empty($masterId) ? null : new StorageNode($masterId);
         self::$HookManager->processEvent(
             'MASTER_STORAGE_NODE',
             [
@@ -350,7 +414,14 @@ class StorageGroup extends FOGController
             unset($StorageNode);
         }
         unset($StorageNode);
-        $StorageNode = empty($winner) ? null : new StorageNode($winner->id);
+        $winnerId = empty($winner) ? null : (int)$winner->id;
+        if ($winnerId === null) {
+            $winnerId = $this->_fallbackNode(
+                $this->get($getter),
+                _('no node in the group answered the probe')
+            );
+        }
+        $StorageNode = empty($winnerId) ? null : new StorageNode($winnerId);
         self::$HookManager->processEvent(
             'OPTIMAL_STORAGE_NODE',
             [

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -204,12 +204,31 @@ class StorageNode extends FOGController
      */
     public function loadOnline()
     {
-        // This probe is an ssh reachability test, so it must follow
-        // FOG_SSH_PORT. Hardcoding 22 reported every node offline -- and so
-        // "No nodes available" on tasking -- whenever ssh was moved
-        // (forums 18210). -1 lets isAvailable resolve the configured port.
-        $test = self::$FOGURLRequests->isAvailable($this->get('ip'), '0.1', -1);
-        $this->set('online', array_shift($test));
+        // FOG reaches a node two ways and both count as "up": ssh for the
+        // transfers, and http(s) for everything _getData() asks for -- the
+        // image, snapin and log file listings all come from
+        // <proto>://<ip>/fog/status/getfiles.php. Probing only ssh reported a
+        // node offline that FOG was in the middle of talking to over http,
+        // which is what a NAS with ssh switched off looks like (forums
+        // 18217). Try ssh first because it is the transport tasking needs,
+        // then fall back rather than declaring the node dead on one port.
+        //
+        // -1 lets isAvailable resolve FOG_SSH_PORT; hardcoding 22 reported
+        // every node offline whenever ssh was moved (forums 18210).
+        //
+        // One second, not 0.1. A tenth of a second is inside the noise for a
+        // switched network and a NAS that has to wake a disk, so the probe
+        // was answering "offline" for hosts that were merely unhurried. 1.5
+        // used a second here and additionally floored anything below one.
+        $ip = $this->get('ip');
+        $test = self::$FOGURLRequests->isAvailable($ip, 1, -1);
+        $online = array_shift($test);
+        if (!$online) {
+            $webPort = 'https' === self::$httpproto ? 443 : 80;
+            $test = self::$FOGURLRequests->isAvailable($ip, 1, $webPort);
+            $online = array_shift($test);
+        }
+        $this->set('online', $online);
     }
     /**
      * Load the location url for us.

--- a/tests/storage-node-probe-advisory.test.php
+++ b/tests/storage-node-probe-advisory.test.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * The storage node availability probe is advisory, and measures something.
+ *
+ * The probe is a TCP connect to a node's ssh or web port. It is useful for
+ * choosing between nodes and cannot tell you whether the image share works,
+ * so three properties have to hold or it starts deciding things it is not
+ * qualified to decide. Each was broken in 1.6 and each produced the same
+ * user-visible symptom -- "No master nodes available" and no capture task,
+ * on a server whose storage was fine (forums 18210, 18217).
+ *
+ *   1. A probe failure must not throw. 1.5 fell back to min($nodes) in both
+ *      getMasterStorageNode() and getOptimalStorageNode(); 1.6 removed the
+ *      fallback, so an unprobeable node -- a NAS with ssh switched off is the
+ *      common one -- blocked task creation outright.
+ *   2. The fallback must say so. 1.5's was silent, which traded a hard stop
+ *      for a puzzling one.
+ *   3. The probe must allow enough time, and try more than one port. A tenth
+ *      of a second is inside the noise for a switched network, and FOG talks
+ *      to a node over http as well as ssh -- _getData() fetches every file
+ *      listing from <proto>://<ip>/fog/status/getfiles.php -- so a node can
+ *      be answering FOG on one port while the probe calls it dead on another.
+ *
+ * Source-level on purpose: reaching these paths for real needs a database,
+ * a storage group and an unreachable host to probe.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = [];
+$checks = 0;
+
+/**
+ * Strips comments so a commented-out line cannot satisfy a check.
+ *
+ * @param string $path the file to read
+ *
+ * @return string the source with comments removed and whitespace squashed
+ */
+function probeSource($path)
+{
+    $clean = '';
+    foreach (token_get_all(file_get_contents($path)) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    return preg_replace('#\s+#', '', $clean);
+}
+
+/**
+ * Extracts one method body by brace depth.
+ *
+ * @param string $src    squashed source
+ * @param string $method the method name
+ *
+ * @return string the body, or '' when the method is absent
+ */
+function probeMethod($src, $method)
+{
+    $at = strpos($src, 'function' . $method . '(');
+    if ($at === false) {
+        return '';
+    }
+    $open = strpos($src, '{', $at);
+    if ($open === false) {
+        return '';
+    }
+    $depth = 0;
+    $len = strlen($src);
+    for ($i = $open; $i < $len; $i++) {
+        if ($src[$i] === '{') {
+            $depth++;
+        } elseif ($src[$i] === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($src, $open, $i - $open + 1);
+            }
+        }
+    }
+    return '';
+}
+
+$group = probeSource($web . '/lib/fog/storagegroup.class.php');
+$node = probeSource($web . '/lib/fog/storagenode.class.php');
+$urls = probeSource($web . '/lib/fog/fogurlrequests.class.php');
+
+// ---------------------------------------------------------------
+// 1. Neither selector may throw when the group has nodes.
+// ---------------------------------------------------------------
+foreach (['getMasterStorageNode', 'getOptimalStorageNode'] as $method) {
+    $body = probeMethod($group, $method);
+    $checks++;
+    if ($body === '') {
+        $failures[] = "StorageGroup::$method() not found";
+        continue;
+    }
+    $checks++;
+    if (strpos($body, '$this->_fallbackNode(') === false) {
+        $failures[] = sprintf(
+            '%s() does not fall back when nothing answers the probe, so an '
+            . 'unreachable node blocks tasking instead of degrading',
+            $method
+        );
+    }
+    // The fallback has to run BEFORE the throw, or it can never be reached.
+    $throw = strpos($body, 'throw new\Exception');
+    $fall = strpos($body, '$this->_fallbackNode(');
+    $checks++;
+    if ($throw !== false && $fall !== false && $fall > $throw) {
+        $failures[] = "$method() falls back after the throw that it exists to avoid";
+    }
+}
+
+// ---------------------------------------------------------------
+// 2. The fallback is not silent.
+// ---------------------------------------------------------------
+$fallback = probeMethod($group, '_fallbackNode');
+$checks++;
+if ($fallback === '') {
+    $failures[] = 'StorageGroup::_fallbackNode() not found';
+} else {
+    $checks++;
+    if (strpos($fallback, 'error_log(') === false) {
+        $failures[] = '_fallbackNode() no longer logs, so a degraded pick is '
+            . 'silent -- which is the 1.5 behaviour this replaced';
+    }
+    $checks++;
+    if (strpos($fallback, 'self::error(') !== false) {
+        $failures[] = '_fallbackNode() logs through self::error(), which is '
+            . 'gated on a logging setting and prints nothing on an ajax '
+            . 'request -- and tasking is an ajax request';
+    }
+    $checks++;
+    if (strpos($fallback, 'min($ids)') === false) {
+        $failures[] = '_fallbackNode() no longer picks deterministically';
+    }
+}
+
+// ---------------------------------------------------------------
+// 3. The probe measures something.
+// ---------------------------------------------------------------
+$online = probeMethod($node, 'loadOnline');
+$checks++;
+if ($online === '') {
+    $failures[] = 'StorageNode::loadOnline() not found';
+} else {
+    $checks++;
+    if (preg_match('#isAvailable\([^)]*,(0\.[0-9]+|0),#', $online)) {
+        $failures[] = 'loadOnline() probes with a sub-second timeout again; '
+            . 'a tenth of a second reports unhurried hosts as offline';
+    }
+    $checks++;
+    if (substr_count($online, 'isAvailable(') < 2) {
+        $failures[] = 'loadOnline() probes only one port, so a node answering '
+            . 'FOG over http is reported offline when ssh is shut';
+    }
+    $checks++;
+    if (strpos($online, '$webPort') === false) {
+        $failures[] = 'loadOnline() no longer falls back to the web port, '
+            . 'which is where _getData() fetches every file listing';
+    }
+}
+
+$avail = probeMethod($urls, 'isAvailable');
+$checks++;
+if ($avail === '') {
+    $failures[] = 'FOGURLRequests::isAvailable() not found';
+} else {
+    $checks++;
+    if (strpos($avail, '$timeout<1') === false) {
+        $failures[] = 'isAvailable() no longer floors a sub-second timeout, '
+            . 'so any caller can reintroduce a 100ms probe';
+    }
+    // The floor has to be applied before the socket that uses it.
+    $floor = strpos($avail, '$timeout<1');
+    $sock = strpos($avail, 'fsockopen(');
+    $checks++;
+    if ($floor !== false && $sock !== false && $floor > $sock) {
+        $failures[] = 'isAvailable() floors the timeout after opening the socket';
+    }
+}
+
+if (count($failures) > 0) {
+    echo 'FAIL storage-node-probe-advisory (' . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS storage-node-probe-advisory ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
Reported on [forums 18217](https://forums.fogproject.org/topic/18217/how-to-upgrade-to-fog-1-6/2): on 1.6 a capture task cannot be created at all when the storage group's node is a Synology NAS — the same setup worked on 1.5. The reporter rolled back to 1.5.10 over it.

His reading is right, and there are **three** changes since 1.5 stacked on top of each other. Each is a problem on its own.

### 1. The fallback was removed — this is what blocks him

1.5's `getMasterStorageNode()` ended:

```php
if (empty($masternode)) {
    $nodes = $this->get($getter);
    $masternode = empty($nodes) ? null : min($nodes);
}
return new StorageNode($masternode);
```

A group whose nodes all failed the probe still produced a node, and tasking continued. 1.6 throws `No master nodes available`; `getOptimalStorageNode()` throws `No nodes available` the same way.

That promoted the probe from *choosing between nodes* to *deciding whether an admin may act at all* — and the probe is a TCP connect to a port that says nothing about whether the image share works.

### 2. The probe moved from ftp to ssh

`28774d5f9`, "Should prefer checking online state via ssh over ftp". A Synology answers ftp and ships with ssh off, so such a node went from permanently online to permanently offline in one step — before the missing fallback even mattered.

### 3. The timeout went 1s → 0.1s, and the floor went with it

1.5's `isAvailable()` carried:

```php
if (empty($timeout) || !$timeout || $timeout < 1) {
    $timeout = 30;
}
```

1.6 dropped it, and `loadOnline()` passes `'0.1'` — a literal 100ms `fsockopen`. That is inside the noise for a switched network and a NAS waking a disk.

## The change

- both selectors **fall back rather than throw**;
- the fallback **logs**, because 1.5's silence traded a hard stop for a puzzling one;
- `loadOnline()` probes ssh **and then the web port** — `_getData()` fetches every image, snapin and log listing from `<proto>://<ip>/fog/status/getfiles.php`, so a node answering there is plainly not dead;
- `isAvailable()` **floors a sub-second timeout** again.

`error_log()` rather than `self::error()` for the warning: `self::error()` writes only when its logging setting is on, and returns without printing anything on an ajax request — and tasking is an ajax request — so the warning would have been invisible exactly where it is needed.

**Cost:** a genuinely dead node now takes 2s to establish instead of 0.1s, because both ports are tried. 1.5 spent 1s. That is the price of not reporting a live node dead, and it is only paid by nodes that fail the first probe.

## Verified against a live database

A scratch group whose only node points at `192.0.2.1` (TEST-NET-1, guaranteed unroutable):

| | `loadOnline` | `getMasterStorageNode` | `getOptimalStorageNode` |
|---|---|---|---|
| deployed | false in 0.10s | **THREW** `No master nodes available` | **THREW** `No nodes available` |
| patched | false in 2.00s | returned the node | returned the node |

…with `FOG storage node availability: no node in the group answered the probe. Group … node id … chosen anyway.` in the web server log. The scratch group and node were removed afterwards.

`tests/storage-node-probe-advisory.test.php` pins all three properties — 17 checks, 9 mutations, all caught. One mutation is specifically "log through `self::error()` instead", since that reads as more idiomatic and is the wrong call here.

**Not ported to `dev-branch`** — 1.5 already has the fallback, the 1s timeout and the floor. This restores 1.5's behaviour rather than changing it.

Related: forums 18210 was the same "No nodes available" symptom from this probe hardcoding port 22, fixed in `97d76ce00`. That made the port configurable but left the hard throw and the 100ms timeout in place, which is why it came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR