### PR TITLE
Bound every installer network fetch, and make the internet check test what FOG downloads

### DIFF
--- a/bin/fetch-plugins.sh
+++ b/bin/fetch-plugins.sh
@@ -73,14 +73,24 @@ say "Fetching plugins ${pluginsVer}"
 # truncated download and an HTTP error page both exit zero often enough to
 # matter, and unpacking either is worse than failing. --fail keeps an error
 # page out of the tarball in the first place.
+#
+# Bounded so an unreachable host costs seconds rather than libcurl's 300 second
+# default connect timeout, five rounds over. --speed-time/--speed-limit catch a
+# connection that opens and then stalls; --max-time is deliberately absent,
+# because a slow but working link must still be allowed to finish a
+# multi-megabyte tarball. This script is runnable on its own, so the bounds are
+# defaulted here rather than assumed to come from lib/common/config.sh.
+: "${inetConnectTimeout:=5}"
 checksum=1
 cnt=0
 while [[ $checksum -ne 0 && $cnt -lt 5 ]]; do
     [[ -f $tmp/$tarball.sha256 ]] && (cd "$tmp" && sha256sum -c "$tarball.sha256" >/dev/null 2>&1)
     checksum=$?
     if [[ $checksum -ne 0 ]]; then
-        curl --silent -fkL -o "$tmp/$tarball" "$url" >/dev/null 2>&1
-        curl --silent -fkL -o "$tmp/$tarball.sha256" "${url}.sha256" >/dev/null 2>&1
+        curl --silent -fkL --connect-timeout "$inetConnectTimeout" \
+            --speed-time 30 --speed-limit 1024 -o "$tmp/$tarball" "$url" >/dev/null 2>&1
+        curl --silent -fkL --connect-timeout "$inetConnectTimeout" \
+            --speed-time 30 --speed-limit 1024 -o "$tmp/$tarball.sha256" "${url}.sha256" >/dev/null 2>&1
     fi
     let cnt+=1
 done

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -40,6 +40,16 @@
 [[ -z $pluginsurl ]] && pluginsurl="${pluginsgit}/releases/download"
 [[ -z $pluginsVer ]] && pluginsVer="$(awk -F\' /"define\('FOG_PLUGINS_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php 2>/dev/null | tr -d '[[:space:]]')"
 [[ -z $pluginsVer ]] && pluginsVer="v1.6.0"
+# Bounds for every network fetch the installer makes, and the answer
+# checkInternetConnection works out for the fetches that follow it. Overridable
+# from .fogsettings for a link slow enough that fifteen seconds is genuinely too
+# short, which is the only reason to raise them -- they exist so an unreachable
+# host costs seconds instead of libcurl's 300 second default connect timeout.
+# internet_ok starts optimistic so any path that reaches a download without
+# having run the check behaves exactly as it did before.
+[[ -z $inetConnectTimeout ]] && inetConnectTimeout=5
+[[ -z $inetMaxTime ]] && inetMaxTime=15
+[[ -z $internet_ok ]] && internet_ok=1
 fog_udpversion="20250223"
 [[ -z $udpcastsrc ]] && udpcastsrc="../packages/udpcast-${fog_udpversion}.tar.gz"
 [[ -z $udpcastout ]] && udpcastout="udpcast-${fog_udpversion}"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1617,8 +1617,15 @@ configureUDPCast() {
     cd $udpcastout
     grep -q 'BCM[0-9][0-9][0-9][0-9]' /proc/cpuinfo >>$error_log 2>&1
     if [[ $? -eq 0 ]]; then
-        wget -qO config.guess "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess" >>$error_log 2>&1
-        wget -qO config.sub "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub" >>$error_log 2>&1
+        # Bounded, and the retry count cut right down. wget defaults to
+        # --tries=20 with no connect timeout at all, so on a Pi that cannot
+        # reach savannah this sat here for twenty full SYN retry cycles, twice,
+        # silently. Both files are a few KB, so a 30 second read timeout cannot
+        # cut a legitimate transfer short.
+        wget -qO config.guess --connect-timeout=$inetConnectTimeout --read-timeout=30 --tries=2 \
+            "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess" >>$error_log 2>&1
+        wget -qO config.sub --connect-timeout=$inetConnectTimeout --read-timeout=30 --tries=2 \
+            "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub" >>$error_log 2>&1
         chmod +x config.guess config.sub >>$error_log 2>&1
     fi
     errorStat $?
@@ -7319,7 +7326,10 @@ downloadfiles() {
     dots "Downloading kernel, init and fog-client binaries"
     clientVer="$(awk -F\' /"define\('FOG_CLIENT_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php | tr -d '[[:space:]]')"
     fosURL="https://github.com/FOGProject/fos/releases/download"
-    fileversions=$(curl -sL -H "Accept: application/vnd.github+json" 'https://api.github.com/repos/FOGProject/fos/releases/latest' | jq '.tag_name, .body' | paste -sd '|')
+    # Bounded like every other fetch here. This one takes --max-time as well as
+    # --connect-timeout because it is a few KB of JSON, not a tarball, so there
+    # is no legitimate slow-link case for it to break.
+    fileversions=$(curl -sL --connect-timeout $inetConnectTimeout --max-time $inetMaxTime -H "Accept: application/vnd.github+json" 'https://api.github.com/repos/FOGProject/fos/releases/latest' | jq '.tag_name, .body' | paste -sd '|')
     tag_name="$(echo $fileversions | awk -F'|' '{print $1}')"
     fileversion="$(echo $fileversions | awk -F'|' '{print $2}')"
     kern_version=$(echo -e $fileversion | sed -n 's/.*Linux kernel \([0-9.]*\).*/\1/p')
@@ -7346,14 +7356,28 @@ downloadfiles() {
         # make sure we download the most recent hash file to start with
         if [[ -f $hashfile && ! $version =~ ^[0-9]\.[0-9]\.[0-9]+$ ]]; then
             rm -f $hashfile
-            curl --silent -kOL $hashurl >>$error_log 2>&1
+            curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 $hashurl >>$error_log 2>&1
         fi
-        while [[ $checksum -ne 0 && $cnt -lt 10 ]]; do
+        # Eight URLs, ten rounds, two curls each: 160 connects, none of them
+        # bounded, all of them silent under one "Downloading kernel, init and
+        # fog-client binaries" line. On a host with no route out that was the
+        # single longest stall the installer could produce. --connect-timeout
+        # bounds an unreachable host and --speed-time/--speed-limit a transfer
+        # that opens and then stops; --max-time is deliberately absent, because
+        # these are multi-megabyte kernels and a slow link must still finish.
+        # When checkInternetConnection has already established the host is
+        # unreachable there is nothing to retry FOR, so make one attempt.
+        tries=10
+        [[ $internet_ok -ne 1 ]] && tries=1
+        while [[ $checksum -ne 0 && $cnt -lt $tries ]]; do
             [[ -f $hashfile ]] && sha256sum -c $hashfile >>$error_log 2>&1
             checksum=$?
             if [[ $checksum -ne 0 ]]; then
-                curl --silent -kOL $url >>$error_log
-                curl --silent -kOL $hashurl >>$error_log
+                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                    --speed-time 30 --speed-limit 1024 $url >>$error_log
+                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                    --speed-time 30 --speed-limit 1024 $hashurl >>$error_log
             fi
             let cnt+=1
         done
@@ -8020,7 +8044,8 @@ _ensureEfitools() {
     # without them.
     $packageinstaller gcc make gnu-efi-devel libuuid-devel openssl-devel \
         help2man perl-File-Slurp >>$error_log 2>&1
-    if ! curl -fsSL "$url" -o "${work}/efitools.tar.gz" >>$error_log 2>&1; then
+    if ! curl -fsSL --connect-timeout $inetConnectTimeout \
+        --speed-time 30 --speed-limit 1024 "$url" -o "${work}/efitools.tar.gz" >>$error_log 2>&1; then
         echo "Failed"
         echo " * Could not download efitools ${ver} from ${url}."
         rm -rf "$work" >>$error_log 2>&1

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1364,67 +1364,138 @@ listPackages() {
     echo $packages;
     exit 0;
 }
+# One bounded reachability probe against a single host. Returns curl's exit
+# status so the caller can name the cause without running three separate tests
+# to find it out.
+#
+# Both bounds matter. Without --connect-timeout, curl inherits libcurl's 300
+# second default, which is exactly what a firewall that DROPs rather than
+# REJECTs outbound traffic costs -- per host, per address family. Without
+# --max-time, a connection that opens and then stalls never returns at all.
+#
+# Deliberately no -k. A proxy presenting its own CA passes an unverified probe
+# and then fails the git clone that follows, and predicting that clone is the
+# entire point of the check. Equally deliberately no -f: a host that answers 404
+# at "/" is still a reachable host, and reachability is what is being measured.
+inetProbe() {
+    local host="$1"
+    if command -v curl >/dev/null 2>&1; then
+        curl -sS --connect-timeout $inetConnectTimeout --max-time $inetMaxTime \
+            -o /dev/null "https://${host}/" >>$error_log 2>&1
+        return $?
+    fi
+    # curl is in every distro's package list, but installPackages has not run
+    # yet at this point, so a minimal image can legitimately reach here without
+    # it. bash's own /dev/tcp keeps the fallback dependency free. It sees only
+    # the TCP handshake -- not TLS, and not a proxy -- so it reports the generic
+    # connect failure (7) rather than claiming to know more than it does.
+    # Bounded by the connect timeout rather than the total: a handshake is all
+    # this does, so there is no transfer phase for $inetMaxTime to govern.
+    timeout $inetConnectTimeout bash -c "exec 3<>/dev/tcp/${host}/443" >>$error_log 2>&1
+    [[ $? -eq 0 ]] && return 0
+    return 7
+}
+# Probe the hosts this install is actually going to pull from, and record the
+# answer somewhere the code that downloads can read it.
+#
+# This used to test DNS, then plain HTTP, then HTTPS, against httpbin.org,
+# neverssl.com, github.com and fogproject.org -- none of them with a timeout,
+# and none of them a host FOG needs. Worse, it opened by running
+# `$packageinstaller curl`, so a connectivity check's first act was a package
+# transaction that needed the very connectivity it was about to test: metadata
+# refresh against every configured mirror, unbounded on Debian/Ubuntu whenever
+# unattended-upgrades holds the dpkg lock (apt has no lock timeout), and on Arch
+# a full system upgrade, because $packageinstaller there is `pacman -Syu`. All
+# of it redirected to the error log, so the screen showed "Testing internet
+# connection" and nothing else for minutes at a time.
+#
+# Nothing read the result either. dns_ok/http_ok/https_ok were set and never
+# looked at, both failure paths returned rather than exited, and the caller
+# ignored the status -- so the install proceeded identically either way and the
+# stall bought a message and nothing more.
+#
+# What the install genuinely needs from the internet is the distro's package
+# repositories -- which installPackages reports on for itself -- and the hosts
+# behind $ipxegit/$ipxeurl and $pluginsgit/$pluginsurl, for the iPXE sources,
+# the iPXE and Secure Boot release assets, and the plugins. Those are what is
+# probed, so pointing any of them at an internal mirror tests the mirror instead
+# of github.com rather than as well as it. One HTTPS request per host settles
+# DNS, TCP and TLS together, and curl's exit status says which of the three
+# failed, so the old three-stage ladder is not needed to produce a specific
+# message.
+#
+# Failure stays non-fatal, as before: offline installs are supported and
+# documented (pre-placed iPXE sources, a pre-placed release tarball, pre-placed
+# plugin directories), so the output is advice plus $internet_ok, not an exit.
+# $internet_ok is what fetchipxeasset and prepipxe read to avoid re-attempting
+# a fetch that has already been shown to be unreachable.
 checkInternetConnection() {
     dots "Testing internet connection"
-    DEBIAN_FRONTEND=noninteractive $packageinstaller curl >>$error_log 2>&1
-
-    http_sites=("httpbin.org" "neverssl.com")
-    https_sites=("github.com" "fogproject.org")
-    dns_ok=0
-    http_ok=0
-    https_ok=0
-
-    for dnsname in "${http_sites[@]}" "${https_sites[@]}"; do
-        echo -n "Testing DNS name resolution (${dnsname})... " >> $error_log
-        getent hosts ${dnsname} >/dev/null 2>&1
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
+    internet_ok=0
+    local url host rc failhost="" failrc=0
+    # Deduplicated because $ipxeurl is derived from $ipxegit and $pluginsurl
+    # from $pluginsgit, so the stock configuration is one host probed once
+    # rather than github.com probed four times.
+    local hosts=$(
+        for url in "$ipxegit" "$ipxeurl" "$pluginsgit" "$pluginsurl"; do
+            host="${url#*://}"
+            echo "${host%%/*}"
+        done | grep . | sort -u
+    )
+    for host in $hosts; do
+        echo -n "Testing connection to ${host}... " >> $error_log
+        inetProbe "$host"
+        rc=$?
+        if [[ $rc -eq 0 ]]; then
+            echo "OK" >> $error_log
             continue
         fi
-        dns_ok=1
-        echo "OK" >> $error_log
-        break
+        echo "Failed (curl exit ${rc})" >> $error_log
+        failhost="$host"
+        failrc=$rc
     done
-    if [[ $dns_ok -eq 0 ]]; then
-        echo "Failed"
-        echo
-        echo "There seems to be a DNS problem. Check the contents of /etc/resolv.conf" | tee -a $error_log
-        echo "If this is CentOS, RHEL, or Fedora or an other RH variant, also check" | tee -a $error_log
-        echo "the DNS entries in /etc/sysconfig/network-scripts/ifcfg-*" | tee -a $error_log
-        echo
-        return
+    if [[ -z $failhost ]]; then
+        internet_ok=1
+        echo "Done"
+        return 0
     fi
-    for url in "${http_sites[@]}"; do
-        echo -n "Testing HTTP connection (http://${url})... " >> $error_log
-        curl --silent http://${url} >/dev/null 2>>$error_log
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
-            continue
-        fi
-        http_ok=1
-        echo "OK" >> $error_log
-        break
-    done
-    for url in "${https_sites[@]}"; do
-        echo -n "Testing HTTPS connection (https://${url})... " >> $error_log
-        curl --silent -k https://${url} >/dev/null 2>>$error_log
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
-            continue
-        fi
-        https_ok=1
-        echo "OK" >> $error_log
-        break
-    done
-    if [[ $http_ok -eq 0 && $https_ok -eq 0 ]]; then
-        echo "Failed"
-        echo
-        echo "There was no interface with an active internet connection found." | tee -a $error_log
-        echo "If you are using a proxy server, please export http_proxy and https_proxy or use .curlrc" | tee -a $error_log
-        echo
-        return
-    fi
-    echo "Done"
+    echo "Failed"
+    echo
+    case $failrc in
+        6)
+            echo "Could not resolve ${failhost}. Check the contents of /etc/resolv.conf," | tee -a $error_log
+            echo "and on RHEL, CentOS, Fedora or another RH variant also the DNS settings" | tee -a $error_log
+            echo "on the connection itself (nmcli con show <name> | grep ipv4.dns)." | tee -a $error_log
+            ;;
+        # 7 and 28 share a message on purpose. A firewall that DROPs outbound
+        # traffic -- the usual cause on an isolated or corporate network --
+        # produces 28 (the connect timeout expiring), not 7; 7 is what an
+        # explicit REJECT or "network unreachable" gives. Naming only $inetMaxTime
+        # against a 28 would report the wrong bound, since it is almost always
+        # $inetConnectTimeout that fired.
+        7|28)
+            echo "Could not reach ${failhost} on port 443 within ${inetConnectTimeout}s to connect" | tee -a $error_log
+            echo "or ${inetMaxTime}s in total. A firewall that drops outbound traffic rather than" | tee -a $error_log
+            echo "rejecting it looks exactly like this." | tee -a $error_log
+            ;;
+        35|60|77)
+            echo "TLS to ${failhost} failed. If a proxy or filter is intercepting HTTPS," | tee -a $error_log
+            echo "its CA has to be trusted by this machine -- git and curl will both fail" | tee -a $error_log
+            echo "the same way until it is." | tee -a $error_log
+            ;;
+        *)
+            echo "Could not reach ${failhost} (curl exit ${failrc})." | tee -a $error_log
+            ;;
+    esac
+    echo
+    echo "The install will continue. FOG needs ${failhost} for the iPXE sources," | tee -a $error_log
+    echo "the iPXE release binaries and the bundled plugins, so those steps are the" | tee -a $error_log
+    echo "ones expected to fail." | tee -a $error_log
+    echo "If you are using a proxy server, please export http_proxy and https_proxy or use .curlrc" | tee -a $error_log
+    echo "For a deliberate offline install, pre-place those sources -- each download" | tee -a $error_log
+    echo "step below prints the exact path it looks in." | tee -a $error_log
+    echo
+    return 0
 }
 join() {
     local IFS="$1"
@@ -1646,6 +1717,15 @@ prepareiPXEsource() {
     # subdirectory of upstream clones) and nothing here needs the network.
     dots "Preparing iPXE build sources"
     if [[ -d $buildipxesrc/.git ]]; then
+        # git has no connect timeout of its own, so an unreachable host stalls
+        # here for as long as the kernel retries the SYN. The fetch is only ever
+        # an update to a checkout that already works, so when the host is known
+        # to be unreachable, skip straight to using what is on disk -- the same
+        # outcome the failed-checkout branch below produces, minus the wait.
+        if [[ $internet_ok -ne 1 ]]; then
+            echo "Skipped (using existing checkout)"
+            return 0
+        fi
         git -C "$buildipxesrc" fetch --tags --force "$ipxegit" >>$error_log 2>&1
         if ! git -C "$buildipxesrc" checkout -q "$ipxeVer" >>$error_log 2>&1; then
             # Offline, or the tag does not exist yet. A usable checkout is
@@ -1694,12 +1774,26 @@ fetchipxeasset() {
     cd ../tmp/
     local checksum=1
     local cnt=0
-    while [[ $checksum -ne 0 && $cnt -lt 10 ]]; do
+    # Ten rounds of two timeout-less curls is the most expensive stall in the
+    # whole installer: on a network that drops outbound traffic each of those
+    # twenty connects sat at libcurl's 300 second default before returning, all
+    # of it silent under one "Downloading iPXE binaries" line. When
+    # checkInternetConnection has already established the host is unreachable
+    # there is nothing to retry FOR, so make the one attempt and report.
+    local tries=10
+    [[ $internet_ok -ne 1 ]] && tries=1
+    while [[ $checksum -ne 0 && $cnt -lt $tries ]]; do
         [[ -f ${tarball}.sha256 ]] && sha256sum -c ${tarball}.sha256 >>$error_log 2>&1
         checksum=$?
         if [[ $checksum -ne 0 ]]; then
-            curl --silent -fkOL "$url" >>$error_log 2>&1
-            curl --silent -fkOL "${url}.sha256" >>$error_log 2>&1
+            # --connect-timeout bounds an unreachable host; --speed-time/-limit
+            # bounds a connection that opens and then stalls. --max-time is
+            # deliberately NOT used here -- these are multi-megabyte tarballs
+            # and a slow but working link must be allowed to finish.
+            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 "$url" >>$error_log 2>&1
+            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 "${url}.sha256" >>$error_log 2>&1
         fi
         let cnt+=1
     done
@@ -1760,6 +1854,7 @@ downloadplugins() {
         return 0
     fi
     if ! pluginsgit="$pluginsgit" pluginsurl="$pluginsurl" pluginsVer="$pluginsVer" \
+        inetConnectTimeout="$inetConnectTimeout" \
         ../bin/fetch-plugins.sh --quiet >>$error_log 2>&1
     then
         # Guidance first: errorStat exits before returning unless $exitFail is

--- a/tests/network-fetch-bounded.test.sh
+++ b/tests/network-fetch-bounded.test.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+#
+# Guards the "unbounded network call in the installer" bug class.
+#
+#   tests/network-fetch-bounded.test.sh
+#
+# curl's default connect timeout is 300 seconds and it has no default total
+# timeout at all. Every installer fetch that omits --connect-timeout therefore
+# costs five minutes per unreachable host, per address family, and the installer
+# sends all of it to $error_log -- so what the admin sees is one "dots" line and
+# then nothing, for as long as it takes. That is what "the installer hangs"
+# almost always turns out to be.
+#
+# The specific instances that were fixed:
+#
+#   1. checkInternetConnection() opened by running `$packageinstaller curl`.
+#      A connectivity check whose first act is a package transaction needs the
+#      connectivity it is about to test: apt has no dpkg-lock timeout, so it
+#      waits forever behind unattended-upgrades, and on Arch $packageinstaller
+#      is `pacman -Syu`, so the check triggered a full system upgrade.
+#   2. Its four probes -- getent, plain HTTP, HTTPS -- had no timeout of any
+#      kind, and pointed at httpbin.org, neverssl.com, github.com and
+#      fogproject.org. Only one of those is a host FOG downloads anything from.
+#   3. It computed dns_ok/http_ok/https_ok and nothing read them. Both failure
+#      paths returned rather than exiting, and the caller ignored the status, so
+#      the whole cost bought a message.
+#   4. fetchipxeasset() looped ten times issuing two timeout-less curls each.
+#
+# What this checks and what it does not: it asserts on the SOURCE for the shape
+# of the calls, and runs inetProbe() for real against an address that cannot be
+# routed. It does not install FOG and it does not need the internet -- 192.0.2.1
+# is TEST-NET-1 (RFC 5737), which must never be routed, so the probe fails
+# whether or not the runner has a route to anywhere. Only the elapsed time is
+# asserted, and only against a ceiling far below the 300s default, so a runner
+# with no network at all (instant failure) passes just as well as one behind a
+# firewall (5s).
+#
+# The result-is-consumed assertions pin the DEFINITION as well as the use.
+# Pinning only "fetchipxeasset mentions internet_ok" would be satisfied by a
+# reintroduced version that mentions it and ignores it, which is the exact
+# defect being guarded -- so the read is checked to sit on the retry count and
+# on the git fetch, where it changes what happens.
+#
+# No root, no package manager, no FOG install.
+#
+# Exit status 0 = pass, 1 = fail.
+
+cd "$(dirname "$0")/.." || exit 1
+FUNCS="lib/common/functions.sh"
+CONF="lib/common/config.sh"
+PLUG="bin/fetch-plugins.sh"
+
+for f in "$FUNCS" "$CONF" "$PLUG"; do
+    [[ -r $f ]] || { echo "cannot read $f -- run this from the repository"; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# body <function-name> <file> -- the text of one shell function, from its
+# opening line to the first line that is a bare closing brace. Crude, but every
+# function in these files is written in exactly that style.
+#
+# Comments are stripped. Without that, every assertion below can be satisfied by
+# the prose explaining the code rather than the code -- and this file's comments
+# name $pluginsgit/$pluginsurl, so "does it probe the plugins host" passed with
+# the probe loop deleted. A gate that its own documentation can satisfy is not a
+# gate. (Same failure the no-session-for-browserless gate hit.)
+body() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$2" | grep -vE '^[[:space:]]*#'
+}
+
+echo "1. the connectivity check does not run the package manager"
+
+if body checkInternetConnection "$FUNCS" | grep -q 'packageinstaller'; then
+    bad "checkInternetConnection still invokes \$packageinstaller"
+else
+    ok "checkInternetConnection does not invoke \$packageinstaller"
+fi
+
+echo
+echo "2. every remote fetch is bounded"
+
+# Remote curls only. The maintenance/* calls to $ipaddress are this same host
+# over loopback or the LAN, which cannot exhibit the 300s stall being guarded.
+# joined <file> -- the file with backslash continuations folded onto one line
+# and comment lines dropped. Both matter: every bounded call here is written
+# across two lines, so a per-line grep sees the flags on one and the URL on the
+# other and reports a false positive on each.
+joined() {
+    sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | grep -vE '^[[:space:]]*#'
+}
+
+# Remote calls only, by exclusion rather than by matching a literal http:// on
+# the line -- several of these build the URL in a variable, and requiring the
+# literal is what let _ensureEfitools' unbounded fetch of git.kernel.org sit
+# here unnoticed. The three exclusions are named individually so a NEW remote
+# call cannot accidentally inherit one:
+#
+#   ipaddress     the maintenance/* posts -- this same host over loopback
+#   dbhttpcode=   backupDB's fetch of backup_db.php, likewise $ipaddress
+#   nodecert.php  a storage node asking its master for a certificate: LAN, not
+#                 the internet. Still unbounded, and still able to stall a node
+#                 install if the master is down -- out of scope here, but a
+#                 real instance of the same class if anyone wants it.
+# `curl` followed by a flag is an invocation; `curl` inside a message is not.
+# Every real call in these files opens with a flag, and dropping echo lines
+# takes care of the one that prints a curl command as help text.
+remotecurls() {
+    joined "$1" \
+        | grep -E '(^|[^-[:alnum:]_])curl[[:space:]]+-' \
+        | grep -vE '^[[:space:]]*echo ' \
+        | grep -v 'ipaddress' \
+        | grep -v 'dbhttpcode=' \
+        | grep -v 'nodecert.php'
+}
+
+# hascap <line> -- true when the call carries a total time cap.
+hascap() { printf '%s\n' "$1" | grep -qE -- '(^| )-m [0-9]|--max-time'; }
+
+# Two rules, and between them every remote call is bounded at both ends:
+#
+#   A. the connect must be bounded, by --connect-timeout or by a total cap
+#   B. a call with NO total cap must carry --speed-time, or a transfer that
+#      opens and then stops never returns
+#
+# A total cap is right for a small body (the fogstorage probe's -m 30) and wrong
+# for a multi-megabyte artifact, where a slow but working link has to be allowed
+# to finish -- which is why B exists rather than simply requiring --max-time
+# everywhere.
+unbounded=0
+nostall=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    short=$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-96)
+    if ! printf '%s\n' "$line" | grep -q -- '--connect-timeout' && ! hascap "$line"; then
+        unbounded=$((unbounded + 1))
+        printf '        no connect bound: %s\n' "$short"
+    fi
+    if ! hascap "$line" && ! printf '%s\n' "$line" | grep -q -- '--speed-time'; then
+        nostall=$((nostall + 1))
+        printf '        no stall guard:   %s\n' "$short"
+    fi
+done < <(remotecurls "$FUNCS"; remotecurls "$PLUG")
+
+if [[ $unbounded -eq 0 ]]; then
+    ok "every remote curl bounds its connect"
+else
+    bad "$unbounded remote curl call(s) carry neither --connect-timeout nor a total cap"
+fi
+if [[ $nostall -eq 0 ]]; then
+    ok "every remote curl without a total cap guards against a stalled transfer"
+else
+    bad "$nostall remote curl call(s) have neither a total cap nor --speed-time"
+fi
+
+# The asset downloads must NOT carry --max-time: these are multi-megabyte
+# tarballs and a slow but working link has to be allowed to finish. The stall
+# they need protecting from is a transfer that opens and then stops, which is
+# --speed-time/--speed-limit's job, not --max-time's.
+# The wrong fix for a stalled download is to cap it, which is why the two are
+# mutually exclusive: carrying --speed-time is the statement "this one is an
+# artifact fetch and may legitimately take a while", and --max-time on top of
+# that reintroduces the failure on slow links that the stall guard exists to
+# avoid.
+both=0
+for f in "$FUNCS" "$PLUG"; do
+    n=$(remotecurls "$f" | grep -- '--speed-time' | grep -c -- '--max-time')
+    both=$((both + n))
+done
+if [[ $both -eq 0 ]]; then
+    ok "no artifact download carries both --speed-time and --max-time"
+else
+    bad "$both call(s) carry --speed-time AND --max-time -- a slow link will still fail"
+fi
+
+# wget's defaults are worse than curl's: no connect timeout at all, and
+# --tries=20, so an unreachable host costs twenty full SYN retry cycles.
+unboundedwget=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    printf '%s\n' "$line" | grep -q -- '--connect-timeout' && continue
+    unboundedwget=$((unboundedwget + 1))
+    printf '        unbounded: %s\n' "$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-100)"
+done < <(joined "$FUNCS" | grep 'wget ')
+
+if [[ $unboundedwget -eq 0 ]]; then
+    ok "no wget in $FUNCS lacks --connect-timeout"
+else
+    bad "$unboundedwget wget call(s) have no --connect-timeout (and wget defaults to --tries=20)"
+fi
+
+echo
+echo "3. the probe verifies TLS"
+
+if body inetProbe "$FUNCS" | grep -qE '(^|[[:space:]])(-k|--insecure)([[:space:]]|$)'; then
+    bad "inetProbe passes -k -- a proxy with its own CA passes the probe and then fails the git clone"
+else
+    ok "inetProbe does not pass -k"
+fi
+
+echo
+echo "4. the result is consumed, not just computed"
+
+# The original bug was not that the check was wrong, it was that nothing read
+# it. Pin the two places that act on the answer, by the line that acts.
+for fn in fetchipxeasset downloadfiles; do
+    if body "$fn" "$FUNCS" | grep -q 'internet_ok.*tries=1'; then
+        ok "$fn drops its retry count when the host is unreachable"
+    else
+        bad "$fn does not act on \$internet_ok -- ten rounds of retries against a dead host"
+    fi
+done
+
+if body prepareiPXEsource "$FUNCS" | grep -q 'internet_ok'; then
+    ok "prepareiPXEsource skips its git fetch when the host is unreachable"
+else
+    bad "prepareiPXEsource does not act on \$internet_ok -- git has no connect timeout of its own"
+fi
+
+if grep -q 'internet_ok=1' "$CONF"; then
+    ok "\$internet_ok is defaulted in $CONF, so a path that skips the check behaves as before"
+else
+    bad "\$internet_ok has no default -- an install that never calls the check would read it as unset"
+fi
+
+echo
+echo "5. the check probes the hosts FOG actually downloads from"
+
+probed=$(body checkInternetConnection "$FUNCS")
+for v in ipxegit ipxeurl pluginsgit pluginsurl; do
+    if printf '%s' "$probed" | grep -q "\$$v"; then
+        ok "probes \$$v"
+    else
+        bad "does not probe \$$v -- an override to an internal mirror goes untested"
+    fi
+done
+for h in httpbin.org neverssl.com fogproject.org; do
+    if printf '%s' "$probed" | grep -q "$h"; then
+        bad "still probes $h, which FOG downloads nothing from"
+    else
+        ok "no longer probes $h"
+    fi
+done
+
+echo
+echo "6. an unroutable host fails fast (behavioural)"
+
+error_log=$(mktemp)
+trap 'rm -f "$error_log"' EXIT
+inetConnectTimeout=5
+inetMaxTime=15
+# shellcheck source=/dev/null
+source "$FUNCS" >/dev/null 2>&1
+
+start=$SECONDS
+inetProbe 192.0.2.1 >/dev/null 2>&1
+rc=$?
+elapsed=$((SECONDS - start))
+
+if [[ $rc -eq 0 ]]; then
+    bad "inetProbe reported TEST-NET-1 (192.0.2.1) as reachable"
+else
+    ok "inetProbe reports TEST-NET-1 as unreachable (exit $rc)"
+fi
+# 20s ceiling against a 300s default: generous enough that a loaded runner or a
+# doubled $inetConnectTimeout still passes, tight enough that the unbounded
+# version cannot.
+if [[ $elapsed -le 20 ]]; then
+    ok "inetProbe returned in ${elapsed}s (ceiling 20s, libcurl's default is 300s)"
+else
+    bad "inetProbe took ${elapsed}s -- something is not bounding the connect"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## The problem

`checkInternetConnection()` could sit silent for minutes under one `Testing internet connection...` line, and the answer it eventually produced was never read.

Three causes:

1. **It opened by running `$packageinstaller curl`.** A connectivity check whose first act is a package transaction needs the connectivity it is about to test — metadata refresh against every mirror, unbounded on Debian/Ubuntu whenever unattended-upgrades holds the dpkg lock (apt has no lock timeout), and on Arch a **full system upgrade**, because `$packageinstaller` there is `pacman -Syu`. It was also redundant: `curl` is in every distro's package list and `installPackages` runs before anything that uses it.
2. **No timeouts on anything.** libcurl's default connect timeout is 300s and there is no default total timeout, so each unreachable host cost five minutes, per address family. `getent hosts` has no timeout to give it either.
3. **Nothing read the result.** `dns_ok`/`http_ok`/`https_ok` were set and never looked at, both failure paths `return`ed rather than exited, and the caller ignored the status — so the install proceeded identically either way.

It also probed httpbin.org, neverssl.com, github.com and fogproject.org. Only one of those is a host FOG downloads anything from.

## What this does

**Probes what the install actually needs.** The hosts behind `$ipxegit`/`$ipxeurl` and `$pluginsgit`/`$pluginsurl` — the iPXE sources, the iPXE and Secure Boot release assets, and the plugins. Pointing any of them at an internal mirror now tests the mirror instead of github.com rather than as well as it. One HTTPS request per host settles DNS, TCP and TLS together, and curl's exit status names which of the three failed, so the old three-stage ladder isn't needed to produce a specific message.

No `-k`: a proxy presenting its own CA passes an unverified probe and then fails the `git clone` that follows, and predicting that clone is the point of the check.

**The result is now `$internet_ok`, and the fetches read it.** Writing the regression test turned up four more instances of the same unbounded-fetch class, three worse than the original:

| Where | Was | Now |
|---|---|---|
| `downloadfiles()` | 8 URLs × 10 rounds × 2 timeout-less curls = **160 unbounded connects**, on the step that runs every install and upgrade | bounded; 1 round when the host is known unreachable |
| the `api.github.com` FOS-release lookup | unbounded | `--connect-timeout` + `--max-time` (it's a few KB of JSON) |
| `_ensureEfitools()` | unbounded fetch of git.kernel.org | bounded |
| udpcast `config.guess`/`config.sub` wgets (Pi path) | no connect timeout, and wget defaults to `--tries=20` | bounded, `--tries=2` |
| `fetchipxeasset()` | 10 rounds × 2 timeout-less curls | bounded; 1 round when unreachable |
| `bin/fetch-plugins.sh` | 5 rounds × 2 timeout-less curls | bounded (defaults them itself — it's runnable standalone) |
| `prepareiPXEsource()` | `git fetch` with no connect timeout of its own | skipped when the host is unreachable |

`--max-time` is deliberately **not** used on the artifact downloads: those are multi-megabyte kernels and tarballs, and a slow but working link has to be allowed to finish. `--speed-time`/`--speed-limit` catch a transfer that opens and then stalls, which is the failure `--max-time` would otherwise be reached for.

**Offline installs are unaffected.** Failure stays non-fatal, the checksum of a pre-placed tarball is still tested before any download is attempted, and a pre-placed source tree is still used as-is. Verified: `fetchipxeasset` returns 0 in 0s from a pre-placed tarball with `$internet_ok=0` and an unroutable host.

## Deliberately left alone

The `maintenance/*` posts and `nodecert.php` go to `$ipaddress` or `$snmysqlhost` — this host, or the master over the LAN, not the internet. `nodecert.php` is still unbounded and can still stall a node install if the master is down. That's a real, smaller instance of the same class; it's noted in the test rather than changed here.

## Testing

`tests/network-fetch-bounded.test.sh` gates the class with two rules that between them bound both ends of every remote call: the connect must be bounded by `--connect-timeout` or a total cap, and a call with no total cap must carry `--speed-time`. It also asserts the two are mutually exclusive — capping the kernel download is the tempting wrong fix — and pins that `$internet_ok` is read *where it changes what happens*, not merely mentioned.

All 13 assertions were mutation-verified by reintroducing the defect each one guards. One initially could not fail: *"does it probe the plugins host"* passed with the probe loop deleted, because the grep was matching the comment naming `$pluginsgit` rather than the code. `body()` now strips comments — the same trap the `no-session-for-browserless` gate hit.

Measured, against a reachable host, a blackholed TEST-NET address, an unresolvable name, and a mixed set:

```
reachable          Done     0s
blackholed         Failed   5s   (was 300s+ per host per address family)
unresolvable name  Failed   0s
mixed              Failed   5s
```

Full suite: **51 passed, 0 failed** (`sh tests/run-all.sh`). `run-all.sh` globs `*.test.sh`, so the new test needs no wiring.

Also modernized the RH DNS advice, which pointed at `/etc/sysconfig/network-scripts/ifcfg-*` — not where DNS has lived since NetworkManager keyfiles. It now names `nmcli`.

## Note for whoever merges

#1123 also touches `lib/common/functions.sh` heavily, in a different area (install-settings resolution). No dependency either way — whichever lands second may need a text merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
