### PR TITLE
Sync the version on merge, not just on the daily sweep

### DIFF
--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -1,0 +1,68 @@
+name: Sync generated files and version
+
+# Merge-triggered trigger stub. All the logic lives in FOGProject/fog-workflows'
+# update-lang-fix-psr-and-sync-version.yml; this file exists only because GitHub
+# Actions has no cross-repo merge trigger, so something has to live here to react
+# to a merge.
+#
+# The pre-commit hook cannot cover this. It is client-side, so a PR merged
+# through GitHub's web UI (squash, merge commit or rebase) never runs it and
+# FOG_VERSION goes stale until the daily sweep fires at 10:10 UTC. This closes
+# that window.
+#
+# pull_request_target, NOT push -- and that distinction is the whole safety
+# argument, not caution. The sweep pushes its fixup commit straight to the
+# branch, and a direct push is not a PR merge, so it cannot re-fire this stub.
+# The 2026-07-28 runaway that put ~30 commits on dev-branch in about 20 minutes
+# was a push-triggered stub doing exactly that. The schedule in fog-workflows
+# stays exactly as it is, and remains the backstop for direct pushes and for
+# rc-*/feature-* branches.
+#
+# pull_request_target rather than pull_request because secrets are withheld from
+# fork PRs, and the reusable workflow needs FOG_WORKFLOWS_PRIVATE_KEY to mint its
+# App token. The usual pull_request_target hazard does not apply here: nothing
+# checks out the PR head. The reusable workflow checks out FOGProject/fogproject
+# at the base branch -- code a maintainer has already merged.
+#
+# One file, identical on every branch that carries it, for the same reason
+# tests.yml is: fixing it should not mean editing it on three branches. GitHub
+# reads this from the PR's BASE branch, so each branch's copy only ever acts on
+# merges into that branch, and the allowlist below is what scopes it.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: fog-sync-on-merge-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # An allowlist, not "not stable". Branches cut from working-1.6 inherit this
+    # file, and an rc-*/feature-* branch must NOT be merge-synced: fog-version.sh
+    # reports drift on every run for rc (it increments off the committed suffix
+    # rather than a commit count), so a per-merge sync would bump the RC suffix
+    # on every merge. Those stay on the daily sweep. stable is excluded because
+    # its version is owned entirely by fog-workflows' stable-releases.yml.
+    #
+    # `closed` fires on abandoned PRs too, hence the merged check -- and the
+    # reusable workflow uses its `branch` input verbatim, with no validation
+    # against its own watched list, so constraining it is this file's job.
+    if: >-
+      github.event.pull_request.merged == true
+      && contains(fromJson('["working-1.6", "dev-branch"]'), github.event.pull_request.base.ref)
+
+    # Least privilege, stated rather than inherited. Everything the reusable
+    # workflow writes -- the commit, the push, and the version badge -- uses a
+    # GitHub App token, so nothing on this path needs a writable GITHUB_TOKEN. A
+    # called workflow can never hold more permission than its caller, so leaving
+    # this to the repo-wide default would make the effective permission whatever
+    # that happens to be. See fos' create_release.yml for the same reasoning.
+    permissions:
+      contents: read
+
+    uses: FOGProject/fog-workflows/.github/workflows/update-lang-fix-psr-and-sync-version.yml@main
+    with:
+      branch: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
## Blocked on FOGProject/fog-workflows#17 — draft until that merges

Opened as a draft deliberately. fog-workflows#17 moves the shared workflow's version-badge write onto an App token; without it, **every merge into this branch goes red** on that step. Mark ready once #17 is in.

## What

Adds `.github/workflows/sync-generated-files.yml` — a trigger stub that calls `FOGProject/fog-workflows`' `update-lang-fix-psr-and-sync-version.yml` when a PR is merged. No logic lives here; it is the same shape as `tests.yml`.

## Why

`FOG_VERSION` is derived from the commit count since `master`, and the pre-commit hook that keeps it correct is **client-side**. A PR merged through GitHub's web UI — squash, merge commit, or rebase — never runs it. Today the only thing that notices is fog-workflows' 10:10 UTC sweep, so a merged PR can leave a wrong version string on the branch for the best part of a day. This reacts to the merge instead.

The shared workflow already accepts a `branch` input over `workflow_call` (`stable-releases.yml` calls it exactly this way), so the stub is `uses:` plus two conditions.

## `pull_request_target`, not `push` — this is the whole design

This is the same idea as the stub that was reverted on 2026-07-28 after putting ~30 commits on `dev-branch` in about 20 minutes, so the difference matters and is not "we'll be careful this time".

That stub triggered on `push`. The sweep pushes its fixup commit **directly to the branch**, `push` saw it, and the workflow fed itself. `pull_request_target: closed` cannot do that: a direct push is not a PR merge, so the bot cannot raise the event that would call this again. The loop is closed by the shape of the event, not by an actor-name guard that has to be kept correct.

(Two other fixes already landed since that incident and still hold: `fog-version.sh`'s two-pass `+1` anticipation, and byte-idempotent translation regen via `--omit-header --no-location` + `msgcat --no-wrap --sort-output`. This adds a third, structural, layer.)

`pull_request_target` rather than `pull_request` because secrets are withheld from fork PRs and the reusable workflow needs `FOG_WORKFLOWS_PRIVATE_KEY` to mint its App token — and most contributions here come from forks. The usual `pull_request_target` hazard does not apply: nothing checks out the PR *head*. The reusable workflow checks out `FOGProject/fogproject` at the **base branch** — code a maintainer has already merged, the same tree the daily schedule builds.

## The branch allowlist is deliberate

It is an allowlist, not a `!= 'stable'` test, for two reasons:

- Branches cut from `working-1.6` **inherit this file**, so a denylist would quietly start merge-syncing `feature-*` and `rc-*`.
- `rc-*` must not be merge-synced at all: `fog-version.sh` increments `rc` off the *committed* suffix rather than a commit count, so it reports drift on **every** run. A per-merge sync there would bump the RC suffix on every merge.

`rc-*`/`feature-*` stay on the daily sweep, which is unchanged and still covers direct pushes. `stable` is excluded because its version is owned entirely by `stable-releases.yml`.

`stable` gets this file on its own at the next release merge, where it is inert — `stable` is not in the allowlist. Nothing to do there.

## Trade-off being accepted

One `fog-workflows[bot]` commit after nearly every merged PR. That is inherent: the version is derived from commit count, so keeping it correct within minutes of a merge costs a commit per merge. It deliberately reverses the earlier "daily caps this at one per branch per day" choice, buying a correct version string for a noisier history.

## Verification

- `actionlint` clean.
- After merge, the acceptance test is that the bot's fixup push queues **no second run** — confirm in the Actions tab. Then `sh .githooks/lib/fog-version.sh working-1.6 head` at that commit should print `false` on line 3, i.e. it converged in exactly one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqufBbuckux8kitJeW3uAK
