### PR TITLE
Sync the version on merge, not just on the daily sweep (dev-branch)

### DIFF
--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -1,0 +1,68 @@
+name: Sync generated files and version
+
+# Merge-triggered trigger stub. All the logic lives in FOGProject/fog-workflows'
+# update-lang-fix-psr-and-sync-version.yml; this file exists only because GitHub
+# Actions has no cross-repo merge trigger, so something has to live here to react
+# to a merge.
+#
+# The pre-commit hook cannot cover this. It is client-side, so a PR merged
+# through GitHub's web UI (squash, merge commit or rebase) never runs it and
+# FOG_VERSION goes stale until the daily sweep fires at 10:10 UTC. This closes
+# that window.
+#
+# pull_request_target, NOT push -- and that distinction is the whole safety
+# argument, not caution. The sweep pushes its fixup commit straight to the
+# branch, and a direct push is not a PR merge, so it cannot re-fire this stub.
+# The 2026-07-28 runaway that put ~30 commits on dev-branch in about 20 minutes
+# was a push-triggered stub doing exactly that. The schedule in fog-workflows
+# stays exactly as it is, and remains the backstop for direct pushes and for
+# rc-*/feature-* branches.
+#
+# pull_request_target rather than pull_request because secrets are withheld from
+# fork PRs, and the reusable workflow needs FOG_WORKFLOWS_PRIVATE_KEY to mint its
+# App token. The usual pull_request_target hazard does not apply here: nothing
+# checks out the PR head. The reusable workflow checks out FOGProject/fogproject
+# at the base branch -- code a maintainer has already merged.
+#
+# One file, identical on every branch that carries it, for the same reason
+# tests.yml is: fixing it should not mean editing it on three branches. GitHub
+# reads this from the PR's BASE branch, so each branch's copy only ever acts on
+# merges into that branch, and the allowlist below is what scopes it.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: fog-sync-on-merge-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # An allowlist, not "not stable". Branches cut from working-1.6 inherit this
+    # file, and an rc-*/feature-* branch must NOT be merge-synced: fog-version.sh
+    # reports drift on every run for rc (it increments off the committed suffix
+    # rather than a commit count), so a per-merge sync would bump the RC suffix
+    # on every merge. Those stay on the daily sweep. stable is excluded because
+    # its version is owned entirely by fog-workflows' stable-releases.yml.
+    #
+    # `closed` fires on abandoned PRs too, hence the merged check -- and the
+    # reusable workflow uses its `branch` input verbatim, with no validation
+    # against its own watched list, so constraining it is this file's job.
+    if: >-
+      github.event.pull_request.merged == true
+      && contains(fromJson('["working-1.6", "dev-branch"]'), github.event.pull_request.base.ref)
+
+    # Least privilege, stated rather than inherited. Everything the reusable
+    # workflow writes -- the commit, the push, and the version badge -- uses a
+    # GitHub App token, so nothing on this path needs a writable GITHUB_TOKEN. A
+    # called workflow can never hold more permission than its caller, so leaving
+    # this to the repo-wide default would make the effective permission whatever
+    # that happens to be. See fos' create_release.yml for the same reasoning.
+    permissions:
+      contents: read
+
+    uses: FOGProject/fog-workflows/.github/workflows/update-lang-fix-psr-and-sync-version.yml@main
+    with:
+      branch: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
## Blocked on FOGProject/fog-workflows#17 — draft until that merges

Opened as a draft deliberately. fog-workflows#17 moves the shared workflow's version-badge write onto an App token; without it, **every merge into this branch goes red** on that step. Mark ready once #17 is in. Ideally land #1160 (`working-1.6`) first as well, so the file's home branch has it.

## What

Port of #1160 to `dev-branch`. Adds `.github/workflows/sync-generated-files.yml`, a trigger stub calling `FOGProject/fog-workflows`' `update-lang-fix-psr-and-sync-version.yml` on merge. **Byte-identical to the `working-1.6` copy** — verified same blob hash, `9c8ca7f`.

One file rather than one scoped per branch, for the same reason `tests.yml` is one file: fixing it should not mean editing it on three branches. GitHub reads a `pull_request_target` workflow from the PR's **base branch**, so this copy only ever acts on merges into `dev-branch`; the allowlist inside is what scopes it.

## Why

`FOG_VERSION` is derived from the commit count since `master`, and the pre-commit hook that keeps it correct is client-side — a PR merged through the web UI never runs it. Until now the only thing that noticed was the 10:10 UTC sweep, leaving a wrong version string on the branch for up to a day.

## `pull_request_target`, not `push`

The stub reverted on 2026-07-28 — the one that put ~30 commits on **this branch** in about 20 minutes — triggered on `push`. The sweep pushes its fixup directly to the branch, `push` saw it, and the workflow fed itself. `pull_request_target: closed` cannot do that: a direct push is not a PR merge, so the bot cannot raise the event that calls this again. The loop is closed by the shape of the event rather than by a guard that has to be maintained.

## Two consequences specific to `dev-branch`

**`stable`'s version number will advance faster.** `fog-version.sh` computes `stable`'s version from `git rev-list master..dev-branch --count`, so every extra sync commit here feeds into it. It is never *wrong* — that count is what the version is defined as — just larger. Accepted deliberately rather than engineered around; changing the counting rule for the release line is a bigger, riskier change and is not in scope here.

**The release pipeline will trip this stub, harmlessly.** `stable-releases.yml`'s final `sync-branches` job runs `gh pr create -B dev-branch -H stable` then `gh pr merge stable --merge` — a PR merge whose base is `dev-branch` — so this fires and re-syncs `dev-branch` once the release lands. That is correct (the commit count really did change) and cannot loop. The earlier `gh pr merge dev-branch --merge` has base `stable`, which is not in the allowlist, so it does not fire.

## Trade-off being accepted

One `fog-workflows[bot]` commit after nearly every merged PR — inherent to a commit-count-derived version, and a deliberate reversal of the earlier "one per branch per day" cap.

## Verification

- `actionlint` clean.
- After merge: confirm the bot's fixup push queues **no second run**, then `sh .githooks/lib/fog-version.sh dev-branch head` prints `false` on line 3.
- `dev-branch` deliberately carries **no** `FOG_CHANNEL` line — confirm the sweep does not add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqufBbuckux8kitJeW3uAK
