### PR TITLE
Honor $databaseFieldsNotInt in isValid() too

### DIFF
--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1224,12 +1224,26 @@ abstract class FOGController extends FOGBase
     public function isValid()
     {
         try {
+            // The same opt-out save() honors (GH-1153): a key ending in "id"
+            // that the model has declared is not a foreign key gets the
+            // generic non-empty check, not the integer one. Without this an
+            // OIDC provider whose clientId is "fog-web" is valid enough to
+            // save and then invalid forever after, so its login button
+            // silently never renders. Built here rather than read in the
+            // loop because key() has to run over the declared names too.
+            $notInt = [];
+            foreach ($this->databaseFieldsNotInt as $strKey) {
+                $notInt[$this->key($strKey)] = true;
+            }
+
             foreach ($this->databaseFieldsRequired as &$key) {
                 $key = $this->key($key);
                 $val = $this->get($key);
 
                 // If key ends with ID (case-insensitive), require integer >= 1
-                if (strtolower(substr($key, -2)) === 'id') {
+                if (strtolower(substr($key, -2)) === 'id'
+                    && !isset($notInt[$key])
+                ) {
                     if (filter_var($val, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
                         throw new \Exception(self::$foglang['RequiredDB'] . ": " . $key);
                     }

--- a/tests/databasefields-notint.test.php
+++ b/tests/databasefields-notint.test.php
@@ -189,6 +189,49 @@ if (strpos($squashed, $build) !== false
 }
 
 // ---------------------------------------------------------------
+// 1b. isValid() honors the same opt-out -- the half GH-1153 missed.
+//
+// save() and isValid() each carry their own copy of the "ends in id, so
+// it is a foreign key" inference, and only save()'s was fixed. The half
+// that was missed is the quieter one: the object saves, and then every
+// later isValid() says no. An enabled OIDC provider whose clientId is
+// "fog-web" simply had no login button, with nothing logged anywhere.
+// ---------------------------------------------------------------
+$at = strpos($squashed, 'publicfunctionisValid(){');
+$checks++;
+if ($at === false) {
+    $failures[] = 'FOGController::isValid() not found';
+    $isValidBody = '';
+} else {
+    $end = strpos($squashed, 'publicfunction', $at + 20);
+    $isValidBody = substr(
+        $squashed,
+        $at,
+        $end === false ? null : $end - $at
+    );
+}
+
+$checks++;
+if ($isValidBody !== '' && strpos($isValidBody, $build) === false) {
+    $failures[] = 'FOGController::isValid() does not build the $notInt lookup';
+}
+
+$vBranch = "if(strtolower(substr(\$key,-2))==='id'&&!isset(\$notInt[\$key]))";
+$checks++;
+if ($isValidBody !== '' && strpos($isValidBody, $vBranch) === false) {
+    $failures[] = 'isValid()\'s foreign-key branch does not exclude $notInt keys';
+}
+
+$checks++;
+if ($isValidBody !== ''
+    && strpos($isValidBody, $build) !== false
+    && strpos($isValidBody, $vBranch) !== false
+    && strpos($isValidBody, $build) > strpos($isValidBody, $vBranch)
+) {
+    $failures[] = 'isValid() builds $notInt after the branch that reads it';
+}
+
+// ---------------------------------------------------------------
 // 2. Every model's *id keys match their column's actual type.
 // ---------------------------------------------------------------
 $iter = new \RecursiveIteratorIterator(


### PR DESCRIPTION
## The bug

`FOGController::save()` and `FOGController::isValid()` each carry their own copy of
the "this key ends in `id`, so it holds a foreign key" inference. #1153 fixed
`save()` and gave models `$databaseFieldsNotInt` to opt out. It did not fix
`isValid()`, which still runs any required `*id` field through
`FILTER_VALIDATE_INT`.

So a model could save its string identifier and then fail validation forever
afterwards.

## What that costs today

The whole OIDC plugin. `OIDC::$databaseFieldsRequired` holds `clientId` — a string
the provider chooses (`fog-web`, or a GUID on Entra). Two call sites read
`isValid()` and both fail silently:

| Call site | Effect |
|---|---|
| `AddOIDCRoutes::loginButtons()` | the provider is skipped, so the "Sign in with …" button never renders — the login page looks exactly as it does with no provider configured |
| `OIDCFlow::_enabledProvider()` | throws `Unknown identity provider`, so even a hand-typed `/ext/oidc/start?provider=N` is refused |

Nothing is logged in either path.

## Verification

Against a real Keycloak (`quay.io/keycloak/keycloak:26.0`) running on the lab box,
with an enabled provider row pointing at it:

```
=== LIVE (deployed, unpatched) ===
isValid: false
login buttons: []
=== SHADOW (this commit overlaid) ===
isValid: true
login buttons: [{"label":"Sign in with Test IdP","url":"\/fog\/ext\/oidc\/start?provider=3","icon":"fa fa-id-badge"}]
```

## The fix

`isValid()` builds the same `$notInt` lookup from the same property, the same way
`save()` does, and its `*id` branch consults it.

`tests/databasefields-notint.test.php` grows a section that pins `isValid()`'s copy
specifically: the lookup exists, the branch consults it, and the lookup is built
before the branch reads it. Five mutations verified, all caught — the guard
removed, the lookup removed, the lookup moved after the branch, the guard reduced
to a comment, and the `save()` half broken (so the original gate is confirmed still
live). `sh tests/run-all.sh` → 50 passed, 0 failed.

## Downstream

None. No route class list change, no schema change, no OpenAPI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
