### PR TITLE
Give nginx back the query string on routed requests

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6117,7 +6117,16 @@ EOF
                         echo "        try_files \$uri =404;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    location ~ ^${webrootre}(.*)\$ {" >> "$etcconf"
-                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php;" >> "$etcconf"
+                        # $is_args$args, because a try_files fallback to a
+                        # plain URI hands the router an EMPTY query string.
+                        # Apache's rewrite carries QSA and always has, so
+                        # every routed endpoint that reads a query parameter
+                        # -- the API's expand/start/length, and the OIDC
+                        # plugin's provider/state/code -- worked there and
+                        # silently saw nothing here. Route::queryParam()
+                        # re-parses REQUEST_URI to survive the old vhosts
+                        # this leaves behind; that fallback stays.
+                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php\$is_args\$args;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    proxy_cookie_domain ~(?P<secure_domain>([-0-9a-z]+\.)?[-0-9a-z]+\.[a-z]+)$ \"$secure_domain; secure\";" >> "$etcconf"
                         echo "}" >> "$etcconf"
@@ -6169,7 +6178,16 @@ EOF
                         echo "        try_files \$uri =404;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    location ~ ^${webrootre}(.*)\$ {" >> "$etcconf"
-                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php;" >> "$etcconf"
+                        # $is_args$args, because a try_files fallback to a
+                        # plain URI hands the router an EMPTY query string.
+                        # Apache's rewrite carries QSA and always has, so
+                        # every routed endpoint that reads a query parameter
+                        # -- the API's expand/start/length, and the OIDC
+                        # plugin's provider/state/code -- worked there and
+                        # silently saw nothing here. Route::queryParam()
+                        # re-parses REQUEST_URI to survive the old vhosts
+                        # this leaves behind; that fallback stays.
+                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php\$is_args\$args;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    proxy_cookie_domain ~(?P<secure_domain>([-0-9a-z]+\.)?[-0-9a-z]+\.[a-z]+)$ \"$secure_domain; secure\";" >> "$etcconf"
                         echo "}" >> "$etcconf"
@@ -6302,7 +6320,16 @@ EOF
                         echo "        try_files \$uri =404;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    location ~ ^${webrootre}(.*)\$ {" >> "$etcconf"
-                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php;" >> "$etcconf"
+                        # $is_args$args, because a try_files fallback to a
+                        # plain URI hands the router an EMPTY query string.
+                        # Apache's rewrite carries QSA and always has, so
+                        # every routed endpoint that reads a query parameter
+                        # -- the API's expand/start/length, and the OIDC
+                        # plugin's provider/state/code -- worked there and
+                        # silently saw nothing here. Route::queryParam()
+                        # re-parses REQUEST_URI to survive the old vhosts
+                        # this leaves behind; that fallback stays.
+                        echo "        try_files \$uri \$uri/ ${webroot}api/index.php\$is_args\$args;" >> "$etcconf"
                         echo "    }" >> "$etcconf"
                         echo "    proxy_cookie_domain ~(?P<secure_domain>([-0-9a-z]+\.)?[-0-9a-z]+\.[a-z]+)$ \"$secure_domain; secure\";" >> "$etcconf"
                         echo "}" >> "$etcconf"

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -4324,11 +4324,23 @@ class Route extends FOGBase
      * body). The original request line still carries the query string, so fall
      * back to parsing REQUEST_URI when $_GET has not been populated.
      *
+     * Apache's rewrite carries QSA and never had the problem; nginx's
+     * try_files fallback did, and the installer now appends $is_args$args to
+     * fix it at the source. This stays because a server that has not re-run
+     * the installer keeps its old vhost, and because a handler cannot tell
+     * which of the two it is running under.
+     *
+     * Public, not protected, because plugins register handlers on this same
+     * router and hit the same problem the moment they read a query parameter
+     * -- the OIDC plugin's ?provider= is how this was found. A plugin calling
+     * filter_input(INPUT_GET, ...) on a routed path silently sees nothing, so
+     * the working answer has to be reachable rather than re-invented.
+     *
      * @param string $key The parameter name to read.
      *
      * @return string|null The raw value, or null when absent.
      */
-    protected static function queryParam($key)
+    public static function queryParam($key)
     {
         $val = filter_input(INPUT_GET, $key);
         if ($val !== null && $val !== false) {

--- a/tests/routed-query-string.test.php
+++ b/tests/routed-query-string.test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * A routed request keeps its query string.
+ *
+ * FOG serves everything that is not a real file through an internal rewrite
+ * to api/index.php. Apache's rewrite carries QSA and always has. nginx's
+ * try_files fallback named a plain URI, and a plain URI hands the router an
+ * EMPTY query string -- so on nginx every routed endpoint that reads a query
+ * parameter saw nothing, with no error anywhere.
+ *
+ * That is not an OIDC problem, it is where it was found: the plugin's
+ * /ext/oidc/start?provider=3 arrived as provider=0 and answered "Unknown
+ * identity provider" on a provider that was configured and enabled. The
+ * API's own expand/start/length reads were already working around it inside
+ * Route::queryParam().
+ *
+ * Two halves, and both are needed:
+ *
+ *   the installer appends $is_args$args, which fixes it at the source, but
+ *   only for a server that re-runs the installer;
+ *
+ *   Route::queryParam() re-parses REQUEST_URI, which is what carries every
+ *   server that does not.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+// ---------------------------------------------------------------
+// 1. Every nginx try_files fallback carries the query string.
+// ---------------------------------------------------------------
+$functions = file_get_contents($root . '/lib/common/functions.sh');
+
+// The three vhost writers (http, https, and the no-certificate variant) each
+// emit their own copy, so counting matters as much as matching: a fourth
+// added without the suffix is the same bug again.
+preg_match_all(
+    '#try_files \\\\\$uri \\\\\$uri/ \$\{webroot\}api/index\.php([^;"]*);#',
+    $functions,
+    $matches
+);
+$checks++;
+if (count($matches[0]) < 3) {
+    $failures[] = sprintf(
+        'expected at least 3 nginx router fallbacks in functions.sh, found %d',
+        count($matches[0])
+    );
+}
+foreach ($matches[1] as $i => $suffix) {
+    $checks++;
+    if (strpos($suffix, '$is_args') === false
+        || strpos($suffix, '$args') === false
+    ) {
+        $failures[] = sprintf(
+            'nginx router fallback #%d does not append $is_args$args, so a '
+            . 'routed request reaches the router with an empty query string',
+            $i + 1
+        );
+    }
+}
+
+// Apache's side is QSA and must stay that way -- counted the same way, and
+// for the same reason: there are three of these too.
+preg_match_all(
+    '#RewriteRule \^\$\{webrootre\}\(\.\*\)\$ \$\{webroot\}api/index\.php '
+    . '\[([^\]]*)\]#',
+    $functions,
+    $apache
+);
+$checks++;
+if (count($apache[0]) < 3) {
+    $failures[] = sprintf(
+        'expected at least 3 apache router rewrites in functions.sh, found %d',
+        count($apache[0])
+    );
+}
+foreach ($apache[1] as $i => $flags) {
+    $checks++;
+    if (strpos($flags, 'QSA') === false) {
+        $failures[] = sprintf(
+            'apache router rewrite #%d no longer carries QSA, so it drops '
+            . 'the query string the way nginx used to',
+            $i + 1
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// 2. Route::queryParam() is public and still falls back.
+// ---------------------------------------------------------------
+$route = file_get_contents(
+    $root . '/packages/web/lib/router/route.class.php'
+);
+$squashed = preg_replace('#\s+#', '', $route);
+
+$signature = 'publicstaticfunctionqueryParam($key)';
+$checks++;
+$at = strpos($squashed, $signature);
+if ($at === false) {
+    $failures[] = 'Route::queryParam() is not public -- a plugin handler '
+        . 'cannot reach it and will re-invent filter_input(INPUT_GET)';
+    $body = '';
+} else {
+    // Scoped to the method: REQUEST_URI appears three times in this file,
+    // so an unscoped search passes while queryParam's own copy is gone.
+    $end = strpos($squashed, 'function', $at + strlen($signature));
+    $body = substr($squashed, $at, $end === false ? null : $end - $at);
+}
+
+// The fallback is the whole point of the method; without it the method is
+// just filter_input with extra steps.
+$checks++;
+if ($body !== '' && strpos($body, '$_SERVER[\'REQUEST_URI\']??\'\'') === false) {
+    $failures[] = 'Route::queryParam() no longer re-parses REQUEST_URI';
+}
+$checks++;
+if ($body !== '' && strpos($body, 'parse_str($qs,$parsed);') === false) {
+    $failures[] = 'Route::queryParam() no longer parses the recovered query '
+        . 'string';
+}
+
+if (count($failures) > 0) {
+    echo "FAIL routed-query-string (" . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS routed-query-string ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
## The bug

Anything that is not a real file is served through an internal rewrite to
`api/index.php`. Apache does that with `[QSA,L]` and carries the query string.
nginx did it with a `try_files` fallback naming a plain URI — and a plain URI
hands the router an **empty** query string.

So on nginx, every routed endpoint that reads a query parameter silently saw
nothing. Measured on the lab server before the fix:

```
PROBE id=0 qs='' fi=NULL get=NULL
```

`Route::queryParam()` has been working around this since #529 by re-parsing
`REQUEST_URI`, which is why the API's `expand` / `start` / `length` still worked.
Nothing outside `Route` could — the method was `protected`.

## What it cost

The whole OIDC plugin, on every nginx install. Its login button links to
`/ext/oidc/start?provider=3`; `OIDCFlow` read the id with
`filter_input(INPUT_GET, 'provider')`, got `null`, and refused a configured,
enabled provider with **"Unknown identity provider"**. `callback()` reads `state`,
`code` and `error` the same way, so the flow could not have completed either.

## The fix — two halves, both needed

| Half | Fixes | Doesn't fix |
|---|---|---|
| installer appends `$is_args$args` to all three nginx vhost writers | every server that re-runs the installer | an existing vhost — nothing rewrites one |
| `Route::queryParam()` keeps its `REQUEST_URI` fallback and becomes **public** | every server that doesn't | — |

Making it public is the point of the second half: a plugin registering a handler
on this same router hits exactly the same wall, and the working answer should be
reachable rather than re-invented. The OIDC plugin's `?provider=` is how this was
found; the companion fix is FOGProject/fog-plugins#14.

Apache is untouched — it was always correct, and the test now pins that too.

## Verification

Live on the lab server. Before the vhost fix, `/fog/ext/oidc/start?provider=3`
302'd straight back to the login page with "Unknown identity provider". After:

```
location: https://127.0.0.1:8443/realms/fog/protocol/openid-connect/auth?response_type=code
  &client_id=fog-web&redirect_uri=https%3A%2F%2F10.255.20.1%2Ffog%2Fext%2Foidc%2Fcallback
  &scope=openid+profile+email&state=…&nonce=…&code_challenge=…&code_challenge_method=S256
```

and a full sign-in against a real Keycloak now completes end to end.

`tests/routed-query-string.test.php` **counts** the fallbacks rather than matching
one, so a fourth vhost writer added without the suffix fails here — same for the
three Apache rewrites and their `QSA`. Five mutations verified, all caught.
`sh tests/run-all.sh` → 51 passed, 0 failed.

## Downstream

None. No route class list change, no schema change, no OpenAPI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
