### PR TITLE
Pin fog-plugins v1.6.8

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.7');
+        define('FOG_PLUGINS_VERSION', 'v1.6.8');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Carries FOGProject/fog-plugins#14 — the OIDC flow reads its query parameters through `Route::queryParam()`, which #1163 made public.

Without this bump the fix cannot reach a server: `bin/fetch-plugins.sh` downloads whatever `FOG_PLUGINS_VERSION` names.

Release: https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR