### PR TITLE
Publish local ESP boot as per-arch archives with a manifest

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -212,8 +212,11 @@ usage() {
     echo -e "\t                       \t\t\tkernels for UEFI Secure Boot"
     echo -e "\t      --secure-boot-cert\tCertificate matching --secure-boot-key"
     echo -e "\t                        \t\t\t(both are required together)"
-    echo -e "\t      --no-secure-boot\t\tDo not generate a Secure Boot signing"
-    echo -e "\t                      \t\t\tkey, and leave the FOS kernels unsigned"
+    echo -e "\t      --no-secure-boot\t\tDo not publish Secure Boot ENROLMENT"
+    echo -e "\t                      \t\t\tmaterial: no MOK.der, no PK/KEK/db.auth,"
+    echo -e "\t                      \t\t\tand no 'Enroll Secure Boot Key' menu"
+    echo -e "\t                      \t\t\tentry. Binaries are still signed -- a"
+    echo -e "\t                      \t\t\tsignature is inert with Secure Boot off"
     echo -e "\t      --no-ca-trust\t\tDo not add this server's CA to this"
     echo -e "\t                   \t\t\tserver's own system trust store"
     exit 0
@@ -1262,13 +1265,21 @@ while [[ -z $blGo ]]; do
                     # does not hold the signing key.
                     _signLocalIpxe
                     # Separate call, not folded into the one above, because the
-                    # two do not share a trigger. Signing needs Secure Boot keys;
-                    # publishing does not -- booting a machine from an iPXE
+                    # two do not share a trigger. Signing needs a Secure Boot
+                    # key; publishing does not -- booting a machine from an iPXE
                     # binary on its own ESP predates Secure Boot, and unsigned
                     # copies still work on every machine booting with it off. The
                     # web root is also rebuilt from scratch every run by
                     # configureHttpd, so publishing has to happen even on a run
                     # that signed nothing.
+                    #
+                    # Also downstream of _publishSecureBootKit and
+                    # _publishSecureBootAuthVars, which run inside configureHttpd
+                    # above via downloadfiles(). Each archive carries whatever
+                    # enrolment material those two actually published -- MOK.der
+                    # and the PK/KEK/db variable updates -- so one archive on a
+                    # USB stick holds every enrolment route. Taken by existence,
+                    # so a server that published neither simply ships neither.
                     _publishLocalBootFiles
                     configureFTP
                     configureSnapins

--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -132,113 +132,72 @@ uses a copy. This matters if you keep the pair somewhere the installer
 rebuilds, such as under the web root: without the copy it would be deleted
 mid-install.
 
+>[!note]
+>**`--no-secure-boot` declines enrolment, not signatures.** It stops the server
+>publishing `MOK.der` and the `PK`/`KEK`/`db` variable updates, and with them the
+>*Enroll Secure Boot Key* PXE menu entry, which is gated on `MOK.der` existing.
+>The signing key is still generated and the binaries are still signed.
+>
+>That is deliberate: an appended PE signature is inert on a machine booting with
+>Secure Boot **off** — which is every machine on a server that passed this flag —
+>so signing costs nothing. Leaving the binaries unsigned instead would only mean
+>that the day you do enrol, or move one of these files onto a machine that
+>already has Secure Boot on, the file is useless and nothing on the server can
+>fix it short of a re-install.
+
 ---
 
 ## Local ESP boot files
 
-**Not a customization point — a generated directory, rebuilt on every run.**
+**Not a customization point — generated archives, rebuilt on every run.**
 
-Machines whose firmware has no PXE boot option, and machines you would rather
-not have to reorder the boot menu on for every task, can be booted into FOG from
-an iPXE binary on their own EFI System Partition. The installer publishes the
-binaries for that here, so you can fetch one over HTTP instead of hand-rolling a
+Machines whose firmware has no PXE boot option, and machines you would rather not
+reorder the boot menu on for every task, can be booted into FOG from an iPXE
+binary on their own EFI System Partition. The installer publishes ready-to-copy
+archives for that here, so you can fetch one over HTTP instead of hand-rolling a
 symlink from the TFTP tree into your web root:
 
 ```
 <webroot>/service/localboot/
+  manifest.json               index of everything below
+  fog-esp-x86_64.zip          fog-esp-x86_64-10sec.zip
+  fog-esp-i386.zip            fog-esp-i386-10sec.zip
+  fog-esp-arm64.zip           fog-esp-arm64-10sec.zip
 ```
+
+One archive per architecture and delay variant, and nothing else. Each holds a
+single top-level directory named after the archive — **copy its contents onto the
+ESP** (`\EFI\FOG\` is a good place) and point the firmware boot manager at one of
+the entry points below.
+
+>[!note]
+>Where the `zip` package is missing the installer falls back to `.tar.gz`.
+>`manifest.json` always names the file that was actually produced, so fetch the
+>name it gives rather than assuming an extension.
 
 **This is not a Secure Boot feature and does not need Secure Boot keys.** Local
 ESP boot predates Secure Boot by years; Secure Boot only added the requirement
-for a signature. The directory is published either way:
+for a signature. The archives are published either way — a server with no key
+publishes the same set unsigned, which is what every machine booting with Secure
+Boot **off** needs anyway.
 
-- **No Secure Boot keys on the server** — the binaries are published unsigned.
-  They work on any machine booting with Secure Boot **off**, which is what local
-  ESP boot has always needed. Nothing else changes.
-- **Secure Boot keys present** — the installer signs FOG's own iPXE builds with
-  your key first, so the same binaries also work on a machine booting with
-  Secure Boot **on**, provided your MOK is already enrolled on it (see
-  `service/secureboot/` and the *Enroll Secure Boot Key* menu entry).
+### Which archive
 
-### What is published
+`-10sec` is the only choice you have to make up front. Those binaries each wait
+10 seconds before DHCP, which is what lets a link come up on a switch running STP
+or port power-save. They are otherwise identical.
 
-A curated set, not the whole TFTP tree — 25 files, about 12MB. Per architecture
-(x86_64 at the top level, plus `i386-efi/` and `arm64-efi/`):
-
-| File | Use |
-| --- | --- |
-| `ipxe.efi` | **Start here.** Carries iPXE's own NIC drivers, all of them. |
-| `snp.efi` | Uses the firmware's UEFI SNP protocol instead. For hardware iPXE's own drivers do not cover, where the firmware does provide SNP. |
-| `intel.efi`, `realtek.efi` | Single-vendor builds, for when the all-drivers build misbehaves on that specific NIC. |
-| `10secdelay/ipxe.efi` | `ipxe.efi` plus a 10-second pause before DHCP, which is what lets a link come up on a switch running STP or port power-save. |
-
-Plus `secureboot/`, which is upstream's Microsoft-signed shim, the loaders it
-chains to, and MokManager — the first stages of a Secure Boot chain. These are
-never re-signed by FOG. They are absent on an HTTPS-only install, which does not
-stage them.
+It is a separate archive rather than a second set of files inside one because
+iPXE runs exactly the file called `autoexec.ipxe` and has no way to ask you which
+set you want — so a combined folder made choosing mean renaming one file over
+another. Choosing at download time removes the step: the binaries inside a
+`-10sec` archive carry the same plain names, and its single `autoexec.ipxe` is
+already the right one.
 
 >[!warning]
->`secureboot/ipxe.efi` is not a shortcut. It is upstream's signed build and it
->does carry iPXE's own NIC drivers, so it looks like the one file you need — but
->booted locally off an ESP it does not load them. Use it only as a chain stage
->that hands off to one of FOG's binaries above, never as the binary that has to
->bring up the network.
-
-`snponly.efi` is deliberately **not** published even though TFTP serves it. It
-binds only the device iPXE was loaded from, and booted off an ESP that device is
-the disk — so it never finds a NIC. It is the right binary for netboot and the
-wrong one here. The EMBED-less `autoexec/` builds are left out for a similar
-reason: they carry no boot script and fetch `autoexec.ipxe` from wherever they
-were loaded, which this directory does not provide. Both remain available over
-TFTP if you are assembling something deliberately.
-
-### `esp/` — the ready-to-copy kit
-
-Everything above is a menu. `esp/` is the opposite: **one folder you copy onto an
-EFI System Partition verbatim**, with the files already carrying the names the
-Secure Boot chain requires.
-
-```
-esp/snponly-shimx64.efi   point your boot manager at EITHER shim
-esp/snponly.efi             …this one loads snponly.efi
-esp/ipxe-shimx64.efi      point your boot manager at EITHER shim
-esp/ipxe.efi                …this one loads ipxe.efi
-esp/mmx64.efi             MokManager — how you enrol the key
-esp/autoexec.ipxe         chains the standard set, with fallbacks
-esp/autoexec-10sec.ipxe   chains the 10-second-delay set instead
-esp/fogipxe.efi           FOG's build, all drivers      ← the one that boots
-esp/fogsnp.efi            FOG's build, firmware SNP
-esp/fogintel.efi          FOG's build, Intel only
-esp/fogrealtek.efi        FOG's build, Realtek only
-esp/fogipxe10sec.efi      the same four, each waiting 10s
-esp/fogsnp10sec.efi         before DHCP
-esp/fogintel10sec.efi
-esp/fogrealtek10sec.efi
-esp/arm64-efi/            the same set, aa64 shims
-```
-
-The chain is: shim → its loader → `autoexec.ipxe` → one of the `fog*.efi`. shim
-establishes MOK trust, so the FOG binary — signed with your Secure Boot key —
-loads; and because it carries FOG's boot script compiled in, it finds the server
-itself.
-
-**Both shims are published; pick whichever your firmware gets along with.**
-`snponly-shimx64.efi` loads `snponly.efi`, `ipxe-shimx64.efi` loads `ipxe.efi`.
-Neither loader needs to drive a NIC — each only reads `autoexec.ipxe` out of the
-same folder and chains onward — so the choice is about which shim your firmware
-accepts, not about network hardware. One `autoexec.ipxe` serves both.
-
-**`mmx64.efi` is not optional.** shim launches MokManager from its own directory
-when it cannot verify the next stage, and that is the only way to enrol your key
-— shim's `MokList` is a boot-services-only variable, so nothing in a running OS
-can write it. Without MokManager beside the shim, an ESP that has not been
-enrolled yet is a dead end with no route out.
-
-**Two sets of binaries, two scripts.** The `10sec` binaries are identical except
-that each waits 10 seconds before DHCP, which is what lets a link come up on a
-switch running STP or port power-save. iPXE runs exactly the file called
-`autoexec.ipxe` and has no way to ask you which set you want, so choosing means
-swapping the file: rename `autoexec-10sec.ipxe` over `autoexec.ipxe`.
+>For the same reason, do **not** extract the plain and `-10sec` archives into the
+>same folder. They contain the same filenames with different bytes. Each unpacks
+>into its own named directory, so this only happens if you go out of your way.
 
 >[!note]
 >The delay has to live in the binary, not the script — `sleep` is an optional
@@ -247,28 +206,146 @@ swapping the file: rename `autoexec-10sec.ipxe` over `autoexec.ipxe`.
 >your boot manager reads no script at all, so there the embedded delay is the
 >only route to one.
 
+### What is inside
+
+```
+fog-esp-x86_64/
+  README.txt              what it is, both enrolment routes, which file to boot
+  MANIFEST.json           every file here with its sha256 and what it is for
+  autoexec.ipxe           chains the FOG builds in preference order
+  snponly-shimx64.efi   ] upstream's Microsoft-signed shim and the loader it
+  snponly.efi           ]  hands off to — point the boot manager at either shim
+  ipxe-shimx64.efi      ]
+  ipxe.efi              ]
+  mmx64.efi               MokManager
+  fogipxe.efi             FOG's build, all of iPXE's NIC drivers   ← start here
+  fogsnp.efi              FOG's build, firmware SNP protocol
+  fogintel.efi            FOG's build, Intel only
+  fogrealtek.efi          FOG's build, Realtek only
+  fogsnponly.efi          FOG's build, SNP bound to the load device
+  MOK.der               ] present when the server publishes enrolment material
+  PK.auth KEK.auth      ]
+  db.auth               ]
+  fog-enroll-mok.sh     ] enrol from a booted Linux OS via mokutil
+  fog-enroll-mok.desktop]
+```
+
+arm64 substitutes `snponly-shimaa64.efi`, `ipxe-shimaa64.efi` and `mmaa64.efi`.
+The `.auth` blobs and `MOK.der` are absent on a server that publishes no
+enrolment material (`--no-secureboot`, or a run where key generation failed).
+
+**Both shims are published; pick whichever your firmware gets along with.**
+`snponly-shimx64.efi` loads `snponly.efi`, `ipxe-shimx64.efi` loads `ipxe.efi`.
+Neither loader needs to drive a NIC — each only reads `autoexec.ipxe` out of the
+same folder and chains onward — so the choice is about which shim your firmware
+accepts, not about network hardware. One `autoexec.ipxe` serves both.
+
 **Two names are not yours to choose.** shim picks its second stage by rewriting
 its own `-shim<arch>.efi` suffix to `.efi`, so `snponly-shimx64.efi` will load
 `snponly.efi` and nothing else, and it must be upstream's copy — that is what
 shim's embedded certificate vouches for. This is why FOG's own builds are here
-under `fog` names instead of their natural ones: putting FOG's `ipxe.efi` next
-to `ipxe-shimx64.efi` would have shim try to load an image it cannot verify.
+under `fog` names instead of their natural ones: putting FOG's `ipxe.efi` next to
+`ipxe-shimx64.efi` would have shim try to load an image it cannot verify.
+
+**`mmx64.efi` is not optional, and neither is `MOK.der`.** shim launches
+MokManager from its own directory when it cannot verify the next stage, and that
+is the only way to enrol your key — shim's `MokList` is a boot-services-only
+variable, so nothing in a running OS can write it. MokManager then enrols by
+browsing the ESP for a certificate, which is what `MOK.der` is. Without both, an
+ESP that has not been enrolled yet is a dead end.
+
+>[!warning]
+>`ipxe.efi` in these archives is upstream's signed build, not FOG's. It does
+>carry iPXE's own NIC drivers, so it looks like the one file you need — but
+>booted locally off an ESP it does not load them. It works only as a chain stage
+>that hands off to one of the `fog*.efi`, never as the binary that has to bring
+>up the network. That is the whole reason FOG's own builds have to be here.
+
+### Booting it
+
+**Secure Boot off** — point the boot manager straight at `fogipxe.efi`.
+
+**Secure Boot on, via shim** — point the boot manager at `snponly-shimx64.efi`
+(or `ipxe-shimx64.efi`). The first time on a machine, shim cannot verify FOG's
+binary yet, so it launches MokManager: choose *Enroll key from disk* and select
+`MOK.der`. Reboot, and it boots from then on.
+
+**Secure Boot on, via firmware Setup Mode** — put the machine into Setup Mode in
+its firmware and enrol `PK.auth`, `KEK.auth` and `db.auth`. Firmware then
+verifies FOG's signed binaries directly, so you can point the boot manager at
+`fogipxe.efi` with no shim and no MokManager at all.
+
+>[!important]
+>**The Setup Mode route is the only Secure Boot path i386 has**, and it does
+>work. Upstream signs no shim for ia32, so the `i386` archives contain no shim,
+>loader or MokManager — but they do contain the `.auth` blobs, and a signed
+>`fogipxe.efi` verified directly against `db` needs none of that machinery.
+
+### If `fogipxe.efi` does not bring up your network
+
+Try `fogsnp.efi`, then `fogintel.efi` or `fogrealtek.efi`, then `fogsnponly.efi`.
+`autoexec.ipxe` already tries them in that order.
+
+`fogsnponly.efi` is last on purpose: it binds only the device iPXE was loaded
+from, and booted off an ESP that device is the disk, so it usually finds no NIC.
+It is included because it is the right binary when something chainloads it over
+the network, and there is hardware where it works — but it is the least likely
+of the five to be the answer here.
 
 >[!important]
 >`autoexec.ipxe`'s fallbacks tell you **which files you copied**, not which
 >driver works. They fire only when a binary is missing or fails verification.
 >Once one loads and runs, control never comes back — a variant that starts but
 >finds no NIC stops at its own prompt rather than falling through to the next.
->If `fogipxe.efi` doesn't drive your NIC, replace it; the script won't do it
->for you.
+>If `fogipxe.efi` doesn't drive your NIC, replace it; the script won't do it for
+>you.
 
-x86_64 and arm64 only — those are the two architectures upstream signs a shim
-for. An i386 machine with Secure Boot off needs none of this; take
-`i386-efi/ipxe.efi` from the list above and point the boot manager straight at it.
+### `manifest.json`
+
+A static file written at install time, so you can script against it without
+guessing filenames:
+
+```json
+{
+  "schema": 1,
+  "generated": "2026-08-17T14:02:11Z",
+  "fogVersion": "1.6.0-beta.123",
+  "ipxeVersion": "v2.0.0-fog.6",
+  "archives": [
+    { "path": "fog-esp-x86_64.zip", "arch": "x86_64", "variant": "standard",
+      "root": "fog-esp-x86_64", "size": 6812345, "sha256": "…",
+      "contents": [ { "name": "fogipxe.efi", "size": 1012345, "sha256": "…",
+                      "role": "fog-ipxe", "origin": "fog", "fogSigned": true,
+                      "note": "FOG's build with all of iPXE's own NIC drivers…" } ] }
+  ],
+  "kernels": [
+    { "name": "bzImage", "path": "../ipxe/bzImage", "arch": "x86_64",
+      "kind": "kernel", "size": 12345678, "sha256": "…" }
+  ]
+}
+```
+
+Paths are relative to the manifest's own URL, so it resolves under whatever
+hostname and webroot you reached it by. Every `sha256` is of the bytes as
+published — including after signing — so it is a real integrity check.
+
+`fogSigned` says whether **FOG's** signature is on the file. It is `false` for
+the upstream shim and loaders, which carry Microsoft's and iPXE's signatures
+instead; that is correct, not a gap.
+
+`kernels` lists the FOS kernel and initrd set that is **already published** under
+`service/ipxe/`. Nothing is copied — the archives do not contain a kernel. They
+are listed so this manifest is a single index of everything fetchable for a local
+boot. A kernel and initrd on an ESP would not boot FOG on their own in any case:
+FOS reads per-host, per-task arguments that `boot.php` generates.
 
 ### Notes
 
-Directory listing is off in every subdirectory; fetch files by name.
+Directory listing is off; fetch files by name, or read `manifest.json`.
+
+**Everything here is an archive.** No individual `.efi` has its own URL, which
+means these cannot be used as a UEFI HTTP Boot target or an iPXE `chain`
+destination. If you need that, unpack an archive and serve the file yourself.
 
 **The directory is deleted and rebuilt on every install**, so nothing you put in
 it survives. It is a publication of files from the TFTP tree, not a place to keep
@@ -276,9 +353,12 @@ things — edit the originals under your TFTP directory instead, and they will b
 re-signed and republished on the next run.
 
 Nothing here is secret. These are the same binaries TFTP already serves
-unauthenticated, and FOG already serves the signed FOS kernel over HTTP from
-`service/ipxe/`. If you do not want them published, delete the directory after
-an install; only local-ESP boot depends on it, and it comes back on the next run.
+unauthenticated, upstream's signed shim and loader (downloadable from fog-ipxe's
+release assets anyway), and certificates plus signatures over them — FOG already
+serves the signed FOS kernel over HTTP from `service/ipxe/`. The private keys
+never leave the PKI zone directory. If you do not want the archives published,
+delete the directory after an install; only local-ESP boot depends on it, and it
+comes back on the next run.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
+++ b/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
@@ -483,3 +483,137 @@ every run, and tells an admin who does not want it published to delete it.
    boots a machine from its ESP with Secure Boot off. This is the case the first
    implementation skipped entirely — it gated publishing on `$secureBootMokCert`,
    so a non-Secure-Boot server got nothing.
+
+---
+
+## Superseded: the published layout is now archives (2026-08-17)
+
+Everything above about *why* these binaries exist, which names shim reserves, and
+what the hardware testing established still holds and is still the reason the
+feature is shaped as it is. **What changed is Design §2 and §4 — what gets
+published and how.** Recorded here rather than edited in above, so the reasoning
+that led to the first shape stays readable.
+
+Reworks GH-1117. Prompted by looking at the tree on a server running the result:
+
+```
+service/localboot:
+  10secdelay  arm64-efi  esp  i386-efi  index.php
+  intel.efi  ipxe.efi  realtek.efi  secureboot  snp.efi
+```
+
+### What was wrong
+
+§2 published a *menu* and §4 published a *kit*, and they were the same bytes
+twice — `localbootfiles` under the TFTP names at the root, `localbootespfiles`
+under `esp/` with the `fog*` names. Consequences, all visible in that listing:
+
+- **arm64 in four places**: `arm64-efi/`, `10secdelay/arm64-efi/`,
+  `esp/arm64-efi/`, `secureboot/arm64-efi/`.
+- **The delay set was inconsistent between the two lists.** The menu published
+  only `10secdelay/ipxe.efi`; the kit published all four 10sec variants. Neither
+  list was wrong on its own terms; together they said two different things.
+- **Nothing told a downloader which file to take**, and with listing off the only
+  way to enumerate the directory was to already know the filenames.
+
+The premise that the two lists served two audiences did not survive contact.
+The *only* reason the kit needed different filenames is that shim reserves
+`snponly.efi` and `ipxe.efi` on an ESP — and those names are the strictly safer
+choice everywhere. So one correctly-named folder serves both the admin
+assembling an ESP and the admin who wants one binary out of it.
+
+### What replaced it
+
+Six archives and a `manifest.json`, and nothing else. One archive per
+(architecture × delay variant), each holding a single top-level directory named
+after itself.
+
+**The delay variant is its own archive.** §4 shipped both binary sets plus
+`autoexec.ipxe` and `autoexec-10sec.ipxe` in one folder, and choosing meant
+renaming one over the other — because iPXE runs exactly the file called
+`autoexec.ipxe` and cannot be asked which set you want. Choosing at *download*
+time deletes the step: the binaries in a `-10sec` archive carry the plain names
+and its single `autoexec.ipxe` is already correct. It costs each variant its own
+copy of the upstream shim set, which is the only reason the total is not smaller
+than the tree it replaced.
+
+**`manifest.json` is what makes curation honest.** §2 curated by *omission* —
+which is how FOG's `snponly.efi` came to be unavailable at all, and how an
+archive-less directory ended up saying nothing about which of five binaries to
+reach for. A manifest carries the same advice per file (`role`, `origin`,
+`fogSigned`, a prose `note`) without having to withhold anything to give it. It
+is a static file written at install time, deliberately not a PHP endpoint that
+lists the directory on request — that would be a directory listing with a
+traversal surface, to save writing a file that changes only when the installer
+runs.
+
+### Reversals
+
+| Was | Now | Why |
+| --- | --- | --- |
+| FOG's `snponly.efi` excluded | published as `fogsnponly.efi`, tried **last** in the ladder | The exclusion was only forced because `snponly.efi` is a shim-reserved name. Under the `fog` prefix there is no collision, the manifest note carries the disk-not-NIC caveat, and there is hardware where it works. |
+| `MOK.der` not in the kit | in every archive | MokManager enrols by browsing the ESP for a certificate. Shipping MokManager without one is still a dead end — it just fails one screen later. §4 missed this. |
+| No `.auth` blobs in the kit | `PK`/`KEK`/`db.auth` in every archive | They are signed EFI variable updates a machine in Setup Mode writes to put this server's certificate straight into `db`, after which firmware verifies a signed `fogipxe.efi` **directly** — no shim, no MokManager, no MOK. |
+| "i386 has no Secure Boot chain to assemble" (§4) | **wrong, and corrected** | True that upstream signs no shim for ia32. But the `db` route needs no shim, so i386 Secure Boot local boot works. The conclusion followed from treating the shim chain as the only route. |
+| Publishing gated on nothing; **signing** gated on `--no-secure-boot` | signing always runs; the opt-out declines **enrolment** | A PE signature is inert with Secure Boot off, so signing costs nothing, while an unsigned binary is useless the day anyone enrols with nothing on the server able to fix it. The flag now stops `MOK.der`, the `.auth` blobs, and so the PXE enrol entry — applied in `_ensureSecureBootPlatformKeys` and `_publishSecureBootKit` instead of by blanking `$secureBootKey`. |
+| ~~Curated list of loose files~~ | archives only | See the trade below. |
+
+### Traded away, deliberately
+
+**No individual binary has a URL any more**, so nothing published here can be a
+UEFI HTTP Boot target or an iPXE `chain` destination — which `service/secureboot/mmx64.efi`
+demonstrates is a real use (the PXE menu chains that single file over HTTP, and
+that is exactly why it is copied there). Accepted because the archive serves the
+"prepare an ESP" case that this feature exists for, and publishing the loose set
+alongside is purely additive if the other case ever turns up.
+
+### Bug found in adjacent code
+
+`_copyIpxeTree()` records a sha256 of every file it lays down in
+`${tftpdirdst}/.fog-ipxe-manifest`, so a later run can tell FOG's copy from one
+the admin replaced. `_signLocalIpxe()` re-signs those `.efi` **in place**
+afterwards and never re-stamped. On the *second* install of a Secure Boot server
+every `.efi` compares unequal: FOG stops updating its own binaries and reports
+all 45 as admin-modified, every run, permanently.
+
+The note under *Resolved during implementation* above — "nothing stamps or
+verifies `/tftpboot` contents, so no re-stamping is needed" — was true when
+written and stopped being true when `.fog-ipxe-manifest` landed. Fixed by
+`_restampIpxeManifest()`, which rewrites only the lines for files actually
+signed; an entry deliberately carrying the *original* sum for a file the admin
+really did replace is copied through untouched, so that file stays protected.
+
+### Rejected during the rework
+
+| Alternative | Why not |
+| --- | --- |
+| Keep the menu/kit split, dedupe with symlinks | Preserves the two-tree mental model, which is the thing that was confusing. A symlink inside the web root would work — same SELinux label, `Options +FollowSymLinks` already emitted, so the objection that killed the TFTP-tree symlink does not apply — but archiving symlinks is a trap and the split was the problem, not the copying. |
+| Loose files *and* archives | ~8MB more and, more to the point, it keeps the Secure Boot material as a third loose copy of what `service/secureboot/` already holds. The single-file URL it buys is real but hypothetical here. |
+| Bundle `bzImage`/`init.xz` per arch | 60–80MB per architecture, and it would not produce a working local boot on its own: FOS reads per-host, per-task kernel arguments that `boot.php` generates. Listed in the manifest's `kernels` section instead — no bytes moved, and the manifest becomes the single index. |
+| Grab `.usb`/`.iso` if present | A coherent but *different* feature (boot iPXE off a USB stick without touching the ESP), with its own layout question. Not published, and not silently dropped — say so if it is wanted. |
+| Build the manifest with `jq` | `jq` is in the install list, so it is normally there — but a missing package would mean publishing no manifest at all, which is the whole feature. Hand-written through a `_jsonStr` escaper instead: everything encoded here is content this file produced, so the escaping problem is bounded. Same reasoning as the `tar` fallback for `zip`. |
+| Symlink the enrolment material from `../secureboot/` | `_publishSecureBootKit()` `rm -rf`s that directory when there is no MOK, so a link inside an archive could dangle. Copies keep each archive self-contained, and the files are a few KB. |
+
+### Verification (in addition to the list above)
+
+`tests/localboot-publish.test.sh`, 62 assertions. Every mock file's **content is
+its own path in the tree**, so provenance is read out of the file rather than
+inferred — which is what pins the failure that is otherwise invisible on the
+server: a `-10sec` archive whose `fogipxe.efi` came from the plain tree shows up
+only as "the delay does nothing" on a switch running STP.
+
+Also covered: the manifest parses as JSON under an independent implementation
+(python, not the shell that wrote it) with every sha256 matching the published
+bytes; no BIOS artifact and no EMBED-less `autoexec/` build leaks in; upstream
+keeps the two shim-reserved names; the HTTPS-only shape publishes six archives
+and correctly omits an `autoexec.ipxe` no loader could read; a server with no
+enrolment material still succeeds; an empty tree reports `Failed` rather than
+publishing silently; a re-run is stable; and the `.fog-ipxe-manifest` regression
+is pinned end to end.
+
+Steps 3/3b of the original verification list are replaced by: fetch
+`manifest.json`, check each archive's sha256 against it, and confirm the
+directory itself 404s. Step 4 becomes: extract `fog-esp-x86_64.zip` and point the
+boot manager at `snponly-shimx64.efi`. New step: enrol `db.auth` from
+`fog-esp-i386.zip` through firmware Setup Mode and boot `fogipxe.efi` directly,
+with no shim — the path this spec originally said did not exist.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1287,7 +1287,11 @@ listPackages() {
             packages=$(echo $packages | sed -e 's/[-a-zA-Z]*dhcp[-a-zA-Z]*//g')
             ;;
     esac
-    packages="$packages jq unzip attr ${webserver}"
+    # zip is the WRITER and is a separate package from unzip on every distro
+    # here -- _publishLocalBootFiles() builds the local ESP boot archives with
+    # it. Named "zip" identically on apt/dnf/pacman/apk, so it needs no
+    # per-distro alternatives list.
+    packages="$packages jq unzip zip attr ${webserver}"
     case $osid in
         1)
             packages="$packages php-bcmath bc"
@@ -5364,7 +5368,9 @@ _collectPkiNames() {
     local needRoot=0 needWeb=0 needSB=0
     [[ ! -f $rootCAPem ]] && needRoot=1
     [[ ! -f "$(_pkiZoneDir web)/ca/.fogWebCA.pem" ]] && needWeb=1
-    [[ ${secureboot:-1} != 0 && ! -f "$(_pkiZoneDir secureboot)/ca/.fogSBCA.pem" ]] && needSB=1
+    # Not conditional on $secureboot: that flag declines ENROLMENT, not signing,
+    # so the Secure Boot CA is minted on every server. See _ensureSecureBootKeys.
+    [[ ! -f "$(_pkiZoneDir secureboot)/ca/.fogSBCA.pem" ]] && needSB=1
     [[ $needRoot -eq 0 && $needWeb -eq 0 && $needSB -eq 0 ]] && return 0
     [[ -n $extraServerNames || -n $internalDomains ]] && return 0
 
@@ -8011,17 +8017,26 @@ _ensureSecureBootKeys() {
     local cert="${keydir}/MOK.pem"
     local f
 
-    # Explicit opt-out. Left unset rather than half-set, so every downstream
-    # function's existing "no key configured" branch does the right thing.
-    # Defaulted and string-compared on purpose: an unset $secureboot under
-    # `-eq` is arithmetic, evaluates empty as 0, and would silently opt every
-    # caller that reaches here without config.sh straight out of the feature.
-    if [[ ${secureboot:-1} == 0 ]]; then
-        secureBootKey=""
-        secureBootCert=""
-        secureBootMokCert=""
-        return 0
-    fi
+    # $secureboot=0 is deliberately NOT handled here any more, and the keys are
+    # minted for an opted-out server exactly as for any other.
+    #
+    # What the opt-out turns off is ENROLMENT -- publishing MOK.der and the
+    # PK/KEK/db variable updates, and with them the PXE menu entry, which
+    # BootMenu gates on service/secureboot/MOK.der existing
+    # (bootmenu.class.php:2089). It does not turn off SIGNING, because an
+    # appended PE signature is inert on a machine booting with Secure Boot off
+    # -- which is every machine on an opted-out server -- and costs nothing.
+    # Leaving the binaries unsigned instead only means that the day anyone does
+    # enrol, or moves one of these files onto a machine that already has Secure
+    # Boot on, the file is useless and nothing on this server can fix it without
+    # a re-install.
+    #
+    # So the gate every downstream signer already has -- "is there a key?" --
+    # now answers yes on every server, and _signLocalIpxe/_resignRefind/
+    # _resignKernels/_resignCustomKernels sign unconditionally. The opt-out is
+    # re-applied in _ensureSecureBootPlatformKeys and _publishSecureBootKit,
+    # which are the two functions that publish enrolment material.
+    #
     # An admin-supplied pair always wins and is never touched or overwritten.
     # Their certificate is also what gets enrolled, exactly as before -- an
     # admin bringing their own Secure Boot intermediate points
@@ -8074,7 +8089,12 @@ _ensureSecureBootKeys() {
     # The old MOK.key/MOK.pem are left on disk untouched, so an admin who needs
     # to re-sign something with the previously enrolled key still can.
     if createSecureBootIntermediateCA; then
-        if [[ -f $key && -f $cert ]]; then
+        # Suppressed on an opted-out server: it publishes no MOK.der and offers
+        # no "Enroll Secure Boot Key" menu item, so both routes this names are
+        # absent and the notice would only send an admin looking for a 404. The
+        # keys are still minted and the binaries still signed -- see the top of
+        # this function -- there is simply nothing to enrol them with yet.
+        if [[ -f $key && -f $cert && ${secureboot:-1} != 0 ]]; then
             echo
             echo "  ###################################################################"
             echo "  # NOTICE: this server's Secure Boot trust has moved from a self-  #"
@@ -8192,6 +8212,13 @@ _ensureSecureBootPlatformKeys() {
     secureBootKEKKey=""
     secureBootKEKCert=""
 
+    # The platform keys exist for one job -- signing the PK/KEK/db variable
+    # updates a client writes in Setup Mode -- so this is one of the two places
+    # the $secureboot opt-out is applied. Signing keys are minted regardless
+    # (see _ensureSecureBootKeys); enrolment material is not. Blanked rather
+    # than merely skipped so _publishSecureBootAuthVars takes its "no platform
+    # keys" branch and clears any blobs a previous, non-opted-out run left.
+    [[ ${secureboot:-1} == 0 ]] && return 0
     # No signing key means the whole feature is opted out; there is nothing for
     # a platform key to authorise.
     [[ -z $secureBootKey || -z $secureBootCert ]] && return 0
@@ -8267,7 +8294,14 @@ _publishSecureBootKit() {
     # rotated signing leaf never invalidates an enrolment; in flat mode
     # $secureBootMokCert is the same file as $secureBootCert and this is
     # byte-identical to before.
-    if [[ -z $secureBootMokCert ]]; then
+    #
+    # $secureboot=0 lands here too, and this is the second of the two places the
+    # opt-out is applied. Declining Secure Boot means declining ENROLMENT: no
+    # MOK.der, and so no PXE menu entry either, since BootMenu gates that on
+    # this file existing (bootmenu.class.php:2089). The binaries are still
+    # signed -- see _ensureSecureBootKeys for why signing is not part of what
+    # the flag turns off.
+    if [[ -z $secureBootMokCert || ${secureboot:-1} == 0 ]]; then
         rm -rf "$kitdir" >>$error_log 2>&1
         return 0
     fi
@@ -8804,6 +8838,43 @@ _resignRefind() {
     fi
     echo "Done"
 }
+# Re-stamp .fog-ipxe-manifest for the files just signed.
+#
+# _copyIpxeTree() records a sha256 of every file it lays down so a later run can
+# tell FOG's own copy from one the admin replaced, and decline to overwrite
+# theirs -- the "Kept your own copies of these iPXE files" report. Signing
+# rewrites those bytes AFTER that stamp was taken, so without this every .efi
+# compares unequal on the NEXT run: FOG stops updating its own binaries and
+# names all 45 as admin-modified, every run, permanently. Found by reading; it
+# needs two installs of a Secure Boot server to show up, which is why the
+# original design's "nothing stamps or verifies /tftpboot" note was true when
+# written and is not now.
+#
+# Only lines for files actually signed are rewritten. Everything else is copied
+# through byte for byte -- including an entry deliberately carrying the ORIGINAL
+# sum for a file the admin really did replace, which is what keeps that file
+# from being quietly overwritten on the run after this one.
+_restampIpxeManifest() {
+    local tftproot="$1"; shift
+    local manifest="${tftproot}/.fog-ipxe-manifest"
+    [[ -f $manifest && $# -gt 0 ]] || return 0
+    command -v sha256sum >/dev/null 2>&1 || return 0
+    local rel sum staging="${manifest}.restamp"
+    declare -A resigned=()
+    for rel in "$@"; do resigned["$rel"]=1; done
+    : > "$staging" 2>>$error_log || return 0
+    while IFS='|' read -r sum rel; do
+        [[ -z $sum || -z $rel ]] && continue
+        if [[ -n ${resigned[$rel]:-} ]]; then
+            sum=$(sha256sum "${tftproot}/${rel}" 2>/dev/null | cut -d' ' -f1)
+            # A file that vanished between signing and here: drop the line
+            # rather than carry a sum that matches nothing.
+            [[ -z $sum ]] && continue
+        fi
+        printf '%s|%s\n' "$sum" "$rel" >> "$staging" 2>>$error_log
+    done < "$manifest"
+    mv -f "$staging" "$manifest" >>$error_log 2>&1
+}
 # Sign FOG's own iPXE binaries so one can be chainloaded from a machine's ESP
 # under Secure Boot.
 #
@@ -8839,6 +8910,9 @@ _resignRefind() {
 # verbatim, so these already carry FOG's embedded boot scripts, config overlays
 # and the whole variant matrix. The only per-site input to a build is the CA, and
 # an HTTPS-with-your-own-CA install has already compiled locally before this runs.
+#
+# Runs on every server, including one that passed --no-secureboot: that flag
+# declines enrolment, not signatures. See _ensureSecureBootKeys.
 _signLocalIpxe() {
     [[ -z $secureBootKey || -z $secureBootCert ]] && return 0
     local tftproot="${tftpdirdst%/}"
@@ -8849,6 +8923,7 @@ _signLocalIpxe() {
         return 0
     fi
     local fpath certpem anchorpem failed=0 signed=0
+    local restamp=()
     certpem=$(_secureBootCertPem) || return 0
     # Verified against the anchor, signed with the leaf -- the same split-PKI
     # handling _resignRefind() uses. See _secureBootAnchorPem().
@@ -8898,13 +8973,21 @@ _signLocalIpxe() {
                 --output "${fpath}.signing" "$fpath" >>$error_log 2>&1; then
             chown --reference="$fpath" "${fpath}.signing" >>$error_log 2>&1
             chmod --reference="$fpath" "${fpath}.signing" >>$error_log 2>&1
-            mv -f "${fpath}.signing" "$fpath" >>$error_log 2>&1 || failed=1
+            if mv -f "${fpath}.signing" "$fpath" >>$error_log 2>&1; then
+                # Collected rather than stamped here: the sum has to be taken
+                # after the mv, and rewriting the manifest once at the end is
+                # one pass over it instead of one per file.
+                restamp+=("${fpath#${tftproot}/}")
+            else
+                failed=1
+            fi
         else
             rm -f "${fpath}.signing" >>$error_log 2>&1
             failed=1
         fi
     done < <(find "$tftproot" -path "${tftproot}/secureboot" -prune -o \
                 -type f -name '*.efi' -print 2>>$error_log)
+    [[ ${#restamp[@]} -gt 0 ]] && _restampIpxeManifest "$tftproot" "${restamp[@]}"
     [[ $signed -eq 0 ]] && return 0
     if [[ $failed -ne 0 ]]; then
         echo "Failed"
@@ -8918,189 +9001,235 @@ _signLocalIpxe() {
     # a number here means work actually happened.
     echo "Done (${count})"
 }
-# The binaries an ESP needs, relative to $tftpdirdst -- a CURATED list, not a
-# sweep of every *.efi in the tree. The tree carries 45 FOG binaries (5 names x
-# 3 architectures x 3 embed variants) and publishing all of them says nothing
-# about which one an admin should reach for. This says it.
+# ===========================================================================
+# Local ESP boot: the published archives
+# ===========================================================================
 #
-# Kept, per architecture -- x86_64 at the root, i386-efi/, arm64-efi/:
+# Machines this exists for cannot fetch a boot file over the network -- that is
+# the whole problem -- so the files have to be reachable over HTTP to get onto
+# an ESP at all. The TFTP tree is not web-served, which until this existed meant
+# every admin hand-rolling symlinks into the document root.
 #
-#   ipxe.efi      iPXE's own NIC drivers, all of them. The primary choice, and
-#                 the one the Secure Boot chain has to reach: a machine that
-#                 cannot netboot usually cannot because its firmware provides no
-#                 UEFI SNP protocol, so a binary that needs one is no use to it.
-#   snp.efi       Drives the NIC through the firmware's SNP protocol instead,
-#                 binding every SNP device it can see. For firmware that does
-#                 provide one and hardware iPXE's own drivers do not cover.
-#   intel.efi     Single-vendor native builds, for the case where the
-#   realtek.efi   all-drivers build misbehaves on that specific NIC.
+# What is published is SIX ARCHIVES and a manifest, and nothing else:
 #
-# Plus 10secdelay/ipxe.efi per architecture: identical to ipxe.efi but for a
-# "sleep 10" ahead of DHCP, which is what makes a link come up on a switch
-# running STP or port power-save. That is a network-side problem, so it applies
-# to a locally-booted binary exactly as it does to a netbooted one -- but only
-# the primary is published in that flavour. Needing both the delay AND a
-# fallback driver is rare enough to copy by hand off TFTP.
+#   service/localboot/manifest.json          the index
+#   service/localboot/fog-esp-<arch>.zip     ready-to-copy ESP folder
+#   service/localboot/fog-esp-<arch>-10sec.zip          "  , 10s DHCP delay
 #
-# Deliberately NOT published:
+# One archive per (architecture x delay variant), each holding a single
+# top-level directory named after the archive. That shape replaced a directory
+# tree that published the same bytes twice -- a "menu" of binaries under their
+# TFTP names at the root, and a "kit" of the same binaries renamed fog*.efi
+# under esp/ -- with arm64 appearing in four different places and the 10-second
+# set present in one list but not the other.
 #
-#   snponly.efi   Binds ONLY the device iPXE was loaded from. Loaded off an ESP
-#                 that device is the disk, so it never finds a NIC. It is the
-#                 right binary for netboot and the wrong one here -- which is
-#                 exactly the kind of mistake an uncurated directory invites.
-#                 (Upstream's secureboot/snponly.efi below is a different case:
-#                 it only has to read autoexec.ipxe off the same ESP and chain
-#                 onward, so it needs no NIC of its own.)
-#   autoexec/     The EMBED-less builds. They carry no boot script and fetch
-#                 autoexec.ipxe from wherever they were loaded -- which this
-#                 does not publish, so they would arrive inert. Still on TFTP
-#                 for anyone assembling that setup deliberately.
-#   .kpxe/.lkrn/  BIOS artifacts. Not PE images, and an ESP cannot boot them.
-#   .usb/.iso
+# WHY THE ARCHIVE, AND NOT LOOSE FILES: the two audiences turned out to be one.
+# The only reason the kit needed different filenames is that two names on an ESP
+# are reserved (see below), and those names are strictly the safer choice
+# everywhere -- so publishing one correctly-named folder serves both the admin
+# assembling an ESP and the admin who wants a single binary out of it. The cost,
+# recorded because it is a real one: no single binary has a URL any more, so
+# nothing here can be a UEFI HTTP Boot target or an iPXE `chain` destination.
+# Publishing the loose set alongside is purely additive if that is ever wanted.
 #
-# The upstream secureboot/ set is published whole. It is only ten files and each
-# one is a stage of a chain: shim, the loader it hands off to, and MokManager.
-# shim.c rewrites its own "-shim<arch>.efi" suffix to ".efi" to pick its second
-# stage, so snponly-shimx64.efi loads snponly.efi and ipxe-shimx64.efi loads
-# ipxe.efi -- the pairs have to travel together or neither works.
+# WHY THE DELAY VARIANT IS ITS OWN ARCHIVE, rather than a second set of binaries
+# and a second script inside one: iPXE runs exactly the file called
+# autoexec.ipxe and has no way to ask which set you want, so a combined folder
+# made choosing mean renaming a file over another. Choosing at download time
+# removes the step entirely -- the binaries inside a -10sec archive carry the
+# plain names, and its single autoexec.ipxe is already the right one. It costs
+# each variant its own copy of the upstream shim set, which is the only reason
+# the total is not smaller than the tree it replaced.
 #
-# Do not mistake upstream's secureboot/ipxe.efi for a replacement for the FOG
-# binaries above. It is built with iPXE's own NIC drivers and looks like it makes
-# all of this unnecessary -- sign nothing, ship upstream's pair and a two-line
+# TWO NAMES ARE NOT FREE CHOICES, and this is the whole reason the fog* prefix
+# exists. shim picks its second stage by rewriting its OWN "-shim<arch>.efi"
+# suffix to ".efi". So snponly-shimx64.efi will load "snponly.efi" and nothing
+# else, and it has to be upstream's copy, because upstream's is what shim's
+# embedded certificate vouches for. That reserves snponly.efi -- and ipxe.efi
+# for the other pair. Dropping FOG's ipxe.efi in beside ipxe-shimx64.efi would
+# have shim try to load an image it cannot verify.
+#
+# BOTH shim pairs ship. Each derives its own second stage from its own filename,
+# so they are independent entry points -- point the boot manager at
+# snponly-shimx64.efi or at ipxe-shimx64.efi and the rest follows. Neither stage
+# 2 needs a NIC: both only read autoexec.ipxe out of the same directory and
+# chain onward, which is why upstream's ipxe.efi is fine HERE despite the
+# finding below.
+#
+# DO NOT mistake upstream's ipxe.efi for a replacement for the FOG binaries. It
+# is built with iPXE's own NIC drivers and looks like it makes all of this
+# unnecessary -- sign nothing, ship upstream's pair and a two-line
 # autoexec.ipxe. Tested on hardware: booted locally off an ESP it does NOT load
-# those drivers. Both upstream loaders therefore dead-end on exactly the hardware
-# this feature exists for, which is why the chain has to reach FOG's own build.
-# Nothing in either source tree predicts this; it took a machine to find.
-localbootfiles=(
-    ipxe.efi
-    snp.efi
-    intel.efi
-    realtek.efi
-    10secdelay/ipxe.efi
-    i386-efi/ipxe.efi
-    i386-efi/snp.efi
-    i386-efi/intel.efi
-    i386-efi/realtek.efi
-    10secdelay/i386-efi/ipxe.efi
-    arm64-efi/ipxe.efi
-    arm64-efi/snp.efi
-    arm64-efi/intel.efi
-    arm64-efi/realtek.efi
-    10secdelay/arm64-efi/ipxe.efi
-    secureboot/snponly.efi
-    secureboot/snponly-shimx64.efi
-    secureboot/ipxe.efi
-    secureboot/ipxe-shimx64.efi
-    secureboot/mmx64.efi
-    secureboot/arm64-efi/snponly.efi
-    secureboot/arm64-efi/snponly-shimaa64.efi
-    secureboot/arm64-efi/ipxe.efi
-    secureboot/arm64-efi/ipxe-shimaa64.efi
-    secureboot/arm64-efi/mmaa64.efi
-)
-# The ready-to-copy ESP kit: "src|dst", relative to $tftpdirdst and to the
-# published esp/ directory respectively.
+# those drivers. Both upstream loaders therefore dead-end on exactly the
+# hardware this feature exists for, which is why the chain has to reach FOG's
+# own build. Nothing in either source tree predicts this; it took a machine to
+# find.
 #
-# Everything above is a menu to choose from. This is the opposite -- one folder
-# an admin copies verbatim onto an ESP, with the files already carrying the names
-# the chain requires. It exists because two of those names are NOT free choices.
+# MokManager ships too. shim launches mm<arch>.efi FROM ITS OWN DIRECTORY when
+# it cannot verify the next stage, and that is the only way to enrol a MOK --
+# shim's MokList is a boot-services-only variable, so nothing in a running OS
+# can write it. Without mmx64.efi beside the shim, an ESP that has not been
+# enrolled yet is a dead end with no route out of it. Found the hard way: it had
+# to be downloaded by hand.
 #
-# shim picks its second stage by rewriting its OWN "-shim<arch>.efi" suffix to
-# ".efi". So snponly-shimx64.efi will load "snponly.efi" and nothing else, and it
-# has to be upstream's copy, because upstream's is what its embedded certificate
-# vouches for. That reserves "snponly.efi" -- and, if the other pair is ever used,
-# "ipxe.efi" too. FOG's own builds therefore cannot keep their natural names on an
-# ESP, hence the "fog" prefix. It is not cosmetic: dropping FOG's ipxe.efi in
-# beside ipxe-shimx64.efi would have shim load an image it cannot verify.
+# MOK.der ships WITH it, which the first implementation missed. MokManager
+# enrols by browsing the ESP for a certificate, so shipping MokManager without
+# one is still a dead end -- it just fails one screen later.
 #
-# The kit is x86_64 and arm64 only, because those are the two architectures
-# upstream signs a shim for. i386 has no signed shim, so there is no Secure Boot
-# chain to assemble -- an i386 machine booting with Secure Boot off just takes
-# i386-efi/ipxe.efi from the menu above and needs none of this.
+# PK/KEK/db.auth ship as well, and they are what make the i386 archive worth
+# building. Those are signed EFI variable updates a machine in Setup Mode
+# writes to put THIS server's certificate straight into db, after which firmware
+# verifies a signed fogipxe.efi directly -- no shim, no MokManager, no MOK.
+# Upstream signs no shim for ia32, so the earlier design concluded i386 had no
+# Secure Boot path at all. Via db it does.
 #
-# Copied AFTER _signLocalIpxe() has run, so the fog*.efi here already carry
-# FOG's signature wherever the server holds keys.
-# BOTH shim pairs ship, not just the snponly one. Each shim derives its own
-# second stage from its own filename, so the two are independent entry points and
-# an admin picks whichever their firmware gets along with -- point the boot
-# manager at snponly-shimx64.efi or at ipxe-shimx64.efi, and the rest follows.
+# STILL NOT PUBLISHED: the EMBED-less autoexec/ builds, which carry no boot
+# script and would only chain the binaries already here; and the BIOS artifacts
+# (.kpxe/.lkrn/.usb/.iso), which are not PE images and which an ESP cannot boot.
+# Both remain on TFTP for anyone assembling that setup deliberately.
 #
-# Neither stage 2 needs a NIC. Both only read autoexec.ipxe out of this same
-# directory and chain onward, which is why upstream's ipxe.efi is fine HERE
-# despite not driving a NIC when booted locally as a final stage. One
-# autoexec.ipxe serves both, because both resolve it against the directory they
-# were loaded from.
+# Everything here is public by nature: FOG's own binaries, upstream's signed
+# shim and loader (downloadable from fog-ipxe's release assets anyway), and
+# certificates plus signatures over them. FOG already serves the MOK-signed
+# bzImage over unauthenticated HTTP from service/ipxe, so this is not a new
+# class of exposure. The private keys never leave the PKI zone directory.
+# The files one archive holds, as "src|dst" -- src relative to $tftpdirdst, dst
+# relative to the archive's top-level directory.
 #
-# This is also the collision the fog* prefix exists to avoid: upstream's
-# ipxe.efi has to keep its own name for ipxe-shimx64.efi to find it, so FOG's
-# all-drivers build cannot be called ipxe.efi in this directory.
-# MokManager ships too. shim launches mm<arch>.efi FROM ITS OWN DIRECTORY when it
-# cannot verify the next stage, and that is the only way to enrol a MOK -- shim's
-# MokList is a boot-services-only variable, so nothing in a running OS can write
-# it. Without mmx64.efi beside the shim, an ESP that has not been enrolled yet is
-# a dead end with no route out of it. Found the hard way: it had to be downloaded
-# by hand.
-localbootespfiles=(
-    "secureboot/snponly-shimx64.efi|snponly-shimx64.efi"
-    "secureboot/snponly.efi|snponly.efi"
-    "secureboot/ipxe-shimx64.efi|ipxe-shimx64.efi"
-    "secureboot/ipxe.efi|ipxe.efi"
-    "secureboot/mmx64.efi|mmx64.efi"
-    "ipxe.efi|fogipxe.efi"
-    "snp.efi|fogsnp.efi"
-    "intel.efi|fogintel.efi"
-    "realtek.efi|fogrealtek.efi"
-    "10secdelay/ipxe.efi|fogipxe10sec.efi"
-    "10secdelay/snp.efi|fogsnp10sec.efi"
-    "10secdelay/intel.efi|fogintel10sec.efi"
-    "10secdelay/realtek.efi|fogrealtek10sec.efi"
-    "secureboot/arm64-efi/snponly-shimaa64.efi|arm64-efi/snponly-shimaa64.efi"
-    "secureboot/arm64-efi/snponly.efi|arm64-efi/snponly.efi"
-    "secureboot/arm64-efi/ipxe-shimaa64.efi|arm64-efi/ipxe-shimaa64.efi"
-    "secureboot/arm64-efi/ipxe.efi|arm64-efi/ipxe.efi"
-    "secureboot/arm64-efi/mmaa64.efi|arm64-efi/mmaa64.efi"
-    "arm64-efi/ipxe.efi|arm64-efi/fogipxe.efi"
-    "arm64-efi/snp.efi|arm64-efi/fogsnp.efi"
-    "arm64-efi/intel.efi|arm64-efi/fogintel.efi"
-    "arm64-efi/realtek.efi|arm64-efi/fogrealtek.efi"
-    "10secdelay/arm64-efi/ipxe.efi|arm64-efi/fogipxe10sec.efi"
-    "10secdelay/arm64-efi/snp.efi|arm64-efi/fogsnp10sec.efi"
-    "10secdelay/arm64-efi/intel.efi|arm64-efi/fogintel10sec.efi"
-    "10secdelay/arm64-efi/realtek.efi|arm64-efi/fogrealtek10sec.efi"
-)
-# The kit's autoexec.ipxe, written into each architecture's directory.
+#   $1  architecture: x86_64 | i386 | arm64
+#   $2  variant: empty for the standard set, "10sec" for the delayed one
 #
-# Static, not a template. default.ipxe is generated per install because it embeds
-# the server address; this has no per-server content at all -- it chains a sibling
-# by relative filename, and FOG's build carries the DHCP/next-server script
-# compiled in, so it finds the server by itself. iPXE resolves a bare filename
-# against the URI the running binary was loaded from, which on an ESP is the
-# directory this sits in.
+# The delay lives in the BINARY, not in a script: `sleep` is an optional iPXE
+# command that FOG's own builds enable but upstream's signed loader may not, and
+# the loader is what runs autoexec.ipxe. It is also the only route to a delay at
+# all when a fog*.efi is launched straight from the boot manager, which reads no
+# script.
+_espKitFiles() {
+    local arch="$1" variant="$2"
+    local fogdir="" sbdir="secureboot" shimsfx="x64" mm="mmx64.efi" name
+    case $arch in
+        i386)
+            fogdir="i386-efi/"
+            # No shim, loader or MokManager: upstream signs none for ia32. The
+            # archive is still built, because Setup Mode enrolment via db.auth
+            # needs no shim -- see the header.
+            sbdir=""
+            ;;
+        arm64)
+            fogdir="arm64-efi/"
+            sbdir="secureboot/arm64-efi"
+            shimsfx="aa64"
+            mm="mmaa64.efi"
+            ;;
+    esac
+    if [[ -n $sbdir ]]; then
+        echo "${sbdir}/snponly-shim${shimsfx}.efi|snponly-shim${shimsfx}.efi"
+        echo "${sbdir}/snponly.efi|snponly.efi"
+        echo "${sbdir}/ipxe-shim${shimsfx}.efi|ipxe-shim${shimsfx}.efi"
+        echo "${sbdir}/ipxe.efi|ipxe.efi"
+        echo "${sbdir}/${mm}|${mm}"
+    fi
+    # FOG's own builds, pre-named for the ESP. Ordered as autoexec.ipxe tries
+    # them, so the list reads as the preference order it is.
+    for name in ipxe snp intel realtek snponly; do
+        echo "${variant:+10secdelay/}${fogdir}${name}.efi|fog${name}.efi"
+    done
+}
+# What each published file is, for the manifest. Kept as data rather than
+# comments because it is what replaced curation-by-omission: the earlier
+# directory said which binary to use by leaving the others out, which is how
+# fogsnponly.efi came to be unavailable at all. A manifest can carry the same
+# advice without having to withhold a file to give it.
+_espFileRole() {
+    case "$1" in
+        snponly-shim*.efi|ipxe-shim*.efi) echo "shim" ;;
+        snponly.efi|ipxe.efi)             echo "upstream-loader" ;;
+        mmx64.efi|mmaa64.efi)             echo "mokmanager" ;;
+        fogipxe.efi)                      echo "fog-ipxe" ;;
+        fogsnp.efi)                       echo "fog-snp" ;;
+        fogintel.efi)                     echo "fog-intel" ;;
+        fogrealtek.efi)                   echo "fog-realtek" ;;
+        fogsnponly.efi)                   echo "fog-snponly" ;;
+        autoexec.ipxe)                    echo "script" ;;
+        MOK.der)                          echo "enrolment-cert" ;;
+        PK.auth|KEK.auth|db.auth)         echo "enrolment-var" ;;
+        fog-enroll-mok.*)                 echo "helper" ;;
+        README.txt|MANIFEST.json)         echo "doc" ;;
+        *)                                echo "other" ;;
+    esac
+}
+_espFileOrigin() {
+    case "$1" in
+        snponly-shim*.efi|ipxe-shim*.efi|snponly.efi|ipxe.efi|mmx64.efi|mmaa64.efi)
+            echo "upstream" ;;
+        autoexec.ipxe|README.txt|MANIFEST.json)
+            echo "generated" ;;
+        *)  echo "fog" ;;
+    esac
+}
+_espFileNote() {
+    case "$1" in
+        snponly-shim*.efi|ipxe-shim*.efi)
+            echo "Microsoft-signed shim. Point your boot manager at this. It loads the matching loader beside it, named by rewriting this file's own -shim<arch>.efi suffix to .efi." ;;
+        snponly.efi|ipxe.efi)
+            echo "Upstream's signed loader, shim's second stage. It only reads autoexec.ipxe from this same directory and chains onward; it does not drive a NIC when booted from an ESP." ;;
+        mmx64.efi|mmaa64.efi)
+            echo "MokManager. shim launches it from this directory when it cannot verify the next stage; enrol MOK.der here. Not optional -- nothing in a running OS can write shim's MokList." ;;
+        fogipxe.efi)
+            echo "FOG's build with all of iPXE's own NIC drivers. Try this first: a machine that cannot netboot usually cannot because its firmware provides no UEFI SNP protocol, so a binary needing one is no use to it." ;;
+        fogsnp.efi)
+            echo "FOG's build driving the NIC through the firmware's SNP protocol, binding every SNP device it can see. For firmware that does provide one and hardware iPXE's own drivers do not cover." ;;
+        fogintel.efi)
+            echo "FOG's build, Intel driver only. For when the all-drivers build misbehaves on that specific NIC." ;;
+        fogrealtek.efi)
+            echo "FOG's build, Realtek driver only. For when the all-drivers build misbehaves on that specific NIC." ;;
+        fogsnponly.efi)
+            echo "FOG's build bound to the SNP device iPXE was loaded FROM. Booted off an ESP that device is the disk, so it usually finds no NIC -- which is why autoexec.ipxe tries it last. Included because it is the right binary when something chainloads it over the network, and there is hardware where it works." ;;
+        autoexec.ipxe)
+            echo "Read by the upstream loader out of this directory. Chains the FOG binaries in preference order. Its fallbacks fire only when a file is MISSING or fails verification -- not when one loads and then finds no NIC." ;;
+        MOK.der)
+            echo "This server's certificate, in the DER form MokManager wants. Enrol it once per machine through MokManager, after which any binary here that FOG signed will load." ;;
+        PK.auth|KEK.auth|db.auth)
+            echo "Signed EFI variable update. Written by a machine in Setup Mode to trust this server's certificate directly, with no shim and no MokManager -- the only Secure Boot route available on i386, and the one that scales everywhere else." ;;
+        fog-enroll-mok.sh|fog-enroll-mok.desktop)
+            echo "Enrols MOK.der via mokutil from a booted Linux OS. Not read by firmware; it is here so one folder carries every enrolment route." ;;
+        README.txt)
+            echo "What this archive is and how to use it." ;;
+        *)  echo "" ;;
+    esac
+}
+# The kit's autoexec.ipxe.
 #
-# The fallback covers WHICH FILES GOT COPIED, not which driver works. Say it that
-# way in the docs too. `chain X || goto Y` only branches when the image fails to
-# LOAD -- absent, malformed, or rejected by shim's verification. Once an image
-# loads and runs, control never returns: FOG's embedded script ends its own
-# failure path with `prompt ... && shell || reboot`, so a binary that starts fine
-# but binds no NIC parks there. The next branch is never reached. That is the
-# difference from the net0/net1/net2 ladder in the netboot script, which works
-# because it stays inside one iPXE instance rather than handing off.
+# Static, not a template. default.ipxe is generated per install because it
+# embeds the server address; this has no per-server content at all -- it chains
+# a sibling by relative filename, and FOG's build carries the DHCP/next-server
+# script compiled in, so it finds the server by itself. iPXE resolves a bare
+# filename against the URI the running binary was loaded from, which on an ESP
+# is the directory this sits in.
 #
-# Still worth having: it means one kit boots whether the admin copied the whole
-# folder or only the variant their hardware needs.
-# $1 is the binary-set suffix: empty for the standard set, "10sec" for the
-# delayed one. Two scripts are written per architecture rather than one with a
-# branch, because iPXE runs exactly the file called autoexec.ipxe and there is no
-# way for it to ask which set you want -- choosing means swapping the file.
+# THE FALLBACK LADDER COVERS WHICH FILES GOT COPIED, NOT WHICH DRIVER WORKS, and
+# the docs must say it in those words. `chain X || goto Y` only branches when the
+# image fails to LOAD -- absent, malformed, or rejected by shim's verification.
+# Once an image loads and runs, control never returns: FOG's embedded script ends
+# its own failure path with `prompt ... && shell || reboot`, so a binary that
+# starts fine but binds no NIC parks there and the next branch is never reached.
+# That is the difference from the net0/net1/net2 ladder in the netboot script,
+# which works because it stays inside one iPXE instance rather than handing off.
+#
+# Still worth having: it means one archive boots whether the admin copied the
+# whole folder or only the variant their hardware needs.
+#
+# fogsnponly.efi is last on purpose -- it is the one most likely to load
+# cleanly and then find nothing, so anything with a chance of working should
+# have been tried before it.
 _espAutoexecScript() {
-    local sfx="$1" note
-    if [[ -n $sfx ]]; then
+    local variant="$1" note
+    if [[ -n $variant ]]; then
         note="# THE 10-SECOND-DELAY SET. Each binary waits 10s before DHCP, which is what
-# lets a link come up on a switch running STP or port power-save. Rename this
-# over autoexec.ipxe to use it."
+# lets a link come up on a switch running STP or port power-save."
     else
         note="# The standard set. If the link is not up in time on your switch -- STP or
-# port power-save -- rename autoexec-10sec.ipxe over this file instead."
+# port power-save -- download the -10sec archive instead."
     fi
     cat <<ESPAUTOEXEC
 #!ipxe
@@ -9111,134 +9240,373 @@ ${note}
 #
 # The fallbacks fire only if a file is MISSING or fails verification -- not if it
 # loads and then finds no NIC. Copy the variant your hardware needs.
-chain fogipxe${sfx}.efi || goto trysnp
+chain fogipxe.efi || goto trysnp
 :trysnp
-chain fogsnp${sfx}.efi || goto tryintel
+chain fogsnp.efi || goto tryintel
 :tryintel
-chain fogintel${sfx}.efi || goto tryrealtek
+chain fogintel.efi || goto tryrealtek
 :tryrealtek
-chain fogrealtek${sfx}.efi || goto nofogbinary
+chain fogrealtek.efi || goto trysnponly
+:trysnponly
+chain fogsnponly.efi || goto nofogbinary
 :nofogbinary
 echo No usable FOG iPXE binary found on this ESP.
 prompt --key s --timeout 10000 Hit 's' for the iPXE shell; reboot in 10 seconds && shell || reboot
 ESPAUTOEXEC
 }
-# Publish the EFI binaries an ESP needs, under the web root.
+# The archive's README. Written per archive rather than once, because which of
+# the two enrolment routes is even available depends on whether a shim landed.
+#   $1 arch  $2 variant  $3 archive stem  $4 1 if an upstream loader is present
+_espKitReadme() {
+    local arch="$1" variant="$2" stem="$3" haveloader="$4"
+    cat <<ESPREADME
+${stem}
+$(printf '%*s' ${#stem} '' | tr ' ' '=')
+
+FOG Project -- iPXE boot files for an EFI System Partition (${arch}${variant:+, ${variant} DHCP delay}).
+
+Copy the CONTENTS of this folder onto the ESP -- \\EFI\\FOG\\ is a good place --
+then point the firmware boot manager at one of the entry points below.
+${variant:+
+This is the 10-second-delay set. Every FOG binary here waits 10s before DHCP,
+which is what lets a link come up on a switch running STP or port power-save.
+The files are otherwise identical to the plain ${stem%-${variant}} archive and
+carry the same names, so do not extract both into the same folder.
+}
+WHICH FILE TO BOOT
+------------------
+$(if [[ $haveloader -eq 1 ]]; then cat <<'ESPSB'
+  Secure Boot ON, via shim:
+      Point the boot manager at snponly-shim*.efi  (or ipxe-shim*.efi -- either
+      works; each loads the loader whose name matches its own). The loader reads
+      autoexec.ipxe from this folder and chains FOG's build.
+      First time on a machine: shim cannot verify FOG's binary yet, so it
+      launches MokManager. Choose "Enroll key from disk" and select MOK.der
+      here. Reboot; it boots from then on.
+
+  Secure Boot ON, via firmware Setup Mode (no shim, no MokManager):
+      Put the machine into Setup Mode in its firmware, then enrol PK.auth,
+      KEK.auth and db.auth. Firmware then verifies FOG's signed binaries
+      directly and you can boot fogipxe.efi straight from the boot manager.
+
+  Secure Boot OFF:
+      Point the boot manager straight at fogipxe.efi.
+ESPSB
+else cat <<'ESPNOSB'
+  Secure Boot OFF:
+      Point the boot manager straight at fogipxe.efi.
+
+  Secure Boot ON, via firmware Setup Mode:
+      There is no Microsoft-signed shim for this architecture, so the shim
+      route does not exist here -- but the Setup Mode route does. Put the
+      machine into Setup Mode in its firmware, enrol PK.auth, KEK.auth and
+      db.auth, and firmware will then verify FOG's signed fogipxe.efi
+      directly. Point the boot manager at it.
+      (If those .auth files are absent, this server publishes no enrolment
+      material and only the Secure Boot OFF route is available.)
+ESPNOSB
+fi)
+
+IF fogipxe.efi DOES NOT BRING UP YOUR NETWORK
+---------------------------------------------
+Try fogsnp.efi, then fogintel.efi or fogrealtek.efi, then fogsnponly.efi.
+$(if [[ $haveloader -eq 1 ]]; then cat <<'ESPLADDER'
+autoexec.ipxe already tries them in that order -- but ONLY when a file is
+missing or fails verification. Once a binary loads and runs, control never comes
+back, so one that starts and then finds no NIC stops at its own prompt rather
+than falling through. If it is the wrong driver, you have to change which file
+is there.
+ESPLADDER
+else cat <<'ESPNOLADDER'
+There is no autoexec.ipxe in this archive, because nothing here reads one --
+that is upstream's signed loader's job and this archive has no loader. Point
+the boot manager at whichever binary you want to try; there is no fallback
+chain to do it for you.
+ESPNOLADDER
+fi)
+
+fogsnponly.efi binds only the device iPXE was loaded from. Booted off an ESP
+that device is the disk, so it usually finds no NIC at all -- which is why it is
+tried last.
+
+MANIFEST.json lists every file here with its sha256 and what it is for.
+Full documentation: docs/SUPPORTED_CUSTOMIZATIONS.md, "Local ESP boot files".
+ESPREADME
+}
+# Quote a string as a JSON scalar.
 #
-# The machines this exists for cannot fetch a boot file over the network -- that
-# is the whole problem -- so the binaries have to be reachable over HTTP to get
-# onto their ESP in the first place. The TFTP tree is not web-served, which until
-# now meant every admin hand-rolling their own symlinks into the document root.
+# Deliberately not jq, even though jq is in the package list. Everything this
+# feature encodes is content this file itself produced -- our own filenames,
+# the role/note text above, hex checksums, decimal sizes -- so the escaping
+# problem is bounded, and one code path that always works beats a dependency
+# whose absence would mean publishing no manifest at all. That is the same
+# reasoning as the tar fallback for zip below: a partly-failed package install
+# should cost a server some polish, not the whole feature.
+#
+# Covers the characters JSON forbids in a string; anything else in the ASCII
+# range is legal unescaped, and nothing here emits a control character.
+_jsonStr() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\n'/\\n}"
+    printf '"%s"' "$s"
+}
+# One JSON array describing every file in a staged archive directory.
+#
+# Called BEFORE MANIFEST.json is written, so MANIFEST.json is deliberately
+# absent from its own inventory -- a file cannot carry its own checksum.
+#   $1 staged directory   $2 Secure Boot anchor PEM, or empty
+_espKitContentsJson() {
+    local dir="$1" anchor="$2"
+    local f name sum size fogsigned first=1
+    printf '['
+    while IFS= read -r f; do
+        name="${f##*/}"
+        sum=$(sha256sum "$f" 2>/dev/null | cut -d' ' -f1)
+        size=$(wc -c < "$f" 2>/dev/null | tr -d '[:space:]')
+        [[ -z $sum || -z $size ]] && continue
+        # Asked of the file rather than inferred from whether this server holds
+        # keys, so the answer stays right for the upstream binaries (which carry
+        # Microsoft's and iPXE's signatures, never FOG's) and for a run where
+        # signing partly failed.
+        fogsigned=false
+        if [[ -n $anchor && $name == *.efi ]] && \
+           sbverify --cert "$anchor" "$f" >/dev/null 2>&1; then
+            fogsigned=true
+        fi
+        [[ $first -eq 0 ]] && printf ','
+        first=0
+        printf '{"name":%s,"size":%s,"sha256":%s,"role":%s,"origin":%s,"fogSigned":%s,"note":%s}' \
+            "$(_jsonStr "$name")" "$size" "$(_jsonStr "$sum")" \
+            "$(_jsonStr "$(_espFileRole "$name")")" \
+            "$(_jsonStr "$(_espFileOrigin "$name")")" \
+            "$fogsigned" "$(_jsonStr "$(_espFileNote "$name")")"
+    done < <(find "$dir" -maxdepth 1 -type f 2>/dev/null | sort)
+    printf ']'
+}
+# The FOS kernel/init set, listed but NOT copied.
+#
+# Bundling them would be 60-80MB per architecture and would still not produce a
+# working local boot on its own: FOS reads per-host, per-task kernel arguments
+# that boot.php generates, so a kernel and initrd sitting on an ESP do nothing
+# until someone hand-writes those. That is a different feature with its own
+# design questions.
+#
+# Listing them costs nothing and makes this manifest the single index for
+# everything fetchable for a local boot. No new exposure: every PXE client
+# already fetches these over unauthenticated HTTP from the same directory
+# (bootmenu.class.php, $_booturl).
+_espKernelsJson() {
+    local ipxedir="${webdirdest%/}/service/ipxe"
+    local n arch kind sum size first=1
+    printf '['
+    for n in bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz; do
+        [[ -f ${ipxedir}/${n} ]] || continue
+        case $n in
+            bzImage)          arch=x86_64; kind=kernel ;;
+            bzImage32)        arch=i386;   kind=kernel ;;
+            arm_Image)        arch=arm64;  kind=kernel ;;
+            init.xz)          arch=x86_64; kind=init ;;
+            init_32.xz)       arch=i386;   kind=init ;;
+            arm_init.cpio.gz) arch=arm64;  kind=init ;;
+        esac
+        sum=$(sha256sum "${ipxedir}/${n}" 2>/dev/null | cut -d' ' -f1)
+        size=$(wc -c < "${ipxedir}/${n}" 2>/dev/null | tr -d '[:space:]')
+        [[ -z $sum || -z $size ]] && continue
+        [[ $first -eq 0 ]] && printf ','
+        first=0
+        printf '{"name":%s,"path":%s,"arch":%s,"kind":%s,"size":%s,"sha256":%s}' \
+            "$(_jsonStr "$n")" "$(_jsonStr "../ipxe/${n}")" \
+            "$(_jsonStr "$arch")" "$(_jsonStr "$kind")" \
+            "$size" "$(_jsonStr "$sum")"
+    done
+    printf ']'
+}
+# Build and publish the archives.
 #
 # NOT gated on Secure Boot, and not gated on _signLocalIpxe() having signed
 # anything. Booting a machine from an iPXE binary on its own ESP is a plain
-# feature that predates Secure Boot by years -- firmware with no PXE option, or a
-# queued task that would otherwise need the boot order changed. Secure Boot only
-# added the requirement for a signature. So a server with no Secure Boot keys
-# publishes the same directory with unsigned binaries in it, and those work on
-# every machine booting with Secure Boot off. Signing, where keys exist, has
-# already happened in place upstream of this by the time it runs.
+# feature that predates Secure Boot by years -- firmware with no PXE option, or
+# a queued task that would otherwise need the boot order changed. Secure Boot
+# only added the requirement for a signature.
 #
 # That is also why this lives at service/localboot/ rather than under
 # service/secureboot/: _publishSecureBootKit() rm -rf's its whole kit directory
-# when there is no MOK to publish, which would take this with it on exactly the
-# servers that still want it.
+# when it has no MOK to publish, which would take this with it on exactly the
+# servers that still want it. The enrolment material it publishes is COPIED into
+# each archive rather than linked, so an archive stays self-contained and a
+# server that later opts out of enrolment cannot dangle a reference inside one.
 #
-# COPIES, not a symlink to $tftpdirdst, which was the first attempt. Three
-# reasons, and the last two are what settled it:
-#
-#   1. SELinux. setSELinuxContext() labels the TFTP tree tftpdir_t, and httpd_t
-#      has no rule permitting it to read that type -- so a symlink 403s on every
-#      enforcing host. That is the same failure GH-963 fixed in the other
-#      direction, where tftpd_t could not read default_t. Relabelling to
-#      public_content_t would fix it, but widens the tree to ftpd, rsync and
-#      samba as well, to serve a feature that needs none of them. Files created
-#      here inherit the web root's own label and need no policy change at all.
-#   2. No vhost changes. A real directory takes an index.php that 404s, exactly
-#      as the Secure Boot kit and service/ipxe already do, so nothing has to be
-#      added to configureHttpd(). A symlink needed Options -Indexes emitted in
-#      all three Apache variants, and rested on apache matching <Directory>
-#      against the unresolved path (GH-529) -- a dependency that fails OPEN,
-#      exposing a listing of the whole TFTP tree, if it is ever wrong.
-#   3. Narrower. A link publishes the tree as it will be; this publishes the
-#      fixed list above. Nothing an admin later drops into $tftpdirdst becomes
-#      web-reachable, so there is no standing rule against using that directory.
-#
-# Everything here is public by nature: FOG's own binaries, and upstream's signed
-# shim and loader, which are downloadable from fog-ipxe's release assets anyway.
-# FOG already serves the MOK-signed bzImage over unauthenticated HTTP from
-# service/ipxe, so this is not a new class of exposure.
+# COPIES, never a symlink to $tftpdirdst, which was the first design. SELinux
+# labels the TFTP tree tftpdir_t and httpd_t has no rule permitting it to read
+# that type, so a link 403s on every enforcing host; it also needed Options
+# -Indexes across three Apache variants and rested on Apache matching
+# <Directory> against the unresolved path (GH-529), a dependency that fails
+# OPEN. Files created here inherit the web root's own label and need no policy
+# change at all.
 _publishLocalBootFiles() {
     local tftproot="${tftpdirdst%/}"
     [[ -d $tftproot ]] || return 0
     local bootdir="${webdirdest%/}/service/localboot"
-    dots "Publishing local ESP boot files"
+    local kitdir="${webdirdest%/}/service/secureboot"
+    dots "Publishing local ESP boot archives"
     # Rebuilt rather than updated in place: a variant dropped upstream should
-    # disappear here too, and a stale copy must not outlive the binary it came
-    # from. Safe to do unconditionally -- configureHttpd() rm -rf's the whole web
-    # root every run, so there is never anything here worth keeping.
+    # disappear here too, and a stale archive must not outlive the binaries it
+    # was built from. Safe unconditionally -- configureHttpd() rm -rf's the
+    # whole web root every run, so there is never anything here worth keeping.
     rm -rf "$bootdir" >>$error_log 2>&1
     mkdir -p "$bootdir" >>$error_log 2>&1
-    local rel dir copied=0 failed=0
-    for rel in "${localbootfiles[@]}"; do
-        # Missing is not a failure. An HTTPS install stages no Secure Boot
-        # binaries at all -- downloadipxesecureboot() skips it -- so the
-        # secureboot/ entries are absent on those servers by design.
-        [[ -f ${tftproot}/${rel} ]] || continue
-        mkdir -p "${bootdir}/$(dirname "$rel")" >>$error_log 2>&1
-        if cp -f "${tftproot}/${rel}" "${bootdir}/${rel}" >>$error_log 2>&1; then
-            copied=$((copied + 1))
-        else
-            failed=1
-        fi
+    # Resolved once. Empty on a server with no signing key, which makes every
+    # fogSigned in the manifest false -- correctly.
+    local anchorpem=""
+    if [[ -n $secureBootKey && -n $secureBootCert ]] && \
+       command -v sbverify >/dev/null 2>&1; then
+        anchorpem=$(_secureBootAnchorPem) || anchorpem=""
+    fi
+    local work
+    work=$(mktemp -d 2>>$error_log) || {
+        echo "Failed"
+        echo " * Could not create a staging directory. See $error_log."
+        return 0
+    }
+    local arch variant stem staged pair src dst f
+    local copied haveloader contents archive ext asum asize
+    local built=0 failed=0 archjson="" first=1
+    for arch in x86_64 i386 arm64; do
+        for variant in "" 10sec; do
+            stem="fog-esp-${arch}${variant:+-${variant}}"
+            staged="${work}/${stem}"
+            mkdir -p "$staged" >>$error_log 2>&1
+            copied=0
+            haveloader=0
+            while IFS= read -r pair; do
+                [[ -z $pair ]] && continue
+                src="${pair%%|*}"
+                dst="${pair#*|}"
+                # Missing is not a failure. An HTTPS install stages no Secure
+                # Boot binaries at all -- downloadipxesecureboot() skips it --
+                # so the upstream entries are absent on those servers by design,
+                # and the archive is still worth building without them.
+                [[ -f ${tftproot}/${src} ]] || continue
+                if cp -f "${tftproot}/${src}" "${staged}/${dst}" >>$error_log 2>&1; then
+                    copied=$((copied + 1))
+                    case $dst in
+                        snponly.efi|ipxe.efi) haveloader=1 ;;
+                    esac
+                else
+                    failed=1
+                fi
+            done < <(_espKitFiles "$arch" "$variant")
+            # Nothing for this architecture in the tree at all: no archive,
+            # rather than an archive holding only a README.
+            if [[ $copied -eq 0 ]]; then
+                rm -rf "$staged" >>$error_log 2>&1
+                continue
+            fi
+            # Whatever enrolment material this server actually published. Taken
+            # by existence rather than by asking whether Secure Boot is
+            # configured, so an opted-out server ships neither and a server with
+            # only a MOK ships only that.
+            for f in MOK.der PK.auth KEK.auth db.auth \
+                     fog-enroll-mok.sh fog-enroll-mok.desktop; do
+                [[ -f ${kitdir}/${f} ]] && \
+                    cp -f "${kitdir}/${f}" "${staged}/${f}" >>$error_log 2>&1
+            done
+            # Only where something can read it. Nothing in an i386 archive, or
+            # in any archive on an HTTPS-only install, ever loads autoexec.ipxe
+            # -- upstream's loader is what reads it -- so shipping one there
+            # would be an inert file implying a chain that is not present.
+            [[ $haveloader -eq 1 ]] && \
+                _espAutoexecScript "$variant" > "${staged}/autoexec.ipxe" 2>>$error_log
+            _espKitReadme "$arch" "$variant" "$stem" "$haveloader" \
+                > "${staged}/README.txt" 2>>$error_log
+            contents=$(_espKitContentsJson "$staged" "$anchorpem")
+            {
+                printf '{\n'
+                printf '  "archive": %s,\n' "$(_jsonStr "$stem")"
+                printf '  "arch": %s,\n' "$(_jsonStr "$arch")"
+                printf '  "variant": %s,\n' "$(_jsonStr "${variant:-standard}")"
+                printf '  "contents": %s\n' "$contents"
+                printf '}\n'
+            } > "${staged}/MANIFEST.json" 2>>$error_log
+            ext="zip"
+            # Both writers change directory so the archive holds "$stem/..."
+            # rather than the staging path, which means $bootdir has to be
+            # absolute. It always is -- $docroot is a distro default under / and
+            # --docroot is normalised with a leading slash (installfog.sh) -- but
+            # that is the dependency to keep in mind if docroot handling changes.
+            if command -v zip >/dev/null 2>&1; then
+                # -X drops the extra attribute blocks, so a re-run over
+                # unchanged binaries differs only by mtime.
+                ( cd "$work" && zip -q -r -X "${bootdir}/${stem}.zip" "$stem" ) \
+                    >>$error_log 2>&1
+            else
+                # zip is in the install list, so this is a fallback for a server
+                # whose package install partly failed rather than an expected
+                # path. tar is a hard dependency of the installer already.
+                ext="tar.gz"
+                tar -czf "${bootdir}/${stem}.tar.gz" -C "$work" "$stem" \
+                    >>$error_log 2>&1
+            fi
+            archive="${stem}.${ext}"
+            if [[ ! -f ${bootdir}/${archive} ]]; then
+                failed=1
+                rm -rf "$staged" >>$error_log 2>&1
+                continue
+            fi
+            asum=$(sha256sum "${bootdir}/${archive}" 2>/dev/null | cut -d' ' -f1)
+            asize=$(wc -c < "${bootdir}/${archive}" 2>/dev/null | tr -d '[:space:]')
+            [[ $first -eq 0 ]] && archjson="${archjson},"
+            first=0
+            archjson="${archjson}$(printf \
+                '{"path":%s,"arch":%s,"variant":%s,"root":%s,"size":%s,"sha256":%s,"contents":%s}' \
+                "$(_jsonStr "$archive")" "$(_jsonStr "$arch")" \
+                "$(_jsonStr "${variant:-standard}")" "$(_jsonStr "$stem")" \
+                "${asize:-0}" "$(_jsonStr "$asum")" "$contents")"
+            built=$((built + 1))
+            rm -rf "$staged" >>$error_log 2>&1
+        done
     done
-    # The ready-to-copy kit, on top of the menu above. Its sources are the same
-    # files, so a missing one is skipped here for the same reason: an HTTPS
-    # install stages no secureboot/ at all, which costs the kit its shim and
-    # leaves an unsigned-boot-only folder rather than a broken one.
-    local src dst
-    for rel in "${localbootespfiles[@]}"; do
-        src="${rel%%|*}"
-        dst="${rel#*|}"
-        [[ -f ${tftproot}/${src} ]] || continue
-        mkdir -p "${bootdir}/esp/$(dirname "$dst")" >>$error_log 2>&1
-        if cp -f "${tftproot}/${src}" "${bootdir}/esp/${dst}" >>$error_log 2>&1; then
-            copied=$((copied + 1))
-        else
-            failed=1
-        fi
-    done
-    # One per architecture directory, because iPXE looks for autoexec.ipxe beside
-    # the binary that is running, not at a fixed path.
-    local espdir
-    for espdir in "${bootdir}/esp" "${bootdir}/esp/arm64-efi"; do
-        [[ -d $espdir ]] || continue
-        _espAutoexecScript "" > "${espdir}/autoexec.ipxe" 2>>$error_log
-        _espAutoexecScript "10sec" > "${espdir}/autoexec-10sec.ipxe" 2>>$error_log
-    done
-    # The same 404 stub the Secure Boot kit uses, in EVERY directory rather than
-    # just the top one. DirectoryIndex names index.php in every variant
-    # configureHttpd() emits, but it only suppresses a listing where an
-    # index.php actually exists -- and mod_autoindex is live on a stock
-    # /var/www/html, because the "Options +FollowSymLinks" emitted there MERGES
-    # with the distro's own "Options Indexes FollowSymLinks" rather than
-    # replacing it. Without a stub per directory, arm64-efi/ and friends list.
-    while IFS= read -r dir; do
-        echo '<?php header("HTTP/1.1 404 Not Found");' > "${dir}/index.php"
-    done < <(find "$bootdir" -type d -print 2>>$error_log)
-    find "$bootdir" -type d -exec chmod 755 {} \; >>$error_log 2>&1
-    find "$bootdir" ! -type d -exec chmod 644 {} \; >>$error_log 2>&1
+    rm -rf "$work" >>$error_log 2>&1
+    # Static, written once here. Deliberately NOT a PHP endpoint that lists the
+    # directory on request: that would be a directory listing with a traversal
+    # surface, to save writing a file that changes only when the installer runs.
+    # Paths are relative to this file's own URL so it resolves under whatever
+    # hostname and webroot the admin reached it by.
+    {
+        printf '{\n'
+        printf '  "schema": 1,\n'
+        printf '  "generated": %s,\n' \
+            "$(_jsonStr "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)")"
+        printf '  "fogVersion": %s,\n' "$(_jsonStr "${version}")"
+        printf '  "ipxeVersion": %s,\n' "$(_jsonStr "${ipxeVer}")"
+        printf '  "archives": [%s],\n' "$archjson"
+        printf '  "kernels": %s\n' "$(_espKernelsJson)"
+        printf '}\n'
+    } > "${bootdir}/manifest.json" 2>>$error_log
+    # The same 404 stub the Secure Boot kit and service/ipxe use. One directory
+    # now instead of ten: DirectoryIndex names index.php in every variant
+    # configureHttpd() emits, but only suppresses a listing where an index.php
+    # actually exists -- and mod_autoindex is live on a stock /var/www/html,
+    # because the "Options +FollowSymLinks" emitted there MERGES with the
+    # distro's own "Options Indexes FollowSymLinks" rather than replacing it.
+    echo '<?php header("HTTP/1.1 404 Not Found");' > "${bootdir}/index.php"
+    chmod 0755 "$bootdir" >>$error_log 2>&1
+    find "$bootdir" -type f -exec chmod 0644 {} \; >>$error_log 2>&1
     # _publishSecureBootKit()'s own chown -R does not reach here; this is a
     # sibling of that directory, not a child of it.
     chown -R "${apacheuser}":"${apacheuser}" "$bootdir" >>$error_log 2>&1
-    if [[ $failed -ne 0 || $copied -eq 0 ]]; then
+    if [[ $failed -ne 0 || $built -eq 0 || ! -s ${bootdir}/manifest.json ]]; then
         echo "Failed"
-        echo " * Could not publish the local ESP boot files to $bootdir."
+        echo " * Could not publish the local ESP boot archives to $bootdir."
         echo "   Netboot is unaffected; assembling an ESP from that URL will be"
         echo "   missing files. See $error_log."
         return 0
     fi
-    echo "Done"
+    echo "Done (${built})"
 }
 # Sign CUSTOM kernels for UEFI Secure Boot.
 #

--- a/tests/localboot-publish.test.sh
+++ b/tests/localboot-publish.test.sh
@@ -1,0 +1,476 @@
+#!/bin/bash
+#
+# Guards what service/localboot/ publishes and what it must never publish.
+#
+#   tests/localboot-publish.test.sh
+#
+# The directory used to be built from two lists that described the same bytes
+# twice -- a "menu" of binaries under their TFTP names at the root, and a "kit"
+# of the same binaries renamed fog*.efi under esp/. arm64 appeared in four
+# places, and the 10-second-delay set was complete in one list and a single file
+# in the other. It is now six archives and a manifest.
+#
+# What this pins, in rough order of how badly it fails if wrong:
+#
+#   1. The delay variants are not crossed. A -10sec archive whose fogipxe.efi
+#      came from the plain tree, or the reverse, is undetectable on the server
+#      and shows up as "the delay does nothing" on a switch running STP. Every
+#      mock file's CONTENT is its own path in the tree, so provenance is checked
+#      by reading the file rather than by trusting the copy loop.
+#   2. The manifest is valid JSON with sums that match the bytes. It is written
+#      by hand rather than by jq (see _jsonStr) precisely so the whole feature
+#      does not vanish when a package is missing -- which puts the burden of
+#      proving the encoding right here. Validated with python3, deliberately a
+#      different implementation from the one that wrote it.
+#   3. Nothing unpublishable leaks in: the EMBED-less autoexec/ builds, and the
+#      BIOS artifacts (.kpxe/.usb/.iso), which are not PE images at all.
+#   4. The degraded shapes still produce something useful rather than failing:
+#      an HTTPS-only install stages no secureboot/, and a server may hold no
+#      enrolment material.
+#   5. _restampIpxeManifest keeps .fog-ipxe-manifest matching the bytes on disk
+#      after signing rewrites them. Without it _copyIpxeTree reports all 45
+#      .efi as admin-modified on the SECOND install of a Secure Boot server and
+#      stops updating FOG's own binaries, permanently.
+#
+# Needs bash, sha256sum, python3, and tar or unzip. No network, no root, no
+# install. sbsign is NOT needed: the signing path is exercised through
+# _restampIpxeManifest directly, which is where the bug was.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "SKIP: sha256sum is not installed"; exit 0; }
+# Probed by RUNNING it, not by command -v: on Windows "python3" resolves to an
+# App Execution Alias that exists on PATH and then refuses to run, so a
+# presence check passes and every assertion downstream of it silently compares
+# empty strings. A test that reports a false pass is worse than one that skips.
+PY=""
+for c in python3 python py; do
+    if [[ "$("$c" -c 'print("ok")' 2>/dev/null)" == "ok" ]]; then PY="$c"; break; fi
+done
+[[ -n $PY ]] || { echo "SKIP: no working python interpreter found"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+version="1.6.0-test"
+ipxeVer="v2.0.0-fog.test"
+apacheuser="$(id -un)"
+
+# A python reader, so the manifest is parsed by something other than the shell
+# that wrote it.
+cat > "$WORK/mq.py" <<'PYEOF'
+import json, sys
+m = json.load(open(sys.argv[1]))
+cmd = sys.argv[2]
+arg = sys.argv[3] if len(sys.argv) > 3 else None
+arg2 = sys.argv[4] if len(sys.argv) > 4 else None
+
+
+def arch(path):
+    for a in m["archives"]:
+        if a["path"] == path:
+            return a
+    raise SystemExit("no such archive: " + path)
+
+
+if cmd == "paths":
+    print("\n".join(sorted(a["path"] for a in m["archives"])))
+elif cmd == "roots":
+    print("\n".join(sorted(a["root"] for a in m["archives"])))
+elif cmd == "count":
+    print(len(m["archives"]))
+elif cmd == "field":
+    print(arch(arg)[arg2])
+elif cmd == "files":
+    print("\n".join(sorted(f["name"] for f in arch(arg)["contents"])))
+elif cmd == "filesum":
+    print([f["sha256"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
+elif cmd == "filenote":
+    print([f["note"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
+elif cmd == "kernels":
+    print("\n".join(sorted(k["name"] for k in m["kernels"])))
+elif cmd == "kernelpath":
+    print([k["path"] for k in m["kernels"] if k["name"] == arg][0])
+elif cmd == "top":
+    print(m[arg])
+PYEOF
+
+# Windows python writes CRLF, so multi-line output would carry a stray CR into
+# every comparison and into filenames read out of it. A no-op on Linux.
+mq() { "$PY" "$WORK/mq.py" "$@" | tr -d '\015'; }
+
+# Every mock file's content IS its path in the tree, so a copy landing in the
+# wrong archive is caught by reading it rather than inferred from a size.
+mk_tree() {
+    local root="$1" withsb="$2" d n
+    rm -rf "$root"
+    for d in "" "i386-efi/" "arm64-efi/" "10secdelay/" \
+             "10secdelay/i386-efi/" "10secdelay/arm64-efi/" "autoexec/"; do
+        mkdir -p "${root}/${d}"
+        for n in ipxe snp snponly intel realtek; do
+            printf '%s' "${d}${n}.efi" > "${root}/${d}${n}.efi"
+        done
+    done
+    # Not PE images; an ESP cannot boot them and they must never be published.
+    printf 'kpxe' > "${root}/undionly.kkpxe"
+    printf 'usb'  > "${root}/ipxe.usb"
+    printf 'iso'  > "${root}/ipxe.iso"
+    printf 'lkrn' > "${root}/ipxe.lkrn"
+    if [[ $withsb == yes ]]; then
+        mkdir -p "${root}/secureboot/arm64-efi"
+        for n in snponly.efi snponly-shimx64.efi ipxe.efi ipxe-shimx64.efi mmx64.efi; do
+            printf '%s' "secureboot/${n}" > "${root}/secureboot/${n}"
+        done
+        for n in snponly.efi snponly-shimaa64.efi ipxe.efi ipxe-shimaa64.efi mmaa64.efi; do
+            printf '%s' "secureboot/arm64-efi/${n}" > "${root}/secureboot/arm64-efi/${n}"
+        done
+    fi
+}
+
+mk_web() {
+    local root="$1" withenrol="$2" n
+    rm -rf "$root"
+    mkdir -p "${root}/service/ipxe" "${root}/service/secureboot"
+    for n in bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz; do
+        printf '%s' "$n" > "${root}/service/ipxe/${n}"
+    done
+    if [[ $withenrol == yes ]]; then
+        for n in MOK.der PK.auth KEK.auth db.auth \
+                 fog-enroll-mok.sh fog-enroll-mok.desktop; do
+            printf '%s' "$n" > "${root}/service/secureboot/${n}"
+        done
+    fi
+}
+
+extract() {
+    mkdir -p "$2"
+    case "$1" in
+        *.zip)    unzip -qq -o "$1" -d "$2" ;;
+        *.tar.gz) tar -xzf "$1" -C "$2" ;;
+    esac
+}
+top_entries() {
+    case "$1" in
+        *.zip)    unzip -Z1 "$1" ;;
+        *.tar.gz) tar -tzf "$1" ;;
+    esac | sed 's#/.*##' | sort -u
+}
+
+echo "localboot publish:"
+
+# --- the normal case ---------------------------------------------------------
+tftpdirdst="$WORK/tftp"
+webdirdest="$WORK/web"
+mk_tree "$tftpdirdst" yes
+mk_web "$webdirdest" yes
+secureBootKey=""
+secureBootCert=""
+
+_publishLocalBootFiles >/dev/null
+BOOT="$webdirdest/service/localboot"
+MAN="$BOOT/manifest.json"
+
+if [[ -f $MAN ]]; then ok "manifest.json is written"; else bad "manifest.json missing"; fi
+if "$PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$MAN" >/dev/null 2>&1; then
+    ok "manifest.json is valid JSON (parsed by python, not by what wrote it)"
+else
+    bad "manifest.json is not valid JSON"
+    "$PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$MAN" 2>&1 | head -3
+fi
+
+is "$(mq "$MAN" count)" "6" "six archives are published"
+is "$(mq "$MAN" top schema)" "1" "the manifest declares its schema"
+is "$(mq "$MAN" top fogVersion)" "1.6.0-test" "the manifest records the FOG version"
+is "$(mq "$MAN" top ipxeVersion)" "v2.0.0-fog.test" "the manifest records the iPXE version"
+
+# Derived from the filesystem, not from the manifest: the archive format falls
+# back to tar.gz where zip is absent, and a test that could not tell the
+# difference would compare empty paths and pass.
+if [[ -f $BOOT/fog-esp-x86_64.zip ]]; then EXT=".zip"; else EXT=".tar.gz"; fi
+is "$(mq "$MAN" paths | tr '\n' ' ')" \
+   "fog-esp-arm64-10sec${EXT} fog-esp-arm64${EXT} fog-esp-i386-10sec${EXT} fog-esp-i386${EXT} fog-esp-x86_64-10sec${EXT} fog-esp-x86_64${EXT} " \
+   "one archive per architecture and delay variant"
+
+# Nothing loose. The whole point of the reorganisation.
+is "$(find "$BOOT" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" "0" \
+   "the published directory has no subdirectories at all"
+is "$(find "$BOOT" -name '*.efi' | wc -l | tr -d ' ')" "0" \
+   "no loose .efi is published beside the archives"
+if [[ -f $BOOT/index.php ]] && grep -q '404' "$BOOT/index.php"; then
+    ok "the 404 stub is in place"
+else
+    bad "the 404 stub is missing"
+fi
+
+# --- provenance: the delay variants must not be crossed ----------------------
+for pair in "fog-esp-x86_64${EXT}|ipxe.efi" \
+            "fog-esp-x86_64-10sec${EXT}|10secdelay/ipxe.efi" \
+            "fog-esp-i386${EXT}|i386-efi/ipxe.efi" \
+            "fog-esp-i386-10sec${EXT}|10secdelay/i386-efi/ipxe.efi" \
+            "fog-esp-arm64${EXT}|arm64-efi/ipxe.efi" \
+            "fog-esp-arm64-10sec${EXT}|10secdelay/arm64-efi/ipxe.efi"; do
+    a="${pair%%|*}"; want="${pair#*|}"
+    d="$WORK/x/${a%%.*}"
+    rm -rf "$d"; extract "$BOOT/$a" "$d"
+    is "$(cat "$d/${a%%.*}/fogipxe.efi" 2>/dev/null)" "$want" \
+       "$a fogipxe.efi comes from $want"
+done
+
+# One top-level directory named after the archive, so two extracted side by side
+# cannot silently overwrite each other -- they carry the same inner filenames.
+is "$(top_entries "$BOOT/fog-esp-x86_64${EXT}" | tr '\n' ' ')" "fog-esp-x86_64 " \
+   "the archive holds exactly one top-level directory, named for itself"
+
+# --- what a full archive contains --------------------------------------------
+X="$WORK/x/fog-esp-x86_64/fog-esp-x86_64"
+for f in snponly-shimx64.efi snponly.efi ipxe-shimx64.efi ipxe.efi mmx64.efi \
+         fogipxe.efi fogsnp.efi fogintel.efi fogrealtek.efi fogsnponly.efi \
+         autoexec.ipxe README.txt MANIFEST.json \
+         MOK.der PK.auth KEK.auth db.auth \
+         fog-enroll-mok.sh fog-enroll-mok.desktop; do
+    [[ -f $X/$f ]] || bad "x86_64 archive is missing $f"
+done
+[[ -f $X/fogsnponly.efi ]] && ok "fogsnponly.efi is published (it was excluded before)"
+[[ -f $X/MOK.der ]] && ok "MOK.der travels with MokManager"
+[[ -f $X/db.auth ]] && ok "the Setup Mode variable updates travel too"
+
+# Upstream's names are the ones shim resolves to; FOG's must not take them.
+is "$(cat "$X/snponly.efi")" "secureboot/snponly.efi" \
+   "snponly.efi is UPSTREAM's copy, which is what shim's certificate vouches for"
+is "$(cat "$X/ipxe.efi")" "secureboot/ipxe.efi" \
+   "ipxe.efi is upstream's copy for the same reason"
+is "$(cat "$X/fogsnponly.efi")" "snponly.efi" \
+   "FOG's snponly ships under the fog prefix instead"
+
+# Nothing unpublishable leaked in.
+for junk in undionly.kkpxe ipxe.usb ipxe.iso ipxe.lkrn; do
+    [[ -e $X/$junk ]] && bad "BIOS artifact $junk was published"
+done
+ok "no BIOS artifact (.kpxe/.usb/.iso/.lkrn) is published"
+if grep -rq 'autoexec/' "$X"/*.efi 2>/dev/null; then
+    bad "an EMBED-less autoexec/ build was published"
+else
+    ok "the EMBED-less autoexec/ builds are not published"
+fi
+
+# --- the fallback ladder -----------------------------------------------------
+is "$(grep -c '^chain fog' "$X/autoexec.ipxe")" "5" "autoexec.ipxe chains all five builds"
+is "$(grep '^chain fog' "$X/autoexec.ipxe" | tail -1)" "chain fogsnponly.efi || goto nofogbinary" \
+   "fogsnponly.efi is tried LAST -- it is the one most likely to load and find no NIC"
+is "$(grep '^chain fog' "$X/autoexec.ipxe" | head -1)" "chain fogipxe.efi || goto trysnp" \
+   "fogipxe.efi is tried first"
+
+X10="$WORK/x/fog-esp-x86_64-10sec/fog-esp-x86_64-10sec"
+if [[ -f $X10/autoexec-10sec.ipxe ]]; then
+    bad "the delay variant still ships a second script to rename over the first"
+else
+    ok "the delay archive has ONE autoexec.ipxe -- no rename step"
+fi
+if grep -q '10-SECOND-DELAY' "$X10/autoexec.ipxe"; then
+    ok "the delay archive's script says which set it is"
+else
+    bad "the delay archive's script does not identify itself"
+fi
+is "$(grep -c '10secdelay' "$X10/autoexec.ipxe")" "0" \
+   "the delay archive's binaries carry the plain names"
+
+# --- manifest sums match the bytes -------------------------------------------
+sum_of() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1; }
+is "$(mq "$MAN" field "fog-esp-x86_64${EXT}" sha256)" "$(sum_of "$BOOT/fog-esp-x86_64${EXT}")" \
+   "the manifest's archive sha256 matches the archive"
+is "$(mq "$MAN" field "fog-esp-x86_64${EXT}" size)" \
+   "$(wc -c < "$BOOT/fog-esp-x86_64${EXT}" | tr -d '[:space:]')" \
+   "the manifest's archive size matches the archive"
+badsum=0
+while IFS= read -r f; do
+    [[ -f $X/$f ]] || { badsum=1; continue; }
+    [[ "$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" "$f")" == "$(sum_of "$X/$f")" ]] || badsum=1
+done < <(mq "$MAN" files "fog-esp-x86_64${EXT}")
+is "$badsum" "0" "every per-file sha256 in the manifest matches the extracted file"
+
+# A file cannot carry its own checksum, so MANIFEST.json is absent from its own
+# inventory -- deliberate, and worth pinning so it is not "fixed" into a lie.
+if mq "$MAN" files "fog-esp-x86_64${EXT}" | grep -qx 'MANIFEST.json'; then
+    bad "MANIFEST.json lists itself, so its own sum cannot be right"
+else
+    ok "MANIFEST.json is absent from its own inventory"
+fi
+
+# The in-archive manifest agrees with the root one.
+if "$PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$X/MANIFEST.json" >/dev/null 2>&1; then
+    ok "the in-archive MANIFEST.json is valid JSON"
+else
+    bad "the in-archive MANIFEST.json is not valid JSON"
+fi
+is "$("$PY" -c 'import json,sys;print(" ".join(sorted(f["name"] for f in json.load(open(sys.argv[1]))["contents"])))' "$X/MANIFEST.json")" \
+   "$(mq "$MAN" files "fog-esp-x86_64${EXT}" | tr '\n' ' ' | sed 's/ $//')" \
+   "the in-archive manifest lists the same files as the root manifest"
+
+# The notes are what replaced curation-by-omission; an empty one for the file
+# that used to be excluded would put the advice nowhere.
+if [[ -n "$(mq "$MAN" filenote "fog-esp-x86_64${EXT}" fogsnponly.efi)" ]]; then
+    ok "fogsnponly.efi carries the caveat that used to be an exclusion"
+else
+    bad "fogsnponly.efi is published with no explanation of when it fails"
+fi
+
+# --- kernels are listed, not copied ------------------------------------------
+is "$(mq "$MAN" kernels | tr '\n' ' ')" \
+   "arm_Image arm_init.cpio.gz bzImage bzImage32 init.xz init_32.xz " \
+   "the FOS kernel/init set is listed in the manifest"
+is "$(mq "$MAN" kernelpath bzImage)" "../ipxe/bzImage" \
+   "kernels are referenced by relative path, so any hostname resolves them"
+if [[ -e $X/bzImage ]]; then
+    bad "a kernel was copied into an archive"
+else
+    ok "no kernel is copied into an archive (60-80MB not moved)"
+fi
+
+# --- HTTPS-only install: nothing stages secureboot/ --------------------------
+mk_tree "$tftpdirdst" no
+mk_web "$webdirdest" yes
+_publishLocalBootFiles >/dev/null
+is "$(mq "$MAN" count)" "6" "an HTTPS-only install still publishes six archives"
+rm -rf "$WORK/n"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/n"
+N="$WORK/n/fog-esp-x86_64"
+if [[ -e $N/snponly-shimx64.efi || -e $N/mmx64.efi ]]; then
+    bad "shim material appeared without a staged secureboot/"
+else
+    ok "no shim material when none was staged"
+fi
+[[ -f $N/fogipxe.efi ]] && ok "FOG's own builds still ship without a shim"
+if [[ -e $N/autoexec.ipxe ]]; then
+    bad "autoexec.ipxe shipped with no loader that could ever read it"
+else
+    ok "autoexec.ipxe is omitted when no loader is present to read it"
+fi
+[[ -f $N/db.auth ]] && ok "the Setup Mode route survives an HTTPS-only install"
+
+# --- i386 has no shim, but does have the Setup Mode route --------------------
+mk_tree "$tftpdirdst" yes
+_publishLocalBootFiles >/dev/null
+rm -rf "$WORK/i"; extract "$BOOT/fog-esp-i386${EXT}" "$WORK/i"
+I="$WORK/i/fog-esp-i386"
+if [[ -e $I/snponly-shimx64.efi ]]; then
+    bad "an x64 shim was put in the i386 archive"
+else
+    ok "the i386 archive has no shim -- upstream signs none for ia32"
+fi
+[[ -f $I/db.auth ]] && ok "the i386 archive DOES carry db.auth (the only SB route it has)"
+[[ -f $I/fogipxe.efi ]] && ok "the i386 archive carries FOG's builds"
+if grep -q 'Setup Mode' "$I/README.txt"; then
+    ok "the i386 README names the Setup Mode route"
+else
+    bad "the i386 README does not explain its only Secure Boot route"
+fi
+# The README must not describe a fallback chain the archive does not contain.
+# It nearly did: the ladder paragraph was unconditional, so an archive with no
+# loader -- i386, or any arch on an HTTPS-only install -- told the admin that
+# "autoexec.ipxe already tries them in that order" about a file that is not
+# there.
+if grep -q 'no autoexec.ipxe in this archive' "$I/README.txt"; then
+    ok "the i386 README says there is no fallback chain, because there is none"
+else
+    bad "the i386 README describes an autoexec.ipxe the archive does not contain"
+fi
+if grep -q 'autoexec.ipxe already tries them' "$X/README.txt"; then
+    ok "the x86_64 README does describe the ladder, because it has one"
+else
+    bad "the x86_64 README omits the fallback ladder it ships"
+fi
+
+# --- a server with no enrolment material at all ------------------------------
+mk_web "$webdirdest" no
+_publishLocalBootFiles >/dev/null
+is "$(mq "$MAN" count)" "6" "a server publishing no enrolment material still succeeds"
+rm -rf "$WORK/e"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/e"
+E="$WORK/e/fog-esp-x86_64"
+if [[ -e $E/MOK.der || -e $E/db.auth ]]; then
+    bad "enrolment material appeared on a server that publishes none"
+else
+    ok "no enrolment material when the server has none to give"
+fi
+[[ -f $E/fogipxe.efi ]] && ok "the boot binaries ship regardless"
+
+# --- an empty tree must report failure, not publish nothing quietly ----------
+mk_tree "$tftpdirdst" no
+rm -f "$tftpdirdst"/*.efi "$tftpdirdst"/*/*.efi "$tftpdirdst"/*/*/*.efi
+out="$(_publishLocalBootFiles)"
+if [[ $out == *Failed* ]]; then
+    ok "an empty tree reports Failed rather than publishing an empty directory"
+else
+    bad "an empty tree was published silently (got: ${out})"
+fi
+
+# --- re-running is stable ----------------------------------------------------
+mk_tree "$tftpdirdst" yes
+mk_web "$webdirdest" yes
+_publishLocalBootFiles >/dev/null
+first_files="$(mq "$MAN" files "fog-esp-x86_64${EXT}" | tr '\n' ' ')"
+first_sum="$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" fogipxe.efi)"
+_publishLocalBootFiles >/dev/null
+is "$(mq "$MAN" files "fog-esp-x86_64${EXT}" | tr '\n' ' ')" "$first_files" \
+   "a re-run publishes the same file list"
+is "$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" fogipxe.efi)" "$first_sum" \
+   "a re-run publishes the same bytes"
+
+# --- .fog-ipxe-manifest survives signing -------------------------------------
+#
+# The regression this pins costs a Secure Boot server every future iPXE update:
+# _copyIpxeTree records a sum, signing rewrites the file, and on the next run
+# every .efi looks like the admin replaced it.
+echo
+echo "ipxe manifest re-stamp:"
+tftpdirsrc="$WORK/sign-src"
+tftpdirdst="$WORK/sign-dst"
+mkdir -p "$tftpdirsrc/i386-efi" "$tftpdirdst"
+printf 'unsigned-ipxe'  > "$tftpdirsrc/ipxe.efi"
+printf 'unsigned-snp'   > "$tftpdirsrc/i386-efi/snp.efi"
+printf 'admin-owned'    > "$tftpdirsrc/custom.efi"
+_copyIpxeTree
+is "$ipxeSkipped" "" "baseline: nothing preserved on a first copy"
+
+# The admin genuinely replaced one file; its ORIGINAL sum must stay recorded.
+printf 'ADMIN BUILD' > "$tftpdirdst/custom.efi"
+_copyIpxeTree
+is "$ipxeSkipped" "custom.efi" "baseline: the admin's file is preserved"
+
+# Stand in for sbsign: rewrite the bytes of the two FOG files in place, exactly
+# as signing does, then re-stamp only those.
+printf 'signed-ipxe' > "$tftpdirdst/ipxe.efi"
+printf 'signed-snp'  > "$tftpdirdst/i386-efi/snp.efi"
+_restampIpxeManifest "$tftpdirdst" ipxe.efi i386-efi/snp.efi
+
+_copyIpxeTree
+if [[ $ipxeSkipped == *ipxe.efi* && $ipxeSkipped != *custom* ]]; then
+    bad "signed binaries are still reported as admin-modified"
+else
+    ok "signed binaries are NOT reported as admin-modified"
+fi
+is "$ipxeSkipped" "custom.efi" "and the admin's own file is still protected"
+is "$(cat "$tftpdirdst/ipxe.efi")" "unsigned-ipxe" \
+   "FOG's own binary updates again on the next run"
+is "$(cat "$tftpdirdst/custom.efi")" "ADMIN BUILD" \
+   "the admin's binary still survives"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || { echo "  (see $error_log)"; exit 1; }
+exit 0


### PR DESCRIPTION
Reworks #1117. **Based on `claude/fog-issue-1119-phase-2` (#1123), not `working-1.6`** — the `.fog-ipxe-manifest` fix below depends on `_copyIpxeTree()`, which only exists on that branch. Retarget once #1123 merges.

## Why

`_publishLocalBootFiles()` published the same bytes twice — `localbootfiles` as a "menu" under the TFTP names, `localbootespfiles` as a "kit" under `esp/` with the `fog*` names #1117 introduced. On a real server:

```
service/localboot:
  10secdelay  arm64-efi  esp  i386-efi  index.php
  intel.efi  ipxe.efi  realtek.efi  secureboot  snp.efi
```

arm64 in four places (`arm64-efi/`, `10secdelay/arm64-efi/`, `esp/arm64-efi/`, `secureboot/arm64-efi/`). The delay set complete in one list and a single file in the other. And with listing off, the only way to enumerate the directory was to already know the filenames.

The premise that two lists served two audiences did not survive contact. The *only* reason the kit needed different filenames is that shim reserves `snponly.efi` and `ipxe.efi` on an ESP — and those names are the strictly safer choice everywhere. One correctly-named folder serves both.

## What is published now

```
service/localboot/
  index.php  manifest.json
  fog-esp-x86_64.zip   fog-esp-x86_64-10sec.zip
  fog-esp-i386.zip     fog-esp-i386-10sec.zip
  fog-esp-arm64.zip    fog-esp-arm64-10sec.zip
```

Each archive holds one top-level directory named after itself: upstream's shim pair(s) and MokManager, FOG's five builds under `fog*` names, `autoexec.ipxe`, `README.txt`, `MANIFEST.json`, plus whatever enrolment material the server publishes.

**The delay variant is its own archive, which removes a step rather than adding one.** iPXE runs exactly the file called `autoexec.ipxe` and cannot be asked which set you want, so a combined folder made choosing mean renaming one file over another. Chosen at download time, the binaries in a `-10sec` archive carry the plain names and its single `autoexec.ipxe` is already correct.

**`manifest.json` is what makes curation honest.** The old directory curated by *omission* — which is how FOG's `snponly.efi` came to be unavailable at all. A manifest carries the same advice per file (`role`, `origin`, `fogSigned`, a prose `note`) without withholding anything to give it. Static, written at install time — deliberately not a PHP endpoint that lists the directory on request, which would be a directory listing with a traversal surface.

## Reversals from the original design

| Was | Now |
| --- | --- |
| FOG's `snponly.efi` excluded | published as `fogsnponly.efi`, tried **last**, caveat in its manifest note |
| `MOK.der` not in the kit | in every archive — MokManager enrols by browsing the ESP for a certificate, so shipping it without one was a dead end one screen later |
| no `.auth` blobs | `PK`/`KEK`/`db.auth` in every archive |
| "i386 has no Secure Boot chain to assemble" | **corrected** — see below |
| signing gated on `--no-secure-boot` | signing always runs; the flag declines enrolment |

### i386 Secure Boot works, and the docs said it did not

Shipping the `.auth` blobs means a machine in Setup Mode writes this server's certificate straight into `db`, after which firmware verifies a signed `fogipxe.efi` **directly — no shim, no MokManager, no MOK**. Upstream signs no shim for ia32, which is why the original design concluded i386 had no Secure Boot path. Via `db` it does.

### Bug fix: `.fog-ipxe-manifest` goes stale after signing

`_copyIpxeTree()` records a sha256 of every TFTP file so a later run can tell FOG's copy from one the admin replaced. `_signLocalIpxe()` re-signs those `.efi` **in place** afterwards and never re-stamped. On the *second* install of a Secure Boot server all 45 `.efi` compare unequal: FOG stops updating its own binaries and prints "Kept your own copies of these iPXE files" for every one, permanently.

`_restampIpxeManifest()` rewrites only the lines for files actually signed — an entry deliberately carrying the *original* sum for a file the admin really did replace is copied through untouched, so that file stays protected.

### `--no-secure-boot` declines enrolment, not signatures

It now suppresses `MOK.der`, the `.auth` blobs, and therefore the *Enroll Secure Boot Key* PXE entry (`BootMenu` already gates that on `MOK.der` existing). Keys are minted and binaries signed on every server: a PE signature is inert with Secure Boot off and costs nothing, whereas an unsigned binary is useless the day anyone enrols, with nothing on the server able to fix it short of a re-install. Applied in `_ensureSecureBootPlatformKeys()` and `_publishSecureBootKit()` instead of by blanking `$secureBootKey`. Installer help text updated — it claimed the flag left the FOS kernels unsigned.

## Trade-off, recorded because it is real

**No individual binary has a URL any more**, so nothing published here can be a UEFI HTTP Boot target or an iPXE `chain` destination — `service/secureboot/mmx64.efi` shows that is a real use, since the PXE menu chains that single file over HTTP. Accepted because the archive serves the "prepare an ESP" case this feature exists for; publishing the loose set alongside is purely additive if the other case turns up.

## Testing

`tests/localboot-publish.test.sh`, **64 assertions, all passing**. Every mock file's content is its own path in the tree, so provenance is read out of the file rather than trusted — which pins the failure that is otherwise invisible on a server: a `-10sec` archive whose `fogipxe.efi` came from the plain tree surfaces only as "the delay does nothing" on a switch running STP.

Also covered: the manifest parses as JSON under an independent implementation (python, not the shell that wrote it) with every sha256 matching the published bytes; no BIOS artifact (`.kpxe`/`.usb`/`.iso`/`.lkrn`) and no EMBED-less `autoexec/` build leaks in; upstream keeps the two shim-reserved names; the HTTPS-only shape publishes six archives and correctly omits an `autoexec.ipxe` no loader could read; the README never describes a fallback chain its archive lacks; a server with no enrolment material still succeeds; an empty tree reports `Failed` rather than publishing silently; re-runs are stable; and the `.fog-ipxe-manifest` regression is pinned end to end.

Both archive writers exercised — `zip` and the `tar -czf` fallback — and the produced `.zip` verified with both `unzip` and PowerShell `Expand-Archive`, which is the path that motivated preferring zip over tar.gz.

Full suite: 8 failures, **all pre-existing** — confirmed identical against a clean worktree at the base commit (`api-server-owned-fields`, `autoload-core-wins`, `no-session-for-browserless`, `plugin-extension-points`, `route-result-wrappers`, `ipxe-tree-preservation`, `pki-idempotence`, `trust-anchor`). `pxe-secureboot-menu-gating.test.php`, the one most exposed to the opt-out change, passes.

**Not yet verified:** hardware (both enrolment routes, including the i386 Setup Mode path) and an SELinux-enforcing distro.

## Not done, deliberately

- **`bzImage`/`init.xz` are listed, not bundled.** 60–80MB per architecture, and they would not produce a working local boot on their own — FOS reads per-host, per-task kernel arguments that `boot.php` generates. The manifest's `kernels` section points at the existing `service/ipxe/` copies with sha256s, so it indexes everything fetchable for a local boot without moving a byte.
- **`.usb`/`.iso` not published.** A coherent but different feature (boot iPXE off a USB stick without touching the ESP), with its own layout question. Say so if it is wanted.

## Downstream

No REST route or `Route::$validClasses` change, so no `OpenAPI::document()` update and no FogApi class-list sync.

## Note for reviewers

`zip` is added to the package list (`functions.sh`). It is a separate package from `unzip` on every supported distro and is named `zip` identically on apt/dnf/pacman/apk, so no per-distro alternatives list is needed. A server whose package install partly failed falls back to `.tar.gz`, and `manifest.json` names whichever file was produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4x6HMrU32XFUNEqMbstbV
