### PR TITLE
Port: string identifiers read as foreign keys, and php-fpm error log ownership

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4382,6 +4382,37 @@ EOF
                 if [[ -n $phpsessdir && $phpsessdir == /* && $phpsessdir != "/" && -d $phpsessdir && $phpsessdir == *session* ]]; then
                     chown -R ${apacheuser}:${apacheuser} "$phpsessdir" >>$error_log 2>&1
                 fi
+                # The pool's error log is orphaned by the same user change,
+                # and it fails more quietly than the session directory: the
+                # pool cannot open it, so every error_log() call from FOG's
+                # PHP is discarded and the file stays zero bytes forever.
+                # Nothing reports it -- not the browser, not the master's own
+                # error.log -- so it reads as an install with no errors.
+                #
+                # Measured on a Fedora nginx install: the RPM ships
+                # /var/log/php-fpm owned apache:root and www-error.log owned
+                # apache:apache, the pool runs as $apacheuser after the
+                # rewrite above, and `test -w` says no to both.
+                #
+                # The file is chowned unconditionally; the directory only when
+                # its own name marks it as php-fpm's. On Debian the log sits
+                # directly in /var/log, and chowning that to the web user
+                # would be a far worse bug than the one being fixed.
+                #
+                # logrotate keeps the ownership: the packaged php-fpm rule
+                # carries no `create` line, so a rotated file inherits the
+                # attributes of the one it replaced.
+                phpfpmlog=$(sed -n "s/^[;[:space:]]*php_admin_value\[error_log\][[:space:]]*=[[:space:]]*//p" $phpfpmconf | tail -1 | tr -d '"')
+                if [[ -n $phpfpmlog && $phpfpmlog == /* && $phpfpmlog != "/" && -d $(dirname "$phpfpmlog") ]]; then
+                    [[ -f $phpfpmlog ]] || touch "$phpfpmlog" >>$error_log 2>&1
+                    chown ${apacheuser}:${apacheuser} "$phpfpmlog" >>$error_log 2>&1
+                    phpfpmlogdir=$(dirname "$phpfpmlog")
+                    case "$(basename "$phpfpmlogdir")" in
+                        *fpm*|*php*)
+                            chown ${apacheuser}:${apacheuser} "$phpfpmlogdir" >>$error_log 2>&1
+                            ;;
+                    esac
+                fi
                 sed -i 's/listen = .*/listen = 127.0.0.1:9000/g' $phpfpmconf >>$error_log 2>&1
                 sed -i 's/^[;]pm\.max_requests = .*/pm.max_requests = 2000/g' $phpfpmconf >>$error_log 2>&1
                 sed -i 's/^[;]php_admin_value\[memory_limit\] = .*/php_admin_value[memory_limit] = 256M/g' $phpfpmconf >>$error_log 2>&1

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -58,6 +58,19 @@ abstract class FOGController extends FOGBase
      */
     protected $databaseFieldsRequired = array();
     /**
+     * Keys that end in "id" but do not hold a foreign key.
+     *
+     * save() and isValid() both infer "this is an integer id" from the key's
+     * name, which is right for every real foreign key in the tree and wrong
+     * for a string identifier that happens to end the same way -- a system
+     * UUID, a task id kept in a text column. The name is a proxy for the
+     * column's type, and the model is the only thing that knows the actual
+     * type, so it says so here.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = array();
+    /**
      * Additional elements unrelated to DB side directly for object.
      *
      * @var array
@@ -406,6 +419,13 @@ abstract class FOGController extends FOGBase
                 $required[$reqKeyNorm] = true;
             }
 
+            // Keys the model has declared are NOT foreign keys, normalized the
+            // same way, so the branch below can ask about $key directly.
+            $notInt = [];
+            foreach ($this->databaseFieldsNotInt as $strKey) {
+                $notInt[$this->key($strKey)] = true;
+            }
+
             foreach ($this->databaseFields as $rawKey => $column) {
                 $key = $this->key($rawKey);
                 $column = trim($column);
@@ -429,8 +449,11 @@ abstract class FOGController extends FOGBase
                     $val = (int)$validId;
                 }
 
-                // Keys ending with "id" (case-insensitive)
-                elseif (strtolower(substr($key, -2)) === 'id') {
+                // Keys ending with "id" (case-insensitive), unless the model
+                // has said this one is a string rather than a foreign key.
+                elseif (strtolower(substr($key, -2)) === 'id'
+                    && !isset($notInt[$key])
+                ) {
                     $isRequired = isset($required[$key]);
                     $isEmpty = ($val === null) || (is_string($val) && trim($val) === '');
 
@@ -947,12 +970,23 @@ abstract class FOGController extends FOGBase
     public function isValid()
     {
         try {
+            // The same opt-out save() honors. Both methods carry their own
+            // copy of the "ends in id, so it is a foreign key" inference, so
+            // both need the exclusion: fixing only save() lets an object save
+            // its string identifier and then fail validation forever after.
+            $notInt = [];
+            foreach ($this->databaseFieldsNotInt as $strKey) {
+                $notInt[$this->key($strKey)] = true;
+            }
+
             foreach ($this->databaseFieldsRequired as $reqKey) {
                 $key = $this->key($reqKey);
                 $val = $this->get($key);
 
                 // If key ends with ID (case-insensitive), require integer >= 1
-                if (strtolower(substr($key, -2)) === 'id') {
+                if (strtolower(substr($key, -2)) === 'id'
+                    && !isset($notInt[$key])
+                ) {
                     if (filter_var($val, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
                         throw new Exception(self::$foglang['RequiredDB'] . ": " . $key);
                     }

--- a/packages/web/lib/fog/inventory.class.php
+++ b/packages/web/lib/fog/inventory.class.php
@@ -78,6 +78,19 @@ class Inventory extends FOGController
         'hostID',
     );
     /**
+     * sysuuid ends in "id" without being a foreign key.
+     *
+     * iSystemUUID is a VARCHAR(255) holding the SMBIOS system UUID, which is
+     * a hyphenated hex string. Without this, save() read the key's name as a
+     * foreign key, failed FILTER_VALIDATE_INT and wrote 0 -- so the UUID was
+     * silently lost on every inventory write, with no error anywhere.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = array(
+        'sysuuid',
+    );
+    /**
      * Additional fields
      *
      * @var array

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -41,6 +41,27 @@ class TaskLog extends FOGController
         'createdBy' => 'createdBy',
     );
     /**
+     * taskID is a foreign key held in a text column.
+     *
+     * taskLog.taskID is mediumtext -- it has been since the table was added,
+     * and it is the only *id column in the 1.5 schema that is not an integer
+     * besides inventory's UUID. save() therefore read it as an integer,
+     * FILTER_VALIDATE_INT rejected nothing (the values are numeric strings)
+     * only as long as the value was clean, and any non-numeric one was
+     * written as 0.
+     *
+     * 1.6 fixed the column instead (schema 336, GH-1156). A column type
+     * change is a data migration, and a maintenance branch is the wrong
+     * place to run one over a table that can hold every task this server
+     * has ever run, so this line does the same job without touching the
+     * schema: the value is stored as it is given.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = array(
+        'taskID',
+    );
+    /**
      * Initializes the class to set the ip from the remote.
      *
      * @param mixed $data the data to initialize with.

--- a/tests/databasefields-notint.test.php
+++ b/tests/databasefields-notint.test.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * A model key ending in "id" that is not a foreign key says so.
+ *
+ * FOGController infers "this is an integer id" from the key's name ending in
+ * "id". That is right for every real foreign key in the tree and wrong for a
+ * string identifier spelled the same way, and the two failure modes differ:
+ *
+ *   required -> throws "Required database field is empty: <key>" while the
+ *               field holds a perfectly good value, so the object can never
+ *               be saved;
+ *   optional -> filter_var fails, the value is replaced with 0 and written,
+ *               so the real value is lost with no error anywhere.
+ *
+ * The inference lives in TWO methods -- save() and isValid() -- each with its
+ * own copy. Fixing one is the trap: the object saves, and then every later
+ * isValid() says no. Both are pinned below.
+ *
+ * There is no column-type sweep here, unlike the 1.6 test this is ported
+ * from. That test reads commons/schema-expected.php, a generated manifest of
+ * the live schema; this branch has no such file, and deriving types by regex
+ * over commons/schema.php's accumulated ALTER statements gives wrong answers
+ * -- it matched a `msState` belonging to a different table when the sweep was
+ * run by hand. So the sweep was done once, against a real 1.5.10 install's
+ * information_schema, keyed on the (table, column) pairs the models actually
+ * declare. It found exactly two, and both are pinned by name below:
+ *
+ *   inventory.iSystemUUID  varchar(255)
+ *   taskLog.taskID         mediumtext
+ *
+ * All 38 plugin *id columns were checked the same way, from their own
+ * Schema::createTable() type lists; every one is INTEGER.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = [];
+$checks = 0;
+
+/**
+ * Reads a bracketed PHP array literal assigned to a property.
+ *
+ * Deliberately textual: loading the models would need the autoloader, a
+ * database and a booted FOG. Comments are stripped through the tokenizer
+ * first so a commented-out entry cannot satisfy the test.
+ *
+ * @param string $src  the file's source
+ * @param string $prop the property name, without the dollar
+ *
+ * @return array the quoted strings found, empty when not declared
+ */
+function notIntArrayLiteral($src, $prop)
+{
+    $clean = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    $at = strpos($clean, '$' . $prop);
+    if ($at === false) {
+        return [];
+    }
+    // array( ... ) on this branch, but accept [ ... ] too so a future
+    // restyling does not read as a missing declaration.
+    $paren = strpos($clean, '(', $at);
+    $brack = strpos($clean, '[', $at);
+    if ($paren === false && $brack === false) {
+        return [];
+    }
+    if ($paren === false || ($brack !== false && $brack < $paren)) {
+        $open = $brack;
+        $openChar = '[';
+        $closeChar = ']';
+    } else {
+        $open = $paren;
+        $openChar = '(';
+        $closeChar = ')';
+    }
+    $depth = 0;
+    $len = strlen($clean);
+    for ($i = $open; $i < $len; $i++) {
+        if ($clean[$i] === $openChar) {
+            $depth++;
+        } elseif ($clean[$i] === $closeChar) {
+            $depth--;
+            if ($depth === 0) {
+                $body = substr($clean, $open, $i - $open + 1);
+                preg_match_all('#[\'"]([^\'"]+)[\'"]#', $body, $m);
+                return array_map('strtolower', $m[1]);
+            }
+        }
+    }
+    return [];
+}
+
+// ---------------------------------------------------------------
+// 1. The base class declares the opt-out and both methods honor it.
+// ---------------------------------------------------------------
+$controller = file_get_contents($web . '/lib/fog/fogcontroller.class.php');
+$squashed = preg_replace('#\s+#', '', $controller);
+
+$checks++;
+if (strpos($squashed, 'protected$databaseFieldsNotInt=array();') === false
+    && strpos($squashed, 'protected$databaseFieldsNotInt=[];') === false
+) {
+    $failures[] = 'FOGController does not declare $databaseFieldsNotInt';
+}
+
+$build = 'foreach($this->databaseFieldsNotIntas$strKey){'
+    . '$notInt[$this->key($strKey)]=true;}';
+
+// save(): the branch is an elseif, because the primary key is handled first.
+$saveBranch = "elseif(strtolower(substr(\$key,-2))==='id'&&!isset(\$notInt[\$key]))";
+$checks++;
+if (strpos($squashed, $saveBranch) === false) {
+    $failures[] = 'save()\'s foreign-key branch does not exclude $notInt keys';
+}
+
+// isValid(): scoped to the method, because the file holds two of everything.
+$at = strpos($squashed, 'publicfunctionisValid(){');
+$checks++;
+if ($at === false) {
+    $failures[] = 'FOGController::isValid() not found';
+    $body = '';
+} else {
+    $end = strpos($squashed, 'publicfunction', $at + 20);
+    $body = substr($squashed, $at, $end === false ? null : $end - $at);
+}
+
+$validBranch = "if(strtolower(substr(\$key,-2))==='id'&&!isset(\$notInt[\$key]))";
+$checks++;
+if ($body !== '' && strpos($body, $validBranch) === false) {
+    $failures[] = 'isValid()\'s foreign-key branch does not exclude $notInt keys';
+}
+
+// Each method needs its own lookup, built before the branch that reads it.
+$checks++;
+if ($body !== '' && strpos($body, $build) === false) {
+    $failures[] = 'isValid() does not build the $notInt lookup';
+}
+$checks++;
+if ($body !== ''
+    && strpos($body, $build) !== false
+    && strpos($body, $validBranch) !== false
+    && strpos($body, $build) > strpos($body, $validBranch)
+) {
+    $failures[] = 'isValid() builds $notInt after the branch that reads it';
+}
+$checks++;
+if (substr_count($squashed, $build) < 2) {
+    $failures[] = 'the $notInt lookup is built fewer than twice -- save() and '
+        . 'isValid() each need their own';
+}
+// save()'s copy has to come before save()'s branch, same as isValid()'s.
+$checks++;
+if (strpos($squashed, $build) !== false
+    && strpos($squashed, $saveBranch) !== false
+    && strpos($squashed, $build) > strpos($squashed, $saveBranch)
+) {
+    $failures[] = 'save() builds $notInt after the branch that reads it';
+}
+
+// ---------------------------------------------------------------
+// 2. The two casualties are declared.
+// ---------------------------------------------------------------
+$known = [
+    'inventory.class.php' => ['sysuuid', 'iSystemUUID is varchar(255)'],
+    'tasklog.class.php' => ['taskid', 'taskLog.taskID is mediumtext'],
+];
+foreach ($known as $file => $want) {
+    list($key, $why) = $want;
+    $checks++;
+    $src = file_get_contents($web . '/lib/fog/' . $file);
+    if (!in_array($key, notIntArrayLiteral($src, 'databaseFieldsNotInt'), true)) {
+        $failures[] = sprintf(
+            '%s does not declare %s in $databaseFieldsNotInt (%s)',
+            $file,
+            $key,
+            $why
+        );
+    }
+}
+
+if (count($failures) > 0) {
+    echo "FAIL databasefields-notint (" . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS databasefields-notint ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
Ports the two of today's `working-1.6` fixes that this branch actually has.

## 1. String identifiers read as foreign keys — #1153 + #1162

`FOGController` infers "this is an integer id" from the key's *name* ending in
`id`. Right for every real foreign key in the tree, wrong for a string
identifier spelled the same way. The inference lives in **two** methods,
`save()` and `isValid()`, each with its own copy — which is the trap: fixing
only `save()` leaves an object that saves and then fails validation forever
after. Both are fixed here, in one commit, because splitting them serves nobody
on a maintenance branch.

### The casualty list is exhaustive, not "the ones that got noticed"

Every `*id` key every model declares was resolved to its `(table, column)` pair
and typed against a **real 1.5.10 install's `information_schema`**; all 38
plugin `*id` columns were typed from their own `Schema::createTable()` lists.
Exactly two are not integers:

| Model key | Column | Type | Effect | Fix here |
|---|---|---|---|---|
| `inventory.sysuuid` | `iSystemUUID` | `varchar(255)` | SMBIOS system UUID written as `0` on **every** inventory write | declared not-int |
| `taskLog.taskID` | `taskID` | `mediumtext` | a non-numeric value written as `0` | declared not-int |

### Reproduced and fixed on a real 1.5 server

Shadow tree in `~` on the 1.5 lab box, running against its own database — the
live tree was never touched (`grep` for the guard on `/var/www/html/fog` after:
0):

```
=== UNPATCHED (live 1.5 code) ===
wrote id=2 sysuuid sent=4C4C4544-0031-3010-8039-CAC04F565831 stored='0'  LOST
=== PATCHED (this port) ===
wrote id=3 sysuuid sent=4C4C4544-0031-3010-8039-CAC04F565831 stored='4C4C4544-0031-3010-8039-CAC04F565831'  MATCH
```

Both probe rows were destroyed; `inventory` is back to 0 rows.

### `taskLog.taskID` is fixed differently from 1.6, on purpose

1.6 fixed the **column** (schema 336, #1156). A column type change is a data
migration, and a maintenance branch is the wrong place to run one over a table
that can hold every task a server has ever run. Declaring the field does the
same job with no schema change. The comment in `tasklog.class.php` says so, and
points at #1156.

## 2. php-fpm's error log — #1165

Same defect here: the installer rewrites the pool to run as `$apacheuser` and
leaves the packaged log owned by the distro's user, so the pool cannot open the
file named by its own `php_admin_value[error_log]` and **every `error_log()`
call from FOG's PHP is discarded**. The log sits at zero bytes looking like an
install with no errors, and nothing reports it.

Guarded exactly like the session-path `chown` directly above it; the directory
is only re-owned when its own basename marks it as php-fpm's, because on Debian
the log sits directly in `/var/log`.

## Not ported: #1163

The nginx query-string fix does not apply to this branch, and the check was not
"it looks similar":

- **the installer writes no nginx vhost at all here** — zero `location ~` and
  zero `try_files` in `lib/common/functions.sh`; only the Apache rewrite, which
  carries `[QSA,L]` and was never affected;
- **`Route` reads no query parameters here** — no `INPUT_GET`, no
  `QUERY_STRING`, no `$_GET[`, and no `queryParam()` to make public;
- there is no OIDC plugin on this branch to be broken by it.

## Test

`tests/databasefields-notint.test.php` pins both methods separately, including
that each builds its own lookup *before* the branch that reads it, plus the two
casualties by name. It deliberately carries **no** column-type sweep: 1.6's
version reads `commons/schema-expected.php`, which this branch does not have,
and deriving types by regex from `schema.php`'s accumulated `ALTER` statements
gives wrong answers — it matched an `msState` belonging to a different table
when tried. The sweep was done once, properly, against a live schema; the test
pins its findings.

Eight mutations verified, all caught, including a comment-only one.
`sh tests/run-all.sh` → 8 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
