### PR TITLE
Bound every installer network fetch (port of #1159)

### DIFF
--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -27,6 +27,16 @@
 # rather than whatever happened to be tagged the day someone installed.
 [[ -z $ipxeVer ]] && ipxeVer="$(awk -F\' /"define\('FOG_IPXE_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php 2>/dev/null | tr -d '[[:space:]]')"
 [[ -z $ipxeVer ]] && ipxeVer="v2.0.0-fog.6"
+# Bounds for every network fetch the installer makes, and the answer
+# checkInternetConnection works out for the fetches that follow it. Overridable
+# from .fogsettings for a link slow enough that fifteen seconds is genuinely too
+# short, which is the only reason to raise them -- they exist so an unreachable
+# host costs seconds instead of libcurl's 300 second default connect timeout.
+# internet_ok starts optimistic so any path that reaches a download without
+# having run the check behaves exactly as it did before.
+[[ -z $inetConnectTimeout ]] && inetConnectTimeout=5
+[[ -z $inetMaxTime ]] && inetMaxTime=15
+[[ -z $internet_ok ]] && internet_ok=1
 [[ -z $udpcastsrc ]] && udpcastsrc="../packages/udpcast-20250223.tar.gz"
 [[ -z $udpcastout ]] && udpcastout="udpcast-20250223"
 [[ -z $servicesrc ]] && servicesrc="../packages/service"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -668,67 +668,136 @@ getAllNetworkInterfaces() {
     fi
     echo -n $interfaces
 }
+# One bounded reachability probe against a single host. Returns curl's exit
+# status so the caller can name the cause without running three separate tests
+# to find it out.
+#
+# Both bounds matter. Without --connect-timeout, curl inherits libcurl's 300
+# second default, which is exactly what a firewall that DROPs rather than
+# REJECTs outbound traffic costs -- per host, per address family. Without
+# --max-time, a connection that opens and then stalls never returns at all.
+#
+# Deliberately no -k. A proxy presenting its own CA passes an unverified probe
+# and then fails the git clone that follows, and predicting that clone is the
+# entire point of the check. Equally deliberately no -f: a host that answers 404
+# at "/" is still a reachable host, and reachability is what is being measured.
+inetProbe() {
+    local host="$1"
+    if command -v curl >/dev/null 2>&1; then
+        curl -sS --connect-timeout $inetConnectTimeout --max-time $inetMaxTime \
+            -o /dev/null "https://${host}/" >>$error_log 2>&1
+        return $?
+    fi
+    # curl is in every distro's package list, but installPackages has not run
+    # yet at this point, so a minimal image can legitimately reach here without
+    # it. bash's own /dev/tcp keeps the fallback dependency free. It sees only
+    # the TCP handshake -- not TLS, and not a proxy -- so it reports the generic
+    # connect failure (7) rather than claiming to know more than it does.
+    #
+    # Bounded by the connect timeout rather than the total: a handshake is all
+    # this does, so there is no transfer phase for $inetMaxTime to govern.
+    timeout $inetConnectTimeout bash -c "exec 3<>/dev/tcp/${host}/443" >>$error_log 2>&1
+    [[ $? -eq 0 ]] && return 0
+    return 7
+}
+# Probe the hosts this install is actually going to pull from, and record the
+# answer somewhere the code that downloads can read it.
+#
+# This used to test DNS, then plain HTTP, then HTTPS, against httpbin.org,
+# neverssl.com, github.com and fogproject.org -- none of them with a timeout,
+# and none of them a host FOG needs. Worse, it opened by running
+# `$packageinstaller curl`, so a connectivity check's first act was a package
+# transaction that needed the very connectivity it was about to test: metadata
+# refresh against every configured mirror, unbounded on Debian/Ubuntu whenever
+# unattended-upgrades holds the dpkg lock (apt has no lock timeout), and on Arch
+# a full system upgrade, because $packageinstaller there is `pacman -Syu`. All
+# of it redirected to the error log, so the screen showed "Testing internet
+# connection" and nothing else for minutes at a time.
+#
+# Nothing read the result either. dns_ok/http_ok/https_ok were set and never
+# looked at, both failure paths returned rather than exited, and the caller
+# ignored the status -- so the install proceeded identically either way and the
+# stall bought a message and nothing more.
+#
+# What the install genuinely needs from the internet is the distro's package
+# repositories -- which installPackages reports on for itself -- and the host
+# behind $ipxegit/$ipxeurl, for the iPXE sources and the iPXE and Secure Boot
+# release assets. Those are what is probed, so pointing them at an internal
+# mirror tests the mirror instead of github.com rather than as well as it. One
+# HTTPS request per host settles DNS, TCP and TLS together, and curl's exit
+# status says which of the three failed, so the old three-stage ladder is not
+# needed to produce a specific message.
+#
+# Failure stays non-fatal, as before: offline installs are supported and
+# documented (pre-placed iPXE sources, a pre-placed release tarball), so the
+# output is advice plus $internet_ok, not an exit. $internet_ok is what
+# fetchipxeasset, downloadfiles and prepareiPXEsource read to avoid
+# re-attempting a fetch that has already been shown to be unreachable.
 checkInternetConnection() {
     dots "Testing internet connection"
-    DEBIAN_FRONTEND=noninteractive $packageinstaller curl >>$error_log 2>&1
-
-    http_sites=("httpbin.org" "neverssl.com")
-    https_sites=("github.com" "fogproject.org")
-    dns_ok=0
-    http_ok=0
-    https_ok=0
-
-    for dnsname in "${http_sites[@]}" "${https_sites[@]}"; do
-        echo -n "Testing DNS name resolution (${dnsname})... " >> $error_log
-        getent hosts ${dnsname} >/dev/null 2>&1
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
+    internet_ok=0
+    local url host rc failhost="" failrc=0
+    # Deduplicated because $ipxeurl is derived from $ipxegit, so the stock
+    # configuration is one host probed once rather than github.com probed twice.
+    local hosts=$(
+        for url in "$ipxegit" "$ipxeurl"; do
+            host="${url#*://}"
+            echo "${host%%/*}"
+        done | grep . | sort -u
+    )
+    for host in $hosts; do
+        echo -n "Testing connection to ${host}... " >> $error_log
+        inetProbe "$host"
+        rc=$?
+        if [[ $rc -eq 0 ]]; then
+            echo "OK" >> $error_log
             continue
         fi
-        dns_ok=1
-        echo "OK" >> $error_log
-        break
+        echo "Failed (curl exit ${rc})" >> $error_log
+        failhost="$host"
+        failrc=$rc
     done
-    if [[ $dns_ok -eq 0 ]]; then
-        echo "Failed"
-        echo
-        echo "There seems to be a DNS problem. Check the contents of /etc/resolv.conf" | tee -a $error_log
-        echo "If this is CentOS, RHEL, or Fedora or an other RH variant, also check" | tee -a $error_log
-        echo "the DNS entries in /etc/sysconfig/network-scripts/ifcfg-*" | tee -a $error_log
-        echo
-        return
+    if [[ -z $failhost ]]; then
+        internet_ok=1
+        echo "Done"
+        return 0
     fi
-    for url in "${http_sites[@]}"; do
-        echo -n "Testing HTTP connection (http://${url})... " >> $error_log
-        curl --silent http://${url} >/dev/null 2>>$error_log
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
-            continue
-        fi
-        http_ok=1
-        echo "OK" >> $error_log
-        break
-    done
-    for url in "${https_sites[@]}"; do
-        echo -n "Testing HTTPS connection (https://${url})... " >> $error_log
-        curl --silent -k https://${url} >/dev/null 2>>$error_log
-        if [[ $? -ne 0 ]]; then
-            echo "Failed" >> $error_log
-            continue
-        fi
-        https_ok=1
-        echo "OK" >> $error_log
-        break
-    done
-    if [[ $http_ok -eq 0 && $https_ok -eq 0 ]]; then
-        echo "Failed"
-        echo
-        echo "There was no interface with an active internet connection found." | tee -a $error_log
-        echo "If you are using a proxy server, please export http_proxy and https_proxy or use .curlrc" | tee -a $error_log
-        echo
-        return
-    fi
-    echo "Done"
+    echo "Failed"
+    echo
+    case $failrc in
+        6)
+            echo "Could not resolve ${failhost}. Check the contents of /etc/resolv.conf," | tee -a $error_log
+            echo "and on RHEL, CentOS, Fedora or another RH variant also the DNS settings" | tee -a $error_log
+            echo "on the connection itself (nmcli con show <name> | grep ipv4.dns)." | tee -a $error_log
+            ;;
+        # 7 and 28 share a message on purpose. A firewall that DROPs outbound
+        # traffic -- the usual cause on an isolated or corporate network --
+        # produces 28 (the connect timeout expiring), not 7; 7 is what an
+        # explicit REJECT or "network unreachable" gives. Naming only $inetMaxTime
+        # against a 28 would report the wrong bound, since it is almost always
+        # $inetConnectTimeout that fired.
+        7|28)
+            echo "Could not reach ${failhost} on port 443 within ${inetConnectTimeout}s to connect" | tee -a $error_log
+            echo "or ${inetMaxTime}s in total. A firewall that drops outbound traffic rather than" | tee -a $error_log
+            echo "rejecting it looks exactly like this." | tee -a $error_log
+            ;;
+        35|60|77)
+            echo "TLS to ${failhost} failed. If a proxy or filter is intercepting HTTPS," | tee -a $error_log
+            echo "its CA has to be trusted by this machine -- git and curl will both fail" | tee -a $error_log
+            echo "the same way until it is." | tee -a $error_log
+            ;;
+        *)
+            echo "Could not reach ${failhost} (curl exit ${failrc})." | tee -a $error_log
+            ;;
+    esac
+    echo
+    echo "The install will continue. FOG needs ${failhost} for the iPXE sources and" | tee -a $error_log
+    echo "the iPXE release binaries, so those steps are the ones expected to fail." | tee -a $error_log
+    echo "If you are using a proxy server, please export http_proxy and https_proxy or use .curlrc" | tee -a $error_log
+    echo "For a deliberate offline install, pre-place those sources -- each download" | tee -a $error_log
+    echo "step below prints the exact path it looks in." | tee -a $error_log
+    echo
+    return 0
 }
 join() {
     local IFS="$1"
@@ -762,8 +831,15 @@ configureUDPCast() {
     cd $udpcastout
     grep -q 'BCM[0-9][0-9][0-9][0-9]' /proc/cpuinfo >>$error_log 2>&1
     if [[ $? -eq 0 ]]; then
-        wget -qO config.guess "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess" >>$error_log 2>&1
-        wget -qO config.sub "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub" >>$error_log 2>&1
+        # Bounded, and the retry count cut right down. wget defaults to
+        # --tries=20 with no connect timeout at all, so on a Pi that cannot
+        # reach savannah this sat here for twenty full SYN retry cycles, twice,
+        # silently. Both files are a few KB, so a 30 second read timeout cannot
+        # cut a legitimate transfer short.
+        wget -qO config.guess --connect-timeout=$inetConnectTimeout --read-timeout=30 --tries=2 \
+            "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess" >>$error_log 2>&1
+        wget -qO config.sub --connect-timeout=$inetConnectTimeout --read-timeout=30 --tries=2 \
+            "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub" >>$error_log 2>&1
         chmod +x config.guess config.sub >>$error_log 2>&1
     fi
     errorStat $?
@@ -856,6 +932,15 @@ prepareiPXEsource() {
     # subdirectory of upstream clones) and nothing here needs the network.
     dots "Preparing iPXE build sources"
     if [[ -d $buildipxesrc/.git ]]; then
+        # git has no connect timeout of its own, so an unreachable host stalls
+        # here for as long as the kernel retries the SYN. The fetch is only ever
+        # an update to a checkout that already works, so when the host is known
+        # to be unreachable, skip straight to using what is on disk -- the same
+        # outcome the failed-checkout branch below produces, minus the wait.
+        if [[ $internet_ok -ne 1 ]]; then
+            echo "Skipped (using existing checkout)"
+            return 0
+        fi
         git -C "$buildipxesrc" fetch --tags --force "$ipxegit" >>$error_log 2>&1
         if ! git -C "$buildipxesrc" checkout -q "$ipxeVer" >>$error_log 2>&1; then
             # Offline, or the tag does not exist yet. A usable checkout is
@@ -904,12 +989,26 @@ fetchipxeasset() {
     cd ../tmp/
     local checksum=1
     local cnt=0
-    while [[ $checksum -ne 0 && $cnt -lt 10 ]]; do
+    # Ten rounds of two timeout-less curls is the most expensive stall in the
+    # whole installer: on a network that drops outbound traffic each of those
+    # twenty connects sat at libcurl's 300 second default before returning, all
+    # of it silent under one "Downloading iPXE binaries" line. When
+    # checkInternetConnection has already established the host is unreachable
+    # there is nothing to retry FOR, so make the one attempt and report.
+    local tries=10
+    [[ $internet_ok -ne 1 ]] && tries=1
+    while [[ $checksum -ne 0 && $cnt -lt $tries ]]; do
         [[ -f ${tarball}.sha256 ]] && sha256sum -c ${tarball}.sha256 >>$error_log 2>&1
         checksum=$?
         if [[ $checksum -ne 0 ]]; then
-            curl --silent -fkOL "$url" >>$error_log 2>&1
-            curl --silent -fkOL "${url}.sha256" >>$error_log 2>&1
+            # --connect-timeout bounds an unreachable host; --speed-time/-limit
+            # bounds a connection that opens and then stalls. --max-time is
+            # deliberately NOT used here -- these are multi-megabyte tarballs
+            # and a slow but working link must be allowed to finish.
+            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 "$url" >>$error_log 2>&1
+            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 "${url}.sha256" >>$error_log 2>&1
         fi
         let cnt+=1
     done
@@ -4870,14 +4969,28 @@ downloadfiles() {
         # make sure we download the most recent hash file to start with
         if [[ -f $hashfile ]]; then
             rm -f $hashfile
-            curl --silent -kOL $hashurl >>$error_log 2>&1
+            curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                --speed-time 30 --speed-limit 1024 $hashurl >>$error_log 2>&1
         fi
-        while [[ $checksum -ne 0 && $cnt -lt 10 ]]; do
+        # Eight URLs, ten rounds, two curls each: 160 connects, none of them
+        # bounded, all of them silent under one "Downloading kernel, init and
+        # fog-client binaries" line. On a host with no route out that was the
+        # single longest stall the installer could produce. --connect-timeout
+        # bounds an unreachable host and --speed-time/--speed-limit a transfer
+        # that opens and then stops; --max-time is deliberately absent, because
+        # these are multi-megabyte kernels and a slow link must still finish.
+        # When checkInternetConnection has already established the host is
+        # unreachable there is nothing to retry FOR, so make one attempt.
+        tries=10
+        [[ $internet_ok -ne 1 ]] && tries=1
+        while [[ $checksum -ne 0 && $cnt -lt $tries ]]; do
             [[ -f $hashfile ]] && sha256sum --check $hashfile >>$error_log 2>&1
             checksum=$?
             if [[ $checksum -ne 0 ]]; then
-                curl --silent -kOL $url >>$error_log
-                curl --silent -kOL $hashurl >>$error_log
+                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                    --speed-time 30 --speed-limit 1024 $url >>$error_log
+                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                    --speed-time 30 --speed-limit 1024 $hashurl >>$error_log
             fi
             let cnt+=1
         done

--- a/tests/network-fetch-bounded.test.sh
+++ b/tests/network-fetch-bounded.test.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+#
+# Guards the "unbounded network call in the installer" bug class.
+#
+#   tests/network-fetch-bounded.test.sh
+#
+# curl's default connect timeout is 300 seconds and it has no default total
+# timeout at all. Every installer fetch that omits --connect-timeout therefore
+# costs five minutes per unreachable host, per address family, and the installer
+# sends all of it to $error_log -- so what the admin sees is one "dots" line and
+# then nothing, for as long as it takes. That is what "the installer hangs"
+# almost always turns out to be.
+#
+# The specific instances that were fixed:
+#
+#   1. checkInternetConnection() opened by running `$packageinstaller curl`.
+#      A connectivity check whose first act is a package transaction needs the
+#      connectivity it is about to test: apt has no dpkg-lock timeout, so it
+#      waits forever behind unattended-upgrades, and on Arch $packageinstaller
+#      is `pacman -Syu`, so the check triggered a full system upgrade.
+#   2. Its four probes -- getent, plain HTTP, HTTPS -- had no timeout of any
+#      kind, and pointed at httpbin.org, neverssl.com, github.com and
+#      fogproject.org. Only one of those is a host FOG downloads anything from.
+#   3. It computed dns_ok/http_ok/https_ok and nothing read them. Both failure
+#      paths returned rather than exiting, and the caller ignored the status, so
+#      the whole cost bought a message.
+#   4. fetchipxeasset() looped ten times issuing two timeout-less curls each.
+#
+# What this checks and what it does not: it asserts on the SOURCE for the shape
+# of the calls, and runs inetProbe() for real against an address that cannot be
+# routed. It does not install FOG and it does not need the internet -- 192.0.2.1
+# is TEST-NET-1 (RFC 5737), which must never be routed, so the probe fails
+# whether or not the runner has a route to anywhere. Only the elapsed time is
+# asserted, and only against a ceiling far below the 300s default, so a runner
+# with no network at all (instant failure) passes just as well as one behind a
+# firewall (5s).
+#
+# The result-is-consumed assertions pin the DEFINITION as well as the use.
+# Pinning only "fetchipxeasset mentions internet_ok" would be satisfied by a
+# reintroduced version that mentions it and ignores it, which is the exact
+# defect being guarded -- so the read is checked to sit on the retry count and
+# on the git fetch, where it changes what happens.
+#
+# No root, no package manager, no FOG install.
+#
+# Exit status 0 = pass, 1 = fail.
+
+cd "$(dirname "$0")/.." || exit 1
+FUNCS="lib/common/functions.sh"
+CONF="lib/common/config.sh"
+
+for f in "$FUNCS" "$CONF"; do
+    [[ -r $f ]] || { echo "cannot read $f -- run this from the repository"; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# body <function-name> <file> -- the text of one shell function, from its
+# opening line to the first line that is a bare closing brace. Crude, but every
+# function in these files is written in exactly that style.
+#
+# Comments are stripped. Without that, every assertion below can be satisfied by
+# the prose explaining the code rather than the code -- and this file's comments
+# name $pluginsgit/$pluginsurl, so "does it probe the plugins host" passed with
+# the probe loop deleted. A gate that its own documentation can satisfy is not a
+# gate. (Same failure the no-session-for-browserless gate hit.)
+body() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$2" | grep -vE '^[[:space:]]*#'
+}
+
+echo "1. the connectivity check does not run the package manager"
+
+if body checkInternetConnection "$FUNCS" | grep -q 'packageinstaller'; then
+    bad "checkInternetConnection still invokes \$packageinstaller"
+else
+    ok "checkInternetConnection does not invoke \$packageinstaller"
+fi
+
+echo
+echo "2. every remote fetch is bounded"
+
+# Remote curls only. The maintenance/* calls to $ipaddress are this same host
+# over loopback or the LAN, which cannot exhibit the 300s stall being guarded.
+# joined <file> -- the file with backslash continuations folded onto one line
+# and comment lines dropped. Both matter: every bounded call here is written
+# across two lines, so a per-line grep sees the flags on one and the URL on the
+# other and reports a false positive on each.
+joined() {
+    sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | grep -vE '^[[:space:]]*#'
+}
+
+# Remote calls only, by exclusion rather than by matching a literal http:// on
+# the line -- several of these build the URL in a variable, and requiring the
+# literal is what let _ensureEfitools' unbounded fetch of git.kernel.org sit
+# here unnoticed. The three exclusions are named individually so a NEW remote
+# call cannot accidentally inherit one:
+#
+#   ipaddress     the maintenance/* posts -- this same host over loopback
+#   dbhttpcode=   backupDB's fetch of backup_db.php, likewise $ipaddress
+#   nodecert.php  a storage node asking its master for a certificate: LAN, not
+#                 the internet. Still unbounded, and still able to stall a node
+#                 install if the master is down -- out of scope here, but a
+#                 real instance of the same class if anyone wants it.
+# `curl` followed by a flag is an invocation; `curl` inside a message is not.
+# Every real call in these files opens with a flag, and dropping echo lines
+# takes care of the one that prints a curl command as help text.
+remotecurls() {
+    joined "$1" \
+        | grep -E '(^|[^-[:alnum:]_])curl[[:space:]]+-' \
+        | grep -vE '^[[:space:]]*echo ' \
+        | grep -v 'ipaddress' \
+        | grep -v 'dbhttpcode=' \
+        | grep -v 'nodecert.php'
+}
+
+# hascap <line> -- true when the call carries a total time cap.
+hascap() { printf '%s\n' "$1" | grep -qE -- '(^| )-m [0-9]|--max-time'; }
+
+# Two rules, and between them every remote call is bounded at both ends:
+#
+#   A. the connect must be bounded, by --connect-timeout or by a total cap
+#   B. a call with NO total cap must carry --speed-time, or a transfer that
+#      opens and then stops never returns
+#
+# A total cap is right for a small body (the fogstorage probe's -m 30) and wrong
+# for a multi-megabyte artifact, where a slow but working link has to be allowed
+# to finish -- which is why B exists rather than simply requiring --max-time
+# everywhere.
+unbounded=0
+nostall=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    short=$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-96)
+    if ! printf '%s\n' "$line" | grep -q -- '--connect-timeout' && ! hascap "$line"; then
+        unbounded=$((unbounded + 1))
+        printf '        no connect bound: %s\n' "$short"
+    fi
+    if ! hascap "$line" && ! printf '%s\n' "$line" | grep -q -- '--speed-time'; then
+        nostall=$((nostall + 1))
+        printf '        no stall guard:   %s\n' "$short"
+    fi
+done < <(remotecurls "$FUNCS")
+
+if [[ $unbounded -eq 0 ]]; then
+    ok "every remote curl bounds its connect"
+else
+    bad "$unbounded remote curl call(s) carry neither --connect-timeout nor a total cap"
+fi
+if [[ $nostall -eq 0 ]]; then
+    ok "every remote curl without a total cap guards against a stalled transfer"
+else
+    bad "$nostall remote curl call(s) have neither a total cap nor --speed-time"
+fi
+
+# The asset downloads must NOT carry --max-time: these are multi-megabyte
+# tarballs and a slow but working link has to be allowed to finish. The stall
+# they need protecting from is a transfer that opens and then stops, which is
+# --speed-time/--speed-limit's job, not --max-time's.
+# The wrong fix for a stalled download is to cap it, which is why the two are
+# mutually exclusive: carrying --speed-time is the statement "this one is an
+# artifact fetch and may legitimately take a while", and --max-time on top of
+# that reintroduces the failure on slow links that the stall guard exists to
+# avoid.
+both=$(remotecurls "$FUNCS" | grep -- '--speed-time' | grep -c -- '--max-time')
+if [[ $both -eq 0 ]]; then
+    ok "no artifact download carries both --speed-time and --max-time"
+else
+    bad "$both call(s) carry --speed-time AND --max-time -- a slow link will still fail"
+fi
+
+# wget's defaults are worse than curl's: no connect timeout at all, and
+# --tries=20, so an unreachable host costs twenty full SYN retry cycles.
+#
+# Same discipline as remotecurls: a flag after the command is an invocation,
+# prose is not. On this branch most wgets go to $ipaddress (this host over
+# loopback, including $probeUrl, which is built from it), so only the udpcast
+# config.guess/config.sub pair is genuinely remote.
+remotewgets() {
+    joined "$1" \
+        | grep -E '(^|[^-[:alnum:]_])wget[[:space:]]+-' \
+        | grep -vE '^[[:space:]]*(echo|dots) ' \
+        | grep -v 'ipaddress' \
+        | grep -v 'probeUrl' \
+        | grep -v 'packages='
+}
+
+unboundedwget=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    printf '%s\n' "$line" | grep -q -- '--connect-timeout' && continue
+    unboundedwget=$((unboundedwget + 1))
+    printf '        unbounded: %s\n' "$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-100)"
+done < <(remotewgets "$FUNCS")
+
+if [[ $unboundedwget -eq 0 ]]; then
+    ok "no wget in $FUNCS lacks --connect-timeout"
+else
+    bad "$unboundedwget wget call(s) have no --connect-timeout (and wget defaults to --tries=20)"
+fi
+
+echo
+echo "3. the probe verifies TLS"
+
+if body inetProbe "$FUNCS" | grep -qE '(^|[[:space:]])(-k|--insecure)([[:space:]]|$)'; then
+    bad "inetProbe passes -k -- a proxy with its own CA passes the probe and then fails the git clone"
+else
+    ok "inetProbe does not pass -k"
+fi
+
+echo
+echo "4. the result is consumed, not just computed"
+
+# The original bug was not that the check was wrong, it was that nothing read
+# it. Pin the two places that act on the answer, by the line that acts.
+for fn in fetchipxeasset downloadfiles; do
+    if body "$fn" "$FUNCS" | grep -q 'internet_ok.*tries=1'; then
+        ok "$fn drops its retry count when the host is unreachable"
+    else
+        bad "$fn does not act on \$internet_ok -- ten rounds of retries against a dead host"
+    fi
+done
+
+if body prepareiPXEsource "$FUNCS" | grep -q 'internet_ok'; then
+    ok "prepareiPXEsource skips its git fetch when the host is unreachable"
+else
+    bad "prepareiPXEsource does not act on \$internet_ok -- git has no connect timeout of its own"
+fi
+
+if grep -q 'internet_ok=1' "$CONF"; then
+    ok "\$internet_ok is defaulted in $CONF, so a path that skips the check behaves as before"
+else
+    bad "\$internet_ok has no default -- an install that never calls the check would read it as unset"
+fi
+
+echo
+echo "5. the check probes the hosts FOG actually downloads from"
+
+probed=$(body checkInternetConnection "$FUNCS")
+for v in ipxegit ipxeurl; do
+    if printf '%s' "$probed" | grep -q "\$$v"; then
+        ok "probes \$$v"
+    else
+        bad "does not probe \$$v -- an override to an internal mirror goes untested"
+    fi
+done
+for h in httpbin.org neverssl.com fogproject.org; do
+    if printf '%s' "$probed" | grep -q "$h"; then
+        bad "still probes $h, which FOG downloads nothing from"
+    else
+        ok "no longer probes $h"
+    fi
+done
+
+echo
+echo "6. an unroutable host fails fast (behavioural)"
+
+error_log=$(mktemp)
+trap 'rm -f "$error_log"' EXIT
+inetConnectTimeout=5
+inetMaxTime=15
+# shellcheck source=/dev/null
+source "$FUNCS" >/dev/null 2>&1
+
+start=$SECONDS
+inetProbe 192.0.2.1 >/dev/null 2>&1
+rc=$?
+elapsed=$((SECONDS - start))
+
+if [[ $rc -eq 0 ]]; then
+    bad "inetProbe reported TEST-NET-1 (192.0.2.1) as reachable"
+else
+    ok "inetProbe reports TEST-NET-1 as unreachable (exit $rc)"
+fi
+# 20s ceiling against a 300s default: generous enough that a loaded runner or a
+# doubled $inetConnectTimeout still passes, tight enough that the unbounded
+# version cannot.
+if [[ $elapsed -le 20 ]]; then
+    ok "inetProbe returned in ${elapsed}s (ceiling 20s, libcurl's default is 300s)"
+else
+    bad "inetProbe took ${elapsed}s -- something is not bounding the connect"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Port of #1159 to the 1.5 line. Verified present here first: `checkInternetConnection()` was **byte-identical** to the version fixed there, and every fetch it guards had the same unbounded shape.

## The problem

`Testing internet connection...` could sit silent for minutes, and the answer it produced was never read.

1. **It opened by running `$packageinstaller curl`** — a connectivity check whose first act is a package transaction needing the connectivity it's about to test. Metadata refresh against every mirror, unbounded on Debian/Ubuntu whenever unattended-upgrades holds the dpkg lock (apt has no lock timeout), and on Arch a **full system upgrade**, because `$packageinstaller` there is `pacman -Syu`. Redundant too: `curl` is in every distro's package list and `installPackages` runs before anything that uses it.
2. **No timeouts on anything.** libcurl defaults to a 300s connect timeout and no total timeout, so each unreachable host cost five minutes, per address family. `getent hosts` has none to give it either.
3. **Nothing read the result.** `dns_ok`/`http_ok`/`https_ok` were set and never looked at, both failure paths `return`ed rather than exited, and the caller ignored the status.

It probed httpbin.org, neverssl.com, github.com and fogproject.org — only one of which is a host FOG downloads from.

## What this does

Probes the host behind `$ipxegit`/`$ipxeurl` — the iPXE sources and the iPXE/Secure Boot release assets — so an override to an internal mirror is tested *instead of* github.com rather than as well as it. One HTTPS request settles DNS, TCP and TLS together, and curl's exit status names which failed. No `-k`: a proxy presenting its own CA passes an unverified probe and then fails the `git clone` that follows.

The result is `$internet_ok`, and the fetches read it:

| Where | Was | Now |
|---|---|---|
| `downloadfiles()` | 8 URLs × 10 rounds × 2 timeout-less curls = **160 unbounded connects**, on the step that runs every install and upgrade | bounded; 1 round when unreachable |
| `fetchipxeasset()` | 10 rounds × 2 timeout-less curls | bounded; 1 round when unreachable |
| `prepareiPXEsource()` | `git fetch` with no connect timeout of its own | skipped when unreachable |
| udpcast `config.guess`/`config.sub` wgets | no connect timeout, and wget defaults to `--tries=20` | bounded, `--tries=2` |

`--max-time` is deliberately **not** used on the artifact downloads — multi-megabyte kernels and tarballs, where a slow but working link must be allowed to finish. `--speed-time`/`--speed-limit` catch a transfer that opens and then stalls.

**Offline installs are unaffected.** Failure stays non-fatal, the checksum of a pre-placed tarball is still tested before any download is attempted, and a pre-placed source tree is still used as-is.

## Differences from #1159

All because this branch predates the repo splits:

- No `$pluginsgit`/`$pluginsurl` to probe and no `bin/fetch-plugins.sh` — the plugin repo split is 1.6-only.
- No `_ensureEfitools()`.
- This branch uses `wget` where 1.6 uses `curl` for its `$ipaddress`-local calls, so the test's wget rule excludes those by name.

## Testing

`tests/network-fetch-bounded.test.sh` ported with it; `run-all.sh` already globs `*.test.sh`. All 13 assertions **mutation-verified against this branch's source** — each made to fail by reintroducing the defect it guards.

Full suite: **8 passed, 0 failed**.

Also modernized the RH DNS advice, which pointed at `/etc/sysconfig/network-scripts/ifcfg-*` — not where DNS has lived since NetworkManager keyfiles. It now names `nmcli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
