### PR TITLE
Verify TLS on the installer's downloads and its calls to itself

### DIFF
--- a/bin/fetch-plugins.sh
+++ b/bin/fetch-plugins.sh
@@ -87,9 +87,12 @@ while [[ $checksum -ne 0 && $cnt -lt 5 ]]; do
     [[ -f $tmp/$tarball.sha256 ]] && (cd "$tmp" && sha256sum -c "$tarball.sha256" >/dev/null 2>&1)
     checksum=$?
     if [[ $checksum -ne 0 ]]; then
-        curl --silent -fkL --connect-timeout "$inetConnectTimeout" \
+        # No -k. The sha256 fetched on the next line comes down the same
+        # connection, so an unverified transport voids the checksum as well as
+        # the tarball -- and this tarball becomes PHP that runs in the web tier.
+        curl --silent -fL --connect-timeout "$inetConnectTimeout" \
             --speed-time 30 --speed-limit 1024 -o "$tmp/$tarball" "$url" >/dev/null 2>&1
-        curl --silent -fkL --connect-timeout "$inetConnectTimeout" \
+        curl --silent -fL --connect-timeout "$inetConnectTimeout" \
             --speed-time 30 --speed-limit 1024 -o "$tmp/$tarball.sha256" "${url}.sha256" >/dev/null 2>&1
     fi
     let cnt+=1

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -477,6 +477,25 @@ registerStorageNode() {
     # -s: without it curl draws its progress meter straight into the installer's
     # own output, so this step used to print two lines of transfer statistics in
     # the middle of the dotted "Checking if this node is registered....." line.
+    #
+    # -k stays here, and in the calls below, ON PURPOSE. Every other -k in
+    # this installer has been removed; these four -- two in this function, one
+    # in updateStorageNodeCredentials, one in _requestNodeCert -- are the
+    # genuine chicken-and-egg. On a fresh storage node installfog.sh runs
+    # registerStorageNode -> updateStorageNodeCredentials -> _installNodeWebCert
+    # -> _installCATrustAnchor in that order, so at this moment the node is
+    # serving a certificate nothing has issued yet and holds no anchor for
+    # anything: verification cannot succeed, because the very thing that makes
+    # it possible is what registering is a precondition of. Using
+    # _resolveSelfCacert here would resolve to nothing and then hard-fail.
+    #
+    # What that costs is bounded and worth stating: an attacker on the path
+    # between this node and its own web tier sees the node's storage
+    # credentials. It does NOT see the database password -- that never travels
+    # this way -- and _requestNodeCert below is separately protected by an HMAC
+    # over $snmysqlpass, which is the real control on the node<->master trust
+    # bootstrap. Closing this properly needs the master to hand a node its
+    # anchor out of band, which is a design change, not a flag change.
     storageNodeExists=$(curl -s -X POST -d "ip=${ipaddress}" -d "fogverified" -kL ${httpproto}://${ipaddress}${webroot}/maintenance/check_node_exists.php -o -)
     echo "Done"
     if [[ $storageNodeExists != exists ]]; then
@@ -529,6 +548,9 @@ registerStorageNode() {
 updateStorageNodeCredentials() {
     [[ -z $webroot ]] && webroot="/fog/"   # see registerStorageNode, GH-529
     dots "Ensuring node username and passwords match"
+    # -k on purpose -- see registerStorageNode. This is called from the node
+    # path before any anchor exists, and from the master path after one does;
+    # the shared function has to work in the earlier of the two.
     curl -s -k -X POST -d "nodePass" -d "ip=$(echo -n $ipaddress|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "fogverified" $httpproto://$ipaddress${webroot}/maintenance/create_update_node.php
     echo "Done"
 }
@@ -623,7 +645,10 @@ backupDB() {
         local dbhttpcode=""
         local dbcurlstat=0
         local dbjqstat=0
-        dbhttpcode=$(curl -sk --max-redirs 0 -w '%{http_code}' -o "$dbraw" "$url" 2>"$dbcurlerr")
+        # Verified, not -k: this is an HTTPS call to this server, and
+        # _resolveSelfCacert names the anchor for the chain it is serving.
+        _resolveSelfCacert
+        dbhttpcode=$(curl -s "${selfCacertOpts[@]}" --max-redirs 0 -w '%{http_code}' -o "$dbraw" "$url" 2>"$dbcurlerr")
         dbcurlstat=$?
         jq -r '. | ._content' < "$dbraw" > "$dbbackupfile" 2>>"$dbcurlerr"
         dbjqstat=$?
@@ -704,7 +729,8 @@ checkWebTier() {
     local probeBody=$(mktemp)
     # We care whether bytes came back at all, not just about the status code,
     # because a pre-output fatal loses exactly that.
-    curl -sS -k --noproxy '*' -m 30 -fL -o "$probeBody" "$probeUrl" >>$error_log 2>&1
+    _resolveSelfCacert
+    curl -sS "${selfCacertOpts[@]}" --noproxy '*' -m 30 -fL -o "$probeBody" "$probeUrl" >>$error_log 2>&1
     local probeStat=$?
     local probeSize=$(stat -c %s "$probeBody" 2>/dev/null)
     [[ -z $probeSize ]] && probeSize=0
@@ -827,8 +853,42 @@ updateDB() {
     case $dbupdate in
         [Yy]|[Yy][Ee][Ss])
             dots "Updating Database"
-            curl -X POST -H "X-Fog-Install-Token: ${installToken}" -d "schemaupdate=1" --noproxy '*' -fksL ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema -o - >>$error_log 2>&1
-            errorStat $?
+            # Verified. This request carries X-Fog-Install-Token, which
+            # grants a schema deploy on a server that has no users yet; -k
+            # handed that to whoever answered on $ipaddress.
+            _resolveSelfCacert
+            curl -X POST -H "X-Fog-Install-Token: ${installToken}" -d "schemaupdate=1" --noproxy '*' "${selfCacertOpts[@]}" -fsL ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema -o - >>$error_log 2>&1
+            local schemarc=$?
+            # errorStat tails $error_log, so curl's own "SSL certificate
+            # problem" line is already visible -- but it does not say what to
+            # do about it, and this is the one place where verifying instead
+            # of passing -k can stop an upgrade that used to finish. Name the
+            # two installs it can happen on before handing over.
+            case $schemarc in
+                35|51|60|77)
+                    echo "Failed!"
+                    echo
+                    echo " * TLS verification failed talking to this server's own web tier at"
+                    echo "   ${httpproto}://${ipaddress}${webroot} -- so the schema was NOT deployed."
+                    echo " * This step used to skip verification, which handed the schema"
+                    echo "   install token to whatever answered on that address. It no longer"
+                    echo "   does, so a certificate this host cannot verify now stops here."
+                    echo " * Two causes, both fixable:"
+                    echo "     - the web certificate was replaced by hand, so the chain in"
+                    echo "       ${sslcachain:-the vhost} no longer describes what is served"
+                    echo "     - the certificate does not cover the address ${ipaddress}"
+                    echo "       (re-run with --external-ca, or issue one that names it)"
+                    echo " * Full error in $error_log"
+                    echo
+                    tail -n 5 $error_log
+                    # Exit rather than fall through to errorStat: the schema
+                    # not deploying has always been fatal here, and errorStat
+                    # would reprint a generic banner over a message that has
+                    # already said more than it can.
+                    exit $schemarc
+                    ;;
+            esac
+            errorStat $schemarc
             ;;
         *)
             echo
@@ -1797,9 +1857,16 @@ fetchipxeasset() {
             # bounds a connection that opens and then stalls. --max-time is
             # deliberately NOT used here -- these are multi-megabyte tarballs
             # and a slow but working link must be allowed to finish.
-            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+            #
+            # No -k. This is an ordinary internet download from a host with a
+            # perfectly good certificate, and the sha256 below does not save
+            # us -- it is fetched over the same unverified connection, so
+            # whoever could substitute the tarball could substitute the hash
+            # with it. checkInternetConnection() already explains a TLS
+            # failure here as an untrusted intercepting proxy.
+            curl --silent -fOL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 "$url" >>$error_log 2>&1
-            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+            curl --silent -fOL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 "${url}.sha256" >>$error_log 2>&1
         fi
         let cnt+=1
@@ -3768,6 +3835,12 @@ _requestNodeCert() {
     mac=$(printf '%s\n%s' "$type" "$b64" \
         | openssl dgst -sha256 -hmac "$snmysqlpass" -hex 2>>$error_log \
         | awk '{print $NF}')
+    # -k on purpose. This is the node<->master bootstrap: a node that has
+    # never been issued a certificate has no anchor for the master either. The
+    # control on this request is not TLS but the HMAC computed just above, keyed
+    # on $snmysqlpass -- a secret only a genuine node of this master holds -- and
+    # what comes back is a certificate chain the caller validates on its own
+    # terms. See registerStorageNode for the full reasoning.
     resp=$(curl -sS -k -X POST \
         -d "type=${type}" \
         -d "hmac=${mac}" \
@@ -3983,6 +4056,38 @@ _resolveTrustAnchor() {
     [[ -s $out ]] || return 1
     trustAnchorPem="$out"
     return 0
+}
+# The --cacert arguments for an HTTPS call this server makes to ITSELF.
+#
+# Sets $selfCacertOpts, which callers splice in as "${selfCacertOpts[@]}". Empty
+# when there is nothing to anchor, or when the install is serving plain HTTP, in
+# which case curl verifies against the system store and the call is unchanged.
+#
+# Why a helper and not just the system store: _installCATrustAnchor() writes the
+# anchor there, but it runs at installfog.sh:1175 -- AFTER configureHttpd,
+# backupDB and updateDB, which are the calls that need it. On a fresh install
+# the store therefore does not know FOG's CA yet at the moment those three fire.
+# The anchor FILE exists by then (configureHttpd has just written the chain), so
+# naming it explicitly is correct whatever the store happens to contain, and
+# stays correct on an --external-ca install where the served chain terminates in
+# the admin's root rather than FOG's.
+#
+# --cacert REPLACES curl's default bundle rather than adding to it, and these
+# calls address the server by $ipaddress, so both halves have to hold: the
+# served chain must terminate in the anchor this resolves, and the leaf must
+# cover that address. FOG-issued certificates satisfy both by construction. An
+# admin who hand-replaced the certificate without telling the installer has
+# satisfied neither, and updateDB says so rather than failing blankly.
+#
+# These calls used to pass -k. That mattered more than it looks: the schema
+# update carries X-Fog-Install-Token, a secret that grants a schema deploy on a
+# server with no users yet, and it was being handed to whoever answered.
+_resolveSelfCacert() {
+    selfCacertOpts=()
+    [[ $httpproto == https ]] || return 0
+    _resolveTrustAnchor >>$error_log 2>&1 || return 0
+    [[ -s $trustAnchorPem ]] || return 0
+    selfCacertOpts=(--cacert "$trustAnchorPem")
 }
 # Anchor this server's own CA in this server's own system trust store.
 #
@@ -7417,7 +7522,7 @@ downloadfiles() {
         # make sure we download the most recent hash file to start with
         if [[ -f $hashfile && ! $version =~ ^[0-9]\.[0-9]\.[0-9]+$ ]]; then
             rm -f $hashfile
-            curl --silent -kOL --connect-timeout $inetConnectTimeout \
+            curl --silent -OL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 $hashurl >>$error_log 2>&1
         fi
         # Eight URLs, ten rounds, two curls each: 160 connects, none of them
@@ -7435,9 +7540,12 @@ downloadfiles() {
             [[ -f $hashfile ]] && sha256sum -c $hashfile >>$error_log 2>&1
             checksum=$?
             if [[ $checksum -ne 0 ]]; then
-                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                # No -k, same reasoning as fetchipxeasset(): the hash file
+                # travels the same connection as the payload, so skipping
+                # verification here voids the checksum too.
+                curl --silent -OL --connect-timeout $inetConnectTimeout \
                     --speed-time 30 --speed-limit 1024 $url >>$error_log
-                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                curl --silent -OL --connect-timeout $inetConnectTimeout \
                     --speed-time 30 --speed-limit 1024 $hashurl >>$error_log
             fi
             let cnt+=1

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+#
+# Guards the "installer skips TLS verification" bug class.
+#
+#   tests/installer-tls-verification.test.sh
+#
+# The installer used to pass -k / --no-check-certificate on essentially every
+# HTTPS call it made, and the flag had spread by copy: a new fetch was written
+# by pasting an existing one, so nobody ever decided to disable verification --
+# it was inherited. Three groups, and they are not the same problem:
+#
+#   A. Internet downloads -- the iPXE tarball, the FOS kernels and inits, the
+#      fog-client binaries, the bundled plugins, the FOGUpdater tarball. All
+#      from hosts with valid certificates. The sha256 alongside each does NOT
+#      make -k safe: the hash travels the same unverified connection as the
+#      payload, so anyone able to substitute one substitutes both. What lands
+#      is a kernel FOS boots, PHP the web tier runs, and a tarball that becomes
+#      the FOG server itself.
+#   B. This server calling ITSELF -- backupDB fetching backup_db.php, the
+#      schema probe, and the schema update. The last of those carries
+#      X-Fog-Install-Token, a secret that grants a schema deploy on a server
+#      that has no users yet, and -k handed it to whoever answered on that
+#      address. These cannot simply drop the flag, because they can run before
+#      _installCATrustAnchor() has taught the system store about FOG's CA --
+#      hence _resolveSelfCacert(), which names the anchor file directly.
+#   C. The node<->master bootstrap -- registerStorageNode(),
+#      updateStorageNodeCredentials() and _requestNodeCert(). These are a
+#      genuine chicken-and-egg: on a fresh storage node they run BEFORE
+#      _installNodeWebCert() and _installCATrustAnchor(), so there is no anchor
+#      for anything yet and verification cannot succeed. They keep -k, with the
+#      reasoning written at the call site, and _requestNodeCert() is separately
+#      protected by an HMAC keyed on $snmysqlpass.
+#
+# So this file does not say "never -k". It says: exactly the four Group C calls
+# -- registerStorageNode() makes two of them -- and no others. The count is pinned deliberately -- a NEW unverified
+# call cannot be added without also editing this number, which is a visible act
+# in the diff rather than a silent inheritance.
+#
+# Comments are stripped before every source assertion. This file's own prose
+# names -k, --insecure and --no-check-certificate repeatedly, and the block
+# comments now sitting at the Group A and Group C sites name them too; a gate
+# that its own documentation satisfies is not a gate. (Same failure the
+# no-session-for-browserless and network-fetch-bounded gates hit.)
+#
+# No root, no network, no FOG install. The behavioural section builds a
+# throwaway CA in a temp directory and points $fogprogramdir at it.
+#
+# Exit status 0 = pass, 1 = fail.
+
+cd "$(dirname "$0")/.." || exit 1
+FUNCS="lib/common/functions.sh"
+PLUG="bin/fetch-plugins.sh"
+UPD="utils/FOGUpdater/fogupdater.sh"
+
+for f in "$FUNCS" "$PLUG" "$UPD"; do
+    [[ -r $f ]] || { echo "cannot read $f -- run this from the repository"; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# joined <file> -- backslash continuations folded onto one line, comment lines
+# dropped. Both matter: several of these calls are written across two or three
+# lines, so a per-line grep sees the flags on one and the URL on another.
+joined() {
+    sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | grep -vE '^[[:space:]]*#'
+}
+
+# body <function-name> <file> -- the text of one shell function, comments
+# stripped. Every function in these files opens "name() {" and closes on a bare
+# brace in column one.
+body() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$2" | grep -vE '^[[:space:]]*#'
+}
+
+# unverified <file> -- every line invoking curl or wget with verification off.
+#
+# The curl match is deliberately loose about where the k sits: -k, --insecure,
+# and k bundled into a cluster (-fksL, -sk, -kL) all count, and the bundle form
+# is how most of these were actually written. Matching only " -k " would have
+# missed six of the ten sites this change removed.
+unverified() {
+    joined "$1" \
+        | grep -E '(^|[^-[:alnum:]_])(curl|wget)[[:space:]]' \
+        | grep -vE '^[[:space:]]*echo ' \
+        | grep -E -- '--insecure|--no-check-certificate|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'
+}
+
+echo "1. only the documented node-bootstrap calls skip verification"
+
+# The allowlist is by URL, not by line number: each of the three is the only
+# call in this tree that talks to that endpoint.
+allowed_re='check_node_exists\.php|create_update_node\.php|nodecert\.php'
+
+found=0
+stray=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    found=$((found + 1))
+    if ! printf '%s\n' "$line" | grep -qE "$allowed_re"; then
+        stray=$((stray + 1))
+        printf '        unverified: %s\n' \
+            "$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-96)"
+    fi
+done < <(unverified "$FUNCS"; unverified "$PLUG"; unverified "$UPD")
+
+if [[ $stray -eq 0 ]]; then
+    ok "no unverified call outside the node-bootstrap allowlist"
+else
+    bad "$stray call(s) skip TLS verification and are not a documented node-bootstrap call"
+fi
+
+# Pinning the count as well as the allowlist. Without this a fourth call to
+# create_update_node.php -- or a new one to nodecert.php -- would inherit the
+# exemption silently, which is exactly how the flag spread in the first place.
+if [[ $found -eq 4 ]]; then
+    ok "exactly 4 unverified calls remain (the Group C node bootstrap)"
+else
+    bad "expected exactly 4 unverified calls, found $found -- if this is deliberate, say why here"
+fi
+
+# And each of the four must actually be the one it claims to be, not four
+# copies of one. A regression that duplicated the check_node_exists call and
+# deleted the others would satisfy both assertions above.
+for ep in check_node_exists.php create_update_node.php nodecert.php; do
+    n=$( { unverified "$FUNCS"; } | grep -c -- "$ep")
+    case "$ep:$n" in
+        create_update_node.php:2|check_node_exists.php:1|nodecert.php:1)
+            ok "$ep: $n unverified call(s), as expected" ;;
+        *)
+            bad "$ep: $n unverified call(s), expected 1 (2 for create_update_node.php)" ;;
+    esac
+done
+
+echo
+echo "2. the internet downloads verify (Group A)"
+
+# Named individually rather than swept, so deleting a fetch cannot pass this
+# section by making its assertion vacuous.
+for fn in fetchipxeasset downloadfiles; do
+    if body "$fn" "$FUNCS" | grep -qE -- '--insecure|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
+        bad "$fn still skips verification -- its sha256 arrives over the same connection"
+    else
+        ok "$fn verifies TLS"
+    fi
+done
+
+if joined "$PLUG" | grep -E 'curl[[:space:]]' | grep -qE -- '--insecure|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
+    bad "$PLUG still skips verification -- what it fetches becomes PHP the web tier runs"
+else
+    ok "$PLUG verifies TLS"
+fi
+
+if joined "$UPD" | grep -q -- '--no-check-certificate'; then
+    bad "$UPD still passes --no-check-certificate"
+else
+    ok "$UPD verifies TLS"
+fi
+
+echo
+echo "3. the server's calls to itself are anchored (Group B)"
+
+if grep -q '^_resolveSelfCacert() {' "$FUNCS"; then
+    ok "_resolveSelfCacert() is defined"
+else
+    bad "_resolveSelfCacert() is gone -- the Group B calls have nothing to anchor against"
+fi
+
+helper=$(body _resolveSelfCacert "$FUNCS")
+
+# Pin the DEFINITION, not just that callers mention it. A helper rewritten to
+# set nothing, or to hand back -k, would satisfy every call-site assertion
+# below while restoring the whole bug.
+if printf '%s' "$helper" | grep -q -- '--cacert'; then
+    ok "_resolveSelfCacert names an anchor with --cacert"
+else
+    bad "_resolveSelfCacert does not pass --cacert -- it is not anchoring anything"
+fi
+if printf '%s' "$helper" | grep -q '_resolveTrustAnchor'; then
+    ok "_resolveSelfCacert resolves the anchor from the served chain"
+else
+    bad "_resolveSelfCacert does not call _resolveTrustAnchor"
+fi
+if printf '%s' "$helper" | grep -qE -- '--insecure|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
+    bad "_resolveSelfCacert hands back an insecure flag"
+else
+    ok "_resolveSelfCacert hands back no insecure flag"
+fi
+if printf '%s' "$helper" | grep -q 'httpproto == https'; then
+    ok "_resolveSelfCacert is a no-op on a plain-HTTP install"
+else
+    bad "_resolveSelfCacert does not gate on \$httpproto -- an http install would get a stray --cacert"
+fi
+
+# The three call sites, each pinned to the function it lives in and to the
+# endpoint it talks to, so a spliced-in "${selfCacertOpts[@]}" somewhere else
+# cannot stand in for the one that was removed.
+check_site() {
+    local fn="$1" needle="$2" what="$3" text
+    text=$(body "$fn" "$FUNCS")
+    if ! printf '%s' "$text" | grep -q '_resolveSelfCacert'; then
+        bad "$what: $fn never calls _resolveSelfCacert"
+        return
+    fi
+    if ! printf '%s' "$text" | grep -q "$needle" ; then
+        bad "$what: the call to $needle is gone from $fn"
+        return
+    fi
+    if ! joined "$FUNCS" | grep "$needle" | grep -q 'selfCacertOpts\[@\]'; then
+        bad "$what: the call to $needle does not splice in \"\${selfCacertOpts[@]}\""
+        return
+    fi
+    ok "$what is anchored"
+}
+
+check_site backupDB 'dbhttpcode=' "backupDB's fetch of backup_db.php"
+check_site updateDB 'X-Fog-Install-Token' "the schema update (carries the install token)"
+
+# The schema probe is not inside a function with a name worth pinning, so it is
+# matched on the variable the response lands in.
+if joined "$FUNCS" | grep 'probeBody' | grep -q 'selfCacertOpts\[@\]'; then
+    ok "the schema probe is anchored"
+else
+    bad "the schema probe does not splice in \"\${selfCacertOpts[@]}\""
+fi
+
+echo
+echo "4. the helper behaves (behavioural)"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+error_log="$tmp/error.log"
+fogprogramdir="$tmp/opt-fog"
+mkdir -p "$fogprogramdir"
+
+# shellcheck source=/dev/null
+source "$FUNCS" >/dev/null 2>&1
+
+# A plain-HTTP install must be left exactly as it was: no --cacert, and no
+# attempt to resolve an anchor that will not exist.
+httpproto=http
+rootCAPem=""
+sslcachain=""
+selfCacertOpts=(poison)
+_resolveSelfCacert
+if [[ ${#selfCacertOpts[@]} -eq 0 ]]; then
+    ok "http install: no --cacert added"
+else
+    bad "http install: got ${#selfCacertOpts[@]} option(s), expected none"
+fi
+
+# https with nothing to anchor -- curl falls back to the system store, which is
+# the right answer on an install whose certificate came from a public CA.
+httpproto=https
+selfCacertOpts=(poison)
+_resolveSelfCacert
+if [[ ${#selfCacertOpts[@]} -eq 0 ]]; then
+    ok "https with no anchor: falls back to the system store"
+else
+    bad "https with no anchor: got ${selfCacertOpts[*]}, expected nothing"
+fi
+
+# https with a real root on disk -- the anchor must be named explicitly, which
+# is the whole point: the system store does not know it yet at the moment
+# backupDB and updateDB run.
+if command -v openssl >/dev/null 2>&1; then
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+        -keyout "$tmp/ca.key" -out "$tmp/ca.pem" \
+        -subj "/CN=fog-tls-gate-test" >/dev/null 2>&1
+    rootCAPem="$tmp/ca.pem"
+    selfCacertOpts=()
+    _resolveSelfCacert
+    if [[ ${#selfCacertOpts[@]} -eq 2 && ${selfCacertOpts[0]} == "--cacert" && -s ${selfCacertOpts[1]} ]]; then
+        ok "https with a root on disk: --cacert points at a non-empty anchor"
+    else
+        bad "https with a root on disk: got '${selfCacertOpts[*]}'"
+    fi
+else
+    echo "  SKIP  openssl absent, cannot build a throwaway CA"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/utils/FOGUpdater/fogupdater.sh
+++ b/utils/FOGUpdater/fogupdater.sh
@@ -9,12 +9,15 @@ echo " *                                                             *"
 echo " * Your FOG server may go offline during this upgrade process! *"
 echo " *                                                             *"
 echo " ***************************************************************"
+# No --no-check-certificate anywhere in this script: fogproject.org and the
+# update mirrors all present valid certificates, and what comes back is the
+# tarball this utility then unpacks and installs as the FOG server.
 dots "Checking latest version"
 if [[ -z $trunk ]]; then
-    latest=$(wget --no-check-certificate -qO - --post-data="stable" https://fogproject.org/version/index.php)
+    latest=$(wget -qO - --post-data="stable" https://fogproject.org/version/index.php)
     latest=$(echo $latest | $(pwd)/jq32 .stable)
 else
-    latest=$(wget --no-check-certificate -qO - --post-data="dev" https://fogproject.org/version/index.php)
+    latest=$(wget -qO - --post-data="dev" https://fogproject.org/version/index.php)
     latest=$(echo $latest | $(pwd)/jq32 .dev)
 fi
 [[ -z $latest ]] && errorStat 1
@@ -40,7 +43,7 @@ for url in $updatemirrors; do
     dots "Attempting Download"
     fileplace="$downloaddir/fog_${latest}.tar.gz"
     [[ -z $trunk ]] && filedownload="fog_${latest}.tar.gz" || filedownload='dev-branch'
-    wget --no-check-certificate -qO $fileplace $url/$filedownload >/dev/null 2>&1
+    wget -qO $fileplace $url/$filedownload >/dev/null 2>&1
     case $? in
         0)
             echo "Done"


### PR DESCRIPTION
The installer passed `-k` / `--no-check-certificate` on essentially every HTTPS call it made. Nobody ever decided to disable verification — a new fetch was written by copying an existing one, so the flag spread by inheritance until fourteen call sites carried it.

Three groups, and they are not the same problem.

## A — Internet downloads (10 sites, flag removed)

The iPXE tarball, the FOS kernels and inits, the fog-client binaries, the bundled plugins, the FOGUpdater tarball. All from hosts with valid certificates.

The sha256 alongside each did **not** make `-k` safe: the hash comes down the same unverified connection as the payload, so whoever can substitute one can substitute both. What lands is a kernel FOS boots, PHP the web tier runs, and a tarball FOGUpdater unpacks as the FOG server itself.

`checkInternetConnection()` already runs first and already explains a TLS failure here as an untrusted intercepting proxy — so a corporate-MITM environment is told what to fix before any of these run, rather than discovering it at the first download.

| File | Sites |
|---|---|
| `lib/common/functions.sh` — `fetchipxeasset()` | 2 |
| `lib/common/functions.sh` — `downloadfiles()` | 3 |
| `bin/fetch-plugins.sh` | 2 |
| `utils/FOGUpdater/fogupdater.sh` | 3 |

## B — This server calling itself (3 sites, anchored)

`backupDB()`'s fetch of `backup_db.php`, `checkWebTier()`'s probe, and `updateDB()`'s schema deploy.

The last of those carries `X-Fog-Install-Token`, a secret that grants a schema deploy on a server that has no users yet — and `-k` handed it to whoever answered on that address.

These could not simply drop the flag: all three run *before* `_installCATrustAnchor()` teaches the system store about FOG's CA, so the store does not know the certificate yet. New helper `_resolveSelfCacert()` names the anchor file directly instead:

```bash
_resolveSelfCacert() {
    selfCacertOpts=()
    [[ $httpproto == https ]] || return 0
    _resolveTrustAnchor >>$error_log 2>&1 || return 0
    [[ -s $trustAnchorPem ]] || return 0
    selfCacertOpts=(--cacert "$trustAnchorPem")
}
```

Correct whatever the system store happens to contain, and correct on an `--external-ca` install where the served chain terminates in the admin's root rather than FOG's. It is a no-op on a plain-HTTP install, and falls back to the system store when there is nothing to anchor.

## C — The node/master bootstrap (4 calls, documented, unchanged)

`registerStorageNode()` (two calls), `updateStorageNodeCredentials()`, `_requestNodeCert()`.

A genuine chicken-and-egg: on a fresh storage node `installfog.sh` runs `registerStorageNode` → `updateStorageNodeCredentials` → `_installNodeWebCert` → `_installCATrustAnchor` in that order, so at that moment the node is serving a certificate nothing has issued yet and holds no anchor for anything. Verification cannot succeed, because the thing that makes it possible is what registering is a precondition of.

They keep `-k`, with the reasoning **and the cost** now written at the call site. `_requestNodeCert()` is separately protected by an HMAC keyed on `$snmysqlpass`, which is the real control on that exchange.

## The one behaviour change worth flagging

`--cacert` *replaces* curl's default bundle rather than adding to it, so an admin who replaced the web certificate by hand — without `--external-ca`, so `$sslcachain` no longer describes what is served — now hits a failure where `-k` used to sail through.

`backupDB()` already reports curl's own stderr and prompts. `updateDB()` is the fatal one, so it now names the two causes and points at the chain file instead of failing behind a generic banner:

```
 * TLS verification failed talking to this server's own web tier at
   https://10.0.0.5/fog/ -- so the schema was NOT deployed.
 * This step used to skip verification, which handed the schema
   install token to whatever answered on that address. It no longer
   does, so a certificate this host cannot verify now stops here.
 * Two causes, both fixable:
     - the web certificate was replaced by hand, so the chain in
       /opt/fog/pki/web/ca/.fogWebCAchain.pem no longer describes what is served
     - the certificate does not cover the address 10.0.0.5
       (re-run with --external-ca, or issue one that names it)
```

## Gate

`tests/installer-tls-verification.test.sh`, 20 assertions. It does not say "never `-k`" — it says *exactly* the four Group C calls and no others:

- the allowlist is pinned **by endpoint** (`check_node_exists.php`, `create_update_node.php` ×2, `nodecert.php`) **and** the total count is pinned at four, so a new unverified call cannot inherit the exemption without editing a number in the diff;
- per-endpoint counts too, so four copies of one call cannot stand in for the four;
- `_resolveSelfCacert()`'s **definition** is pinned, not just that callers mention it — a helper rewritten to set nothing would otherwise satisfy every call-site assertion;
- comments are stripped before every source assertion (this file's own prose names `-k`, `--insecure` and `--no-check-certificate` throughout — the same trap the `no-session-for-browserless` and `network-fetch-bounded` gates hit);
- behavioural section builds a throwaway CA in a temp dir and runs the helper for real: http → no options, https with no anchor → no options, https with a root on disk → `--cacert <non-empty file>`.

Twelve mutations tried, twelve caught (re-adding `-k` at each of the four Group A clusters, reverting each of the three Group B call sites, gutting the helper four different ways, adding a brand-new `-k` call elsewhere, deleting a Group C call).

`sh tests/run-all.sh` → **53 passed, 0 failed**.

## Verification

Against the live 1.6 server: the helper resolves `--cacert /opt/fog/pki/web/ca/.trustAnchor.pem` and both the `backupDB` and the `checkWebTier` request shapes answer 200 through it.

## Downstream

None. No REST route, no schema, no class list.