### PR TITLE
Port: verify TLS on the installer's downloads and its calls to itself

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -103,6 +103,19 @@ registerStorageNode() {
     # unset. Every fallback in this file now matches the installer's.
     [[ -z $webroot ]] && webroot="/fog/"
     dots "Checking if this node is registered"
+    # --no-check-certificate stays here, and in the two calls below, ON PURPOSE.
+    # Every other unverified call in this installer has been removed; these
+    # three are the genuine chicken-and-egg. On a fresh storage node
+    # installfog.sh runs registerStorageNode -> updateStorageNodeCredentials
+    # -> _installCATrustAnchor in that order, so at this moment the node holds
+    # no anchor for anything and verification cannot succeed -- the thing that
+    # would make it possible is what registering is a precondition of.
+    #
+    # What that costs is bounded and worth stating: an attacker on the path
+    # between this node and its own web tier sees the node's storage
+    # credentials. It does NOT see the database password, which never travels
+    # this way. Closing it properly needs the master to hand a node its anchor
+    # out of band, which is a design change, not a flag change.
     storageNodeExists=$(wget --no-check-certificate -qO - ${httpproto}://${ipaddress}${webroot}/maintenance/check_node_exists.php --post-data="ip=${ipaddress}")
     echo "Done"
     if [[ $storageNodeExists != exists ]]; then
@@ -117,6 +130,9 @@ registerStorageNode() {
 updateStorageNodeCredentials() {
     [[ -z $webroot ]] && webroot="/fog/"   # see registerStorageNode, GH-529
     dots "Ensuring node username and passwords match"
+    # -k on purpose -- see registerStorageNode. This is called from the node
+    # path before any anchor exists, and from the master path after one does;
+    # the shared function has to work in the earlier of the two.
     curl -s -k -X POST -d "nodePass" -d "ip=$(echo -n $ipaddress|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "fogverified" $httpproto://$ipaddress${webroot}maintenance/create_update_node.php
     echo "Done"
 }
@@ -165,7 +181,10 @@ backupDB() {
         # update run at 05:57 and one at 17:57 on the same day produced the
         # same filename and the second silently overwrote the first.
         dbbackupfile="$backupPath/fogDBbackups/fog_sql_${version}_$(date +"%Y%m%d_%H%M%S").sql"
-        wget --no-check-certificate -O "$dbbackupfile" "${httpproto}://${ipaddress}${webroot}/maintenance/backup_db.php" --post-data="type=sql&fogajaxonly=1" >>$error_log 2>&1 || dbbackupstat=1
+        # Verified, not --no-check-certificate: this is an HTTPS call to this
+        # server, and _resolveSelfCacert names the CA it is serving under.
+        _resolveSelfCacert
+        wget "${selfCacertOpts[@]}" -O "$dbbackupfile" "${httpproto}://${ipaddress}${webroot}/maintenance/backup_db.php" --post-data="type=sql&fogajaxonly=1" >>$error_log 2>&1 || dbbackupstat=1
         [[ ! -s $dbbackupfile ]] && dbbackupstat=1
     fi
     if [[ -z $dbbackupfile ]]; then
@@ -200,7 +219,8 @@ checkWebTier() {
     local probeBody=$(mktemp)
     # No -q on the body: we care whether bytes came back at all, not just about
     # the status code, because that is exactly what a pre-output fatal loses.
-    wget --no-check-certificate -q -O "$probeBody" --no-proxy "$probeUrl" >>$error_log 2>&1
+    _resolveSelfCacert
+    wget "${selfCacertOpts[@]}" -q -O "$probeBody" --no-proxy "$probeUrl" >>$error_log 2>&1
     local probeStat=$?
     local probeSize=$(stat -c %s "$probeBody" 2>/dev/null)
     [[ -z $probeSize ]] && probeSize=0
@@ -298,8 +318,40 @@ updateDB() {
     case $dbupdate in
         [Yy]|[Yy][Ee][Ss])
             dots "Updating Database"
-            wget --no-check-certificate -qO - --header="X-Fog-Install-Token: ${installToken}" --post-data="schemaupdate=1" --no-proxy ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema >>$error_log 2>&1
-            errorStat $?
+            # Verified. This request carries X-Fog-Install-Token, which grants
+            # a schema deploy on a server that has no users yet;
+            # --no-check-certificate handed that to whoever answered on
+            # $ipaddress.
+            _resolveSelfCacert
+            wget "${selfCacertOpts[@]}" -qO - --header="X-Fog-Install-Token: ${installToken}" --post-data="schemaupdate=1" --no-proxy ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema >>$error_log 2>&1
+            local schemarc=$?
+            # errorStat tails $error_log, so wget's own certificate error is
+            # already visible -- but it does not say what to do about it, and
+            # this is the one place where verifying instead of skipping can
+            # stop an upgrade that used to finish. wget reports every TLS
+            # failure as exit 5.
+            if [[ $schemarc -eq 5 ]]; then
+                echo "Failed!"
+                echo
+                echo " * TLS verification failed talking to this server's own web tier at"
+                echo "   ${httpproto}://${ipaddress}${webroot} -- so the schema was NOT deployed."
+                echo " * This step used to skip verification, which handed the schema"
+                echo "   install token to whatever answered on that address. It no longer"
+                echo "   does, so a certificate this host cannot verify now stops here."
+                echo " * Two causes, both fixable:"
+                echo "     - the web certificate was replaced by hand, so ${rootCAPem:-the FOG CA}"
+                echo "       is no longer what signed it"
+                echo "     - the certificate does not cover the address ${ipaddress}"
+                echo " * Full error in $error_log"
+                echo
+                tail -n 5 $error_log
+                # Exit rather than fall through to errorStat: the schema not
+                # deploying has always been fatal here, and errorStat would
+                # reprint a generic banner over a message that has already
+                # said more than it can.
+                exit $schemarc
+            fi
+            errorStat $schemarc
             ;;
         *)
             echo
@@ -1005,9 +1057,15 @@ fetchipxeasset() {
             # bounds a connection that opens and then stalls. --max-time is
             # deliberately NOT used here -- these are multi-megabyte tarballs
             # and a slow but working link must be allowed to finish.
-            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+            # No -k. This is an ordinary internet download from a host with a
+            # perfectly good certificate, and the sha256 below does not save
+            # us -- it is fetched over the same unverified connection, so
+            # whoever could substitute the tarball could substitute the hash
+            # with it. checkInternetConnection() already explains a TLS
+            # failure here as an untrusted intercepting proxy.
+            curl --silent -fOL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 "$url" >>$error_log 2>&1
-            curl --silent -fkOL --connect-timeout $inetConnectTimeout \
+            curl --silent -fOL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 "${url}.sha256" >>$error_log 2>&1
         fi
         let cnt+=1
@@ -3963,6 +4021,43 @@ _caTrustLayout() {
 #
 # Reads only the certificate, never a key, so it is deliberately placed on the
 # far side of _hardenPkiPermissions.
+# The certificate-authority argument for an HTTPS call this server makes to
+# ITSELF.
+#
+# Sets $selfCacertOpts, which callers splice in as "${selfCacertOpts[@]}". Empty
+# when there is nothing to anchor, or when the install is serving plain HTTP --
+# which is the default here, so on most installs this is a no-op and the calls
+# are unchanged. When it is empty the tool verifies against the system store,
+# which is the right answer for a certificate from a public CA.
+#
+# Why a helper and not just the system store: _installCATrustAnchor() writes
+# $rootCAPem there, but it runs at installfog.sh:805 -- AFTER configureHttpd,
+# checkWebTier, backupDB and updateDB, which are the calls that need it. On a
+# fresh install the store therefore does not know FOG's CA yet at the moment
+# those fire. The file exists by then, so naming it explicitly is correct
+# whatever the store happens to contain.
+#
+# $rootCAPem deliberately, not the chain: it is exactly what
+# _installCATrustAnchor would have anchored, so the two agree by construction,
+# and the leaf's issuing intermediate is served by the web server itself.
+#
+# Both callers are wget, whose flag is --ca-certificate. It REPLACES the
+# default bundle rather than adding to it, and these calls address the server
+# by $ipaddress, so both halves have to hold: the served chain must terminate
+# in $rootCAPem, and the leaf must cover that address. FOG-issued certificates
+# satisfy both by construction. An admin who hand-replaced the certificate has
+# satisfied neither, and updateDB says so rather than failing blankly.
+#
+# These calls used to pass --no-check-certificate. That mattered more than it
+# looks: the schema update carries X-Fog-Install-Token, a secret that grants a
+# schema deploy on a server with no users yet, and it was being handed to
+# whoever answered.
+_resolveSelfCacert() {
+    selfCacertOpts=()
+    [[ $httpproto == https ]] || return 0
+    [[ -n $rootCAPem && -s $rootCAPem ]] || return 0
+    selfCacertOpts=(--ca-certificate="$rootCAPem")
+}
 _installCATrustAnchor() {
     local anchor="$rootCAPem" st=0
     # Default-on, --no-ca-trust to decline, persisted in .fogsettings -- the
@@ -5000,7 +5095,7 @@ downloadfiles() {
         # make sure we download the most recent hash file to start with
         if [[ -f $hashfile ]]; then
             rm -f $hashfile
-            curl --silent -kOL --connect-timeout $inetConnectTimeout \
+            curl --silent -OL --connect-timeout $inetConnectTimeout \
                 --speed-time 30 --speed-limit 1024 $hashurl >>$error_log 2>&1
         fi
         # Eight URLs, ten rounds, two curls each: 160 connects, none of them
@@ -5018,9 +5113,12 @@ downloadfiles() {
             [[ -f $hashfile ]] && sha256sum --check $hashfile >>$error_log 2>&1
             checksum=$?
             if [[ $checksum -ne 0 ]]; then
-                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                # No -k, same reasoning as fetchipxeasset(): the hash file
+                # travels the same connection as the payload, so skipping
+                # verification here voids the checksum too.
+                curl --silent -OL --connect-timeout $inetConnectTimeout \
                     --speed-time 30 --speed-limit 1024 $url >>$error_log
-                curl --silent -kOL --connect-timeout $inetConnectTimeout \
+                curl --silent -OL --connect-timeout $inetConnectTimeout \
                     --speed-time 30 --speed-limit 1024 $hashurl >>$error_log
             fi
             let cnt+=1

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+#
+# Guards the "installer skips TLS verification" bug class.
+#
+#   tests/installer-tls-verification.test.sh
+#
+# Port of the working-1.6 gate (GH-1169). The installer passed -k /
+# --no-check-certificate on essentially every HTTPS call it made, and the flag
+# had spread by copy: a new fetch was written by pasting an existing one, so
+# nobody ever decided to disable verification -- it was inherited. Three
+# groups, and they are not the same problem:
+#
+#   A. Internet downloads -- the iPXE tarball, the FOS kernels and inits, the
+#      fog-client binaries, the FOGUpdater tarball. All from hosts with valid
+#      certificates. The sha256 alongside each does NOT make -k safe: the hash
+#      travels the same unverified connection as the payload, so anyone able
+#      to substitute one substitutes both. What lands is a kernel FOS boots
+#      and a tarball that becomes the FOG server itself.
+#   B. This server calling ITSELF -- backupDB's fetch of backup_db.php, the
+#      web-tier probe, and the schema update. The last of those carries
+#      X-Fog-Install-Token, a secret that grants a schema deploy on a server
+#      that has no users yet, and --no-check-certificate handed it to whoever
+#      answered on that address. These cannot simply drop the flag, because
+#      they run before _installCATrustAnchor() has taught the system store
+#      about FOG's CA -- hence _resolveSelfCacert(), which names $rootCAPem
+#      directly.
+#   C. The node/master bootstrap -- registerStorageNode() and
+#      updateStorageNodeCredentials(). A genuine chicken-and-egg: on a fresh
+#      storage node they run BEFORE _installCATrustAnchor(), so there is no
+#      anchor for anything yet and verification cannot succeed. They keep the
+#      flag, with the reasoning written at the call site.
+#
+# So this file does not say "never -k". It says: exactly the three Group C
+# calls, and no others. The count is pinned deliberately -- a NEW unverified
+# call cannot be added without also editing this number, which is a visible
+# act in the diff rather than a silent inheritance.
+#
+# Comments are stripped before every source assertion. This file's own prose
+# names -k and --no-check-certificate repeatedly, and the block comments now
+# sitting at the Group A and Group C sites name them too; a gate that its own
+# documentation satisfies is not a gate. (Same failure the
+# no-session-for-browserless and network-fetch-bounded gates hit.)
+#
+# No root, no network, no FOG install. The behavioural section builds a
+# throwaway CA in a temp directory.
+#
+# Exit status 0 = pass, 1 = fail.
+
+cd "$(dirname "$0")/.." || exit 1
+FUNCS="lib/common/functions.sh"
+UPD="utils/FOGUpdater/fogupdater.sh"
+
+for f in "$FUNCS" "$UPD"; do
+    [[ -r $f ]] || { echo "cannot read $f -- run this from the repository"; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# joined <file> -- backslash continuations folded onto one line, comment lines
+# dropped. Both matter: several of these calls are written across two or three
+# lines, so a per-line grep sees the flags on one and the URL on another.
+joined() {
+    sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | grep -vE '^[[:space:]]*#'
+}
+
+# body <function-name> <file> -- the text of one shell function, comments
+# stripped. Every function in these files opens "name() {" and closes on a bare
+# brace in column one.
+body() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$2" | grep -vE '^[[:space:]]*#'
+}
+
+# unverified <file> -- every line invoking curl or wget with verification off.
+#
+# The curl match is deliberately loose about where the k sits: -k, --insecure,
+# and k bundled into a cluster (-fkOL, -sk, -kL) all count, and the bundle form
+# is how most of these were actually written. Matching only " -k " would have
+# missed five of the eleven sites this change removed.
+unverified() {
+    joined "$1" \
+        | grep -E '(^|[^-[:alnum:]_])(curl|wget)[[:space:]]' \
+        | grep -vE '^[[:space:]]*echo ' \
+        | grep -E -- '--insecure|--no-check-certificate|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'
+}
+
+echo "1. only the documented node-bootstrap calls skip verification"
+
+# The allowlist is by URL, not by line number: each of the three is the only
+# call in this tree that talks to that endpoint.
+allowed_re='check_node_exists\.php|create_update_node\.php'
+
+found=0
+stray=0
+while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    found=$((found + 1))
+    if ! printf '%s\n' "$line" | grep -qE "$allowed_re"; then
+        stray=$((stray + 1))
+        printf '        unverified: %s\n' \
+            "$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-96)"
+    fi
+done < <(unverified "$FUNCS"; unverified "$UPD")
+
+if [[ $stray -eq 0 ]]; then
+    ok "no unverified call outside the node-bootstrap allowlist"
+else
+    bad "$stray call(s) skip TLS verification and are not a documented node-bootstrap call"
+fi
+
+# Pinning the count as well as the allowlist. Without this a third call to
+# create_update_node.php would inherit the exemption silently, which is exactly
+# how the flag spread in the first place.
+if [[ $found -eq 3 ]]; then
+    ok "exactly 3 unverified calls remain (the Group C node bootstrap)"
+else
+    bad "expected exactly 3 unverified calls, found $found -- if this is deliberate, say why here"
+fi
+
+# And each of the three must actually be the one it claims to be, not three
+# copies of one. A regression that duplicated the check_node_exists call and
+# deleted the others would satisfy both assertions above.
+for ep in check_node_exists.php create_update_node.php; do
+    n=$(unverified "$FUNCS" | grep -c -- "$ep")
+    case "$ep:$n" in
+        create_update_node.php:2|check_node_exists.php:1)
+            ok "$ep: $n unverified call(s), as expected" ;;
+        *)
+            bad "$ep: $n unverified call(s), expected 1 (2 for create_update_node.php)" ;;
+    esac
+done
+
+echo
+echo "2. the internet downloads verify (Group A)"
+
+# Named individually rather than swept, so deleting a fetch cannot pass this
+# section by making its assertion vacuous.
+for fn in fetchipxeasset downloadfiles; do
+    if body "$fn" "$FUNCS" | grep -qE -- '--insecure|--no-check-certificate|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
+        bad "$fn still skips verification -- its sha256 arrives over the same connection"
+    else
+        ok "$fn verifies TLS"
+    fi
+done
+
+if joined "$UPD" | grep -q -- '--no-check-certificate'; then
+    bad "$UPD still passes --no-check-certificate"
+else
+    ok "$UPD verifies TLS"
+fi
+
+echo
+echo "3. the server's calls to itself are anchored (Group B)"
+
+if grep -q '^_resolveSelfCacert() {' "$FUNCS"; then
+    ok "_resolveSelfCacert() is defined"
+else
+    bad "_resolveSelfCacert() is gone -- the Group B calls have nothing to anchor against"
+fi
+
+helper=$(body _resolveSelfCacert "$FUNCS")
+
+# Pin the DEFINITION, not just that callers mention it. A helper rewritten to
+# set nothing, or to hand back --no-check-certificate, would satisfy every
+# call-site assertion below while restoring the whole bug.
+if printf '%s' "$helper" | grep -q -- '--ca-certificate'; then
+    ok "_resolveSelfCacert names an anchor with --ca-certificate"
+else
+    bad "_resolveSelfCacert does not pass --ca-certificate -- it is not anchoring anything"
+fi
+if printf '%s' "$helper" | grep -q 'rootCAPem'; then
+    ok "_resolveSelfCacert anchors on \$rootCAPem, the same file _installCATrustAnchor uses"
+else
+    bad "_resolveSelfCacert does not read \$rootCAPem"
+fi
+if printf '%s' "$helper" | grep -qE -- '--insecure|--no-check-certificate|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
+    bad "_resolveSelfCacert hands back an insecure flag"
+else
+    ok "_resolveSelfCacert hands back no insecure flag"
+fi
+if printf '%s' "$helper" | grep -q 'httpproto == https'; then
+    ok "_resolveSelfCacert is a no-op on a plain-HTTP install"
+else
+    bad "_resolveSelfCacert does not gate on \$httpproto -- an http install would get a stray flag"
+fi
+
+# The three call sites, each pinned to the function it lives in and to the
+# endpoint it talks to, so a spliced-in "${selfCacertOpts[@]}" somewhere else
+# cannot stand in for the one that was removed.
+check_site() {
+    local fn="$1" needle="$2" what="$3" text
+    text=$(body "$fn" "$FUNCS")
+    if ! printf '%s' "$text" | grep -q '_resolveSelfCacert'; then
+        bad "$what: $fn never calls _resolveSelfCacert"
+        return
+    fi
+    if ! printf '%s' "$text" | grep -q "$needle"; then
+        bad "$what: the call to $needle is gone from $fn"
+        return
+    fi
+    if ! joined "$FUNCS" | grep "$needle" | grep -q 'selfCacertOpts\[@\]'; then
+        bad "$what: the call to $needle does not splice in \"\${selfCacertOpts[@]}\""
+        return
+    fi
+    ok "$what is anchored"
+}
+
+check_site backupDB 'backup_db.php' "backupDB's fetch of backup_db.php"
+check_site updateDB 'X-Fog-Install-Token' "the schema update (carries the install token)"
+check_site checkWebTier 'probeBody' "the web-tier probe"
+
+echo
+echo "4. the helper behaves (behavioural)"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+error_log="$tmp/error.log"
+
+# shellcheck source=/dev/null
+source "$FUNCS" >/dev/null 2>&1
+
+# A plain-HTTP install -- the default here -- must be left exactly as it was.
+httpproto=http
+rootCAPem="$tmp/ca.pem"
+printf 'not a real certificate\n' > "$rootCAPem"
+selfCacertOpts=(poison)
+_resolveSelfCacert
+if [[ ${#selfCacertOpts[@]} -eq 0 ]]; then
+    ok "http install: no --ca-certificate added"
+else
+    bad "http install: got ${#selfCacertOpts[@]} option(s), expected none"
+fi
+
+# https with nothing to anchor -- wget falls back to the system store, which is
+# the right answer on an install whose certificate came from a public CA.
+httpproto=https
+rootCAPem=""
+selfCacertOpts=(poison)
+_resolveSelfCacert
+if [[ ${#selfCacertOpts[@]} -eq 0 ]]; then
+    ok "https with no anchor: falls back to the system store"
+else
+    bad "https with no anchor: got ${selfCacertOpts[*]}, expected nothing"
+fi
+
+# https with a real root on disk -- the anchor must be named explicitly, which
+# is the whole point: the system store does not know it yet at the moment
+# backupDB and updateDB run.
+if command -v openssl >/dev/null 2>&1; then
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+        -keyout "$tmp/ca.key" -out "$tmp/ca.pem" \
+        -subj "/CN=fog-tls-gate-test" >/dev/null 2>&1
+    rootCAPem="$tmp/ca.pem"
+    selfCacertOpts=()
+    _resolveSelfCacert
+    if [[ ${#selfCacertOpts[@]} -eq 1 && ${selfCacertOpts[0]} == "--ca-certificate=$tmp/ca.pem" ]]; then
+        ok "https with a root on disk: --ca-certificate points at it"
+    else
+        bad "https with a root on disk: got '${selfCacertOpts[*]}'"
+    fi
+else
+    echo "  SKIP  openssl absent, cannot build a throwaway CA"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/utils/FOGUpdater/fogupdater.sh
+++ b/utils/FOGUpdater/fogupdater.sh
@@ -9,12 +9,15 @@ echo " *                                                             *"
 echo " * Your FOG server may go offline during this upgrade process! *"
 echo " *                                                             *"
 echo " ***************************************************************"
+# No --no-check-certificate anywhere in this script: fogproject.org and the
+# update mirrors all present valid certificates, and what comes back is the
+# tarball this utility then unpacks and installs as the FOG server.
 dots "Checking latest version"
 if [[ -z $trunk ]]; then
-    latest=$(wget --no-check-certificate -qO - --post-data="stable" https://fogproject.org/version/index.php)
+    latest=$(wget -qO - --post-data="stable" https://fogproject.org/version/index.php)
     latest=$(echo $latest | $(pwd)/jq32 .stable)
 else
-    latest=$(wget --no-check-certificate -qO - --post-data="dev" https://fogproject.org/version/index.php)
+    latest=$(wget -qO - --post-data="dev" https://fogproject.org/version/index.php)
     latest=$(echo $latest | $(pwd)/jq32 .dev)
 fi
 [[ -z $latest ]] && errorStat 1
@@ -40,7 +43,7 @@ for url in $updatemirrors; do
     dots "Attempting Download"
     fileplace="$downloaddir/fog_${latest}.tar.gz"
     [[ -z $trunk ]] && filedownload="fog_${latest}.tar.gz" || filedownload='dev-branch'
-    wget --no-check-certificate -qO $fileplace $url/$filedownload >/dev/null 2>&1
+    wget -qO $fileplace $url/$filedownload >/dev/null 2>&1
     case $? in
         0)
             echo "Done"


### PR DESCRIPTION
Port of #1169 from `working-1.6`. Same bug class, same three groups, one branch-specific difference in how Group B is anchored.

The installer passed `-k` / `--no-check-certificate` on essentially every HTTPS call it made. Nobody ever decided to disable verification — a new fetch was written by copying an existing one, so the flag spread by inheritance until eleven call sites carried it.

## A — Internet downloads (8 sites, flag removed)

The iPXE tarball, the FOS kernels and inits, the fog-client binaries, the FOGUpdater tarball. All from hosts with valid certificates.

The sha256 alongside each did **not** make `-k` safe: the hash comes down the same unverified connection as the payload, so whoever can substitute one can substitute both. What lands is a kernel FOS boots and a tarball FOGUpdater unpacks as the FOG server itself.

`checkInternetConnection()` runs first and already explains a TLS failure as an untrusted intercepting proxy, so a corporate-MITM environment is told what to fix before any of these run.

| Site | Count |
|---|---|
| `lib/common/functions.sh` — `fetchipxeasset()` | 2 |
| `lib/common/functions.sh` — `downloadfiles()` | 3 |
| `utils/FOGUpdater/fogupdater.sh` | 3 |

## B — This server calling itself (3 sites, anchored)

`backupDB()`'s fetch of `backup_db.php`, `checkWebTier()`'s probe, and `updateDB()`'s schema deploy.

The last of those carries `X-Fog-Install-Token`, a secret that grants a schema deploy on a server with no users yet — and `--no-check-certificate` handed it to whoever answered on that address.

All three run *before* `_installCATrustAnchor()` teaches the system store about FOG's CA (`installfog.sh:790-792` against `:805`), so they could not simply drop the flag. New helper:

```bash
_resolveSelfCacert() {
    selfCacertOpts=()
    [[ $httpproto == https ]] || return 0
    [[ -n $rootCAPem && -s $rootCAPem ]] || return 0
    selfCacertOpts=(--ca-certificate="$rootCAPem")
}
```

**Where this differs from #1169.** `working-1.6` has `_resolveTrustAnchor()`/`_rootFromChain()`, which build a bundle from `$rootCAPem` plus the root extracted from `$sslcachain`; neither exists on this branch, and importing them into a maintenance branch to serve three calls is more machinery than the job needs. `$rootCAPem` alone anchors the same chain — it is exactly the file `_installCATrustAnchor()` would have installed, so the two agree by construction, and the leaf's issuing intermediate is served by the web server itself. All three callers here are `wget`, whose flag is `--ca-certificate` rather than curl's `--cacert`.

## C — The node/master bootstrap (3 calls, documented, unchanged)

`registerStorageNode()` (two calls) and `updateStorageNodeCredentials()`.

A genuine chicken-and-egg: on a fresh storage node these run before `_installCATrustAnchor()`, so there is no anchor for anything yet and verification cannot succeed. They keep the flag, with the reasoning **and the cost** now written at the call site. 1.6's fourth Group C call, `_requestNodeCert()`, does not exist here.

## Blast radius

Smaller than on 1.6. `$httpproto` defaults to `http` on this branch and https is opt-in, so **on most installs the helper is a no-op and the calls are byte-identical to before.**

On an https install, `--ca-certificate` replaces wget's default bundle rather than adding to it, so an admin who replaced the web certificate by hand now hits a failure where the flag used to sail through. `updateDB()` names the two causes and exits, rather than failing behind `errorStat`'s generic banner (wget reports every TLS failure as exit 5):

```
 * TLS verification failed talking to this server's own web tier at
   https://10.0.0.5/fog/ -- so the schema was NOT deployed.
 * This step used to skip verification, which handed the schema
   install token to whatever answered on that address. It no longer
   does, so a certificate this host cannot verify now stops here.
 * Two causes, both fixable:
     - the web certificate was replaced by hand, so /opt/fog/snapins/ssl/CA/.fogCA.pem
       is no longer what signed it
     - the certificate does not cover the address 10.0.0.5
```

## Gate

`tests/installer-tls-verification.test.sh`, 18 assertions. It does not say "never `-k`" — it says *exactly* the three Group C calls and no others:

- allowlist pinned **by endpoint** (`check_node_exists.php`, `create_update_node.php` ×2) **and** the total count pinned at three, so a new unverified call cannot inherit the exemption without editing a number in the diff;
- per-endpoint counts too, so three copies of one call cannot stand in for the three;
- `_resolveSelfCacert()`'s **definition** is pinned, not just that callers mention it;
- comments stripped before every source assertion (this file's own prose names the flags throughout — the same trap the `no-session-for-browserless` and `network-fetch-bounded` gates hit);
- behavioural section: http → no options, https with no anchor → no options, https with a throwaway CA on disk → `--ca-certificate=<that file>`.

Eleven mutations tried, eleven caught.

`sh tests/run-all.sh` → **10 passed, 0 failed**.

## Downstream

None. No REST route, no schema, no class list.