### PR TITLE
Trigger the merge sync from an event that actually reaches this file (dev-branch)

### DIFF
--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -10,27 +10,45 @@ name: Sync generated files and version
 # FOG_VERSION goes stale until the daily sweep fires at 10:10 UTC. This closes
 # that window.
 #
-# pull_request_target, NOT push -- and that distinction is the whole safety
-# argument, not caution. The sweep pushes its fixup commit straight to the
-# branch, and a direct push is not a PR merge, so it cannot re-fire this stub.
-# The 2026-07-28 runaway that put ~30 commits on dev-branch in about 20 minutes
-# was a push-triggered stub doing exactly that. The schedule in fog-workflows
-# stays exactly as it is, and remains the backstop for direct pushes and for
-# rc-*/feature-* branches.
+# WHY `pull_request`, AND NOT `pull_request_target`
 #
-# pull_request_target rather than pull_request because secrets are withheld from
-# fork PRs, and the reusable workflow needs FOG_WORKFLOWS_PRIVATE_KEY to mint its
-# App token. The usual pull_request_target hazard does not apply here: nothing
-# checks out the PR head. The reusable workflow checks out FOGProject/fogproject
-# at the base branch -- code a maintainer has already merged.
+# `pull_request_target` looks like the right answer -- it is the variant that
+# gets secrets on fork PRs -- and the first version of this file used it. It
+# never fired once. GitHub reads a `pull_request_target` workflow from the
+# repository's DEFAULT branch (`stable` here), not from the PR's base branch, so
+# a copy living on working-1.6 and dev-branch is simply never consulted: the
+# workflow did not even appear in the Actions list, and four PRs merged into
+# working-1.6 without it running.
+#
+# `pull_request` is read from the base branch instead, so this file works where
+# it actually lives. Do not "fix" it back to `pull_request_target` without also
+# putting the file on `stable` -- and note that then only stable's copy would
+# execute, which makes editing the version on this branch a no-op.
+#
+# WHY NOT `push`
+#
+# That distinction is the whole safety argument, not caution. The sweep pushes
+# its fixup commit straight to the branch, and a direct push is not a PR merge,
+# so it cannot re-fire this stub. The 2026-07-28 runaway that put ~30 commits on
+# dev-branch in about 20 minutes was a push-triggered stub doing exactly that.
+# The schedule in fog-workflows stays exactly as it is, and remains the backstop
+# for direct pushes and for rc-*/feature-* branches.
+#
+# WHY THE SAME-REPO GUARD
+#
+# `pull_request` withholds secrets from fork PRs, and the reusable workflow needs
+# FOG_WORKFLOWS_PRIVATE_KEY to mint its App token -- so on a fork PR it would
+# fail rather than work. Skipping is right: a merged fork PR is picked up by the
+# daily sweep, exactly as a direct push already is. Better a gap the schedule
+# already covers than a red X on every external contribution.
 #
 # One file, identical on every branch that carries it, for the same reason
-# tests.yml is: fixing it should not mean editing it on three branches. GitHub
-# reads this from the PR's BASE branch, so each branch's copy only ever acts on
-# merges into that branch, and the allowlist below is what scopes it.
+# tests.yml is: fixing it should not mean editing it on three branches. Each
+# branch's copy only ever acts on merges into that branch, and the allowlist
+# below is what scopes it.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
 
 concurrency:
@@ -51,6 +69,7 @@ jobs:
     # against its own watched list, so constraining it is this file's job.
     if: >-
       github.event.pull_request.merged == true
+      && github.event.pull_request.head.repo.full_name == github.repository
       && contains(fromJson('["working-1.6", "dev-branch"]'), github.event.pull_request.base.ref)
 
     # Least privilege, stated rather than inherited. Everything the reusable


### PR DESCRIPTION
## Fixes a bug in #1160: the stub never actually fired

Corrects the trigger on `.github/workflows/sync-generated-files.yml`. My mistake in #1160, caught by checking whether it had run.

## What happened

The stub added in #1160 has not run once. Four PRs merged into `working-1.6` since it landed (#1162, #1163, #1164, #1165) and it produced no runs — it didn't even appear in the repository's Actions workflow list:

```
$ gh api repos/FOGProject/fogproject/actions/workflows
.github/workflows/tests.yml            [active]
Check FOG version                      [disabled_manually]
```

`working-1.6` is currently `1.6.0-beta.3572` where `fog-version.sh` says it should be `1.6.0-beta.3588` — 16 commits stale, waiting for the daily sweep, which is exactly the gap #1160 was meant to close.

## Why

`pull_request_target` is read from the repository's **default branch** — `stable` — not from the PR's base branch. GitHub documents it directly: *"runs in the context of the default branch of the base repository."* That's the general rule for most events; `push` and `create` are the exceptions that resolve per-ref. So a copy living on `working-1.6`/`dev-branch` is never consulted, no matter how correct its contents.

I reasoned from `tests.yml` as precedent, which was wrong: that uses `pull_request`, evaluated from the head-into-base merge ref. That's exactly why one copy per base branch works there, and why it works without a copy on `stable`.

## The fix

`pull_request: types: [closed]` — read from the base branch, so it reaches this file where it already lives.

The alternative, putting the stub on `stable`, does work and gives fuller coverage. It was rejected because only `stable`'s copy would ever execute: editing this file on `working-1.6` would silently do nothing, and every future change to sync behaviour would need a PR into the release branch.

## What that costs

Fork PRs. `pull_request` withholds secrets from forks, and the reusable workflow needs `FOG_WORKFLOWS_PRIVATE_KEY` to mint its App token — so a merged fork PR would fail rather than sync. The added same-repo guard skips those, and the daily sweep picks them up. That's the same gap, and the same backstop, that direct pushes already rely on — and a gap the schedule already covers beats a red X on every external contribution.

## Unchanged

Still `pull_request`-family rather than `push`, so the bot's own fixup push cannot re-fire it and the 2026-07-28 loop stays closed. Still the same branch allowlist keeping `rc-*`/`feature-*` on the schedule. Still no logic in this repo.

The header now records why `pull_request_target` is wrong here, so nobody switches it back on the reasonable-looking grounds that it's the variant which gets fork secrets.

## Verification

`actionlint` clean; trigger and guard confirmed by parsing the file. The real proof is the next merged PR: it should produce a `Sync generated files and version` run, and that run's own push should queue **no second run**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqufBbuckux8kitJeW3uAK
