### PR TITLE
Let a USER_LOGGING_OUT listener say where to go next

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -945,7 +945,7 @@ abstract class FOGBase
      *
      * @return void
      */
-    public static function redirect($url = '')
+    public static function redirect($url = '', $status = 308)
     {
         if (self::$service) {
             return;
@@ -955,7 +955,20 @@ abstract class FOGBase
         header('X-XSS-Protection: 1; mode=block');
         header('X-Robots-Tag: none');
         header('X-Frame-Options: SAMEORIGIN');
-        header("Location: $url", true, 308);
+        /*
+         * 308 stays the default because every existing caller redirects to a
+         * fixed place and has done for years. It is the wrong answer for a
+         * ONE-OFF destination: 308 is permanent and cacheable, so a browser
+         * may keep sending that URL to the same target without asking again.
+         * Single logout is exactly that case -- the target carries an
+         * id_token_hint that is valid for one sign-in -- so those callers
+         * pass 302. (fog-plugins#15)
+         */
+        $status = (int)$status;
+        if (!in_array($status, [301, 302, 303, 307, 308], true)) {
+            $status = 308;
+        }
+        header("Location: $url", true, $status);
         exit;
     }
     /**

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -593,12 +593,33 @@ class User extends FOGController
     /**
      * Perform logout cleanup
      *
-     * @return void
+     * Returns where the browser should go next, which is normally nothing --
+     * the caller then uses its own default. A USER_LOGGING_OUT listener may
+     * set it to send the browser somewhere else instead, and the one case
+     * that needs this is an external identity provider: destroying FOG's
+     * session leaves the provider's SSO session untouched, so clicking the
+     * provider button again signs straight back into the same account and
+     * there is no way to become somebody else (fog-plugins#15). Ending that
+     * session is a redirect to the provider's end_session_endpoint, and
+     * only the plugin that started the session knows the URL.
+     *
+     * The hook runs BEFORE the session is destroyed on purpose: whatever a
+     * listener needs to build that URL -- an id_token_hint, the endpoint it
+     * cached at sign-in -- is in $_SESSION, and a moment later it is not.
+     *
+     * A listener that sets nothing changes nothing, so this is inert on an
+     * install with no such plugin.
+     *
+     * @return string somewhere to redirect, or '' for the caller's default
      */
     public function logout()
     {
+        $redirect = '';
         self::$HookManager
-            ->processEvent('USER_LOGGING_OUT');
+            ->processEvent(
+                'USER_LOGGING_OUT',
+                ['redirect' => &$redirect]
+            );
         // Clear all the cookies
         self::clearAuthCookie();
 
@@ -608,9 +629,13 @@ class User extends FOGController
             ->set('name', '')
             ->set('password', '', true);
 
-        // If the session is already gone, return.
+        // If the session is already gone, return. Still hands back whatever
+        // the hook asked for: a listener that recorded its provider's
+        // end-session URL from a cookie rather than the session is still
+        // owed the redirect, and silently dropping it here would make single
+        // logout work or not depending on session state.
         if (session_status() !== PHP_SESSION_ACTIVE) {
-            return;
+            return $redirect;
         }
         // Preserve any queued flash messages across the session rebuild so
         // they can toast on the login page after we redirect (e.g. the
@@ -625,6 +650,7 @@ class User extends FOGController
         if ($messages) {
             $_SESSION['FOG_MESSAGES'] = $messages;
         }
+        return $redirect;
     }
 
     /**

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -44,8 +44,33 @@ $nodes = [
 
 // Handle logout or login nodes
 if (isset($node) && in_array($node, ['logout', 'login'])) {
+    $logoutRedirect = '';
     if ($node === 'logout') {
-        $currentUser->logout();
+        // A USER_LOGGING_OUT listener may name somewhere else to go -- an
+        // external provider's end_session_endpoint, so signing out of FOG
+        // also ends the SSO session that would otherwise sign the same
+        // account straight back in (fog-plugins#15). Empty on every install
+        // without such a plugin, which is the unchanged path below.
+        $logoutRedirect = (string)$currentUser->logout();
+    }
+    if ('' !== $logoutRedirect) {
+        /*
+         * Only an absolute http(s) URL, and only from a listener. Anything
+         * else falls back to the normal destination rather than being sent
+         * as-is: this value reaches a Location header, and "whatever a hook
+         * put there" is not a good enough answer for that. PHP's header()
+         * has refused embedded CR/LF since 5.1.2, so the residual risk is an
+         * open redirect rather than a split response -- which is precisely
+         * what the scheme check below is for.
+         *
+         * 302, not the 308 default: the target carries a single-use
+         * id_token_hint and must not be cached as a permanent redirect for
+         * ?node=logout.
+         */
+        if (preg_match('#^https?://#i', $logoutRedirect)) {
+            FOGCore::redirect($logoutRedirect, 302);
+            exit;
+        }
     }
     FOGCore::redirect('../management/index.php');
     exit;

--- a/tests/logout-redirect-seam.test.php
+++ b/tests/logout-redirect-seam.test.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Guards the USER_LOGGING_OUT redirect seam.
+ *
+ *   tests/logout-redirect-seam.test.php
+ *
+ * Signing out of FOG destroys FOG's session and nothing else. When the
+ * session was established by an external identity provider that leaves the
+ * provider's SSO session open, so clicking the provider button again signs
+ * straight back into the same account and there is no way to become somebody
+ * else (fog-plugins#15). Ending that session is a redirect to the provider's
+ * end_session_endpoint, and only the plugin that opened it knows the URL --
+ * hence a seam rather than anything OIDC-shaped in core.
+ *
+ * Four properties, and each is a way the seam has already been got wrong or
+ * could quietly stop working:
+ *
+ *   1. the hook is passed a redirect BY REFERENCE. Passed by value it looks
+ *      identical at the call site and does nothing at all.
+ *   2. the hook fires BEFORE the session is destroyed. A listener builds the
+ *      URL out of $_SESSION -- the id_token_hint, the cached endpoint -- so
+ *      firing it after session_destroy() hands it an empty array.
+ *   3. logout() RETURNS the value and index.php USES it. Returning it and
+ *      then ignoring it is the failure mode that reads as working code.
+ *   4. the redirect is validated and is not a 308. 308 is permanent and
+ *      cacheable, and the target carries a single-use id_token_hint.
+ *
+ * Source assertions only -- no DB, no session, no provider.
+ *
+ * Exit 0 = pass, 1 = fail.
+ */
+$root = dirname(__DIR__);
+$user = $root . '/packages/web/lib/fog/user.class.php';
+$index = $root . '/packages/web/management/index.php';
+$base = $root . '/packages/web/lib/fog/fogbase.class.php';
+
+$pass = 0;
+$fail = 0;
+function ok($m)
+{
+    global $pass;
+    ++$pass;
+    echo "  ok    $m\n";
+}
+function bad($m)
+{
+    global $fail;
+    ++$fail;
+    echo "  FAIL  $m\n";
+}
+
+foreach ([$user, $index, $base] as $f) {
+    if (!is_readable($f)) {
+        echo "cannot read $f\n";
+        exit(1);
+    }
+}
+
+/**
+ * Source with comments stripped.
+ *
+ * Every assertion below can otherwise be satisfied by the prose explaining
+ * the code rather than the code: this seam's comments name
+ * USER_LOGGING_OUT, the reference, the ordering and the 302, all of them.
+ * A gate its own documentation passes is not a gate.
+ *
+ * @param string $file the file to read
+ *
+ * @return string
+ */
+function src($file)
+{
+    $out = '';
+    foreach (token_get_all(file_get_contents($file)) as $t) {
+        if (is_array($t)) {
+            if (in_array($t[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            $out .= $t[1];
+            continue;
+        }
+        $out .= $t;
+    }
+    return $out;
+}
+
+/**
+ * The body of one method, comments already stripped.
+ *
+ * @param string $src  stripped source
+ * @param string $name the method name
+ *
+ * @return string
+ */
+function body($src, $name)
+{
+    $at = strpos($src, 'function ' . $name . '(');
+    if (false === $at) {
+        return '';
+    }
+    return substr($src, $at, 3000);
+}
+
+$userSrc = src($user);
+$indexSrc = src($index);
+$baseSrc = src($base);
+$logout = body($userSrc, 'logout');
+
+echo "1. the hook can actually change something\n";
+
+// By reference. Passed by value this compiles, runs, and does nothing --
+// which is indistinguishable from working until somebody tries it.
+if (preg_match('#processEvent\s*\(\s*[\'"]USER_LOGGING_OUT[\'"]\s*,\s*\[\s*[\'"]redirect[\'"]\s*=>\s*&\s*\$#', $logout)) {
+    ok('USER_LOGGING_OUT is passed $redirect by reference');
+} else {
+    bad('USER_LOGGING_OUT does not pass a by-reference redirect -- a listener cannot set anything');
+}
+
+echo "\n2. the hook fires while the session still exists\n";
+
+// Ordering is the whole reason a listener can work at all. Compare offsets
+// rather than trusting the source to stay in this order.
+$hookAt = strpos($logout, 'USER_LOGGING_OUT');
+$destroyAt = strpos($logout, 'session_destroy');
+if (false === $hookAt || false === $destroyAt) {
+    bad('cannot locate USER_LOGGING_OUT and session_destroy in logout()');
+} elseif ($hookAt < $destroyAt) {
+    ok('USER_LOGGING_OUT fires before session_destroy()');
+} else {
+    bad('USER_LOGGING_OUT fires AFTER session_destroy() -- $_SESSION is gone by then');
+}
+
+echo "\n3. the value is returned and consumed\n";
+
+if (preg_match('#return\s+\$redirect\s*;#', $logout)) {
+    ok('logout() returns the redirect');
+} else {
+    bad('logout() does not return the redirect');
+}
+
+// Both early exits must hand it back too, or single logout works or does not
+// depending on whether a session happened to be active.
+if (2 <= preg_match_all('#return\s+\$redirect\s*;#', $logout)) {
+    ok('every return path in logout() hands the redirect back');
+} else {
+    bad('a return path in logout() drops the redirect');
+}
+
+// Consumed, and pinned to the line that ACTS on it. "index.php mentions
+// logout()" would be satisfied by a version that calls it and discards the
+// result, which is the defect this pins.
+if (preg_match('#=\s*\(string\)\$currentUser->logout\(\)#', $indexSrc)) {
+    ok('index.php captures logout()\'s return value');
+} else {
+    bad('index.php calls logout() without capturing what it returns');
+}
+if (preg_match('#FOGCore::redirect\s*\(\s*\$logoutRedirect\s*,\s*302\s*\)#', $indexSrc)) {
+    ok('index.php redirects to it with 302');
+} else {
+    bad('index.php never redirects to the returned value with a 302');
+}
+
+echo "\n4. the destination is checked, and is not cacheable\n";
+
+// An open redirect is the realistic risk: header() has refused CR/LF since
+// PHP 5.1.2, so this is not response splitting.
+if (preg_match('#preg_match\s*\(\s*\'\#\^https\?://\#i\'\s*,\s*\$logoutRedirect\s*\)#', $indexSrc)) {
+    ok('index.php requires an absolute http(s) URL before redirecting');
+} else {
+    bad('index.php does not check the scheme of the hook-supplied URL');
+}
+
+// redirect() must still default to 308 for the callers that have always got
+// one, and must accept an override.
+if (preg_match('#function\s+redirect\s*\(\s*\$url\s*=\s*\'\'\s*,\s*\$status\s*=\s*308\s*\)#', $baseSrc)) {
+    ok('FOGCore::redirect() still defaults to 308');
+} else {
+    bad('FOGCore::redirect() no longer defaults to 308 -- every existing caller changes behaviour');
+}
+if (preg_match('#in_array\s*\(\s*\$status\s*,\s*\[\s*301\s*,\s*302\s*,\s*303\s*,\s*307\s*,\s*308\s*\]\s*,\s*true\s*\)#', $baseSrc)) {
+    ok('FOGCore::redirect() rejects a status that is not a redirect');
+} else {
+    bad('FOGCore::redirect() passes its status through unchecked');
+}
+
+printf("\n%d passed, %d failed\n", $pass, $fail);
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
Core half of [fog-plugins#15](https://github.com/FOGProject/fog-plugins/issues/15). Nothing here is OIDC-shaped — the provider knowledge stays in the plugin.

## Problem

Logging out of FOG destroys FOG's session and nothing else. When the session was established by an external identity provider, that leaves the provider's SSO session open — so clicking the provider button again signs straight back into the same account with no credential prompt. On an account whose `uAuthSource` is not local there is no other way in at all, so becoming somebody else means clearing cookies or a private window.

Ending the provider session is a redirect to its `end_session_endpoint` carrying an `id_token_hint`. Only the plugin that opened the session knows that URL, and core had nowhere for it to say so: `USER_LOGGING_OUT` fired with **no arguments**, and `management/index.php` then redirected to a hardcoded path.

## Change

The hook is passed a redirect **by reference**, `logout()` returns it, and `index.php` uses it when set. A listener that sets nothing changes nothing — which is every install without such a plugin.

## Three details that are the whole correctness of it

**The hook still fires before `session_destroy()`.** A listener builds that URL out of `$_SESSION` — the id_token, the endpoint cached at sign-in — and a moment later there is nothing to build it from.

**Both of `logout()`'s exits return the value.** Dropping it on the already-no-session path would make single logout work or not depending on session state.

**302, not `redirect()`'s 308 default.** 308 is permanent and cacheable, and the target carries a single-use `id_token_hint` — a browser that remembered `?node=logout` → that URL would replay a stale hint forever. `FOGCore::redirect()` therefore takes an optional status, **still defaulting to 308** so no existing caller changes, and rejects anything that is not a redirect code.

`index.php` requires an absolute `http(s)` URL before sending it. `header()` has refused CR/LF since PHP 5.1.2, so this is not response splitting — it is an open redirect, and "whatever a hook put there" is not a good enough answer for a `Location` header.

## Gate

`tests/logout-redirect-seam.test.php`, 9 assertions, comments stripped first (the seam's own prose names every token asserted on). Two worth calling out:

- **Ordering is checked by comparing offsets**, not by trusting the source to stay in this order.
- **Consumption is pinned to the line that ACTS on the value.** "index.php mentions `logout()`" would pass with the result discarded — which is the defect that reads as working code.

Nine mutations tried, nine caught: pass-by-value, each of the two dropped returns, discarding the value in index.php, reverting to 308, dropping the scheme check, changing the default status, dropping the status validation, and moving the hook after `session_destroy()`.

`sh tests/run-all.sh` → **57 passed, 0 failed**.

## Downstream

No REST route, no schema, no class list. `FOGCore::redirect()` gains an optional second parameter with a default that preserves every existing call.