### PR TITLE
Give an install one login URL an identity provider cannot take away

### DIFF
--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -53,6 +53,41 @@ if (isset($node) && in_array($node, ['logout', 'login'])) {
 
 // Render login page if user is not valid
 if (!isset($node) || (!in_array($node, $nodes) && !$currentUser->isValid())) {
+    /*
+     * Somewhere else to send an anonymous visitor instead of the login form
+     * -- an external identity provider, where the install has decided
+     * everyone signs in through one (fog-plugins#17). A listener that sets
+     * nothing changes nothing, which is every install without such a plugin.
+     *
+     * NOT offered when FOG_LOCAL_LOGIN is defined. management/login.php
+     * defines it, and that is the whole of how the break-glass page is
+     * guaranteed: the hook is not fired and overruled there, it is never
+     * reached. A forced-redirect setting can otherwise lock every
+     * administrator out of a server permanently -- provider down, expired
+     * certificate, broken discovery -- with no way back in through a
+     * browser, including for the local account that exists for exactly that.
+     *
+     * Only for a visitor who is NOT signed in, and only on the form render,
+     * so nothing here can bounce a working session or an in-flight callback.
+     */
+    if (!defined('FOG_LOCAL_LOGIN')) {
+        $loginRedirect = '';
+        $HookManager->processEvent(
+            'LOGIN_PAGE_REDIRECT',
+            ['redirect' => &$loginRedirect]
+        );
+        // Absolute http(s) only. This reaches a Location header, and
+        // "whatever a hook put there" is not a good enough answer for one.
+        // 302, not redirect()'s cacheable 308 default: a browser that
+        // remembered the login page as permanently moved to a provider that
+        // has since been turned off would have no way back.
+        if ('' !== $loginRedirect
+            && preg_match('#^https?://#i', $loginRedirect)
+        ) {
+            FOGCore::redirect($loginRedirect, 302);
+            exit;
+        }
+    }
     $Page
         ->setTitle($foglang['Login'])
         ->setSecTitle($foglang['ManagementLogin'])

--- a/packages/web/management/login.php
+++ b/packages/web/management/login.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * The local login page, which never routes anywhere else.
+ *
+ * PHP version 7.4+
+ *
+ * @category Index_Page
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ * @version  1.0
+ */
+
+/*
+ * A FOG server can be configured to send everyone straight to an external
+ * identity provider (fog-plugins#17), and that setting can lock every
+ * administrator out permanently: if the provider is unreachable, its
+ * certificate has expired, discovery breaks, or it is simply misconfigured,
+ * an unconditional redirect means there is no way back in through a browser
+ * -- including for the local break-glass account that exists for exactly
+ * this situation.
+ *
+ * So this file. It is the equivalent of ServiceNow's login.do: one URL that
+ * always renders FOG's own username and password form, whatever any provider
+ * or plugin would rather happen.
+ *
+ *     https://<fog>/fog/management/login.php
+ *
+ * The guarantee is STRUCTURAL, not a flag somebody remembers to honour.
+ * index.php only offers the LOGIN_PAGE_REDIRECT hook when this constant is
+ * absent, so a redirect listener is not consulted-and-overruled here -- it is
+ * never reached. A plugin cannot opt back in, and a plugin that is broken,
+ * half-installed or throwing cannot take this page down with it, because it
+ * is not asked anything.
+ *
+ * Everything else is index.php's, deliberately: the same bootstrap, the same
+ * ProcessLogin, the same CSRF token, the same session. A second copy of the
+ * login form is a second place for an authentication bug to live, and the
+ * one thing a break-glass page must not be is subtly different from the real
+ * one.
+ */
+define('FOG_LOCAL_LOGIN', true);
+
+require __DIR__ . DIRECTORY_SEPARATOR . 'index.php';

--- a/tests/local-login-entrypoint.test.php
+++ b/tests/local-login-entrypoint.test.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * The local login page must never be routable to an identity provider.
+ *
+ * An install can be configured to send every anonymous visitor straight to
+ * an external provider (fog-plugins#17), and that is a setting which can
+ * lock every administrator out of their own server: provider down, expired
+ * certificate, broken discovery, mistyped issuer. A browser then has no way
+ * back in -- including for the local break-glass account that exists for
+ * exactly that failure, and which tests/break-glass-auth-sources.test.php
+ * spends its whole length keeping alive.
+ *
+ * management/login.php is the way back: FOG's own login form at one URL
+ * that always renders it, the equivalent of ServiceNow's login.do.
+ *
+ * What makes that a guarantee rather than a promise is STRUCTURAL, and it
+ * is the only thing here worth pinning. index.php offers the
+ * LOGIN_PAGE_REDIRECT hook only when FOG_LOCAL_LOGIN is undefined, so on
+ * login.php a redirect listener is never reached -- not consulted and
+ * overruled, not asked politely. A plugin cannot opt back in, and a plugin
+ * that is half-installed or throwing cannot take this page down with it,
+ * because it is not asked anything.
+ *
+ * Every way that breaks is silent. Moving the processEvent call one line
+ * out of its guard, dropping the reference from the hook argument, letting
+ * an unvalidated string reach a Location header, or reformatting login.php
+ * into its own copy of the form -- all four leave a login page that still
+ * renders and still logs people in, on every install that has no such
+ * plugin. The failure only appears on the install that needed the escape
+ * hatch, at the moment it needed it.
+ *
+ * This is inspection, not execution: reaching index.php's login branch for
+ * real needs a bootstrapped session, a database and a rendered Page. The
+ * property being pinned is where the hook call SITS relative to the guard,
+ * which is a fact about the source.
+ *
+ * Usage: php tests/local-login-entrypoint.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$indexFile = 'packages/web/management/index.php';
+$loginFile = 'packages/web/management/login.php';
+
+/**
+ * Source text with comments and whitespace stripped.
+ *
+ * Comments go first, and it matters more here than usual: both files carry
+ * long prose naming FOG_LOCAL_LOGIN, LOGIN_PAGE_REDIRECT and the redirect
+ * itself, so a test reading raw text would be satisfied by its own
+ * documentation with the code deleted.
+ *
+ * @param string $file path to read
+ *
+ * @return string stripped source
+ */
+function strippedSource($file)
+{
+    $out = '';
+    foreach (token_get_all(file_get_contents($file)) as $c) {
+        if (is_array($c)
+            && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $out .= is_array($c) ? $c[1] : $c;
+    }
+    return preg_replace('#\s+#', '', $out);
+}
+
+/**
+ * Body of the first `if` whose condition contains a needle.
+ *
+ * Brace counting is done on tokens rather than on the stripped string so a
+ * brace inside a string literal or an interpolation cannot close the block
+ * early -- the containment claim below is the whole test, and a containment
+ * claim computed from a substring search is not one.
+ *
+ * @param string $file      path to read
+ * @param string $condition text the condition must contain, stripped form
+ *
+ * @return string|null stripped body between the braces, or null
+ */
+function guardBody($file, $condition)
+{
+    $pieces = [];
+    foreach (token_get_all(file_get_contents($file)) as $c) {
+        if (is_array($c)
+            && in_array(
+                $c[0],
+                [T_COMMENT, T_DOC_COMMENT, T_WHITESPACE],
+                true
+            )
+        ) {
+            continue;
+        }
+        $pieces[] = is_array($c)
+            ? [$c[0], $c[1]]
+            : [null, $c];
+    }
+    $n = count($pieces);
+    for ($i = 0; $i < $n; $i++) {
+        if (T_IF !== $pieces[$i][0]) {
+            continue;
+        }
+        if ($i + 1 >= $n || '(' !== $pieces[$i + 1][1]) {
+            continue;
+        }
+        $depth = 0;
+        $cond = '';
+        for ($j = $i + 1; $j < $n; $j++) {
+            $tok = $pieces[$j][1];
+            if (null === $pieces[$j][0] && '(' === $tok) {
+                $depth++;
+            } elseif (null === $pieces[$j][0] && ')' === $tok) {
+                if (0 === --$depth) {
+                    break;
+                }
+            }
+            $cond .= $tok;
+        }
+        if (false === strpos($cond . ')', $condition)) {
+            continue;
+        }
+        // A guard written without braces cannot contain anything, so an
+        // alternative-syntax or single-statement rewrite reads as "not
+        // found" rather than quietly passing with an empty body.
+        if ($j + 1 >= $n || '{' !== $pieces[$j + 1][1]) {
+            return null;
+        }
+        $depth = 0;
+        $body = '';
+        for ($k = $j + 1; $k < $n; $k++) {
+            $type = $pieces[$k][0];
+            $tok = $pieces[$k][1];
+            if ((null === $type && '{' === $tok)
+                || T_CURLY_OPEN === $type
+                || T_DOLLAR_OPEN_CURLY_BRACES === $type
+            ) {
+                $depth++;
+            } elseif (null === $type && '}' === $tok) {
+                if (0 === --$depth) {
+                    return $body;
+                }
+            }
+            if ($depth > 0 && $k > $j + 1) {
+                $body .= $tok;
+            }
+        }
+        return null;
+    }
+    return null;
+}
+
+/*
+ * 1. The page exists at all, and is a real entry point rather than a
+ *    redirect or an alias somebody could point elsewhere.
+ */
+if (!is_file($loginFile)) {
+    $fails[] = $loginFile . ' is missing; a forced-redirect install has no'
+        . ' way back to FOG\'s own login form';
+} else {
+    $login = strippedSource($loginFile);
+
+    /*
+     * The constant is what index.php reads, so it has to be defined BEFORE
+     * index.php runs. Defining it afterwards is the mutation that looks
+     * entirely fine in review and does nothing whatsoever.
+     */
+    $defineAt = strpos($login, "define('FOG_LOCAL_LOGIN',true);");
+    $requireAt = strpos($login, "require__DIR__");
+    if (false === $defineAt) {
+        $fails[] = 'management/login.php no longer defines FOG_LOCAL_LOGIN;'
+            . ' index.php would offer LOGIN_PAGE_REDIRECT here like anywhere'
+            . ' else and the break-glass page would redirect to the provider'
+            . ' that is broken';
+    }
+    if (false === $requireAt) {
+        $fails[] = 'management/login.php no longer requires index.php';
+    }
+    if (false !== $defineAt && false !== $requireAt
+        && $defineAt > $requireAt
+    ) {
+        $fails[] = 'management/login.php defines FOG_LOCAL_LOGIN after'
+            . ' loading index.php, which is after index.php has already'
+            . ' decided whether to redirect';
+    }
+    if (false === strpos($login, "'index.php'")) {
+        $fails[] = 'management/login.php no longer loads index.php by name';
+    }
+
+    /*
+     * And it stays a two-liner. The moment this file grows its own form or
+     * its own credential handling it becomes a second authentication path,
+     * which is the one thing a break-glass page must not be -- a bug fixed
+     * on the normal login would not be fixed on the emergency one, and
+     * nobody exercises the emergency one until the day it has to work.
+     */
+    foreach (['uname', 'upass', '<form', 'ProcessLogin'] as $marker) {
+        if (false !== stripos($login, $marker)) {
+            $fails[] = 'management/login.php carries its own login markup or'
+                . ' handling (' . $marker . '); it must reuse index.php so'
+                . ' the emergency form cannot drift from the real one';
+        }
+    }
+}
+
+/*
+ * 2. The hook, and where it sits.
+ *
+ * Presence is not the property. LOGIN_PAGE_REDIRECT firing is fine; it
+ * firing on login.php is the lockout. So the call has to be found INSIDE
+ * the guard's braces, not merely somewhere after the word "defined".
+ */
+$index = strippedSource($indexFile);
+$body = guardBody($indexFile, "!defined('FOG_LOCAL_LOGIN')");
+if (null === $body) {
+    if (false !== strpos($index, "'LOGIN_PAGE_REDIRECT'")) {
+        $fails[] = 'index.php fires LOGIN_PAGE_REDIRECT but no longer wraps'
+            . ' it in an if (!defined(\'FOG_LOCAL_LOGIN\')) guard, so'
+            . ' management/login.php redirects to the identity provider like'
+            . ' every other page';
+    } else {
+        $fails[] = 'index.php has no FOG_LOCAL_LOGIN guard';
+    }
+} else {
+    if (false === strpos($body, "processEvent('LOGIN_PAGE_REDIRECT'")) {
+        $fails[] = 'the FOG_LOCAL_LOGIN guard in index.php no longer'
+            . ' contains the LOGIN_PAGE_REDIRECT call; if the call moved out'
+            . ' of the guard the break-glass page redirects with it';
+    }
+    /*
+     * By reference, or the listener writes into a copy and every install
+     * with a forced-redirect plugin silently keeps showing the local form
+     * -- the failure in the harmless direction, which is exactly why it
+     * would ship.
+     */
+    if (false === strpos($body, "['redirect'=>&\$loginRedirect]")) {
+        $fails[] = 'index.php no longer passes $loginRedirect by reference'
+            . ' to LOGIN_PAGE_REDIRECT; a listener cannot return anything'
+            . ' any other way';
+    }
+    /*
+     * What a hook put in a variable is not a good enough answer for a
+     * Location header. Absolute http(s) only.
+     */
+    if (false === strpos($body, "preg_match('#^https?://#i',\$loginRedirect)")
+    ) {
+        $fails[] = 'index.php no longer validates the LOGIN_PAGE_REDIRECT'
+            . ' value as an absolute http(s) URL before putting it in a'
+            . ' Location header';
+    }
+    /*
+     * 302, not redirect()'s cacheable 308 default. A browser that cached
+     * the login page as permanently moved to a provider which has since
+     * been switched off would have no way back -- the same lockout this
+     * whole file exists to prevent, arriving through the cache instead.
+     */
+    if (false === strpos($body, 'FOGCore::redirect($loginRedirect,302);')) {
+        $fails[] = 'index.php no longer redirects with a temporary 302; a'
+            . ' cached permanent redirect to a dead provider is its own'
+            . ' lockout';
+    }
+    if (false === strpos($body, "\$loginRedirect='';")) {
+        $fails[] = 'index.php no longer initialises $loginRedirect, so an'
+            . ' install with no listener redirects on whatever was left in'
+            . ' scope';
+    }
+}
+
+/*
+ * 3. One guard, one hook site. A second unguarded processEvent for the same
+ *    event -- added later for the API or a fragment endpoint -- reinstates
+ *    the lockout while every assertion above still passes.
+ */
+$hookSites = substr_count($index, "processEvent('LOGIN_PAGE_REDIRECT'");
+if ($hookSites > 1) {
+    $fails[] = 'index.php fires LOGIN_PAGE_REDIRECT ' . $hookSites
+        . ' times; only the one inside the FOG_LOCAL_LOGIN guard is'
+        . ' verified here, and an unguarded second site redirects the'
+        . ' break-glass page';
+}
+
+if (count($fails) > 0) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo '  - ' . $f . "\n";
+    }
+    exit(1);
+}
+echo "ok: management/login.php cannot be routed to an identity provider\n";
+exit(0);


### PR DESCRIPTION
## The problem this gets ahead of

FOGProject/fog-plugins#17 asks for a "forced redirect" mode: every anonymous
visitor goes straight to the configured identity provider instead of landing on
FOG's login form. That is a reasonable thing to want and a genuinely dangerous
switch, because there is currently no URL that survives it.

If the provider is unreachable, its certificate expired, its discovery document
broke, its client secret rotated or its issuer was mistyped, an unconditional
redirect means **the FOG login form is no longer reachable at any address**.
Including for the local break-glass account — the one `tests/break-glass-auth-sources.test.php`
spends its whole length keeping able to sign in, on the reasoning that an IdP
outage must never lock an install out of itself. Without this, that guard
protects an account nobody can reach a form to type into.

So the escape hatch lands **before** the thing it is an escape from, not
alongside it.

## What this adds

`packages/web/management/login.php` — the equivalent of ServiceNow's `login.do`.
One URL that always renders FOG's own username and password form:

```
https://<fog>/fog/management/login.php
```

And `LOGIN_PAGE_REDIRECT` in `index.php`, the seam #17 will consume. It fires
only for a visitor who is not signed in and only on the form render, so it
cannot bounce a working session or an in-flight provider callback. An install
with no listener sets nothing and redirects nowhere — this changes no behaviour
on its own.

## Why it is a guarantee and not a promise

The whole design is that the guarantee is **structural**. `index.php` offers
the hook only when `FOG_LOCAL_LOGIN` is undefined; `login.php` defines it before
loading `index.php`. So on that page a redirect listener is not consulted and
overruled — it is **never reached**. A plugin cannot opt back in, and a plugin
that is half-installed, misconfigured or throwing cannot take the page down with
it, because nothing asks it anything.

Everything else is `index.php`'s, deliberately: same bootstrap, same
`ProcessLogin`, same CSRF token, same session. A second copy of the login form
is a second place for an authentication bug to live, and the one thing an
emergency login must not be is subtly different from the real one — nobody
exercises it until the day it has to work.

Two details in the redirect that are not incidental:

- **Absolute `http(s)` only.** What a hook left in a variable is not a good
  enough answer for a `Location` header.
- **302, not `redirect()`'s cacheable 308 default.** A browser that remembered
  the login page as permanently moved to a provider since switched off would
  have no way back — the same lockout, arriving through the cache.

## Verification

`tests/local-login-entrypoint.test.php` pins **where the hook call sits relative
to its guard**, by token-level brace containment rather than a substring search,
because every way this breaks is silent: moving the call one line out of the
guard, dropping the reference from its argument, or letting `login.php` grow its
own form all leave a login page that still renders and still works on every
install that has no such plugin. The failure only shows up on the install that
needed the escape hatch, at the moment it needed it. Comments are stripped
first — both files' prose names every symbol the test searches for.

- 10/10 mutations caught (unwrap the guard, invert it, drop the `&`, drop the
  URL check, 308 instead of 302, drop the initialisation, add a second unguarded
  hook site, define the constant after the `require`, grow a form in
  `login.php`, delete `login.php`).
- `sh tests/run-all.sh` → **57 passed, 0 failed**.
- Rendered live in a throwaway shadow tree against the real database:
  `index.php` and `login.php` both answered `200`, `4647` bytes, byte-identical
  apart from the CSP nonce and the memory-peak comment, and `login.php` serves
  the real form (`name="uname"`, `name="upass"`, CSRF meta, same POST action).

Not verified by a live listener: no `LOGIN_PAGE_REDIRECT` consumer exists yet.
The suppression is proven structurally and by the gate above, not by watching a
plugin fail to redirect.

## Related

- FOGProject/fog-plugins#17 — forced redirect. This seam is what it consumes,
  and `login.php` is its mandatory escape hatch. That PR should refuse to enable
  the mode without pointing the administrator at this URL first.
- FOGProject/fog-plugins#15 — OIDC single logout, which depends on #1174.
- `tests/break-glass-auth-sources.test.php` — the account this page gives a form.

Docs for `login.php` belong in `FOGProject/fog-docs` and are better written
alongside #17, when there is a setting to document it against.

## Downstream

None. No route class added or removed, no schema change, no `FOG_BCACHE_VER`
bump needed (no JS or CSS touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
