### PR TITLE
Address this server's own web tier by name, not by address

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -619,7 +619,8 @@ backupDB() {
     dbhastables=$(mysql $sqloptionsuser --password="${snmysqlpass}" --skip-column-names --execute="SHOW TABLES" $mysqldbname 2>>$error_log | head -n 1)
     if [[ -n $dbhastables ]]; then
         [[ ! -d $backupPath/fogDBbackups ]] && mkdir -p $backupPath/fogDBbackups >>$error_log 2>&1
-        url="${httpproto}://$ipaddress$webroot/maintenance/backup_db.php"
+        local selfName=$(_servedCertName)
+        url="${httpproto}://${selfName}$webroot/maintenance/backup_db.php"
         # %H, not %I: %I is the 12-hour clock with no AM/PM marker, so an
         # update run at 05:57 and one at 17:57 on the same day produced the
         # same filename and the second silently overwrote the first.
@@ -725,12 +726,15 @@ checkWebTier() {
     # unauthenticated node and a plain GET renders regardless -- and a token in
     # a query string lands in the web server access log and, on failure, in the
     # installer's tee'd stdout. The deploy itself uses the header channel.
-    local probeUrl="${httpproto}://${ipaddress}${webroot}management/index.php?node=schema"
+    local selfName=$(_servedCertName)
+    local probeUrl="${httpproto}://${selfName}${webroot}management/index.php?node=schema"
     local probeBody=$(mktemp)
     # We care whether bytes came back at all, not just about the status code,
-    # because a pre-output fatal loses exactly that.
+    # because a pre-output fatal loses exactly that. %{http_code} is captured
+    # alongside so a 500 can be named as a 500 rather than as "curl exit 22".
     _resolveSelfCacert
-    curl -sS "${selfCacertOpts[@]}" --noproxy '*' -m 30 -fL -o "$probeBody" "$probeUrl" >>$error_log 2>&1
+    local probeCode=""
+    probeCode=$(curl -sS "${selfCacertOpts[@]}" --noproxy '*' -m 30 -fL -w '%{http_code}' -o "$probeBody" "$probeUrl" 2>>$error_log)
     local probeStat=$?
     local probeSize=$(stat -c %s "$probeBody" 2>/dev/null)
     [[ -z $probeSize ]] && probeSize=0
@@ -739,17 +743,96 @@ checkWebTier() {
         echo "Done"
         return 0
     fi
+    # Say which failure this was. Every outcome used to print the same "almost
+    # always a PHP fatal" advice, including a TLS handshake that was rejected
+    # before any response existed to be empty -- which reads as a dead site and
+    # sends an administrator to the PHP error log for a trust problem.
+    local reason="" advice="plain"
+    case $probeStat in
+        0)
+            reason="the server answered ${probeCode:-200} with an empty body"
+            advice="php"
+            ;;
+        22)
+            reason="the server answered HTTP ${probeCode:-4xx/5xx}"
+            advice="php"
+            ;;
+        35|51|60|77)
+            reason="TLS verification failed (curl ${probeStat})"
+            advice="tls"
+            ;;
+        6)
+            reason="the name ${selfName} did not resolve from this server"
+            ;;
+        7)
+            reason="the connection to ${selfName} was refused"
+            ;;
+        28)
+            reason="the request timed out after 30s"
+            ;;
+        *)
+            reason="curl exited ${probeStat}"
+            ;;
+    esac
+    # A rejected certificate says nothing about whether the web tier renders.
+    # Prove that separately before deciding this is fatal: if the same URL
+    # answers with content when verification is skipped, the site is up and
+    # what failed is trust, which must not abort an install that was otherwise
+    # fine. The retry is only ever a DIAGNOSTIC -- it carries no token, and the
+    # schema deploy in updateDB still refuses to degrade this way.
+    if [[ $advice == tls ]]; then
+        local retryBody=$(mktemp)
+        curl -sS -k --noproxy '*' -m 30 -fL -o "$retryBody" "$probeUrl" >>$error_log 2>&1
+        local retryStat=$?
+        local retrySize=$(stat -c %s "$retryBody" 2>/dev/null)
+        [[ -z $retrySize ]] && retrySize=0
+        rm -f "$retryBody"
+        if [[ $retryStat -eq 0 && $retrySize -gt 0 ]]; then
+            echo "Warning"
+            echo
+            echo "   The web server IS serving FOG at:"
+            echo "     $probeUrl"
+            echo "   but this host cannot verify the certificate it presents."
+            echo
+            echo "   ${reason}. The page rendered when verification was skipped,"
+            echo "   so this is a trust problem and not a broken site -- the"
+            echo "   install continues."
+            echo
+            echo "   Likely causes:"
+            echo "     - the certificate is managed outside FOG (acme.sh, certbot)"
+            echo "       and has not been declared: set acmeLeaf=\"yes\" in"
+            echo "       ${fogprogramdir:-the FOG program dir}/.fogsettings"
+            echo "     - the served chain does not terminate in the anchor FOG"
+            echo "       resolved (${sslcachain:-the vhost})"
+            echo
+            echo "   Note the schema deploy verifies strictly and will NOT"
+            echo "   continue past this -- it carries an install token."
+            echo
+            return 0
+        fi
+    fi
     echo "Failed!"
     echo
     echo "   The web server did not return a usable page for:"
     echo "     $probeUrl"
     echo "   (curl exit ${probeStat}, ${probeSize} bytes of body)"
+    echo "   Reason: ${reason}."
     echo
-    echo "   An empty or truncated response with a 500 is almost always a PHP"
-    echo "   fatal in the FOG boot chain rather than a database problem. In a"
-    echo "   browser this looks like a blank white page. Check your web"
-    echo "   server's error log."
-    echo "   PHP in use: $(php -v 2>/dev/null | head -1)"
+    if [[ $advice == php ]]; then
+        echo "   An empty or truncated response with a 500 is almost always a PHP"
+        echo "   fatal in the FOG boot chain rather than a database problem. In a"
+        echo "   browser this looks like a blank white page. Check your web"
+        echo "   server's error log."
+        echo "   PHP in use: $(php -v 2>/dev/null | head -1)"
+    elif [[ $advice == tls ]]; then
+        echo "   The certificate was rejected AND the page did not render with"
+        echo "   verification skipped, so the web tier is not answering usefully"
+        echo "   on this address either. Check the web server is running and that"
+        echo "   ${selfName} resolves to this server from this server."
+    else
+        echo "   Check the web server is running and reachable at ${selfName}"
+        echo "   from this host. Full error in $error_log"
+    fi
     echo
     [[ -z $exitFail ]] && exit 1
     return 1
@@ -829,6 +912,12 @@ verifySchemaDeploy() {
     return 1
 }
 updateDB() {
+    # Every URL below -- the POST, the failure messages and the browser
+    # instructions -- addresses the server by the name its certificate
+    # carries. Dialling $ipaddress verified only by luck: FOG's own leaf
+    # happens to carry IP SANs, and a leaf from a public CA cannot, because
+    # no public CA issues for an address.
+    local selfName=$(_servedCertName)
     # This substitution has to happen on BOTH paths. It used to sit inside the
     # [Yy] branch, and dbupdate is set in exactly one place (bin/installfog.sh,
     # under -y), so every interactive install baked the literal '/images/'
@@ -857,7 +946,7 @@ updateDB() {
             # grants a schema deploy on a server that has no users yet; -k
             # handed that to whoever answered on $ipaddress.
             _resolveSelfCacert
-            curl -X POST -H "X-Fog-Install-Token: ${installToken}" -d "schemaupdate=1" --noproxy '*' "${selfCacertOpts[@]}" -fsL ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema -o - >>$error_log 2>&1
+            curl -X POST -H "X-Fog-Install-Token: ${installToken}" -d "schemaupdate=1" --noproxy '*' "${selfCacertOpts[@]}" -fsL ${httpproto}://${selfName}${webroot}management/index.php?node=schema -o - >>$error_log 2>&1
             local schemarc=$?
             # errorStat tails $error_log, so curl's own "SSL certificate
             # problem" line is already visible -- but it does not say what to
@@ -869,15 +958,20 @@ updateDB() {
                     echo "Failed!"
                     echo
                     echo " * TLS verification failed talking to this server's own web tier at"
-                    echo "   ${httpproto}://${ipaddress}${webroot} -- so the schema was NOT deployed."
+                    echo "   ${httpproto}://${selfName}${webroot} -- so the schema was NOT deployed."
                     echo " * This step used to skip verification, which handed the schema"
                     echo "   install token to whatever answered on that address. It no longer"
                     echo "   does, so a certificate this host cannot verify now stops here."
-                    echo " * Two causes, both fixable:"
-                    echo "     - the web certificate was replaced by hand, so the chain in"
-                    echo "       ${sslcachain:-the vhost} no longer describes what is served"
-                    echo "     - the certificate does not cover the address ${ipaddress}"
-                    echo "       (re-run with --external-ca, or issue one that names it)"
+                    echo " * The address is no longer the likely cause -- this call now"
+                    echo "   dials ${selfName}, taken from the served certificate's own CN,"
+                    echo "   so it is a name that certificate covers by construction."
+                    echo " * Two causes remain, both fixable:"
+                    echo "     - the served chain does not terminate in the anchor FOG"
+                    echo "       resolved (${sslcachain:-the vhost}), i.e. the certificate was"
+                    echo "       replaced without telling the installer -- re-run with"
+                    echo "       --external-ca, or declare it with acmeLeaf=\"yes\""
+                    echo "     - ${selfName} does not resolve to this server FROM this server"
+                    echo "       (check /etc/hosts and this host's resolver, not just DNS)"
                     echo " * Full error in $error_log"
                     echo
                     tail -n 5 $error_log
@@ -902,7 +996,7 @@ updateDB() {
             # is safe: it still requires possession of the token.
             local userCount=$(fogUserCount)
             if [[ -z $userCount || $userCount -gt 0 ]]; then
-                echo "   ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema"
+                echo "   ${httpproto}://${selfName}${webroot}management/index.php?node=schema"
                 echo
                 echo " * Log in as a FOG administrator there, then click"
                 echo "   Install/Update now."
@@ -920,7 +1014,7 @@ updateDB() {
                 echo "   (the FOG_SCHEMA_INSTALL_TOKEN line), with:"
                 echo "     curl -X POST -H \"X-Fog-Install-Token: <token>\" \\"
                 echo "       -d \"schemaupdate=1\" \\"
-                echo "       \"${httpproto}://${ipaddress}${webroot}management/index.php?node=schema\""
+                echo "       \"${httpproto}://${selfName}${webroot}management/index.php?node=schema\""
             fi
             if [[ -z $userCount || $userCount -eq 0 ]]; then
                 # Only a userless install can use the token, and only in a URL
@@ -928,7 +1022,7 @@ updateDB() {
                 # instruction when the user probe could not run, so we neither
                 # publish a secret needlessly nor strand a fresh install.
                 [[ -z $userCount ]] && echo " * If this is a brand new install with no FOG users yet, use:"
-                echo "   ${httpproto}://${ipaddress}${webroot}management/index.php?node=schema&fogtoken=${installToken}"
+                echo "   ${httpproto}://${selfName}${webroot}management/index.php?node=schema&fogtoken=${installToken}"
             fi
             echo
             read -p " * Press [Enter] key when database is updated/installed."
@@ -4319,6 +4413,56 @@ _resolveTrustAnchor() {
     trustAnchorPem="$out"
     return 0
 }
+# The name this server's own certificate says it is.
+#
+# Every HTTPS call the installer makes to itself has to address the server by a
+# name the SERVED leaf actually covers. Anchoring correctly is not enough: a
+# chain that verifies against the right root is still rejected when the address
+# dialled is not in the certificate, and that is one of the two halves
+# _resolveSelfCacert() below depends on.
+#
+# So ask the certificate rather than guessing. One rule covers both cases a FOG
+# server can be in: a FOG-issued leaf carries CN=$hostname (_createWebLeaf sets
+# exactly that), and a leaf from a public CA carries whatever the admin had
+# issued. Neither needs a new setting to describe it.
+#
+# The VHOST is consulted first, and that ordering is the point. On an install
+# whose certificate is managed outside FOG -- acme.sh, certbot, a corporate
+# issuance process -- $sslpubcert still names FOG's own leaf while the web
+# server serves somebody else's, so reading FOG's copy answers confidently with
+# a name that is not being presented to anybody.
+#
+# Falling back to $hostname converges rather than guesses: _createWebLeaf sets
+# the leaf's CN FROM $hostname, so on a fresh install -- where configureHttpd
+# has not written a leaf yet -- $hostname is the same answer one step early.
+# $ipaddress is last and is only ever right for a FOG-issued certificate, since
+# no public CA will issue for an address at all.
+_servedCertName() {
+    local cert cn candidate
+    local -a candidates=()
+    if [[ -n $etcconf && -f $etcconf ]]; then
+        # ssl_certificate_key and SSLCertificateKeyFile do NOT match: both
+        # patterns require whitespace immediately after the directive name, and
+        # those two continue with '_' and 'K'. Same reason SSLCertificateChainFile
+        # is excluded -- it is the chain, not the leaf whose subject we want.
+        candidate=$(grep -aoiE '^[[:space:]]*(SSLCertificateFile|ssl_certificate)[[:space:]]+[^;[:space:]]+' "$etcconf" 2>/dev/null \
+            | awk '{print $NF}' | head -1)
+        [[ -n $candidate ]] && candidates+=("$candidate")
+    fi
+    candidates+=("$sslpubcert" "$sslfullchain")
+    for cert in "${candidates[@]}"; do
+        [[ -n $cert && -f $cert ]] || continue
+        # -nameopt multiline rather than parsing the one-line form: the compact
+        # subject is rendered differently across openssl versions (leading
+        # slash, spaces around '='), and a CN containing a comma cannot be
+        # split out of it reliably at all.
+        cn=$(openssl x509 -noout -subject -nameopt multiline -in "$cert" 2>/dev/null \
+            | awk -F' = ' '/commonName/{print $2; exit}')
+        [[ -n $cn ]] && { echo "$cn"; return 0; }
+    done
+    [[ -n $hostname ]] && { echo "$hostname"; return 0; }
+    echo "$ipaddress"
+}
 # The --cacert arguments for an HTTPS call this server makes to ITSELF.
 #
 # Sets $selfCacertOpts, which callers splice in as "${selfCacertOpts[@]}". Empty
@@ -4347,6 +4491,12 @@ _resolveTrustAnchor() {
 _resolveSelfCacert() {
     selfCacertOpts=()
     [[ $httpproto == https ]] || return 0
+    # A leaf issued outside FOG chains to a PUBLIC root the system store
+    # already holds. --cacert REPLACES that store rather than adding to it, so
+    # naming FOG's own root here does not add trust -- it removes the only
+    # trust that would have worked, and turns a verifiable ACME certificate
+    # into an unverifiable one. Leave curl's default bundle in place.
+    [[ $acmeLeaf == yes || $publicWebCert == yes ]] && return 0
     _resolveTrustAnchor >>$error_log 2>&1 || return 0
     [[ -s $trustAnchorPem ]] || return 0
     selfCacertOpts=(--cacert "$trustAnchorPem")

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -96,7 +96,17 @@ echo "1. only the documented node-bootstrap calls skip verification"
 
 # The allowlist is by URL, not by line number: each of the three is the only
 # call in this tree that talks to that endpoint.
-allowed_re='check_node_exists\.php|create_update_node\.php|nodecert\.php'
+#
+# probeUrl is the fourth entry and the only one that is not a node bootstrap.
+# checkWebTier retries its liveness probe once with -k after a verification
+# failure, purely to establish whether the web tier renders at all -- a
+# certificate this host cannot verify says nothing about whether the site is
+# up, and aborting an otherwise-fine install on that is what GH-1147 did in
+# reverse. The retry is safe to exempt because it carries NO credential: the
+# body is written to a temp file, read for its size, and deleted. The
+# token-carrying schema post next to it still refuses to degrade, which is
+# what check 2 below pins.
+allowed_re='check_node_exists\.php|create_update_node\.php|nodecert\.php|probeUrl'
 
 found=0
 stray=0
@@ -119,10 +129,10 @@ fi
 # Pinning the count as well as the allowlist. Without this a fourth call to
 # create_update_node.php -- or a new one to nodecert.php -- would inherit the
 # exemption silently, which is exactly how the flag spread in the first place.
-if [[ $found -eq 4 ]]; then
-    ok "exactly 4 unverified calls remain (the Group C node bootstrap)"
+if [[ $found -eq 5 ]]; then
+    ok "exactly 5 unverified calls remain (Group C node bootstrap + the liveness retry)"
 else
-    bad "expected exactly 4 unverified calls, found $found -- if this is deliberate, say why here"
+    bad "expected exactly 5 unverified calls, found $found -- if this is deliberate, say why here"
 fi
 
 # And each of the four must actually be the one it claims to be, not four

--- a/tests/network-fetch-bounded.test.sh
+++ b/tests/network-fetch-bounded.test.sh
@@ -104,7 +104,12 @@ joined() {
 # call cannot accidentally inherit one:
 #
 #   ipaddress     the maintenance/* posts -- this same host over loopback
-#   dbhttpcode=   backupDB's fetch of backup_db.php, likewise $ipaddress
+#   selfName      the schema post and the liveness probe. Same host, same
+#                 loopback: these address it by the name its own certificate
+#                 carries instead of by $ipaddress, because no public CA will
+#                 issue for an address and the old form could not verify on an
+#                 ACME install. A rename, not a new remote fetch.
+#   dbhttpcode=   backupDB's fetch of backup_db.php, likewise this same host
 #   nodecert.php  a storage node asking its master for a certificate: LAN, not
 #                 the internet. Still unbounded, and still able to stall a node
 #                 install if the master is down -- out of scope here, but a
@@ -117,6 +122,7 @@ remotecurls() {
         | grep -E '(^|[^-[:alnum:]_])curl[[:space:]]+-' \
         | grep -vE '^[[:space:]]*echo ' \
         | grep -v 'ipaddress' \
+        | grep -v 'selfName' \
         | grep -v 'dbhttpcode=' \
         | grep -v 'nodecert.php'
 }

--- a/tests/selfcall-verification.test.sh
+++ b/tests/selfcall-verification.test.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+#
+# Guards how the installer addresses and verifies its own web tier.
+#
+#   tests/selfcall-verification.test.sh
+#
+# Three calls in this installer are made BY the FOG server TO the FOG server:
+# backupDB()'s dump fetch, checkWebTier()'s liveness probe, and updateDB()'s
+# schema POST. They used to pass -k. GH-1169 made them verify, which is right --
+# the schema POST carries X-Fog-Install-Token, and -k handed that to whatever
+# answered -- but it verified a chain fetched from an address rather than a name.
+#
+# That combination is unsatisfiable on any server whose certificate came from a
+# public CA, because no public CA will issue for an IP address. Measured on a
+# live Let's Encrypt install: five DNS SANs, no IP SAN, so dialling the address
+# failed the hostname check even before the anchor was considered. The install
+# aborted at checkWebTier and took updateDB and _publishLocalBootFiles with it.
+#
+# So the name comes from the certificate that is actually being SERVED, and the
+# anchor is left alone when that certificate was issued outside FOG. Both are
+# pinned here, along with the split that keeps GH-1169's fix intact: the
+# liveness probe may retry insecurely to prove the site is up, and the
+# token-carrying schema POST may never do that.
+#
+# Needs openssl. Runs entirely on generated fixtures -- no install, no network,
+# no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+command -v openssl >/dev/null 2>&1 || {
+    echo "SKIP: openssl is not installed"
+    exit 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()    { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()   { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# --- fixtures ----------------------------------------------------------------
+# Two self-signed leaves with different CNs, so "read the served one" and "read
+# FOG's own one" are distinguishable answers rather than the same string twice.
+mkleaf() {
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+        -subj "/CN=$1/O=FOG Project" \
+        -keyout "$WORK/$2.key" -out "$WORK/$2.pem" >/dev/null 2>&1
+}
+mkleaf "served.example.org" served
+mkleaf "fogown.example.org" fogown
+
+reset_env() {
+    etcconf=""; sslpubcert=""; sslfullchain=""
+    hostname=""; ipaddress=""
+    acmeLeaf=""; publicWebCert=""; httpproto="https"
+    selfCacertOpts=(); trustAnchorPem=""
+    # Not decoration: _resolveSelfCacert redirects to $error_log, and an unset
+    # one is an ambiguous redirect that fails the whole command, so the
+    # function returns empty opts and every anchoring assertion passes for the
+    # wrong reason.
+    error_log="$WORK/error.log"
+}
+
+echo "== _servedCertName: which certificate is asked =="
+
+# A. The vhost wins over FOG's own copy. This is the case that matters: on an
+#    externally-managed install $sslpubcert still names FOG's leaf while the web
+#    server serves somebody else's.
+reset_env
+etcconf="$WORK/apache.conf"
+printf '<VirtualHost *:443>\n    SSLCertificateFile %s\n    SSLCertificateKeyFile %s\n</VirtualHost>\n' \
+    "$WORK/served.pem" "$WORK/served.key" > "$etcconf"
+sslpubcert="$WORK/fogown.pem"
+check "$(_servedCertName)" "served.example.org" "A: reads the CN of the cert the vhost names, not FOG's own"
+
+# B. nginx spells it differently and must parse the same way.
+reset_env
+etcconf="$WORK/nginx.conf"
+printf 'server {\n    ssl_certificate %s;\n    ssl_certificate_key %s;\n}\n' \
+    "$WORK/served.pem" "$WORK/served.key" > "$etcconf"
+sslpubcert="$WORK/fogown.pem"
+check "$(_servedCertName)" "served.example.org" "B: parses nginx ssl_certificate"
+
+# C. ssl_certificate_key must NOT be mistaken for the leaf. It is a key file, so
+#    openssl x509 yields nothing and the answer would silently fall through to
+#    the next candidate -- passing for the wrong reason unless pinned.
+reset_env
+etcconf="$WORK/keyonly.conf"
+printf 'server {\n    ssl_certificate_key %s;\n}\n' "$WORK/served.key" > "$etcconf"
+sslpubcert="$WORK/fogown.pem"
+check "$(_servedCertName)" "fogown.example.org" "C: ssl_certificate_key is not read as the leaf"
+
+# D. No vhost to consult -- fall back to FOG's own leaf.
+reset_env
+sslpubcert="$WORK/fogown.pem"
+check "$(_servedCertName)" "fogown.example.org" "D: falls back to \$sslpubcert"
+
+# E. No readable certificate anywhere -- fall back to \$hostname, which is what
+#    _createWebLeaf would have set that CN from anyway.
+reset_env
+sslpubcert="$WORK/does-not-exist.pem"
+hostname="fog.example.org"
+check "$(_servedCertName)" "fog.example.org" "E: falls back to \$hostname"
+
+# F. Nothing at all -- the address, last.
+reset_env
+ipaddress="10.0.0.5"
+check "$(_servedCertName)" "10.0.0.5" "F: falls back to \$ipaddress last"
+
+echo "== _resolveSelfCacert: when FOG's root is the wrong anchor =="
+
+printf 'not-a-real-anchor\n' > "$WORK/anchor.pem"
+_resolveTrustAnchor() { trustAnchorPem="$WORK/anchor.pem"; return 0; }
+
+# G. Plain HTTP verifies against the system store, unchanged.
+reset_env; httpproto="http"
+_resolveSelfCacert
+check "${#selfCacertOpts[@]}" "0" "G: no --cacert on a plain HTTP install"
+
+# H/I. The regression this exists for. An ACME leaf chains to a PUBLIC root the
+#      system store already holds, and --cacert REPLACES that store -- so naming
+#      FOG's root removes the only trust that would have worked.
+reset_env; acmeLeaf="yes"
+_resolveSelfCacert
+check "${#selfCacertOpts[@]}" "0" "H: no --cacert when acmeLeaf=yes"
+
+reset_env; publicWebCert="yes"
+_resolveSelfCacert
+check "${#selfCacertOpts[@]}" "0" "I: no --cacert when publicWebCert=yes"
+
+# J. The ordinary FOG-issued install still pins to FOG's own anchor.
+reset_env
+_resolveSelfCacert
+check "${selfCacertOpts[0]}" "--cacert" "J: still anchors on a FOG-issued install"
+
+echo "== the liveness/secret split (source-level) =="
+
+# K. GH-1169's actual fix. The schema POST carries an install token that grants
+#    a schema deploy on a server with no users yet; it must never fall back to
+#    skipping verification, however convenient that would be.
+schemaLine=$(grep -n 'X-Fog-Install-Token' "$FUNCS" | grep 'curl' | head -1)
+if [[ -n $schemaLine && $schemaLine != *" -k "* && $schemaLine != *"-sk"* ]]; then
+    ok "K: the token-carrying schema POST does not pass -k"
+else
+    bad "K: the schema POST appears to skip verification"
+fi
+
+# L. The probe's insecure retry is a diagnostic and must stay inside the TLS
+#    branch -- a blanket retry would re-hide the empty-body case this check was
+#    written for (forums topic 18204).
+if awk '/^checkWebTier\(\) \{/,/^\}/' "$FUNCS" | grep -q 'advice == tls' \
+   && awk '/advice == tls/,/^    fi/' "$FUNCS" | grep -q 'curl -sS -k'; then
+    ok "L: checkWebTier's insecure retry is guarded to the TLS branch"
+else
+    bad "L: could not confirm the retry is TLS-only"
+fi
+
+# M. Every self-call addresses the name, not the address.
+if ! awk '/^checkWebTier\(\) \{/,/^\}/' "$FUNCS" | grep -q 'probeUrl=.*\${ipaddress}'; then
+    ok "M: checkWebTier dials the resolved name, not \$ipaddress"
+else
+    bad "M: checkWebTier still dials \$ipaddress"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## What broke

An update on a live Let's Encrypt server aborted at `checkWebTier` with `curl exit 60`. Because that check `exit 1`s at `installfog.sh:1231`, **everything downstream was skipped**:

```
1231:  checkWebTier             ← exit 1
1233:  updateDB                 ← schema migration
1283:  _publishLocalBootFiles   ← the ESP archives
```

New web code deployed against an un-migrated schema, and the run still printed `Done!` on its way out.

## Why

#1169 was right to stop these three self-calls passing `-k` — the schema POST carries `X-Fog-Install-Token`, which grants a schema deploy on a server with no users yet, and `-k` handed it to whatever answered. What it verified *against* was the problem.

`_resolveSelfCacert()`'s own comment states the two halves — *"the served chain must terminate in the anchor this resolves, and the leaf must cover that address"* — and asserts FOG-issued certificates satisfy both. They do. Nothing else does, and on a public certificate **both fail together**. Measured on the affected server:

```
subject=CN=fog.arrowheaddental.com
issuer=C=US, O=Let's Encrypt, CN=YE2
SAN: five DNS names, no IP entry at all
```

The chain terminates in a public root, not `$rootCAPem`, and `--cacert` **replaces** curl's bundle rather than adding to it — so naming FOG's root did not add trust, it removed the only trust that would have worked. And no public CA issues for an address, so dialling `$ipaddress` failed the name check as well.

Not intermittent — unsatisfiable, on every install of that shape.

This only became reachable when `httpproto` went `https` for everyone in #1123, since `_resolveSelfCacert()` returns early on `http`. Neither change is wrong alone.

## What changed

**`_servedCertName()`** reads the CN off the certificate actually being served. One rule covers both cases without a new setting: a FOG-issued leaf carries `CN=$hostname` because `_createWebLeaf()` sets exactly that, and a public one carries whatever was issued.

The **vhost is asked first**, and that ordering is the point — where the certificate is managed outside FOG, `$sslpubcert` still names FOG's own leaf while the web server serves somebody else's, so reading FOG's copy answers confidently with a name nobody is being shown. Falling back to `$hostname` converges rather than guesses: it is the same answer one step early, before `configureHttpd` has written a leaf. `$ipaddress` stays last, and is only ever right for a FOG-issued certificate.

**`_resolveSelfCacert()`** now leaves `--cacert` off entirely when the leaf was issued outside FOG (`acmeLeaf`/`publicWebCert`). The system store already holds that root; replacing it is what broke the case.

**`checkWebTier`** stops guessing at the cause. Every outcome printed the same "almost always a PHP fatal" advice — including a handshake rejected before any response existed to be empty, which reads as a dead site and sends an admin to the PHP error log for a trust problem. Exits are classified now, `%{http_code}` is captured so a 500 is named as a 500, and on a TLS failure the probe retries **once** with `-k` purely to establish whether the tier renders. If it does, the install continues with a warning naming the likely causes: trust is not liveness, and this check exists to catch a dead site, not an undeclared certificate.

That retry carries no credential — body written to a temp file, read for its size, deleted. The schema POST beside it still refuses to degrade.

## Tests

`tests/selfcall-verification.test.sh`, 13 assertions. **Ten fail against the previous code.** The three that pass are behaviour deliberately preserved — no `--cacert` on plain HTTP, anchoring still applied on a FOG-issued install, and the schema POST still verifying — which is the honest split rather than a restatement.

Two existing guards needed updating rather than loosening, both with the reason written into the test:

- `installer-tls-verification` allowlists the diagnostic retry by `probeUrl` and pins the count at five instead of four. Its check 2 — that the token-carrying POST does not degrade — is untouched and still passing.
- `network-fetch-bounded` excludes `selfName` the way it already excludes `ipaddress`. That rename did not turn a loopback POST into a remote fetch.

Full suite: **57 passed, 0 failed.**

## Not in this PR

Deliberately scoped to unbreaking these installs. Left for a follow-up:

- **Detecting external certificate management.** `acmeLeaf` is still hand-declared only (`functions.sh:4909`, *"Set BY HAND in .fogsettings"*), so an unattended `-y` run has nothing telling it a certificate is managed by `acme.sh` or `certbot`. Detection should *declare* it — persisting the cert paths and keeping FOG managing the vhost — rather than abdicate via `novhost=yes`.
- **The vhost's own `ServerName`.** Still `$ipaddress`, with the name demoted to an alias, while the certificate is name-first. Correcting that touches Apache vhost selection and wants its own commit, fallback and test. Every IP must stay as an alias — an IP-configured client talks over HTTP, and it is the general failsafe.

No REST route or `Route::$validClasses` change, so no `OpenAPI::document()` update and no FogApi class-list sync.

## Verification still owed

Hardware/live: an update on the affected server completing through `updateDB` without touching the Let's Encrypt leaf. Not yet run — the box is mid-incident and the workaround there is `installfog.sh -X`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtAqkznJ3qnh166rx7Adhq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtAqkznJ3qnh166rx7Adhq)_