### PR TITLE
Ship plugins v1.6.9

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.8');
+        define('FOG_PLUGINS_VERSION', 'v1.6.9');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
The installer reads `FOG_PLUGINS_VERSION` to decide which `fog-plugins` release
to download, so a merged plugin change reaches no server until this moves.

[v1.6.9](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.9) carries
three OIDC changes, and two of them are the plugin half of seams that landed
here:

| Plugin PR | What it does | Core seam |
|---|---|---|
| fog-plugins#16 | Refresh the account from the provider on every sign-in — the display name used to be written once, at first sign-in, and never again | — |
| fog-plugins#18 (issue #15) | Single logout, off by default per provider | `USER_LOGGING_OUT` return value (#1174) |
| fog-plugins#19 (issue #17) | Send the login page straight to the provider, off by default per provider | `LOGIN_PAGE_REDIRECT` (#1175) |

So this pin is what makes #1174 and #1175 do anything at all: without it both
seams are present, correct, and unconsumed.

The forced-redirect setting's escape hatch is `management/login.php`, which
#1175 added here — one URL that always renders FOG's own form and never routes
to an identity provider.

`sh tests/run-all.sh` → **59 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
