### PR TITLE
Detect an externally-managed web certificate, and make the vhost name-first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,35 @@ The web root the user edits live is `/var/www/fog/` (symlinked to `/var/www/html
 
 Net effect: a typical commit will also include a `system.class.php` version bump, and often `messages.pot` + `.po` churn and/or PSR-2 reformatting. Expect it; don't be surprised by the extra files.
 
+### Commit authorship
+
+Commits are **authored by the maintainer and co-authored by the agent**, not the
+other way round. Set this per-clone before committing:
+
+```bash
+git config user.name  "JJ Fullmer"
+git config user.email "7743340+darksidemilk@users.noreply.github.com"
+```
+
+That address is the GitHub noreply for `darksidemilk` and is what the existing
+history already uses (`git log --author=darksidemilk`) — don't invent a variant,
+and don't fall back to `Claude <noreply@anthropic.com>` as the author.
+
+Then end the message with a co-author trailer:
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+No model name in the trailer, and no model identifier anywhere else in a commit
+message, PR title/body, or code comment. Some older commits in this history do
+carry one (`Claude Opus 5`); they are not the pattern to copy.
+
 ---
 
 ## Directory Structure
+
+
 
 ```
 fogproject/

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -13,7 +13,7 @@ mechanics here — that is the same split `PKI_ZONES.md` and
 
 ---
 
-## The three kinds of key
+## The four kinds of key
 
 Every managed key is one of these, and confusing them is the source of most bugs
 in this area:
@@ -22,11 +22,25 @@ in this area:
 |---|---|---|
 | **Preference** | The admin's decision. Persisted so it survives an upgrade, and *nothing* may silently reverse it | `secureboot`, `catrust`, `fwconfigure`, `fog_update_channel`, `internalSubnets`, `kernelBackupGenerations` |
 | **Record** | Written so it can be read back for reference. The installer recomputes the real value every run and ignores what is stored | `fogprogramdir`, `fog_git_path`, `packages`, `php_ver` |
-| **Hand-set** | Nothing in the installer writes it; it survives only because the merge preserves unknown lines | `acmeLeaf`, `snmysqlexternal`, `dhcpengine`, `tftpAdvOpts`, `inetConnectTimeout` |
+| **Hand-set** | Nothing in the installer writes it; it survives only because the merge preserves unknown lines | `snmysqlexternal`, `dhcpengine`, `tftpAdvOpts`, `inetConnectTimeout` |
+| **Inferred preference** | A preference the installer may write *once* from what it observed, and then treats as the admin's | `acmeLeaf`, `webCertFile`, `webKeyFile`, `httpsRedirect` |
 
 The preference/record distinction is load-bearing. A preference that gets
 recomputed is a setting the admin cannot make stick; a record that gets trusted
 is a stale path silently relocating the install. Both have shipped as bugs.
+
+**An inferred preference is written once and never re-derived.** `acmeLeaf` used
+to be hand-set only, and forgetting it was expensive: `createSSLCA()` regenerated
+the web leaf from the original CSR while the private key on disk was an ACME key,
+leaving a mismatched pair and a web server that would not start. So the installer
+now infers it from evidence about the certificate itself and records it, together
+with `webCertFile`/`webKeyFile` naming the files it found.
+
+The guard that makes this a preference rather than a measurement is the same one
+`httpsRedirect` uses: the inference is skipped entirely once the key has a value.
+Re-deriving every run would let a heuristic overrule an admin who cleared it,
+which is the failure mode a *record* has and a preference must not. Clearing all
+three by hand is the documented way back to FOG managing the leaf.
 
 **Hand-set keys work because of ordering**, not because anything supports them:
 `lib/common/config.sh` guards its defaults with `[[ -z $x ]]`, and `.fogsettings`

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4440,15 +4440,8 @@ _resolveTrustAnchor() {
 _servedCertName() {
     local cert cn candidate
     local -a candidates=()
-    if [[ -n $etcconf && -f $etcconf ]]; then
-        # ssl_certificate_key and SSLCertificateKeyFile do NOT match: both
-        # patterns require whitespace immediately after the directive name, and
-        # those two continue with '_' and 'K'. Same reason SSLCertificateChainFile
-        # is excluded -- it is the chain, not the leaf whose subject we want.
-        candidate=$(grep -aoiE '^[[:space:]]*(SSLCertificateFile|ssl_certificate)[[:space:]]+[^;[:space:]]+' "$etcconf" 2>/dev/null \
-            | awk '{print $NF}' | head -1)
-        [[ -n $candidate ]] && candidates+=("$candidate")
-    fi
+    candidate=$(_vhostCertPath)
+    [[ -n $candidate ]] && candidates+=("$candidate")
     candidates+=("$sslpubcert" "$sslfullchain")
     for cert in "${candidates[@]}"; do
         [[ -n $cert && -f $cert ]] || continue
@@ -5063,6 +5056,14 @@ writeUpdateFile() {
         # CSR (stale public key) while the private key on disk is the ACME
         # key, producing a cert/key mismatch that stops the web server.
         acmeLeaf
+        # Where the externally-managed leaf and its key actually live, captured
+        # from the vhost the admin wrote. Persisted because FOG regenerates the
+        # vhost on every run: without these it would re-emit its OWN
+        # $sslpubcert, pointing the web server at a certificate whose key is not
+        # the one on disk. Empty on an ordinary install, which means "FOG's
+        # own". Only ever written alongside acmeLeaf=yes.
+        webCertFile
+        webKeyFile
         # How many prior kernel/init generations backupPreservedCustomizations()
         # keeps under customizations/kernel-backups. A genuine persisted
         # preference like fog_update_channel, not a record: an admin who chose
@@ -6663,6 +6664,121 @@ endManagedVhost() {
     unset vhostfinal vhostprior
     return $st
 }
+# The certificate path the live vhost actually serves, or empty.
+#
+# Shared by _servedCertName() above and _detectExternalCertManagement() below,
+# which both need it and would otherwise drift apart on the directive-matching.
+_vhostCertPath() {
+    [[ -n $etcconf && -f $etcconf ]] || return 0
+    # ssl_certificate_key and SSLCertificateKeyFile do NOT match: both patterns
+    # require whitespace immediately after the directive name, and those two
+    # continue with '_' and 'K'. SSLCertificateChainFile is excluded for the
+    # same reason -- it is the chain, not the leaf.
+    grep -aoiE '^[[:space:]]*(SSLCertificateFile|ssl_certificate)[[:space:]]+[^;[:space:]]+' "$etcconf" 2>/dev/null \
+        | awk '{print $NF}' | head -1
+}
+# The private-key path the live vhost names, or empty. Companion to
+# _vhostCertPath(); kept separate because the two directives differ per server.
+_vhostKeyPath() {
+    [[ -n $etcconf && -f $etcconf ]] || return 0
+    grep -aoiE '^[[:space:]]*(SSLCertificateKeyFile|ssl_certificate_key)[[:space:]]+[^;[:space:]]+' "$etcconf" 2>/dev/null \
+        | awk '{print $NF}' | head -1
+}
+# Whether the certificate this server serves is managed OUTSIDE FOG.
+#
+# acmeLeaf has always been the answer to that question and has always had to be
+# typed into .fogsettings by hand. The cost of forgetting is not cosmetic:
+# createSSLCA() regenerates the leaf from the ORIGINAL CSR, so an install whose
+# private key on disk is an ACME key ends up with a cert/key mismatch and a web
+# server that will not start. An unattended `-y` upgrade did that silently,
+# which is the whole reason this exists.
+#
+# Echoes a reason and returns 0 when the certificate FOG is about to touch is
+# demonstrably not FOG's own; returns 1 otherwise.
+#
+# Only STRONG signals answer yes, and every one of them is about the
+# certificate itself. The presence of acme.sh or certbot on the box is
+# deliberately NOT among them: plenty of servers run either for an unrelated
+# domain, and treating that as proof would stop FOG managing a leaf it really
+# does issue -- a false positive that costs an admin their renewals. Tooling is
+# reported by _warnExternalCertTooling() instead, which advises and changes
+# nothing. Vhost drift is likewise only advisory: an admin may have edited the
+# vhost for reasons that have nothing to do with the certificate.
+_detectExternalCertManagement() {
+    local p leaf vhostcert
+    # 1. FOG pointed at a file inside an ACME client's tree. The most direct
+    #    evidence available -- somebody already told FOG to use their leaf.
+    for p in "$sslprivkey" "$sslpubcert"; do
+        [[ -n $p ]] || continue
+        case "$p" in
+            /etc/letsencrypt/*|*/.acme.sh/*|/etc/dehydrated/*)
+                echo "$p is inside an ACME client's tree"
+                return 0
+                ;;
+        esac
+    done
+    # 2. The live vhost serving a leaf from outside $sslpath. FOG issues into
+    #    $sslpath and nowhere else, so anywhere else is the admin's file. This
+    #    is the signal that fires on a novhost=yes install, where FOG never
+    #    wrote the vhost and $sslpubcert still names FOG's own unused leaf.
+    vhostcert=$(_vhostCertPath)
+    if [[ -n $vhostcert && -n $sslpath && $vhostcert != "$sslpath"* ]]; then
+        echo "the vhost serves $vhostcert, outside FOG's $sslpath"
+        return 0
+    fi
+    # 3. A leaf sitting at FOG's own path that FOG's own CA did not sign --
+    #    _createCommLeaf() documents dropping a certificate in place as a
+    #    supported thing to do, so this is a real configuration and not an
+    #    error. Decided by verification rather than by matching "FOG" in the
+    #    issuer name, because an admin can rename their CA and a public issuer
+    #    can be called anything.
+    #
+    #    -trusted, not -CAfile: -CAfile ADDS to curl's default locations
+    #    instead of replacing them, and _installCATrustAnchor() puts FOG's own
+    #    CA into this host's store -- so a -CAfile test can answer "verified"
+    #    out of the system store rather than out of the file it was handed.
+    #    Same reasoning as _createWebLeaf()'s own check.
+    leaf="$vhostcert"
+    [[ -n $leaf && -f $leaf ]] || leaf="$sslpubcert"
+    if [[ -n $leaf && -f $leaf && -n $rootCAPem && -f $rootCAPem ]] \
+        && command -v openssl >/dev/null 2>&1; then
+        if ! openssl verify -trusted "$rootCAPem" \
+            ${sslcachain:+-untrusted "$sslcachain"} "$leaf" >/dev/null 2>&1; then
+            echo "$leaf does not chain to this server's own CA"
+            return 0
+        fi
+    fi
+    return 1
+}
+# Advisory only. Names tooling and vhost drift that MIGHT mean the certificate
+# is managed elsewhere, without concluding it -- see the comment above for why
+# neither is allowed to set acmeLeaf on its own.
+_warnExternalCertTooling() {
+    local -a notes=()
+    if command -v acme.sh >/dev/null 2>&1 \
+        || [[ -x $HOME/.acme.sh/acme.sh || -x /root/.acme.sh/acme.sh ]]; then
+        notes+=("acme.sh is installed")
+    fi
+    if command -v certbot >/dev/null 2>&1 \
+        || [[ -d /etc/letsencrypt/live ]] && [[ -n $(ls -A /etc/letsencrypt/live 2>/dev/null) ]]; then
+        notes+=("certbot or /etc/letsencrypt/live is present")
+    fi
+    # Drift: the file exists, has content, and carries none of FOG's markers.
+    if [[ -n $etcconf && -s $etcconf ]] \
+        && ! grep -qF "$FOG_MANAGED_BEGIN" "$etcconf" 2>/dev/null; then
+        notes+=("$etcconf carries no FOG managed block, so it was authored by hand")
+    fi
+    [[ ${#notes[@]} -eq 0 ]] && return 0
+    local n
+    echo " * Note: this server's web certificate looks FOG-issued, but:"
+    for n in "${notes[@]}"; do
+        echo "     - $n"
+    done
+    echo "   If that certificate is in fact managed elsewhere, set"
+    echo "   acmeLeaf=\"yes\" in $fogprogramdir/.fogsettings so FOG stops"
+    echo "   re-issuing it. FOG will keep managing the vhost either way."
+    return 0
+}
 createSSLCA() {
     # This function also emits the web server vhost further down, and those
     # nginx location / apache LocationMatch blocks used to hardcode ^/fog/ --
@@ -6677,6 +6793,49 @@ createSSLCA() {
     [[ ! -d $sslpath/CA ]] && mkdir -p $sslpath/CA >>$error_log 2>&1
     _collectPkiNames
     _resolveRootCA
+    # Detect-then-DECLARE, before anything below decides whether to issue a
+    # leaf. The point is not to hand the vhost back to the admin -- FOG goes on
+    # managing the redirect, the iPXE exclusions and HSTS, which nobody wants to
+    # hand-maintain. It is only to stop re-issuing a certificate FOG did not
+    # issue, which createSSLCA() would otherwise do from the ORIGINAL CSR and
+    # leave the web server unable to start.
+    #
+    # No prompt. Under -y there is nobody to ask, and that is exactly the run
+    # that used to do the damage silently, so the safe behaviour has to be the
+    # DEFAULT rather than an answer. Everything needed is already on disk: the
+    # vhost names the files and the certificate names itself.
+    if [[ $acmeLeaf != yes ]]; then
+        local extReason=""
+        if extReason=$(_detectExternalCertManagement); then
+            acmeLeaf="yes"
+            webCertFile=$(_vhostCertPath)
+            webKeyFile=$(_vhostKeyPath)
+            # Fall back to whatever FOG was already pointed at -- signal 1 of
+            # the detector is exactly the case where those ARE the admin's
+            # files and the vhost may not exist yet.
+            [[ -z $webCertFile ]] && webCertFile="$sslpubcert"
+            [[ -z $webKeyFile ]] && webKeyFile="$sslprivkey"
+            echo " * Detected a web certificate managed outside FOG:"
+            echo "     $extReason"
+            echo " * Recording acmeLeaf=\"yes\" in .fogsettings. FOG will keep"
+            echo "   managing this vhost, but will not re-issue or re-key that"
+            echo "   certificate. Undo by clearing acmeLeaf/webCertFile/webKeyFile."
+        else
+            _warnExternalCertTooling
+        fi
+    fi
+    # Re-emit exactly what the vhost already said rather than FOG's own paths.
+    # Doing it by reassignment here means all four vhost arms below need no
+    # change, and _hardenPkiPermissions already exempts acmeLeaf from locking
+    # the key to root:root 0600 out from under whatever renews it.
+    if [[ $acmeLeaf == yes && -n $webCertFile && -f $webCertFile ]]; then
+        sslpubcert="$webCertFile"
+        # nginx's ssl_certificate must BE the concatenated chain, and the file
+        # we captured is whatever that directive already named -- so it is
+        # correct for nginx by construction and must not be second-guessed.
+        sslfullchain="$webCertFile"
+        [[ -n $webKeyFile && -f $webKeyFile ]] && sslprivkey="$webKeyFile"
+    fi
     # An interface can carry several IPs, so $ipaddress may arrive as a list:
     # newline-separated from fresh detection, or space-separated when read back
     # from .fogsettings. A certificate has a single subject, so the first IP

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6684,6 +6684,42 @@ _vhostKeyPath() {
     grep -aoiE '^[[:space:]]*(SSLCertificateKeyFile|ssl_certificate_key)[[:space:]]+[^;[:space:]]+' "$etcconf" 2>/dev/null \
         | awk '{print $NF}' | head -1
 }
+# The vhost's primary name and its alias list, for both web servers.
+#
+# The certificate has been name-first for a while -- _createWebLeaf() issues
+# CN=$hostname with every address as an IP SAN -- but the vhost was still
+# address-first: ServerName was $ipaddress and the name was demoted to an alias.
+# That was harmless while nothing verified, and stopped being harmless when the
+# installer's own calls to itself started verifying: no public CA will issue for
+# an address, so an ACME server could not satisfy a check keyed on one.
+#
+# So the primary name comes from _servedCertName() -- the same value the
+# self-calls verify against, which is what keeps the vhost's identity and the
+# TLS identity from disagreeing. It falls back to $ipaddress when no name is
+# available, so a DNS-less lab install is unchanged.
+#
+# EVERY address stays, as an alias. That is deliberate and must not be tidied
+# away: on an ACME install the address will never verify over HTTPS, but a
+# client configured with the address still talks to FOG over HTTP, and the alias
+# is the general failsafe for anything addressing this server by number.
+#
+# One helper for both web servers, because the two used to compute this
+# separately and drifted -- see the sweep comment above _rewriteManagedNames().
+# ServerName takes exactly one name (GH-650: a second address on the same NIC
+# emitted a bare "10.0.0.2" line and apache refused to start), so the split
+# matters rather than being cosmetic.
+_resolveVhostNames() {
+    local n seen
+    vhostname=$(_servedCertName)
+    seen=" $vhostname "
+    vhostaliases=""
+    for n in $ipaddresses $hostname $extraServerNames; do
+        [[ -z $n ]] && continue
+        [[ " $seen " == *" $n "* ]] && continue
+        seen="$seen$n "
+        vhostaliases="${vhostaliases} ${n}"
+    done
+}
 # Whether the certificate this server serves is managed OUTSIDE FOG.
 #
 # acmeLeaf has always been the answer to that question and has always had to be
@@ -7026,6 +7062,8 @@ EOF
     for extraname in $extraServerNames; do
         extraServerNamesSuffix="${extraServerNamesSuffix} ${extraname}"
     done
+    # Name-first, addresses as aliases, for both web servers at once.
+    _resolveVhostNames
     case $webserver in
         nginx)
             case $novhost in
@@ -7064,7 +7102,7 @@ EOF
                     beginManagedVhost
                     echo "server {" > "$etcconf"
                     echo "    listen 80;" >> "$etcconf"
-                    echo "    server_name $ipaddresses $hostname${extraServerNamesSuffix};" >> "$etcconf"
+                    echo "    server_name ${vhostname}${vhostaliases};" >> "$etcconf"
                     # Whether :80 SERVES the site or redirects away from it is
                     # the redirect's decision, not $httpproto's. 443 listens
                     # either way -- see the ssl server block emitted in both
@@ -7129,7 +7167,7 @@ EOF
                         fi
                         echo "server {" >> "$etcconf"
                         echo "    listen $ipaddress:443 ssl${nginxhttp2listen};" >> "$etcconf"
-                        echo "    server_name $ipaddresses $hostname${extraServerNamesSuffix};" >> "$etcconf"
+                        echo "    server_name ${vhostname}${vhostaliases};" >> "$etcconf"
                         echo "    root ${docroot};" >> "$etcconf"
                         echo "    index index.html index.htm index.php;" >> "$etcconf"
                         echo "    client_max_body_size 3000m;" >> "$etcconf"
@@ -7283,7 +7321,7 @@ EOF
                         fi
                         echo "server {" >> "$etcconf"
                         echo "    listen $ipaddress:443 ssl${nginxhttp2listen};" >> "$etcconf"
-                        echo "    server_name $ipaddresses $hostname${extraServerNamesSuffix};" >> "$etcconf"
+                        echo "    server_name ${vhostname}${vhostaliases};" >> "$etcconf"
                         echo "    root ${docroot};" >> "$etcconf"
                         echo "    index index.html index.htm index.php;" >> "$etcconf"
                         echo "    client_max_body_size 3000m;" >> "$etcconf"
@@ -7395,9 +7433,6 @@ EOF
                     # exactly one name; the extras go on ServerAlias, which is
                     # variadic, so a multi-homed server still answers to every
                     # address it has.
-                    vhostname="$ipaddress"
-                    vhostaliases=$(echo $ipaddresses | awk '{for (i = 2; i <= NF; i++) printf " %s", $i}')
-                    vhostaliases="${vhostaliases}${extraServerNamesSuffix}"
                     mv -fv "${etcconf}" "${etcconf}.${timestamp}" >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                     # See the nginx branch above -- same scratch-file swap, so
                     # none of the write sites below change.
@@ -7420,7 +7455,7 @@ EOF
                     echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                     echo "    KeepAlive Off" >> "$etcconf"
                     echo "    ServerName $vhostname" >> "$etcconf"
-                    echo "    ServerAlias ${hostname}${vhostaliases}" >> "$etcconf"
+                    [[ -n $vhostaliases ]] && echo "    ServerAlias${vhostaliases}" >> "$etcconf"
                     # maintenance/ holds installer-only endpoints (a full DB dump,
                     # storage-node create/update). Each one gates itself on the
                     # request being same-machine, but the directory is only removed
@@ -7487,7 +7522,7 @@ EOF
                         # Keeps API basic auth working; see the :80 vhost.
                         echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                         echo "    ServerName $vhostname" >> "$etcconf"
-                        echo "    ServerAlias ${hostname}${vhostaliases}" >> "$etcconf"
+                        [[ -n $vhostaliases ]] && echo "    ServerAlias${vhostaliases}" >> "$etcconf"
                         # See the :80 vhost -- installer-only, same-machine only.
                         echo "    <LocationMatch \"^${webrootre}maintenance/\">" >> "$etcconf"
                         echo "        Require local" >> "$etcconf"
@@ -7614,7 +7649,7 @@ EOF
                         # Keeps API basic auth working; see the :80 vhost.
                         echo "    SetEnvIf Authorization \"(.+)\" HTTP_AUTHORIZATION=\$1" >> "$etcconf"
                         echo "    ServerName $vhostname" >> "$etcconf"
-                        echo "    ServerAlias ${hostname}${vhostaliases}" >> "$etcconf"
+                        [[ -n $vhostaliases ]] && echo "    ServerAlias${vhostaliases}" >> "$etcconf"
                         # See the :80 vhost -- installer-only, same-machine only.
                         echo "    <LocationMatch \"^${webrootre}maintenance/\">" >> "$etcconf"
                         echo "        Require local" >> "$etcconf"

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Guards the installer's detection of a web certificate it does not own.
+#
+#   tests/external-cert-detection.test.sh
+#
+# acmeLeaf tells createSSLCA() to leave the web leaf alone. It has always had to
+# be typed into .fogsettings by hand, and the cost of forgetting is not
+# cosmetic: the leaf gets regenerated from the ORIGINAL CSR while the private
+# key on disk is the ACME key, producing a cert/key mismatch that stops the web
+# server. An unattended `-y` upgrade did that silently.
+#
+# So detection has to be right in BOTH directions, and both are pinned here.
+# Missing a real external certificate breaks a working server. Falsely claiming
+# one stops FOG managing a leaf it does issue, which quietly ends that server's
+# renewals. That is why the presence of acme.sh or certbot is deliberately NOT
+# proof -- plenty of servers run either for an unrelated domain.
+#
+# Needs openssl. Runs entirely on generated fixtures -- no install, no network,
+# no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()    { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()   { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# --- fixture: a FOG CA, a leaf it signed, and an unrelated self-signed leaf ---
+mkdir -p "$WORK/ssl" "$WORK/foreign"
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=FOG Server CA" \
+    -keyout "$WORK/ssl/ca.key" -out "$WORK/ssl/ca.pem" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -subj "/CN=fog.example.org" \
+    -keyout "$WORK/ssl/leaf.key" -out "$WORK/ssl/leaf.csr" >/dev/null 2>&1
+openssl x509 -req -in "$WORK/ssl/leaf.csr" -CA "$WORK/ssl/ca.pem" -CAkey "$WORK/ssl/ca.key" \
+    -days 1 -out "$WORK/ssl/leaf.pem" >/dev/null 2>&1
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=fog.example.org" \
+    -keyout "$WORK/foreign/priv.key" -out "$WORK/foreign/fullchain.pem" >/dev/null 2>&1
+
+reset_env() {
+    etcconf=""; sslpath="$WORK/ssl"; rootCAPem="$WORK/ssl/ca.pem"; sslcachain=""
+    sslpubcert="$WORK/ssl/leaf.pem"; sslprivkey="$WORK/ssl/leaf.key"
+    acmeLeaf=""; publicWebCert=""
+    error_log="$WORK/error.log"
+}
+
+echo "== _detectExternalCertManagement: says yes only on real evidence =="
+
+# A. The genuine FOG install. Detection MUST stay quiet -- a false positive here
+#    stops FOG re-issuing its own leaf and silently ends its renewals.
+reset_env
+if _detectExternalCertManagement >/dev/null; then
+    bad "A: fired on a FOG-issued leaf at FOG's own path"
+else
+    ok "A: stays quiet on a genuine FOG-issued leaf"
+fi
+
+# B. FOG pointed straight at an ACME client's tree.
+reset_env
+sslpubcert="/etc/letsencrypt/live/fog.example.org/fullchain.pem"
+out=$(_detectExternalCertManagement) && ok "B: fires when \$sslpubcert is under /etc/letsencrypt" \
+    || bad "B: missed a path inside an ACME tree"
+[[ $out == *"ACME client's tree"* ]] && ok "B2: names the ACME tree as the reason" \
+    || bad "B2: reason did not name the ACME tree (got '$out')"
+
+# C. The novhost=yes shape -- FOG never wrote the vhost, $sslpubcert still names
+#    FOG's own unused leaf, and the web server serves somebody else's file.
+reset_env
+etcconf="$WORK/hand.conf"
+printf '<VirtualHost *:443>\n    SSLCertificateFile %s\n    SSLCertificateKeyFile %s\n</VirtualHost>\n' \
+    "$WORK/foreign/fullchain.pem" "$WORK/foreign/priv.key" > "$etcconf"
+out=$(_detectExternalCertManagement) && ok "C: fires when the vhost serves a cert outside \$sslpath" \
+    || bad "C: missed a vhost-served cert outside \$sslpath"
+[[ $out == *"outside FOG's"* ]] && ok "C2: reason names the path and \$sslpath" \
+    || bad "C2: reason did not name the path (got '$out')"
+
+# D. A foreign leaf dropped AT FOG's own path. _createCommLeaf documents that as
+#    supported, so it is a real configuration -- decided by verification, not by
+#    matching "FOG" in the issuer name, since a CA can be renamed.
+reset_env
+cp "$WORK/foreign/fullchain.pem" "$WORK/ssl/leaf-foreign.pem"
+sslpubcert="$WORK/ssl/leaf-foreign.pem"
+out=$(_detectExternalCertManagement) && ok "D: fires on a leaf that does not chain to FOG's CA" \
+    || bad "D: missed a foreign leaf sitting at FOG's own path"
+
+# E. Already declared -- the caller skips detection entirely, so an admin who
+#    set acmeLeaf by hand is never second-guessed.
+if awk '/Detect-then-DECLARE/,/_warnExternalCertTooling/' "$FUNCS" | grep -q 'acmeLeaf != yes'; then
+    ok "E: detection is skipped when acmeLeaf is already declared"
+else
+    bad "E: detection does not check acmeLeaf first"
+fi
+
+echo "== the paths are captured, and captured from the vhost =="
+
+# F/G. Both directive spellings, so an nginx server is read as well as apache.
+reset_env
+etcconf="$WORK/nginx.conf"
+printf 'server {\n    ssl_certificate %s;\n    ssl_certificate_key %s;\n}\n' \
+    "$WORK/foreign/fullchain.pem" "$WORK/foreign/priv.key" > "$etcconf"
+check "$(_vhostCertPath)" "$WORK/foreign/fullchain.pem" "F: _vhostCertPath reads nginx ssl_certificate"
+check "$(_vhostKeyPath)"  "$WORK/foreign/priv.key"      "G: _vhostKeyPath reads nginx ssl_certificate_key"
+
+# H. The cert directive must not swallow the key directive, in either spelling.
+reset_env
+etcconf="$WORK/apache2.conf"
+printf '    SSLCertificateKeyFile %s\n    SSLCertificateFile %s\n' \
+    "$WORK/foreign/priv.key" "$WORK/foreign/fullchain.pem" > "$etcconf"
+check "$(_vhostCertPath)" "$WORK/foreign/fullchain.pem" "H: KeyFile listed first is not read as the cert"
+
+# I. Persisted, or FOG re-emits its own paths on the next run and points the web
+#    server at a certificate whose key is not the one on disk.
+for k in webCertFile webKeyFile; do
+    if awk '/managedKeys=/,/^    \)/' "$FUNCS" | grep -qE "^\s*$k\s*$"; then
+        ok "I: $k is in managedKeys"
+    else
+        bad "I: $k is not persisted"
+    fi
+done
+
+# J. No prompt on the detect path. Under -y there is nobody to answer, and that
+#    is precisely the run that used to do the damage, so the safe behaviour must
+#    be the default rather than an answer to a question.
+if awk '/Detect-then-DECLARE/,/_warnExternalCertTooling/' "$FUNCS" | grep -qE '(^|[^_[:alnum:]])read($|[[:space:]])'; then
+    bad "J: the detect path prompts, so an unattended run cannot benefit"
+else
+    ok "J: detection never prompts"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/vhost-servername.test.sh
+++ b/tests/vhost-servername.test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Guards the vhost's primary name and its alias list.
+#
+#   tests/vhost-servername.test.sh
+#
+# _createWebLeaf() has issued CN=$hostname with every address as an IP SAN for a
+# while, so the certificate has been name-first. The vhost was not: ServerName
+# was $ipaddress and the name was demoted to an alias. Harmless while nothing
+# verified -- and not harmless once the installer's own calls to itself started
+# verifying, because no public CA will issue for an address.
+#
+# Two properties are pinned, and the second is the one most likely to be
+# "tidied" away by someone reading the first:
+#
+#   1. the primary name is the certificate's name, falling back to the address
+#      only when no name is available (a DNS-less lab install);
+#   2. EVERY address stays as an alias, including on an ACME install where it can
+#      never verify over HTTPS. A client configured with the address still talks
+#      to FOG over HTTP, and the alias is the general failsafe for anything
+#      addressing this server by number.
+#
+# Also pins that ServerName gets exactly one name. GH-650: a second address on
+# the same NIC emitted a bare "10.0.0.2" line of its own and apache refused to
+# start, failing the install at "Starting and checking status of web services".
+#
+# Needs openssl. Runs entirely on generated fixtures -- no install, no network,
+# no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()    { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()   { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+has()   { [[ " $1 " == *" $2 "* ]] && ok "$3" || bad "$3 (not in '$1')"; }
+hasnt() { [[ " $1 " != *" $2 "* ]] && ok "$3" || bad "$3 (unexpectedly in '$1')"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=fog.example.org" \
+    -keyout "$WORK/leaf.key" -out "$WORK/leaf.pem" >/dev/null 2>&1
+
+reset_env() {
+    etcconf=""; sslpubcert=""; sslfullchain=""
+    hostname=""; ipaddress=""; ipaddresses=""; extraServerNames=""
+    vhostname=""; vhostaliases=""
+    error_log="$WORK/error.log"
+}
+
+echo "== name first, addresses as aliases =="
+
+# A/B/C. The ordinary multi-homed server with a certificate.
+reset_env
+sslpubcert="$WORK/leaf.pem"
+hostname="fog.example.org"
+ipaddress="10.0.0.1"; ipaddresses="10.0.0.1 10.0.0.2"
+_resolveVhostNames
+check "$vhostname" "fog.example.org" "A: ServerName is the certificate's name, not the address"
+has "$vhostaliases" "10.0.0.1" "B: the FIRST address is still an alias"
+has "$vhostaliases" "10.0.0.2" "C: the second address is an alias too"
+
+# D. ServerName must not repeat in the aliases -- apache warns on a duplicate,
+#    and nginx treats a repeated server_name as a conflict.
+hasnt "$vhostaliases" "fog.example.org" "D: the primary name is not repeated as an alias"
+
+# E. ServerName takes exactly one word. GH-650 is what happens otherwise.
+check "$(printf '%s' "$vhostname" | wc -w | tr -d ' ')" "1" "E: ServerName is a single name"
+
+# F. Admin extras ride along.
+reset_env
+sslpubcert="$WORK/leaf.pem"
+ipaddresses="10.0.0.1"; extraServerNames="fog.dmz.example.org images.example.org"
+_resolveVhostNames
+has "$vhostaliases" "fog.dmz.example.org"  "F: --extra-server-name reaches the aliases"
+has "$vhostaliases" "images.example.org"   "F2: every extra name, not just the first"
+
+echo "== the DNS-less fallback =="
+
+# G/H. No certificate and no hostname: the address becomes the primary name, and
+#      must NOT then also appear as an alias of itself.
+reset_env
+ipaddress="10.0.0.5"; ipaddresses="10.0.0.5"
+_resolveVhostNames
+check "$vhostname" "10.0.0.5" "G: falls back to the address when no name exists"
+hasnt "$vhostaliases" "10.0.0.5" "H: the fallback address is not aliased to itself"
+
+# I. hostname with no readable certificate still beats the address.
+reset_env
+hostname="fog.example.org"; ipaddress="10.0.0.5"; ipaddresses="10.0.0.5"
+_resolveVhostNames
+check "$vhostname" "fog.example.org" "I: \$hostname is preferred over the address"
+has "$vhostaliases" "10.0.0.5" "I2: and the address is aliased"
+
+echo "== emission (source-level) =="
+
+# J. An empty ServerAlias is an apache config error, and the alias list IS empty
+#    on a single-homed server with no name but its address (case G/H).
+if grep -q '\[\[ -n \$vhostaliases \]\] && echo "    ServerAlias\${vhostaliases}"' "$FUNCS"; then
+    ok "J: ServerAlias is only emitted when there is an alias to emit"
+else
+    bad "J: ServerAlias may be emitted empty"
+fi
+
+# K. nginx's server_name must lead with the primary name too, or the two web
+#    servers disagree about the server's identity again.
+if [[ $(grep -c 'server_name \${vhostname}\${vhostaliases};' "$FUNCS") -eq 3 ]]; then
+    ok "K: all three nginx server_name lines lead with the primary name"
+else
+    bad "K: an nginx server_name line still leads with the address"
+fi
+
+# L. Both web servers derive from ONE helper. They used to compute this
+#    separately, which is how they drifted apart in the first place.
+if [[ $(grep -c '_resolveVhostNames$' "$FUNCS") -eq 1 ]]; then
+    ok "L: the name split is computed once, for both web servers"
+else
+    bad "L: more than one call site computes the name split"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Follow-up to #1176, which fixed the immediate breakage. This does the two things that PR deliberately left out.

## 1. Detect a certificate FOG did not issue

`acmeLeaf` tells `createSSLCA()` to leave the web leaf alone, and it has only ever been settable by hand — `functions.sh` said so in as many words: *"Set BY HAND in .fogsettings"*.

The cost of not knowing is not cosmetic. The leaf gets regenerated from the **original CSR** while the private key on disk is the ACME key, so the pair no longer matches and **the web server will not start**. An unattended `-y` upgrade did that silently, on the one kind of install whose admin had gone furthest out of their way to configure TLS properly.

`_detectExternalCertManagement()` answers the question from what is already on disk — three signals, every one about the certificate itself:

- `$sslpubcert`/`$sslprivkey` inside an ACME client's tree — somebody already told FOG to use their file
- the live vhost serving a leaf from outside `$sslpath` — **this is the signal that fires on a `novhost=yes` server**, where FOG never wrote the vhost and `$sslpubcert` still names FOG's own unused leaf
- a leaf at FOG's own path that FOG's CA did not sign. `_createCommLeaf()` documents dropping a certificate in place as supported, so this is a real configuration. Decided by verification, not by matching "FOG" in the issuer name — a CA can be renamed and a public issuer can be called anything. `-trusted` not `-CAfile`, for the reason `_createWebLeaf()`'s own check gives.

**The presence of `acme.sh` or `certbot` is deliberately not among them.** Plenty of servers run either for an unrelated domain, and treating that as proof would stop FOG re-issuing a leaf it does issue — quietly ending that server's renewals, which is *worse* than the bug being fixed because nothing reports it for ninety days. Same for vhost drift: an admin may have edited the vhost for reasons unrelated to the certificate. Both are reported by `_warnExternalCertTooling()`, which advises and changes nothing.

### Declare, don't abdicate

The existing escape hatch is `novhost=yes`, which buys leaving one file alone at the price of hand-maintaining the redirect, the iPXE exclusions and HSTS forever.

So FOG records `acmeLeaf=yes` and **goes on managing the vhost** — it just stops re-issuing the leaf. `webCertFile`/`webKeyFile` join `managedKeys` holding the paths captured from the vhost, because the vhost is regenerated every run: without persisting them the next run re-emits FOG's own `$sslpubcert` and points the web server at a certificate whose key is not the one on disk. Applied by reassigning the three path vars once, so all four vhost arms need no change and `_hardenPkiPermissions` keeps its existing `acmeLeaf` exemption.

**No prompt anywhere on that path.** Under `-y` there is nobody to answer, and that is exactly the run that used to do the damage — so the safe behaviour has to be the default rather than an answer to a question. Everything needed is already readable: the vhost names the files and the certificate names itself.

## 2. Make the vhost name-first

`_createWebLeaf()` has issued `CN=$hostname` with each address as an IP SAN for a while, so the certificate has been name-first. The vhost was not: `ServerName` was `$ipaddress` and the name was demoted to an alias.

The primary name now comes from `_servedCertName()` — the same value #1176's self-calls verify against. That reuse is the point: the vhost's identity and the TLS identity cannot disagree if they are the same string. Falls back to `$ipaddress` when no name is available, so a DNS-less lab install is unchanged.

**Every address stays as an alias**, including the first, which `ServerName` used to consume. This is the half most likely to be "tidied" away by someone reading only the paragraph above: on an ACME install the address will never verify over HTTPS, but a client configured with the address still talks to FOG over HTTP, and the alias is the general failsafe for anything addressing this server by number. `vhost-servername.test.sh` case B exists to make removing it fail.

`_resolveVhostNames()` computes the split once for both web servers — they derived it separately before, which is how they drifted, and the sweep comment above `_rewriteManagedNames()` already said the two are meant to move together. GH-650's reasoning is preserved: `ServerName` takes exactly one name, and a second address emitted as a bare line is what made apache refuse to start.

Two things fall out: the alias list is deduplicated against the primary name (apache warns on a duplicate, nginx treats a repeated `server_name` as a conflict), and `ServerAlias` is emitted only when non-empty, since the list is genuinely empty on a single-homed server with no name but its address and an empty `ServerAlias` is a config error.

## Docs

`FOGSETTINGS.md` classed `acmeLeaf` as **Hand-set** — "nothing in the installer writes it" — which this makes false. `acmeLeaf`, `webCertFile`, `webKeyFile` and the already-unclassified `httpsRedirect` are a fourth kind: written by the installer from evidence, but only when unset, so they behave as the admin's decision thereafter. The guard is what makes it a preference rather than a record, and that distinction is load-bearing in that file rather than descriptive.

## Tests

| harness | assertions | fail against previous code |
|---|---|---|
| `external-cert-detection.test.sh` | 13 | 11 |
| `vhost-servername.test.sh` | 14 | 12 |

Detection is pinned in **both** directions, because they fail differently: missing a real external certificate breaks a working server, and falsely claiming one ends its renewals. Case A — a genuine FOG-issued leaf at FOG's own path must not trip anything — is the whole reason the weak signals stay advisory.

Full suite: **61 passed, 0 failed.**

## Downstream

- **fog-docs** — the per-key admin reference moved there in `6826fa2e8`, so `webCertFile`/`webKeyFile` need an entry. Not guessed at from this side.

No REST route or `Route::$validClasses` change, so no `OpenAPI::document()` update and no FogApi class-list sync.

## Verification still owed

Live: an update on an ACME server confirming detection fires, `acmeLeaf`/`webCertFile`/`webKeyFile` land in `.fogsettings`, the leaf is untouched, and the regenerated vhost still serves. Also an SELinux-enforcing host, and nginx — the fixtures cover both directive spellings but no real nginx has been reloaded against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtAqkznJ3qnh166rx7Adhq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtAqkznJ3qnh166rx7Adhq)_