### PR TITLE
Ship plugins v1.6.10

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.9');
+        define('FOG_PLUGINS_VERSION', 'v1.6.10');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Fixes where a successful OIDC single logout lands
([fog-plugins#20](https://github.com/FOGProject/fog-plugins/pull/20)).

With single logout and forced redirect both enabled, signing out left the person
on `management/login.php` — the break-glass page this branch added in #1175 —
rather than on FOG's ordinary login page. Single logout is exactly the case where
the provider session **has** been ended, so returning to the redirecting page is
right: the provider is asked again and prompts, which is how you sign out and
sign back in as somebody else.

Reported from a live install after #1177 shipped v1.6.9.

**⚠️ Admins who enabled single logout on v1.6.9 must re-register the post-logout
redirect URI at their provider** — it changes from `…/management/login.php` to
`…/management/index.php`. FOG prints the current value on the provider page.

`sh tests/run-all.sh` → **59 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
