### PR TITLE
Stop an empty certificate file producing a chain with no leaf

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6301,8 +6301,15 @@ _writeWebChainFiles() {
     local leafdir block subj issuer
     sslfullchain=""
     sslchainonly=""
-    [[ -n $sslpubcert && -f $sslpubcert ]] || return 0
-    [[ -n $sslcachain && -f $sslcachain ]] || return 0
+    # -s, not -f. An EMPTY certificate file passes -f, and cat'ing it into the
+    # bundle below contributes nothing -- producing a "full chain" that is only
+    # the CA. The web server then presents the CA as the leaf, whose key is not
+    # $sslprivkey, and refuses to start with "key values mismatch" while
+    # `nginx -t` on the very same config still passes. That took a live server
+    # down, and the leaf on disk was correct the whole time, so nothing about
+    # the failure pointed at the file that was actually wrong.
+    [[ -n $sslpubcert && -s $sslpubcert ]] || return 0
+    [[ -n $sslcachain && -s $sslcachain ]] || return 0
 
     leafdir="$(_pkiZoneDir web)/leaf"
     mkdir -p "$leafdir" >>$error_log 2>&1
@@ -6337,7 +6344,29 @@ _writeWebChainFiles() {
         rm -f "$chainonly" >>$error_log 2>&1
         return 0
     fi
-    cat "$sslpubcert" "$chainonly" > "$fullchain" 2>>$error_log || return 0
+    # Assemble beside the live file, not over it. This bundle is what the web
+    # server serves, so a bad one costs the server its start-up; keeping the
+    # previous chain is always better than installing a broken one.
+    cat "$sslpubcert" "$chainonly" > "${fullchain}.new" 2>>$error_log || return 0
+    # The first certificate in the bundle is the leaf the web server will pair
+    # with $sslprivkey. Check that here rather than let the web server discover
+    # it at start-up: openssl x509 reads only the first certificate, which is
+    # exactly the one being checked.
+    local leafpub keypub
+    leafpub=$(openssl x509 -in "${fullchain}.new" -noout -pubkey 2>>$error_log \
+        | openssl sha256 2>>$error_log)
+    keypub=""
+    [[ -n $sslprivkey && -s $sslprivkey ]] && \
+        keypub=$(openssl pkey -in "$sslprivkey" -pubout 2>>$error_log \
+            | openssl sha256 2>>$error_log)
+    if [[ -n $leafpub && -n $keypub && $leafpub != "$keypub" ]]; then
+        echo " * WARNING: assembled chain does not match $sslprivkey."
+        echo "   Keeping the existing ${fullchain} rather than installing one"
+        echo "   the web server would refuse to load."
+        rm -f "${fullchain}.new" >>$error_log 2>&1
+        return 0
+    fi
+    mv -f "${fullchain}.new" "$fullchain" >>$error_log 2>&1 || return 0
     chmod 0644 "$chainonly" "$fullchain" >>$error_log 2>&1
     sslchainonly="$chainonly"
     sslfullchain="$fullchain"


### PR DESCRIPTION
## What happened

A `--recreate-keys` style install run left nginx unable to start on a live 1.6 server:

```
nginx: [emerg] SSL_CTX_use_PrivateKey("/opt/fog/pki/web/leaf/.webLeaf.key") failed
(SSL: error:05800074:x509 certificate routines::key values mismatch)
```

The leaf on disk was fine. `.webLeaf.pem` and `.webLeaf.key` still matched each other and had not been written in a week. What was wrong was `.webFullChain.pem` — the file the vhost actually serves — which had come out **byte-for-byte identical to the CA**, 2204 bytes against the CA's 2204. It contained no leaf at all, so nginx presented the Web CA as the end-entity certificate and paired it with a key that was never the CA's.

## Cause

`_writeWebChainFiles()` guarded `$sslpubcert` with `-f`, then `cat`'d it into the bundle:

```bash
[[ -n $sslpubcert && -f $sslpubcert ]] || return 0
...
cat "$sslpubcert" "$chainonly" > "$fullchain"
```

`-f` is true for an **empty** file. An empty `$sslpubcert` passes the guard, contributes zero bytes to the `cat`, and the result is a "full chain" consisting only of the CA.

Two things made this hard to diagnose:

- Every error message names `.webLeaf.key`, which was correct. Nothing points at the bundle.
- `ExecStartPre=/usr/sbin/nginx -t` exited `0/SUCCESS` and `ExecStart` failed one second later on the same config, which reads like a transient fault rather than a bad certificate.

## Fix

- `-s` rather than `-f` on `$sslpubcert` and `$sslcachain`, so an empty file is treated as absent instead of as a certificate.
- Assemble the bundle beside the live file and verify its first certificate matches `$sslprivkey` before installing it. Keeping the previous chain always beats installing one the web server will refuse to load. `openssl x509` reads only the first certificate in a bundle, which is exactly the leaf being checked.

## Not fixed here

Why `$sslpubcert` was empty in the first place is a separate question. It is resolved from `.fogsettings` by `_resolveWebLeafPaths()`, which deliberately keeps any value that is not one of a known set of defaults, on the reasoning that an admin may have relocated the file. That default is still right — it just should not be able to produce a chain the server cannot load.

## Testing

- `bash -n lib/common/functions.sh` clean.
- Verified `[[ -f empty ]]` is true and `[[ -s empty ]]` is false.
- Verified the public-key comparison distinguishes a matching key from a non-matching one (matching pair compares equal; an unrelated key does not).
- Applied the equivalent repair to the affected server; nginx is running again.

## Branches

`_writeWebChainFiles()` does not exist on `dev-branch`, so there is nothing to port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)