### PR TITLE
Give an account a way back to local login from the page it is edited on

### DIFF
--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -398,6 +398,56 @@ class UserManagement extends FOGPage
                 '',
                 true
             );
+            /*
+             * Hand the account back to FOG's own password.
+             *
+             * Until this existed the only way to do it was a REST call or
+             * a hand-written UPDATE, which is a bad place to be standing
+             * when the reason you want it is that the directory is down.
+             *
+             * A checkbox that takes effect on Update, rather than a button
+             * of its own: it is two deliberate acts, it reuses the form's
+             * CSRF and its existing handler, and it is undone by not
+             * pressing Update. User::save() permits the clear -- it is the
+             * recovery direction the break-glass guard exists to keep open
+             * -- so nothing here can reduce the number of administrators
+             * able to sign in without a directory.
+             *
+             * The warning is not boilerplate. Whether the account can
+             * still sign in through its provider afterwards depends on how
+             * that provider works, and core cannot tell which kind this is:
+             * a provider that vouches through USER_LOGGING_IN (LDAP) is
+             * refused once the stamp is gone, because passwordValidate()
+             * honours that vouching ONLY for stamped accounts -- that
+             * restriction is what stops a plugin authenticating a local
+             * account. A provider that establishes the session itself
+             * (OIDC) never reaches passwordValidate() and is unaffected.
+             * So the safe instruction is the same either way: set a
+             * password immediately.
+             */
+            $fields[self::makeLabel(
+                $labelClass,
+                'returnlocal',
+                _('Return To Local Login')
+                . '<br/>('
+                . sprintf(
+                    _('lets this account use a FOG password again; sign-in through %s may stop working, so set a password straight afterwards'),
+                    \Initiator::e($authSource)
+                )
+                . ')'
+            )] = self::makeInput(
+                'returnlocal-input',
+                'returnlocal',
+                '',
+                'checkbox',
+                'returnlocal',
+                '',
+                false,
+                false,
+                -1,
+                -1,
+                isset($_POST['returnlocal']) ? ' checked' : ''
+            );
         }
 
         $buttons = self::makeButton(
@@ -463,6 +513,25 @@ class UserManagement extends FOGPage
         $this->obj
             ->set('name', $user)
             ->set('display', $display);
+
+        /*
+         * Return the account to FOG's own password, if asked.
+         *
+         * Only ever clears. There is no path here that SETS an auth source
+         * -- writing one takes local password login away from an account,
+         * which is the direction that can lock an install out of itself,
+         * and it is not something a general-details form should be able to
+         * do as a side effect. Clearing is the recovery direction and
+         * User::save() lets it through unconditionally.
+         *
+         * Guarded on there being one to clear so an unrelated Update on a
+         * local account cannot mark the field dirty.
+         */
+        if (isset($_POST['returnlocal'])
+            && '' !== trim((string)$this->obj->get('authsource'))
+        ) {
+            $this->obj->set('authsource', '');
+        }
     }
     /**
      * Change password div element.

--- a/tests/user-password-tab-local-only.test.php
+++ b/tests/user-password-tab-local-only.test.php
@@ -31,6 +31,15 @@
  * auth source first, and an administrator cannot decide to do that if
  * nothing tells them there is one.
  *
+ *   4. That clear is reachable from the page, and is a CLEAR ONLY. Until
+ *      it was, recovering an account meant a REST call or a hand-written
+ *      UPDATE -- a bad place to be standing when the reason you want it is
+ *      that the directory is down. The direction matters far more than the
+ *      control does: writing an auth source takes local password login
+ *      away from an account, which is how an install locks itself out, and
+ *      a general-details form must not be able to do that as a side
+ *      effect.
+ *
  * Source assertions -- rendering the page needs a database, a session and
  * a loaded user.
  *
@@ -83,12 +92,23 @@ function squashed($file)
  * is the entire claim here, and a containment claim computed from a
  * substring search is not one.
  *
+ * More than one guard can test the same condition -- the render and the
+ * POST both ask whether this account has an auth source -- so a caller can
+ * name something the body itself must contain. Without that the function
+ * answers about whichever happens to come first in the file, and a
+ * mutation that closes the real guard early and reopens an unconditional
+ * one still lands inside the returned block.
+ *
+ * NOTE: whitespace TOKENS are dropped, but whitespace inside a string
+ * literal is not. Needles containing a translated label keep their spaces.
+ *
  * @param string $file      the file
  * @param string $condition text the condition must contain, squashed
+ * @param string $contains  text the body must contain, or '' for the first
  *
- * @return string|null squashed body, or null
+ * @return string|null body, or null
  */
-function guardBody($file, $condition)
+function guardBody($file, $condition, $contains = '')
 {
     $pieces = [];
     foreach (token_get_all(file_get_contents($file)) as $c) {
@@ -127,6 +147,7 @@ function guardBody($file, $condition)
         if (false === strpos($cond . ')', $condition)) {
             continue;
         }
+        $wantedBody = $contains;
         // A braceless guard cannot contain anything, so a single-statement
         // rewrite reads as "not found" rather than passing with an empty
         // body.
@@ -145,14 +166,24 @@ function guardBody($file, $condition)
                 $depth++;
             } elseif (null === $type && '}' === $tok) {
                 if (0 === --$depth) {
-                    return $body;
+                    if ('' === $wantedBody
+                        || false !== strpos($body, $wantedBody)
+                    ) {
+                        return $body;
+                    }
+                    // Wrong guard; keep looking from after it.
+                    $body = null;
+                    $i = $k;
+                    break;
                 }
             }
             if ($depth > 0 && $k > $j + 1) {
                 $body .= $tok;
             }
         }
-        return null;
+        if (null !== $body) {
+            return null;
+        }
     }
     return null;
 }
@@ -279,6 +310,88 @@ if ('' === $general) {
     }
 }
 
+/*
+ * 4. The way back, and only the way back.
+ *
+ * Scoped to the region the guard actually covers -- from the guard's
+ * opening brace to the $buttons assignment that follows it -- rather than
+ * to the method as a whole, so a checkbox rendered unconditionally for
+ * every account does not pass by being somewhere in the same function.
+ */
+$guarded = guardBody(
+    $pageFile,
+    "''!==\$authSource",
+    "_('Signs In With')"
+);
+if (null === $guarded) {
+    $fails[] = 'the authentication source is no longer rendered inside a'
+        . ' guard on the account having one';
+} elseif (false === strpos($guarded, "'returnlocal'")) {
+    $fails[] = 'the General tab offers no way to return the account to'
+        . ' local login inside the same guard; recovering one then means a'
+        . ' REST call or a hand-written UPDATE, which is a bad place to be'
+        . ' standing when the reason you want it is that the directory is'
+        . ' down -- and a control rendered outside that guard offers it on'
+        . ' accounts that have nothing to return';
+}
+/*
+ * Exactly one. A second copy elsewhere on the page is one that is not
+ * covered by the guard above.
+ */
+$controls = substr_count($page, "_('ReturnToLocalLogin')");
+if ($controls > 1) {
+    $fails[] = 'the return-to-local control is rendered ' . $controls
+        . ' times; only the guarded one is verified here';
+}
+
+/*
+ * And the POST half: clears, and ONLY clears.
+ *
+ * The assertion that matters is the second one. A form that can also SET
+ * an auth source can take local password login away from the last
+ * administrator who has one -- User::save() has a guard for exactly that,
+ * but a general-details form has no business being the thing that trips
+ * it, and the failure mode if the guard were ever weakened is an install
+ * nobody can sign in to.
+ */
+$generalPost = methodBody($page, 'publicfunctionuserGeneralPost()');
+if ('' === $generalPost) {
+    $fails[] = 'UserManagement::userGeneralPost() is missing';
+} else {
+    if (false === strpos($generalPost, "isset(\$_POST['returnlocal'])")) {
+        $fails[] = 'userGeneralPost() no longer acts on the return-to-local'
+            . ' request, so ticking the box does nothing';
+    }
+    if (false === strpos($generalPost, "set('authsource','')")) {
+        $fails[] = 'userGeneralPost() no longer clears the authentication'
+            . ' source';
+    }
+    /*
+     * Every write to the column in this method must be the empty string.
+     * Anything else is the page learning to hand an account to a
+     * directory, which is the direction that locks people out.
+     */
+    if (preg_match_all("#set\('authsource',([^)]*)\)#", $generalPost, $m)) {
+        foreach ($m[1] as $written) {
+            if ("''" !== $written) {
+                $fails[] = 'userGeneralPost() writes ' . $written . ' to the'
+                    . ' authentication source; this form may only CLEAR it,'
+                    . ' because setting one takes local password login away'
+                    . ' from the account';
+            }
+        }
+    }
+    /*
+     * Guarded on there being something to clear, so an ordinary Update on
+     * an ordinary local account cannot mark the field dirty and drag it
+     * through User::save()'s break-glass check for no reason.
+     */
+    if (false === strpos($generalPost, "\$this->obj->get('authsource')")) {
+        $fails[] = 'userGeneralPost() clears the authentication source'
+            . ' without first checking there is one';
+    }
+}
+
 if (count($fails) > 0) {
     echo 'FAIL: ' . count($fails) . " problem(s):\n";
     foreach ($fails as $f) {
@@ -286,5 +399,6 @@ if (count($fails) > 0) {
     }
     exit(1);
 }
-echo "ok: only a locally-authenticating account is offered a password\n";
+echo "ok: only a locally-authenticating account is offered a password,"
+    . " and there is a way back\n";
 exit(0);


### PR DESCRIPTION
Follow-up to #1182, which removed the Password tab from accounts carrying
`uAuthSource` and said the supported recovery is to clear that source first. It
did not say that clearing it required a REST call or a hand-written `UPDATE` —
which is a bad place to be standing, because the reason you want it is usually
that the directory is down.

## What it adds

A **Return To Local Login** checkbox on the General tab, beside the read-only
**Signs In With** field that already explains why the Password tab is absent.
Tick it, press Update, and the Password tab is there on the next render.

A checkbox on the existing form rather than a button of its own: two deliberate
acts, reuses the form's CSRF and handler, undone by not pressing Update. No new
endpoint, no new JS.

## Only ever clears — this is the part that matters

| Direction | Allowed here | Why |
|---|---|---|
| Clear the auth source | **yes** | The recovery direction. `User::save()` lets it through unconditionally — `_assertAuthSourceKeepsBreakGlass()` returns early on an empty pending value precisely so the guard can never refuse the recovery it exists to protect |
| Set an auth source | **no** | Takes local password login *away* from an account — the direction that locks an install out of itself. A general-details form has no business doing that as a side effect of an unrelated rename |

Nothing this form can do reduces the number of administrators able to sign in
without a directory.

## The warning on the field is not boilerplate

Whether the account can still sign in through its provider afterwards depends on
how that provider works, and **core cannot tell which kind it is holding**:

- A provider that vouches through `USER_LOGGING_IN` (LDAP today) is **refused**
  once the stamp is gone. `passwordValidate()` honours that vouching *only* for
  stamped accounts, and that restriction is load-bearing — it is what stops a
  plugin authenticating a local account. So directory login stops working, and
  the stored hash (no longer the directory password) will not stand in for it.
- A provider that establishes the session itself (OIDC) never reaches
  `passwordValidate()` and is unaffected.

Both cases have the same safe instruction, which is what the field says: **set a
password straight afterwards.**

The clear is guarded on there being one, so an ordinary Update on an ordinary
local account cannot mark the column dirty and drag it through `save()`'s
break-glass check for nothing.

## Access control

Reachable by whoever can already edit the user. That does extend account-takeover
reach from local accounts to directory ones — clear the source, set a password,
sign in — but the same holder can already do exactly that to every local account,
including the superadmin, through the Password tab. A consistent boundary rather
than a new one. Flagging it explicitly because it is an auth-surface change.

## Verification

**14/14 mutations caught** across both halves of the gate. `sh tests/run-all.sh`
→ **62 passed, 0 failed**.

The gate grew a token-level containment check for this and needed it: the first
version sliced the guarded region as a string, and a mutation that closed the
real guard early and reopened an unconditional one **survived**. `guardBody()`
now takes what the body must contain, so it answers about the right guard rather
than whichever comes first in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR
