### PR TITLE
Pin iPXE to v2.0.0-fog.7

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -102,7 +102,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.6');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.7');
         // ADR 0009: the bundled plugins live in FOGProject/fog-plugins and are
         // no longer committed here. Same shape as the iPXE pin above -- the
         // installer reads this to pick which release to download, so a given


### PR DESCRIPTION
Makes HTTPS netboot work at all against a FOG server whose web certificate is issued by FOG's own CA — which is every `-S` install that has not supplied a public certificate.

FOG issues its Web CA with a **critical** `nameConstraints` extension, on purpose: it is what stops a compromised web leaf from being usable to impersonate anything outside this server's own names. Upstream iPXE has no parser for that extension, and a critical extension a validator cannot parse is one it *must* reject. So the Web CA was rejected before the leaf was ever considered, and every client died at the first chain with

```
Operation not supported (https://ipxe.org/3c16e283)
```

then reboot-looped.

Two fixes were available: stop constraining the CA, or teach iPXE the extension. [fog-ipxe#6](https://github.com/FOGProject/fog-ipxe/pull/6) does the second — `permittedSubtrees`/`excludedSubtrees` over dNSName and iPAddress, enforced across the whole validated path, with constraint types iPXE cannot evaluate refused at *parse* time so an unenforceable constraint fails closed rather than being silently skipped. Reasoning and the rejected alternatives are in `docs/adr/0016-ipxe-enforces-x509-name-constraints.md` (#1184).

Verified end to end on a UEFI Secure Boot VM: the stock binary fails to parse the Web CA; the patched one validates the chain and reaches the FOG boot menu over HTTPS.

## Servers do not self-heal

`/tftpboot` is only rewritten when the installer re-runs. A server that builds iPXE with its own CA embedded (`$rebuildIpxeWithMyCA`) additionally needs that rebuild before the patched code is in its binaries — the stamp comparison in `_needsLocalIpxeBuild()` schedules it automatically off this version change, because the stamp records the iPXE version it was built from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)