### PR TITLE
Pin iPXE to v2.0.0-fog.7

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.6');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.7');
         // GH-850: the base path is installer-driven. Initiator loads the
         // generated commons/fogpaths.php (written from the installer's
         // $fogprogramdir) before the autoloader runs, so in a normal boot this


### PR DESCRIPTION
Same fix as #1187 on `working-1.6`, and this branch has the same bug: `_nameConstraints()` here writes `nameConstraints = critical` into both intermediates too, so a 1.5 server's Web CA is rejected by stock iPXE for exactly the same reason.

Makes HTTPS netboot work at all against a FOG server whose web certificate is issued by FOG's own CA — which is every `-S` install that has not supplied a public certificate.

The Web CA carries a **critical** `nameConstraints` extension on purpose: it is what stops a compromised web leaf from being usable to impersonate anything outside this server's own names. Upstream iPXE has no parser for that extension, and a critical extension a validator cannot parse is one it *must* reject. So the Web CA was rejected before the leaf was ever considered, and every client died at the first chain with

```
Operation not supported (https://ipxe.org/3c16e283)
```

then reboot-looped.

[fog-ipxe#6](https://github.com/FOGProject/fog-ipxe/pull/6) teaches iPXE the extension rather than weakening the CA — `permittedSubtrees`/`excludedSubtrees` over dNSName and iPAddress, enforced across the whole validated path, with constraint types iPXE cannot evaluate refused at *parse* time so an unenforceable constraint fails closed rather than being silently skipped. Full reasoning is in ADR 0016 on `working-1.6` (#1184); this branch keeps no `docs/adr` tree.

Verified end to end on a UEFI Secure Boot VM against the 1.6 server: the stock binary fails to parse the Web CA; the patched one validates the chain and reaches the FOG boot menu over HTTPS. The binaries are the same build on both branches.

## What a re-run does here

`/tftpboot` is only rewritten when the installer re-runs. On this branch every `https` install rebuilds iPXE locally and unconditionally — there is no build stamp and no manifest comparison in `fetchipxeasset()` — so the re-run picks up the patched sources by way of `prepareiPXEsource()` checking `$buildipxesrc` out at `$ipxeVer`, and overwrites the old binaries outright. `working-1.6`'s stamp-and-manifest layer is not present here, which is why the two PR descriptions differ on this point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)