### PR TITLE
Make autoexec.ipxe the boot script, not the opt-in

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -125,6 +125,9 @@ usage() {
     echo -e "\t                              \t\tenrolled before a client netboots"
     echo -e "\t      --no-rebuild-ipxe-with-my-ca\tUndo the above"
     echo -e "\t      --netboot-proto\t\thttp or https: the protocol iPXE uses to"
+    echo -e "\t      --boot-delay\t\tseconds to sleep before the first DHCP"
+    echo -e "\t\t\t\t\tattempt, for switches slow out of STP or"
+    echo -e "\t\t\t\t\tpowersave. 0 (default) writes no sleep."
     echo -e "\t                     \t\t\tfetch boot.php. Defaults to http, and"
     echo -e "\t                     \t\t\tto https when the certificate is public"
     echo -e "\t                     \t\t\tor iPXE was rebuilt with your CA"
@@ -225,7 +228,7 @@ usage() {
 sextraServerNames=()
 
 shortopts="h?odEUHSCKYyXTFf:c:W:D:B:s:e:N:l"
-longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,no-force-https,https-redirect,no-https-redirect,public-web-cert,no-public-web-cert,rebuild-ipxe-with-my-ca,no-rebuild-ipxe-with-my-ca,install-mode:,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot,no-ca-trust,hostname:,extra-server-name:,kernel-backup-count:,restore-kernel-backup,netboot-proto:,web-ca-cert:,web-ca-key:,web-ca-root:,secureboot-ca-cert:,internal-domain:,internal-subnet:,no-sb-name-constraints"
+longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,no-force-https,https-redirect,no-https-redirect,public-web-cert,no-public-web-cert,rebuild-ipxe-with-my-ca,no-rebuild-ipxe-with-my-ca,install-mode:,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot,no-ca-trust,hostname:,extra-server-name:,kernel-backup-count:,restore-kernel-backup,netboot-proto:,boot-delay:,web-ca-cert:,web-ca-key:,web-ca-root:,secureboot-ca-cert:,internal-domain:,internal-subnet:,no-sb-name-constraints"
 
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
@@ -569,6 +572,18 @@ while :; do
             esac
             shift 2
             ;;
+        --boot-delay)
+            # Bounded rather than free: this is a sleep every client waits
+            # through on every boot, and a fat-fingered 600 is indistinguishable
+            # from a hung PXE stack to the person standing at the machine.
+            if [[ ! $2 =~ ^[0-9]+$ ]] || [[ $2 -gt 120 ]]; then
+                echo "$1 requires a whole number of seconds, 0 to 120"
+                usage
+                exit 3
+            fi
+            sbootdelay="$2"
+            shift 2
+            ;;
         --no-sb-name-constraints)
             ssbNameConstraints="no"
             shift
@@ -877,6 +892,7 @@ _applyInstallMode
 # that somebody actually passed --netboot-proto. It used to, and that is how a
 # value one run derived went on overriding the keys it was derived from.
 [[ -n $snetbootproto ]] && netbootproto=$snetbootproto
+[[ -n $sbootdelay ]] && bootdelay=$sbootdelay
 [[ -n $swebExtCACert ]] && webExtCACert=$swebExtCACert
 [[ -n $swebExtCAKey ]] && webExtCAKey=$swebExtCAKey
 [[ -n $swebExtCARoot ]] && webExtCARoot=$swebExtCARoot

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2134,6 +2134,114 @@ _preserveStockIpxe() {
 #
 # Protection begins with the FIRST run after this lands: before that there is no
 # manifest, nothing can be compared, and a file with no entry is treated as
+# Which BIOS boot file DHCP should hand out, given --boot-delay.
+#
+# EFI takes its delay from autoexec.ipxe (_applyBootDelay). BIOS cannot: there
+# is no efi_autoexec_load() on that platform, so its script is still compiled in
+# and the delay still needs a separate binary. 10secdelay/ is that binary, and
+# it is exactly ten seconds -- no build exists for any other value. So every
+# non-zero delay maps to the same file, and the install says so rather than
+# letting --boot-delay 7 look like it did something here.
+_biosBootFile() {
+    if [[ ${bootdelay:-0} -gt 0 ]]; then
+        echo "10secdelay/undionly.kkpxe"
+    else
+        echo "undionly.kkpxe"
+    fi
+}
+# Write the pre-DHCP sleep into autoexec.ipxe, per --boot-delay.
+#
+# Some switches take several seconds to bring a port out of STP listening or
+# out of powersave, and iPXE's first DHCP attempt goes out before that. FOG has
+# always shipped a second copy of every binary with a 10-second sleep compiled
+# in (10secdelay/) as the answer. On EFI that is now two lines of text in a
+# file instead, which is the whole point of dropping EMBED.
+#
+# Bracketed by sentinel comments rather than matched on the sleep line. An
+# admin may have added their own sleep for their own reason, and a bare
+# /^sleep /d would silently eat it. The sentinels also make the option
+# idempotent in both directions: the block is removed and rewritten every run,
+# so lowering the delay or clearing it works exactly like raising it.
+#
+# Written in place with a redirect rather than sed -i or a temp-and-mv, because
+# by the time this runs the file may already be hard-linked into i386-efi/,
+# arm64-efi/ and the secureboot tree. A rename would replace the inode and
+# leave those links pointing at the old content -- exactly the drift the links
+# exist to prevent.
+#
+# Legacy BIOS cannot be served this way: it has no efi_autoexec_load(), so its
+# script is still compiled in and 10secdelay/ still holds a BIOS build.
+# configureDHCP points BIOS clients there when a delay is set.
+_applyBootDelay() {
+    local script="${tftpdirdst%/}/autoexec.ipxe"
+    [[ -f $script ]] || return 0
+    local delay="${bootdelay:-0}"
+    local tmp
+    tmp=$(mktemp) || return 0
+    awk -v delay="$delay" '
+        # Prefix match, not anchored: the BEGIN line carries a trailing
+        # "(installfog.sh --boot-delay...)" note, so a $-anchored pattern never
+        # matches what this same function writes and the blocks stack on every
+        # run instead of being replaced.
+        /^# FOG-BOOT-DELAY-BEGIN/ { skip = 1 }
+        skip { if ( $0 ~ /^# FOG-BOOT-DELAY-END/ ) skip = 0; next }
+        { print }
+        NR == 1 && delay > 0 {
+            print "# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)"
+            print "echo Sleeping " delay " seconds to wait for STP/Powersave to switchoff and on"
+            print "sleep " delay
+            print "# FOG-BOOT-DELAY-END"
+        }
+    ' "$script" > "$tmp" 2>>$error_log
+    # Never truncate the real script on a failed rewrite -- an empty
+    # autoexec.ipxe is a server that netboots nothing.
+    if [[ -s $tmp ]]; then
+        cat "$tmp" > "$script" 2>>$error_log
+    fi
+    rm -f "$tmp" >>$error_log 2>&1
+    if [[ $delay -gt 0 && $delay -ne 10 ]]; then
+        echo " * NOTE: --boot-delay $delay applies to EFI clients, which read"
+        echo "   the sleep from autoexec.ipxe. Legacy BIOS embeds its script, so"
+        echo "   DHCP points it at 10secdelay/, which is exactly 10 seconds."
+    fi
+}
+# Retire the pre-v2.0.0-fog.8 autoexec/ tree.
+#
+# It held a duplicate set of EMBED-less EFI binaries, opted into by pointing
+# DHCP at autoexec/<file>. Every EFI binary is EMBED-less now and the TFTP root
+# carries the script, so the directory is an exact duplicate of the root and no
+# release ships it any more.
+#
+# Deleted rather than left in place: _copyIpxeTree() only ever writes, so a
+# leftover autoexec/ would go on serving whichever release last created it,
+# getting quietly older with every upgrade while looking maintained. A stale
+# netboot binary is worse than a missing path -- a missing path fails
+# immediately and visibly, where a stale one boots and misbehaves.
+#
+# A site whose DHCP still names autoexec/<file> has to be told, because TFTP
+# answers a missing file with an error the client renders as a generic PXE
+# failure with no clue in it. Warn and name the replacement rather than failing
+# the install: the DHCP server handing out that name is frequently not this
+# machine, so this run cannot fix it and should not block on it.
+_retireAutoexecDir() {
+    # Never let an unset tftpdirdst turn this into rm -rf /autoexec.
+    [[ -n $tftpdirdst ]] || return 0
+    local dir="${tftpdirdst%/}/autoexec"
+    [[ -d $dir ]] || return 0
+    dots "Retiring the obsolete autoexec/ directory"
+    rm -rf "$dir" >>$error_log 2>&1
+    if [[ -d $dir ]]; then
+        echo "Failed"
+        echo " * Could not remove $dir. See $error_log."
+        return 0
+    fi
+    echo "Done"
+    echo " * NOTE: autoexec/ has been removed. Every EFI binary in the TFTP"
+    echo "   root now reads autoexec.ipxe, so the duplicate tree served no"
+    echo "   purpose. If any DHCP server hands out a boot filename starting"
+    echo "   \"autoexec/\", drop that prefix -- autoexec/snponly.efi becomes"
+    echo "   snponly.efi."
+}
 # FOG's -- the same "unknown is not modified" rule the kernel path uses, and the
 # only choice that lets an ordinary upgrade still update anything.
 _copyIpxeTree() {
@@ -2365,75 +2473,69 @@ configureTFTPandPXE() {
         done
         echo "   Delete one to have FOG's version installed on the next run."
     fi
-    # iPXE resolves the bare name "autoexec.ipxe" against its current working
-    # URI -- the TFTP directory the running .efi was itself fetched from -- not
-    # against a fixed path. So our EMBED-less binaries under autoexec/ look
-    # inside autoexec/, and the Secure Boot chain's under secureboot/ look
-    # inside secureboot/. Publish every such path.
+    # autoexec.ipxe is now THE boot script for every EFI binary FOG ships, and
+    # the TFTP root is the primary copy.
     #
-    # This is what the Secure Boot chain needs: upstream's signed snponly.efi
-    # has no script compiled in, so without this it asks for a file that was
-    # never created. See GH-960.
+    # Since fog-ipxe v2.0.0-fog.8 no EFI target is built with EMBED=, so each
+    # one downloads autoexec.ipxe and EXECUTES it. That inverts the rule this
+    # block used to enforce. Previously the root held EMBED-marked binaries,
+    # which download the script and then never run it -- first_image() returns
+    # the embedded one ahead of it, nothing unregisters it, and at "boot"
+    # initrd_load_all() concatenates 2 KB of iPXE script ahead of init.xz, so
+    # the kernel finds no compression magic and panics with
     #
-    # Every directory an EMBED-less binary can be booted from therefore needs
-    # its own copy. Hard link, not copies: they are meant to be one script, and
-    # a link keeps them from drifting -- an admin who edits the boot logic
-    # should not have to know how many copies exist.
+    #     VFS: Unable to mount root fs on "/dev/ram0" or unknown-block(1,0)
     #
-    # The root of $tftpdirdst is deliberately NOT in this list, and any root
-    # copy left by an earlier release is removed below.
+    # (forums #18213). An EMBED-less binary executes the script instead, and
+    # image_exec() unregisters it for the duration, so it is gone before boot
+    # runs. Removing EMBED from every EFI target is what makes a root
+    # autoexec.ipxe safe -- and necessary, because efi_autoexec_network() falls
+    # back to /autoexec.ipxe when the binary's own directory has none.
     #
-    # Not a symlink -- some TFTP daemons refuse to follow those, and a hard link
-    # is indistinguishable from a regular file to every daemon.
+    # Legacy BIOS still embeds its script and is unaffected: there is no
+    # efi_autoexec_load() on that platform, so a root autoexec.ipxe is a file it
+    # never asks for.
     #
-    # Relinked unconditionally on every run. In practice the copy loop above
-    # truncates the existing file in place and the link survives, but that is
-    # cp's behaviour rather than a guarantee, and an admin who replaced the
-    # file with an editor that writes-and-renames will have broken the link.
-    # ln -f is idempotent, so re-running costs nothing and restores the
-    # invariant either way.
-    if [[ -f $tftpdirdst/autoexec/autoexec.ipxe ]]; then
+    # Hard link, not copy: every path is meant to be one script, and a link
+    # keeps them from drifting -- an admin who edits the boot logic should not
+    # have to know how many copies exist. Not a symlink, because some TFTP
+    # daemons refuse to follow those while a hard link is indistinguishable from
+    # a regular file to every daemon.
+    #
+    # Relinked unconditionally on every run: the copy loop truncates in place
+    # and the link usually survives, but that is cp's behaviour rather than a
+    # guarantee, and an editor that writes-and-renames breaks it. ln -f is
+    # idempotent.
+    # Before the links, so every path picks the delay up from one rewrite.
+    _applyBootDelay
+    if [[ -f $tftpdirdst/autoexec.ipxe ]]; then
         local autoexecpath
         for autoexecpath in \
-            $tftpdirdst/autoexec/i386-efi/autoexec.ipxe \
-            $tftpdirdst/autoexec/arm64-efi/autoexec.ipxe \
+            $tftpdirdst/i386-efi/autoexec.ipxe \
+            $tftpdirdst/arm64-efi/autoexec.ipxe \
             $tftpdirdst/secureboot/autoexec.ipxe \
             $tftpdirdst/secureboot/arm64-efi/autoexec.ipxe; do
             # Skip rather than create: the secureboot directories only exist if
             # that asset was staged, and an autoexec.ipxe with no binary beside
             # it serves no one.
             [[ -d $(dirname $autoexecpath) ]] || continue
-            ln -f $tftpdirdst/autoexec/autoexec.ipxe $autoexecpath >>$error_log 2>&1
+            ln -f $tftpdirdst/autoexec.ipxe $autoexecpath >>$error_log 2>&1
         done
     fi
-    # Remove any autoexec.ipxe at the root of $tftpdirdst. Earlier releases
-    # linked one there. Dropping it from the list above is not enough on its
-    # own -- an upgrade would leave the existing file in place and the install
-    # would stay broken -- so it is deleted here.
-    #
-    # Nothing we ship at the root reads it. The root holds the EMBED-marked
-    # binaries, which run their compiled-in script; only the EMBED-less ones
-    # under autoexec/ and secureboot/ ever execute a downloaded autoexec.ipxe.
-    #
-    # Every EFI binary nonetheless *downloads* it. efi_probe() calls
-    # efi_autoexec_load() unconditionally, which registers the script before any
-    # driver is connected. An EMBED-marked binary then never executes it --
-    # first_image() returns the embedded script, which sorts ahead of it -- so
-    # nothing ever unregisters it. iPXE has no notion of an image that was
-    # loaded but not wanted, and only fdt/shim images are ever hidden.
-    #
-    # At "boot", initrd_load_all() concatenates every registered non-hidden
-    # image into the ramdisk in registration order. autoexec.ipxe registered
-    # first, so the kernel is handed 2 KB of iPXE script where it expects the
-    # head of init.xz, does not find the compression magic, falls back to
-    # treating the blob as a legacy initrd, and panics with
-    #
-    #     VFS: Unable to mount root fs on "/dev/ram0" or unknown-block(1,0)
-    #
-    # See forums #18213. This costs nothing: the file is a hard link to
-    # autoexec/autoexec.ipxe, so its content -- including any local edit, which
-    # the link shares -- survives in every other published path.
-    rm -f $tftpdirdst/autoexec.ipxe >>$error_log 2>&1
+    # _copyIpxeTree() hashed autoexec.ipxe as it laid it down; _applyBootDelay
+    # then rewrote it, and the links above propagated that to every other path.
+    # Without re-stamping, the next run compares the delayed file against the
+    # pristine sum, reads the difference as "the admin replaced this", and stops
+    # updating the boot script for good -- the same trap _signLocalIpxe() hits
+    # and for the same reason. Naming a path the manifest does not carry is
+    # harmless: only existing lines are rewritten.
+    _restampIpxeManifest "${tftpdirdst%/}" \
+        autoexec.ipxe \
+        i386-efi/autoexec.ipxe \
+        arm64-efi/autoexec.ipxe \
+        secureboot/autoexec.ipxe \
+        secureboot/arm64-efi/autoexec.ipxe
+    _retireAutoexecDir
     chown -R $username $tftpdirdst >>$error_log 2>&1
     chown -R $username $webdirdest/service/ipxe >>$error_log 2>&1
     find $tftpdirdst -type d -exec chmod 755 {} \; >>$error_log 2>&1
@@ -5064,6 +5166,12 @@ writeUpdateFile() {
         # own". Only ever written alongside acmeLeaf=yes.
         webCertFile
         webKeyFile
+        # Seconds of pre-DHCP sleep written into autoexec.ipxe, for switches
+        # that take time to come out of STP/powersave. A genuine preference: it
+        # is the admin's answer to their own network hardware, and losing it on
+        # upgrade brings back the intermittent "no DHCP answer" boots it was set
+        # to cure. 0 (the default) writes no sleep at all.
+        bootdelay
         # How many prior kernel/init generations backupPreservedCustomizations()
         # keeps under customizations/kernel-backups. A genuine persisted
         # preference like fog_update_channel, not a record: an admin who chose
@@ -10455,7 +10563,10 @@ _resignCustomKernels() {
 # Hoisted into a helper so the live Kea config (configureKeaDHCP) and the
 # copy-ready sample (writeKeaSample) can never drift apart.
 _keaBaseClasses() {
-    cat <<'EOFCLS'
+    # Piped through sed rather than unquoting the heredoc: the block is JSON and
+    # keeping it literal is what stops a stray $ or backtick in a future edit
+    # being expanded by the shell. Only the BIOS name varies -- see _biosBootFile.
+    cat <<'EOFCLS' | sed "s|\"boot-file-name\": \"undionly.kkpxe\"|\"boot-file-name\": \"$(_biosBootFile)\"|"
         {
             "name": "FOG-Legacy-BIOS",
             "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00000'",
@@ -10814,7 +10925,7 @@ configureDHCP() {
             echo "}" >> "$dhcptouse"
             echo "class \"Legacy\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00000\";" >> "$dhcptouse"
-            echo "    filename \"undionly.kkpxe\";" >> "$dhcptouse"
+            echo "    filename \"$(_biosBootFile)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"UEFI-32-2\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00002\";" >> "$dhcptouse"

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -102,7 +102,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.7');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.8');
         // ADR 0009: the bundled plugins live in FOGProject/fog-plugins and are
         // no longer committed here. Same shape as the iPXE pin above -- the
         // installer reads this to pick which release to download, so a given


### PR DESCRIPTION
Installer half of [fog-ipxe#7](https://github.com/FOGProject/fog-ipxe/pull/7), which stops embedding a script in any EFI binary. Publish `autoexec.ipxe` at the TFTP root, hard-link it beside every EFI binary, retire the `autoexec/` tree that no longer ships, and add `--boot-delay` so the 10-second STP/powersave sleep is a setting rather than a second set of binaries.

> **Do not merge before** fog-ipxe#7 is tagged and the `FOG_IPXE_VERSION` bump is added here. The installer expects the new tarball layout; against `v2.0.0-fog.7` it would delete the `autoexec/` tree that release still depends on.

## What reversed

`configureTFTPandPXE()` used to **delete** any `autoexec.ipxe` at the TFTP root. That comment is worth keeping in mind, because the reasoning still holds — it is the premise that changed:

> `efi_probe()` calls `efi_autoexec_load()` unconditionally, so an EMBED-marked binary downloads `autoexec.ipxe` and then never runs it, because `first_image()` returns the embedded script ahead of it. Nothing unregisters it, so `initrd_load_all()` concatenates 2 KB of iPXE script ahead of `init.xz` and the kernel panics with `VFS: Unable to mount root fs on "/dev/ram0"` (forums #18213). `efi_autoexec_network()` falls back to `/autoexec.ipxe` when the binary's own directory has none, so one embedded EFI binary anywhere was enough to poison every client that fell back to the root.

With no EFI binary embedding anything, the script is *executed* rather than merely registered, and `image_exec()` unregisters it for the duration — so it is gone before `boot` runs. Legacy BIOS is untouched: no `efi_autoexec_load()` there, so a root `autoexec.ipxe` is a file it never asks for.

## `--boot-delay`

Seconds of sleep before the first DHCP attempt. Bounded 0–120: this is a wait every client sits through on every boot, and a fat-fingered 600 is indistinguishable from a hung PXE stack to whoever is standing at the machine.

`_applyBootDelay()` brackets the inserted lines with sentinel comments rather than matching on the `sleep` line, so an admin's own sleep is never eaten and the option works in both directions — lowering or clearing rewrites the block exactly like raising it. Verified as a unit: insert → change value → clear round-trips to a file byte-identical to the original, and re-applying the same value is stable.

It writes in place with a redirect rather than a temp-and-mv, because by then the file may already be hard-linked and a rename would leave those links on the old inode — the drift the links exist to prevent.

BIOS cannot be served this way and `10secdelay/` is exactly ten seconds, so `_biosBootFile()` maps any non-zero delay to that build (both the ISC and Kea generators) and the run says so when the two cannot agree.

## The manifest trap

`_copyIpxeTree()` hashes each file as it lays it down, and `_applyBootDelay()` rewrites `autoexec.ipxe` afterwards. Without re-stamping, the next run reads the difference as "the admin replaced this file", declines to update it, and the boot script is frozen for good — the same trap `_signLocalIpxe()` hits, for the same reason. `_restampIpxeManifest()` is called for `autoexec.ipxe` and every path it is linked into.

## Breaking

A DHCP `filename` beginning `autoexec/` stops resolving; drop the prefix. FOG's own generated `dhcpd.conf` and Kea config never used those paths, so only hand-written configs are affected. `_retireAutoexecDir()` deletes the stale tree rather than leaving it — it would otherwise go on serving whichever release last created it, getting quietly older every upgrade while looking maintained — and prints the mapping.

## Still to do on this PR

- [ ] `FOG_IPXE_VERSION` → `v2.0.0-fog.8` once tagged
- [ ] Live boot test on the Secure Boot VM
- [ ] `fog-docs` note for the `autoexec/` filename change

🤖 Generated with [Claude Code](https://claude.com/claude-code)