### PR TITLE
Stop the published iPXE tarball overwriting a local CA build

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2026,11 +2026,25 @@ _resolveIpxeTrust() {
 # at an unchanged iPXE tag. A version-only check would skip that rebuild, and
 # the failure lands at a PXE client as a TLS error with nothing on the server to
 # connect it to the cause.
+#
+# The third field, bin=, is the sha256 of snponly.efi AS IT SITS IN THE STAGING
+# TREE, and it is what turns the stamp from an intention into a fact. Without
+# it the stamp said "a build was run for this tag and this CA" and nothing
+# more: downloadipxe() unpacks the published tarball over the staging tree on
+# every run, so the run AFTER a build found the published, CA-less binaries
+# waiting there, matched the stamp on tag and CA alone, skipped the rebuild,
+# and copied the published binaries to the TFTP root. Every HTTPS netboot then
+# died at boot.php with iPXE's "Permission denied" out of x509.c -- no trusted
+# root to build a path to -- while the install printed nothing at all about the
+# build having been skipped. Comparing the staged bytes is also what lets
+# downloadipxe() decide whether unpacking is safe.
 _ipxeBuildStampValue() {
-    local sum=""
+    local sum="" bin="" staged
     [[ -n $ipxetrust && -f $ipxetrust ]] && \
         sum=$(sha256sum "$ipxetrust" 2>/dev/null | cut -d' ' -f1)
-    printf 'ipxe=%s ca=%s' "${ipxeVer:-unknown}" "${sum:-none}"
+    staged="$(readlink -f "$tftpdirsrc" 2>/dev/null)/snponly.efi"
+    [[ -s $staged ]] && bin=$(sha256sum "$staged" 2>/dev/null | cut -d' ' -f1)
+    printf 'ipxe=%s ca=%s bin=%s' "${ipxeVer:-unknown}" "${sum:-none}" "${bin:-none}"
 }
 # Does this server compile its own iPXE?
 #
@@ -2344,6 +2358,25 @@ downloadipxe() {
     # subdirectories worth keeping. See GH-959.
     local tarball="fog-ipxe-${ipxeVer}.tar.gz"
     local dest=$(readlink -f $tftpdirsrc)
+    # Never unpack the published binaries over a local build.
+    #
+    # --rebuild-ipxe-with-my-ca compiles this server's CA into the binary, the
+    # only thing that lets iPXE fetch boot.php over TLS from a private CA. That
+    # build writes into this same staging tree, so unpacking here first destroys
+    # it -- and because the old stamp did not describe the staged bytes,
+    # _needsLocalIpxeBuild() then read its own stamp as "already built", skipped
+    # the rebuild, and let the published binaries through to the TFTP root. The
+    # first install worked and every install after it silently broke netboot.
+    #
+    # "No build needed" is now exactly the condition under which unpacking must
+    # not happen, because it can only be true when the built binaries are still
+    # sitting here. Every other state -- a new release, a changed CA, a staging
+    # tree someone emptied -- fails that test and unpacks as it always did.
+    if [[ $rebuildIpxeWithMyCA == yes ]] && ! _needsLocalIpxeBuild; then
+        dots "Downloading iPXE binaries (${ipxeVer})"
+        echo "Kept local build"
+        return 0
+    fi
     dots "Downloading iPXE binaries (${ipxeVer})"
     # Downloaded on EVERY install, including one that is about to rebuild.
     #

--- a/tests/ipxe-build-stamp.test.sh
+++ b/tests/ipxe-build-stamp.test.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# Guards the stamp that decides whether iPXE gets rebuilt with this server's CA.
+#
+#   tests/ipxe-build-stamp.test.sh
+#
+# --rebuild-ipxe-with-my-ca compiles the FOG CA into the iPXE binaries with
+# CERT=/TRUST=, which is the only thing that lets a PXE client fetch boot.php
+# over TLS from a private CA. The build is 10-25 minutes, so a stamp in the
+# TFTP root records what was built and lets later runs skip it.
+#
+# The stamp used to record only the iPXE release tag and the CA bytes -- an
+# intention, not a fact. downloadipxe() unpacks the published tarball into the
+# same staging tree the build writes to, on every run, so:
+#
+#   run 1  unpack -> build -> stamp -> TFTP root gets the CA-embedded binaries
+#   run 2  unpack (published binaries land on top of the build)
+#          -> stamp still matches on tag and CA -> rebuild skipped
+#          -> TFTP root gets the PUBLISHED binaries, which trust nothing
+#
+# Nothing in the install output mentioned the skip. The failure surfaced only at
+# a booting client, as iPXE "Permission denied" from x509.c -- EACCES_USELESS,
+# "found no usable certificates" -- because the binary had no trusted root to
+# build a path to. First install fine, every install after it broken.
+#
+# So the stamp now also carries the sha256 of snponly.efi as it sits in the
+# staging tree, and downloadipxe() skips the unpack precisely when that says a
+# local build is already staged. Both halves are pinned below, including the
+# mutation that the old stamp could not see.
+#
+# Needs sha256sum. No install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "SKIP: sha256sum is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+# Stand in for the download. Leaves a marker so a test can tell whether the
+# published tarball would have been unpacked over the staging tree.
+fetchipxeasset() { : > "$WORK/fetched"; return 0; }
+
+tftpdirsrc="$WORK/src"
+tftpdirdst="$WORK/dst"
+mkdir -p "$tftpdirsrc" "$tftpdirdst"
+
+ipxeVer="v2.0.0-fog.8"
+sslcachain=""
+sslcapem="$WORK/ca.pem"
+echo "-----BEGIN CERTIFICATE----- fixture -----END CERTIFICATE-----" > "$sslcapem"
+
+stamp="$tftpdirdst/.fog-ipxe-build"
+
+# The two states snponly.efi can be in. They only have to differ.
+published() { echo "published-binary-trusts-nothing" > "$tftpdirsrc/snponly.efi"; }
+locallybuilt() { echo "built-with-CERT-and-TRUST"    > "$tftpdirsrc/snponly.efi"; }
+
+# What a completed build writes: the stamp, taken while the built binary is the
+# one in the staging tree. Mirrors configureTFTPandPXE's ipxeBuildStampPending.
+writestamp() { _resolveIpxeTrust; _ipxeBuildStampValue > "$stamp"; }
+
+needs() { _needsLocalIpxeBuild && echo yes || echo no; }
+
+echo "ipxe build stamp:"
+
+# --- the build only ever happens when it was asked for ----------------------
+rebuildIpxeWithMyCA="no"
+published
+rm -f "$stamp"
+is "$(needs)" "no" "no rebuild when --rebuild-ipxe-with-my-ca is off"
+
+rebuildIpxeWithMyCA="yes"
+is "$(needs)" "yes" "rebuild when asked for and nothing has been built"
+
+# --- a build that is genuinely still staged is not repeated ------------------
+locallybuilt
+writestamp
+is "$(needs)" "no" "no rebuild when the built binary is still staged"
+
+# --- THE REGRESSION ---------------------------------------------------------
+# The tarball unpack replaces the built binary. Tag and CA are untouched, so
+# the old two-field stamp still matched here and the rebuild was skipped.
+published
+is "$(needs)" "yes" "rebuild after the published tarball overwrites the build"
+
+# --- and the other two inputs still force a rebuild on their own -------------
+locallybuilt
+writestamp
+ipxeVer="v2.0.1-fog.1"
+is "$(needs)" "yes" "rebuild when the iPXE release moves"
+ipxeVer="v2.0.0-fog.8"
+
+echo "-----BEGIN CERTIFICATE----- rotated -----END CERTIFICATE-----" > "$sslcapem"
+is "$(needs)" "yes" "rebuild when the CA bytes change"
+echo "-----BEGIN CERTIFICATE----- fixture -----END CERTIFICATE-----" > "$sslcapem"
+
+# --- downloadipxe must not unpack over a staged build ------------------------
+locallybuilt
+writestamp
+rm -f "$WORK/fetched"
+downloadipxe >/dev/null 2>&1
+is "$([[ -e $WORK/fetched ]] && echo fetched || echo kept)" "kept" \
+    "download skipped while a local build is staged"
+is "$(cat "$tftpdirsrc/snponly.efi")" "built-with-CERT-and-TRUST" \
+    "the staged build survives the download step"
+
+# ...but it must still unpack in every other state, or an upgrade never lands.
+ipxeVer="v2.0.1-fog.1"
+rm -f "$WORK/fetched"
+downloadipxe >/dev/null 2>&1
+is "$([[ -e $WORK/fetched ]] && echo fetched || echo kept)" "fetched" \
+    "download still runs when the release moves"
+ipxeVer="v2.0.0-fog.8"
+
+rebuildIpxeWithMyCA="no"
+rm -f "$WORK/fetched"
+downloadipxe >/dev/null 2>&1
+is "$([[ -e $WORK/fetched ]] && echo fetched || echo kept)" "fetched" \
+    "download always runs on a server that does not build"
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## What broke

`--rebuild-ipxe-with-my-ca` compiles this server's CA into the iPXE binaries with `CERT=`/`TRUST=`. It is the only thing that lets a PXE client fetch `boot.php` over TLS when the web certificate chains to a private CA, and it is a 10-25 minute build, so a stamp in the TFTP root records what was built and later runs skip it.

The stamp recorded an *intention*, not a fact — the iPXE release tag and the sha256 of the CA, nothing about the binaries. `downloadipxe()` unpacks the published tarball into the same staging tree the build writes to, on **every** run, deliberately (that is where the pristine copy for `stock/` comes from). So:

| run | what happens |
|---|---|
| 1 | unpack → build → stamp → TFTP root gets the CA-embedded binaries, HTTPS netboot works |
| 2 | unpack, and the published binaries land on top of the build → the stamp still matches on tag and CA, so the rebuild is skipped → the TFTP root gets the **published** binaries, which trust nothing |

Nothing in the install output said the build had been skipped; the only line about it was `Rebuild iPXE with your CA: Yes` at the top. The failure surfaced at a booting client as iPXE `Permission denied (https://ipxe.org/0216eb8f)`, which decodes to `EACCES_USELESS` from `crypto/x509.c` — *"found no usable certificates"* — because the binary had no trusted root to build a path to.

First install fine, every install after it silently broken.

Found on a live 1.6 lab server: `/tftpboot/snponly.efi` contained no FOG CA at all, while the CA-embedded binaries from the previous run's build were still sitting in `/opt/fog/ipxe/build/ipxe-efi/src/bin-x86_64-efi/`.

## The fix

The stamp gains a third field, `bin=`, the sha256 of `snponly.efi` **as it sits in the staging tree**, so it describes what is actually there rather than what was once intended. That makes "no build needed" mean "the built binaries are still staged", which is exactly the condition under which the unpack must be skipped — so `downloadipxe()` skips it there, and unpacks in every other state: a new release, a changed CA, a staging tree someone emptied, or a server that does not build at all.

An existing stamp has no `bin=` field and therefore cannot match, so the next run rebuilds once and repairs the server it was written on.

## Test

`tests/ipxe-build-stamp.test.sh`, auto-discovered by `tests/run-all.sh`. Pins both halves. Mutation-verified: reverting the `bin=` field fails `rebuild after the published tarball overwrites the build` and nothing else.

## Downstream

None. No route classes, no schema, no API surface.