### PR TITLE
Stop the served TLS chain growing a copy of the intermediate per install

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6440,9 +6440,18 @@ _resolveWebLeafPaths() {
         || $sslprivkey == "${webdir}/.webLeaf.key" ]]; then
         sslprivkey="${leafdir}/.webLeaf.key"
     fi
+    # The fourth comparison repairs a server whose $sslpubcert was pointed at
+    # _writeWebChainFiles()'s own output. That path is FOG's derived bundle and
+    # can never be a legitimate input, so naming it means something adopted it
+    # by accident -- which is exactly what createSSLCA() did from the vhost.
+    # Deliberately the exact path and not "any file with a chain in it": an
+    # ACME client's own fullchain.pem is a real and supported value here, and
+    # repointing that at FOG's leaf would swap the admin's certificate for one
+    # nothing is renewing.
     if [[ -z $sslpubcert \
         || "$(readlink -f "$sslpubcert" 2>/dev/null)" == "$(readlink -f "$webdirdest/management/other/ssl/srvpublic.crt" 2>/dev/null)" \
-        || $sslpubcert == "${webdir}/.webLeaf.pem" ]]; then
+        || $sslpubcert == "${webdir}/.webLeaf.pem" \
+        || $sslpubcert == "${leafdir}/.webFullChain.pem" ]]; then
         sslpubcert="${leafdir}/.webLeaf.pem"
     fi
 }
@@ -6528,7 +6537,23 @@ _writeWebChainFiles() {
     # Assemble beside the live file, not over it. This bundle is what the web
     # server serves, so a bad one costs the server its start-up; keeping the
     # previous chain is always better than installing a broken one.
-    cat "$sslpubcert" "$chainonly" > "${fullchain}.new" 2>>$error_log || return 0
+    # The LEAF out of $sslpubcert, not the whole file: `openssl x509` reads only
+    # the first certificate, which is the leaf in any bundle a web server will
+    # accept.
+    #
+    # Load-bearing rather than tidy. $sslpubcert is admin-overridable, and one
+    # value in particular is this function's own output -- createSSLCA() adopts
+    # whatever path the live vhost names, which is $fullchain on every server
+    # FOG has already configured. `cat "$sslpubcert" "$chainonly"` then fed the
+    # bundle its own contents plus one more intermediate, once per install.
+    # Fourteen certificates in, browsers still shrugged and iPXE did not: it
+    # validates a chain pairwise from the trusted root upwards, so the second
+    # copy of the intermediate is checked against the first as its issuer,
+    # fails, and every HTTPS netboot dies at boot.php with "Permission denied".
+    # Reading only the leaf makes the loop structurally impossible and collapses
+    # an already-grown bundle back to leaf+chain on the next run.
+    { openssl x509 -in "$sslpubcert" 2>>$error_log; cat "$chainonly"; } \
+        > "${fullchain}.new" 2>>$error_log || return 0
     # The first certificate in the bundle is the leaf the web server will pair
     # with $sslprivkey. Check that here rather than let the web server discover
     # it at start-up: openssl x509 reads only the first certificate, which is
@@ -6963,13 +6988,28 @@ _detectExternalCertManagement() {
                 ;;
         esac
     done
-    # 2. The live vhost serving a leaf from outside $sslpath. FOG issues into
-    #    $sslpath and nowhere else, so anywhere else is the admin's file. This
-    #    is the signal that fires on a novhost=yes install, where FOG never
-    #    wrote the vhost and $sslpubcert still names FOG's own unused leaf.
+    # 2. The live vhost serving a leaf from outside the paths FOG issues into.
+    #    Anywhere else is the admin's file. This is the signal that fires on a
+    #    novhost=yes install, where FOG never wrote the vhost and $sslpubcert
+    #    still names FOG's own unused leaf.
+    #
+    #    $sslpath alone WAS the whole test, on the stated premise that "FOG
+    #    issues into $sslpath and nowhere else". That premise died when the
+    #    zoned PKI moved FOG's own web leaf to $fogprogramdir/pki/web/leaf, and
+    #    the test did not follow. So on an ordinary FOG-issued HTTPS server the
+    #    vhost named a certificate FOG had issued, in a tree FOG owns, and this
+    #    concluded the admin managed it: acmeLeaf=yes recorded on a server
+    #    nothing external was touching, and $sslpubcert repointed at
+    #    _writeWebChainFiles()'s own output. See that function for what the
+    #    second half then did to the served chain.
+    #
+    #    Matched on the pki/ tree rather than on each zone's leaf directory:
+    #    the question is "did FOG write this", and every zone under pki/ is
+    #    FOG's, including ones added later.
     vhostcert=$(_vhostCertPath)
-    if [[ -n $vhostcert && -n $sslpath && $vhostcert != "$sslpath"* ]]; then
-        echo "the vhost serves $vhostcert, outside FOG's $sslpath"
+    if [[ -n $vhostcert && -n $sslpath && $vhostcert != "$sslpath"* \
+        && $vhostcert != "${fogprogramdir%/}/pki/"* ]]; then
+        echo "the vhost serves $vhostcert, outside FOG's $sslpath and PKI tree"
         return 0
     fi
     # 3. A leaf sitting at FOG's own path that FOG's own CA did not sign --

--- a/tests/web-chain-feedback.test.sh
+++ b/tests/web-chain-feedback.test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Guards the served TLS chain against feeding on its own output.
+#
+#   tests/web-chain-feedback.test.sh
+#
+# _writeWebChainFiles() assembles what the web server sends: the leaf from
+# $sslpubcert, then the intermediates out of $sslcachain, into
+# pki/web/leaf/.webFullChain.pem. The vhost is pointed at that bundle.
+#
+# Which meant the bundle was reachable as an INPUT. createSSLCA() adopts
+# whatever certificate path the live vhost names, via
+# _detectExternalCertManagement() signal 2 -- "the vhost serves a leaf from
+# outside FOG's own paths, so the admin must manage it". That test only knew
+# about $sslpath, and the zoned PKI had long since moved FOG's own web leaf to
+# $fogprogramdir/pki/web/leaf. So on an ordinary FOG-issued HTTPS server the
+# signal fired on FOG's own file, recorded acmeLeaf=yes, and set
+# $sslpubcert=.webFullChain.pem. From then on
+#
+#     cat "$sslpubcert" "$chainonly" > fullchain.new
+#
+# appended one more copy of the intermediate on every install. Observed live at
+# fourteen certificates: leaf + 13 identical "CN=FOG Web CA".
+#
+# Browsers tolerate that. iPXE does not -- it validates pairwise from the
+# trusted root upwards (crypto/x509.c), so copy 2 is checked against copy 1 as
+# its issuer, fails x509_check_issuer, and every HTTPS netboot dies at
+# boot.php. Nothing server-side says why.
+#
+# Three fixes, all pinned here: the detector knows the PKI tree is FOG's, the
+# assembler reads only the leaf out of $sslpubcert, and _resolveWebLeafPaths()
+# repoints an $sslpubcert that names the derived bundle -- while leaving an
+# admin's own fullchain.pem alone, because that is a supported value.
+#
+# Needs openssl. Runs on generated fixtures -- no install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+# --- fixture: root -> intermediate -> leaf, the shape FOG issues -------------
+fogprogramdir="$WORK/opt/fog"
+sslpath="$WORK/opt/fog/snapins/ssl"
+webdirdest="$WORK/var/www/fog"
+leafdir="$fogprogramdir/pki/web/leaf"
+cadir="$fogprogramdir/pki/web/ca"
+mkdir -p "$leafdir" "$cadir" "$sslpath" "$webdirdest/management/other/ssl"
+
+openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 30 \
+    -subj "/CN=FOG Server CA" -keyout "$cadir/root.key" -out "$cadir/root.pem" \
+    >/dev/null 2>&1 || { echo "ERROR: fixture root CA failed" >&2; exit 1; }
+openssl req -new -nodes -newkey rsa:2048 -sha256 -subj "/CN=FOG Web CA" \
+    -keyout "$cadir/.fogWebCA.key" -out "$cadir/int.csr" >/dev/null 2>&1
+printf 'basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n' \
+    > "$cadir/int.ext"
+openssl x509 -req -in "$cadir/int.csr" -CA "$cadir/root.pem" -CAkey "$cadir/root.key" \
+    -CAcreateserial -sha256 -days 30 -extfile "$cadir/int.ext" \
+    -out "$cadir/.fogWebCA.pem" >/dev/null 2>&1
+openssl req -new -nodes -newkey rsa:2048 -sha256 -subj "/CN=fogserver" \
+    -keyout "$leafdir/.webLeaf.key" -out "$leafdir/leaf.csr" >/dev/null 2>&1
+openssl x509 -req -in "$leafdir/leaf.csr" -CA "$cadir/.fogWebCA.pem" \
+    -CAkey "$cadir/.fogWebCA.key" -CAcreateserial -sha256 -days 30 \
+    -out "$leafdir/.webLeaf.pem" >/dev/null 2>&1
+
+# root+intermediate, the shape createWebIntermediateCA writes.
+sslcachain="$cadir/.fogWebCAchain.pem"
+cat "$cadir/.fogWebCA.pem" "$cadir/root.pem" > "$sslcachain"
+
+sslprivkey="$leafdir/.webLeaf.key"
+fullchain="$leafdir/.webFullChain.pem"
+
+ncerts() { grep -c 'BEGIN CERTIFICATE' "$1" 2>/dev/null; }
+
+echo "web chain feedback:"
+
+# --- the assembler, run over and over ----------------------------------------
+sslpubcert="$leafdir/.webLeaf.pem"
+_writeWebChainFiles
+is "$(ncerts "$fullchain")" "2" "a normal run assembles leaf + intermediate"
+
+# THE REGRESSION. $sslpubcert names the bundle this function writes, which is
+# what createSSLCA() adopted from the vhost on every FOG-issued HTTPS server.
+sslpubcert="$fullchain"
+for _ in 1 2 3 4 5; do _writeWebChainFiles; done
+is "$(ncerts "$fullchain")" "2" "five runs against its own output stay at leaf + intermediate"
+is "$(openssl x509 -in "$fullchain" -noout -subject 2>/dev/null)" \
+   "subject=CN=fogserver" "the leaf is still first in the bundle"
+
+# An already-grown bundle collapses rather than needing a migration.
+{ openssl x509 -in "$leafdir/.webLeaf.pem"
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13; do openssl x509 -in "$cadir/.fogWebCA.pem"; done
+} > "$fullchain" 2>/dev/null
+is "$(ncerts "$fullchain")" "14" "fixture reproduces the live 14-certificate bundle"
+_writeWebChainFiles
+is "$(ncerts "$fullchain")" "2" "the next run collapses a grown bundle back"
+
+# --- the cause: FOG's own PKI tree is not evidence of an external cert -------
+etcconf="$WORK/fog.conf"
+rootCAPem="$cadir/root.pem"
+sslpubcert="$leafdir/.webLeaf.pem"
+
+echo "    ssl_certificate ${fullchain};" > "$etcconf"
+_detectExternalCertManagement >/dev/null 2>&1
+is "$?" "1" "a vhost serving FOG's own pki/ leaf is not external"
+
+echo "    ssl_certificate /etc/letsencrypt/live/fog/fullchain.pem;" > "$etcconf"
+_detectExternalCertManagement >/dev/null 2>&1
+is "$?" "0" "a vhost serving someone else's leaf still is external"
+
+# --- and the input stops naming the output ----------------------------------
+sslpubcert="$fullchain"
+_resolveWebLeafPaths
+is "$sslpubcert" "$leafdir/.webLeaf.pem" "an \$sslpubcert naming the derived bundle is repointed"
+
+sslpubcert="/etc/letsencrypt/live/fog/fullchain.pem"
+_resolveWebLeafPaths
+is "$sslpubcert" "/etc/letsencrypt/live/fog/fullchain.pem" \
+    "an ACME client's own fullchain is left alone"
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## What broke

`_writeWebChainFiles()` assembles what the web server sends — the leaf from `$sslpubcert`, then the intermediates out of `$sslcachain` — into `pki/web/leaf/.webFullChain.pem`, and the vhost is pointed at that bundle. Which made the bundle reachable as an **input**.

`createSSLCA()` adopts whatever certificate path the live vhost names, via `_detectExternalCertManagement()` signal 2: *"the vhost serves a leaf from outside FOG's own paths, so the admin manages it."* That test knew only about `$sslpath`, on its own stated premise that FOG issues there and nowhere else. The premise died when the zoned PKI moved FOG's web leaf to `$fogprogramdir/pki/web/leaf`; the test did not follow.

So on an ordinary FOG-issued HTTPS server the signal fired on FOG's own file. It recorded `acmeLeaf=yes` on a server nothing external was touching, and set `$sslpubcert` to `.webFullChain.pem` — this function's own output. From then on:

```
cat "$sslpubcert" "$chainonly" > fullchain.new
```

appended one more copy of the intermediate on **every install**. `acmeLeaf=yes` also stopped `_createWebLeaf()` ever truncating that file, so nothing broke the cycle.

Observed on a live 1.6 server at fourteen certificates — the leaf plus thirteen byte-identical `CN=FOG Web CA`, same serial, same sha256 — while `.webLeaf.pem` and `.webChain.pem` were both still one certificate each, which is the fingerprint of a feedback loop rather than a broken writer.

Browsers tolerate it. iPXE does not: it validates a chain pairwise from the trusted root upwards (`crypto/x509.c`, `x509_validate_chain`), so the second copy of the intermediate is checked against the first as its issuer, fails `x509_check_issuer`, and every HTTPS netboot dies at `boot.php` with `Permission denied` and nothing server-side to explain it.

## The fix

Three changes, smallest first:

- **The assembler takes only the leaf** out of `$sslpubcert` — `openssl x509` reads the first certificate, which is the leaf in any bundle a web server will accept. Makes the loop structurally impossible whatever the path is pointed at, and collapses an already-grown bundle back to leaf+chain on the next run, so no migration step is needed.
- **The detector treats `$fogprogramdir/pki/` as FOG's**, alongside `$sslpath`. Matched on the `pki/` tree rather than each zone's leaf directory: the question is "did FOG write this", and every zone under `pki/` is FOG's, including ones added later.
- **`_resolveWebLeafPaths()` repoints an `$sslpubcert` that names the derived bundle**, repairing a `.fogsettings` already carrying it. Deliberately that exact path and not "any file with a chain in it" — an ACME client's own `fullchain.pem` is a real and supported value there, and repointing it would swap the admin's certificate for one nothing is renewing.

`acmeLeaf` is left alone once recorded. Clearing it automatically would resume re-issuing over a certificate an admin had deliberately told FOG not to touch, which is the more dangerous direction of the two.

## Test

`tests/web-chain-feedback.test.sh`, auto-discovered by `tests/run-all.sh`. Nine assertions, including a fixture that reproduces the live fourteen-certificate bundle and checks the next run collapses it. Mutation-verified: each of the three changes reverted on its own fails only its own assertions.

## Downstream

None. No route classes, no schema, no API surface.