### PR TITLE
Fix the hook and event dispatch contract

### DIFF
--- a/docs/adr/0017-hook-dispatch-contract.md
+++ b/docs/adr/0017-hook-dispatch-contract.md
@@ -1,0 +1,174 @@
+# The hook dispatch contract
+
+## Status
+
+accepted
+
+## Context
+
+The hook system is FOG's plugin ABI. Every bundled plugin and every plugin
+neither the project nor its maintainer has ever read registers callbacks
+through `EventManager::register()` and receives them through
+`HookManager::processEvent()`. ADR 0013 made a promise about *one* part of that
+surface — the reverse `class_alias` in each namespaced file — and said nothing
+about the rest of it, because the rest of it had never been written down.
+
+A scan of the four files (`eventmanager`, `hookmanager`, `event`, `hook`) found
+thirteen defects, recorded as F-11 through F-26 in `docs/refactor-facts.md` and
+argued in `docs/hook-event-plan.md`. Most were fixed without anything
+observable changing. Five were decisions, because fixing them changes what a
+plugin can rely on, and four of those leave no trace in the code afterwards —
+which is what this ADR is for.
+
+Three findings frame the rest:
+
+- **No core hook or event has ever loaded on any FOG server.** All eleven files
+  under `lib/hooks` and `lib/events` declare `public $active = false;`. They are
+  worked examples an admin opts into. Every live listener on every install comes
+  from a plugin, so "what plugins can rely on" *is* the contract, not a subset
+  of it.
+- **`register()`'s error handler was itself fatal.** It interpolated
+  `$listener[0]` inside the `catch` meant to swallow a bad listener, so any
+  non-array object — a Closure, say — raised an `\Error` that
+  `catch (\Exception)` does not catch, during `LoadGlobals`. HTTP 500, empty
+  body, every entry point, until the file was deleted from disk.
+- **`docs/plugin-development.md` documented that exact shape three times**, in
+  the §7 examples for the Phase 2 authentication seams. Nothing in
+  `fog-plugins` follows the guide, which is why it survived.
+
+## Decision
+
+### 1. A hook listener is `[Hook, 'method']` or a Closure
+
+Both have an **owner**: the object for the pair, and for a closure whatever
+`$this` it was written inside, recovered with
+`ReflectionFunction::getClosureThis()`. A closure declared in a hook
+constructor is owned by that hook.
+
+A closure with no bound `$this` — a `static function`, or one created outside a
+hook — has no owner and always runs; registering it is the opt-in.
+
+Anything else is refused, and the refusal is logged naming the offending class
+and event. A bare function name and `[Class::class, 'staticMethod']` have no
+owner, and an owner is what a listener needs in order to have an `$active` at
+all.
+
+The Closure form is admitted because the authoring guide has documented it
+since ADR 0014 and it is the natural shape for a plugin contributing a single
+route or login button. Making the documentation true was cheaper than making
+it false.
+
+### 2. `$active` decides whether a listener runs, and nothing else does
+
+Read from the class's declared default at load, and from the live property at
+dispatch. Both by truthiness, so there is one notion of active read the same
+way at both ends.
+
+It used to be neither of those things. At load, a regular expression over the
+file's source text looked for the literal `$active = true;` — `\s?` is
+zero-or-one, the match was case-sensitive, and it could not tell a comment from
+code, so `public $active  = true;` with two spaces was inactive, `TRUE` was
+inactive, and `public $active = false;` with `= true;` written in the comment
+above it was *active*. At dispatch, any listener whose file path contained the
+substring `plugins` was force-activated regardless of its flag.
+
+A value computed in a constructor is deliberately still not consulted at load —
+that was true of the regex too — but it *is* honoured at dispatch, which is why
+the dispatch-time read stays rather than gating construction on the flag.
+
+### 3. A plugin's file path is not part of the activation decision
+
+The force-activation is deleted. Its reason had expired: when `capone` was the
+only plugin, plugins had no hooks of their own, and hooks were adopted into the
+plugin system by copying core's example hooks — every one of which declares
+`$active = false`. Force-truthing anything on a plugin path made a copied
+example work without its author noticing the flag. Plugins have shipped their
+own hooks for years and all 87 bundled hook and event files set
+`$active = true`, so the net catches nothing.
+
+It was never free. It made `$active` decorative for every plugin hook — a
+plugin could not turn one of its own hooks off — and it was a bare `stripos`
+over the whole path, so an install whose base directory contained the string
+would have force-activated core's hooks too.
+
+### 4. Hooks and events are peers that share a base class for historical reasons
+
+`Hook extends Event`, so `$listener instanceof Event` — the only type check
+separating the two — accepted a hook as an event listener. `notify()` would
+then call `Event::onEvent()` on it, and the inherited default printed the event
+name into the response.
+
+A `Hook` is now refused where an event listener is expected, and
+`Event::onEvent()`'s default does nothing.
+
+Making `Hook` extend `FOGBase` directly, so the two are genuine peers, is the
+honest modelling change and is **not** taken here: it changes the answer to
+`$obj instanceof Event` for every hook in existence and needs its own issue.
+
+### 5. `notify()` on a HookManager is an error
+
+It is refused and logged, naming `processEvent()`. It previously returned
+`true` having invoked nothing, because it iterates listeners as objects while
+`HookManager` stores arrays.
+
+Delegating to `processEvent()` was considered and rejected. The two have
+genuinely different calling conventions — `processEvent()` merges an `event`
+key into the payload and calls a named method that can mutate its arguments
+through references, `notify()` passes a copy to a fixed method and discards the
+result — so quietly making one behave as the other blurs the boundary
+decision 4 sharpens.
+
+## Consequences
+
+**For plugin authors.** The documented closure form works. `$active` means what
+it says, in a plugin as in core. A registration that fails says which class and
+which event, in one line, instead of naming neither.
+
+**What can break.** Exactly one thing: a plugin hook that declares
+`$active = false` and relied on the force-activation to run anyway. All 87
+bundled files set it true, and `Event::$active` defaults to `true`, so a hook
+that simply omits the property is unaffected — only an explicit `false` is, and
+writing `false` while expecting the hook to run is not a coherent intent.
+
+Second-order, and smaller: a third-party hook file dropped into `lib/hooks`
+whose `$active` line has unusual spacing starts working, and one whose comment
+contains `= true;` stops. `configureHttpd()` removes the web tree on upgrade,
+so files there do not survive an upgrade in any case.
+
+**For performance.** Nothing here was done for speed, and the measurement says
+that was right: the whole subsystem costs 1–2 ms of an 11–543 ms page render,
+and the per-listener `ReflectionClass` everyone assumes is the expensive part
+totalled 14–168 µs per request. That reflection is gone regardless — it existed
+only to feed the path substring — which is the deletion doing the work rather
+than an optimization.
+
+**This is not an ADR 0013 question.** That ADR's promise concerns the reverse
+`class_alias` specifically, and 1.6.0 is unreleased. There is no shipped 1.6
+plugin ABI, which is why none of the five decisions needed a deprecation
+window.
+
+## Alternatives considered
+
+**Fix the authoring guide instead of accepting closures.** Cheaper, and wrong:
+the guide describes the seam a third-party identity provider is most likely to
+use, and the shape it describes is the ergonomic one. The only technical
+objection — that a closure has no `$active` — dissolved once
+`getClosureThis()` turned out to recover the owning hook.
+
+**Narrow the force-activation rather than deleting it**, by asking
+`Initiator::_isPluginPath()` instead of running `stripos` over the whole path.
+That removes the base-directory misfire and leaves `$active` decorative for
+every plugin hook, which is the half that actually costs something.
+
+**Gate plugin hook construction on `$active` too**, so the flag is read in one
+place and the dispatch-time check disappears. Rejected: it would break a hook
+that computes `$active` in its constructor — `$this->active =
+self::getSetting('FOO');` is the natural way to write "on only when this
+setting is enabled" — which works today for plugin hooks. No core or bundled
+plugin does it, so this protects third-party code only, and the cost of
+protecting it is one property read per listener.
+
+**Rewrite the two managers as one dispatcher with two listener kinds.** The
+right shape — `load()`, `register()` and dispatch all branched on which manager
+they were, which is a class doing two jobs — but it moves every line a plugin
+can observe at once, and every defect found was fixable without it.

--- a/docs/hook-event-plan.md
+++ b/docs/hook-event-plan.md
@@ -1,0 +1,558 @@
+# HOOK AND EVENT SUBSYSTEM — scan and proposal
+
+**Status: implemented.** Written as a scan and proposal; the five decisions in
+§5 were taken on 2026-08-19 and H.0 through H.9 landed as ten commits on
+`fix-hook-event-contract`, with `docs/adr/0017-hook-dispatch-contract.md` as
+the durable statement of what was decided. H.10 is deliberately not done and
+is listed in §4 as its own issue. This document is kept as the reasoning
+behind the ADR, not as an outstanding proposal.
+
+Baseline: `working-1.6` @ `9cb646cba`. Facts proved here are recorded as
+**F-11 … F-22** in `docs/refactor-facts.md`, which outranks this document.
+
+**Evidence method.** Static reading, plus a running copy of the live 1.6 tree
+at `/home/telliott/hookevent-lab` (a `cp -a` of `/var/www/html/fog-1.6`, driven
+over `php -S` against the live database; see `_metrics/START.md`). Claims are
+`VERIFIED` (I ran it and watched it happen), `INFERRED` (I reasoned it from the
+source), `UNKNOWN` (I cannot see it from here).
+
+---
+
+## The headline: three of the seven observations understate the problem
+
+| The brief says | What is actually true |
+|---|---|
+| "a failed registration returns normally and the caller cannot tell" | Only for *some* failures. Hand `register()` a closure or any non-array object and the `catch` block **itself** throws an `\Error`, which nothing catches — **HTTP 500, zero-byte body, every entry point, until the file is deleted**. F-13 |
+| "the hook system is the plugin ABI" | And the authoring guide documents that exact 500 three times, in the §7 examples for the Phase 2 auth seams. Copying the documented example takes the server down. F-14 |
+| "a hook whose property is `false` but whose file contains the literal string is active today" | Confirmed, and it is worse in the other direction too: `public $active  = true;` with two spaces is **inactive**, and so is `TRUE`. Six variants characterized. F-15 |
+| "several things below are wrong today" | Also: no core hook or event has ever loaded on any FOG server (F-11); two of the six shipped event names are never fired (F-19); `HookManager::notify()` returns `true` having invoked nothing (F-17) |
+| goal 3: measure efficiency before optimizing | Measured. The whole subsystem is **1–2 ms of an 11–543 ms page**, and the reflection the force-activation needs costs **14–168 µs**. Drop the goal. F-20 |
+
+The one place the brief *over*states: the plugin path force-activation is not
+obviously redundant — it is load-bearing (F-16). But its blast radius is far
+smaller than it looks, because `Event::$active` already **defaults to `true`**
+(`event.class.php:50`). Removing the force-activation only silences a plugin
+hook that *explicitly wrote* `$active = false;`.
+
+---
+
+## 1. The defect list, as found
+
+Ordered by what it costs when it fires, not by where it lives.
+
+### D1 — `register()`'s error handler is itself fatal · `VERIFIED` F-13
+
+`eventmanager.class.php:114` interpolates `$listener[0]` inside the `catch`
+meant to swallow the failure. A Closure — or any non-`ArrayAccess` object —
+raises `Error: Cannot use object of type X as array`, which `catch (\Exception)`
+does not catch. Registration runs inside a hook constructor during
+`LoadGlobals`, so it escapes `base.inc.php` and takes the whole application
+down, on every entry point, with an empty body.
+
+### D2 — the authoring guide documents D1's shape · `VERIFIED` F-14
+
+`docs/plugin-development.md:588, 622, 636` register a closure against
+`API_PLUGIN_ROUTES`, `PAGE_EXEMPT_NODES` and `LOGIN_PAGE_PROVIDERS`. `register()`
+has never accepted a closure. Nothing in `fog-plugins` follows the guide (the
+real OIDC plugin uses `Hook::registerInstalled()`), so this has never been
+caught in-house. It is the section a third-party auth-provider author is most
+likely to copy, and copying it is D1.
+
+### D3 — the failures that *are* caught are invisible and cost a database row each · `VERIFIED`
+
+The remaining shapes — array-of-2 whose `[0]` is not a `Hook`, or whose method
+does not exist — log and return normally. `FOGBase::log()` ignores `$logfile`
+and `$logbrow` entirely but always calls `logHistory()`, so once an admin is
+signed in that is **one `history` row per failed registration per request**,
+forever. And the message names neither the class nor the event correctly:
+
+```
+[2026-08-18 20:14:58] [2026-08-18 20:14:58] Could not register: Error: Class must extend hook, $s: Event, LAB_SILENT: Class
+```
+
+`$s:` is a typo for `%s:` (both here and in `notify()`), the format has six
+specifiers for seven arguments so `$listener[0]` — the only field that says
+*which* class failed — is dropped, and the timestamp is stamped twice
+(`log()` then `logHistory()`).
+
+### D4 — activation is decided by a regex over source text · `VERIFIED` F-15
+
+`eventmanager.class.php:248-252` line-scans each non-plugin file for
+`$active\s?=\s?true;`. `\s?` is zero-or-one, the match is case-sensitive, and
+the scan does not distinguish code from comments.
+
+| source line | property | loaded today |
+|---|---|---|
+| `public $active = true;` | true | yes |
+| `public $active  = true;` | true | **no** |
+| `public $active =  true;` | true | **no** |
+| `public $active=true;` | true | yes |
+| `public $active = TRUE;` | true | **no** |
+| `public $active = false; // set $active = true; to enable` | **false** | **yes** |
+
+The last row is not hypothetical: writing the toggle into a comment, the
+obvious way to document it, turns the hook on.
+
+### D5 — dispatch force-activates on a path substring · `VERIFIED` F-16
+
+`hookmanager.class.php:102-105` sets `$function[0]->active = true` whenever the
+listener's file path contains the substring `plugins`. Established by
+experiment: a plugin hook declaring `$active = false` **still fires**. So the
+property is decorative for every plugin hook, and `fileitems()`'s
+installed-plugin filter is not what makes this redundant.
+
+`INFERRED`: because it is a bare `stripos` over the whole path, an install
+whose base directory contains the string — `/var/www/myplugins/fog` — would
+force-activate every core hook too. `Initiator::_isPluginPath()` already exists
+and answers the question properly, but it is `private`.
+
+### D6 — `HookManager::notify()` reports success and does nothing · `VERIFIED` F-17
+
+Inherited from `EventManager`. It iterates listeners as objects
+(`$element->active`) while `HookManager` stores `[$object, 'method']` arrays.
+Under PHP 8 the property read is a warning, yields `null`, the closure returns,
+nothing is invoked — and `notify()` returns **`true`**. No core call site and no
+bundled plugin reaches it (`VERIFIED` by grep of both trees), so this is a trap
+for third-party code only.
+
+### D7 — `Hook extends Event` defeats the type check that separates them · `VERIFIED` F-18
+
+`EventManager::register()` guards with `$listener instanceof Event`, which a
+`Hook` satisfies. So a hook can be registered as an event listener, and
+`notify()` then calls `Event::onEvent()` — whose default body `printf`s
+`"<EVENT> Registered"` straight into the response. Every bundled plugin event
+overrides `onEvent()`; the one shipped core event, `hostlist.event.php`, does
+**not**, so the inherited printer is reachable from shipped code.
+
+Answering the brief's question directly: **hooks and events are peers, not
+kinds of one another.** They share a base class only for `log()` and the
+`active`/`logLevel` fields. Their dispatch contracts are genuinely different —
+`processEvent()` merges an `event` key into the payload and calls a named method
+that mutates arguments through embedded references; `notify()` calls a fixed
+method and discards the result. The inheritance buys reuse of four fields and
+costs the only type check that keeps the two apart.
+
+### D8 — "nobody is listening" is treated as an exception · `VERIFIED`
+
+`eventmanager.class.php:175-177` throws, catches, logs, returns `false`.
+`hookmanager.class.php:89-91` handles the identical condition with a bare
+`return`. On this lab server `hasListeners('HOST_CHECKIN')` is `false`, so the
+throw path is the *normal* path for one of the five shipped notify sites.
+
+### D9 — `notify()` repeats the GH-707 mistake `processEvent()` was fixed for · `VERIFIED` F-21
+
+`processEvent()` caches the event-name list in `$knownEvents` precisely because
+asking the database on every fire cost 2000 round trips on a 1000-host tasking.
+`notify()` still does an uncached `NotifyEventManager->exists()` SELECT on every
+call: **0.155 ms of the 0.178 ms** a listener-less `notify()` costs.
+
+### D10 — two shipped event names are never fired · `VERIFIED` F-19
+
+`slack`, `ntfy` and `pushbullet` all register `HOST_IMAGE_FAIL` and
+`HOST_IMAGEUP_COMPLETE`. Core `notify()`s neither. So "image failed" and
+"upload complete" notifications have never worked in 1.6. Conversely
+`HOST_CHECKIN` is notified on every task checkin and nothing has ever listened.
+
+### D11 — `load()` distinguishes the managers by an ordering accident · `VERIFIED` F-22
+
+Two sequential `instanceof` checks; `HookManager extends EventManager` satisfies
+both, and reaches `.hook.php`/`hooks` only because the second assignment
+overwrites the first. Swapping the blocks makes every HookManager load
+`.event.php`, and nothing would say so. (The brief's observation 1, confirmed
+exactly as stated.)
+
+### D12 — the parent enumerates its children by name · `VERIFIED`
+
+`register()` switches on `self::shortName($this)` with a case per subclass and a
+throwing `default`. The comment above it records that this already caused a
+total registration failure once, during the namespace migration. Any third-party
+subclass of either manager hits `default` and silently registers nothing.
+
+### D13 — no core hook or event has ever loaded · `VERIFIED` F-11
+
+All eleven files under `lib/hooks` and `lib/events` declare
+`public $active = false;` and none matches the activation regex. They are
+examples an admin opts into. Not a defect in itself — but it means the *entire*
+live listener population on every FOG server comes from plugins, which is the
+premise every risk assessment below rests on.
+
+---
+
+## 2. The measurement (brief goal 3) — and the recommendation to drop it
+
+`VERIFIED`, twelve authenticated management pages, six plugins installed
+(`ldap location ntfy oidc ou windowskey`). Full table in F-20.
+
+| per request | value |
+|---|---|
+| hook objects constructed | 42 — all from plugins |
+| event objects constructed | 5 |
+| construction wall time | 0.8–1.6 ms |
+| source-text regex scan | 0.40–0.49 ms |
+| `processEvent()` calls | 75–246 (37–158 return immediately, no listener) |
+| listener callbacks invoked | 24–331 |
+| `ReflectionClass` per listener per fire | 24–331, **14–168 µs total** |
+| peak memory | 2–4 MiB, flat |
+| page wall time | 11–543 ms |
+
+**Recommendation: drop goal 3.** The load path is under 1% of a request, memory
+does not move, and the reflection everyone assumes is the expensive part is a
+rounding error. The one exception is D9's uncached SELECT, and that is worth
+fixing because it is a correctness-of-design wart (the identical bug was fixed
+next door), not because 0.155 ms matters.
+
+Nothing below trades clarity for speed. If a proposal here makes the code
+slower and clearer, take it.
+
+---
+
+## 3. What a third-party plugin cannot see
+
+Stated per the brief's requirement, because three proposals below have a safety
+argument that depends on reading plugin source, and three do not.
+
+`fog-plugins` is 87 hook and event files across 16 plugins. Servers run plugins
+neither of us has read, and since ADR 0009 those can live outside the web tree
+in `FOG_PLUGIN_DIR`.
+
+| Proposal | Safety argument | Strength |
+|---|---|---|
+| H.1 fix the fatal catch | Structural — no working plugin can depend on a crash | **Independent of plugin source** |
+| H.4 fix `load()` ordering | Structural — no observable change | **Independent** |
+| H.6 `notify()` no-listener path | Structural — no core caller reads the return value (`VERIFIED`) | **Independent** |
+| H.5 replace the `shortName` switch | Structural for valid callers; a third-party *manager subclass* would start working where it silently did nothing | **Independent**, improvement only |
+| H.3 read `$active` instead of regex-matching | Rests on F-12: zero of 87 shipped files diverge. A third-party file under `lib/hooks` could | **Depends on source we can read + a structural argument for the rest** |
+| H.8 remove the force-activation | Rests on F-12 **plus** the structural fact that `Event::$active` defaults to `true`, so only an *explicit* `$active = false` is affected | **Mostly structural** |
+| H.7 make `HookManager::notify()` honest | Rests on nothing being able to depend on a silent no-op | **Independent**, but it is still a visible change |
+
+---
+
+## 4. Proposed commit sequence
+
+Tree green after every commit. `sh tests/run-all.sh` is the gate throughout.
+
+### H.0 — Characterization tests · blast radius **none**
+
+One new `tests/hook-event-contract.test.php`, following the standalone-script
+convention (`tests/plugin-extension-points.test.php` is the closest model:
+`require commons/init.php`, `new Initiator()`, no database, exit 0/1). Pins
+today's behaviour **including the parts that are wrong**, so every later
+behaviour change shows up as a test that must be edited on purpose.
+
+Pins: the four `register()` shapes and their outcomes; the six-row activation
+table; `Hook` accepted by `EventManager::register()`; `HookManager::notify()`
+returning `true` having invoked nothing; `load()`'s extension choice per manager.
+
+`INFERRED` constraint: `EventManager`/`HookManager` extend `FOGBase`, so
+construct them with `ReflectionClass::newInstanceWithoutConstructor()` to keep
+the test database-free. That covers `register()`, `hasListeners()` and the
+extension choice. `notify()` calls `getClass('NotifyEventManager')->exists()`
+and therefore needs a stub or a `SKIP`; the runner already supports `SKIP`.
+
+### H.1 — A failed registration must never be fatal · blast radius **none for working plugins**
+
+- Describe the listener safely in the `catch` instead of indexing it
+  (`is_array($listener)` → describe `[0]`, else `get_class()`/`gettype()`).
+- Fix the format string: `$s` → `%s`, and one specifier per argument, so the
+  message actually names the class that failed.
+
+This alone converts D1 from a site-wide outage into a log line. Nothing that
+works today changes. What changes is that a plugin currently 500ing the server
+now leaves the server up with that one hook not registered — strictly better,
+and its population is "installs that are down right now".
+
+### H.2 — `register()` accepts a Closure · blast radius **purely additive**
+
+Decision 1: make the documented shape work rather than deleting it from the
+docs. Two listener forms, and the rule is one sentence — **a listener is either
+`[Hook, 'method']` or a `Closure`, and its owner is what carries `$active`.**
+
+| form | owner | activation |
+|---|---|---|
+| `[$hook, 'method']` (unchanged) | `$listener[0]` | `$owner->active` |
+| `Closure` written inside a hook | `ReflectionFunction::getClosureThis()` — `VERIFIED` to return the hook | `$owner->active`, identically |
+| `static function` / closure with no bound `$this` | none | always active; the registration is the opt-in |
+
+Anything else — a bare function name, `[ClassName::class, 'staticMethod']` —
+stays rejected, because an owner is what a listener needs in order to have an
+`$active` at all, and the array form's `instanceof Hook` guard is unchanged.
+
+Storage stays byte-identical for existing entries: an array listener is stored
+as the array it is today, a closure is stored as itself, and the dispatch loop
+branches on `is_array()`. `VERIFIED` that nothing outside the two manager
+classes reads `$data`, in core, in `packages/service` or in `fog-plugins`, so
+the mixed array is not observable.
+
+Net effect on the guide: `docs/plugin-development.md:588, 622, 636` become
+correct as written and need no edit. Worth one added line there anyway noting
+that `registerInstalled()` remains the shape to prefer for a hook registering
+several callbacks, since it also carries the installed-plugin guard.
+
+Must land with or before H.1 either way — otherwise the documented seam stops
+crashing and starts silently doing nothing, which is harder to diagnose than
+the crash.
+
+### H.3 — Read `$active` instead of grepping for it · blast radius **nothing shipped; see Decision 2**
+
+Replace the line-by-line regex with
+`(new \ReflectionClass($class))->getDefaultProperties()['active']` — the
+declared default, which is exactly what the regex was trying to approximate, so
+a value set in a constructor is still not consulted and behaviour is unchanged
+for every shipped file (F-12). Autoloading the class is an include, not a
+construction; the class map is already O(1).
+
+### H.4 — Fix `load()`'s manager discrimination · blast radius **none**
+
+`HookManager` first with an `else`, or better a `protected $fileExtension` /
+`$fileDir` pair declared on each class so the parent stops branching on its
+children's types at all. No observable change; removes a reordering trap.
+
+### H.5 — Each manager validates its own listeners · blast radius **improvement only**
+
+Delete the `shortName()` switch. `EventManager::register()` keeps the
+`instanceof Event` path; `HookManager::register()` overrides it, validates the
+`[Hook, method]` pair, and stores. The parent stops enumerating its children and
+the throwing `default` arm disappears — the shape the comment at `:66-69` says
+already broke every registration once.
+
+### H.6 — `notify()` stops treating silence as an error · blast radius **none**
+
+- `!isset($this->data[$event])` → plain `return false;`, matching
+  `processEvent()`'s bare return. Keeps the existing return value, so no caller
+  can notice; `VERIFIED` that no core call site reads it.
+- Cache the notify-event name list in a static, mirroring `$knownEvents`, with
+  the same comment explaining why staleness is safe.
+
+### H.7 — `HookManager::notify()` stops claiming success · blast radius **third-party callers only**
+
+Decision 3. Override it in `HookManager` to log and return `false` instead of
+inheriting a loop that cannot read its own listeners. Nothing in core,
+`packages/service` or `fog-plugins` calls it (`VERIFIED`), so the only code that
+notices is third-party code whose listeners have never fired — which now gets a
+log line saying why.
+
+### H.8 — Delete the force-activation · blast radius **plugin hooks that explicitly declare `$active = false`**
+
+Decision 4, and it is **one commit, not two.** The earlier plan had a narrowing
+step first — make `Initiator::_isPluginPath()` public and use it in place of
+`stripos($filename, 'plugins')` — to kill the base-directory misfire. With the
+force-activation deleted outright there is nothing left to narrow, so
+`_isPluginPath()` stays private and untouched.
+
+What goes with it: `processEvent()`'s `ReflectionClass`, `getFileName()` and
+`stripos` exist *only* to feed the substring test, so all three go too. The
+dispatch loop becomes: method exists, `$active`, merge, call.
+
+This is the one commit in the sequence that changes what a running server does.
+It lands with the ADR (§7).
+
+### H.9 — Stop a `Hook` being registered as an event · blast radius **none in shipped code**
+
+Decision 5. One `instanceof Hook` guard in `EventManager::register()`, plus
+`Event::onEvent()`'s default body changing from `printf` to a no-op. Every
+bundled plugin event overrides `onEvent()`; the one shipped file that does not,
+`lib/events/hostlist.event.php`, is inactive (F-11) and its author plainly did
+not intend "print the event name into the page" as behaviour.
+
+### H.10 — The dead event names · **split out, not part of this work**
+
+`HOST_IMAGE_FAIL` and `HOST_IMAGEUP_COMPLETE` need a core `notify()` at the
+right place. That is making a notification feature work for the first time, not
+refactoring a subsystem, and it needs its own issue and its own test. Listed
+here only so it is not lost.
+
+---
+
+## 5. Decisions taken
+
+All five settled 2026-08-19. The reasoning that survives is recorded here; the
+reasoning that did not is recorded too, because it was wrong in a way worth not
+repeating.
+
+**The release-freeze argument is struck from this document.** Four of the five
+recommendations below originally leaned on "ADR 0013 promised the plugin ABI
+holds for all of 1.6." That is not what ADR 0013 says. Its §2 makes one
+promise — the reverse `class_alias` in each namespaced file is supported for
+all of 1.6 and cannot be removed before 1.7 — about *the alias*, not about every
+behaviour a plugin can observe. And 1.6.0 has not been released: `working-1.6`
+stamps `1.6.0-beta.NNNN`, so there is no installed base of third-party 1.6
+plugins to keep faith with. Nothing here should be deferred to a "1.7" that is
+two releases away from existing. Where a recommendation survived the correction
+it is because it had a second, structural reason; where it did not, it changed.
+
+### Decision 1 — `register()` accepts a Closure · **taken: yes**
+
+Originally recommended against, on the freeze. With that struck, the only
+remaining objection was that a closure has no `active` and no plugin node — and
+that objection dissolves: `ReflectionFunction::getClosureThis()` recovers the
+hook a closure was written inside (`VERIFIED`), so `$active` governs a closure
+exactly as it governs `[$this, 'method']`. Implementation shape is H.2 above.
+
+The residual cost is honest and small: the dispatch loop gains one `is_array()`
+branch, and a `static function` listener has no owner and is therefore always
+active. That last is a rule to document, not a hole — the alternative is
+refusing a listener form the guide has been recommending for the whole of the
+Phase 2 seam work.
+
+### Decision 2 — read `$active` from the declaration, not from a regex · **taken: yes**
+
+H.3 as written. Zero shipped files change (F-12). Two invisible populations
+change, in opposite directions, and both changes deliver what the file says:
+a spacing or `TRUE` variant is inactive today and starts working; a `false`
+declaration with `= true;` in a comment is active today and stops.
+
+### Decision 3 — `HookManager::notify()` · **taken: log and return `false`**
+
+The recommendation stands but its reason does not. "Delegating to
+`processEvent()` would start running code that has never run on any server" was
+an upgrade-safety argument, and with 1.6.0 unreleased there is no upgrade path
+to protect — that argument is void.
+
+What replaces it: Decision 5 sharpens the boundary between hooks and events by
+refusing a `Hook` where an event listener is expected. Making
+`HookManager::notify()` quietly behave like `processEvent()` blurs the same
+boundary in the same release. `notify()` and `processEvent()` have genuinely
+different calling conventions — one merges an `event` key and mutates arguments
+through references, the other passes by value and discards the result — so
+`notify()` on a HookManager is a category error, and the useful thing to do
+with a category error is say so.
+
+### Decision 4 — remove the plugin path force-activation · **taken: yes, delete it**
+
+H.8, one commit. The safety net is understood, not merely tolerated: it dates
+from when `capone` was the only plugin and hooks were adopted into the plugin
+system by copying core's example hooks, which are all `$active = false`. Force-
+truthing every plugin-path hook made a copied example work without the author
+having to notice the flag. Plugins now ship their own hooks and all 87 of them
+set `$active = true` (F-12), so the net has nothing left to catch.
+
+`$active` is an intended flag: set it false and the hook does not run, wherever
+the file lives. Removing the force-activation is what makes that sentence true.
+
+### Decision 5 — reject a `Hook` passed to `EventManager::register()` · **taken: yes**
+
+Plus changing `Event::onEvent()`'s default from `printf` to a no-op.
+
+Making `Hook` extend `FOGBase` directly — so hooks and events are genuine peers
+rather than one being a kind of the other — is no longer deferred on the freeze
+argument, but it is still not part of this work: it changes the answer to
+`$obj instanceof Event` for every hook, and the defect it would close (F-18) is
+already closed by the one-line guard. It belongs in its own issue with its own
+blast-radius argument, not folded into a bug-fix sequence.
+
+### A refinement that falls out of Decisions 2 and 4
+
+With the force-activation gone, `processEvent()` no longer needs
+`ReflectionClass`, `getFileName()` or the `stripos` — those three lines exist
+only to feed the substring test. That removes the whole measured reflection
+cost (F-20) by deletion rather than by optimization.
+
+**Keep the dispatch-time `$active` read; do not also gate plugin hook
+construction on it.** Gating construction would make `$active` mean one thing
+everywhere and delete one more branch, but it would break a hook that computes
+`$active` in its constructor — `$this->active = self::getSetting('FOO');` is the
+natural way to write "on only when this setting is enabled", and for plugin
+hooks it works today. `VERIFIED` that no core or bundled-plugin code does it, so
+this is protecting third-party code only; the cost of protecting it is one
+property read per listener per fire, which the measurement says is free.
+
+## 6. Alternatives considered and rejected
+
+**Rewrite the two managers as one dispatcher with two listener kinds.** It is
+the right shape — `load()`, `register()` and dispatch all branch on which
+manager they are, which is a class doing two jobs. Rejected here, not deferred
+to a release: it moves every line a plugin can observe at once, and every defect
+on the list above is fixable without it. Worth its own issue, on its own
+evidence, whenever someone wants to make that argument.
+
+**Make activation a database setting rather than a property.** Would let an
+admin toggle a core example hook without editing a file, and would kill D4
+outright. Rejected: it puts a database read in the boot path before
+`LoadGlobals` has finished, and core hooks are examples — the audience for the
+toggle is someone already editing the file.
+
+**Cache the discovered listener set.** The obvious "efficiency" move, and the
+measurement (F-20) says there is nothing to win: 1–2 ms, and a cache keyed on
+the file list is a new invalidation bug in exchange.
+
+**Delete the eleven inactive core hooks.** Tempting after F-11 — they have never
+run on any server. Rejected: they are the worked examples the authoring guide
+points at, and deleting them is a docs decision, not a refactor.
+
+---
+
+## 7. Does this warrant an ADR?
+
+**Yes — one, and narrower than it first looks.**
+
+The argument for: Decisions 1 through 5 change what a plugin author can rely
+on, and four of them leave no trace in the code. A future maintainer looking at
+`hookmanager.class.php` needs to know the missing force-activation is a decision
+and not an omission — that is exactly what an ADR is for, and it is the same
+argument that produced ADR 0012 for a two-line polling guard. The
+force-activation in particular has a *reason* behind it (Decision 4: copied
+core example hooks, back when `capone` was the only plugin), and a reason that
+has expired is worth writing down precisely so nobody re-adds the net.
+
+Note this is **not** an ADR 0013 question. That ADR's promise is about the
+reverse `class_alias` specifically, and 1.6.0 is unreleased — there is no
+shipped ABI here to break, which is why none of the five decisions needed a
+deprecation window.
+
+The argument against, which I do not find sufficient: most of the list (H.1,
+H.4, H.5, H.6) is bug fixing with no observable contract change, and an ADR per
+bug fix is noise.
+
+**Proposal:** one ADR — *"The hook dispatch contract: a listener is
+`[Hook, 'method']` or a Closure, and `$active` is what decides whether it
+runs"* — stating the five settled points: the two listener forms and how a
+closure gets an owner; that activation is read from the declaration at load and
+from the property at dispatch, and from nothing else; that a plugin's file path
+no longer overrides it, and why the net existed; that hooks and events are peers
+sharing a base class for historical reasons, so a `Hook` is not an event
+listener; and that `notify()` on a HookManager is an error rather than a no-op.
+
+Written with H.8, because that is the commit that changes what a running server
+does. It stands alongside ADR 0013 rather than amending it.
+
+---
+
+## 8. UNKNOWN
+
+1. **Third-party plugin hooks that explicitly set `$active = false`.** Decision
+   4's entire residual risk. Unknowable without a survey of installs.
+2. **Third-party hook files dropped into `lib/hooks`** — Decision 2's exposure.
+   Narrowed but not closed by `configureHttpd()` wiping the web tree.
+3. **Whether any third-party code calls `$HookManager->notify()`.** If it does,
+   it has never worked, so this is a question about who gets a new log line.
+4. **`dev-branch`.** Not examined. Every finding above is stated for
+   `working-1.6` only. D1's fatal catch and D4's regex look old enough to be
+   present on 1.5 as well, but that is `INFERRED` from age, not checked — and
+   1.5's plugin population is much larger, so the port is a separate decision.
+5. **Whether the `stripos(path, 'plugins')` misfire has ever fired in the
+   field.** It needs a base directory containing the string; the failure would
+   look like core example hooks mysteriously being active.
+
+---
+
+## 9. Which claim here, if false, would hurt most?
+
+**F-12 — that all 87 bundled plugin hooks and events set `$active = true`, and
+that the source-text regex and the real property agree in every one.**
+
+Decisions 2 and 4 both rest on it. If it is wrong — if even one bundled plugin
+hook has a spacing variant, or relies on the force-activation because it
+declares `false` — then H.3 and H.8 stop being no-ops on code we ship and become
+changes that break a plugin FOG itself distributes, which is precisely the
+"needs editing = breaking change" line the brief draws.
+
+It is a single `find | grep -L` and it is written down in the facts ledger. It
+is also the claim most likely to rot: the next plugin someone writes is the one
+that breaks it. That is the argument for putting the check in `tests/` as part
+of H.0, not only in a document.
+
+The runner-up is F-16 — that the force-activation is load-bearing. If it were
+*not* (if `fileitems()`'s filter really did make it redundant), Decision 4 would
+collapse into an obvious deletion with no risk at all. I proved it by experiment
+rather than by reading, which is why it is stated as a positive result rather
+than an absence.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -330,6 +330,32 @@ public function __construct()
 }
 ```
 
+A listener may also be a **closure**, which is the shape the three
+authentication seams in §7 use — one callback, registered inline, no method to
+name:
+
+```php
+self::$HookManager->register('LOGIN_PAGE_PROVIDERS', function ($args) { /* ... */ });
+```
+
+Both shapes are supported and nothing else is: a bare function name and
+`[SomeClass::class, 'staticMethod']` are refused. Prefer `registerInstalled()`
+when a hook registers several callbacks, since it also carries the
+installed-plugin guard.
+
+**`$active` decides whether your callbacks run.** `Hook` inherits
+`public $active = true;` from `Event`, so you get it for free and only need to
+declare it if you want the hook off. It is read from the class's declared
+default when the file is loaded, and from the live property each time an event
+fires — so a hook is free to compute it in its constructor, and a plugin can
+turn one of its own hooks off. A closure obeys the `$active` of the hook it was
+written inside; a closure with no `$this` — a `static function`, or one created
+outside a hook — has no owner and always runs.
+
+> Before 1.6.0 a hook whose file path contained the string `plugins` was
+> force-activated regardless of its flag, so `$active` was decorative for every
+> plugin hook. See `docs/adr/0017-hook-dispatch-contract.md`.
+
 The example ships three hooks:
 
 - **Menu** (`AddHelloWorldMenuItem`) — `MAIN_MENU_DATA` adds the sidebar entry;
@@ -806,6 +832,12 @@ Fire your own events with `&`‑by‑reference args so listeners can mutate them
   status codes are honest (`500` vs `400`).
 - **Hook constructors must early‑return** when the node isn't in
   `$pluginsinstalled`, or your hooks run for a plugin that isn't enabled.
+  `registerInstalled()` does this for you.
+- **A registration that fails is logged, not thrown.** `register()` catches an
+  unusable listener, writes one line naming the class and the event, and
+  returns — so a typo in a method name costs you a hook that silently never
+  fires. If a callback isn't running, check the log before you check the event
+  name.
 - **List columns** in the JS must match `$headerData` order and the keys the
   router emits (`mainlink`, `id`, friendly field names).
 - **An external plugin's assets are served through a symlink FOG maintains for

--- a/docs/refactor-facts.md
+++ b/docs/refactor-facts.md
@@ -1,0 +1,489 @@
+# FOG Modernization: Verified Facts Ledger
+
+**This file outranks any plan.** If a plan contradicts something here, the plan
+is wrong and must be corrected before implementation.
+
+Append-only. Never edit or delete an entry. If something here turns out to be
+wrong, add a new entry that supersedes it and mark the old one `SUPERSEDED BY
+F-nn`. The history of what we believed and when is part of the value.
+
+Every entry carries the command that proved it. If you cannot write the command,
+it does not belong in this file. Put it in the plan's `INFERRED` or `UNKNOWN`
+section instead.
+
+Baseline unless stated otherwise: `working-1.6`.
+
+---
+
+## Corrections to the approved Phase 0 plan
+
+These were found by verification after approval. Fix the plan document before
+writing any code.
+
+### C-01 — Wrong line number on the second-place claim
+
+The plan cites `lib/common/functions.sh:150` for
+`cp -Rf $webdirsrc/* $webdirdest/`, in both the vendoring recommendation and the
+`fetch-plugins.sh` interaction section. **The actual line is 6592.** Line 150 is
+inside `backupPreservedCustomizations()`, in a comment about `errorStat()`
+severity.
+
+The underlying claim is correct. The citation is not, and it was tagged
+`VERIFIED`.
+
+**Action:** correct both citations. Then re-check every other `functions.sh:`
+line number in the plan the same way. If more than one is off, treat all line
+numbers in that document as approximate until individually confirmed.
+
+```
+grep -n 'cp -Rf \$webdirsrc' lib/common/functions.sh    # 6592
+```
+
+### C-02 — UNKNOWN #4 is closed, and the answer is favourable
+
+Ordering at `functions.sh:6579-6593` is: restore `fog_web_*.BACKUP` first (inside
+the `copybackold` block), then `cp -Rf $webdirsrc/* $webdirdest/`. **New files
+win.** A stale committed `vendor/` is restored and then overwritten, not left in
+place.
+
+The committed-`vendor/` recommendation survives. Remove UNKNOWN #4 and cite this.
+
+```
+sed -n '6579,6593p' lib/common/functions.sh
+```
+
+### C-03 — The installer force-lowercases class filenames on every upgrade
+
+Not flagged by any plan or brief so far. `functions.sh:6583-6588`:
+
+```bash
+dots "Ensuring all classes are lowercased"
+for i in $(find $webdirdest -type f -name "*[A-Z]*\.class\.php" -o -name "*[A-Z]*\.event\.php" -o -name "*[A-Z]*\.hook\.php"); do
+    mv "$i" "$(echo $i | tr A-Z a-z)"
+done
+```
+
+Consequences:
+
+- The lowercase filename convention is **enforced by the installer**, not merely
+  observed. Any Phase 3 file named `Host.class.php` gets silently renamed on a
+  production server at upgrade time.
+- PSR-4 files under `src/` are safe: they are `Host.php`, which does not match
+  `*.class.php`. Committed `vendor/` is safe for the same reason.
+- Pre-existing bug, tangential but real: `tr A-Z a-z` is applied to the whole
+  path `$i`, not the basename. A `webdirdest` containing an uppercase letter
+  produces an `mv` to a directory that does not exist.
+
+**Action:** add to Phase 3's constraint list. Any namespaced file must use a
+bare `.php` suffix, never `.class.php`, or the installer will rename it.
+
+### C-04 — F3's conclusion is overstated; Composer deletes the obstacles
+
+The plan uses `mysqldump.class.php`'s 13 types in one file to conclude PSR-4 can
+never serve the tree. But that file is `ifsnop/mysqldump-php`, on Packagist,
+GPL-3.0, properly namespaced and one-class-per-file upstream. Line 15 is
+`//namespace Ifsnop\Mysqldump;` — commented out so FOG's filename autoloader
+could find it. `lib/router/altorouter.class.php` is the same story
+(`//namespace AltoRouter;`, `@author Danny van Kooten`, MIT).
+
+So PR 0.3 is not only groundwork for a future JWT library. It is the mechanism
+that **retires existing hand-vendored code** which currently has no version, no
+lockfile, no licence metadata and no upgrade path. That is a materially stronger
+argument for Composer than the one in the plan, and it belongs in the ADR.
+
+**Action:** add this to 0.3's rationale. Do **not** do the swaps inside 0.3.
+They are separate follow-up PRs, one per library, each of which must first diff
+the vendored copy against the upstream tag to find local modifications beyond
+the commented namespace.
+
+```
+grep -n 'namespace' packages/web/lib/db/mysqldump.class.php packages/web/lib/router/altorouter.class.php
+```
+
+### C-05 — Dependabot ships with 0.3, not after
+
+Committed `vendor/` means a CVE in a dependency requires a FOG release. That is
+acceptable only if the CVE is discovered automatically. Add Dependabot (or
+equivalent) on `composer.lock` in the same PR that introduces `composer.json`,
+not as a follow-up.
+
+---
+
+## Verified facts
+
+### F-01 — The release tarball is byte-for-byte the tracked tree
+`.gitattributes` is three lines, no `export-ignore`. Anything committed ships.
+```
+cat .gitattributes
+```
+
+### F-02 — `packages/web/lib/plugins/` is not tracked in this repo
+Zero tracked files. Gitignored per ADR 0009; contents come from
+`FOGProject/fog-plugins` via `bin/fetch-plugins.sh`. Any tree-wide change is two
+PRs in two repositories.
+```
+git ls-files packages/web/lib/plugins | wc -l    # 0
+```
+
+### F-03 — Zero namespace declarations in tracked PHP
+**SUPERSEDED BY F-06.** The claim holds; the command under-covers by nine files.
+This is what makes the backslash-prefix pass a genuine no-op.
+```
+git ls-files '*.php' | xargs grep -l '^namespace ' | wc -l    # 0
+```
+
+### F-04 — `mysqldump.class.php` declares 13 types in one file
+Twelve resolve only as a side effect of loading `Mysqldump`. Relevant to PSR-4
+only until C-04's swap happens.
+```
+grep -c '^class \|^abstract class \|^interface ' packages/web/lib/db/mysqldump.class.php    # 13
+```
+
+### F-05 — The web tree is copied to the docroot at `functions.sh:6592`
+Plain `cp -Rf $webdirsrc/* $webdirdest/`. No exclusions. Supersedes the plan's
+`:150` citation.
+```
+sed -n '6592p' lib/common/functions.sh
+```
+
+### F-06 — Zero namespace declarations across all 311 tracked PHP files
+Supersedes F-03, whose claim was right but whose command was not. `git ls-files
+'*.php'` misses the nine daemon entry points under `packages/service/`, which are
+extensionless and open with `#!/usr/bin/php -q` before `<?php`. Those nine files
+are PHP, they load into the same process as everything else, and a namespace
+declaration in one of them would break the backslash-prefix no-op argument just as
+badly. Select on content, not on filename.
+
+Note `^namespace` and not `namespace`: `mysqldump.class.php:16` and
+`altorouter.class.php:15` both carry a commented-out `//namespace` line (see
+C-04), which is not a declaration and must not be counted as one.
+```
+git ls-files | while IFS= read -r f; do
+    head -2 "$f" 2>/dev/null | grep -q '<?php' && printf '%s\n' "$f"
+done > /tmp/fogphp.txt
+wc -l < /tmp/fogphp.txt                                  # 311
+grep -c 'packages/service/FOG' /tmp/fogphp.txt           # 9  (the daemons are in)
+xargs grep -l '^namespace ' < /tmp/fogphp.txt | wc -l    # 0
+```
+
+### F-07 — The installer's lowercase pass yields a duplicate pair, not a rename
+Amends C-03, which says an uppercase-named class file "gets silently renamed".
+It does not — it gets **duplicated**, which is worse.
+
+Order inside `configureHttpd()` is: restore `fog_web_*.BACKUP` (`:6582`) →
+lowercase-rename loop (`:6583-6588`) → `cp -Rf $webdirsrc/*` (`:6592`). The loop
+only ever sees the *restored* tree. So a source file named `Host.class.php` is
+untouched on the upgrade that installs it; on the next upgrade it arrives from the
+backup, is renamed to `host.class.php`, and then `cp -Rf` lays the CamelCase
+original back down beside it. The server ends up serving both.
+
+Two files with one autoloader map key is the readdir-order collision documented at
+`packages/web/commons/init.php:242-250` — identical code resolving to a different
+file on different installs. That is the failure mode, not a rename.
+```
+sed -n '6579,6592p' lib/common/functions.sh
+```
+
+### F-08 — The lowercase pass is gated behind the opt-in `-o` / `--oldcopy` flag
+Also amends C-03's "on every upgrade". The whole block sits inside
+`if [[ $copybackold -gt 0 ]]` (`functions.sh:6579`). `copybackold` defaults to 0
+(`functions.sh:4144`) and is only ever raised by the `-o` / `--oldcopy` installer
+flag (`bin/installfog.sh:281-283`, applied at `:732`). So F-07 fires only on an
+upgrade where the admin asked to copy the old web folder back.
+
+This narrows the blast radius; it does not remove it. `lib/fog/FOGPagePost.class
+.php` and `lib/fog/FOGPageRender.class.php` match the pattern today and are
+therefore already exposed on any `--oldcopy` upgrade.
+`lib/pages/UserGroupManagement.page.php` is not — `.page.php` is absent from the
+three `-name` patterns, which is luck rather than design.
+```
+sed -n '6579p;4144p' lib/common/functions.sh
+grep -n 'scopybackold=1' bin/installfog.sh                      # 282
+git ls-files 'packages/web/**' | grep -E '[A-Z].*\.(class|event|hook)\.php$'
+```
+
+### F-09 — Composer records the repo's own commit SHA unless the root package declares a `version`
+Only shows up once `vendor/` is committed, which is why it was not in the
+plan. `vendor/composer/installed.php` carries a `reference` field for the root
+package, and with no `version` in `composer.json` Composer fills it from git —
+so every `composer install` rewrites a tracked file to whatever `HEAD` is. A
+permanent false diff and a guaranteed merge conflict on a shared branch.
+
+Declaring `"version"` makes the field `null`. It is pinned to the series
+(`1.6.0`), not the build (`1.6.0-beta.NNNN`), so it is not something the
+FOG_VERSION hooks should stamp and does not go stale every commit.
+```
+cd packages/web && composer install && cd - && git status --short packages/web/vendor
+# prints nothing; before the version pin it printed " M .../installed.php"
+```
+
+### F-10 — `psrfix()` rewrites third-party source unless `vendor/` is excluded
+The pre-commit hook runs `php-cs-fixer --rules=@PSR2` over every staged
+`packages/web/*.php`. With `vendor/` committed and no exclusion that includes
+Composer's own files — nine of them on an empty install, more with every
+dependency. That makes a dependency unupdatable: `composer install` rewrites
+the files, the fixer rewrites them back, and the diff never settles.
+
+Ordering consequence, and the reason the implementation deviates from the
+approved plan: the three vendor exclusions must land in a commit **before**
+the one that adds `vendor/`, not after it. Hooks run from the working tree, so
+an exclusion added later is added too late for the commit that needed it.
+```
+git add packages/web/vendor
+git diff --cached --name-only -- 'packages/web/*.php'                                  # 9 files
+git diff --cached --name-only -- 'packages/web/*.php' ':(exclude)packages/web/vendor/*' # none
+git restore --staged packages/web/vendor
+```
+
+### F-11 — No core hook or event is ever loaded
+`load()` starts a non-plugin file only when its source text matches
+`$active\s?=\s?true;`. All eleven files under `packages/web/lib/hooks` and
+`packages/web/lib/events` declare `public $active = false;` and none matches.
+So every listener that runs on a stock server comes from a plugin; the eleven
+core files are examples an admin opts into, not shipped behaviour. Anything
+that reasons about "core hooks" as live code is reasoning about dead code.
+```
+cd packages/web/lib
+ls hooks/*.hook.php events/*.event.php | wc -l                       # 11
+grep -lP '\$active\s?=\s?true;' hooks/*.hook.php events/*.event.php | wc -l   # 0
+grep -lP 'public \$active = false;' hooks/*.hook.php events/*.event.php | wc -l  # 11
+```
+
+### F-12 — Every bundled plugin hook and event sets `$active = true`, and the regex agrees
+87 files across the 16 plugins in `FOGProject/fog-plugins`; the source-text
+regex and the real property value disagree in none of them. This is the
+"anything currently depends on the defect" search the hook/event brief asked
+for, on the half of the population we can see: on shipped code, replacing the
+regex with a property read is a no-op. It says nothing about plugins we have
+never read (see F-16).
+```
+cd /home/telliott/fog-plugins
+find . \( -name '*.hook.php' -o -name '*.event.php' \) | wc -l                       # 87
+find . \( -name '*.hook.php' -o -name '*.event.php' \) -exec grep -LP '\$active\s?=\s?true;' {} + | wc -l   # 0
+```
+
+### F-13 — A listener that is an object but not an array makes `register()` fatal, not logged
+`eventmanager.class.php:114` interpolates `$listener[0]` inside the `catch`
+that is supposed to swallow the failure. When the listener is a Closure or any
+non-`ArrayAccess` object, that line raises `Error: Cannot use object of type X
+as array` — an `\Error`, which `catch (\Exception)` does not catch. Registration
+happens in a hook constructor during `LoadGlobals`, so the Error escapes
+`base.inc.php` and the whole application answers **HTTP 500 with a zero-byte
+body**, on every entry point, until the file is deleted from disk. This is the
+same symptom as the autoload collision at `commons/init.php:242-250`, and it
+is indistinguishable from it in a browser.
+
+Reproduced in `/home/telliott/hookevent-lab` (see `_metrics/START.md`) by
+dropping a hook with `public $active = true;` and a closure `register()` into
+`lib/hooks`:
+```
+[PHP Fatal error: Uncaught Error: Cannot use object of type Closure as array
+ in .../lib/fog/eventmanager.class.php:114
+ #4 .../lib/fog/eventmanager.class.php(279): FOG\FOGBase::startClassFromFiles()]
+curl -s -o /dev/null -w '%{http_code} %{size_download}\n' .../management/index.php   # 500 0
+```
+
+### F-14 — The plugin authoring guide documents the F-13 shape three times
+`docs/plugin-development.md` §7 is the reference for the three Phase 2
+authentication seams (ADR 0014), and all three examples register a closure.
+Nothing in `fog-plugins` follows them — the real OIDC plugin uses
+`Hook::registerInstalled()`, i.e. `[$this, 'method']` — so the guide describes
+a shape that has never worked, in the section a third-party author is most
+likely to copy, and copying it takes the server down rather than failing
+quietly.
+```
+grep -nP "register\('[A-Z_]+',\s*function" docs/plugin-development.md   # 588, 622, 636
+grep -n 'API_PLUGIN_ROUTES' /home/telliott/fog-plugins/oidc/hooks/addoidcroutes.hook.php  # 57, inside registerInstalled([...])
+```
+
+### F-15 — The activation regex disagrees with the property in both directions
+`\s?` is zero-or-one and the scan does not distinguish code from comments, so
+whether a hook runs is decided by its whitespace. Characterized in the lab by
+varying one line and watching for the F-13 fatal (500 = the file was loaded,
+200 = it never was):
+
+| source line | real property | loaded today |
+|---|---|---|
+| `public $active = true;` | true | yes |
+| `public $active  = true;` (two spaces) | true | **no** |
+| `public $active =  true;` (two after `=`) | true | **no** |
+| `public $active=true;` | true | yes |
+| `public $active = TRUE;` | true | **no** |
+| `public $active = false; // set $active = true; to enable` | **false** | **yes** |
+
+The last row is the one that matters: the obvious way to document the toggle in
+a comment turns the hook on. No shipped file is in either failing state (F-11,
+F-12).
+The `loaded today` column was confirmed end to end in the lab by varying that
+one line in a hook whose `register()` triggers F-13, so a 500 means the file
+was loaded and a 200 means it never was. The regex verdict on its own:
+```
+php /home/telliott/hookevent-lab/_metrics/active-regex-verdict.php
+# public $active = true;                    regex=LOADED  property=true
+# public $active  = true;                   regex=skipped property=true
+# public $active =  true;                   regex=skipped property=true
+# public $active=true;                      regex=LOADED  property=true
+# public $active = TRUE;                    regex=skipped property=true
+# public $active = false; // ... = true; .. regex=LOADED  property=false
+```
+
+### F-16 — The plugin path force-activation is load-bearing, not redundant
+`hookmanager.class.php:102-104` sets `$function[0]->active = true` for any
+listener whose file path contains `plugins`. `FOGBase::fileitems()` does filter
+plugin files to installed-and-enabled plugins before this point, so the
+force-activation is not what gates *whether a plugin's code runs* — but it is
+the only thing that reads the hook's own `active` property out of the decision.
+A plugin hook declaring `public $active = false;` still fires. Verified by
+dropping such a hook into an installed plugin's `hooks/` directory in the lab
+and confirming its callback ran on `MAIN_MENU_DATA`.
+
+Consequence for any proposal that removes it: every bundled plugin is safe
+(F-12), and every third-party plugin hook that does not set `$active = true`
+goes silently inactive. We cannot enumerate that population.
+
+### F-17 — `HookManager::notify()` is a silent no-op that reports success
+`HookManager` inherits `notify()`, which iterates listeners as objects
+(`$element->active`), while `HookManager` stores them as `[$object, 'method']`
+arrays. Under PHP 8 that is a warning, not an error: the property read yields
+null, the closure returns, nothing is invoked, and `notify()` returns **true**.
+No core call site and no bundled plugin reaches it, so this is a trap for
+third-party code only.
+```
+# lab: $HookManager->register('E', [$hook,'menuData']); $HookManager->notify('E', []);
+# => returns true, invokes nothing, logs:
+# PHP Warning: Attempt to read property "active" on array in .../eventmanager.class.php on line 183
+```
+
+### F-18 — `Hook extends Event` defeats the only type check separating the two
+`EventManager::register()` guards with `$listener instanceof Event`, which a
+`Hook` satisfies. A hook object can therefore be registered as an event
+listener, and `notify()` then calls `Event::onEvent()` — whose default body
+`printf`s `"<EVENT> Registered"` straight into the response. On a client
+protocol endpoint that is arbitrary text prepended to a `##@GO` reply.
+```
+# lab: $EventManager->register('LAB_MIX', $hookObject);
+# => accepted; notify('LAB_MIX') returns true and prints 'LAB_MIX Registered'
+```
+
+### F-19 — Two of the six shipped event names are never fired, and one fired name has no listeners
+`notify()` is called from five places in core with five names. The bundled
+notification plugins (`slack`, `ntfy`, `pushbullet`) register six. They do not
+match: `HOST_IMAGE_FAIL` and `HOST_IMAGEUP_COMPLETE` have listeners in all three
+plugins and no `notify()` anywhere in the tree, so "image failed" and "upload
+complete" notifications have never fired; `HOST_CHECKIN` is notified on every
+task checkin and nothing has ever listened to it.
+```
+cd packages
+grep -rn -e '->notify(' web/lib --include=*.php | wc -l        # 6 call sites, 5 distinct names
+grep -rh -A1 '>register(' web/lib/plugins/*/events/*.event.php | grep -o "'[A-Z_a-z]*'" | sort -u
+grep -rn 'HOST_IMAGE_FAIL\|HOST_IMAGEUP_COMPLETE' web/lib --include=*.php | grep -v plugins   # nothing
+```
+
+### F-20 — The whole subsystem costs about 1–2 ms of a page render, and no measurable memory
+Measured in the lab across twelve authenticated management pages, on a server
+with six plugins installed (`ldap location ntfy oidc ou windowskey`).
+
+| per request | value |
+|---|---|
+| hook objects constructed | 42 (all from plugins; F-11 means zero from core) |
+| event objects constructed | 5 |
+| construction wall time | 0.8–1.6 ms |
+| source-text regex scan of the 11 core files | 0.40–0.49 ms |
+| `processEvent()` calls | 75–246, of which 37–158 have no listener and early-return |
+| listener callbacks invoked | 24–331 |
+| `ReflectionClass` constructions (one per listener per fire) | 24–331, costing **14–168 µs in total** |
+| peak memory | 2–4 MiB, flat across every page |
+| page wall time for comparison | 11–543 ms |
+
+So goal 3 of the hook/event brief is answered by dropping it: the reflection
+the force-activation needs is a rounding error, and the load path is under 1%
+of a request. Nothing here justifies trading clarity for speed.
+```
+# /home/telliott/hookevent-lab/_metrics/{START.md,drive.sh,metrics.jsonl}
+```
+
+### F-21 — `notify()` repeats the GH-707 mistake `processEvent()` was fixed for
+`processEvent()` caches the `hookevent` name list in a static (`$knownEvents`)
+precisely because asking the database on every fire cost 2000 round trips on a
+1000-host tasking. `notify()` still does an uncached `NotifyEventManager
+->exists()` SELECT on **every** call. Measured at 0.155 ms of the 0.178 ms a
+listener-less `notify()` costs — 87% of the call is bookkeeping for a debugging
+aid. It matters less than GH-707 did only because notify() fires per task, not
+per row.
+```
+# lab: 20 x notify('HOST_CHECKIN') => 3.56 ms total, 3.10 ms of it the exists() SELECT
+```
+
+### F-22 — `load()` tells the two managers apart by an ordering accident
+`eventmanager.class.php:218-225` runs `if ($this instanceof EventManager)` then
+`if ($this instanceof HookManager)`. `HookManager extends EventManager`, so a
+HookManager satisfies both and reaches `.hook.php`/`hooks` only because the
+second assignment overwrites the first. Swapping the two blocks makes every
+HookManager load `.event.php` files, and neither PHP nor any test would say so.
+```
+sed -n '218,225p' packages/web/lib/fog/eventmanager.class.php
+```
+
+### F-23 — ADR 0013's promise is about the alias, not about every plugin-observable behaviour
+Its §2 says the reverse `class_alias` "is supported for all of 1.6" and cannot
+be removed before 1.7. Nothing in it freezes the hook contract, the `$active`
+semantics or `register()`'s accepted listener shapes. Combined with 1.6.0 being
+unreleased — `working-1.6` stamps `1.6.0-beta.NNNN` — there is no shipped 1.6
+plugin ABI, so "we cannot change that inside 1.6" is not an argument any plan
+in this repository may lean on. It was leaned on four times in the first draft
+of `docs/hook-event-plan.md` and was wrong every time.
+```
+grep -n 'supported for all of 1.6' docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
+grep -n "FOG_VERSION" packages/web/lib/fog/system.class.php   # 1.6.0-beta.NNNN, channel Beta
+```
+
+### F-24 — Why the plugin force-activation exists, from the maintainer
+Recorded because the code carries no comment saying it and the reason is the
+whole argument for deleting it. When `capone` was the only plugin, plugins had
+no hooks of their own; hooks were adopted into the plugin system by copying
+core's example hooks, and every core example declares `$active = false`. Force-
+truthing any hook on a plugin path made a copied example work without the author
+noticing the flag. Plugins now ship their own hooks and all 87 set
+`$active = true` (F-12), so the net catches nothing.
+```
+# No command -- this is maintainer knowledge, not a property of the tree.
+# The half that IS checkable is F-12, which is what makes the net redundant.
+```
+
+### F-25 — `ReflectionFunction::getClosureThis()` recovers the hook a closure was written inside
+This is what lets `register()` accept a Closure without inventing new activation
+semantics: a closure written in a hook constructor is bound to that hook, so
+`$active` governs it exactly as it governs `[$this, 'method']`. A `static
+function` returns null and is therefore always active.
+```
+php -r '
+class H { public $active = false;
+  public function make() { return function ($a) { return get_class($this); }; } }
+$h = new H(); $c = $h->make();
+var_dump((new ReflectionFunction($c))->getClosureThis() === $h);          # true
+var_dump((new ReflectionFunction(static function () {}))->getClosureThis()); # NULL
+'
+```
+
+### F-26 — Nothing outside the two manager classes reads their `$data`
+`EventManager::$data` and `HookManager::$data` are `public`, so the stored
+listener shape looks like ABI. It is not: no other file in `packages/web`,
+`packages/service` or `fog-plugins` touches it. That is what makes storing a
+Closure alongside the existing `[object, 'method']` arrays a non-event.
+```
+grep -rn 'HookManager->data\|EventManager->data' packages /home/telliott/fog-plugins   # nothing
+```
+
+---
+
+## How to add an entry
+
+```
+### F-nn — One-line claim in the present tense
+Two or three sentences of consequence. What breaks if this is false.
+```
+the exact command, with the expected output as a comment
+```
+```
+
+Number sequentially. Do not reuse numbers, including for superseded entries.

--- a/packages/web/lib/fog/event.class.php
+++ b/packages/web/lib/fog/event.class.php
@@ -175,7 +175,16 @@ abstract class Event extends FOGBase
     {
     }
     /**
-     * This is a default function for events only.
+     * What EventManager::notify() calls. Subclasses override it.
+     *
+     * Deliberately empty. It used to printf the event name into the response,
+     * which meant an event class that had not overridden it wrote text into
+     * whatever output was being produced -- a page, or a client protocol reply
+     * that the fog-client parses positionally. Every bundled plugin event
+     * overrides this; lib/events/hostlist.event.php, the one core event, does
+     * not, and it is only inactive that saved it.
+     *
+     * A listener that does nothing should do nothing.
      *
      * @param string $event the event to work off.
      * @param mixed  $data  the data, though unused.
@@ -184,11 +193,6 @@ abstract class Event extends FOGBase
      */
     public function onEvent($event, $data)
     {
-        printf(
-            '%s %s',
-            $event,
-            _('Registered')
-        );
     }
 }
 

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -82,60 +82,11 @@ class EventManager extends FOGBase
             if (!is_array($listener) && !is_object($listener)) {
                 throw new \Exception(_('Listener must be an array or an object'));
             }
-            // Short name: the cases below are bare class names and the
-            // default arm throws. A namespaced FQCN would hit that default
-            // for every register() call, so no hook and no event would ever
-            // register -- and the throw is caught and merely logged.
-            switch (self::shortName($this)) {
-                case 'EventManager':
-                    if (!($listener instanceof Event)) {
-                        throw new \Exception(_('Class must extend event'));
-                    }
-                    if (!isset($this->data[$event])) {
-                        $this->data[$event] = [];
-                    }
-                    array_push($this->data[$event], $listener);
-                    break;
-                case 'HookManager':
-                    // A hook listener is either [Hook, method] or a Closure.
-                    // Both have an owner -- the object for the pair, and
-                    // whatever $this the closure was written inside for the
-                    // closure -- and the owner is what carries $active, so
-                    // admitting closures needs no new activation rule. A
-                    // closure with no bound $this has no owner and is
-                    // therefore always active: its registration is the opt-in.
-                    //
-                    // docs/plugin-development.md has documented the closure
-                    // form for the three Phase 2 authentication seams since
-                    // ADR 0014; until now it did not work.
-                    if ($listener instanceof \Closure) {
-                        $this->data[$event][] = $listener;
-                        break;
-                    }
-                    if (!is_array($listener) || count($listener ?: []) !== 2) {
-                        throw new \Exception(
-                            _('Listener must be [class,function] or a closure')
-                        );
-                    }
-                    if (!($listener[0] instanceof Hook)) {
-                        throw new \Exception(_('Class must extend hook'));
-                    }
-                    if (!method_exists($listener[0], $listener[1])) {
-                        $msg = sprintf(
-                            '%s: %s->%s',
-                            _('Method does not exist'),
-                            self::shortName($listener[0]),
-                            $listener[1]
-                        );
-                        throw new \Exception($msg);
-                    }
-                    $this->data[$event][] = $listener;
-                    break;
-                default:
-                    throw new \Exception(
-                        _('Register must be managed from hooks or events')
-                    );
+            $this->acceptListener($listener);
+            if (!isset($this->data[$event])) {
+                $this->data[$event] = [];
             }
+            $this->data[$event][] = $listener;
         } catch (\Exception $e) {
             $string = sprintf(
                 '%s: %s: %s, %s: %s, %s: %s',
@@ -156,6 +107,34 @@ class EventManager extends FOGBase
             );
         }
         return $this;
+    }
+    /**
+     * Refuses a listener this manager cannot dispatch.
+     *
+     * The override point that replaced a switch on self::shortName($this),
+     * with a case per subclass and a default arm that threw. A parent
+     * enumerating its children by name is fragile in exactly the way the
+     * comment above that switch recorded: during the namespace migration every
+     * register() call landed on the default arm, so no hook and no event
+     * registered anywhere, and because the throw is caught and logged the
+     * application went on serving pages with every hook silently absent. It
+     * also meant any subclass of either manager -- something a plugin is free
+     * to write -- registered nothing at all and was told so only in the log.
+     *
+     * Each manager now answers for its own listener shapes and inherits the
+     * one it does not override.
+     *
+     * @param mixed $listener The listener as the caller supplied it.
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    protected function acceptListener($listener)
+    {
+        if (!($listener instanceof Event)) {
+            throw new \Exception(_('Class must extend event'));
+        }
     }
     /**
      * Names a listener for a log line, whatever shape it arrived in.

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -27,6 +27,25 @@ namespace FOG;
 class EventManager extends FOGBase
 {
     /**
+     * The file extension this manager's listeners are declared in.
+     *
+     * Declared per class rather than decided in load(), which used to run two
+     * sequential instanceof checks -- EventManager first, then HookManager.
+     * HookManager extends EventManager, so it satisfied both, and reached
+     * .hook.php only because the second assignment overwrote the first.
+     * Swapping the blocks made every HookManager load .event.php instead, and
+     * nothing would have said so.
+     *
+     * @var string
+     */
+    protected $fileExtension = '.event.php';
+    /**
+     * The directory under BASEPATH those files live in.
+     *
+     * @var string
+     */
+    protected $fileDirectory = 'events';
+    /**
      * Items log level.
      *
      * @var int
@@ -302,15 +321,9 @@ class EventManager extends FOGBase
      */
     public function load()
     {
-        // Sets up regex and paths to scan for
-        if ($this instanceof EventManager) {
-            $extension = '.event.php';
-            $dirpath = 'events';
-        }
-        if ($this instanceof HookManager) {
-            $extension = '.hook.php';
-            $dirpath = 'hooks';
-        }
+        // Each manager says what it loads; see $fileExtension.
+        $extension = $this->fileExtension;
+        $dirpath = $this->fileDirectory;
         $strlen = -strlen($extension);
         list(
             $normalfiles,

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -78,9 +78,24 @@ class EventManager extends FOGBase
                     array_push($this->data[$event], $listener);
                     break;
                 case 'HookManager':
+                    // A hook listener is either [Hook, method] or a Closure.
+                    // Both have an owner -- the object for the pair, and
+                    // whatever $this the closure was written inside for the
+                    // closure -- and the owner is what carries $active, so
+                    // admitting closures needs no new activation rule. A
+                    // closure with no bound $this has no owner and is
+                    // therefore always active: its registration is the opt-in.
+                    //
+                    // docs/plugin-development.md has documented the closure
+                    // form for the three Phase 2 authentication seams since
+                    // ADR 0014; until now it did not work.
+                    if ($listener instanceof \Closure) {
+                        $this->data[$event][] = $listener;
+                        break;
+                    }
                     if (!is_array($listener) || count($listener ?: []) !== 2) {
                         throw new \Exception(
-                            _('Second paramater must be in [class,function]')
+                            _('Listener must be [class,function] or a closure')
                         );
                     }
                     if (!($listener[0] instanceof Hook)) {

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -58,6 +58,22 @@ class EventManager extends FOGBase
      */
     public $data = [];
     /**
+     * Names already present in notifyEvents, as a lookup set.
+     *
+     * The same fix HookManager::$knownEvents carries for GH-707, applied to
+     * the other half of the subsystem. notify() asked the database whether it
+     * had seen the name before on EVERY call -- an exists() SELECT that was
+     * 87% of the cost of a notify() nobody was listening to. The table is a
+     * discovery aid for the notification plugins' settings pages, so the
+     * answer is safe to remember for the life of the process: nothing here
+     * removes names, so the only staleness possible is a name another process
+     * added after we loaded, which costs at worst one redundant save(), and
+     * save() is an upsert.
+     *
+     * @var array|null
+     */
+    private static $knownNotifyEvents = null;
+    /**
      * The events to work from.
      *
      * @var mixed
@@ -107,6 +123,31 @@ class EventManager extends FOGBase
             );
         }
         return $this;
+    }
+    /**
+     * Remembers an event name in notifyEvents, once per process.
+     *
+     * @param string $event The event name to record.
+     *
+     * @return void
+     */
+    private static function _recordEventName($event)
+    {
+        if (self::$knownNotifyEvents === null) {
+            self::$knownNotifyEvents = array_flip(
+                Route::getIds('notifyevent', false, 'name')
+            );
+        }
+        if (isset(self::$knownNotifyEvents[$event])) {
+            return;
+        }
+        // Marked known before the save, not after, so an event fired from
+        // inside save() could never recurse into saving the same name again.
+        // Matches HookManager::processEvent().
+        self::$knownNotifyEvents[$event] = true;
+        self::getClass('NotifyEvent')
+            ->set('name', $event)
+            ->save();
     }
     /**
      * Refuses a listener this manager cannot dispatch.
@@ -198,16 +239,6 @@ class EventManager extends FOGBase
      */
     public function notify($event, $eventData = [])
     {
-        $exists = self::getClass('NotifyEventManager')->exists(
-            $event,
-            '',
-            'name'
-        );
-        if (!$exists) {
-            self::getClass('NotifyEvent')
-                ->set('name', $event)
-                ->save();
-        }
         try {
             if (!is_string($event)) {
                 throw new \Exception(_('Event must be a string'));
@@ -215,22 +246,28 @@ class EventManager extends FOGBase
             if (!is_array($eventData)) {
                 throw new \Exception(_('Event Data must be an array'));
             }
+            // After the guards, not before them: this used to run first, so a
+            // caller who passed something that was not an event name got it
+            // written to the database before being told it was invalid.
+            self::_recordEventName($event);
             if (!isset($this->data[$event])) {
-                throw new \Exception(_('Event and data are not set'));
+                // Nobody is listening. That is not an error -- it is the
+                // ordinary case for four of the five names core notifies, and
+                // for HOST_CHECKIN it is the only case there has ever been --
+                // so it returns like processEvent() does instead of throwing
+                // into the handler below and logging a line per checkin.
+                return false;
             }
-            $runEvent = function ($element) use ($event, $eventData) {
+            foreach ((array) $this->data[$event] as &$element) {
                 if (!$element->active) {
-                    return;
+                    continue;
                 }
                 $element->onEvent($event, $eventData);
-            };
-            foreach ((array) $this->data[$event] as &$element) {
-                $runEvent($element);
                 unset($element);
             }
         } catch (\Exception $e) {
             $string = sprintf(
-                '%s: %s: %s, $s: %s',
+                '%s: %s: %s, %s: %s',
                 _('Could not notify'),
                 _('Error'),
                 $e->getMessage(),

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -118,8 +118,8 @@ class EventManager extends FOGBase
                 $string,
                 $this->logLevel,
                 0,
-                $this,
-                0
+                0,
+                $this
             );
         }
         return $this;
@@ -278,8 +278,8 @@ class EventManager extends FOGBase
                 $string,
                 $this->logLevel,
                 0,
-                $this,
-                0
+                0,
+                $this
             );
 
             return false;

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -253,6 +253,49 @@ class EventManager extends FOGBase
         return true;
     }
     /**
+     * Whether a hook or event file's class declares itself active.
+     *
+     * Reads the declared default of $active off the class, which is what the
+     * source-text regex this replaced was trying to approximate. A value
+     * assigned in a constructor is still not consulted, exactly as before, so
+     * no shipped file changes verdict -- all eleven core hooks and events
+     * declare `public $active = false;` and none of the 87 bundled plugin
+     * files disagrees with the old regex either.
+     *
+     * Two things do change, both deliberately. Spacing and case no longer
+     * decide anything. And a file that declares no $active at all now
+     * inherits Event's default of true and runs, where the regex found no
+     * literal and skipped it -- which is the point of asking the class: the
+     * class genuinely is active.
+     *
+     * Truthiness, not identity, so this agrees with the check
+     * HookManager::processEvent() makes at dispatch. One notion of active.
+     *
+     * @param string $file   Absolute path to the .hook.php/.event.php file.
+     * @param int    $strlen Negative length of the extension, as load() has it.
+     *
+     * @return bool
+     */
+    private static function _declaresActive($file, $strlen)
+    {
+        $className = str_replace(
+            ["\t","\n",' '],
+            '_',
+            substr(
+                basename($file),
+                0,
+                $strlen
+            )
+        );
+        // class-name consumer: handed to class_exists() and ReflectionClass,
+        // both of which resolve a namespaced name and a global one alike.
+        if (!class_exists($className)) {
+            return false;
+        }
+        $defaults = (new \ReflectionClass($className))->getDefaultProperties();
+        return !empty($defaults['active']);
+    }
+    /**
      * Loads the events or hooks.
      *
      * @return void
@@ -277,31 +320,20 @@ class EventManager extends FOGBase
             $dirpath,
             true
         );
-        // Scan non plugin files and see if the active flag is set.
-        // If active, start the class, otherwise on to next file.
+        // Non-plugin files opt in through $active. Ask the class, not the
+        // file: this used to be a line-by-line regex for the literal text
+        // `$active = true;`, which decided whether a hook ran on its
+        // whitespace and its case, and could not tell a comment from code.
+        // `public $active  = true;` with two spaces was inactive, and so was
+        // `TRUE`, while `public $active = false;` with `= true;` written in
+        // the comment above it -- the obvious way to document the toggle --
+        // was active.
         $startfiles = [];
         foreach ($normalfiles as &$file) {
-            if (false === ($fh = fopen($file, 'rb'))) {
-                continue;
-            }
-            while (feof($fh) === false) {
-                unset($active);
-                $line = fgets($fh, 4096);
-                if (false === $line) {
-                    continue;
-                }
-                preg_match(
-                    '#(\$active\s?=\s?true;)#',
-                    $line,
-                    $linefound
-                );
-                if (count($linefound ?: []) < 1) {
-                    continue;
-                }
+            if (self::_declaresActive($file, $strlen)) {
                 $startfiles[] = $file;
-                break;
             }
-            fclose($fh);
+            unset($file);
         }
         unset($normalfiles);
         $startfiles = self::fastmerge(

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -104,14 +104,14 @@ class EventManager extends FOGBase
             }
         } catch (\Exception $e) {
             $string = sprintf(
-                '%s: %s: %s, $s: %s, %s: %s',
+                '%s: %s: %s, %s: %s, %s: %s',
                 _('Could not register'),
                 _('Error'),
                 $e->getMessage(),
                 _('Event'),
                 $event,
                 _('Class'),
-                $listener[0]
+                self::_describeListener($listener)
             );
             self::log(
                 $string,
@@ -122,6 +122,36 @@ class EventManager extends FOGBase
             );
         }
         return $this;
+    }
+    /**
+     * Names a listener for a log line, whatever shape it arrived in.
+     *
+     * This used to be a bare `$listener[0]`, written inside the very catch
+     * that exists to swallow a bad listener. Handing register() an object that
+     * is not an array -- a Closure, say -- therefore raised "Cannot use object
+     * of type X as array", which is an \Error and not caught by
+     * catch (\Exception). Registration runs in a hook constructor during
+     * LoadGlobals, so that escaped to the top and the whole application
+     * answered 500 with an empty body, on every entry point, until the file
+     * was deleted from disk. An error handler must not be able to fail harder
+     * than the error it is reporting.
+     *
+     * @param mixed $listener The listener as the caller supplied it.
+     *
+     * @return string
+     */
+    private static function _describeListener($listener)
+    {
+        if (is_array($listener)) {
+            $first = reset($listener);
+            // Short name: this is log text, not a class reference.
+            return is_object($first) ? self::shortName($first) : gettype($first);
+        }
+        if (is_object($listener)) {
+            // Short name: as above.
+            return self::shortName($listener);
+        }
+        return gettype($listener);
     }
     /**
      * Tells whether anything is registered against an event.

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -176,6 +176,20 @@ class EventManager extends FOGBase
         if (!($listener instanceof Event)) {
             throw new \Exception(_('Class must extend event'));
         }
+        // Hook extends Event, so the guard above accepts a hook -- the only
+        // type check separating the two, and it does not. What follows from
+        // that is not theoretical: notify() would then call Event::onEvent()
+        // on it, and hooks do not implement onEvent(), so the inherited
+        // default ran. That default used to print the event name into the
+        // response, which on a client protocol endpoint is arbitrary text in
+        // front of a ##@GO reply.
+        //
+        // The two have genuinely different dispatch contracts -- see
+        // HookManager::notify() -- so a hook is refused here rather than
+        // silently dispatched as something it is not.
+        if ($listener instanceof Hook) {
+            throw new \Exception(_('A hook is not an event listener'));
+        }
     }
     /**
      * Names a listener for a log line, whatever shape it arrived in.

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -47,9 +47,9 @@ class HookManager extends EventManager
     /**
      * Data to store and use.
      *
-     * @var mixed
+     * @var array
      */
-    public $data;
+    public $data = [];
     /**
      * Events to work off.
      *
@@ -73,6 +73,50 @@ class HookManager extends EventManager
      * @var array|null
      */
     private static $knownEvents = null;
+    /**
+     * Refuses a listener this manager cannot dispatch.
+     *
+     * A hook listener is either [Hook, method] or a Closure. Both have an
+     * owner -- the object for the pair, and whatever $this the closure was
+     * written inside for the closure -- and the owner is what carries
+     * $active, so admitting closures needed no new activation rule. A closure
+     * with no bound $this has no owner and always runs: registering it is the
+     * opt-in.
+     *
+     * docs/plugin-development.md has documented the closure form for the
+     * three Phase 2 authentication seams since ADR 0014.
+     *
+     * @param mixed $listener The listener as the caller supplied it.
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    protected function acceptListener($listener)
+    {
+        if ($listener instanceof \Closure) {
+            return;
+        }
+        if (!is_array($listener) || count($listener ?: []) !== 2) {
+            throw new \Exception(
+                _('Listener must be [class,function] or a closure')
+            );
+        }
+        if (!($listener[0] instanceof Hook)) {
+            throw new \Exception(_('Class must extend hook'));
+        }
+        if (!method_exists($listener[0], $listener[1])) {
+            throw new \Exception(
+                sprintf(
+                    '%s: %s->%s',
+                    _('Method does not exist'),
+                    // Short name: this is log text, not a class reference.
+                    self::shortName($listener[0]),
+                    $listener[1]
+                )
+            );
+        }
+    }
     /**
      * Processes the system for customizable elements.
      *

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -90,27 +90,43 @@ class HookManager extends EventManager
             return;
         }
         foreach ((array) $this->data[$event] as &$function) {
-            $active = false;
-            // class-name consumer: handed straight to ReflectionClass,
-            // which resolves a namespaced name and a global one alike.
-            $className = get_class($function[0]);
-            $refClass = new \ReflectionClass($className);
-            $filename = $refClass->getFileName();
-            if (!method_exists($function[0], $function[1])) {
-                continue;
+            // Two listener shapes, one activation rule. A pair's owner is its
+            // object; a closure's owner is whatever $this it was written
+            // inside, which for a closure declared in a hook constructor is
+            // that hook. Either way the owner is what carries $active, so a
+            // closure obeys the flag exactly as [$this, 'method'] does. A
+            // closure with no bound $this has no owner and always runs.
+            if ($function instanceof \Closure) {
+                $owner = (new \ReflectionFunction($function))->getClosureThis();
+                $callable = $function;
+            } else {
+                $owner = $function[0];
+                if (!method_exists($owner, $function[1])) {
+                    continue;
+                }
+                $callable = [$owner, $function[1]];
             }
-            if (stripos($filename, 'plugins') !== false) {
-                $function[0]->active = true;
+            if ($owner instanceof Hook) {
+                // class-name consumer: handed straight to ReflectionClass,
+                // which resolves a namespaced name and a global one alike.
+                $className = get_class($owner);
+                $refClass = new \ReflectionClass($className);
+                $filename = $refClass->getFileName();
+                if (stripos($filename, 'plugins') !== false) {
+                    $owner->active = true;
+                }
+                if (!$owner->active) {
+                    continue;
+                }
             }
-            $active = $function[0]->active;
-            if (!$active) {
-                continue;
-            }
+            // Kept in a variable rather than inlined into the call: a listener
+            // is free to declare its parameter by reference, and only a
+            // variable can bind to one.
             $mergedArr = self::fastmerge(
                 ['event' => $event],
                 $arguments
             );
-            $function[0]->{$function[1]}($mergedArr);
+            $callable($mergedArr);
             unset($function);
         }
     }

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -74,6 +74,47 @@ class HookManager extends EventManager
      */
     private static $knownEvents = null;
     /**
+     * Refuses to notify. A hook is not an event listener.
+     *
+     * notify() is EventManager's, and it iterates listeners as objects --
+     * $element->active, $element->onEvent(). HookManager stores them as
+     * [object, method] arrays and Closures, so under PHP 8 the property read
+     * on an array is a warning that yields null, every listener is skipped,
+     * and the inherited method returned TRUE having invoked nothing.
+     *
+     * Nothing in core, in packages/service or in fog-plugins calls it, so the
+     * only code this reaches is third-party code whose listeners have never
+     * fired. Say so rather than fixing it silently: the two are not two spellings
+     * of one thing. processEvent() merges an `event` key into the payload and
+     * calls a named method that can mutate its arguments through references;
+     * notify() passes a copy to a fixed method and discards the result. Quietly
+     * making one behave as the other would blur a boundary the rest of this
+     * work is sharpening -- see EventManager::register(), which no longer
+     * accepts a Hook as an event listener either.
+     *
+     * @param string $event     the event to notify against
+     * @param array  $eventData the data to pass
+     *
+     * @return bool
+     */
+    public function notify($event, $eventData = [])
+    {
+        self::log(
+            sprintf(
+                '%s: %s. %s',
+                _('Cannot notify from the hook manager'),
+                is_string($event) ? $event : gettype($event),
+                _('Use processEvent instead')
+            ),
+            $this->logLevel,
+            0,
+            0,
+            $this
+        );
+
+        return false;
+    }
+    /**
      * Refuses a listener this manager cannot dispatch.
      *
      * A hook listener is either [Hook, method] or a Closure. Both have an

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -27,6 +27,18 @@ namespace FOG;
 class HookManager extends EventManager
 {
     /**
+     * The file extension this manager's listeners are declared in.
+     *
+     * @var string
+     */
+    protected $fileExtension = '.hook.php';
+    /**
+     * The directory under BASEPATH those files live in.
+     *
+     * @var string
+     */
+    protected $fileDirectory = 'hooks';
+    /**
      * Log level if needed.
      *
      * @var int

--- a/packages/web/lib/fog/hookmanager.class.php
+++ b/packages/web/lib/fog/hookmanager.class.php
@@ -186,7 +186,7 @@ class HookManager extends EventManager
         if (!isset($this->data[$event])) {
             return;
         }
-        foreach ((array) $this->data[$event] as &$function) {
+        foreach ((array) $this->data[$event] as $function) {
             // Two listener shapes, one activation rule. A pair's owner is its
             // object; a closure's owner is whatever $this it was written
             // inside, which for a closure declared in a hook constructor is
@@ -203,18 +203,14 @@ class HookManager extends EventManager
                 }
                 $callable = [$owner, $function[1]];
             }
-            if ($owner instanceof Hook) {
-                // class-name consumer: handed straight to ReflectionClass,
-                // which resolves a namespaced name and a global one alike.
-                $className = get_class($owner);
-                $refClass = new \ReflectionClass($className);
-                $filename = $refClass->getFileName();
-                if (stripos($filename, 'plugins') !== false) {
-                    $owner->active = true;
-                }
-                if (!$owner->active) {
-                    continue;
-                }
+            // $active decides, wherever the file lives. This used to reflect
+            // on the listener's class, take its filename and force
+            // active = true whenever the path contained the substring
+            // "plugins" -- so the flag was decorative for every plugin hook
+            // and a plugin could not turn one of its own hooks off. See
+            // docs/adr/0017.
+            if ($owner instanceof Hook && !$owner->active) {
+                continue;
             }
             // Kept in a variable rather than inlined into the call: a listener
             // is free to declare its parameter by reference, and only a
@@ -224,7 +220,6 @@ class HookManager extends EventManager
                 $arguments
             );
             $callable($mergedArr);
-            unset($function);
         }
     }
 }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4421,6 +4421,10 @@ msgstr "Installierte Plugins"
 msgid "List of MACs"
 msgstr "Alle %s auflisten"
 
+#, fuzzy
+msgid "Listener must be [class,function] or a closure"
+msgstr "Listener muss ein Array oder ein Objekt sein"
+
 msgid "Listener must be an array or an object"
 msgstr "Listener muss ein Array oder ein Objekt sein"
 
@@ -6540,9 +6544,6 @@ msgstr "Die Suche lieferte kein passendes Ergebnis"
 #, fuzzy
 msgid "Search settings"
 msgstr "Service-Status"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1191,6 +1191,10 @@ msgid "Cannot filter %s on: %s"
 msgstr ""
 
 #, fuzzy
+msgid "Cannot notify from the hook manager"
+msgstr "Prüfe, ob ich der Gruppenmanager bin"
+
+#, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Es können keine Tasks auf ausstehende Hosts ausgeführt werden!"
 
@@ -8571,6 +8575,9 @@ msgstr ""
 
 msgid "Use extreme caution with this setting"
 msgstr "Seien Sie seeehr vorsichtig mit diesen Einstellungen"
+
+msgid "Use processEvent instead"
+msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -244,6 +244,9 @@ msgstr "Speichergruppe gelöscht"
 msgid "A group name is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
@@ -6151,9 +6154,6 @@ msgstr "Service-Status"
 msgid "Refresh the settings cache"
 msgstr "Service-Status"
 
-msgid "Registered"
-msgstr "Registriert"
-
 msgid "Registered Hosts"
 msgstr "Registrierte Hosts"
 
@@ -10303,6 +10303,9 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
+
+#~ msgid "Registered"
+#~ msgstr "Registriert"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6150,9 +6150,6 @@ msgstr "Service-Status"
 msgid "Refresh the settings cache"
 msgstr "Service-Status"
 
-msgid "Register must be managed from hooks or events"
-msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
-
 msgid "Registered"
 msgstr "Registriert"
 
@@ -10296,6 +10293,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Register must be managed from hooks or events"
+#~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2224,9 +2224,6 @@ msgstr "Ereignis"
 msgid "Event Data must be an array"
 msgstr "Ereignisdaten müssen ein Array sein."
 
-msgid "Event and data are not set"
-msgstr "Ereignis und Daten sind nicht gesetzt"
-
 msgid "Event must be a string"
 msgstr "Ereignisname muss eine Zeichenfolge sein."
 
@@ -10028,6 +10025,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
+
+#~ msgid "Event and data are not set"
+#~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
 #, fuzzy
 #~ msgid "Export Host Exts"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2226,9 +2226,6 @@ msgstr "Add Event"
 msgid "Event Data must be an array"
 msgstr "Event must be a string"
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr "Event must be a string"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -249,6 +249,9 @@ msgstr "Storage Group deleted"
 msgid "A group name is required!"
 msgstr "An image name is required!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "An image already exists with this name!"
@@ -6149,9 +6152,6 @@ msgstr "Service Status"
 msgid "Refresh the settings cache"
 msgstr "Service Status"
 
-msgid "Registered"
-msgstr "Registered"
-
 msgid "Registered Hosts"
 msgstr "Registered Hosts"
 
@@ -10275,6 +10275,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Registered"
+#~ msgstr "Registered"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1194,6 +1194,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Cannot set taskings to pending or invalid items"
@@ -8567,6 +8570,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6149,9 +6149,6 @@ msgstr "Service Status"
 msgid "Refresh the settings cache"
 msgstr "Service Status"
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr "Registered"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4421,6 +4421,9 @@ msgstr "Installed Plugins"
 msgid "List of MACs"
 msgstr "List All %s"
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -6540,9 +6543,6 @@ msgstr ""
 #, fuzzy
 msgid "Search settings"
 msgstr "Service Status"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2265,9 +2265,6 @@ msgstr "Añadir evento"
 msgid "Event Data must be an array"
 msgstr "Evento debe ser una cadena"
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr "Evento debe ser una cadena"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1210,6 +1210,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "No se puede establecer taskings de pendiente o elementos no válidos"
@@ -8749,6 +8752,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4527,6 +4527,9 @@ msgstr "No disponible"
 msgid "List of MACs"
 msgstr ""
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -6693,9 +6696,6 @@ msgstr ""
 #, fuzzy
 msgid "Search settings"
 msgstr "Estado del servicio"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -247,6 +247,9 @@ msgstr "Nombre del grupo de almacenamiento"
 msgid "A group name is required!"
 msgstr "Se requiere un nombre de imagen!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
@@ -6296,9 +6299,6 @@ msgstr "Estado del servicio"
 msgid "Refresh the settings cache"
 msgstr "Estado del servicio"
 
-msgid "Registered"
-msgstr "Registrado"
-
 #, fuzzy
 msgid "Registered Hosts"
 msgstr "Registrado"
@@ -10460,6 +10460,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "impresora Alias"
+
+#~ msgid "Registered"
+#~ msgstr "Registrado"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6296,9 +6296,6 @@ msgstr "Estado del servicio"
 msgid "Refresh the settings cache"
 msgstr "Estado del servicio"
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr "Registrado"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6151,9 +6151,6 @@ msgstr "Service-Status"
 msgid "Refresh the settings cache"
 msgstr "Service-Status"
 
-msgid "Register must be managed from hooks or events"
-msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
-
 msgid "Registered"
 msgstr "Registriert"
 
@@ -10297,6 +10294,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Register must be managed from hooks or events"
+#~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1191,6 +1191,10 @@ msgid "Cannot filter %s on: %s"
 msgstr ""
 
 #, fuzzy
+msgid "Cannot notify from the hook manager"
+msgstr "Prüfe, ob ich der Gruppenmanager bin"
+
+#, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Es können keine Tasks auf ausstehende Hosts ausgeführt werden!"
 
@@ -8572,6 +8576,9 @@ msgstr ""
 
 msgid "Use extreme caution with this setting"
 msgstr "Seien Sie seeehr vorsichtig mit diesen Einstellungen"
+
+msgid "Use processEvent instead"
+msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4422,6 +4422,10 @@ msgstr "Installierte Plugins"
 msgid "List of MACs"
 msgstr "Alle %s auflisten"
 
+#, fuzzy
+msgid "Listener must be [class,function] or a closure"
+msgstr "Listener muss ein Array oder ein Objekt sein"
+
 msgid "Listener must be an array or an object"
 msgstr "Listener muss ein Array oder ein Objekt sein"
 
@@ -6541,9 +6545,6 @@ msgstr "Die Suche lieferte kein passendes Ergebnis"
 #, fuzzy
 msgid "Search settings"
 msgstr "Service-Status"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -244,6 +244,9 @@ msgstr "Speichergruppe gelöscht"
 msgid "A group name is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
@@ -6152,9 +6155,6 @@ msgstr "Service-Status"
 msgid "Refresh the settings cache"
 msgstr "Service-Status"
 
-msgid "Registered"
-msgstr "Registriert"
-
 msgid "Registered Hosts"
 msgstr "Registrierte Hosts"
 
@@ -10304,6 +10304,9 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
+
+#~ msgid "Registered"
+#~ msgstr "Registriert"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2224,9 +2224,6 @@ msgstr "Ereignis"
 msgid "Event Data must be an array"
 msgstr "Ereignisdaten müssen ein Array sein."
 
-msgid "Event and data are not set"
-msgstr "Ereignis und Daten sind nicht gesetzt"
-
 msgid "Event must be a string"
 msgstr "Ereignisname muss eine Zeichenfolge sein."
 
@@ -10029,6 +10026,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
+
+#~ msgid "Event and data are not set"
+#~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
 #, fuzzy
 #~ msgid "Export Host Exts"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -250,6 +250,9 @@ msgstr "Groupe de stockage supprimé"
 msgid "A group name is required!"
 msgstr "Un nom de l'image est nécessaire!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
@@ -6151,9 +6154,6 @@ msgstr "État du service"
 msgid "Refresh the settings cache"
 msgstr "État du service"
 
-msgid "Registered"
-msgstr "Inscrit"
-
 msgid "Registered Hosts"
 msgstr "hôtes inscrits"
 
@@ -10281,6 +10281,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "imprimante Alias"
+
+#~ msgid "Registered"
+#~ msgstr "Inscrit"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6151,9 +6151,6 @@ msgstr "État du service"
 msgid "Refresh the settings cache"
 msgstr "État du service"
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr "Inscrit"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4423,6 +4423,9 @@ msgstr "Plugins installés"
 msgid "List of MACs"
 msgstr "Lister tous les %s"
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -6542,9 +6545,6 @@ msgstr ""
 #, fuzzy
 msgid "Search settings"
 msgstr "État du service"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1195,6 +1195,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Impossible de définir les affectations en cours ou éléments non valides"
@@ -8569,6 +8572,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2228,9 +2228,6 @@ msgstr "Ajouter un évènement"
 msgid "Event Data must be an array"
 msgstr "Événement doit être une chaîne"
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr "Événement doit être une chaîne"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -244,6 +244,9 @@ msgstr "Storage Group cancellato"
 msgid "A group name is required!"
 msgstr "È richiesto un nome di gruppo!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 msgid "A host already exists with this name!"
 msgstr "Un host già esiste con questo nome!"
 
@@ -5939,9 +5942,6 @@ msgstr "Stato servizio"
 msgid "Refresh the settings cache"
 msgstr "Stato servizio"
 
-msgid "Registered"
-msgstr "Registrato"
-
 msgid "Registered Hosts"
 msgstr "host registrati"
 
@@ -9912,6 +9912,9 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Registro deve essere gestito da hook o eventi"
+
+#~ msgid "Registered"
+#~ msgstr "Registrato"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4262,6 +4262,10 @@ msgstr "plugin installati"
 msgid "List of MACs"
 msgstr "Elencare tutti %s"
 
+#, fuzzy
+msgid "Listener must be [class,function] or a closure"
+msgstr "Listener deve essere un array o un oggetto"
+
 msgid "Listener must be an array or an object"
 msgstr "Listener deve essere un array o un oggetto"
 
@@ -6312,9 +6316,6 @@ msgstr "Risultati di ricerca che restituiscono false"
 #, fuzzy
 msgid "Search settings"
 msgstr "Stato servizio"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2158,9 +2158,6 @@ msgstr "Evento"
 msgid "Event Data must be an array"
 msgstr "Event data deve essere un array"
 
-msgid "Event and data are not set"
-msgstr "Event e data non sono impostati"
-
 msgid "Event must be a string"
 msgstr "Evento deve essere una stringa"
 
@@ -9646,6 +9643,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Percorso non disponibile"
+
+#~ msgid "Event and data are not set"
+#~ msgstr "Event e data non sono impostati"
 
 #, fuzzy
 #~ msgid "Export Host Exts"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1153,6 +1153,10 @@ msgid "Cannot filter %s on: %s"
 msgstr ""
 
 #, fuzzy
+msgid "Cannot notify from the hook manager"
+msgstr "Controllare se sono il responsabile del gruppo"
+
+#, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Impossibile affidare attività ad host in attesa"
 
@@ -8266,6 +8270,9 @@ msgstr ""
 
 msgid "Use extreme caution with this setting"
 msgstr "Usa la massima attenzione con questa impostazione"
+
+msgid "Use processEvent instead"
+msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5938,9 +5938,6 @@ msgstr "Stato servizio"
 msgid "Refresh the settings cache"
 msgstr "Stato servizio"
 
-msgid "Register must be managed from hooks or events"
-msgstr "Registro deve essere gestito da hook o eventi"
-
 msgid "Registered"
 msgstr "Registrato"
 
@@ -9905,6 +9902,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "stampante Alias"
+
+#~ msgid "Register must be managed from hooks or events"
+#~ msgstr "Registro deve essere gestito da hook o eventi"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -233,6 +233,9 @@ msgstr "グループを選択してください。"
 msgid "A group name is required!"
 msgstr "グループ名は必須です！"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 msgid "A host already exists with this name!"
 msgstr "この名前のホストは既に存在します！"
 
@@ -5893,9 +5896,6 @@ msgstr ""
 msgid "Refresh the settings cache"
 msgstr "FOG 設定"
 
-msgid "Registered"
-msgstr "登録済み"
-
 msgid "Registered Hosts"
 msgstr "登録済みホスト"
 
@@ -10919,6 +10919,9 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "登録はフックまたはイベントから管理する必要があります"
+
+#~ msgid "Registered"
+#~ msgstr "登録済み"
 
 #~ msgid "Releasing Staff Initials"
 #~ msgstr "返却担当者のイニシャル"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4219,6 +4219,10 @@ msgstr "インストール済みプラグイン"
 msgid "List of MACs"
 msgstr "すべての %s を一覧表示"
 
+#, fuzzy
+msgid "Listener must be [class,function] or a closure"
+msgstr "2 番目のパラメーターは array(class,function) 形式である必要があります"
+
 msgid "Listener must be an array or an object"
 msgstr "リスナーは配列またはオブジェクトである必要があります"
 
@@ -6260,10 +6264,6 @@ msgstr "検索結果が false を返しました"
 #, fuzzy
 msgid "Search settings"
 msgstr "設定"
-
-#, fuzzy
-msgid "Second paramater must be in [class,function]"
-msgstr "2 番目のパラメーターは array(class,function) 形式である必要があります"
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5892,9 +5892,6 @@ msgstr ""
 msgid "Refresh the settings cache"
 msgstr "FOG 設定"
 
-msgid "Register must be managed from hooks or events"
-msgstr "登録はフックまたはイベントから管理する必要があります"
-
 msgid "Registered"
 msgstr "登録済み"
 
@@ -10912,6 +10909,9 @@ msgstr ""
 
 #~ msgid "Rebranding element has been successfully updated!"
 #~ msgstr "ブランド設定を更新しました！"
+
+#~ msgid "Register must be managed from hooks or events"
+#~ msgstr "登録はフックまたはイベントから管理する必要があります"
 
 #~ msgid "Releasing Staff Initials"
 #~ msgstr "返却担当者のイニシャル"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2139,9 +2139,6 @@ msgstr "イベント"
 msgid "Event Data must be an array"
 msgstr "イベントデータは配列である必要があります"
 
-msgid "Event and data are not set"
-msgstr "イベントとデータが設定されていません"
-
 msgid "Event must be a string"
 msgstr "イベントは文字列で指定してください"
 
@@ -9892,6 +9889,9 @@ msgstr ""
 
 #~ msgid "Especially when your organization has many hosts"
 #~ msgstr "特に、多数のホストを管理している組織では"
+
+#~ msgid "Event and data are not set"
+#~ msgstr "イベントとデータが設定されていません"
 
 #~ msgid "Exit to Hard Drive Type"
 #~ msgstr "ハードドライブへの起動方法"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1134,6 +1134,10 @@ msgid "Cannot filter %s on: %s"
 msgstr ""
 
 #, fuzzy
+msgid "Cannot notify from the hook manager"
+msgstr "自身がグループマネージャーか確認しています"
+
+#, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "保留中のホストにタスクを設定できません"
 
@@ -8195,6 +8199,9 @@ msgstr ""
 
 msgid "Use extreme caution with this setting"
 msgstr "この設定は十分注意して使用してください"
+
+msgid "Use processEvent instead"
+msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -210,6 +210,9 @@ msgstr ""
 msgid "A group name is required!"
 msgstr ""
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 msgid "A host already exists with this name!"
 msgstr ""
 
@@ -5210,9 +5213,6 @@ msgid "Refresh Settings Cache"
 msgstr ""
 
 msgid "Refresh the settings cache"
-msgstr ""
-
-msgid "Registered"
 msgstr ""
 
 msgid "Registered Hosts"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1011,6 +1011,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 msgid "Cannot task pending hosts"
 msgstr ""
 
@@ -7279,6 +7282,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3733,6 +3733,9 @@ msgstr ""
 msgid "List of MACs"
 msgstr ""
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -5547,9 +5550,6 @@ msgid "Search results returned false"
 msgstr ""
 
 msgid "Search settings"
-msgstr ""
-
-msgid "Second paramater must be in [class,function]"
 msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1889,9 +1889,6 @@ msgstr ""
 msgid "Event Data must be an array"
 msgstr ""
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5212,9 +5212,6 @@ msgstr ""
 msgid "Refresh the settings cache"
 msgstr ""
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1194,6 +1194,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "Não é possível definir taskings para pendente ou artigos inválidos"
@@ -8568,6 +8571,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -249,6 +249,9 @@ msgstr "Grupo de armazenamento excluído"
 msgid "A group name is required!"
 msgstr "Um nome de imagem é necessário!"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
@@ -6150,9 +6153,6 @@ msgstr "status do serviço"
 msgid "Refresh the settings cache"
 msgstr "status do serviço"
 
-msgid "Registered"
-msgstr "Registrado"
-
 msgid "Registered Hosts"
 msgstr "hosts registrados"
 
@@ -10280,6 +10280,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Registered"
+#~ msgstr "Registrado"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6150,9 +6150,6 @@ msgstr "status do serviço"
 msgid "Refresh the settings cache"
 msgstr "status do serviço"
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr "Registrado"
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2227,9 +2227,6 @@ msgstr "Adicionar Evento"
 msgid "Event Data must be an array"
 msgstr "Evento deve ser uma string"
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr "Evento deve ser uma string"
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4422,6 +4422,9 @@ msgstr "Plugins instalados"
 msgid "List of MACs"
 msgstr "Listar todos os %s"
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -6541,9 +6544,6 @@ msgstr ""
 #, fuzzy
 msgid "Search settings"
 msgstr "status do serviço"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -249,6 +249,9 @@ msgstr "存储组中删除"
 msgid "A group name is required!"
 msgstr "图像名是必需的！"
 
+msgid "A hook is not an event listener"
+msgstr ""
+
 #, fuzzy
 msgid "A host already exists with this name!"
 msgstr "图像已经存在具有此名称！"
@@ -6150,9 +6153,6 @@ msgstr "服务状态"
 msgid "Refresh the settings cache"
 msgstr "服务状态"
 
-msgid "Registered"
-msgstr "注册"
-
 msgid "Registered Hosts"
 msgstr "注册主机"
 
@@ -10280,6 +10280,9 @@ msgstr ""
 
 #~ msgid "Printer Alias"
 #~ msgstr "打印机别名"
+
+#~ msgid "Registered"
+#~ msgstr "注册"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4422,6 +4422,9 @@ msgstr "已安装的插件"
 msgid "List of MACs"
 msgstr "列表中的所有%s"
 
+msgid "Listener must be [class,function] or a closure"
+msgstr ""
+
 msgid "Listener must be an array or an object"
 msgstr ""
 
@@ -6541,9 +6544,6 @@ msgstr ""
 #, fuzzy
 msgid "Search settings"
 msgstr "服务状态"
-
-msgid "Second paramater must be in [class,function]"
-msgstr ""
 
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2227,9 +2227,6 @@ msgstr "添加事件"
 msgid "Event Data must be an array"
 msgstr "事件必须是字符串"
 
-msgid "Event and data are not set"
-msgstr ""
-
 msgid "Event must be a string"
 msgstr "事件必须是字符串"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1194,6 +1194,9 @@ msgstr ""
 msgid "Cannot filter %s on: %s"
 msgstr ""
 
+msgid "Cannot notify from the hook manager"
+msgstr ""
+
 #, fuzzy
 msgid "Cannot task pending hosts"
 msgstr "无法设置taskings未决的或无效的项目"
@@ -8568,6 +8571,9 @@ msgid "Use [FOG_SNAPIN_PATH] in the arguments to point at the folder where the p
 msgstr ""
 
 msgid "Use extreme caution with this setting"
+msgstr ""
+
+msgid "Use processEvent instead"
 msgstr ""
 
 msgid "Use the buttons below to create a new power management task to all hosts in this group."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6150,9 +6150,6 @@ msgstr "服务状态"
 msgid "Refresh the settings cache"
 msgstr "服务状态"
 
-msgid "Register must be managed from hooks or events"
-msgstr ""
-
 msgid "Registered"
 msgstr "注册"
 

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -331,19 +331,35 @@ if (false !== strpos($loader, 'active' . chr(92) . 's?=')) {
     $fails[] = 'the source-text activation regex is back in EventManager';
 }
 
-// F-22. load() picks the extension with two sequential instanceof checks, and
-// HookManager satisfies both. It reaches .hook.php only because the second
-// assignment overwrites the first, so reordering the blocks silently makes
-// every HookManager load .event.php.
-$body = substr($loader, strpos($loader, 'public function load()'));
-$evtAt = strpos($body, "'.event.php'");
-$hookAt = strpos($body, "'.hook.php'");
-if (false === $evtAt || false === $hookAt) {
-    $fails[] = 'load() no longer chooses between .event.php and .hook.php by'
-        . ' assignment; if the choice moved onto the classes, rewrite this case';
-} elseif ($evtAt > $hookAt) {
-    $fails[] = 'the two instanceof blocks in load() have been reordered, which'
-        . ' makes HookManager load .event.php files';
+// F-22, fixed. load() used to pick its file extension with two sequential
+// instanceof checks. HookManager extends EventManager, so it satisfied both,
+// and reached .hook.php only because the second assignment overwrote the
+// first -- reordering the blocks silently made every HookManager load
+// .event.php. Each manager now declares what it loads.
+foreach ([
+    'FOG\\EventManager' => ['.event.php', 'events'],
+    'FOG\\HookManager' => ['.hook.php', 'hooks'],
+] as $class => list($ext, $dir)) {
+    $obj = $bare($class);
+    foreach (['fileExtension' => $ext, 'fileDirectory' => $dir] as $prop => $want) {
+        $r = new \ReflectionProperty($class, $prop);
+        $r->setAccessible(true);
+        if ($want !== $r->getValue($obj)) {
+            $fails[] = sprintf(
+                '%s::$%s is %s, not %s -- the manager would load the other'
+                . " manager's files",
+                $class,
+                $prop,
+                var_export($r->getValue($obj), true),
+                var_export($want, true)
+            );
+        }
+    }
+}
+$loadBody = substr($loader, strpos($loader, 'public function load()'));
+if (false !== strpos($loadBody, 'instanceof')) {
+    $fails[] = 'load() decides what to load by instanceof again, which cannot'
+        . ' tell a HookManager from the EventManager it extends';
 }
 
 // ------------------------------------------------------ activation, at dispatch

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -170,12 +170,11 @@ if ($hm->hasListeners('CHAR_BAD_METHOD')) {
 // An error handler must not be able to fail harder than the error it reports,
 // so this asserts that nothing escapes, whatever shape arrives.
 foreach ([
-    'closure' => function ($a) {
-    },
     'plain object' => new \stdClass(),
     'string' => 'strlen',
     'integer' => 7,
     'null' => null,
+    'three-element array' => [$hook, 'fire', 'extra'],
 ] as $what => $listener) {
     if ('' !== $escapes($hm, 'CHAR_JUNK', $listener)) {
         $fails[] = "a $what listener escapes register() instead of being logged";
@@ -203,12 +202,11 @@ if (false === strpos($msg, 'stdClass')) {
 if (false === strpos($msg, 'CHAR_LOGGED')) {
     $fails[] = 'the failure message does not name the event';
 }
-// The shape that used to be fatal has to name itself too, or the fix has
-// traded a crash for an unattributable log line.
-$msg = $logged($hm, 'CHAR_LOGGED_CLOSURE', function ($a) {
-});
-if (false === strpos($msg, 'Closure')) {
-    $fails[] = 'a Closure listener is logged without being named';
+// A shape that is still refused has to name itself too, or the fix has traded
+// a crash for an unattributable log line.
+$msg = $logged($hm, 'CHAR_LOGGED_STR', 'strlen');
+if (false === strpos($msg, 'string')) {
+    $fails[] = 'a listener of an unusable type is logged without being named';
 }
 
 // ------------------------------------------------ registering against events
@@ -365,6 +363,88 @@ $hook->seen = [];
 $hm2->processEvent('CHAR_DISPATCH', ['payload' => 2]);
 if (!isset($hook->seen[0]['event']) || 'CHAR_DISPATCH' !== $hook->seen[0]['event']) {
     $fails[] = 'processEvent() no longer merges the event name into the payload';
+}
+
+// ------------------------------------------------------------------- closures
+
+// docs/plugin-development.md has documented the closure form for the three
+// Phase 2 authentication seams since ADR 0014, and until now handing register()
+// one took the server down. Both listener shapes are supported; the owner is
+// what carries $active, so admitting closures needed no new activation rule.
+$closureSaw = [];
+$hm3 = $bare('FOG\HookManager');
+$hm3->register('CHAR_CLOSURE_OK', function ($arguments) use (&$closureSaw) {
+    $closureSaw[] = $arguments;
+});
+if (!$hm3->hasListeners('CHAR_CLOSURE_OK')) {
+    $fails[] = 'a Closure listener does not register';
+}
+$known->setValue(null, [
+    'CHAR_DISPATCH' => true,
+    'CHAR_CORE_DISPATCH' => true,
+    'CHAR_CLOSURE_OK' => true,
+    'CHAR_CLOSURE_OWNED' => true,
+    'CHAR_CLOSURE_REF' => true,
+]);
+$hm3->processEvent('CHAR_CLOSURE_OK', ['payload' => 3]);
+if (count($closureSaw) !== 1) {
+    $fails[] = 'a Closure listener does not fire';
+} elseif (!isset($closureSaw[0]['event'])
+    || 'CHAR_CLOSURE_OK' !== $closureSaw[0]['event']
+) {
+    $fails[] = 'a Closure listener is not handed the merged payload';
+}
+
+// A closure written inside a hook is bound to that hook, so the hook's $active
+// governs it -- the same rule as [$this, 'method'], not a second one.
+class CharClosureHook extends \FOG\Hook
+{
+    public $name = 'CharClosureHook';
+    public $node = 'demo';
+    public $active = false;
+    public $seen = 0;
+
+    public function listener()
+    {
+        return function ($arguments) {
+            $this->seen++;
+        };
+    }
+}
+$owned = $bare('CharClosureHook');
+$hm3->register('CHAR_CLOSURE_OWNED', $owned->listener());
+$hm3->processEvent('CHAR_CLOSURE_OWNED', []);
+if (0 !== $owned->seen) {
+    $fails[] = 'a closure owned by an inactive hook fired anyway; $active has'
+        . ' to mean the same thing for both listener shapes';
+}
+$owned->active = true;
+$hm3->processEvent('CHAR_CLOSURE_OWNED', []);
+if (1 !== $owned->seen) {
+    $fails[] = 'a closure owned by an active hook did not fire';
+}
+
+// A listener is free to declare its parameter by reference, so the payload has
+// to reach it as a variable and not as the return value of the merge. PHP does
+// not refuse the call when it is not -- it emits "Only variables should be
+// passed by reference" and silently drops the binding -- so the diagnostic is
+// the only thing there is to assert on.
+$hm3->register('CHAR_CLOSURE_REF', function (&$arguments) {
+    $arguments['touched'] = true;
+});
+$diagnostics = [];
+set_error_handler(function ($no, $str) use (&$diagnostics) {
+    $diagnostics[] = $str;
+    return true;
+});
+$hm3->processEvent('CHAR_CLOSURE_REF', []);
+restore_error_handler();
+foreach ($diagnostics as $d) {
+    if (false !== stripos($d, 'passed by reference')) {
+        $fails[] = 'the merged payload no longer reaches a listener as a'
+            . ' variable, so a listener declaring its parameter by reference'
+            . ' is silently handed a copy';
+    }
 }
 
 // ---------------------------------------------------------------- hasListeners

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -161,18 +161,28 @@ if ($hm->hasListeners('CHAR_BAD_METHOD')) {
     $fails[] = 'a listener naming a method that does not exist was registered';
 }
 
-// F-13. The catch block interpolates $listener[0]; a Closure is an object and
-// not an array, so the handler that exists to swallow the failure raises an
-// \Error instead -- which catch (\Exception) does not catch. Registration runs
-// in a hook constructor during LoadGlobals, so in production this is HTTP 500
-// with an empty body on every entry point.
+// F-13, fixed. The catch used to interpolate $listener[0]; a Closure is an
+// object and not an array, so the handler that exists to swallow the failure
+// raised an \Error -- which catch (\Exception) does not catch. Registration
+// runs in a hook constructor during LoadGlobals, so that was HTTP 500 with an
+// empty body on every entry point until the file was deleted from disk.
 //
-// F-14. docs/plugin-development.md documents exactly this shape three times,
-// for the three Phase 2 authentication seams.
-if ('Error' !== $escapes($hm, 'CHAR_CLOSURE', function ($a) {
-})) {
-    $fails[] = 'a Closure listener no longer raises \Error out of register();'
-        . ' if that is deliberate, this case and F-13 both need rewriting';
+// An error handler must not be able to fail harder than the error it reports,
+// so this asserts that nothing escapes, whatever shape arrives.
+foreach ([
+    'closure' => function ($a) {
+    },
+    'plain object' => new \stdClass(),
+    'string' => 'strlen',
+    'integer' => 7,
+    'null' => null,
+] as $what => $listener) {
+    if ('' !== $escapes($hm, 'CHAR_JUNK', $listener)) {
+        $fails[] = "a $what listener escapes register() instead of being logged";
+    }
+    if ($hm->hasListeners('CHAR_JUNK')) {
+        $fails[] = "a $what listener was registered";
+    }
 }
 
 // F-19 in miniature: the one diagnostic a swallowed failure produces does not
@@ -183,13 +193,22 @@ $msg = $logged($hm, 'CHAR_LOGGED', [new \stdClass(), 'fire']);
 if (false === strpos($msg, 'Could not register')) {
     $fails[] = 'a swallowed registration failure no longer logs anything';
 }
-if (false === strpos($msg, '$s:')) {
-    $fails[] = 'the literal $s typo is gone from the failure message; good, but'
-        . ' this case pins it deliberately -- rewrite it alongside the fix';
+if (false !== strpos($msg, '$s:')) {
+    $fails[] = 'the failure message still carries the literal $s typo';
 }
-if (false !== strpos($msg, 'stdClass')) {
-    $fails[] = 'the failure message now names the offending class; good, but'
-        . ' this case pins its absence deliberately -- rewrite it';
+if (false === strpos($msg, 'stdClass')) {
+    $fails[] = 'the failure message does not name the class that failed, which'
+        . ' is the only field that says which plugin to go and look at';
+}
+if (false === strpos($msg, 'CHAR_LOGGED')) {
+    $fails[] = 'the failure message does not name the event';
+}
+// The shape that used to be fatal has to name itself too, or the fix has
+// traded a crash for an unattributable log line.
+$msg = $logged($hm, 'CHAR_LOGGED_CLOSURE', function ($a) {
+});
+if (false === strpos($msg, 'Closure')) {
+    $fails[] = 'a Closure listener is logged without being named';
 }
 
 // ------------------------------------------------ registering against events
@@ -201,9 +220,12 @@ if ('' !== $escapes($em, 'CHAR_EVT', $event)) {
     $fails[] = 'the supported event listener shape (an Event object) no longer registers';
 }
 
-// Same defect as the Closure case: a non-Event object reaches $listener[0].
-if ('Error' !== $escapes($em, 'CHAR_EVT_BAD', new \stdClass())) {
-    $fails[] = 'a non-Event object no longer raises \Error out of register()';
+// Same defect as the Closure case, and fixed with it.
+if ('' !== $escapes($em, 'CHAR_EVT_BAD', new \stdClass())) {
+    $fails[] = 'a non-Event object escapes register() instead of being logged';
+}
+if ($em->hasListeners('CHAR_EVT_BAD')) {
+    $fails[] = 'a non-Event object was registered as an event listener';
 }
 
 // F-18. Hook extends Event, so the instanceof guard that is supposed to keep

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -272,11 +272,81 @@ if (false === strpos($printed, 'CHAR_PRINTED')) {
 
 // ------------------------------------------------------------- notify()
 
+// The name-recording cache is what makes notify() reachable from a test at
+// all: it used to ask the notifyevents table on every call, before any guard
+// and before anything a test could intercept.
+$knownNotify = new \ReflectionProperty('FOG\EventManager', 'knownNotifyEvents');
+$knownNotify->setAccessible(true);
+$knownNotify->setValue(null, [
+    'CHAR_NOTIFY' => true,
+    'CHAR_NOTIFY_OFF' => true,
+    'CHAR_NOTIFY_NOBODY' => true,
+]);
+
+$em2 = $bare('FOG\EventManager');
+$heard = $bare('CharEvent');
+$em2->register('CHAR_NOTIFY', $heard);
+if (true !== $em2->notify('CHAR_NOTIFY', ['payload' => 1])) {
+    $fails[] = 'notify() does not report success when a listener ran';
+}
+if ($heard->seen !== ['CHAR_NOTIFY']) {
+    $fails[] = 'notify() did not reach its listener';
+}
+
+$off = $bare('CharEvent');
+$off->active = false;
+$em2->register('CHAR_NOTIFY_OFF', $off);
+$em2->notify('CHAR_NOTIFY_OFF', []);
+if ([] !== $off->seen) {
+    $fails[] = 'notify() dispatched to an inactive event listener';
+}
+
+// Nobody listening is the ordinary case, not an error. It used to throw into
+// the handler, which logs -- and once an admin is signed in FOGBase::log()
+// writes a history row, so a stock server wrote one per host checkin for an
+// event nothing has ever listened to.
+ob_start();
+$em2->logLevel = 9;
+$quiet = $em2->notify('CHAR_NOTIFY_NOBODY', []);
+$em2->logLevel = 0;
+$noise = ob_get_clean();
+if (false !== $quiet) {
+    $fails[] = 'notify() no longer reports that nothing was notified';
+}
+if ('' !== trim($noise)) {
+    $fails[] = 'notify() logs when nobody is listening: ' . trim($noise);
+}
+
+// What it does log has to be readable. The register() half carried a literal
+// $s where a specifier was meant; so did this one.
+$em2->logLevel = 9;
+ob_start();
+$em2->notify(['not', 'a', 'name'], []);
+$badName = ob_get_clean();
+$em2->logLevel = 0;
+if (false !== strpos($badName, '$s:')) {
+    $fails[] = 'the notify failure message still carries the literal $s typo';
+}
+
+// The cases above seed the name cache, so they say nothing about whether
+// notify() still records names it has not seen. Without that the notifyevents
+// table stops filling and the notification plugins lose their event list.
+$notifySrc = file_get_contents($web . '/lib/fog/eventmanager.class.php');
+$notifyBody = substr($notifySrc, strpos($notifySrc, 'public function notify('));
+$notifyBody = substr($notifyBody, 0, strpos($notifyBody, 'public function load('));
+if (false === strpos($notifyBody, '_recordEventName(')) {
+    $fails[] = 'notify() no longer records the event name, so notifyevents'
+        . ' stops filling and the notification plugins lose their event list';
+}
+if (false !== strpos($notifyBody, "getClass('NotifyEventManager')")) {
+    $fails[] = 'notify() asks the database for the name list again, on every'
+        . ' call -- the GH-707 shape processEvent() was fixed for';
+}
+
 // F-17. HookManager inherits notify(), which iterates listeners as objects
 // while HookManager stores them as [object, method] arrays -- so it invokes
-// nothing and returns true. Pinned structurally rather than by calling it:
-// notify() asks the notifyevents table a question before anything a test can
-// intercept.
+// nothing and returns true. Pinned structurally; H.7 in the plan gives
+// HookManager an override, at which point this case gets rewritten.
 $declares = (new \ReflectionMethod('FOG\HookManager', 'notify'))
     ->getDeclaringClass()->getName();
 if ('FOG\EventManager' !== $declares) {

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -263,39 +263,72 @@ if ('FOG\EventManager' !== $declares) {
 
 // ------------------------------------------------------- activation, at load
 
-// F-15. Whether a non-plugin hook runs is decided by a regular expression over
-// the file's source text, so it turns on whitespace and case and does not know
-// a comment from code. The pattern is read out of the shipped source rather
-// than copied, so replacing it fails this case instead of leaving it green
-// against a regex nobody uses any more.
-$loader = file_get_contents($web . '/lib/fog/eventmanager.class.php');
-// Walk out from the regex's own text to the quotes around it, rather than
-// writing a pattern that matches a pattern.
-$at = strpos($loader, 'active' . chr(92) . 's?=' . chr(92) . 's?true;');
-$open = false === $at ? false : strrpos(substr($loader, 0, $at), chr(39));
-$close = false === $open ? false : strpos($loader, chr(39), $open + 1);
-if (false === $close) {
-    $fails[] = 'the activation regex is gone from EventManager; if it was'
-        . ' replaced by reading the property, rewrite this whole section';
-} else {
-    $pattern = substr($loader, $open + 1, $close - $open - 1);
-    $variants = [
-        ['public $active = true;', true],
-        ['public $active  = true;', false],
-        ['public $active =  true;', false],
-        ['public $active=true;', true],
-        ['public $active = TRUE;', false],
-        ['public $active = false; // set $active = true; to enable', true],
-    ];
-    foreach ($variants as list($line, $loads)) {
-        if ((bool) preg_match($pattern, $line) !== $loads) {
-            $fails[] = sprintf(
-                'activation verdict changed for %s (was %s)',
-                var_export($line, true),
-                $loads ? 'loaded' : 'skipped'
-            );
-        }
+// F-15, fixed. Whether a non-plugin hook runs used to be decided by a regular
+// expression over the file's source text, so it turned on whitespace and case
+// and could not tell a comment from code. It now reads the declared default of
+// $active off the class. Same six variants, and the property wins every time.
+$decl = new \ReflectionMethod('FOG\EventManager', '_declaresActive');
+$decl->setAccessible(true);
+
+$variants = [
+    ['V1', 'public $active = true;', true],
+    ['V2', 'public $active  = true;', true],
+    ['V3', 'public $active =  true;', true],
+    ['V4', 'public $active=true;', true],
+    ['V5', 'public $active = TRUE;', true],
+    ['V6', 'public $active = false; // set $active = true; to enable', false],
+    // Declares nothing: inherits Event's default of true, where the regex
+    // found no literal and skipped the file.
+    ['V7', '', true],
+];
+@mkdir($tmp . '/hooks', 0777, true);
+foreach ($variants as list($tag, $line, $active)) {
+    $class = 'CharActive' . $tag;
+    $path = $tmp . '/hooks/' . strtolower($class) . '.hook.php';
+    file_put_contents(
+        $path,
+        "<?php\nclass $class extends \\FOG\\Hook\n{\n"
+        . "    public \$node = 'demo';\n"
+        . ('' === $line ? '' : "    $line\n")
+        . "    public function fire(\$a) {}\n}\n"
+    );
+    require $path;
+    if ($decl->invoke(null, $path, -strlen('.hook.php')) !== $active) {
+        $fails[] = sprintf(
+            'activation verdict for %s is wrong; the property says %s',
+            '' === $line ? 'a file declaring no $active' : var_export($line, true),
+            $active ? 'true' : 'false'
+        );
     }
+}
+
+// A file whose class cannot be resolved is skipped, not fatal. Reflecting on a
+// name nothing declares throws, and load() runs inside LoadGlobals, so an
+// unresolvable file here would be a 500 rather than one hook not starting.
+try {
+    if (false !== $decl->invoke(null, $tmp . '/hooks/charnosuch.hook.php', -strlen('.hook.php'))) {
+        $fails[] = 'a hook file with no resolvable class is treated as active';
+    }
+} catch (\Throwable $t) {
+    $fails[] = 'a hook file with no resolvable class throws ' . get_class($t)
+        . ' out of activation, which during LoadGlobals is a 500';
+}
+
+// The cases above drive the helper directly, so they say nothing about whether
+// load() still uses it. Assert both: that load() asks the helper, and that the
+// source-text regex has not come back beside it.
+$loader = file_get_contents($web . '/lib/fog/eventmanager.class.php');
+$loadBody = substr($loader, strpos($loader, 'public function load()'));
+if (false === strpos($loadBody, '_declaresActive(')) {
+    $fails[] = 'load() no longer decides activation through _declaresActive(),'
+        . ' so the cases above are testing something nothing calls';
+}
+if (false !== strpos($loadBody, 'preg_match')) {
+    $fails[] = 'load() is matching a pattern again; activation is a property,'
+        . ' not a shape in the source text';
+}
+if (false !== strpos($loader, 'active' . chr(92) . 's?=')) {
+    $fails[] = 'the source-text activation regex is back in EventManager';
 }
 
 // F-22. load() picks the extension with two sequential instanceof checks, and

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -343,15 +343,36 @@ if (false !== strpos($notifyBody, "getClass('NotifyEventManager')")) {
         . ' call -- the GH-707 shape processEvent() was fixed for';
 }
 
-// F-17. HookManager inherits notify(), which iterates listeners as objects
-// while HookManager stores them as [object, method] arrays -- so it invokes
-// nothing and returns true. Pinned structurally; H.7 in the plan gives
-// HookManager an override, at which point this case gets rewritten.
+// F-17, fixed. HookManager used to inherit notify(), which iterates listeners
+// as objects while HookManager stores [object, method] arrays -- so under
+// PHP 8 the property read on an array warned, yielded null, every listener was
+// skipped, and the method returned TRUE having invoked nothing. It now refuses,
+// audibly, rather than reporting success for work it did not do.
 $declares = (new \ReflectionMethod('FOG\HookManager', 'notify'))
     ->getDeclaringClass()->getName();
-if ('FOG\EventManager' !== $declares) {
-    $fails[] = 'HookManager now declares its own notify(); that closes F-17,'
-        . ' so rewrite this case to assert what the override does';
+if ('FOG\HookManager' !== $declares) {
+    $fails[] = 'HookManager inherits notify() again, which cannot read its own'
+        . ' listener shape and reports success anyway';
+}
+$hmN = $bare('FOG\HookManager');
+$notified = $bare('CharHook');
+$hmN->register('CHAR_HM_NOTIFY', [$notified, 'fire']);
+$hmN->logLevel = 9;
+ob_start();
+$refused = $hmN->notify('CHAR_HM_NOTIFY', []);
+$refusal = ob_get_clean();
+$hmN->logLevel = 0;
+if (false !== $refused) {
+    $fails[] = 'HookManager::notify() reports success';
+}
+if ([] !== $notified->seen) {
+    $fails[] = 'HookManager::notify() dispatched; if that is deliberate it is a'
+        . ' bigger decision than this case, because notify() and processEvent()'
+        . ' pass their payloads differently';
+}
+if (false === stripos($refusal, 'processEvent')) {
+    $fails[] = 'HookManager::notify() refuses without saying what to call'
+        . ' instead: ' . trim($refusal);
 }
 
 // ------------------------------------------------------- activation, at load

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * What the hook and event managers actually do today.
+ *
+ * The hook system is the plugin ABI: every bundled plugin and every plugin we
+ * have never read registers through EventManager::register() and is dispatched
+ * through HookManager::processEvent(). So the bar for changing it is not "the
+ * tests pass", it is "no plugin needs editing" -- and the only way to hold that
+ * bar is to write down what happens now, including the parts that are wrong, so
+ * that a behaviour change shows up as a case somebody had to edit on purpose
+ * rather than as a silent difference.
+ *
+ * Findings pinned here are recorded as F-11..F-26 in docs/refactor-facts.md and
+ * argued in docs/hook-event-plan.md.
+ *
+ * No database. The managers and the fixture listeners are built with
+ * newInstanceWithoutConstructor() -- Event::__construct() dereferences
+ * self::$FOGUser, which no test has -- and HookManager::$knownEvents is seeded
+ * by reflection so processEvent() never asks the hookevent table whether it has
+ * seen the name before.
+ *
+ * Usage: php tests/hook-event-contract.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$tmp = sys_get_temp_dir() . '/fog-hook-contract-' . getmypid();
+@mkdir($tmp . '/cache', 0777, true);
+@mkdir($tmp . '/log', 0777, true);
+@mkdir($tmp . '/plugins/demo/hooks', 0777, true);
+define('FOG_CACHE_DIR', $tmp . '/cache');
+define('FOG_LOG_DIR', $tmp . '/log');
+define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+
+ini_set('error_log', $tmp . '/php-error.log');
+
+require $web . '/commons/init.php';
+new Initiator();
+
+$fails = [];
+
+/**
+ * A hook that records what it was handed, so dispatch can be observed.
+ */
+class CharHook extends \FOG\Hook
+{
+    public $name = 'CharHook';
+    public $node = 'demo';
+    public $active = true;
+    public $seen = [];
+
+    public function fire($arguments)
+    {
+        $this->seen[] = $arguments;
+    }
+}
+
+/**
+ * An event listener that records the event it was notified of.
+ */
+class CharEvent extends \FOG\Event
+{
+    public $name = 'CharEvent';
+    public $active = true;
+    public $seen = [];
+
+    public function onEvent($event, $data)
+    {
+        $this->seen[] = $event;
+    }
+}
+
+/**
+ * Builds an object without running any constructor in its chain.
+ *
+ * @param string $class Fully qualified class name.
+ *
+ * @return object
+ */
+$bare = function ($class) {
+    return (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+};
+
+/**
+ * Registers a listener and reports what came back out.
+ *
+ * Returns the class of whatever escaped register(), or '' when it returned
+ * normally. Today that distinction is the whole point: some failures are
+ * swallowed and logged, and some take the process with them.
+ *
+ * @param object $manager  The manager to register against.
+ * @param string $event    Event name.
+ * @param mixed  $listener The listener, in whatever shape is being tested.
+ *
+ * @return string
+ */
+$escapes = function ($manager, $event, $listener) {
+    try {
+        $manager->register($event, $listener);
+    } catch (\Throwable $t) {
+        return get_class($t);
+    }
+    return '';
+};
+
+/**
+ * Captures whatever register() logs for a failure.
+ *
+ * FOGBase::log() echoes when the manager's logLevel reaches the message level,
+ * and logHistory() returns before touching the database when there is no valid
+ * user -- which is every test. So raising logLevel is enough to read the one
+ * diagnostic a swallowed registration failure produces.
+ *
+ * @param object $manager  The manager to register against.
+ * @param string $event    Event name.
+ * @param mixed  $listener The listener.
+ *
+ * @return string
+ */
+$logged = function ($manager, $event, $listener) {
+    $was = $manager->logLevel;
+    $manager->logLevel = 9;
+    ob_start();
+    try {
+        $manager->register($event, $listener);
+    } catch (\Throwable $t) {
+        // The fatal cases are asserted separately; here we only want the text.
+    }
+    $out = ob_get_clean();
+    $manager->logLevel = $was;
+    return $out;
+};
+
+// ------------------------------------------------- registering against hooks
+
+$hm = $bare('FOG\HookManager');
+$hook = $bare('CharHook');
+
+if ('' !== $escapes($hm, 'CHAR_OK', [$hook, 'fire'])) {
+    $fails[] = 'the supported listener shape [Hook, method] no longer registers';
+}
+if (!$hm->hasListeners('CHAR_OK')) {
+    $fails[] = 'hasListeners() does not see a listener that register() accepted';
+}
+
+// A pair whose first element is not a Hook, and a pair naming a method that
+// does not exist: both are swallowed. The caller cannot tell, which is why the
+// log line these produce is asserted below.
+if ('' !== $escapes($hm, 'CHAR_BAD_OBJ', [new \stdClass(), 'fire'])) {
+    $fails[] = 'a non-Hook listener now escapes register() instead of being logged';
+}
+if ($hm->hasListeners('CHAR_BAD_OBJ')) {
+    $fails[] = 'a non-Hook listener was registered';
+}
+if ('' !== $escapes($hm, 'CHAR_BAD_METHOD', [$hook, 'noSuchMethod'])) {
+    $fails[] = 'a missing method now escapes register() instead of being logged';
+}
+if ($hm->hasListeners('CHAR_BAD_METHOD')) {
+    $fails[] = 'a listener naming a method that does not exist was registered';
+}
+
+// F-13. The catch block interpolates $listener[0]; a Closure is an object and
+// not an array, so the handler that exists to swallow the failure raises an
+// \Error instead -- which catch (\Exception) does not catch. Registration runs
+// in a hook constructor during LoadGlobals, so in production this is HTTP 500
+// with an empty body on every entry point.
+//
+// F-14. docs/plugin-development.md documents exactly this shape three times,
+// for the three Phase 2 authentication seams.
+if ('Error' !== $escapes($hm, 'CHAR_CLOSURE', function ($a) {
+})) {
+    $fails[] = 'a Closure listener no longer raises \Error out of register();'
+        . ' if that is deliberate, this case and F-13 both need rewriting';
+}
+
+// F-19 in miniature: the one diagnostic a swallowed failure produces does not
+// name the class that failed. The format string carries a literal $s where a
+// specifier was meant, and supplies seven arguments for six specifiers, so
+// $listener[0] -- the only field identifying the culprit -- is dropped.
+$msg = $logged($hm, 'CHAR_LOGGED', [new \stdClass(), 'fire']);
+if (false === strpos($msg, 'Could not register')) {
+    $fails[] = 'a swallowed registration failure no longer logs anything';
+}
+if (false === strpos($msg, '$s:')) {
+    $fails[] = 'the literal $s typo is gone from the failure message; good, but'
+        . ' this case pins it deliberately -- rewrite it alongside the fix';
+}
+if (false !== strpos($msg, 'stdClass')) {
+    $fails[] = 'the failure message now names the offending class; good, but'
+        . ' this case pins its absence deliberately -- rewrite it';
+}
+
+// ------------------------------------------------ registering against events
+
+$em = $bare('FOG\EventManager');
+$event = $bare('CharEvent');
+
+if ('' !== $escapes($em, 'CHAR_EVT', $event)) {
+    $fails[] = 'the supported event listener shape (an Event object) no longer registers';
+}
+
+// Same defect as the Closure case: a non-Event object reaches $listener[0].
+if ('Error' !== $escapes($em, 'CHAR_EVT_BAD', new \stdClass())) {
+    $fails[] = 'a non-Event object no longer raises \Error out of register()';
+}
+
+// F-18. Hook extends Event, so the instanceof guard that is supposed to keep
+// the two apart accepts a hook as an event listener.
+if ('' !== $escapes($em, 'CHAR_EVT_HOOK', $hook)) {
+    $fails[] = 'EventManager::register() now refuses a Hook; that closes F-18,'
+        . ' and this case has to be rewritten to assert the refusal';
+}
+
+// F-18, second half. Event::onEvent()'s default body prints into the response.
+// Every bundled plugin event overrides it; lib/events/hostlist.event.php, the
+// one shipped core event, does not.
+if (!(new \ReflectionMethod('FOG\Event', 'onEvent'))->isPublic()) {
+    $fails[] = 'Event::onEvent() is no longer the public default dispatch target';
+}
+ob_start();
+(new \ReflectionMethod('FOG\Event', 'onEvent'))->invoke($hook, 'CHAR_PRINTED', []);
+$printed = ob_get_clean();
+if (false === strpos($printed, 'CHAR_PRINTED')) {
+    $fails[] = 'Event::onEvent() no longer prints the event name into the'
+        . ' response; that closes half of F-18, so rewrite this case';
+}
+
+// ------------------------------------------------------------- notify()
+
+// F-17. HookManager inherits notify(), which iterates listeners as objects
+// while HookManager stores them as [object, method] arrays -- so it invokes
+// nothing and returns true. Pinned structurally rather than by calling it:
+// notify() asks the notifyevents table a question before anything a test can
+// intercept.
+$declares = (new \ReflectionMethod('FOG\HookManager', 'notify'))
+    ->getDeclaringClass()->getName();
+if ('FOG\EventManager' !== $declares) {
+    $fails[] = 'HookManager now declares its own notify(); that closes F-17,'
+        . ' so rewrite this case to assert what the override does';
+}
+
+// ------------------------------------------------------- activation, at load
+
+// F-15. Whether a non-plugin hook runs is decided by a regular expression over
+// the file's source text, so it turns on whitespace and case and does not know
+// a comment from code. The pattern is read out of the shipped source rather
+// than copied, so replacing it fails this case instead of leaving it green
+// against a regex nobody uses any more.
+$loader = file_get_contents($web . '/lib/fog/eventmanager.class.php');
+// Walk out from the regex's own text to the quotes around it, rather than
+// writing a pattern that matches a pattern.
+$at = strpos($loader, 'active' . chr(92) . 's?=' . chr(92) . 's?true;');
+$open = false === $at ? false : strrpos(substr($loader, 0, $at), chr(39));
+$close = false === $open ? false : strpos($loader, chr(39), $open + 1);
+if (false === $close) {
+    $fails[] = 'the activation regex is gone from EventManager; if it was'
+        . ' replaced by reading the property, rewrite this whole section';
+} else {
+    $pattern = substr($loader, $open + 1, $close - $open - 1);
+    $variants = [
+        ['public $active = true;', true],
+        ['public $active  = true;', false],
+        ['public $active =  true;', false],
+        ['public $active=true;', true],
+        ['public $active = TRUE;', false],
+        ['public $active = false; // set $active = true; to enable', true],
+    ];
+    foreach ($variants as list($line, $loads)) {
+        if ((bool) preg_match($pattern, $line) !== $loads) {
+            $fails[] = sprintf(
+                'activation verdict changed for %s (was %s)',
+                var_export($line, true),
+                $loads ? 'loaded' : 'skipped'
+            );
+        }
+    }
+}
+
+// F-22. load() picks the extension with two sequential instanceof checks, and
+// HookManager satisfies both. It reaches .hook.php only because the second
+// assignment overwrites the first, so reordering the blocks silently makes
+// every HookManager load .event.php.
+$body = substr($loader, strpos($loader, 'public function load()'));
+$evtAt = strpos($body, "'.event.php'");
+$hookAt = strpos($body, "'.hook.php'");
+if (false === $evtAt || false === $hookAt) {
+    $fails[] = 'load() no longer chooses between .event.php and .hook.php by'
+        . ' assignment; if the choice moved onto the classes, rewrite this case';
+} elseif ($evtAt > $hookAt) {
+    $fails[] = 'the two instanceof blocks in load() have been reordered, which'
+        . ' makes HookManager load .event.php files';
+}
+
+// ------------------------------------------------------ activation, at dispatch
+
+// F-16. processEvent() force-activates any listener whose file path contains
+// the substring "plugins", so a plugin hook that declares $active = false runs
+// anyway. Fixture lives under FOG_PLUGIN_DIR so its ReflectionClass filename
+// carries the substring.
+file_put_contents(
+    $tmp . '/plugins/demo/hooks/charplugin.hook.php',
+    "<?php\nclass CharPluginHook extends \\FOG\\Hook\n{\n"
+    . "    public \$name = 'CharPluginHook';\n"
+    . "    public \$node = 'demo';\n"
+    . "    public \$active = false;\n"
+    . "    public \$seen = [];\n"
+    . "    public function fire(\$arguments) { \$this->seen[] = \$arguments; }\n"
+    . "}\n"
+);
+require $tmp . '/plugins/demo/hooks/charplugin.hook.php';
+
+$known = new \ReflectionProperty('FOG\HookManager', 'knownEvents');
+$known->setAccessible(true);
+$known->setValue(null, ['CHAR_DISPATCH' => true, 'CHAR_CORE_DISPATCH' => true]);
+
+$pluginHook = $bare('CharPluginHook');
+$hm2 = $bare('FOG\HookManager');
+$hm2->register('CHAR_DISPATCH', [$pluginHook, 'fire']);
+$hm2->processEvent('CHAR_DISPATCH', ['payload' => 1]);
+if (count($pluginHook->seen) !== 1) {
+    $fails[] = 'a plugin-path hook declaring $active = false no longer fires;'
+        . ' that is the force-activation being removed, so rewrite this case';
+}
+if (true !== $pluginHook->active) {
+    $fails[] = 'processEvent() no longer writes active = true onto the listener';
+}
+
+// The same hook off a plugin path is skipped, which is what makes the
+// force-activation load-bearing rather than decorative.
+$coreHook = $bare('CharHook');
+$coreHook->active = false;
+$hm2->register('CHAR_CORE_DISPATCH', [$coreHook, 'fire']);
+$hm2->processEvent('CHAR_CORE_DISPATCH', ['payload' => 1]);
+if (count($coreHook->seen) !== 0) {
+    $fails[] = 'a non-plugin hook declaring $active = false was dispatched';
+}
+
+// The payload gains the event name, and the listener sees it.
+$hm2->register('CHAR_DISPATCH', [$hook, 'fire']);
+$hook->seen = [];
+$hm2->processEvent('CHAR_DISPATCH', ['payload' => 2]);
+if (!isset($hook->seen[0]['event']) || 'CHAR_DISPATCH' !== $hook->seen[0]['event']) {
+    $fails[] = 'processEvent() no longer merges the event name into the payload';
+}
+
+// ---------------------------------------------------------------- hasListeners
+
+if ($hm2->hasListeners('CHAR_NOBODY')) {
+    $fails[] = 'hasListeners() reports listeners for an event nobody registered';
+}
+// Deliberately blind to active: answering "could anyone care" is all it is for,
+// and Route::deletemass() uses it to skip building payloads nothing would read.
+if (!$hm2->hasListeners('CHAR_CORE_DISPATCH')) {
+    $fails[] = 'hasListeners() now tests the listener active flag; that changes'
+        . ' what Route::deletemass() skips';
+}
+
+// ------------------------------------------------------------------- teardown
+
+$rmrf = function ($dir) use (&$rmrf) {
+    if (!is_dir($dir)) {
+        return;
+    }
+    foreach (array_diff((array) scandir($dir), ['.', '..']) as $e) {
+        $p = "$dir/$e";
+        is_dir($p) ? $rmrf($p) : unlink($p);
+    }
+    rmdir($dir);
+};
+$rmrf($tmp);
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: hook and event registration, activation and dispatch are as recorded\n";
+exit(0);

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -518,22 +518,42 @@ $pluginHook = $bare('CharPluginHook');
 $hm2 = $bare('FOG\HookManager');
 $hm2->register('CHAR_DISPATCH', [$pluginHook, 'fire']);
 $hm2->processEvent('CHAR_DISPATCH', ['payload' => 1]);
-if (count($pluginHook->seen) !== 1) {
-    $fails[] = 'a plugin-path hook declaring $active = false no longer fires;'
-        . ' that is the force-activation being removed, so rewrite this case';
+if (count($pluginHook->seen) !== 0) {
+    $fails[] = 'a hook declaring $active = false fired because its file lives'
+        . ' under a path containing "plugins"';
 }
-if (true !== $pluginHook->active) {
-    $fails[] = 'processEvent() no longer writes active = true onto the listener';
+if (false !== $pluginHook->active) {
+    $fails[] = 'processEvent() writes active = true onto the listener, so the'
+        . ' flag says one thing and the dispatcher does another';
 }
 
-// The same hook off a plugin path is skipped, which is what makes the
-// force-activation load-bearing rather than decorative.
+// The same hook off a plugin path behaves identically. That is the whole
+// point: where the file lives is not part of the activation decision.
 $coreHook = $bare('CharHook');
 $coreHook->active = false;
 $hm2->register('CHAR_CORE_DISPATCH', [$coreHook, 'fire']);
 $hm2->processEvent('CHAR_CORE_DISPATCH', ['payload' => 1]);
 if (count($coreHook->seen) !== 0) {
     $fails[] = 'a non-plugin hook declaring $active = false was dispatched';
+}
+
+// And an active plugin-path hook still fires, so the deletion did not simply
+// turn plugin hooks off.
+$pluginHook->active = true;
+$hm2->processEvent('CHAR_DISPATCH', ['payload' => 1]);
+if (count($pluginHook->seen) !== 1) {
+    $fails[] = 'an active plugin hook does not fire';
+}
+
+// The path substring is gone from the dispatcher entirely, and with it the
+// per-listener ReflectionClass that existed only to feed it.
+$dispatchSrc = file_get_contents($web . '/lib/fog/hookmanager.class.php');
+if (false !== strpos($dispatchSrc, "'plugins'")) {
+    $fails[] = 'processEvent() decides activation from the file path again';
+}
+if (false !== strpos($dispatchSrc, 'ReflectionClass')) {
+    $fails[] = 'processEvent() reflects on the listener class again; nothing'
+        . ' in dispatch needs it now the path test is gone';
 }
 
 // The payload gains the event name, and the listener sees it.

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -249,25 +249,41 @@ if ($em->hasListeners('CHAR_EVT_BAD')) {
     $fails[] = 'a non-Event object was registered as an event listener';
 }
 
-// F-18. Hook extends Event, so the instanceof guard that is supposed to keep
-// the two apart accepts a hook as an event listener.
-if ('' !== $escapes($em, 'CHAR_EVT_HOOK', $hook)) {
-    $fails[] = 'EventManager::register() now refuses a Hook; that closes F-18,'
-        . ' and this case has to be rewritten to assert the refusal';
+// F-18, fixed. Hook extends Event, so `instanceof Event` -- the only type
+// check separating the two -- accepted a hook as an event listener. It is
+// refused now. Note the refusal is observable in what registered, not in what
+// escaped: register() logs and returns whatever happens.
+$hookRefusal = $logged($em, 'CHAR_EVT_HOOK', $hook);
+if ($em->hasListeners('CHAR_EVT_HOOK')) {
+    $fails[] = 'a Hook still registers as an event listener, so notify() will'
+        . ' call Event::onEvent() on an object that never implemented it';
+}
+if (false === stripos($hookRefusal, 'hook')) {
+    $fails[] = 'a Hook is refused as an event listener without saying why: '
+        . trim($hookRefusal);
 }
 
-// F-18, second half. Event::onEvent()'s default body prints into the response.
-// Every bundled plugin event overrides it; lib/events/hostlist.event.php, the
-// one shipped core event, does not.
+// F-18, second half. Event::onEvent()'s default used to print the event name
+// into the response, so an event class that had not overridden it wrote text
+// into whatever output was being produced -- including a client protocol reply
+// the fog-client parses positionally. A listener that does nothing should do
+// nothing.
 if (!(new \ReflectionMethod('FOG\Event', 'onEvent'))->isPublic()) {
     $fails[] = 'Event::onEvent() is no longer the public default dispatch target';
 }
 ob_start();
 (new \ReflectionMethod('FOG\Event', 'onEvent'))->invoke($hook, 'CHAR_PRINTED', []);
 $printed = ob_get_clean();
-if (false === strpos($printed, 'CHAR_PRINTED')) {
-    $fails[] = 'Event::onEvent() no longer prints the event name into the'
-        . ' response; that closes half of F-18, so rewrite this case';
+if ('' !== $printed) {
+    $fails[] = 'Event::onEvent() writes to the response by default: '
+        . var_export($printed, true);
+}
+// The one shipped core event does not override it, which is what made the
+// default reachable from code we ship.
+if ((new \ReflectionMethod('FOG\HostList', 'onEvent'))->getDeclaringClass()
+    ->getName() !== 'FOG\Event'
+) {
+    $fails[] = 'HostList now defines onEvent(); the note above is stale';
 }
 
 // ------------------------------------------------------------- notify()

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -209,6 +209,29 @@ if (false === strpos($msg, 'string')) {
     $fails[] = 'a listener of an unusable type is logged without being named';
 }
 
+// F-12 in the plan: register() used to switch on self::shortName($this), with
+// a case per subclass and a default arm that threw -- caught, logged, and
+// returning normally, so a subclass of either manager registered nothing and
+// said so only in a log line nobody reads. Each manager now answers for its
+// own shapes through an override point.
+class CharManager extends \FOG\HookManager
+{
+}
+$sub = $bare('CharManager');
+if ('' !== $escapes($sub, 'CHAR_SUBCLASS', [$hook, 'fire'])) {
+    $fails[] = 'a subclass of HookManager cannot register a listener';
+}
+if (!$sub->hasListeners('CHAR_SUBCLASS')) {
+    $fails[] = 'a subclass of HookManager silently registers nothing, which is'
+        . ' the shape that took every hook in the system down once already';
+}
+if (false !== strpos(
+    file_get_contents($web . '/lib/fog/eventmanager.class.php'),
+    'switch (self::shortName'
+)) {
+    $fails[] = 'register() identifies its own subclasses by name again';
+}
+
 // ------------------------------------------------ registering against events
 
 $em = $bare('FOG\EventManager');


### PR DESCRIPTION
The hook system is the plugin ABI. A scan of `eventmanager`, `hookmanager`,
`event` and `hook` found thirteen defects; this fixes them, pins the behaviour
first so every change is deliberate, and records the five that were decisions
in `docs/adr/0017-hook-dispatch-contract.md`.

## The one that matters

`register()`'s error handler was itself fatal. It interpolated `$listener[0]`
inside the `catch` meant to swallow a bad listener, so a Closure — or any
non-array object — raised `Error: Cannot use object of type X as array`, which
`catch (\Exception)` does not catch. Registration runs in a hook constructor
during `LoadGlobals`, so it escaped `base.inc.php`: **HTTP 500, zero-byte body,
every entry point, until the file was deleted from disk.**

And `docs/plugin-development.md` documented that exact shape three times, in
the §7 examples for the Phase 2 authentication seams. Nothing in `fog-plugins`
follows the guide — the real OIDC plugin uses `registerInstalled()` — which is
why it survived. Anyone writing a third-party identity provider from the docs
took their server down.

## Also found

- **No core hook or event has ever loaded on any FOG server.** All eleven files
  in `lib/hooks`/`lib/events` are `$active = false` and none matched the
  activation regex. Every live listener on every install comes from a plugin.
- **Activation was a regex over source text.** `\s?` is zero-or-one, the match
  was case-sensitive, and it could not tell a comment from code, so
  `public $active  = true;` with two spaces was inactive, `TRUE` was inactive,
  and `$active = false;` with `= true;` in the comment above it was *active*.
- **`$active` was decorative for every plugin hook.** Dispatch force-set
  `active = true` for any listener whose file path contained the substring
  `plugins`, so a plugin could not turn one of its own hooks off. Verified by
  experiment, not inferred.
- **`HookManager::notify()` returned `true` having invoked nothing** — it
  iterates listeners as objects while HookManager stores arrays.
- **`Hook extends Event`**, so `instanceof Event` accepted a hook as an event
  listener, and `Event::onEvent()`'s default printed the event name into the
  response.
- **`notify()` treated "nobody listening" as an exception** and logged it —
  which writes a `history` row once an admin is signed in — on every host
  checkin, for an event nothing has ever listened to. It also ran an uncached
  `exists()` SELECT per call: the GH-707 shape `processEvent()` was fixed for.
- **`load()` told the two managers apart by an ordering accident**, HookManager
  satisfying both `instanceof` checks.
- **`register()` switched on `self::shortName($this)`** with a throwing default
  — the shape whose comment records it taking every hook in the system down
  once already, during the namespace migration.

## What changes for plugin authors

`register()` now accepts a **Closure** as well as `[Hook, 'method']`. Both have
an owner — for a closure, whatever `$this` it was written inside, recovered
with `ReflectionFunction::getClosureThis()` — and the owner carries `$active`,
so admitting closures needed no new activation rule. The documented seam
examples work as written.

`$active` decides, wherever the file lives.

**Blast radius:** one thing can break — a third-party plugin hook that declares
`$active = false` and relied on the force-activation to run anyway. All 87
bundled hook and event files set it true, and `Event::$active` defaults to
`true`, so a hook that omits the property is unaffected. Only an explicit
`false` is, and writing `false` while expecting the hook to run is not a
coherent intent.

## Verification

Twelve commits, tree green after each (`sh tests/run-all.sh`, 66 passed).

`tests/hook-event-contract.test.php` pins the whole contract — 684 lines, no
database — and was written **first**, asserting the broken behaviour, so every
fix shows up as a case somebody had to rewrite. Each fix is mutation-verified:
widening the activation regex, reordering the `instanceof` blocks, restoring
the force-activation, making the catch safe, emptying `Event::onEvent()`,
dropping the Closure branch, ignoring a closure's owner, inlining the payload
merge, restoring the `notify()` throw, and dropping the name cache are each
caught.

End to end against the live 1.6 lab install with six plugins enabled (`ldap
location ntfy oidc ou windowskey`), nine authenticated pages: a closure owned
by an active plugin hook, a static closure and a `[$this, 'method']` pair all
fired on every page; neither the pair nor the closure belonging to a hook
declaring `$active = false` fired at all.

Performance was measured before proposing anything, and the answer was to stop:
the whole subsystem is 1–2 ms of an 11–543 ms page render, and the
per-listener `ReflectionClass` everyone assumes is expensive totalled 14–168 µs
per request. Nothing here was done for speed. The reflection is gone anyway —
it existed only to feed the path substring — and the activation scan dropped
from 400–490 µs to 77–167 µs per request as a side effect of asking the class
instead of grepping the file.

## Not in this PR

`HOST_IMAGE_FAIL` and `HOST_IMAGEUP_COMPLETE` have listeners in `slack`,
`ntfy` and `pushbullet` and are notified by nothing in core, so those
notifications have never fired. That is making a feature work for the first
time rather than refactoring a subsystem; it needs its own issue and test.

Making `Hook` extend `FOGBase` directly, so hooks and events are genuine peers,
is the honest modelling change and changes `$obj instanceof Event` for every
hook — its own issue too.

## Downstream

None. No route class changes, so FogApi's hardcoded class list is unaffected.

Findings are recorded as F-11 … F-26 in `docs/refactor-facts.md`; the reasoning,
the alternatives and what each decision would have cost are in
`docs/hook-event-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
