### PR TITLE
ESP archives: a boot script that works, rEFInd, and sanboot as the UEFI default

### DIFF
--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -257,7 +257,7 @@ fog-esp-x86_64/
     fogrealtek.efi        FOG's build, Realtek only
     fogsnponly.efi        FOG's build, SNP bound to the load device
   refind/
-    refind.efi            rEFInd, signed by this server — boots the local OS
+    refind.efi            rEFInd, signed by this server — for the refind_efi exit
     refind.conf           rEFInd's config, read from its own directory
 ```
 
@@ -311,10 +311,13 @@ its firmware and enrol `PK.auth`, `KEK.auth` and `db.auth`. Firmware then
 verifies FOG's signed binaries directly, so you can point the boot manager at
 `local\fogipxe.efi` with no shim and no MokManager at all.
 
-**Back out to the locally installed OS** — `refind\refind.efi`. FOG's default
-exit type (`FOG_EFI_BOOT_EXIT_TYPE`, `refind_efi`) chainloads rEFInd when a task
-finishes or when there is no task, so an ESP without it could enter FOG and not
-leave again. You can also point the firmware boot manager straight at it.
+**Back out to the locally installed OS** — the default exit type
+(`FOG_EFI_BOOT_EXIT_TYPE`, `sanboot`) hands straight back to firmware and needs
+nothing on the ESP. `refind\refind.efi` is here for the `refind_efi` exit type,
+which is still selectable globally and per host, and because an ESP assembled by
+hand should carry every route off FOG rather than only the one this server is
+configured for today. You can also point the firmware boot manager straight at
+it.
 
 >[!important]
 >**The Setup Mode route is the only Secure Boot path i386 has**, and it does

--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -160,15 +160,16 @@ symlink from the TFTP tree into your web root:
 ```
 <webroot>/service/localboot/
   manifest.json               index of everything below
-  fog-esp-x86_64.zip          fog-esp-x86_64-10sec.zip
-  fog-esp-i386.zip            fog-esp-i386-10sec.zip
-  fog-esp-arm64.zip           fog-esp-arm64-10sec.zip
+  fog-esp-x86_64.zip
+  fog-esp-i386.zip
+  fog-esp-arm64.zip
 ```
 
-One archive per architecture and delay variant, and nothing else. Each holds a
-single top-level directory named after the archive — **copy its contents onto the
-ESP** (`\EFI\FOG\` is a good place) and point the firmware boot manager at one of
-the entry points below.
+One archive per architecture, and nothing else. Each holds a single top-level
+directory named after the archive — **copy its contents onto the ESP**
+(`\EFI\FOG\` is a good place), **keeping the `local\` and `refind\`
+subdirectories as they are**, and point the firmware boot manager at one of the
+entry points below.
 
 >[!note]
 >Where the `zip` package is missing the installer falls back to `.tar.gz`.
@@ -181,30 +182,55 @@ for a signature. The archives are published either way — a server with no key
 publishes the same set unsigned, which is what every machine booting with Secure
 Boot **off** needs anyway.
 
-### Which archive
+### Why there are two `autoexec.ipxe`, in two directories
 
-`-10sec` is the only choice you have to make up front. Those binaries each wait
-10 seconds before DHCP, which is what lets a link come up on a switch running STP
-or port power-save. They are otherwise identical.
+This is the one thing about the layout worth understanding before you rearrange
+it, because flattening it stops the archive booting at all.
 
-It is a separate archive rather than a second set of files inside one because
-iPXE runs exactly the file called `autoexec.ipxe` and has no way to ask you which
-set you want — so a combined folder made choosing mean renaming one file over
-another. Choosing at download time removes the step: the binaries inside a
-`-10sec` archive carry the same plain names, and its single `autoexec.ipxe` is
-already the right one.
+Since iPXE `v2.0.0-fog.8` none of FOG's EFI binaries has a boot script compiled
+in. They **read** one, from a file called `autoexec.ipxe` — and iPXE looks for
+that name in the directory the running binary was itself loaded from. Two
+different scripts are wanted on one ESP:
 
->[!warning]
->For the same reason, do **not** extract the plain and `-10sec` archives into the
->same folder. They contain the same filenames with different bytes. Each unpacks
->into its own named directory, so this only happens if you go out of your way.
+| File | Read by | What it does |
+| --- | --- | --- |
+| `autoexec.ipxe` at the top | upstream's signed loader, which shim hands off to | Chains `local\fog*.efi` in preference order. That loader drives no NIC off an ESP, so handing off is all it usefully can do. |
+| `local\autoexec.ipxe` | whichever `fog*.efi` runs | FOG's actual boot logic: the DHCP walk across `net0`/`net1`/`net2`, proxyDHCP, `next-server`, then FOG's menu. |
+
+Put both in one directory and they become one file, and a `fog*.efi` you boot
+from the firmware boot manager reads the chain ladder and chains *itself*. One
+directory apiece is the whole reason `local\` exists.
+
+`refind\` is separate for the same class of reason: rEFInd reads `refind.conf`
+from its own directory, which is also where every rEFInd installation puts it.
+
+### Changing how it boots, and the pre-DHCP delay
+
+`local\autoexec.ipxe` is a text file on the ESP. Edit it and the next boot picks
+the change up — no toolchain, no rebuild, nothing to re-download.
+
+The 10-second delay that used to need its own archive is two lines in it. Some
+switches take several seconds to bring a port out of STP listening or out of
+powersave, and iPXE's first DHCP attempt goes out before that. The lines ship
+commented out:
+
+```
+#echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
+#sleep 10
+```
+
+Uncomment them on the ESP, or install the server with `--boot-delay <seconds>`
+and they are written live, bracketed by `# FOG-BOOT-DELAY-BEGIN`/`-END` — the
+same sentinels `--boot-delay` uses in the TFTP copy for netboot clients, so both
+paths get the same delay from one option.
 
 >[!note]
->The delay has to live in the binary, not the script — `sleep` is an optional
->iPXE command that FOG's own builds enable but upstream's signed loader may not,
->and the loader is what runs `autoexec.ipxe`. Booting a `fog*.efi` directly from
->your boot manager reads no script at all, so there the embedded delay is the
->only route to one.
+>There used to be six archives, three of them `-10sec`. They are gone: with the
+>script on disk the delay is a line of text rather than a second set of binaries,
+>and the EFI builds those archives were assembled from stopped being published
+>(GH-1195). The `10secdelay/` directory in the TFTP tree still exists and still
+>matters — legacy BIOS has no `autoexec.ipxe` at all, so its delay is still a
+>separate build.
 
 ### What is inside
 
@@ -212,25 +238,34 @@ already the right one.
 fog-esp-x86_64/
   README.txt              what it is, both enrolment routes, which file to boot
   MANIFEST.json           every file here with its sha256 and what it is for
-  autoexec.ipxe           chains the FOG builds in preference order
+  autoexec.ipxe           the chain ladder — read by upstream's loader only
   snponly-shimx64.efi   ] upstream's Microsoft-signed shim and the loader it
   snponly.efi           ]  hands off to — point the boot manager at either shim
   ipxe-shimx64.efi      ]
   ipxe.efi              ]
   mmx64.efi               MokManager
-  fogipxe.efi             FOG's build, all of iPXE's NIC drivers   ← start here
-  fogsnp.efi              FOG's build, firmware SNP protocol
-  fogintel.efi            FOG's build, Intel only
-  fogrealtek.efi          FOG's build, Realtek only
-  fogsnponly.efi          FOG's build, SNP bound to the load device
   MOK.der               ] present when the server publishes enrolment material
   PK.auth KEK.auth      ]
   db.auth               ]
   fog-enroll-mok.sh     ] enrol from a booted Linux OS via mokutil
   fog-enroll-mok.desktop]
+  local/
+    autoexec.ipxe         FOG's boot script — DHCP, proxyDHCP, next-server
+    fogipxe.efi           FOG's build, all of iPXE's NIC drivers   ← start here
+    fogsnp.efi            FOG's build, firmware SNP protocol
+    fogintel.efi          FOG's build, Intel only
+    fogrealtek.efi        FOG's build, Realtek only
+    fogsnponly.efi        FOG's build, SNP bound to the load device
+  refind/
+    refind.efi            rEFInd, signed by this server — boots the local OS
+    refind.conf           rEFInd's config, read from its own directory
 ```
 
-arm64 substitutes `snponly-shimaa64.efi`, `ipxe-shimaa64.efi` and `mmaa64.efi`.
+arm64 substitutes `snponly-shimaa64.efi`, `ipxe-shimaa64.efi` and `mmaa64.efi`,
+and `refind_aa64.efi`; i386 has no shim set at all and gets `refind_ia32.efi`.
+x86_64 takes `refind.efi` in preference to `refind_x64.efi` where the server has
+one, which is the same preference the PXE boot menu applies — so the ESP and the
+netboot path agree on which binary is canonical.
 The `.auth` blobs and `MOK.der` are absent on a server that publishes no
 enrolment material (`--no-secureboot`, or a run where key generation failed).
 
@@ -243,9 +278,10 @@ accepts, not about network hardware. One `autoexec.ipxe` serves both.
 **Two names are not yours to choose.** shim picks its second stage by rewriting
 its own `-shim<arch>.efi` suffix to `.efi`, so `snponly-shimx64.efi` will load
 `snponly.efi` and nothing else, and it must be upstream's copy — that is what
-shim's embedded certificate vouches for. This is why FOG's own builds are here
-under `fog` names instead of their natural ones: putting FOG's `ipxe.efi` next to
-`ipxe-shimx64.efi` would have shim try to load an image it cannot verify.
+shim's embedded certificate vouches for. That is why the upstream set has to stay
+at the top level, and why FOG's own builds kept the `fog` prefix when they moved
+into `local\` — the names are in every bug report since the archives existed, and
+renaming them now would buy nothing.
 
 **`mmx64.efi` is not optional, and neither is `MOK.der`.** shim launches
 MokManager from its own directory when it cannot verify the next stage, and that
@@ -263,7 +299,7 @@ ESP that has not been enrolled yet is a dead end.
 
 ### Booting it
 
-**Secure Boot off** — point the boot manager straight at `fogipxe.efi`.
+**Secure Boot off** — point the boot manager straight at `local\fogipxe.efi`.
 
 **Secure Boot on, via shim** — point the boot manager at `snponly-shimx64.efi`
 (or `ipxe-shimx64.efi`). The first time on a machine, shim cannot verify FOG's
@@ -273,7 +309,12 @@ binary yet, so it launches MokManager: choose *Enroll key from disk* and select
 **Secure Boot on, via firmware Setup Mode** — put the machine into Setup Mode in
 its firmware and enrol `PK.auth`, `KEK.auth` and `db.auth`. Firmware then
 verifies FOG's signed binaries directly, so you can point the boot manager at
-`fogipxe.efi` with no shim and no MokManager at all.
+`local\fogipxe.efi` with no shim and no MokManager at all.
+
+**Back out to the locally installed OS** — `refind\refind.efi`. FOG's default
+exit type (`FOG_EFI_BOOT_EXIT_TYPE`, `refind_efi`) chainloads rEFInd when a task
+finishes or when there is no task, so an ESP without it could enter FOG and not
+leave again. You can also point the firmware boot manager straight at it.
 
 >[!important]
 >**The Setup Mode route is the only Secure Boot path i386 has**, and it does
@@ -283,8 +324,9 @@ verifies FOG's signed binaries directly, so you can point the boot manager at
 
 ### If `fogipxe.efi` does not bring up your network
 
-Try `fogsnp.efi`, then `fogintel.efi` or `fogrealtek.efi`, then `fogsnponly.efi`.
-`autoexec.ipxe` already tries them in that order.
+Try `local\fogsnp.efi`, then `local\fogintel.efi` or `local\fogrealtek.efi`, then
+`local\fogsnponly.efi`. The top-level `autoexec.ipxe` already tries them in that
+order, where there is an upstream loader to read it.
 
 `fogsnponly.efi` is last on purpose: it binds only the device iPXE was loaded
 from, and booted off an ESP that device is the disk, so it usually finds no NIC.
@@ -297,8 +339,15 @@ of the five to be the answer here.
 >driver works. They fire only when a binary is missing or fails verification.
 >Once one loads and runs, control never comes back — a variant that starts but
 >finds no NIC stops at its own prompt rather than falling through to the next.
->If `fogipxe.efi` doesn't drive your NIC, replace it; the script won't do it for
->you.
+>If `fogipxe.efi` doesn't drive your NIC, point the boot manager at another one;
+>the script won't do it for you.
+
+>[!note]
+>An `i386` archive, and any archive on a server that staged no `secureboot/` tree,
+>has **no** top-level `autoexec.ipxe` — there is no upstream loader in it to read
+>one, and shipping an inert second script would only be something to confuse with
+>the one that does the work. `local\autoexec.ipxe` is always there: the binary
+>that reads it is FOG's own.
 
 ### `manifest.json`
 
@@ -307,14 +356,14 @@ guessing filenames:
 
 ```json
 {
-  "schema": 1,
-  "generated": "2026-08-17T14:02:11Z",
+  "schema": 2,
+  "generated": "2026-08-19T14:02:11Z",
   "fogVersion": "1.6.0-beta.123",
-  "ipxeVersion": "v2.0.0-fog.6",
+  "ipxeVersion": "v2.0.0-fog.8",
   "archives": [
-    { "path": "fog-esp-x86_64.zip", "arch": "x86_64", "variant": "standard",
+    { "path": "fog-esp-x86_64.zip", "arch": "x86_64",
       "root": "fog-esp-x86_64", "size": 6812345, "sha256": "…",
-      "contents": [ { "name": "fogipxe.efi", "size": 1012345, "sha256": "…",
+      "contents": [ { "name": "local/fogipxe.efi", "size": 1012345, "sha256": "…",
                       "role": "fog-ipxe", "origin": "fog", "fogSigned": true,
                       "note": "FOG's build with all of iPXE's own NIC drivers…" } ] }
   ],
@@ -324,6 +373,11 @@ guessing filenames:
   ]
 }
 ```
+
+`schema` is `2`. Schema 1 had a `variant` field on each archive, for the `-10sec`
+set that no longer exists, and named every file by bare basename; `contents[].name`
+is now the path **relative to the archive root**, so `local/` and `refind/` files
+are named as such.
 
 Paths are relative to the manifest's own URL, so it resolves under whatever
 hostname and webroot you reached it by. Every `sha256` is of the bytes as
@@ -366,9 +420,11 @@ comes back on the next run.
 
 **Automatic**, since 1.6.
 
-FOG ships around 55 binaries into your TFTP root (`/tftpboot` on most
+FOG ships around 45 binaries into your TFTP root (`/tftpboot` on most
 distributions): `snponly.efi`, `ipxe.efi`, `undionly.kkpxe`, the `i386-efi/`
-and `arm64-efi/` variants, and the `10secdelay/` and `autoexec/` sets.
+and `arm64-efi/` variants, and `10secdelay/`, which holds BIOS builds only. The
+`autoexec/` tree is retired — every EFI binary in the root reads `autoexec.ipxe`
+now, so the duplicate set served no purpose, and the installer removes it.
 
 If you replace one of those with your own build, **it is no longer overwritten
 on the next install or update.** FOG records the checksum of every file it

--- a/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
+++ b/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
@@ -617,3 +617,146 @@ directory itself 404s. Step 4 becomes: extract `fog-esp-x86_64.zip` and point th
 boot manager at `snponly-shimx64.efi`. New step: enrol `db.auth` from
 `fog-esp-i386.zip` through firmware Setup Mode and boot `fogipxe.efi` directly,
 with no shim — the path this spec originally said did not exist.
+
+---
+
+## Superseded again: EMBED-less iPXE forces two scripts, and kills the delay set (2026-08-19)
+
+The archives above stopped booting a day after they were designed, and nothing in
+the installer noticed. Recorded here rather than edited in above for the same
+reason as the last block: the shape only makes sense alongside the shape it
+replaced.
+
+Fixes GH-1195, and lands GH-1185 with it because both turn on the same layout
+question.
+
+### What changed underneath
+
+fog-ipxe `v2.0.0-fog.8` (fog-ipxe#7) removed `EMBED=` from every EFI target. The
+`fog*.efi` builds these archives publish no longer carry FOG's
+DHCP/proxyDHCP/`next-server` logic — they read it from a file called
+`autoexec.ipxe`, which iPXE resolves against the directory the running binary was
+itself loaded from.
+
+That invalidated two things this spec asserted:
+
+1. **§4's flat archive could not work.** Its single `autoexec.ipxe` was the chain
+   ladder, written for upstream's driverless loader, and it sat in the same
+   directory as the binaries it chained. A `fog*.efi` launched from the firmware
+   boot manager — the Secure Boot OFF route, and the Setup Mode route this spec
+   was proud of adding — read that ladder and executed `chain fogipxe.efi`:
+   itself. Via shim the binary came up with no FOG script at all, so no multi-NIC
+   walk, no proxyDHCP, no `next-server` prompt.
+
+2. **The `-10sec` archives were being published empty of FOG binaries.**
+   `_espKitFiles()` sourced them from `10secdelay/`, which is BIOS-only now, and
+   which `_retireStaleEfiPaths()` actively clears of `.efi` files. The copy loop
+   treats a missing source as fine by design (an HTTPS install stages no
+   `secureboot/`), and `copied` stayed non-zero from the shim set, so three
+   archives were staged, checksummed and advertised in `manifest.json` holding a
+   shim, MokManager, enrolment material, and a README telling the admin to boot a
+   file that was not in them.
+
+### What replaced it
+
+**FOG's builds move into `local/` with their own `autoexec.ipxe`.** Two scripts,
+two directories, and neither binary can reach the other's:
+
+```
+fog-esp-x86_64/
+  autoexec.ipxe          the ladder: chain local/fog*.efi in order
+  snponly-shim*.efi snponly.efi ipxe-shim*.efi ipxe.efi mm*.efi
+  MOK.der PK.auth KEK.auth db.auth  README.txt  MANIFEST.json
+  local/
+    autoexec.ipxe        FOG's real boot script; the delay lives here
+    fogipxe.efi fogsnp.efi fogintel.efi fogrealtek.efi fogsnponly.efi
+  refind/
+    refind.efi refind.conf
+```
+
+The upstream set stays at the top level, non-negotiably: shim derives its second
+stage *and* MokManager from its own directory by name. FOG's builds keep the `fog`
+prefix even though the subdirectory has made the collision impossible — §4's
+reason for the prefix is gone, but the names are in the README, the docs and every
+bug report since GH-1117, and renaming buys nothing.
+
+The root ladder is still gated on an upstream loader being present.
+`local/autoexec.ipxe` is **not** — the binary that reads it is FOG's own, so an
+i386 archive and an HTTPS-only install both need it. That inverts §2's gate,
+which asked "is there something here that reads a script" and answered by looking
+for the loader.
+
+**Three archives, not six.** With the script on disk the delay is two lines of
+text, so `local/autoexec.ipxe` ships them commented out and `--boot-delay` writes
+them live inside the same `# FOG-BOOT-DELAY-BEGIN`/`-END` sentinels
+`_applyBootDelay()` uses on the TFTP copy. So one option now covers netboot and
+ESP boot, where before it covered netboot and the ESP needed a different download.
+
+This directly reverses the note at §4 and in `SUPPORTED_CUSTOMIZATIONS.md` that
+"the delay has to live in the binary, not the script — `sleep` is an optional iPXE
+command that FOG's own builds enable but upstream's signed loader may not". True
+as far as it went, and beside the point: the loader only chains. The `sleep` runs
+in FOG's build, which enables it, immediately before the DHCP it is delaying.
+
+**rEFInd ships in `refind/`** (GH-1185). `FOG_EFI_BOOT_EXIT_TYPE` defaults to
+`refind_efi`, so rEFInd is what a UEFI host chainloads on the way out of the boot
+menu, and an ESP assembled from this kit had no local-boot chainloader on it at
+all. It is the first thing published here that comes from the **web** tree rather
+than `$tftpdirdst` — rEFInd has never existed in the TFTP tree, which is exactly
+why `_publishLocalBootFiles()` never saw it. `_resignRefind()` has already signed
+it by the time this runs (`installfog.sh:1266` vs `:1302`), so nothing needed
+reordering. Its own subdirectory because rEFInd reads `refind.conf` from the
+directory it was loaded from. x86_64 follows `bootmenu.class.php`'s
+`refind.efi`-over-`refind_x64.efi` preference so the ESP and the netboot path
+agree on which binary is canonical.
+
+### The iPXE behaviour this rests on
+
+`efi_autoexec_filesystem()` tries `file:autoexec.ipxe` — resolved against the
+directory of the running image's `FilePath` — and then `file:/autoexec.ipxe` at
+the volume root (`interface/efi/efi_autoexec.c`, `efi_local.c`). A binary loaded
+from an ESP therefore reads the `autoexec.ipxe` beside it, at any depth. That is
+the whole mechanism.
+
+**Worth writing down because the source reads the other way.** For a binary that
+another iPXE `chain`ed, `efi_image_exec()` builds a synthetic device handle and
+installs iPXE's own `EFI_SIMPLE_FILE_SYSTEM_PROTOCOL` on it
+(`image/efi_image.c`, `interface/efi/efi_file.c`); `efi_local_open_volume()`
+resolves through `LocateDevicePath()`, which matches the longest device-path
+prefix and so lands on that synthetic handle. That virtual filesystem serves
+registered images by flat name only — no directories, no passthrough — and
+`image_exec()` unregisters the running script for the duration, so on paper the
+chained binary should find nothing. Observed behaviour on hardware is the sibling
+read, for the chained case as well as the firmware-loaded one.
+
+Hardware wins, and the layout is built on the observed behaviour. Do not
+"correct" it on the strength of the source read. If a client ever does dead-end
+on the chained route specifically — reaching iPXE's bare `autoboot()` instead of
+FOG's script — that synthetic handle is where to look, and the fix would be for
+the root ladder to register the script under the name the child looks for
+(`imgfetch local/autoexec.ipxe`) before chaining.
+
+### Manifest
+
+`schema` goes to `2`. `variant` is gone from each archive, and
+`contents[].name` is the path relative to the archive root
+(`local/fogipxe.efi`), because `_espKitContentsJson()` now recurses.
+
+That last part matters more than it looks. It used `find -maxdepth 1` and stored
+basenames; left alone it would have omitted `local/` and `refind/` **silently**,
+and every consumer — including the test harness's per-file checksum loop, which
+walks the manifest rather than the directory — would have gone on passing. An
+under-reporting manifest reads exactly like a correct one.
+
+### Verification
+
+`tests/localboot-publish.test.sh` grew from 62 to 87 assertions. The mock tree's
+"every file's content is its own path" mechanism carried over unchanged and is
+what proves rEFInd came from the web tree and matches its archive's architecture.
+All 50 of the assertions touching the new behaviour were confirmed to fail against
+the pre-fix `functions.sh` before being relied on.
+
+Hardware step still owed, and the only one that cannot be faked: boot an ESP
+assembled from an archive by both routes — shim → upstream loader → chain, and
+boot manager → `local\fogipxe.efi` directly — and confirm `Checking net0 for
+DHCP...` appears each time rather than iPXE's bare autoboot.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -9977,18 +9977,16 @@ _signLocalIpxe() {
 # an ESP at all. The TFTP tree is not web-served, which until this existed meant
 # every admin hand-rolling symlinks into the document root.
 #
-# What is published is SIX ARCHIVES and a manifest, and nothing else:
+# What is published is THREE ARCHIVES and a manifest, and nothing else:
 #
 #   service/localboot/manifest.json          the index
 #   service/localboot/fog-esp-<arch>.zip     ready-to-copy ESP folder
-#   service/localboot/fog-esp-<arch>-10sec.zip          "  , 10s DHCP delay
 #
-# One archive per (architecture x delay variant), each holding a single
-# top-level directory named after the archive. That shape replaced a directory
-# tree that published the same bytes twice -- a "menu" of binaries under their
-# TFTP names at the root, and a "kit" of the same binaries renamed fog*.efi
-# under esp/ -- with arm64 appearing in four different places and the 10-second
-# set present in one list but not the other.
+# One archive per architecture, each holding a single top-level directory named
+# after the archive. That shape replaced a directory tree that published the
+# same bytes twice -- a "menu" of binaries under their TFTP names at the root,
+# and a "kit" of the same binaries renamed fog*.efi under esp/ -- with arm64
+# appearing in four different places.
 #
 # WHY THE ARCHIVE, AND NOT LOOSE FILES: the two audiences turned out to be one.
 # The only reason the kit needed different filenames is that two names on an ESP
@@ -9999,22 +9997,63 @@ _signLocalIpxe() {
 # nothing here can be a UEFI HTTP Boot target or an iPXE `chain` destination.
 # Publishing the loose set alongside is purely additive if that is ever wanted.
 #
-# WHY THE DELAY VARIANT IS ITS OWN ARCHIVE, rather than a second set of binaries
-# and a second script inside one: iPXE runs exactly the file called
-# autoexec.ipxe and has no way to ask which set you want, so a combined folder
-# made choosing mean renaming a file over another. Choosing at download time
-# removes the step entirely -- the binaries inside a -10sec archive carry the
-# plain names, and its single autoexec.ipxe is already the right one. It costs
-# each variant its own copy of the upstream shim set, which is the only reason
-# the total is not smaller than the tree it replaced.
+# ---------------------------------------------------------------------------
+# WHY FOG'S OWN BINARIES SIT IN local/ AND NOT AT THE TOP LEVEL
+# ---------------------------------------------------------------------------
 #
-# TWO NAMES ARE NOT FREE CHOICES, and this is the whole reason the fog* prefix
-# exists. shim picks its second stage by rewriting its OWN "-shim<arch>.efi"
-# suffix to ".efi". So snponly-shimx64.efi will load "snponly.efi" and nothing
-# else, and it has to be upstream's copy, because upstream's is what shim's
-# embedded certificate vouches for. That reserves snponly.efi -- and ipxe.efi
-# for the other pair. Dropping FOG's ipxe.efi in beside ipxe-shimx64.efi would
-# have shim try to load an image it cannot verify.
+# This is the load-bearing part of the layout, and it is not cosmetic.
+#
+# Since fog-ipxe v2.0.0-fog.8 no EFI target is built with EMBED=, so FOG's own
+# builds no longer carry the DHCP/proxyDHCP/next-server script internally --
+# they READ it, from a file called autoexec.ipxe. iPXE resolves that name
+# against the directory the running binary was itself loaded from
+# (efi_autoexec_filesystem() -> "file:autoexec.ipxe", falling back to
+# "file:/autoexec.ipxe" at the volume root).
+#
+# There are therefore TWO different scripts wanted on one ESP:
+#
+#   the archive root   read by upstream's signed loader, which shim hands off
+#                      to. That loader drives no NIC when booted from an ESP
+#                      (see below), so all it can usefully do is chain FOG's
+#                      build. Its script is the fallback ladder.
+#
+#   local/             read by FOG's own build, which DOES drive the NIC. Its
+#                      script is the real boot logic -- the net0/net1/net2 walk,
+#                      proxyDHCP, next-server, then default.ipxe.
+#
+# Flat, those two are the same file, and the archive could not boot at all: a
+# fog*.efi launched straight from the boot manager read the ladder and executed
+# `chain fogipxe.efi`, which is itself. One directory apiece is the entire fix.
+# Neither script can reach the other's, because neither binary looks outside its
+# own directory. GH-1195.
+#
+# Worth knowing before rearranging this: reading iPXE's source alone suggests a
+# binary that another iPXE `chain`ed resolves autoexec.ipxe through the synthetic
+# handle efi_image_exec() installs iPXE's own EFI_SIMPLE_FILE_SYSTEM_PROTOCOL on
+# -- which serves registered images by flat name and would never reach the ESP at
+# all. Observed behaviour on hardware is the sibling read, for the chained case
+# as well as the firmware-loaded one. Do not "correct" this layout on the
+# strength of the source read; if a client ever does dead-end on the chained
+# route, that handle is where to look.
+#
+# THE 10-SECOND DELAY IS NO LONGER A SECOND SET OF ARCHIVES. It used to be, back
+# when it was two lines compiled into a binary and the choice therefore had to be
+# made at download time. With the script on disk it is two lines of text, so
+# local/autoexec.ipxe carries them commented out, and --boot-delay writes them
+# live -- exactly what _applyBootDelay() already does to the TFTP copy for
+# netboot clients. Six archives become three, one behaviour, one place to look.
+#
+# ---------------------------------------------------------------------------
+#
+# TWO NAMES ARE NOT FREE CHOICES, and this is why the upstream set stays at the
+# root and keeps its own names. shim picks its second stage by rewriting its OWN
+# "-shim<arch>.efi" suffix to ".efi". So snponly-shimx64.efi will load
+# "snponly.efi" and nothing else, and it has to be upstream's copy, because
+# upstream's is what shim's embedded certificate vouches for. That reserves
+# snponly.efi -- and ipxe.efi for the other pair. FOG's builds keep the fog*
+# prefix inside local/ even though the subdirectory has made the collision
+# impossible: the names are in the README, in the docs and in every bug report
+# since GH-1117, and renaming them buys nothing.
 #
 # BOTH shim pairs ship. Each derives its own second stage from its own filename,
 # so they are independent entry points -- point the boot manager at
@@ -10050,29 +10089,33 @@ _signLocalIpxe() {
 # Upstream signs no shim for ia32, so the earlier design concluded i386 had no
 # Secure Boot path at all. Via db it does.
 #
-# STILL NOT PUBLISHED: the EMBED-less autoexec/ builds, which carry no boot
-# script and would only chain the binaries already here; and the BIOS artifacts
-# (.kpxe/.lkrn/.usb/.iso), which are not PE images and which an ESP cannot boot.
-# Both remain on TFTP for anyone assembling that setup deliberately.
+# rEFInd ships in refind/, which is new (GH-1185). FOG_EFI_BOOT_EXIT_TYPE
+# defaults to refind_efi, so rEFInd is what a UEFI host chainloads on the way
+# out of the boot menu -- and an ESP assembled from this kit had no local-boot
+# chainloader on it at all. It comes from the WEB tree rather than $tftpdirdst
+# (it has never existed in the TFTP tree) and _resignRefind() has already signed
+# it by the time this runs. Its own subdirectory because rEFInd reads refind.conf
+# from the directory it was loaded from, which is also where every rEFInd
+# installation on earth puts it.
+#
+# STILL NOT PUBLISHED: the BIOS artifacts (.kpxe/.lkrn/.usb/.iso), which are not
+# PE images and which an ESP cannot boot. They remain on TFTP for anyone
+# assembling that setup deliberately.
 #
 # Everything here is public by nature: FOG's own binaries, upstream's signed
 # shim and loader (downloadable from fog-ipxe's release assets anyway), and
 # certificates plus signatures over them. FOG already serves the MOK-signed
 # bzImage over unauthenticated HTTP from service/ipxe, so this is not a new
 # class of exposure. The private keys never leave the PKI zone directory.
-# The files one archive holds, as "src|dst" -- src relative to $tftpdirdst, dst
-# relative to the archive's top-level directory.
+# The files one archive takes from $tftpdirdst, as "src|dst" -- src relative to
+# $tftpdirdst, dst relative to the archive's top-level directory.
 #
 #   $1  architecture: x86_64 | i386 | arm64
-#   $2  variant: empty for the standard set, "10sec" for the delayed one
 #
-# The delay lives in the BINARY, not in a script: `sleep` is an optional iPXE
-# command that FOG's own builds enable but upstream's signed loader may not, and
-# the loader is what runs autoexec.ipxe. It is also the only route to a delay at
-# all when a fog*.efi is launched straight from the boot manager, which reads no
-# script.
+# See the header for why the upstream set keeps its names at the root while
+# FOG's own builds go under local/.
 _espKitFiles() {
-    local arch="$1" variant="$2"
+    local arch="$1"
     local fogdir="" sbdir="secureboot" shimsfx="x64" mm="mmx64.efi" name
     case $arch in
         i386)
@@ -10096,28 +10139,64 @@ _espKitFiles() {
         echo "${sbdir}/ipxe.efi|ipxe.efi"
         echo "${sbdir}/${mm}|${mm}"
     fi
-    # FOG's own builds, pre-named for the ESP. Ordered as autoexec.ipxe tries
+    # FOG's own builds, pre-named for the ESP. Ordered as the root ladder tries
     # them, so the list reads as the preference order it is.
     for name in ipxe snp intel realtek snponly; do
-        echo "${variant:+10secdelay/}${fogdir}${name}.efi|fog${name}.efi"
+        echo "${fogdir}${name}.efi|local/fog${name}.efi"
     done
+}
+# The files one archive takes from the WEB tree's service/ipxe, same "src|dst"
+# shape. Separate from _espKitFiles() because it is a different source root, not
+# because it is a different kind of file.
+#
+#   $1  architecture: x86_64 | i386 | arm64
+#
+# WHICH rEFInd BINARY IS NOT A STRAIGHT THREE-WAY MAP. refind.efi is a preferred
+# generic: bootmenu.class.php:235-237 uses it in place of refind_x64.efi whenever
+# it exists, so the same preference is applied here. Otherwise the ESP and the
+# PXE path would disagree about which binary is canonical, and a bug report
+# naming "rEFInd" would mean two different files.
+#
+# refind.conf rides along and is deliberately NOT signed -- it is data, not a PE
+# image (see _resignRefind). rEFInd reads it from its own directory, which is
+# what refind/ is for.
+_espRefindFiles() {
+    local arch="$1" ipxedir="${webdirdest%/}/service/ipxe"
+    case $arch in
+        i386)  echo "refind_ia32.efi|refind/refind_ia32.efi" ;;
+        arm64) echo "refind_aa64.efi|refind/refind_aa64.efi" ;;
+        *)
+            if [[ -f ${ipxedir}/refind.efi ]]; then
+                echo "refind.efi|refind/refind.efi"
+            else
+                echo "refind_x64.efi|refind/refind_x64.efi"
+            fi
+            ;;
+    esac
+    echo "refind.conf|refind/refind.conf"
 }
 # What each published file is, for the manifest. Kept as data rather than
 # comments because it is what replaced curation-by-omission: the earlier
 # directory said which binary to use by leaving the others out, which is how
 # fogsnponly.efi came to be unavailable at all. A manifest can carry the same
 # advice without having to withhold a file to give it.
+#
+# Matched on the path relative to the archive root, not on the basename, because
+# there are two files called autoexec.ipxe now and they do different jobs.
 _espFileRole() {
     case "$1" in
         snponly-shim*.efi|ipxe-shim*.efi) echo "shim" ;;
         snponly.efi|ipxe.efi)             echo "upstream-loader" ;;
         mmx64.efi|mmaa64.efi)             echo "mokmanager" ;;
-        fogipxe.efi)                      echo "fog-ipxe" ;;
-        fogsnp.efi)                       echo "fog-snp" ;;
-        fogintel.efi)                     echo "fog-intel" ;;
-        fogrealtek.efi)                   echo "fog-realtek" ;;
-        fogsnponly.efi)                   echo "fog-snponly" ;;
-        autoexec.ipxe)                    echo "script" ;;
+        local/fogipxe.efi)                echo "fog-ipxe" ;;
+        local/fogsnp.efi)                 echo "fog-snp" ;;
+        local/fogintel.efi)               echo "fog-intel" ;;
+        local/fogrealtek.efi)             echo "fog-realtek" ;;
+        local/fogsnponly.efi)             echo "fog-snponly" ;;
+        local/autoexec.ipxe)              echo "boot-script" ;;
+        autoexec.ipxe)                    echo "chain-script" ;;
+        refind/*.efi)                     echo "chainloader" ;;
+        refind/refind.conf)               echo "config" ;;
         MOK.der)                          echo "enrolment-cert" ;;
         PK.auth|KEK.auth|db.auth)         echo "enrolment-var" ;;
         fog-enroll-mok.*)                 echo "helper" ;;
@@ -10129,7 +10208,7 @@ _espFileOrigin() {
     case "$1" in
         snponly-shim*.efi|ipxe-shim*.efi|snponly.efi|ipxe.efi|mmx64.efi|mmaa64.efi)
             echo "upstream" ;;
-        autoexec.ipxe|README.txt|MANIFEST.json)
+        autoexec.ipxe|local/autoexec.ipxe|README.txt|MANIFEST.json)
             echo "generated" ;;
         *)  echo "fog" ;;
     esac
@@ -10139,21 +10218,27 @@ _espFileNote() {
         snponly-shim*.efi|ipxe-shim*.efi)
             echo "Microsoft-signed shim. Point your boot manager at this. It loads the matching loader beside it, named by rewriting this file's own -shim<arch>.efi suffix to .efi." ;;
         snponly.efi|ipxe.efi)
-            echo "Upstream's signed loader, shim's second stage. It only reads autoexec.ipxe from this same directory and chains onward; it does not drive a NIC when booted from an ESP." ;;
+            echo "Upstream's signed loader, shim's second stage. It reads autoexec.ipxe from this same directory and chains onward; it does not drive a NIC when booted from an ESP." ;;
         mmx64.efi|mmaa64.efi)
             echo "MokManager. shim launches it from this directory when it cannot verify the next stage; enrol MOK.der here. Not optional -- nothing in a running OS can write shim's MokList." ;;
-        fogipxe.efi)
+        local/fogipxe.efi)
             echo "FOG's build with all of iPXE's own NIC drivers. Try this first: a machine that cannot netboot usually cannot because its firmware provides no UEFI SNP protocol, so a binary needing one is no use to it." ;;
-        fogsnp.efi)
+        local/fogsnp.efi)
             echo "FOG's build driving the NIC through the firmware's SNP protocol, binding every SNP device it can see. For firmware that does provide one and hardware iPXE's own drivers do not cover." ;;
-        fogintel.efi)
+        local/fogintel.efi)
             echo "FOG's build, Intel driver only. For when the all-drivers build misbehaves on that specific NIC." ;;
-        fogrealtek.efi)
+        local/fogrealtek.efi)
             echo "FOG's build, Realtek driver only. For when the all-drivers build misbehaves on that specific NIC." ;;
-        fogsnponly.efi)
-            echo "FOG's build bound to the SNP device iPXE was loaded FROM. Booted off an ESP that device is the disk, so it usually finds no NIC -- which is why autoexec.ipxe tries it last. Included because it is the right binary when something chainloads it over the network, and there is hardware where it works." ;;
+        local/fogsnponly.efi)
+            echo "FOG's build bound to the SNP device iPXE was loaded FROM. Booted off an ESP that device is the disk, so it usually finds no NIC -- which is why the root autoexec.ipxe tries it last. Included because it is the right binary when something chainloads it over the network, and there is hardware where it works." ;;
+        local/autoexec.ipxe)
+            echo "FOG's boot script, read by whichever fog*.efi in this directory runs. Walks net0/net1/net2 for DHCP, handles proxyDHCP and next-server, then chains default.ipxe from the server. This is the file to edit to change FOG's boot behaviour on this ESP; a pre-DHCP sleep for STP or port power-save is commented out at the top." ;;
         autoexec.ipxe)
-            echo "Read by the upstream loader out of this directory. Chains the FOG binaries in preference order. Its fallbacks fire only when a file is MISSING or fails verification -- not when one loads and then finds no NIC." ;;
+            echo "Read by the upstream loader out of this directory. Chains the FOG builds in local/ in preference order. Its fallbacks fire only when a file is MISSING or fails verification -- not when one loads and then finds no NIC." ;;
+        refind/refind.conf)
+            echo "rEFInd's configuration, read from its own directory. Data, not a PE image, so it carries no signature and needs none." ;;
+        refind/*.efi)
+            echo "rEFInd, signed by this server. FOG's default exit type (refind_efi) chainloads it to boot whatever OS is installed locally, so this is the piece that makes an ESP assembled from this archive able to leave FOG again rather than only enter it." ;;
         MOK.der)
             echo "This server's certificate, in the DER form MokManager wants. Enrol it once per machine through MokManager, after which any binary here that FOG signed will load." ;;
         PK.auth|KEK.auth|db.auth)
@@ -10165,23 +10250,21 @@ _espFileNote() {
         *)  echo "" ;;
     esac
 }
-# The kit's autoexec.ipxe.
+# The archive root's autoexec.ipxe: the fallback ladder.
 #
 # Static, not a template. default.ipxe is generated per install because it
 # embeds the server address; this has no per-server content at all -- it chains
-# a sibling by relative filename, and FOG's build carries the DHCP/next-server
-# script compiled in, so it finds the server by itself. iPXE resolves a bare
-# filename against the URI the running binary was loaded from, which on an ESP
-# is the directory this sits in.
+# a relative path, and iPXE resolves that against the directory the running
+# binary was loaded from, which on an ESP is the directory this sits in.
 #
-# THE FALLBACK LADDER COVERS WHICH FILES GOT COPIED, NOT WHICH DRIVER WORKS, and
-# the docs must say it in those words. `chain X || goto Y` only branches when the
-# image fails to LOAD -- absent, malformed, or rejected by shim's verification.
-# Once an image loads and runs, control never returns: FOG's embedded script ends
-# its own failure path with `prompt ... && shell || reboot`, so a binary that
-# starts fine but binds no NIC parks there and the next branch is never reached.
-# That is the difference from the net0/net1/net2 ladder in the netboot script,
-# which works because it stays inside one iPXE instance rather than handing off.
+# THE LADDER COVERS WHICH FILES GOT COPIED, NOT WHICH DRIVER WORKS, and the docs
+# must say it in those words. `chain X || goto Y` only branches when the image
+# fails to LOAD -- absent, malformed, or rejected by shim's verification. Once an
+# image loads and runs, control never returns: local/autoexec.ipxe ends its own
+# failure path with `prompt ... && shell || reboot`, so a binary that starts fine
+# but binds no NIC parks there and the next branch is never reached. That is the
+# difference from the net0/net1/net2 ladder in local/autoexec.ipxe, which works
+# because it stays inside one iPXE instance rather than handing off.
 #
 # Still worth having: it means one archive boots whether the admin copied the
 # whole folder or only the variant their hardware needs.
@@ -10189,64 +10272,157 @@ _espFileNote() {
 # fogsnponly.efi is last on purpose -- it is the one most likely to load
 # cleanly and then find nothing, so anything with a chance of working should
 # have been tried before it.
-_espAutoexecScript() {
-    local variant="$1" note
-    if [[ -n $variant ]]; then
-        note="# THE 10-SECOND-DELAY SET. Each binary waits 10s before DHCP, which is what
-# lets a link come up on a switch running STP or port power-save."
-    else
-        note="# The standard set. If the link is not up in time on your switch -- STP or
-# port power-save -- download the -10sec archive instead."
-    fi
-    cat <<ESPAUTOEXEC
+_espChainScript() {
+    cat <<'ESPCHAIN'
 #!ipxe
 # Read off the ESP by upstream's signed loader, after shim has established MOK
-# trust. Chains FOG's own build, which carries the FOG boot script compiled in.
-#
-${note}
+# trust. That loader drives no NIC when it is booted from an ESP, so the only
+# useful thing it can do is hand off to FOG's own build -- which does, and which
+# reads its own boot script out of local/autoexec.ipxe once it is running.
 #
 # The fallbacks fire only if a file is MISSING or fails verification -- not if it
 # loads and then finds no NIC. Copy the variant your hardware needs.
-chain fogipxe.efi || goto trysnp
+chain local/fogipxe.efi || goto trysnp
 :trysnp
-chain fogsnp.efi || goto tryintel
+chain local/fogsnp.efi || goto tryintel
 :tryintel
-chain fogintel.efi || goto tryrealtek
+chain local/fogintel.efi || goto tryrealtek
 :tryrealtek
-chain fogrealtek.efi || goto trysnponly
+chain local/fogrealtek.efi || goto trysnponly
 :trysnponly
-chain fogsnponly.efi || goto nofogbinary
+chain local/fogsnponly.efi || goto nofogbinary
 :nofogbinary
-echo No usable FOG iPXE binary found on this ESP.
+echo No usable FOG iPXE binary found in local/ on this ESP.
 prompt --key s --timeout 10000 Hit 's' for the iPXE shell; reboot in 10 seconds && shell || reboot
+ESPCHAIN
+}
+# local/autoexec.ipxe: FOG's real boot script.
+#
+# Whichever fog*.efi in local/ ends up running reads this, whether it got there
+# via the root ladder or straight from the firmware boot manager. Before
+# fog-ipxe v2.0.0-fog.8 this logic was compiled into each binary; it is a file
+# now, which is the whole reason local/ has to be its own directory (see the
+# section header).
+#
+# Keep this in step with fog-ipxe's own autoexec.ipxe and with src/ipxescript,
+# the script the BIOS binaries still embed. All three must behave identically,
+# or which platform a site booted becomes a variable in every bug report.
+#
+# THE DELAY. Some switches take several seconds to bring a port out of STP
+# listening or out of powersave, and iPXE's first DHCP attempt goes out before
+# that. Written live from --boot-delay, bracketed by the same sentinels
+# _applyBootDelay() uses on the TFTP copy so the two read the same way; shipped
+# commented out otherwise, because an admin who discovers the problem on one
+# machine at 2am should be able to fix it by uncommenting a line rather than by
+# reinstalling the server.
+_espLocalAutoexecScript() {
+    local delay="${bootdelay:-0}" delayblock
+    if [[ $delay -gt 0 ]]; then
+        delayblock="# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)
+echo Sleeping ${delay} seconds to wait for STP/Powersave to switchoff and on
+sleep ${delay}
+# FOG-BOOT-DELAY-END"
+    else
+        delayblock="# No pre-DHCP delay is configured. If your switch runs STP or port power-save
+# and the link is not up by the time iPXE first asks for DHCP, uncomment the two
+# lines below -- or reinstall with --boot-delay <seconds>, which writes them here
+# and in the server's own netboot copy at the same time.
+#echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
+#sleep 10"
+    fi
+    cat <<ESPAUTOEXEC
+#!ipxe
+# FOG's boot script, read off the ESP by whichever fog*.efi in this directory
+# runs. Finds a DHCP answer, works out which server to talk to, and chains
+# FOG's menu. Edit this file to change how this ESP boots.
+#
+# Kept in step with the copy on the FOG server's TFTP root -- if the two differ,
+# which one a machine booted becomes a variable in every bug report.
+${delayblock}
+echo Checking net0 for DHCP...
+isset \${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
+echo Received DHCP answer on interface net0 && goto proxycheck
+
+:dhcpnet1
+echo Checking net1 for DHCP...
+isset \${net1/mac} && ifopen net1 && dhcp net1 || goto dhcpnet2
+echo Received DHCP answer on interface net1 && goto proxycheck
+
+:dhcpnet2
+echo Checking net2 for DHCP...
+isset \${net2/mac} && ifopen net2 && dhcp net2 || goto dhcpall
+echo Received DHCP answer on interface net2 && goto proxycheck
+
+:dhcpall
+echo No DHCP answer on any interface, trying proxy DHCP...
+dhcp && goto proxycheck || goto dhcperror
+
+:dhcperror
+echo DHCP error!
+prompt --key s --timeout 10000 DHCP failed, hit 's' for the iPXE shell; reboot in 10 seconds && shell || reboot
+
+:proxycheck
+echo Trying proxy DHCP...
+isset \${proxydhcp/next-server} && set next-server \${proxydhcp/next-server} || goto nextservercheck
+
+:nextservercheck
+echo Checking for next-server...
+isset \${next-server} && goto netboot || goto setserv
+
+:setserv
+echo -n Please enter tftp server: && read next-server && goto netboot || goto setserv
+
+:chainloadfailed
+prompt --key s --timeout 10000 Chainloading failed, hit 's' for the iPXE shell; reboot in 10 seconds && shell || reboot
+
+:netboot
+echo starting netboot to default.ipxe...
+chain tftp://\${next-server}/default.ipxe || goto chainloadfailed
 ESPAUTOEXEC
 }
 # The archive's README. Written per archive rather than once, because which of
 # the two enrolment routes is even available depends on whether a shim landed.
-#   $1 arch  $2 variant  $3 archive stem  $4 1 if an upstream loader is present
+#   $1 arch  $2 archive stem  $3 1 if an upstream loader is present
+#   $4 1 if rEFInd is present
 _espKitReadme() {
-    local arch="$1" variant="$2" stem="$3" haveloader="$4"
+    local arch="$1" stem="$2" haveloader="$3" haverefind="$4"
+    local dirs="local/ subdirectory as it is" why
+    [[ $haverefind -eq 1 ]] && dirs="local/ and refind/ subdirectories as they are"
+    # Why local/ exists reads differently depending on whether there is a second
+    # script in the archive at all. Saying "there are two scripts here" in an
+    # i386 archive, which has no upstream loader and so no root autoexec.ipxe,
+    # would send an admin looking for a file that is not there.
+    if [[ $haveloader -eq 1 ]]; then
+        why="local/ is not tidiness. iPXE reads its boot script, autoexec.ipxe, out of
+the directory the running binary was loaded from, and there are two different
+scripts wanted here: the one in this folder is read by upstream's loader and
+only chains FOG's build, while the one in local/ is FOG's actual boot logic.
+Flatten them together and neither one works."
+    else
+        why="local/ is not tidiness. iPXE reads its boot script, autoexec.ipxe, out of
+the directory the running binary was loaded from, so FOG's builds and the script
+they read have to travel together. Keep them in local/ and it works from
+wherever on the ESP you put the folder."
+    fi
     cat <<ESPREADME
 ${stem}
 $(printf '%*s' ${#stem} '' | tr ' ' '=')
 
-FOG Project -- iPXE boot files for an EFI System Partition (${arch}${variant:+, ${variant} DHCP delay}).
+FOG Project -- iPXE boot files for an EFI System Partition (${arch}).
 
 Copy the CONTENTS of this folder onto the ESP -- \\EFI\\FOG\\ is a good place --
-then point the firmware boot manager at one of the entry points below.
-${variant:+
-This is the 10-second-delay set. Every FOG binary here waits 10s before DHCP,
-which is what lets a link come up on a switch running STP or port power-save.
-The files are otherwise identical to the plain ${stem%-${variant}} archive and
-carry the same names, so do not extract both into the same folder.
-}
+keeping the ${dirs}. Then point the firmware boot
+manager at one of the entry points below.
+
+${why}
+
 WHICH FILE TO BOOT
 ------------------
 $(if [[ $haveloader -eq 1 ]]; then cat <<'ESPSB'
   Secure Boot ON, via shim:
-      Point the boot manager at snponly-shim*.efi  (or ipxe-shim*.efi -- either
+      Point the boot manager at snponly-shimx64.efi  (or ipxe-shimx64.efi -- either
       works; each loads the loader whose name matches its own). The loader reads
-      autoexec.ipxe from this folder and chains FOG's build.
+      autoexec.ipxe from this folder and chains FOG's build out of local\.
       First time on a machine: shim cannot verify FOG's binary yet, so it
       launches MokManager. Choose "Enroll key from disk" and select MOK.der
       here. Reboot; it boots from then on.
@@ -10254,20 +10430,20 @@ $(if [[ $haveloader -eq 1 ]]; then cat <<'ESPSB'
   Secure Boot ON, via firmware Setup Mode (no shim, no MokManager):
       Put the machine into Setup Mode in its firmware, then enrol PK.auth,
       KEK.auth and db.auth. Firmware then verifies FOG's signed binaries
-      directly and you can boot fogipxe.efi straight from the boot manager.
+      directly and you can boot local\fogipxe.efi straight from the boot manager.
 
   Secure Boot OFF:
-      Point the boot manager straight at fogipxe.efi.
+      Point the boot manager straight at local\fogipxe.efi.
 ESPSB
 else cat <<'ESPNOSB'
   Secure Boot OFF:
-      Point the boot manager straight at fogipxe.efi.
+      Point the boot manager straight at local\fogipxe.efi.
 
   Secure Boot ON, via firmware Setup Mode:
       There is no Microsoft-signed shim for this architecture, so the shim
       route does not exist here -- but the Setup Mode route does. Put the
       machine into Setup Mode in its firmware, enrol PK.auth, KEK.auth and
-      db.auth, and firmware will then verify FOG's signed fogipxe.efi
+      db.auth, and firmware will then verify FOG's signed local\fogipxe.efi
       directly. Point the boot manager at it.
       (If those .auth files are absent, this server publishes no enrolment
       material and only the Secure Boot OFF route is available.)
@@ -10276,25 +10452,45 @@ fi)
 
 IF fogipxe.efi DOES NOT BRING UP YOUR NETWORK
 ---------------------------------------------
-Try fogsnp.efi, then fogintel.efi or fogrealtek.efi, then fogsnponly.efi.
+Try local\fogsnp.efi, then local\fogintel.efi or local\fogrealtek.efi, then
+local\fogsnponly.efi.
 $(if [[ $haveloader -eq 1 ]]; then cat <<'ESPLADDER'
-autoexec.ipxe already tries them in that order -- but ONLY when a file is
-missing or fails verification. Once a binary loads and runs, control never comes
-back, so one that starts and then finds no NIC stops at its own prompt rather
-than falling through. If it is the wrong driver, you have to change which file
-is there.
+This folder's autoexec.ipxe already tries them in that order -- but ONLY when a
+file is missing or fails verification. Once a binary loads and runs, control
+never comes back, so one that starts and then finds no NIC stops at its own
+prompt rather than falling through. If it is the wrong driver, point the boot
+manager at a different one.
 ESPLADDER
 else cat <<'ESPNOLADDER'
-There is no autoexec.ipxe in this archive, because nothing here reads one --
-that is upstream's signed loader's job and this archive has no loader. Point
-the boot manager at whichever binary you want to try; there is no fallback
-chain to do it for you.
+There is no chain ladder in this archive, because nothing here reads one -- that
+is upstream's signed loader's job and no loader is signed for this architecture.
+Point the boot manager at whichever binary in local\ you want to try.
 ESPNOLADDER
 fi)
 
-fogsnponly.efi binds only the device iPXE was loaded from. Booted off an ESP
-that device is the disk, so it usually finds no NIC at all -- which is why it is
-tried last.
+local\fogsnponly.efi binds only the device iPXE was loaded from. Booted off an
+ESP that device is the disk, so it usually finds no NIC at all -- which is why it
+is tried last.
+
+CHANGING HOW IT BOOTS
+---------------------
+local\autoexec.ipxe is FOG's boot script: the DHCP walk across net0/net1/net2,
+proxyDHCP, next-server, then FOG's menu. Edit it in place; nothing has to be
+rebuilt. If your switch runs STP or port power-save and the link is not up when
+iPXE first asks for DHCP, uncomment the sleep at the top of it -- or reinstall
+the server with --boot-delay <seconds>, which writes that line for you here and
+for netboot clients at the same time.
+$(if [[ $haverefind -eq 1 ]]; then cat <<'ESPREFIND'
+
+BOOTING THE LOCAL OS AGAIN
+--------------------------
+refind\ holds rEFInd, signed by this server. FOG's default exit type chainloads
+it to boot whatever OS is installed on the machine, so it is what gets a host off
+FOG and back into Windows or Linux. You can also point the firmware boot manager
+straight at it. refind.conf beside it is its configuration; rEFInd reads that
+from its own directory, which is why the two travel together.
+ESPREFIND
+fi)
 
 MANIFEST.json lists every file here with its sha256 and what it is for.
 Full documentation: docs/SUPPORTED_CUSTOMIZATIONS.md, "Local ESP boot files".
@@ -10323,6 +10519,15 @@ _jsonStr() {
 }
 # One JSON array describing every file in a staged archive directory.
 #
+# RECURSES, and "name" is the path relative to the staged root --
+# "local/fogipxe.efi", not "fogipxe.efi". A -maxdepth 1 walk would omit the
+# subdirectories entirely, and it would do it silently: every consumer of this
+# array, including the test harness, checks the files the manifest names rather
+# than the files on disk, so an under-reporting manifest reads as a passing one.
+#
+# The role/origin/note lookups take that same relative path, because two files
+# here are called autoexec.ipxe and they are not the same thing.
+#
 # Called BEFORE MANIFEST.json is written, so MANIFEST.json is deliberately
 # absent from its own inventory -- a file cannot carry its own checksum.
 #   $1 staged directory   $2 Secure Boot anchor PEM, or empty
@@ -10331,7 +10536,7 @@ _espKitContentsJson() {
     local f name sum size fogsigned first=1
     printf '['
     while IFS= read -r f; do
-        name="${f##*/}"
+        name="${f#${dir}/}"
         sum=$(sha256sum "$f" 2>/dev/null | cut -d' ' -f1)
         size=$(wc -c < "$f" 2>/dev/null | tr -d '[:space:]')
         [[ -z $sum || -z $size ]] && continue
@@ -10351,7 +10556,7 @@ _espKitContentsJson() {
             "$(_jsonStr "$(_espFileRole "$name")")" \
             "$(_jsonStr "$(_espFileOrigin "$name")")" \
             "$fogsigned" "$(_jsonStr "$(_espFileNote "$name")")"
-    done < <(find "$dir" -maxdepth 1 -type f 2>/dev/null | sort)
+    done < <(find "$dir" -type f 2>/dev/null | sort)
     printf ']'
 }
 # The FOS kernel/init set, listed but NOT copied.
@@ -10419,6 +10624,7 @@ _publishLocalBootFiles() {
     [[ -d $tftproot ]] || return 0
     local bootdir="${webdirdest%/}/service/localboot"
     local kitdir="${webdirdest%/}/service/secureboot"
+    local ipxedir="${webdirdest%/}/service/ipxe"
     dots "Publishing local ESP boot archives"
     # Rebuilt rather than updated in place: a variant dropped upstream should
     # disappear here too, and a stale archive must not outlive the binaries it
@@ -10439,103 +10645,128 @@ _publishLocalBootFiles() {
         echo " * Could not create a staging directory. See $error_log."
         return 0
     }
-    local arch variant stem staged pair src dst f
-    local copied haveloader contents archive ext asum asize
+    local arch stem staged pair src dst f
+    local copied haveloader haverefind contents archive ext asum asize
     local built=0 failed=0 archjson="" first=1
     for arch in x86_64 i386 arm64; do
-        for variant in "" 10sec; do
-            stem="fog-esp-${arch}${variant:+-${variant}}"
-            staged="${work}/${stem}"
-            mkdir -p "$staged" >>$error_log 2>&1
-            copied=0
-            haveloader=0
-            while IFS= read -r pair; do
-                [[ -z $pair ]] && continue
-                src="${pair%%|*}"
-                dst="${pair#*|}"
-                # Missing is not a failure. An HTTPS install stages no Secure
-                # Boot binaries at all -- downloadipxesecureboot() skips it --
-                # so the upstream entries are absent on those servers by design,
-                # and the archive is still worth building without them.
-                [[ -f ${tftproot}/${src} ]] || continue
-                if cp -f "${tftproot}/${src}" "${staged}/${dst}" >>$error_log 2>&1; then
-                    copied=$((copied + 1))
-                    case $dst in
-                        snponly.efi|ipxe.efi) haveloader=1 ;;
-                    esac
-                else
-                    failed=1
-                fi
-            done < <(_espKitFiles "$arch" "$variant")
-            # Nothing for this architecture in the tree at all: no archive,
-            # rather than an archive holding only a README.
-            if [[ $copied -eq 0 ]]; then
-                rm -rf "$staged" >>$error_log 2>&1
-                continue
-            fi
-            # Whatever enrolment material this server actually published. Taken
-            # by existence rather than by asking whether Secure Boot is
-            # configured, so an opted-out server ships neither and a server with
-            # only a MOK ships only that.
-            for f in MOK.der PK.auth KEK.auth db.auth \
-                     fog-enroll-mok.sh fog-enroll-mok.desktop; do
-                [[ -f ${kitdir}/${f} ]] && \
-                    cp -f "${kitdir}/${f}" "${staged}/${f}" >>$error_log 2>&1
-            done
-            # Only where something can read it. Nothing in an i386 archive, or
-            # in any archive on an HTTPS-only install, ever loads autoexec.ipxe
-            # -- upstream's loader is what reads it -- so shipping one there
-            # would be an inert file implying a chain that is not present.
-            [[ $haveloader -eq 1 ]] && \
-                _espAutoexecScript "$variant" > "${staged}/autoexec.ipxe" 2>>$error_log
-            _espKitReadme "$arch" "$variant" "$stem" "$haveloader" \
-                > "${staged}/README.txt" 2>>$error_log
-            contents=$(_espKitContentsJson "$staged" "$anchorpem")
-            {
-                printf '{\n'
-                printf '  "archive": %s,\n' "$(_jsonStr "$stem")"
-                printf '  "arch": %s,\n' "$(_jsonStr "$arch")"
-                printf '  "variant": %s,\n' "$(_jsonStr "${variant:-standard}")"
-                printf '  "contents": %s\n' "$contents"
-                printf '}\n'
-            } > "${staged}/MANIFEST.json" 2>>$error_log
-            ext="zip"
-            # Both writers change directory so the archive holds "$stem/..."
-            # rather than the staging path, which means $bootdir has to be
-            # absolute. It always is -- $docroot is a distro default under / and
-            # --docroot is normalised with a leading slash (installfog.sh) -- but
-            # that is the dependency to keep in mind if docroot handling changes.
-            if command -v zip >/dev/null 2>&1; then
-                # -X drops the extra attribute blocks, so a re-run over
-                # unchanged binaries differs only by mtime.
-                ( cd "$work" && zip -q -r -X "${bootdir}/${stem}.zip" "$stem" ) \
-                    >>$error_log 2>&1
+        stem="fog-esp-${arch}"
+        staged="${work}/${stem}"
+        # local/ has to exist before the copy loop, because the destinations in
+        # _espKitFiles() carry that prefix and cp will not create it.
+        mkdir -p "${staged}/local" >>$error_log 2>&1
+        copied=0
+        haveloader=0
+        haverefind=0
+        while IFS= read -r pair; do
+            [[ -z $pair ]] && continue
+            src="${pair%%|*}"
+            dst="${pair#*|}"
+            # Missing is not a failure. An HTTPS install stages no Secure
+            # Boot binaries at all -- downloadipxesecureboot() skips it --
+            # so the upstream entries are absent on those servers by design,
+            # and the archive is still worth building without them.
+            [[ -f ${tftproot}/${src} ]] || continue
+            if cp -f "${tftproot}/${src}" "${staged}/${dst}" >>$error_log 2>&1; then
+                copied=$((copied + 1))
+                case $dst in
+                    snponly.efi|ipxe.efi) haveloader=1 ;;
+                esac
             else
-                # zip is in the install list, so this is a fallback for a server
-                # whose package install partly failed rather than an expected
-                # path. tar is a hard dependency of the installer already.
-                ext="tar.gz"
-                tar -czf "${bootdir}/${stem}.tar.gz" -C "$work" "$stem" \
-                    >>$error_log 2>&1
-            fi
-            archive="${stem}.${ext}"
-            if [[ ! -f ${bootdir}/${archive} ]]; then
                 failed=1
-                rm -rf "$staged" >>$error_log 2>&1
-                continue
             fi
-            asum=$(sha256sum "${bootdir}/${archive}" 2>/dev/null | cut -d' ' -f1)
-            asize=$(wc -c < "${bootdir}/${archive}" 2>/dev/null | tr -d '[:space:]')
-            [[ $first -eq 0 ]] && archjson="${archjson},"
-            first=0
-            archjson="${archjson}$(printf \
-                '{"path":%s,"arch":%s,"variant":%s,"root":%s,"size":%s,"sha256":%s,"contents":%s}' \
-                "$(_jsonStr "$archive")" "$(_jsonStr "$arch")" \
-                "$(_jsonStr "${variant:-standard}")" "$(_jsonStr "$stem")" \
-                "${asize:-0}" "$(_jsonStr "$asum")" "$contents")"
-            built=$((built + 1))
+        done < <(_espKitFiles "$arch")
+        # rEFInd, from the web tree. A storage node has no service/ipxe at all
+        # (configureMinHttpd never lays it down), and an admin can have removed
+        # a binary, so absence is not a failure here either -- the archive is
+        # still a working netboot kit without a local-boot chainloader.
+        while IFS= read -r pair; do
+            [[ -z $pair ]] && continue
+            src="${pair%%|*}"
+            dst="${pair#*|}"
+            [[ -f ${ipxedir}/${src} ]] || continue
+            mkdir -p "$(dirname "${staged}/${dst}")" >>$error_log 2>&1
+            if cp -f "${ipxedir}/${src}" "${staged}/${dst}" >>$error_log 2>&1; then
+                copied=$((copied + 1))
+                case $dst in
+                    refind/*.efi) haverefind=1 ;;
+                esac
+            else
+                failed=1
+            fi
+        done < <(_espRefindFiles "$arch")
+        # Nothing for this architecture in the tree at all: no archive,
+        # rather than an archive holding only a README.
+        if [[ $copied -eq 0 ]]; then
             rm -rf "$staged" >>$error_log 2>&1
+            continue
+        fi
+        # Whatever enrolment material this server actually published. Taken
+        # by existence rather than by asking whether Secure Boot is
+        # configured, so an opted-out server ships neither and a server with
+        # only a MOK ships only that.
+        for f in MOK.der PK.auth KEK.auth db.auth \
+                 fog-enroll-mok.sh fog-enroll-mok.desktop; do
+            [[ -f ${kitdir}/${f} ]] && \
+                cp -f "${kitdir}/${f}" "${staged}/${f}" >>$error_log 2>&1
         done
+        # FOG's own boot script goes in unconditionally -- whichever fog*.efi
+        # runs reads it, however that binary was reached. This is NOT gated on
+        # haveloader the way the root ladder is: an i386 archive has no shim and
+        # no upstream loader, and its fog*.efi still needs a script.
+        _espLocalAutoexecScript > "${staged}/local/autoexec.ipxe" 2>>$error_log
+        # The root ladder IS gated, because only upstream's loader reads it.
+        # Without one it would be an inert file implying a chain that is not
+        # present -- and, worse, a second autoexec.ipxe for an admin to confuse
+        # with the one that does something.
+        [[ $haveloader -eq 1 ]] && \
+            _espChainScript > "${staged}/autoexec.ipxe" 2>>$error_log
+        _espKitReadme "$arch" "$stem" "$haveloader" "$haverefind" \
+            > "${staged}/README.txt" 2>>$error_log
+        contents=$(_espKitContentsJson "$staged" "$anchorpem")
+        {
+            printf '{\n'
+            printf '  "archive": %s,\n' "$(_jsonStr "$stem")"
+            printf '  "arch": %s,\n' "$(_jsonStr "$arch")"
+            printf '  "contents": %s\n' "$contents"
+            printf '}\n'
+        } > "${staged}/MANIFEST.json" 2>>$error_log
+        ext="zip"
+        # Both writers change directory so the archive holds "$stem/..."
+        # rather than the staging path, which means $bootdir has to be
+        # absolute. It always is -- $docroot is a distro default under / and
+        # --docroot is normalised with a leading slash (installfog.sh) -- but
+        # that is the dependency to keep in mind if docroot handling changes.
+        # Both recurse, so local/ and refind/ need nothing extra here.
+        if command -v zip >/dev/null 2>&1; then
+            # -X drops the extra attribute blocks, so a re-run over
+            # unchanged binaries differs only by mtime.
+            ( cd "$work" && zip -q -r -X "${bootdir}/${stem}.zip" "$stem" ) \
+                >>$error_log 2>&1
+        else
+            # zip is in the install list, so this is a fallback for a server
+            # whose package install partly failed rather than an expected
+            # path. tar is a hard dependency of the installer already.
+            ext="tar.gz"
+            tar -czf "${bootdir}/${stem}.tar.gz" -C "$work" "$stem" \
+                >>$error_log 2>&1
+        fi
+        archive="${stem}.${ext}"
+        if [[ ! -f ${bootdir}/${archive} ]]; then
+            failed=1
+            rm -rf "$staged" >>$error_log 2>&1
+            continue
+        fi
+        asum=$(sha256sum "${bootdir}/${archive}" 2>/dev/null | cut -d' ' -f1)
+        asize=$(wc -c < "${bootdir}/${archive}" 2>/dev/null | tr -d '[:space:]')
+        [[ $first -eq 0 ]] && archjson="${archjson},"
+        first=0
+        archjson="${archjson}$(printf \
+            '{"path":%s,"arch":%s,"root":%s,"size":%s,"sha256":%s,"contents":%s}' \
+            "$(_jsonStr "$archive")" "$(_jsonStr "$arch")" \
+            "$(_jsonStr "$stem")" \
+            "${asize:-0}" "$(_jsonStr "$asum")" "$contents")"
+        built=$((built + 1))
+        rm -rf "$staged" >>$error_log 2>&1
     done
     rm -rf "$work" >>$error_log 2>&1
     # Static, written once here. Deliberately NOT a PHP endpoint that lists the
@@ -10545,7 +10776,7 @@ _publishLocalBootFiles() {
     # hostname and webroot the admin reached it by.
     {
         printf '{\n'
-        printf '  "schema": 1,\n'
+        printf '  "schema": 2,\n'
         printf '  "generated": %s,\n' \
             "$(_jsonStr "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)")"
         printf '  "fogVersion": %s,\n' "$(_jsonStr "${version}")"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -9680,10 +9680,10 @@ _resignKernels() {
 }
 # Re-sign the rEFInd binaries for UEFI Secure Boot.
 #
-# Why this exists at all: FOG_EFI_BOOT_EXIT_TYPE defaults to 'refind_efi', so on
-# a stock install rEFInd is what EVERY UEFI host chainloads on the way out of
-# the boot menu -- when a task finishes and when no task exists. bootmenu.class
-# emits 'chain -ar ${boot-url}/service/ipxe/refind*.efi', and under EFI that is
+# Why this exists at all: FOG_EFI_BOOT_EXIT_TYPE selects how a UEFI host leaves
+# the boot menu -- when a task finishes and when no task exists -- and
+# 'refind_efi' is one of the choices. bootmenu.class then emits
+# 'chain -ar ${boot-url}/service/ipxe/refind*.efi', and under EFI that is
 # LoadImage/StartImage, so the firmware (or shim, on our signed snponly path)
 # validates it exactly as it validates the FOS kernel. An unsigned rEFInd dies
 # there with SECURITY VIOLATION.
@@ -9693,6 +9693,14 @@ _resignKernels() {
 # and the machine only fails afterwards, on the way to the disk. It reads as a
 # bootloader or partitioning problem, not a Secure Boot one. Reported on the
 # forum against 1.6.3200 (topic 18217), where the reporter fixed it by hand.
+#
+# Still unconditional now that 'sanboot' is the default rather than
+# 'refind_efi', and deliberately so. The default only decides what an untouched
+# server does; rEFInd is still shipped, still restored across upgrades, still
+# offered in the dropdown, and still settable per host. Signing it costs one
+# sbsign per binary on installs that will never boot it, and NOT signing it
+# turns a dropdown selection into a Secure Boot failure two reboots later, with
+# the deceptive symptom above. That trade has not changed.
 #
 # What ships is not a substitute: refind.efi and refind_x64.efi carry Rod
 # Smith's own self-signed certificate, which is in nobody's db, and
@@ -10089,14 +10097,21 @@ _signLocalIpxe() {
 # Upstream signs no shim for ia32, so the earlier design concluded i386 had no
 # Secure Boot path at all. Via db it does.
 #
-# rEFInd ships in refind/, which is new (GH-1185). FOG_EFI_BOOT_EXIT_TYPE
-# defaults to refind_efi, so rEFInd is what a UEFI host chainloads on the way
-# out of the boot menu -- and an ESP assembled from this kit had no local-boot
-# chainloader on it at all. It comes from the WEB tree rather than $tftpdirdst
-# (it has never existed in the TFTP tree) and _resignRefind() has already signed
-# it by the time this runs. Its own subdirectory because rEFInd reads refind.conf
-# from the directory it was loaded from, which is also where every rEFInd
-# installation on earth puts it.
+# rEFInd ships in refind/, which is new (GH-1185). It is what a UEFI host
+# chainloads leaving the boot menu when FOG_EFI_BOOT_EXIT_TYPE is 'refind_efi',
+# and an ESP assembled from this kit had no local-boot chainloader on it at all.
+# It comes from the WEB tree rather than $tftpdirdst (it has never existed in the
+# TFTP tree) and _resignRefind() has already signed it by the time this runs. Its
+# own subdirectory because rEFInd reads refind.conf from the directory it was
+# loaded from, which is also where every rEFInd installation on earth puts it.
+#
+# Published even though the default exit type is now 'sanboot', which needs no
+# chainloader at all -- firmware boots the next entry itself. Two reasons. The
+# archive is assembled by hand onto a disk that may never talk to this server
+# again, so it should carry every route the server supports rather than only the
+# one this server is currently configured for; and refind_efi remains a
+# per-host setting, so a host booting from this ESP can be the one that wants
+# it. It is ~230KB in an archive already several MB of signed binaries.
 #
 # STILL NOT PUBLISHED: the BIOS artifacts (.kpxe/.lkrn/.usb/.iso), which are not
 # PE images and which an ESP cannot boot. They remain on TFTP for anyone
@@ -10238,7 +10253,7 @@ _espFileNote() {
         refind/refind.conf)
             echo "rEFInd's configuration, read from its own directory. Data, not a PE image, so it carries no signature and needs none." ;;
         refind/*.efi)
-            echo "rEFInd, signed by this server. FOG's default exit type (refind_efi) chainloads it to boot whatever OS is installed locally, so this is the piece that makes an ESP assembled from this archive able to leave FOG again rather than only enter it." ;;
+            echo "rEFInd, signed by this server. A boot manager that finds and boots whatever OS is installed locally. Not needed by the default exit type (sanboot hands straight back to firmware), but it is what the refind_efi exit type chainloads, and it is here so an ESP assembled from this archive carries every route off FOG rather than only the configured one." ;;
         MOK.der)
             echo "This server's certificate, in the DER form MokManager wants. Enrol it once per machine through MokManager, after which any binary here that FOG signed will load." ;;
         PK.auth|KEK.auth|db.auth)

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -2931,8 +2931,8 @@ $this->schema[] = [
     . "(`settingKey`, `settingDesc`, `settingValue`, `settingCategory`) "
     . "VALUES "
     . "('FOG_EFI_BOOT_EXIT_TYPE','The method (U)EFI uses to boot the "
-    . "next boot entry/hard drive. Most will require exit. (Default REFIND)',"
-    . "'refind_efi','FOG Boot Settings')",
+    . "next boot entry/hard drive. (Default SANBOOT)',"
+    . "'sanboot','FOG Boot Settings')",
 ];
 // 193
 $this->schema[] = [
@@ -5754,4 +5754,52 @@ $this->schema[] = [
 
         return true;
     },
+];
+// 337
+$this->schema[] = [
+    // sanboot replaces rEFInd as the default UEFI exit type. GH-1185 follow-up.
+    //
+    // FOG_EFI_BOOT_EXIT_TYPE was seeded 'refind_efi' at step 192 because iPXE
+    // could not then boot the next UEFI boot entry itself: `sanboot` on EFI did
+    // nothing useful, so leaving FOG meant chainloading a whole third-party boot
+    // manager over HTTP to do it. iPXE grew UEFI sanboot support, and
+    // BootMenu::__construct()'s 'sanboot' entry already drives it --
+    // `sanboot --drive 0` boots \EFI\Boot\bootx64.efi, with 0x80/0x81/0x82
+    // behind it -- so the third party is no longer buying anything.
+    //
+    // It is strictly less machinery for the same job. rEFInd is a 200-260KB PE
+    // image fetched over unauthenticated HTTP on every single exit from the boot
+    // menu, on every host, whether or not a task ran. Under Secure Boot it also
+    // has to be signed by this server first (_resignRefind), because the copies
+    // upstream ships carry Rod Smith's own certificate or none at all -- so the
+    // stock exit path depended on FOG's PKI having worked. sanboot hands control
+    // to firmware and adds no image to verify.
+    //
+    // WHY THIS ALSO MOVES EXISTING SERVERS, and not just new installs.
+    // Step 192's INSERT IGNORE cannot: the row already exists everywhere, so
+    // editing its seeded value (done, above) only reaches a fresh database.
+    // Every server in the field would keep rEFInd forever, which makes the
+    // change inert where it matters.
+    //
+    // Scoped to rows still holding exactly 'refind_efi'. That value was seeded,
+    // not chosen -- nobody picked it, it was simply what step 192 wrote -- so
+    // moving it is completing the default change rather than overriding a
+    // decision. Anything else an admin selected is left alone, and per-host
+    // `hosts`.`hostExitEfi` is not touched at all: BootMenu reads the host
+    // field FIRST and only falls back to this setting, so an explicit per-host
+    // choice still wins.
+    //
+    // The honest cost, since it is real: an admin who deliberately selected
+    // refind_efi globally is moved to sanboot and has to select it again.
+    // 'refind_efi' stays in Setting::buildExitSelector(), rEFInd is still
+    // shipped, still preserved across installs and still signed, so re-picking
+    // it is one dropdown away and nothing about that path has regressed.
+    "UPDATE `globalSettings`"
+    . " SET `settingValue` = 'sanboot'"
+    . " WHERE `settingKey` = 'FOG_EFI_BOOT_EXIT_TYPE'"
+    . " AND `settingValue` = 'refind_efi'",
+    "UPDATE `globalSettings`"
+    . " SET `settingDesc` = 'The method (U)EFI uses to boot the next boot"
+    . " entry/hard drive. (Default SANBOOT)'"
+    . " WHERE `settingKey` = 'FOG_EFI_BOOT_EXIT_TYPE'",
 ];

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -210,6 +210,12 @@ class BootMenu extends FOGBase
             . '--config-file="%s"';
 
         /** Booting to hard disk via sanboot
+         * The default for both FOG_BOOT_EXIT_TYPE and FOG_EFI_BOOT_EXIT_TYPE, and
+         * the fallback below when neither names a type this class knows. UEFI used
+         * to default to refind_efi instead, because iPXE's sanboot could not then
+         * boot the next UEFI boot entry and leaving FOG meant chainloading rEFInd
+         * over HTTP to do it. It can now, so the third-party boot manager buys
+         * nothing -- see the migration labelled 337 in commons/schema.php.
          * reset console to detected display resolution first to avoid graphical anamolies
          * --drive 0 will boot the first drive found with an efi boot file at the default file path of \EFI\Boot\bootx64.efi (side note, removable install media is found before local disks)
          * could add additional linux detections per distro like `sanboot --drive 0 --no-describe --extra \EFI\rocky` and EFI\centos and EFI\debian etc. but need an || entry for every distro.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 336);
+        define('FOG_SCHEMA', 337);
         define('FOG_BCACHE_VER', 285);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/tests/localboot-publish.test.sh
+++ b/tests/localboot-publish.test.sh
@@ -6,24 +6,29 @@
 #
 # The directory used to be built from two lists that described the same bytes
 # twice -- a "menu" of binaries under their TFTP names at the root, and a "kit"
-# of the same binaries renamed fog*.efi under esp/. arm64 appeared in four
-# places, and the 10-second-delay set was complete in one list and a single file
-# in the other. It is now six archives and a manifest.
+# of the same binaries renamed fog*.efi under esp/. That became six archives, and
+# then three: fog-ipxe v2.0.0-fog.8 stopped shipping the 10secdelay/ EFI builds
+# the -10sec archives were made from, so those three were published holding a
+# shim and no FOG binary at all (GH-1195), and with the boot script on disk the
+# delay is a line of text rather than a second set of binaries.
 #
 # What this pins, in rough order of how badly it fails if wrong:
 #
-#   1. The delay variants are not crossed. A -10sec archive whose fogipxe.efi
-#      came from the plain tree, or the reverse, is undetectable on the server
-#      and shows up as "the delay does nothing" on a switch running STP. Every
-#      mock file's CONTENT is its own path in the tree, so provenance is checked
-#      by reading the file rather than by trusting the copy loop.
+#   1. FOG's own builds are in local/ with their own autoexec.ipxe, and the root
+#      autoexec.ipxe -- read by upstream's loader -- is a separate file that
+#      chains into local/. Flat, those two are one file, and a fog*.efi launched
+#      from the boot manager reads the ladder and chains itself. Every mock
+#      file's CONTENT is its own path in the tree, so provenance is checked by
+#      reading the file rather than by trusting the copy loop.
 #   2. The manifest is valid JSON with sums that match the bytes. It is written
 #      by hand rather than by jq (see _jsonStr) precisely so the whole feature
 #      does not vanish when a package is missing -- which puts the burden of
 #      proving the encoding right here. Validated with python3, deliberately a
 #      different implementation from the one that wrote it.
-#   3. Nothing unpublishable leaks in: the EMBED-less autoexec/ builds, and the
+#   3. Nothing unpublishable leaks in: the retired autoexec/ builds, and the
 #      BIOS artifacts (.kpxe/.usb/.iso), which are not PE images at all.
+#   3a. rEFInd comes from the WEB tree (it has never existed in the TFTP tree)
+#      and the binary in each archive matches the arch the archive is named for.
 #   4. The degraded shapes still produce something useful rather than failing:
 #      an HTTPS-only install stages no secureboot/, and a server may hold no
 #      enrolment material.
@@ -105,6 +110,10 @@ elif cmd == "filesum":
     print([f["sha256"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
 elif cmd == "filenote":
     print([f["note"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
+elif cmd == "filerole":
+    print([f["role"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
+elif cmd == "filesigned":
+    print([f["fogSigned"] for f in arch(arg)["contents"] if f["name"] == arg2][0])
 elif cmd == "kernels":
     print("\n".join(sorted(k["name"] for k in m["kernels"])))
 elif cmd == "kernelpath":
@@ -122,8 +131,10 @@ mq() { "$PY" "$WORK/mq.py" "$@" | tr -d '\015'; }
 mk_tree() {
     local root="$1" withsb="$2" d n
     rm -rf "$root"
-    for d in "" "i386-efi/" "arm64-efi/" "10secdelay/" \
-             "10secdelay/i386-efi/" "10secdelay/arm64-efi/" "autoexec/"; do
+    # autoexec/ is retired (_retireStaleEfiPaths removes it) and 10secdelay/ no
+    # longer holds EFI files. Both are fabricated anyway, as negative controls:
+    # nothing published may come from either.
+    for d in "" "i386-efi/" "arm64-efi/" "10secdelay/" "autoexec/"; do
         mkdir -p "${root}/${d}"
         for n in ipxe snp snponly intel realtek; do
             printf '%s' "${d}${n}.efi" > "${root}/${d}${n}.efi"
@@ -146,12 +157,21 @@ mk_tree() {
 }
 
 mk_web() {
-    local root="$1" withenrol="$2" n
+    local root="$1" withenrol="$2" withrefind="${3:-yes}" n
     rm -rf "$root"
     mkdir -p "${root}/service/ipxe" "${root}/service/secureboot"
     for n in bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz; do
         printf '%s' "$n" > "${root}/service/ipxe/${n}"
     done
+    # rEFInd lives ONLY here, never in the TFTP tree -- which is exactly the
+    # mistake GH-1185 records, the publisher having copied from $tftpdirdst
+    # alone. Content is the filename, so an archive that got the wrong arch's
+    # binary is caught by reading it.
+    if [[ $withrefind == yes ]]; then
+        for n in refind.efi refind_x64.efi refind_ia32.efi refind_aa64.efi refind.conf; do
+            printf '%s' "$n" > "${root}/service/ipxe/${n}"
+        done
+    fi
     if [[ $withenrol == yes ]]; then
         for n in MOK.der PK.auth KEK.auth db.auth \
                  fog-enroll-mok.sh fog-enroll-mok.desktop; do
@@ -196,8 +216,8 @@ else
     "$PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$MAN" 2>&1 | head -3
 fi
 
-is "$(mq "$MAN" count)" "6" "six archives are published"
-is "$(mq "$MAN" top schema)" "1" "the manifest declares its schema"
+is "$(mq "$MAN" count)" "3" "three archives are published -- one per architecture"
+is "$(mq "$MAN" top schema)" "2" "the manifest declares its schema"
 is "$(mq "$MAN" top fogVersion)" "1.6.0-test" "the manifest records the FOG version"
 is "$(mq "$MAN" top ipxeVersion)" "v2.0.0-fog.test" "the manifest records the iPXE version"
 
@@ -206,8 +226,8 @@ is "$(mq "$MAN" top ipxeVersion)" "v2.0.0-fog.test" "the manifest records the iP
 # difference would compare empty paths and pass.
 if [[ -f $BOOT/fog-esp-x86_64.zip ]]; then EXT=".zip"; else EXT=".tar.gz"; fi
 is "$(mq "$MAN" paths | tr '\n' ' ')" \
-   "fog-esp-arm64-10sec${EXT} fog-esp-arm64${EXT} fog-esp-i386-10sec${EXT} fog-esp-i386${EXT} fog-esp-x86_64-10sec${EXT} fog-esp-x86_64${EXT} " \
-   "one archive per architecture and delay variant"
+   "fog-esp-arm64${EXT} fog-esp-i386${EXT} fog-esp-x86_64${EXT} " \
+   "one archive per architecture, and no delay variants"
 
 # Nothing loose. The whole point of the reorganisation.
 is "$(find "$BOOT" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" "0" \
@@ -220,18 +240,23 @@ else
     bad "the 404 stub is missing"
 fi
 
-# --- provenance: the delay variants must not be crossed ----------------------
-for pair in "fog-esp-x86_64${EXT}|ipxe.efi" \
-            "fog-esp-x86_64-10sec${EXT}|10secdelay/ipxe.efi" \
-            "fog-esp-i386${EXT}|i386-efi/ipxe.efi" \
-            "fog-esp-i386-10sec${EXT}|10secdelay/i386-efi/ipxe.efi" \
-            "fog-esp-arm64${EXT}|arm64-efi/ipxe.efi" \
-            "fog-esp-arm64-10sec${EXT}|10secdelay/arm64-efi/ipxe.efi"; do
-    a="${pair%%|*}"; want="${pair#*|}"
+# --- provenance: each archive gets ITS arch's binaries -----------------------
+#
+# Three pairs, not six. The 10secdelay/ rows this loop used to carry were the
+# reason the -10sec archives were worth having, and are why they had to go: the
+# EFI builds behind them no longer exist, so the archives were published empty
+# of FOG binaries and nothing noticed.
+for pair in "fog-esp-x86_64${EXT}|ipxe.efi|refind.efi" \
+            "fog-esp-i386${EXT}|i386-efi/ipxe.efi|refind_ia32.efi" \
+            "fog-esp-arm64${EXT}|arm64-efi/ipxe.efi|refind_aa64.efi"; do
+    a="${pair%%|*}"; rest="${pair#*|}"
+    want="${rest%%|*}"; wantrefind="${rest#*|}"
     d="$WORK/x/${a%%.*}"
     rm -rf "$d"; extract "$BOOT/$a" "$d"
-    is "$(cat "$d/${a%%.*}/fogipxe.efi" 2>/dev/null)" "$want" \
-       "$a fogipxe.efi comes from $want"
+    is "$(cat "$d/${a%%.*}/local/fogipxe.efi" 2>/dev/null)" "$want" \
+       "$a local/fogipxe.efi comes from $want"
+    is "$(cat "$d/${a%%.*}/refind/${wantrefind}" 2>/dev/null)" "$wantrefind" \
+       "$a carries the web tree's ${wantrefind}"
 done
 
 # One top-level directory named after the archive, so two extracted side by side
@@ -242,13 +267,29 @@ is "$(top_entries "$BOOT/fog-esp-x86_64${EXT}" | tr '\n' ' ')" "fog-esp-x86_64 "
 # --- what a full archive contains --------------------------------------------
 X="$WORK/x/fog-esp-x86_64/fog-esp-x86_64"
 for f in snponly-shimx64.efi snponly.efi ipxe-shimx64.efi ipxe.efi mmx64.efi \
-         fogipxe.efi fogsnp.efi fogintel.efi fogrealtek.efi fogsnponly.efi \
+         local/fogipxe.efi local/fogsnp.efi local/fogintel.efi \
+         local/fogrealtek.efi local/fogsnponly.efi local/autoexec.ipxe \
+         refind/refind.efi refind/refind.conf \
          autoexec.ipxe README.txt MANIFEST.json \
          MOK.der PK.auth KEK.auth db.auth \
          fog-enroll-mok.sh fog-enroll-mok.desktop; do
     [[ -f $X/$f ]] || bad "x86_64 archive is missing $f"
 done
-[[ -f $X/fogsnponly.efi ]] && ok "fogsnponly.efi is published (it was excluded before)"
+[[ -f $X/local/fogsnponly.efi ]] && ok "fogsnponly.efi is published (it was excluded before)"
+# The upstream set must stay at the top level: shim derives its second stage AND
+# MokManager from its OWN directory, so moving either into a subfolder breaks the
+# name rewrite it does to find them.
+for f in snponly-shimx64.efi snponly.efi ipxe-shimx64.efi ipxe.efi mmx64.efi; do
+    [[ -f $X/$f ]] || bad "upstream $f is not at the archive top level"
+done
+ok "the upstream shim set stays at the top level, where shim resolves its names"
+# x86_64 follows bootmenu.class.php's refind.efi-over-refind_x64.efi preference,
+# so the ESP and the PXE path agree on which binary is canonical.
+if [[ -f $X/refind/refind.efi && ! -e $X/refind/refind_x64.efi ]]; then
+    ok "x86_64 takes refind.efi over refind_x64.efi, as the boot menu does"
+else
+    bad "x86_64 does not follow the boot menu's rEFInd preference"
+fi
 [[ -f $X/MOK.der ]] && ok "MOK.der travels with MokManager"
 [[ -f $X/db.auth ]] && ok "the Setup Mode variable updates travel too"
 
@@ -257,40 +298,97 @@ is "$(cat "$X/snponly.efi")" "secureboot/snponly.efi" \
    "snponly.efi is UPSTREAM's copy, which is what shim's certificate vouches for"
 is "$(cat "$X/ipxe.efi")" "secureboot/ipxe.efi" \
    "ipxe.efi is upstream's copy for the same reason"
-is "$(cat "$X/fogsnponly.efi")" "snponly.efi" \
-   "FOG's snponly ships under the fog prefix instead"
+is "$(cat "$X/local/fogsnponly.efi")" "snponly.efi" \
+   "FOG's snponly ships under the fog prefix in local/ instead"
 
 # Nothing unpublishable leaked in.
 for junk in undionly.kkpxe ipxe.usb ipxe.iso ipxe.lkrn; do
     [[ -e $X/$junk ]] && bad "BIOS artifact $junk was published"
 done
 ok "no BIOS artifact (.kpxe/.usb/.iso/.lkrn) is published"
-if grep -rq 'autoexec/' "$X"/*.efi 2>/dev/null; then
-    bad "an EMBED-less autoexec/ build was published"
+# Every .efi at any depth, not just "$X"/*.efi -- the FOG builds moved into
+# local/ and a top-level-only glob would stop covering the ones most likely to
+# have come from the wrong place.
+leaked() { find "$X" -name '*.efi' -type f -exec grep -l "$1" {} + 2>/dev/null; }
+if [[ -n "$(leaked 'autoexec/')" ]]; then
+    bad "a retired autoexec/ build was published: $(leaked 'autoexec/')"
 else
-    ok "the EMBED-less autoexec/ builds are not published"
+    ok "the retired autoexec/ builds are not published"
+fi
+if [[ -n "$(leaked '10secdelay')" ]]; then
+    bad "a binary came from the retired 10secdelay/ EFI set: $(leaked '10secdelay')"
+else
+    ok "nothing comes from 10secdelay/ -- it holds BIOS files only now"
 fi
 
-# --- the fallback ladder -----------------------------------------------------
-is "$(grep -c '^chain fog' "$X/autoexec.ipxe")" "5" "autoexec.ipxe chains all five builds"
-is "$(grep '^chain fog' "$X/autoexec.ipxe" | tail -1)" "chain fogsnponly.efi || goto nofogbinary" \
+# --- the root ladder chains INTO local/, and never a bare sibling ------------
+is "$(grep -c '^chain local/fog' "$X/autoexec.ipxe")" "5" \
+   "the root autoexec.ipxe chains all five builds out of local/"
+is "$(grep '^chain local/fog' "$X/autoexec.ipxe" | tail -1)" \
+   "chain local/fogsnponly.efi || goto nofogbinary" \
    "fogsnponly.efi is tried LAST -- it is the one most likely to load and find no NIC"
-is "$(grep '^chain fog' "$X/autoexec.ipxe" | head -1)" "chain fogipxe.efi || goto trysnp" \
+is "$(grep '^chain local/fog' "$X/autoexec.ipxe" | head -1)" \
+   "chain local/fogipxe.efi || goto trysnp" \
    "fogipxe.efi is tried first"
+# THE regression. A bare "chain fogipxe.efi" means the ladder and the binary sit
+# in one directory, so the binary reads the ladder that chains it and loops.
+if grep -qE '^chain fog[a-z]*\.efi' "$X/autoexec.ipxe"; then
+    bad "the root ladder chains a sibling fog*.efi -- that binary would chain itself"
+else
+    ok "the root ladder never chains a sibling, so nothing can chain itself"
+fi
 
-X10="$WORK/x/fog-esp-x86_64-10sec/fog-esp-x86_64-10sec"
-if [[ -f $X10/autoexec-10sec.ipxe ]]; then
-    bad "the delay variant still ships a second script to rename over the first"
+# --- local/autoexec.ipxe is FOG's real boot script ---------------------------
+#
+# Since fog-ipxe v2.0.0-fog.8 the fog*.efi builds carry no compiled-in script, so
+# this file is the only thing that makes them find a DHCP server at all. An
+# archive without it boots to iPXE's bare autoboot: no multi-NIC walk, no
+# proxyDHCP, no next-server prompt.
+L="$X/local/autoexec.ipxe"
+for want in 'dhcp net0' 'dhcp net1' 'dhcp net2' ':proxycheck' ':nextservercheck' \
+            ':netboot' 'default.ipxe'; do
+    grep -q -- "$want" "$L" || bad "local/autoexec.ipxe is missing \"$want\""
+done
+ok "local/autoexec.ipxe carries the full DHCP/proxyDHCP/next-server ladder"
+if grep -q '^chain ' "$X/autoexec.ipxe" && ! grep -q '^chain local/' "$L"; then
+    ok "local/autoexec.ipxe boots the network rather than chaining another binary"
 else
-    ok "the delay archive has ONE autoexec.ipxe -- no rename step"
+    bad "local/autoexec.ipxe looks like a copy of the root ladder"
 fi
-if grep -q '10-SECOND-DELAY' "$X10/autoexec.ipxe"; then
-    ok "the delay archive's script says which set it is"
+
+# The delay is two lines of text now, not a second set of archives. Commented
+# out by default so an admin who hits it at 2am uncomments a line instead of
+# reinstalling; written live when --boot-delay asked for it.
+is "$(grep -c '^#sleep 10' "$L")" "1" \
+   "the pre-DHCP sleep ships commented out, ready to uncomment"
+is "$(grep -c '^sleep ' "$L")" "0" \
+   "no delay is active when --boot-delay was not given"
+if grep -q 'FOG-BOOT-DELAY-BEGIN' "$L"; then
+    bad "the sentinel block is present with no delay configured"
 else
-    bad "the delay archive's script does not identify itself"
+    ok "no sentinel block without --boot-delay"
 fi
-is "$(grep -c '10secdelay' "$X10/autoexec.ipxe")" "0" \
-   "the delay archive's binaries carry the plain names"
+bootdelay=15
+_publishLocalBootFiles >/dev/null
+rm -rf "$WORK/xd"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/xd"
+LD="$WORK/xd/fog-esp-x86_64/local/autoexec.ipxe"
+is "$(grep -c '^sleep 15' "$LD")" "1" \
+   "--boot-delay 15 writes a live sleep into local/autoexec.ipxe"
+if grep -q 'FOG-BOOT-DELAY-BEGIN' "$LD" && grep -q 'FOG-BOOT-DELAY-END' "$LD"; then
+    ok "the delay is bracketed by the same sentinels _applyBootDelay uses"
+else
+    bad "the delay is written without the sentinels that make it replaceable"
+fi
+# The root ladder runs inside upstream's loader, which drives no NIC on an ESP,
+# so a sleep there would delay nothing.
+if grep -q 'sleep' "$WORK/xd/fog-esp-x86_64/autoexec.ipxe"; then
+    bad "the delay was written into the root ladder, where it delays nothing"
+else
+    ok "the delay goes only where DHCP actually happens"
+fi
+unset bootdelay
+_publishLocalBootFiles >/dev/null
+rm -rf "$WORK/x/fog-esp-x86_64"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/x/fog-esp-x86_64"
 
 # --- manifest sums match the bytes -------------------------------------------
 sum_of() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1; }
@@ -305,6 +403,30 @@ while IFS= read -r f; do
     [[ "$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" "$f")" == "$(sum_of "$X/$f")" ]] || badsum=1
 done < <(mq "$MAN" files "fog-esp-x86_64${EXT}")
 is "$badsum" "0" "every per-file sha256 in the manifest matches the extracted file"
+
+# The manifest has to name the subdirectories, and this is the assertion that
+# proves it does. _espKitContentsJson used a -maxdepth 1 walk and stored bare
+# basenames; left that way it would omit local/ and refind/ entirely, and the
+# checksum loop above would still pass because it walks the manifest rather than
+# the directory. An under-reporting manifest reads exactly like a correct one.
+for f in local/fogipxe.efi local/autoexec.ipxe refind/refind.efi refind/refind.conf; do
+    mq "$MAN" files "fog-esp-x86_64${EXT}" | grep -qx "$f" \
+        || bad "the manifest does not list $f"
+done
+ok "the manifest names files by path relative to the archive root, subdirs included"
+is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" local/autoexec.ipxe)" "boot-script" \
+   "local/autoexec.ipxe is described as the boot script"
+is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" autoexec.ipxe)" "chain-script" \
+   "the root autoexec.ipxe is described as the chain script, not the same thing"
+is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" refind/refind.efi)" "chainloader" \
+   "rEFInd is described as the local-boot chainloader"
+is "$(mq "$MAN" filesigned "fog-esp-x86_64${EXT}" refind/refind.conf)" "False" \
+   "refind.conf is not claimed to be signed -- it is data, not a PE image"
+if [[ -n "$(mq "$MAN" filenote "fog-esp-x86_64${EXT}" refind/refind.efi)" ]]; then
+    ok "rEFInd carries a note saying what it is for"
+else
+    bad "rEFInd is published with no explanation"
+fi
 
 # A file cannot carry its own checksum, so MANIFEST.json is absent from its own
 # inventory -- deliberate, and worth pinning so it is not "fixed" into a lie.
@@ -326,7 +448,7 @@ is "$("$PY" -c 'import json,sys;print(" ".join(sorted(f["name"] for f in json.lo
 
 # The notes are what replaced curation-by-omission; an empty one for the file
 # that used to be excluded would put the advice nowhere.
-if [[ -n "$(mq "$MAN" filenote "fog-esp-x86_64${EXT}" fogsnponly.efi)" ]]; then
+if [[ -n "$(mq "$MAN" filenote "fog-esp-x86_64${EXT}" local/fogsnponly.efi)" ]]; then
     ok "fogsnponly.efi carries the caveat that used to be an exclusion"
 else
     bad "fogsnponly.efi is published with no explanation of when it fails"
@@ -348,7 +470,7 @@ fi
 mk_tree "$tftpdirdst" no
 mk_web "$webdirdest" yes
 _publishLocalBootFiles >/dev/null
-is "$(mq "$MAN" count)" "6" "an HTTPS-only install still publishes six archives"
+is "$(mq "$MAN" count)" "3" "an HTTPS-only install still publishes three archives"
 rm -rf "$WORK/n"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/n"
 N="$WORK/n/fog-esp-x86_64"
 if [[ -e $N/snponly-shimx64.efi || -e $N/mmx64.efi ]]; then
@@ -356,11 +478,19 @@ if [[ -e $N/snponly-shimx64.efi || -e $N/mmx64.efi ]]; then
 else
     ok "no shim material when none was staged"
 fi
-[[ -f $N/fogipxe.efi ]] && ok "FOG's own builds still ship without a shim"
+[[ -f $N/local/fogipxe.efi ]] && ok "FOG's own builds still ship without a shim"
 if [[ -e $N/autoexec.ipxe ]]; then
-    bad "autoexec.ipxe shipped with no loader that could ever read it"
+    bad "the root ladder shipped with no loader that could ever read it"
 else
-    ok "autoexec.ipxe is omitted when no loader is present to read it"
+    ok "the root ladder is omitted when no loader is present to read it"
+fi
+# But FOG's own script is NOT gated on that. The binary that reads it is the FOG
+# build, which ships here; withholding it would leave the archive unable to find
+# a DHCP server, which is the whole job.
+if [[ -f $N/local/autoexec.ipxe ]]; then
+    ok "local/autoexec.ipxe ships even with no upstream loader"
+else
+    bad "local/autoexec.ipxe was gated on a loader that does not read it"
 fi
 [[ -f $N/db.auth ]] && ok "the Setup Mode route survives an HTTPS-only install"
 
@@ -375,7 +505,17 @@ else
     ok "the i386 archive has no shim -- upstream signs none for ia32"
 fi
 [[ -f $I/db.auth ]] && ok "the i386 archive DOES carry db.auth (the only SB route it has)"
-[[ -f $I/fogipxe.efi ]] && ok "the i386 archive carries FOG's builds"
+[[ -f $I/local/fogipxe.efi ]] && ok "the i386 archive carries FOG's builds"
+if [[ -f $I/local/autoexec.ipxe ]]; then
+    ok "the i386 archive carries FOG's boot script, having no loader to read a ladder"
+else
+    bad "the i386 archive has FOG binaries and no script for them to read"
+fi
+if [[ -e $I/refind/refind_x64.efi || -e $I/refind/refind.efi ]]; then
+    bad "an x64 rEFInd was put in the i386 archive"
+else
+    ok "the i386 archive gets refind_ia32.efi, not an x64 build"
+fi
 if grep -q 'Setup Mode' "$I/README.txt"; then
     ok "the i386 README names the Setup Mode route"
 else
@@ -386,12 +526,12 @@ fi
 # loader -- i386, or any arch on an HTTPS-only install -- told the admin that
 # "autoexec.ipxe already tries them in that order" about a file that is not
 # there.
-if grep -q 'no autoexec.ipxe in this archive' "$I/README.txt"; then
+if grep -q 'no chain ladder in this archive' "$I/README.txt"; then
     ok "the i386 README says there is no fallback chain, because there is none"
 else
-    bad "the i386 README describes an autoexec.ipxe the archive does not contain"
+    bad "the i386 README describes a ladder the archive does not contain"
 fi
-if grep -q 'autoexec.ipxe already tries them' "$X/README.txt"; then
+if grep -q 'already tries them in that order' "$X/README.txt"; then
     ok "the x86_64 README does describe the ladder, because it has one"
 else
     bad "the x86_64 README omits the fallback ladder it ships"
@@ -400,7 +540,7 @@ fi
 # --- a server with no enrolment material at all ------------------------------
 mk_web "$webdirdest" no
 _publishLocalBootFiles >/dev/null
-is "$(mq "$MAN" count)" "6" "a server publishing no enrolment material still succeeds"
+is "$(mq "$MAN" count)" "3" "a server publishing no enrolment material still succeeds"
 rm -rf "$WORK/e"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/e"
 E="$WORK/e/fog-esp-x86_64"
 if [[ -e $E/MOK.der || -e $E/db.auth ]]; then
@@ -408,7 +548,36 @@ if [[ -e $E/MOK.der || -e $E/db.auth ]]; then
 else
     ok "no enrolment material when the server has none to give"
 fi
-[[ -f $E/fogipxe.efi ]] && ok "the boot binaries ship regardless"
+[[ -f $E/local/fogipxe.efi ]] && ok "the boot binaries ship regardless"
+
+# --- a server with no rEFInd at all ------------------------------------------
+#
+# configureMinHttpd never lays down service/ipxe, so a storage node has no rEFInd
+# to publish, and an admin can have removed one. The archives are still a working
+# netboot kit without a local-boot chainloader; failing the publish over it would
+# trade the whole feature for a missing extra.
+mk_tree "$tftpdirdst" yes
+mk_web "$webdirdest" yes no
+out="$(_publishLocalBootFiles)"
+is "$(mq "$MAN" count)" "3" "a server with no rEFInd still publishes three archives"
+if [[ $out == *Failed* ]]; then
+    bad "a missing rEFInd failed the publish"
+else
+    ok "a missing rEFInd is not a failure"
+fi
+rm -rf "$WORK/nr"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/nr"
+NR="$WORK/nr/fog-esp-x86_64"
+if [[ -d $NR/refind ]]; then
+    bad "an empty refind/ directory was published"
+else
+    ok "no refind/ directory when there is no rEFInd to put in it"
+fi
+[[ -f $NR/local/fogipxe.efi ]] && ok "the boot binaries ship without rEFInd"
+if grep -q 'BOOTING THE LOCAL OS AGAIN' "$NR/README.txt"; then
+    bad "the README describes a rEFInd the archive does not contain"
+else
+    ok "the README omits the rEFInd section when no rEFInd shipped"
+fi
 
 # --- an empty tree must report failure, not publish nothing quietly ----------
 mk_tree "$tftpdirdst" no
@@ -425,11 +594,11 @@ mk_tree "$tftpdirdst" yes
 mk_web "$webdirdest" yes
 _publishLocalBootFiles >/dev/null
 first_files="$(mq "$MAN" files "fog-esp-x86_64${EXT}" | tr '\n' ' ')"
-first_sum="$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" fogipxe.efi)"
+first_sum="$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" local/fogipxe.efi)"
 _publishLocalBootFiles >/dev/null
 is "$(mq "$MAN" files "fog-esp-x86_64${EXT}" | tr '\n' ' ')" "$first_files" \
    "a re-run publishes the same file list"
-is "$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" fogipxe.efi)" "$first_sum" \
+is "$(mq "$MAN" filesum "fog-esp-x86_64${EXT}" local/fogipxe.efi)" "$first_sum" \
    "a re-run publishes the same bytes"
 
 # --- .fog-ipxe-manifest survives signing -------------------------------------


### PR DESCRIPTION
Closes #1195
Closes #1185

Two commits. The first is the ESP archives; the second changes the default UEFI exit type, which is what makes the rEFInd question in #1185 land where it does.

---

## 1. Why the subdirectory

fog-ipxe `v2.0.0-fog.8` (fog-ipxe#7) removed `EMBED=` from every EFI target, so `fog*.efi` no longer carries FOG's DHCP/proxyDHCP/`next-server` logic — it **reads** it, from a file called `autoexec.ipxe`, which iPXE resolves against the directory the running binary was loaded from.

The archive was flat, and its one `autoexec.ipxe` was the chain ladder written for upstream's driverless loader. So a `fog*.efi` launched from the firmware boot manager read the ladder and executed `chain fogipxe.efi` — itself. Via shim the binary came up with no FOG script at all: no multi-NIC walk, no proxyDHCP, no `next-server` prompt. Neither route `README.txt` documents worked.

Two scripts want two directories:

```
fog-esp-x86_64/
  autoexec.ipxe          the ladder: chain local/fog*.efi in order
  snponly-shim*.efi snponly.efi ipxe-shim*.efi ipxe.efi mm*.efi
  MOK.der PK.auth KEK.auth db.auth  README.txt  MANIFEST.json
  local/
    autoexec.ipxe        FOG's real boot script; the delay lives here
    fogipxe.efi fogsnp.efi fogintel.efi fogrealtek.efi fogsnponly.efi
  refind/
    refind.efi refind.conf
```

The upstream set stays at the top level because shim derives its second stage *and* MokManager from its own directory by name. FOG's builds keep the `fog` prefix even though the subdirectory removed the collision that forced it — the names are in the docs and in every bug report since #1117, and renaming buys nothing.

`local/autoexec.ipxe` is **not** gated on an upstream loader being present, which inverts the old gate: the binary that reads it is FOG's own, so an i386 archive and an HTTPS-only install both need one. The root ladder stays gated — nothing else reads it.

## 2. The three `-10sec` archives were being published empty

`_espKitFiles()` sourced them from `10secdelay/`, which is BIOS-only now and which `_retireStaleEfiPaths()` clears of `.efi` files. A missing source is fine by design there (an HTTPS install stages no `secureboot/`), and `copied` stayed non-zero from the shim set — so three archives were staged, checksummed and advertised in `manifest.json` holding a shim, MokManager, enrolment material and a README naming a file that was not in them.

They're gone. With the script on disk the delay is two lines of text: commented out in `local/autoexec.ipxe`, written live by `--boot-delay` inside the same `FOG-BOOT-DELAY` sentinels `_applyBootDelay()` uses on the TFTP copy. One option now covers netboot and ESP boot.

That reverses a note in three places claiming the delay had to live in the binary because `sleep` is optional and upstream's loader may not have it. True, and beside the point — the loader only chains. The `sleep` runs in FOG's build, which enables it, immediately before the DHCP it delays.

## 3. rEFInd (#1185), and sanboot as the UEFI default

rEFInd now ships in `refind/`, sourced from the **web** tree rather than `$tftpdirdst` — it has never existed in the TFTP tree, which is precisely why `_publishLocalBootFiles()` never saw it. `_resignRefind()` has already signed it by the time this runs (`installfog.sh:1266` vs `:1302`), so nothing needed reordering. Own subdirectory because rEFInd reads `refind.conf` from the directory it was loaded from. x86_64 follows `bootmenu.class.php`'s `refind.efi`-over-`refind_x64.efi` preference so the ESP and the netboot path agree on which binary is canonical.

**And the default exit type moves from `refind_efi` to `sanboot`.** `FOG_EFI_BOOT_EXIT_TYPE` was seeded `refind_efi` at schema step 192 because iPXE could not then boot the next UEFI boot entry itself — `sanboot` on EFI did nothing useful, so leaving FOG meant chainloading a whole third-party boot manager over HTTP to do it. iPXE grew UEFI sanboot support, and BootMenu's existing `sanboot` entry already drives it (`sanboot --drive 0` boots `\EFI\Boot\bootx64.efi`, with `0x80`/`0x81`/`0x82` behind it), so the third party is no longer buying anything.

It is strictly less machinery for the same job. rEFInd is a 200–260KB PE image fetched over unauthenticated HTTP on every exit from the boot menu, on every host, whether or not a task ran — and under Secure Boot it has to be signed by this server first, because upstream's copies carry Rod Smith's own certificate or none at all. So the stock exit path depended on FOG's PKI having worked. `sanboot` hands control to firmware and adds no image to verify.

BIOS already worked this way: `FOG_BOOT_EXIT_TYPE` is seeded empty and BootMenu's `if (!$exit || !in_array(...)) $exit = 'sanboot'` catches it. Only the EFI setting carried an explicit value.

**This also moves existing servers**, via new schema step 337. Step 192's `INSERT IGNORE` cannot — the row exists everywhere, so editing its seeded value only reaches a fresh database and every server in the field would keep rEFInd forever. 337 updates rows still holding exactly `refind_efi`, a value that was seeded rather than chosen. Anything else an admin selected is left alone, and `hosts.hostExitEfi` is untouched: BootMenu reads the host field **first**, so an explicit per-host choice still wins.

> [!NOTE]
> The honest cost, since it is real: an admin who deliberately selected `refind_efi` **globally** is moved to `sanboot` and has to select it again. There is no way to distinguish that from the seeded value. `refind_efi` stays in `buildExitSelector()`, rEFInd is still shipped, preserved across installs and signed, so re-picking it is one dropdown away and nothing about that path has regressed.

rEFInd handling is otherwise deliberately unchanged. `_resignRefind()` stays unconditional — the default only decides what an untouched server does, and not signing a binary the dropdown still offers turns a selection into a `SECURITY VIOLATION` two reboots later. The ESP archives still publish it, because a kit assembled by hand onto a disk that may never talk to this server again should carry every route off FOG, not just the one this server is configured for today.

## Manifest

`schema` 2: `variant` is gone, and `contents[].name` is the path relative to the archive root.

`_espKitContentsJson()` used `find -maxdepth 1` and stored basenames, which would have omitted both subdirectories **silently** — every consumer, including the harness's per-file checksum loop, walks the manifest rather than the directory, so an under-reporting manifest reads exactly like a correct one.

## The iPXE behaviour this rests on, and a discrepancy worth knowing

`efi_autoexec_filesystem()` tries `file:autoexec.ipxe` resolved against the directory of the running image's `FilePath`, then `file:/autoexec.ipxe` at the volume root. A binary loaded from an ESP reads the `autoexec.ipxe` beside it, at any depth.

Reading iPXE's source alone suggests the *chained* case behaves differently: `efi_image_exec()` builds a synthetic device handle with iPXE's own `EFI_SIMPLE_FILE_SYSTEM_PROTOCOL` on it, and `efi_local_open_volume()` resolves through `LocateDevicePath()`, which matches the longest device-path prefix and lands on that handle — a virtual filesystem serving registered images by flat name, never reaching the ESP. Observed behaviour on hardware is the sibling read for the chained case too, and the layout is built on that. Recorded in the spec so nobody "corrects" it on the strength of the source read; if a client ever does dead-end on the chained route, that handle is where to look.

## Verified

- `tests/localboot-publish.test.sh`: 62 → 87 assertions, all passing. Every one of the 50 touching new behaviour was confirmed to **fail** against the pre-fix `functions.sh` before being relied on.
- `tests/schema-gate.test.php`: `FOG_SCHEMA` 337 covers `schema.php`'s highest step (337).
- `sh tests/run-all.sh`: 64 passed. The one failure, `web-chain-feedback`, reproduces on the pristine branch — this container's openssl prints `subject=CN = fogserver` where the fixture expects `subject=CN=fogserver`.
- Archives unpacked by hand for all three arches: `local/` holds five binaries plus a script, `refind/` the right arch's binary plus `refind.conf`, i386 has no root ladder and does have `local/autoexec.ipxe`, no `10secdelay` string anywhere, and `bootdelay=15` puts a live `sleep` in `local/autoexec.ipxe` and nowhere else.

**Still owed, and not fakeable:** boot a real ESP by both routes — shim → upstream loader → chain, and boot manager → `local\fogipxe.efi` directly — and confirm `Checking net0 for DHCP...` rather than iPXE's bare autoboot. Plus one UEFI host exiting the boot menu on `sanboot` to a locally installed OS.

## Noted, not fixed

- `bootmenu.class.php:252-253` only swaps to `refind_ia32.efi` when `$refindfile` is still `refind_x64.efi`, so an i386 **netboot** client on a server that has `refind.efi` is handed the x64 build. Now less reachable than it was, since `refind_efi` is no longer the default. Out of scope here; the archives use `refind_ia32.efi` for i386 regardless.
- `fog-docs` has no page for the ESP archives, and its pages describing the exit types will need the `sanboot` default too. Worth its own branch (it carries a French mirror), so not expanded into here.