### PR TITLE
Stop the error handlers going fatal on a non-string event name

### DIFF
--- a/docs/refactor-facts.md
+++ b/docs/refactor-facts.md
@@ -474,6 +474,21 @@ Closure alongside the existing `[object, 'method']` arrays a non-event.
 grep -rn 'HookManager->data\|EventManager->data' packages /home/telliott/fog-plugins   # nothing
 ```
 
+### F-27 — Both catches render `$event` with `%s`, and a non-string `$event` is one of the things they exist to report
+`register()` and `notify()` each throw `_('Event must be a string')` and then
+interpolate that same `$event` into the log line. `%s` on an object with no
+`__toString` is an `\Error`, which `catch (\Exception)` does not catch, so
+the handler goes fatal on exactly the input it was written for. This is the
+`_describeListener()` defect (F-13) one argument along; fixing the listener
+half left this half live on both branches. An array name only warns -- an
+object is the fatal case.
+```
+php -r 'try { echo sprintf("%s", new stdClass); }
+  catch (\Exception $e) { echo "caught\n"; }
+  catch (\Error $e) { echo "ESCAPED: ".$e->getMessage()."\n"; }'
+# ESCAPED: Object of class stdClass could not be converted to string
+```
+
 ---
 
 ## How to add an entry

--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -110,7 +110,7 @@ class EventManager extends FOGBase
                 _('Error'),
                 $e->getMessage(),
                 _('Event'),
-                $event,
+                self::_describeEvent($event),
                 _('Class'),
                 self::_describeListener($listener)
             );
@@ -190,6 +190,23 @@ class EventManager extends FOGBase
         if ($listener instanceof Hook) {
             throw new \Exception(_('A hook is not an event listener'));
         }
+    }
+    /**
+     * Renders an event name for a log line.
+     *
+     * The other half of the _describeListener() defect below, missed when
+     * that one was fixed. One of the conditions that reaches either catch is
+     * "$event is not a string", and %s on an object with no __toString is an
+     * \Error, which catch (\Exception) does not catch -- so reporting the
+     * bad event name was itself fatal.
+     *
+     * @param mixed $event The event as the caller supplied it.
+     *
+     * @return string
+     */
+    private static function _describeEvent($event)
+    {
+        return is_string($event) ? $event : gettype($event);
     }
     /**
      * Names a listener for a log line, whatever shape it arrived in.
@@ -286,7 +303,7 @@ class EventManager extends FOGBase
                 _('Error'),
                 $e->getMessage(),
                 _('Event'),
-                $event
+                self::_describeEvent($event)
             );
             self::log(
                 $string,

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -209,6 +209,22 @@ if (false === strpos($msg, 'string')) {
     $fails[] = 'a listener of an unusable type is logged without being named';
 }
 
+// The same defect one argument along, missed when the listener half was
+// fixed. register() throws when $event is not a string, and the catch then
+// rendered $event with %s -- and %s on an object with no __toString is an
+// \Error, which catch (\Exception) does not catch. So the handler that
+// exists to report a bad event name was itself fatal for the one input that
+// produces a bad event name.
+$objEvent = new \stdClass();
+if ('' !== $escapes($hm, $objEvent, [$hook, 'fire'])) {
+    $fails[] = 'register() goes fatal reporting a non-string event name';
+}
+$msg = $logged($hm, $objEvent, [$hook, 'fire']);
+if (false === strpos($msg, 'object')) {
+    $fails[] = 'the register failure message does not say what the event name'
+        . ' was, which is the only field identifying the bad call';
+}
+
 // F-12 in the plan: register() used to switch on self::shortName($this), with
 // a case per subclass and a default arm that threw -- caught, logged, and
 // returning normally, so a subclass of either manager registered nothing and
@@ -342,6 +358,26 @@ $badName = ob_get_clean();
 $em2->logLevel = 0;
 if (false !== strpos($badName, '$s:')) {
     $fails[] = 'the notify failure message still carries the literal $s typo';
+}
+
+// An array name renders as "Array" and only warns; an object with no
+// __toString is the fatal half. Same \Error, same uncaught 500.
+$em2->logLevel = 9;
+ob_start();
+$objThrew = '';
+try {
+    $em2->notify(new \stdClass(), []);
+} catch (\Throwable $t) {
+    $objThrew = get_class($t);
+}
+$objLog = ob_get_clean();
+$em2->logLevel = 0;
+if ('' !== $objThrew) {
+    $fails[] = 'notify() goes fatal reporting a non-string event name: '
+        . $objThrew;
+}
+if (false === strpos($objLog, 'object')) {
+    $fails[] = 'the notify failure message does not say what the event name was';
 }
 
 // The cases above seed the name cache, so they say nothing about whether


### PR DESCRIPTION
Follow-up to #1194, which fixed one half of this and left the other half live.

## The defect

`EventManager::register()` and `EventManager::notify()` both start by rejecting a `$event` that is not a string:

```php
if (!is_string($event)) {
    throw new Exception(_('Event must be a string'));
}
```

and both catches then render that same `$event` with `%s`:

```php
} catch (\Exception $e) {
    $string = sprintf(
        '%s: %s: %s, %s: %s, %s: %s',
        _('Could not register'), _('Error'), $e->getMessage(),
        _('Event'), $event,                       // <- here
        _('Class'), self::_describeListener($listener)
    );
```

`%s` on an object with no `__toString` is an `\Error`, and `catch (\Exception)` does not catch an `\Error`:

```
$ php -r 'try { echo sprintf("%s", new stdClass); }
  catch (\Exception $e) { echo "caught\n"; }
  catch (\Error $e) { echo "ESCAPED: ".$e->getMessage()."\n"; }'
ESCAPED: Object of class stdClass could not be converted to string
```

So the handler goes fatal on precisely the input the guard exists to reject. `register()` runs from hook constructors during `LoadGlobals`, so it escapes to the top: HTTP 500 with a zero-byte body, on every entry point, until the offending file is removed from disk.

This is exactly the shape #1194 fixed for the *listener* argument (F-13) — the same handler, one argument along. Fixing the listener half left this half untouched on both branches.

An **array** event name renders as `"Array"` with a warning and is survivable; an **object** is the fatal case. The existing contract test covered the array only, which is why this got through.

## The fix

`_describeEvent()` renders the event name the way `_describeListener()` already renders a listener — `is_string($event) ? $event : gettype($event)` — so the log line still identifies the bad call without the handler being able to fail harder than the error it is reporting.

## Verification

Two cases added to `tests/hook-event-contract.test.php`, one per catch. Mutation-verified — reverting either call site to the raw `$event` fails the suite:

```
--- register catch reverted:
FAIL: 2 problem(s):
  - register() goes fatal reporting a non-string event name
  - the register failure message does not say what the event name was...
--- notify catch reverted:
FAIL: 2 problem(s):
  - notify() goes fatal reporting a non-string event name: Error
  - the notify failure message does not say what the event name was
```

Full suite: `66 passed, 0 failed`.

Recorded as F-27 in `docs/refactor-facts.md`.

## Blast radius

None for plugin authors. Nothing changes about which listeners register or run, or what they receive — only the text of a diagnostic, and whether producing it can take the request down. No route change, so no OpenAPI change.

The same defect is present on `dev-branch` and is fixed there in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
