### PR TITLE
Fix four hook/event defects that cannot change which listener runs

### DIFF
--- a/packages/web/lib/fog/eventmanager.class.php
+++ b/packages/web/lib/fog/eventmanager.class.php
@@ -42,6 +42,19 @@ class EventManager extends FOGBase
      */
     public $events;
     /**
+     * Names already present in notifyEvents, as a lookup set.
+     *
+     * notify() used to ask the database whether the event name was already
+     * recorded on EVERY call, and notify() is called from the snapin client
+     * protocol and from taskqueue, so that was a round trip per snapin per
+     * check-in. This is the same mistake HookManager::processEvent() had and
+     * the same fix; see HookManager::$knownEvents for why remembering the
+     * answer for the life of the process is safe.
+     *
+     * @var array|null
+     */
+    private static $knownNotifyEvents = null;
+    /**
      * Registers events and listeners within the system.
      *
      * @param string       $event    the event name to register
@@ -103,9 +116,9 @@ class EventManager extends FOGBase
                 _('Error'),
                 $e->getMessage(),
                 _('Event'),
-                $event,
+                self::_describeEvent($event),
                 _('Class'),
-                self::describeListener($listener)
+                self::_describeListener($listener)
             );
             self::log(
                 $string,
@@ -134,7 +147,7 @@ class EventManager extends FOGBase
      *
      * @return string
      */
-    private static function describeListener($listener)
+    private static function _describeListener($listener)
     {
         if (is_array($listener)) {
             $first = reset($listener);
@@ -144,6 +157,54 @@ class EventManager extends FOGBase
             return get_class($listener);
         }
         return gettype($listener);
+    }
+    /**
+     * Renders an event name for a log line.
+     *
+     * One of the conditions that reaches the catch below is "$event is not a
+     * string", and %s on an object with no __toString is an Error, which
+     * catch (Exception) does not catch. Same defect as _describeListener()
+     * covers for the listener: an error handler must not be able to fail
+     * harder than the error it is reporting.
+     *
+     * @param mixed $event The event as the caller supplied it.
+     *
+     * @return string
+     */
+    private static function _describeEvent($event)
+    {
+        return is_string($event) ? $event : gettype($event);
+    }
+    /**
+     * Records an event name in notifyEvents if it is not already there.
+     *
+     * The table is a discovery aid -- it is what the notify event list is
+     * built from -- so it is written opportunistically rather than being
+     * authoritative. Marked known before the save, not after, so an event
+     * fired from inside save() could not recurse into saving the same name.
+     *
+     * @param string $event the event name to record
+     *
+     * @return void
+     */
+    private static function _recordEventName($event)
+    {
+        if (self::$knownNotifyEvents === null) {
+            self::$knownNotifyEvents = array_flip(
+                (array) self::getSubObjectIDs(
+                    'NotifyEvent',
+                    array(),
+                    'name'
+                )
+            );
+        }
+        if (isset(self::$knownNotifyEvents[$event])) {
+            return;
+        }
+        self::$knownNotifyEvents[$event] = true;
+        self::getClass('NotifyEvent')
+            ->set('name', $event)
+            ->save();
     }
     /**
      * Notifies the system of events.
@@ -157,16 +218,6 @@ class EventManager extends FOGBase
      */
     public function notify($event, $eventData = array())
     {
-        $exists = self::getClass('NotifyEventManager')->exists(
-            $event,
-            '',
-            'name'
-        );
-        if (!$exists) {
-            self::getClass('NotifyEvent')
-                ->set('name', $event)
-                ->save();
-        }
         try {
             if (!is_string($event)) {
                 throw new Exception(_('Event must be a string'));
@@ -174,6 +225,13 @@ class EventManager extends FOGBase
             if (!is_array($eventData)) {
                 throw new Exception(_('Event Data must be an array'));
             }
+            // Recorded here rather than above the try, which is where it used
+            // to sit. Running before the guard meant a caller that passed an
+            // array or an object still got that value handed to
+            // NotifyEvent::set('name') and saved, so the discovery table
+            // collected rows for things that were never event names -- and
+            // the guard then rejected the same value one line later.
+            self::_recordEventName($event);
             if (!isset($this->data[$event])) {
                 throw new Exception(_('Event and data are not set'));
             }
@@ -189,12 +247,12 @@ class EventManager extends FOGBase
             }
         } catch (Exception $e) {
             $string = sprintf(
-                '%s: %s: %s, $s: %s',
+                '%s: %s: %s, %s: %s',
                 _('Could not notify'),
                 _('Error'),
                 $e->getMessage(),
                 _('Event'),
-                $event
+                self::_describeEvent($event)
             );
             self::log(
                 $string,
@@ -216,34 +274,33 @@ class EventManager extends FOGBase
      */
     public function load()
     {
-        // Sets up regex and paths to scan for
-        if ($this instanceof self) {
-            $regext = sprintf(
-                '#^.+%sevents%s.*\.event\.php$#',
-                DS,
-                DS
-            );
-            ;
-            $dirpath = sprintf(
-                '%sevents%s',
-                DS,
-                DS
-            );
-            $strlen = -strlen('.event.php');
-        }
+        // Sets up regex and paths to scan for.
+        //
+        // HookManager extends EventManager, so a HookManager satisfies
+        // `instanceof self` too. This used to be two sequential ifs and the
+        // hook branch was reached only because it ran second and overwrote
+        // what the event branch had just assigned -- reordering the two
+        // blocks silently made every hook load as an event and find nothing.
+        // One decision, taken most-specific first, cannot be reordered wrong.
         if ($this instanceof HookManager) {
-            $regext = sprintf(
-                '#^.+%shooks%s.*\.hook\.php$#',
-                DS,
-                DS
-            );
-            $dirpath = sprintf(
-                '%shooks%s',
-                DS,
-                DS
-            );
-            $strlen = -strlen('.hook.php');
+            $type = 'hook';
+        } else {
+            $type = 'event';
         }
+        $regext = sprintf(
+            '#^.+%s%ss%s.*\.%s\.php$#',
+            DS,
+            $type,
+            DS,
+            $type
+        );
+        $dirpath = sprintf(
+            '%s%ss%s',
+            DS,
+            $type,
+            DS
+        );
+        $strlen = -strlen(sprintf('.%s.php', $type));
         // Initiates plugins used in fileitems function
         $plugins = '';
         // Function simply returns the files based on the regex and data passed.
@@ -316,11 +373,10 @@ class EventManager extends FOGBase
                     $strlen
                 )
             );
-            $decClasses = get_declared_classes();
-            foreach ((array)$decClasses as $key => &$classExist) {
-                $exists[$classExist] = 1;
-                unset($classExist);
-            }
+            // There used to be a loop building a lookup of every declared
+            // class into $exists here, immediately before $exists was
+            // overwritten by the class_exists() call below. It ran once per
+            // hook or event file and its result was never read.
             $exists = class_exists(
                 $className,
                 false
@@ -335,7 +391,7 @@ class EventManager extends FOGBase
                     $className
                 )
             );
-            unset($element, $key);
+            unset($element);
         };
         // Plugins should be established first so menus and what not are setup.
         array_map(

--- a/tests/register-failure-not-fatal.test.php
+++ b/tests/register-failure-not-fatal.test.php
@@ -158,6 +158,80 @@ if (false === strpos($msg, 'Closure')) {
     $fails[] = 'a closure listener is logged without being named';
 }
 
+// The same defect one argument along. Both register() and notify() throw when
+// $event is not a string, and both catches then rendered that same $event with
+// %s -- and %s on an object with no __toString is an Error, which
+// catch (Exception) does not catch. So the handler went fatal on exactly the
+// input the guard exists to reject. An array name only warns; an object is the
+// fatal case, which is why the array-name test above never caught it.
+$objEvent = new stdClass();
+if ('' !== $escapes($hm, $objEvent, array($hook, 'fire'))) {
+    $fails[] = 'register() goes fatal reporting a non-string event name';
+}
+$msg = $logged($hm, $objEvent, array($hook, 'fire'));
+if (false === strpos($msg, 'object')) {
+    $fails[] = 'the register failure message does not say what the event name'
+        . ' was, which is the only field identifying the bad call';
+}
+
+// notify() has the same catch, and reaching it also proves the event name is
+// no longer recorded before the guard: _recordEventName() would query and then
+// save the object as a name, and there is no database here to answer.
+$em->logLevel = 9;
+ob_start();
+$objThrew = '';
+try {
+    $em->notify($objEvent, array());
+} catch (Exception $e) {
+    $objThrew = get_class($e);
+} catch (Throwable $t) {
+    $objThrew = get_class($t);
+}
+$objLog = ob_get_clean();
+$em->logLevel = 0;
+if ('' !== $objThrew) {
+    $fails[] = 'notify() goes fatal reporting a non-string event name: '
+        . $objThrew;
+}
+if (false !== strpos($objLog, '$s:')) {
+    $fails[] = 'the notify failure message still carries the literal $s typo';
+}
+if (false === strpos($objLog, 'object')) {
+    $fails[] = 'the notify failure message does not say what the event name was';
+}
+
+// A name already known is not re-saved, which is what makes notify() reachable
+// without a database at all. It used to ask notifyEvents on every call, above
+// the try and before any guard.
+$knownNotify = new ReflectionProperty('EventManager', 'knownNotifyEvents');
+$knownNotify->setAccessible(true);
+$knownNotify->setValue(null, array('REGFAIL_NOTIFY' => true));
+$notifyThrew = '';
+try {
+    $em->notify('REGFAIL_NOTIFY', array());
+} catch (Exception $e) {
+    $notifyThrew = get_class($e) . ': ' . $e->getMessage();
+} catch (Throwable $t) {
+    $notifyThrew = get_class($t) . ': ' . $t->getMessage();
+}
+if ('' !== $notifyThrew) {
+    $fails[] = 'notify() still reaches the database for a name it has already'
+        . ' seen: ' . $notifyThrew;
+}
+
+// load() picks its file extension and directory from one decision, not from
+// two overlapping ifs where the second had to overwrite the first. A
+// HookManager satisfies `instanceof self` as well, so reordering those two
+// blocks silently made every hook load as an event and find nothing.
+$src = file_get_contents($web . '/lib/fog/eventmanager.class.php');
+if (false !== strpos($src, 'if ($this instanceof self) {')) {
+    $fails[] = 'load() decides between events and hooks by statement order again';
+}
+if (false !== strpos($src, 'get_declared_classes()')) {
+    $fails[] = 'load() builds a lookup of every declared class again, once per'
+        . ' hook or event file, and then overwrites it unread';
+}
+
 if (count($fails) > 0) {
     fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
     foreach ($fails as $f) {
@@ -166,5 +240,5 @@ if (count($fails) > 0) {
     exit(1);
 }
 
-echo "ok: an unusable listener is logged and named, never thrown\n";
+echo "ok: an unusable listener or event name is logged, never thrown\n";
 exit(0);


### PR DESCRIPTION
Follow-up to #1196, which was the fatal-catch fix alone.

**Scoped deliberately.** Every change here is wrong today, and none of them changes which listeners register, which ones fire, or what they receive. The activation regex, the path-substring force-activation and the acceptance of a `Hook` where an event listener is expected are all still here and still untouched — those decide *which* listeners run, and on a released line with a plugin population that is neither small nor enumerable that is a separate decision, not this PR.

## 1. Both error handlers went fatal on a non-string event name

#1196 fixed the listener half: the catch interpolated `$listener[0]`, so an object that was not an array raised an `Error`, which `catch (Exception)` does not catch, and registration runs in a hook constructor during `LoadGlobals` — HTTP 500 with an empty body on every entry point.

The event half was left live. `register()` and `notify()` both start with:

```php
if (!is_string($event)) {
    throw new Exception(_('Event must be a string'));
}
```

and both catches then render that same `$event` with `%s`:

```
$ php -r 'try { echo sprintf("%s", new stdClass); }
  catch (Exception $e) { echo "caught\n"; }
  catch (Error $e) { echo "ESCAPED: ".$e->getMessage()."\n"; }'
ESCAPED: Object of class stdClass could not be converted to string
```

Same uncaught `Error`, same handler, for the one input the guard exists to reject. An **array** name renders as `"Array"` with a warning and survives; an **object** is the fatal case — which is why the array-name test in #1196 did not catch it.

## 2. `notify()` recorded the event name before validating it

The `NotifyEventManager` lookup and the `NotifyEvent` save sat *above* the `try`:

```php
$exists = self::getClass('NotifyEventManager')->exists($event, '', 'name');
if (!$exists) {
    self::getClass('NotifyEvent')->set('name', $event)->save();
}
try {
    if (!is_string($event)) {
        throw new Exception(_('Event must be a string'));
    }
```

So a caller passing an array or an object had that value written into the discovery table, and then rejected by the guard one line later. It was also a database round trip on **every** call — `notify()` is reached from the snapin client protocol (`snapinclient.class.php`, four call sites), from `taskqueue`, and from `user.class.php` on every failed login. That is the same mistake `processEvent()` had; this is the same fix and the same cache rationale, and the docblock points at `HookManager::$knownEvents` for it.

## 3. `load()` chose its paths with two sequential `if`s

```php
if ($this instanceof self)        { /* event regex, dir, offset */ }
if ($this instanceof HookManager) { /* hook  regex, dir, offset */ }
```

`HookManager extends EventManager`, so a HookManager satisfies **both**. The hook branch was reached only because it ran second and overwrote what the event branch had just assigned — swap the two blocks and every hook silently loads as an event and finds nothing. Now one decision, most-specific first.

The generalized `sprintf`s produce byte-identical output to the strings they replace:

```
event  regex=#^.+/events/.*\.event\.php$#  dir=/events/  strlen=-10
hook   regex=#^.+/hooks/.*\.hook\.php$#    dir=/hooks/   strlen=-9
orig   regex=#^.+/events/.*\.event\.php$#  dir=/events/  strlen=-10
orig   regex=#^.+/hooks/.*\.hook\.php$#    dir=/hooks/   strlen=-9
```

## 4. `load()` built a lookup of every declared class and threw it away

```php
$decClasses = get_declared_classes();
foreach ((array)$decClasses as $key => &$classExist) {
    $exists[$classExist] = 1;
    unset($classExist);
}
$exists = class_exists($className, false);   // <- overwrites it, unread
```

Once per hook or event file. Removed.

Also fixes the malformed `notify()` format string, which carried a literal `$s` where a specifier was meant and so dropped the failing event's name from the one diagnostic it produces.

## Verification

All four gated in `tests/register-failure-not-fatal.test.php` and mutation-verified — reverting any one fails the suite:

```
--- M1 register catch reverted:   register() goes fatal reporting a non-string event name
--- M2 notify catch reverted:     notify() goes fatal reporting a non-string event name: Error
--- M3 record moved back above the guard:
                                  notify() still reaches the database for a name it has already seen
--- M4 load() ordering restored:  load() decides between events and hooks by statement order again
--- M5 dead loop restored:        load() builds a lookup of every declared class again
```

Full suite: `11 passed, 0 failed`.

## Blast radius

None for plugin authors. No listener shape is newly accepted or newly refused, no listener's activation changes, and no payload changes. The only externally visible differences are that a diagnostic can no longer take the request down with it, and that the `notifyEvents` table stops collecting rows for values that were never event names. No route change, so no OpenAPI change.

The companion `working-1.6` PR for defect 1 is #1200; defects 2–4 were already fixed there by #1194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
