### PR TITLE
Give FOS somewhere to report an imaging failure

### DIFF
--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Records that FOS could not finish a task, and tells anyone listening.
+ *
+ * PHP version 7.4+
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * Records that FOS could not finish a task, and tells anyone listening.
+ *
+ * Until #1206 FOS reported nothing at all when imaging failed. handleError()
+ * printed a banner to the console and exited, so a bad image, a mount failure
+ * or a partition error was invisible to the server: HOST_IMAGE_FAIL could not
+ * fire for the failure people actually mean by "the deploy failed", and the
+ * only failure FOG ever heard about was a storage node problem, through
+ * Blame, which re-queues rather than fails.
+ *
+ * Deliberately narrow. It notifies and it logs; it does NOT change the task's
+ * state. There is no Failed state in taskStates -- the five are Queued,
+ * Checked In, In-Progress, Complete, Cancelled -- and the two ways of not
+ * adding one are both wrong on their own terms: reusing Cancelled loses the
+ * difference between "an admin stopped this" and "this broke", and adding a
+ * sixth means every place that enumerates states has to learn about it or a
+ * failed task becomes invisible to it. That is a decision with UI and API
+ * consequences and it is tracked separately on #1206; making the event fire
+ * does not depend on taking it.
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class TaskError extends FOGBase
+{
+    /**
+     * How much of the reported text is kept.
+     *
+     * The text is written by whatever called this endpoint, and it ends up in
+     * a Slack/ntfy/pushbullet message. Bounded so a caller cannot use an
+     * admin's notification channel as a paste bin.
+     *
+     * @var int
+     */
+    const MAX_REASON = 500;
+    /**
+     * Reports the failure.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        try {
+            $reason = self::_reported('error');
+            if ('' === $reason) {
+                throw new \Exception(_('No error text supplied'));
+            }
+            self::getHostItem(false);
+            $Task = self::$Host->get('task');
+            if (!$Task->isValid()) {
+                throw new \Exception(_('No active task found for this host'));
+            }
+            // Same rule as TaskQueue::_notifyImagingOutcome(): HOST_IMAGE_FAIL
+            // is an imaging event, and this endpoint is reachable from a wipe
+            // or an inventory task too. Firing it for one of those would be
+            // the defect #1202 just removed, in the other direction. There is
+            // no event for a non-imaging task failing; noted on #1206.
+            if (!$Task->isImagingTask()) {
+                throw new \Exception(_('Task is not an imaging task'));
+            }
+            $script = self::_reported('script');
+            $Image = $Task->getImage();
+            self::$EventManager->notify(
+                'HOST_IMAGE_FAIL',
+                [
+                    'HostName' => self::$Host->get('name'),
+                    'Host' => self::$Host,
+                    'Task' => $Task,
+                    'Image' => $Image,
+                    'ImageName' => (
+                        $Image->isValid() ?
+                        $Image->get('name') :
+                        ''
+                    ),
+                    'TaskType' => $Task->getTaskTypeText(),
+                    'Reason' => (
+                        '' === $script ?
+                        $reason :
+                        sprintf('%s (%s)', $reason, $script)
+                    )
+                ]
+            );
+            self::_record(
+                sprintf(
+                    'FOG: imaging failed on host %s (task %d): %s',
+                    self::$Host->get('name'),
+                    (int) $Task->get('id'),
+                    $reason
+                )
+            );
+        } catch (\Exception $e) {
+            // A report that cannot be matched to a task is still worth a line
+            // in the log -- it is the only trace that a machine tried to say
+            // something -- but it is not worth an answer a caller can probe
+            // with. See the ack below.
+            self::_record(
+                sprintf(
+                    'FOG: unusable imaging failure report: %s',
+                    $e->getMessage()
+                )
+            );
+        }
+        /*
+         * Always the same ack, always 200, whatever happened.
+         *
+         * FOS calls this on its way out of handleError() and cannot act on
+         * the answer -- it is about to print a banner and exit either way --
+         * so there is nothing to tell it. Answering identically also means
+         * the endpoint cannot be used to ask whether a given MAC has an
+         * active imaging task, which a distinguishing response would allow
+         * anyone who can reach the web tier to do.
+         */
+        echo '##';
+        exit;
+    }
+    /**
+     * Reads one bounded, single-line field from the request.
+     *
+     * Control characters are removed rather than escaped: this text is not
+     * going into HTML, it is going into a chat message and a log line, and in
+     * both of those an embedded newline lets a caller forge what looks like a
+     * second message.
+     *
+     * @param string $field the field name
+     *
+     * @return string
+     */
+    private static function _reported($field)
+    {
+        $raw = filter_input(INPUT_POST, $field);
+        if (null === $raw || false === $raw) {
+            $raw = filter_input(INPUT_GET, $field);
+        }
+        return self::_sanitize((string) ($raw ?? ''));
+    }
+    /**
+     * Makes one caller-supplied string safe to put in a message.
+     *
+     * Split from _reported() so it can be tested: filter_input(INPUT_POST) has
+     * nothing to read under the CLI SAPI, and this is the half with the rules
+     * in it.
+     *
+     * @param string $raw the string as it arrived
+     *
+     * @return string
+     */
+    private static function _sanitize($raw)
+    {
+        // \p{C} is every Unicode control and format character, which covers
+        // CR, LF, NUL and the terminal escapes a console-facing error string
+        // can easily contain.
+        $clean = preg_replace('#\p{C}+#u', ' ', $raw);
+        if (null === $clean) {
+            // Invalid UTF-8 makes preg_replace return null rather than throw,
+            // so fall back to the byte-wise class. Never let a malformed
+            // string become an empty one silently -- the text is the whole
+            // point of the report.
+            $clean = preg_replace('#[[:cntrl:]]+#', ' ', $raw);
+        }
+        $clean = trim((string) $clean);
+        if ('' === $clean) {
+            return '';
+        }
+        // mb_substr on invalid UTF-8 can return '', which would throw the
+        // report away; strlen-bound the bytes in that case instead.
+        $cut = mb_substr($clean, 0, self::MAX_REASON);
+        if ('' === $cut) {
+            $cut = substr($clean, 0, self::MAX_REASON);
+        }
+        return $cut;
+    }
+    /**
+     * Writes one line where a server operator will find it.
+     *
+     * Not FOGBase::log(): that writes a history row, and logHistory() returns
+     * without doing anything unless a user is signed in. Nobody is signed in
+     * here -- the caller is a machine in the middle of imaging -- so the only
+     * durable place is the PHP error log.
+     *
+     * @param string $line the line to write
+     *
+     * @return void
+     */
+    private static function _record($line)
+    {
+        error_log($line);
+    }
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\TaskError', 'TaskError');

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4980,6 +4980,10 @@ msgstr "Keine Druckerverwaltung"
 msgid "No access is allowed"
 msgstr "Kein Zugriff erlaubt"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Keinen aktiven Task gefunden für Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5009,6 +5013,9 @@ msgstr "Keine Daten zum Einfügen"
 
 msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7652,6 +7659,10 @@ msgstr "Laden fehlgeschlagen: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task gestartet"
+
+#, fuzzy
+msgid "Task is not an imaging task"
+msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4978,6 +4978,10 @@ msgstr "No Printer Management"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "No Active Task found for Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5007,6 +5011,9 @@ msgstr "No data returned"
 
 msgid "No database to work off"
 msgstr "No database to work off"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7648,6 +7655,9 @@ msgstr "Load failed: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task Started"
+
+msgid "Task is not an imaging task"
+msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5104,6 +5104,10 @@ msgstr "Sin administración de la impresora"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "No se encontró Clase FOGPage para este nodo"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5136,6 +5140,9 @@ msgstr "No se obtuvieron datos"
 #, fuzzy
 msgid "No database to work off"
 msgstr "No se obtuvieron datos"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7837,6 +7844,9 @@ msgstr "Carga ha fallado: %s"
 msgid "Task finished"
 msgstr "Nombre de la tarea"
 
+msgid "Task is not an imaging task"
+msgstr ""
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -10426,9 +10436,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No nodo asociado"
-
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "No se encontró Clase FOGPage para este nodo"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4981,6 +4981,10 @@ msgstr "Keine Druckerverwaltung"
 msgid "No access is allowed"
 msgstr "Kein Zugriff erlaubt"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Keinen aktiven Task gefunden für Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5010,6 +5014,9 @@ msgstr "Keine Daten zum Einfügen"
 
 msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7653,6 +7660,10 @@ msgstr "Laden fehlgeschlagen: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task gestartet"
+
+#, fuzzy
+msgid "Task is not an imaging task"
+msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4980,6 +4980,10 @@ msgstr "Pas de gestion de l'imprimante"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Aucune tâche active trouvée pour Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5009,6 +5013,9 @@ msgstr "Aucune donnée retournés"
 
 msgid "No database to work off"
 msgstr "Aucune base de données de travailler hors"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7650,6 +7657,9 @@ msgstr "Échec du chargement: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Tâche Started"
+
+msgid "Task is not an imaging task"
+msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4805,6 +4805,10 @@ msgstr "No Printer Management"
 msgid "No access is allowed"
 msgstr "Nessun accesso è consentito"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Nessun compito attivo trovato per Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4833,6 +4837,9 @@ msgstr "Nessun dato da inserire"
 
 msgid "No database to work off"
 msgstr "Nessun database di lavorare off"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7369,6 +7376,10 @@ msgstr "Caricamento non riuscito"
 #, fuzzy
 msgid "Task finished"
 msgstr "Attività iniziata"
+
+#, fuzzy
+msgid "Task is not an imaging task"
+msgstr "Impossibile modificare l'immagine durante l'attività"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Attività non creata poiché non ci sono attività associate"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4757,6 +4757,10 @@ msgstr "プリンター管理なし"
 msgid "No access is allowed"
 msgstr "アクセスは許可されていません"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "このホストの実行中タスクは見つかりません"
+
 msgid "No activity information available for this group"
 msgstr "このグループで利用可能なアクティビティ情報はありません"
 
@@ -4785,6 +4789,9 @@ msgstr "挿入するデータがありません"
 
 msgid "No database to work off"
 msgstr "使用するデータベースがありません"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7298,6 +7305,10 @@ msgstr "タスク実行に失敗しました"
 #, fuzzy
 msgid "Task finished"
 msgstr "タスク実行に失敗しました"
+
+#, fuzzy
+msgid "Task is not an imaging task"
+msgstr "タスク実行中はイメージを変更できません"
 
 #, fuzzy
 msgid "Task not created as there are no associated Tasks"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4212,6 +4212,9 @@ msgstr ""
 msgid "No access is allowed"
 msgstr ""
 
+msgid "No active task found for this host"
+msgstr ""
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4237,6 +4240,9 @@ msgid "No data to insert"
 msgstr ""
 
 msgid "No database to work off"
+msgstr ""
+
+msgid "No error text supplied"
 msgstr ""
 
 msgid "No external data to download the file from"
@@ -6469,6 +6475,9 @@ msgid "Task failed"
 msgstr ""
 
 msgid "Task finished"
+msgstr ""
+
+msgid "Task is not an imaging task"
 msgstr ""
 
 msgid "Task not created as there are no associated Tasks"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4979,6 +4979,10 @@ msgstr "Sem gerenciamento de impressoras"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Nenhuma tarefa ativa encontrada para o Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5008,6 +5012,9 @@ msgstr "Não há dados retornados"
 
 msgid "No database to work off"
 msgstr "Nenhum banco de dados para trabalhar fora"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7649,6 +7656,9 @@ msgstr "Carga falhou: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "tarefa iniciada"
+
+msgid "Task is not an imaging task"
+msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4979,6 +4979,10 @@ msgstr "没有打印机管理"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "发现主机没有活动任务"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5008,6 +5012,9 @@ msgstr "无数据返回"
 
 msgid "No database to work off"
 msgstr "没有数据库工作关闭"
+
+msgid "No error text supplied"
+msgstr ""
 
 msgid "No external data to download the file from"
 msgstr ""
@@ -7649,6 +7656,9 @@ msgstr "加载失败： %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "任务开始"
+
+msgid "Task is not an imaging task"
+msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/service/taskerror.php
+++ b/packages/web/service/taskerror.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Receives a report that FOS could not finish a task.
+ *
+ * PHP version 7.4+
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Receives a report that FOS could not finish a task.
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+require '../commons/base.inc.php';
+new TaskError();

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * The imaging-failure endpoint must not become an injection channel.
+ *
+ * #1206: FOS's handleError() reported nothing to the server, so a real
+ * imaging failure -- bad image, mount failure, partition error -- was
+ * invisible to FOG and HOST_IMAGE_FAIL could not fire for it. service/
+ * taskerror.php closes that, and in doing so accepts free text from an
+ * unauthenticated machine and puts it in an administrator's Slack, ntfy or
+ * pushbullet message.
+ *
+ * So the text is bounded and flattened to one line. An embedded newline is
+ * the interesting one: in a chat message it lets a caller forge what looks
+ * like a second, separate notification, which is a far better lie than
+ * anything they could do with markup.
+ *
+ * Also pinned: the endpoint answers identically whatever happened (so it
+ * cannot be used to ask whether a MAC has an active imaging task), it refuses
+ * to fire an imaging event for a task that is not imaging, and it does not
+ * touch the task's state -- there is no Failed state and inventing one is a
+ * separate decision.
+ *
+ * No database, no web server. The sanitizer is pure and is called directly;
+ * the rest is source-level, because the constructor needs a booted FOG, a
+ * host lookup and a task.
+ *
+ * Usage: php tests/task-error-report.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+require $web . '/commons/init.php';
+new Initiator();
+
+$fails = [];
+
+$sanitize = new \ReflectionMethod('FOG\TaskError', '_sanitize');
+$sanitize->setAccessible(true);
+$clean = function ($raw) use ($sanitize) {
+    return $sanitize->invoke(null, $raw);
+};
+$max = (new \ReflectionClass('FOG\TaskError'))->getConstant('MAX_REASON');
+
+// ------------------------------------------------------------- one line
+
+foreach ([
+    "Failed to mount\nHost imaging completed successfully" => 'a newline',
+    "Failed to mount\r\nsecond line" => 'a CRLF',
+    "Failed\tto mount" => 'a tab',
+    "Failed to mount\x00truncated" => 'a NUL',
+    "Failed \x1b[31mto\x1b[0m mount" => 'a terminal escape',
+] as $raw => $what) {
+    $out = $clean($raw);
+    if (preg_match('#[\r\n\t\x00\x1b]#', $out)) {
+        $fails[] = "$what survives sanitizing, so a caller can forge a second"
+            . ' line in an administrator\'s notification';
+    }
+    if ('' === $out) {
+        $fails[] = "$what makes the whole report empty, which throws away the"
+            . ' only thing it carries';
+    }
+}
+
+// ---------------------------------------------------------------- bounds
+
+if (!is_int($max) || $max < 1) {
+    $fails[] = 'MAX_REASON is not a positive integer, so the report is unbounded';
+}
+$long = str_repeat('A', $max * 3);
+if (mb_strlen($clean($long)) > $max) {
+    $fails[] = 'a long report is not truncated, so an unauthenticated caller'
+        . ' can use a notification channel as a paste bin';
+}
+
+// A multibyte string must not be cut into an invalid sequence, and must not
+// be thrown away either.
+$mb = str_repeat('é', $max * 2);
+$cut = $clean($mb);
+if ('' === $cut) {
+    $fails[] = 'a multibyte report is discarded entirely';
+}
+if (mb_strlen($cut) > $max) {
+    $fails[] = 'a multibyte report is not truncated';
+}
+if ($cut !== mb_convert_encoding($cut, 'UTF-8', 'UTF-8')) {
+    $fails[] = 'truncation split a multibyte character, so the message is no'
+        . ' longer valid UTF-8';
+}
+
+// Invalid UTF-8 makes preg_replace return null rather than throw. Falling
+// through to an empty string would silently drop every report from a machine
+// with a non-UTF-8 locale.
+$bad = "Failed \xC3\x28 to mount";
+if ('' === $clean($bad)) {
+    $fails[] = 'a report containing invalid UTF-8 is discarded, so a machine'
+        . ' with the wrong locale reports nothing at all';
+}
+
+if ('' !== $clean('   ') || '' !== $clean('')) {
+    $fails[] = 'an empty report is not treated as empty';
+}
+
+// --------------------------------------------------------------- the class
+
+$src = file_get_contents($web . '/lib/reg-task/taskerror.class.php');
+
+if (false === strpos($src, '$Task->isImagingTask()')) {
+    $fails[] = 'the endpoint no longer checks the task is an imaging one, so a'
+        . ' failed wipe fires HOST_IMAGE_FAIL';
+}
+if (false === strpos($src, "notify(\n                'HOST_IMAGE_FAIL'")) {
+    $fails[] = 'the endpoint no longer notifies HOST_IMAGE_FAIL, which is the'
+        . ' whole reason it exists';
+}
+// Every added key of #1202's payload, so a listener behaves the same whether
+// the failure came from here or from TaskQueue::checkout().
+foreach (['HostName', 'Host', 'Task', 'Image', 'ImageName', 'TaskType', 'Reason'] as $key) {
+    if (false === strpos($src, "'" . $key . "' =>")) {
+        $fails[] = "the endpoint's payload is missing $key, so a listener sees"
+            . ' a different shape depending on which failure path fired';
+    }
+}
+if (substr_count($src, "echo '##';") !== 1) {
+    $fails[] = 'the endpoint does not answer identically on every path, so the'
+        . ' response says whether the MAC had an active imaging task';
+}
+if (false !== strpos($src, "set('stateID'")) {
+    $fails[] = 'the endpoint changes the task state; taskStates has no Failed'
+        . ' and choosing one is a separate decision (#1206)';
+}
+if (false === strpos($src, 'error_log(')) {
+    $fails[] = 'the endpoint leaves no server-side trace of a failure';
+}
+
+// The entry point has to be a real file: service/*.php are served directly,
+// not routed, so nothing rewrites this path.
+if (!is_file($web . '/service/taskerror.php')) {
+    $fails[] = 'service/taskerror.php does not exist, so nothing can report';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: the imaging-failure report is bounded, single-line and uniform\n";
+exit(0);


### PR DESCRIPTION
The server half of #1206. The FOS half is [FOGProject/fos#152](https://github.com/FOGProject/fos/pull/152) — this one is useful on its own (an older FOS just never calls it), the FOS one is not useful without this.

## The gap

`handleError()` in FOS prints a banner to the console and `exit 1`s. It makes **no request to the server**, so a real imaging failure — bad image, mount failure, partition error, any of the ~40 `handleError` call sites across `fog.download`, `fog.upload` and `fog.mount` — has always been invisible to FOG. The only failure the server ever heard about was a storage node problem, through `fog.checkmount` → `blame.php`, and that re-queues rather than fails.

#1205 wired `HOST_IMAGE_FAIL` to `TaskQueue::checkout()`'s catch, which covers "imaging ran and FOG then failed to *record* it". This covers the failure people actually mean.

`service/taskerror.php` takes the host identity FOS already sends everywhere else, plus the error text and the script that raised it, and fires `HOST_IMAGE_FAIL` with the payload #1205 defined — the same keys from either path, so a listener behaves identically whichever failure reached it.

## Deliberately narrow, in three ways

**It does not change the task's state.** `taskStates` has no Failed — the five are Queued, Checked In, In-Progress, Complete, Cancelled. Reusing Cancelled loses the difference between "an admin stopped this" and "this broke"; adding a sixth means every place that enumerates states has to learn about it or a failed task becomes invisible there. That is a decision with UI and API consequences, it stays on #1206, and making the event fire does not depend on taking it.

**It refuses a task that is not imaging.** `HOST_IMAGE_FAIL` is an imaging event and this endpoint is reachable from a wipe or an inventory task too. Firing it there would be the defect #1202 just removed, pointing the other way. There is no event for a non-imaging task failing; noted on the issue.

**It answers `##` with 200 on every path, including every rejection.** FOS calls this on its way out and cannot act on the reply. Answering identically also means the endpoint cannot be used to ask whether a given MAC has an active imaging task.

## The text

Bounded to 500 characters and flattened to one line. This is unauthenticated in the same way every other `service/*.php` is — identified by MAC, reachable by anything that can reach the web tier — and the text lands in an administrator's Slack, ntfy or pushbullet message. An embedded newline there forges what looks like a second, separate notification, which is a better lie than anything markup could manage:

```
error=Could not mount images folder (fog.mount)
   Args Passed: --target /images
Host imaging completed successfully
```

comes out as one line, with the forged "success" visibly part of the failure text.

`\p{C}` rather than a newline-only strip, because a console-facing error string can carry terminal escapes too; `preg_replace` returns null rather than throwing on invalid UTF-8, so there is a byte-wise fallback — a machine with the wrong locale must not silently report nothing.

## Not a REST route

`service/*.php` is served directly and is not in `Route::defineRoutes()`, so `OpenAPI::document()` is unaffected — same as `blame.php` and the `Post_Stage` endpoints. No schema change, so no `FOG_SCHEMA` bump. No change to `Route::$validClasses`, so no FogApi sync.

## Verification

Live, against this install's real database, using a throwaway host on a locally-administered MAC (`02:00:00:00:0E:11`) that matches no hardware, so nothing could ever PXE boot into the task:

| case | result |
|---|---|
| deploy task | `FOG: imaging failed on host … (task 62): Could not mount images folder (fog.mount) Args Passed: --target /images Host imaging completed successfully` — **newlines flattened** |
| capture task | notified and logged |
| wipe task | refused: `Task is not an imaging task` |
| unknown MAC | refused: `Invalid Host` |
| 4000-char report | cut to exactly 500 |
| every one of them | HTTP 200, body `##` |

`HOST_IMAGE_FAIL` now appears in `notifyEvents`, which is proof `notify()` was genuinely reached and got past its guards. Fixture and shadow tree removed afterwards; host count back to 86.

`tests/task-error-report.test.php`, mutation-verified — dropping the control-character strip, the length bound, the imaging gate, the uniform ack, or adding a state change each fails the suite. Full suite: `68 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
