### PR TITLE
Give a FOS report somewhere to live: taskLog and a log of its own (schema 338)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1691,6 +1691,20 @@ installFOGServices() {
     # labelling result instead of whether the directory was created -- a failed
     # mkdir or chown here would have printed OK.
     setSELinuxContext "$servicelogs/plugins" httpd_sys_rw_content_t
+    # Where the web tier records what FOS told it (fogproject#1206). Its own
+    # subdirectory for the same reason the plugin runner's is: the writer is
+    # the web user, rotation renames and unlinks, and $servicelogs itself is
+    # root's -- the eight daemons' logs live there and nothing running as the
+    # web user should be able to unlink them.
+    dots "Creating FOS report log directory"
+    mkdir -p $servicelogs/fos >>$error_log 2>&1
+    chown ${apacheuser}:${apacheuser} $servicelogs/fos >>$error_log 2>&1
+    errorStat $?
+    # Outside the dots/errorStat pair, like every other caller. The _rw_ label
+    # is not optional here: GH-964, /opt/fog inherits usr_t, httpd_t may READ
+    # usr_t but not write it, so without this the directory exists, looks
+    # right, and every report is dropped with nothing but an AVC to say so.
+    setSELinuxContext "$servicelogs/fos" httpd_sys_rw_content_t
     # servicemaster.log is where service_lib.php writes every daemon's start,
     # stop and fatal lines, and where PHP's own error_log is pointed. The
     # runner has to be able to append to it or its supervisor lines silently

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -758,7 +758,7 @@ return [
             ],
         ],
         'taskLog' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` int(11) NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, PRIMARY KEY (`id`), KEY `taskID` (`taskID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` int(11) NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, `logType` varchar(16) NOT NULL DEFAULT \'state\', `logText` text DEFAULT NULL, PRIMARY KEY (`id`), KEY `taskID` (`taskID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'id' => 'mediumint(9) NOT NULL',
                 'taskID' => 'int(11) NOT NULL',

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5803,3 +5803,55 @@ $this->schema[] = [
     . " entry/hard drive. (Default SANBOOT)'"
     . " WHERE `settingKey` = 'FOG_EFI_BOOT_EXIT_TYPE'",
 ];
+// 338
+$this->schema[] = [
+    // taskLog gains a type and a body, so a task can log something that is
+    // not a state change. GH-1206 follow-up.
+    //
+    // Every row in this table so far is one state transition: taskID,
+    // taskStateID, who, when, from where. There has never been anywhere to
+    // put WHAT happened, which is why FOS reporting a failure (#1207) had
+    // only the PHP error log to land in -- a file nobody correlates with a
+    // task, on a server whose operator has to know to go looking.
+    //
+    // `logType` defaults to 'state' and the ALTER backfills every existing
+    // row with it, which is what those rows are. The writer at
+    // TaskingElement::taskLog() is deliberately left alone: the default is
+    // the correct value for it, so a state row costs no extra column.
+    // 'error' and 'warning' are what FOS reports arrive as.
+    //
+    // `logText` is NULL, not '', so "no body" and "an empty body" stay
+    // distinguishable -- a state row has no body at all.
+    //
+    // A closure rather than a bare ALTER for the same reason step 336 is
+    // one: ADD COLUMN has no IF NOT EXISTS below MariaDB 10.0.2/MySQL 8.0.29,
+    // so a re-run has to converge on its own rather than error.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'taskLog' "
+            . "AND `COLUMN_NAME` IN ('logType','logText')"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        $adds = [];
+        if (!in_array('logType', $cols)) {
+            $adds[] = "ADD `logType` VARCHAR(16) NOT NULL DEFAULT 'state'";
+        }
+        if (!in_array('logText', $cols)) {
+            $adds[] = "ADD `logText` TEXT NULL DEFAULT NULL";
+        }
+        if (count($adds) < 1) {
+            return true;
+        }
+        self::$DB->query(
+            "ALTER TABLE `taskLog` " . implode(', ', $adds)
+        );
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/foglogpaths.class.php
+++ b/packages/web/lib/fog/foglogpaths.class.php
@@ -54,13 +54,16 @@ class FOGLogPaths
      * top level is added here and nowhere else -- '' is the top level itself,
      * 'plugins' is the plugin runner's, which is separate because that daemon
      * runs as the web user and rotation needs write on the directory
-     * (ADR 0010).
+     * (ADR 0010). 'fos' is where the web tier records what FOS told it, and
+     * is separate for the same reason: that writer IS the web tier, and the
+     * top level belongs to root's daemons.
      *
      * @var array
      */
     const FOG_SUBDIRS = [
         '',
         'plugins',
+        'fos',
     ];
     /**
      * The path FOG's logs are reached by in the enumeration views.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 337);
+        define('FOG_SCHEMA', 338);
         define('FOG_BCACHE_VER', 285);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -41,8 +41,29 @@ class TaskLog extends FOGController
         'stateID' => 'taskStateID',
         'ip' => 'ip',
         'createdTime' => 'createTime',
-        'createdBy' => 'createdBy'
+        'createdBy' => 'createdBy',
+        'type' => 'logType',
+        'text' => 'logText'
     ];
+    /**
+     * A row recording a state transition, which is what every row was
+     * before schema 338.
+     *
+     * @var string
+     */
+    const TYPE_STATE = 'state';
+    /**
+     * A row recording that something went wrong and the task stopped.
+     *
+     * @var string
+     */
+    const TYPE_ERROR = 'error';
+    /**
+     * A row recording that something went wrong and the task carried on.
+     *
+     * @var string
+     */
+    const TYPE_WARNING = 'warning';
     /**
      * Initializes the class to set the ip from the remote.
      *

--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -23,8 +23,18 @@ namespace FOG;
  * only failure FOG ever heard about was a storage node problem, through
  * Blame, which re-queues rather than fails.
  *
- * Deliberately narrow. It notifies and it logs; it does NOT change the task's
- * state. There is no Failed state in taskStates -- the five are Queued,
+ * A report lands in three places, none of which is the task's state:
+ *
+ *   a `taskLog` row, typed 'error' or 'warning', with the text in it. This
+ *     is the one that is correlated with the task -- it carries taskID and
+ *     the state the task was in, and it survives long after a log rotates;
+ *   FOG's own log file, /var/log/fog/fos/fosreports.log, which the Log
+ *     Viewer lists like any other because 'fos' is in FOGLogPaths;
+ *   HOST_IMAGE_FAIL, so the notification plugins fire -- errors only, and
+ *     imaging tasks only.
+ *
+ * Deliberately narrow in the one way that matters: it does NOT change the
+ * task's state. There is no Failed state in taskStates -- the five are Queued,
  * Checked In, In-Progress, Complete, Cancelled -- and the two ways of not
  * adding one are both wrong on their own terms: reusing Cancelled loses the
  * difference between "an admin stopped this" and "this broke", and adding a
@@ -52,6 +62,38 @@ class TaskError extends FOGBase
      */
     const MAX_REASON = 500;
     /**
+     * The report types a caller may send, mapped to the TaskLog type.
+     *
+     * A warning is a report that FOS carried on after, so it is worth a row
+     * and a log line but is not a failure and must not fire HOST_IMAGE_FAIL.
+     * Anything unrecognised is treated as an error: a report FOG cannot
+     * classify is not a reason to throw it away.
+     *
+     * @var array
+     */
+    const TYPES = [
+        'error' => TaskLog::TYPE_ERROR,
+        'warning' => TaskLog::TYPE_WARNING
+    ];
+    /**
+     * Where the reports are written, under FOG's log directory.
+     *
+     * Its own subdirectory, not the top level, because the writer here is
+     * the web tier and the top level is root's -- the same split ADR 0010
+     * made for the plugin runner, and for the same reason: rotation renames
+     * and unlinks, so directory write on the shared log directory would let
+     * this delete the daemons' logs.
+     *
+     * @var string
+     */
+    const LOG_SUBDIR = 'fos';
+    /**
+     * The file within that directory.
+     *
+     * @var string
+     */
+    const LOG_FILE = 'fosreports.log';
+    /**
      * Reports the failure.
      *
      * @return void
@@ -60,24 +102,49 @@ class TaskError extends FOGBase
     {
         parent::__construct();
         try {
-            $reason = self::_reported('error');
-            if ('' === $reason) {
-                throw new \Exception(_('No error text supplied'));
+            $text = self::_reported('text');
+            if ('' === $text) {
+                throw new \Exception(_('No report text supplied'));
+            }
+            $type = self::_reportedType();
+            $script = self::_reported('script');
+            if ('' !== $script) {
+                $text = sprintf('%s (%s)', $text, $script);
             }
             self::getHostItem(false);
             $Task = self::$Host->get('task');
             if (!$Task->isValid()) {
                 throw new \Exception(_('No active task found for this host'));
             }
+            // Recorded for EVERY task type, imaging or not. A wipe that dies
+            // on a bad disk is exactly as worth having in the task's log as a
+            // deploy that dies on a bad image, and this is the half of the
+            // report that carries no notification consequences.
+            self::_logRow($Task, $type, $text);
+            self::_record(
+                sprintf(
+                    'FOG: %s reported by host %s (task %d): %s',
+                    $type,
+                    self::$Host->get('name'),
+                    (int) $Task->get('id'),
+                    $text
+                )
+            );
+            if (TaskLog::TYPE_ERROR !== $type) {
+                // A warning means FOS carried on. Nothing failed, so nothing
+                // gets told that something did.
+                return;
+            }
             // Same rule as TaskQueue::_notifyImagingOutcome(): HOST_IMAGE_FAIL
             // is an imaging event, and this endpoint is reachable from a wipe
             // or an inventory task too. Firing it for one of those would be
             // the defect #1202 just removed, in the other direction. There is
-            // no event for a non-imaging task failing; noted on #1206.
+            // no event for a non-imaging task failing; noted on #1206. The row
+            // and the log line above are written either way, so the report is
+            // not lost by falling through here.
             if (!$Task->isImagingTask()) {
-                throw new \Exception(_('Task is not an imaging task'));
+                return;
             }
-            $script = self::_reported('script');
             $Image = $Task->getImage();
             self::$EventManager->notify(
                 'HOST_IMAGE_FAIL',
@@ -92,20 +159,8 @@ class TaskError extends FOGBase
                         ''
                     ),
                     'TaskType' => $Task->getTaskTypeText(),
-                    'Reason' => (
-                        '' === $script ?
-                        $reason :
-                        sprintf('%s (%s)', $reason, $script)
-                    )
+                    'Reason' => $text
                 ]
-            );
-            self::_record(
-                sprintf(
-                    'FOG: imaging failed on host %s (task %d): %s',
-                    self::$Host->get('name'),
-                    (int) $Task->get('id'),
-                    $reason
-                )
             );
         } catch (\Exception $e) {
             // A report that cannot be matched to a task is still worth a line
@@ -114,7 +169,7 @@ class TaskError extends FOGBase
             // with. See the ack below.
             self::_record(
                 sprintf(
-                    'FOG: unusable imaging failure report: %s',
+                    'FOG: unusable report from FOS: %s',
                     $e->getMessage()
                 )
             );
@@ -131,6 +186,46 @@ class TaskError extends FOGBase
          */
         echo '##';
         exit;
+    }
+    /**
+     * Writes the report against the task.
+     *
+     * taskStateID is the state the task was in when the report arrived, not
+     * a new state: nothing here changes the task. It is the useful half of
+     * "when did this happen" -- a failure during In-Progress and a failure
+     * while still Queued are different problems.
+     *
+     * @param Task   $Task the task being reported against
+     * @param string $type the TaskLog type constant
+     * @param string $text the report body
+     *
+     * @return void
+     */
+    private static function _logRow($Task, $type, $text)
+    {
+        self::getClass('TaskLog')
+            ->set('taskID', $Task->get('id'))
+            ->set('stateID', $Task->get('stateID'))
+            ->set('createdBy', 'fos')
+            ->set('type', $type)
+            ->set('text', $text)
+            ->save();
+    }
+    /**
+     * Reads the report type, as a TaskLog type constant.
+     *
+     * Unrecognised input becomes an error rather than being rejected. The
+     * caller is a machine that has already failed at something; the report
+     * is worth more than the label on it, and a stricter reading would throw
+     * away the report of a FOS newer than this server.
+     *
+     * @return string
+     */
+    private static function _reportedType()
+    {
+        $sent = strtolower(self::_reported('type'));
+
+        return self::TYPES[$sent] ?? TaskLog::TYPE_ERROR;
     }
     /**
      * Reads one bounded, single-line field from the request.
@@ -193,8 +288,17 @@ class TaskError extends FOGBase
      *
      * Not FOGBase::log(): that writes a history row, and logHistory() returns
      * without doing anything unless a user is signed in. Nobody is signed in
-     * here -- the caller is a machine in the middle of imaging -- so the only
-     * durable place is the PHP error log.
+     * here -- the caller is a machine in the middle of imaging.
+     *
+     * Its own file, so that "what have the machines been telling us" is one
+     * `tail` rather than a grep through everything else the web tier logs,
+     * and so the Log Viewer can offer it by name.
+     *
+     * error_log() is the fallback, not the destination. The directory is
+     * created by the installer, so a server whose web tree has been updated
+     * but which has not been re-installed has nowhere to write yet -- and a
+     * report that reaches no log at all would be the exact failure this
+     * whole path exists to end.
      *
      * @param string $line the line to write
      *
@@ -202,7 +306,63 @@ class TaskError extends FOGBase
      */
     private static function _record($line)
     {
+        $stamped = sprintf(
+            '[%s] %s' . PHP_EOL,
+            date('Y-m-d H:i:s'),
+            $line
+        );
+        $file = self::_logPath();
+        if ('' !== $file) {
+            self::_rotate($file);
+            if (false !== @file_put_contents($file, $stamped, FILE_APPEND)) {
+                return;
+            }
+        }
         error_log($line);
+    }
+    /**
+     * The report log's path, or '' if it cannot be written.
+     *
+     * The directory is never created here. It is the installer's, which
+     * gives it to the web user with the right SELinux label (GH-964:
+     * /opt/fog inherits usr_t and httpd_t may read it but not write it, so
+     * an unlabelled mkdir would produce a directory that looks right and
+     * silently swallows every write on an enforcing host).
+     *
+     * @return string
+     */
+    private static function _logPath()
+    {
+        $dir = FOG_LOG_DIR . DS . self::LOG_SUBDIR;
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return '';
+        }
+
+        return $dir . DS . self::LOG_FILE;
+    }
+    /**
+     * Keeps one old copy once the file passes SERVICE_LOG_SIZE.
+     *
+     * The same setting the daemons rotate on, so an admin who has already
+     * decided how big a FOG log may get does not have to decide again. One
+     * generation rather than the daemons' five: this file gains a line per
+     * failed task, not a line per poll.
+     *
+     * @param string $file the log file
+     *
+     * @return void
+     */
+    private static function _rotate($file)
+    {
+        $max = (int) self::getSetting('SERVICE_LOG_SIZE');
+        if ($max < 1) {
+            return;
+        }
+        $size = @filesize($file);
+        if (false === $size || $size < $max) {
+            return;
+        }
+        @rename($file, $file . '.1');
     }
 }
 

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5014,9 +5014,6 @@ msgstr "Keine Daten zum Einfügen"
 msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5128,6 +5125,9 @@ msgstr "Keine Abfrage übergeben"
 
 msgid "No query result, use query() first"
 msgstr "Kein Abfrageergebnis, verwenden Sie zuerst query()"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
@@ -7659,10 +7659,6 @@ msgstr "Laden fehlgeschlagen: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task gestartet"
-
-#, fuzzy
-msgid "Task is not an imaging task"
-msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"
@@ -10398,6 +10394,10 @@ msgstr ""
 
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#, fuzzy
+#~ msgid "Task is not an imaging task"
+#~ msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5012,9 +5012,6 @@ msgstr "No data returned"
 msgid "No database to work off"
 msgstr "No database to work off"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5126,6 +5123,9 @@ msgstr "No query sent"
 
 msgid "No query result, use query() first"
 msgstr "No query result, use query() first"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "No results found"
@@ -7655,9 +7655,6 @@ msgstr "Load failed: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task Started"
-
-msgid "Task is not an imaging task"
-msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5141,9 +5141,6 @@ msgstr "No se obtuvieron datos"
 msgid "No database to work off"
 msgstr "No se obtuvieron datos"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5254,6 +5251,9 @@ msgid "No query passed"
 msgstr "No hay valores pasados"
 
 msgid "No query result, use query() first"
+msgstr ""
+
+msgid "No report text supplied"
 msgstr ""
 
 #, fuzzy
@@ -7843,9 +7843,6 @@ msgstr "Carga ha fallado: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Nombre de la tarea"
-
-msgid "Task is not an imaging task"
-msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5015,9 +5015,6 @@ msgstr "Keine Daten zum Einfügen"
 msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5129,6 +5126,9 @@ msgstr "Keine Abfrage übergeben"
 
 msgid "No query result, use query() first"
 msgstr "Kein Abfrageergebnis, verwenden Sie zuerst query()"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
@@ -7660,10 +7660,6 @@ msgstr "Laden fehlgeschlagen: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Task gestartet"
-
-#, fuzzy
-msgid "Task is not an imaging task"
-msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"
@@ -10399,6 +10395,10 @@ msgstr ""
 
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#, fuzzy
+#~ msgid "Task is not an imaging task"
+#~ msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5014,9 +5014,6 @@ msgstr "Aucune donnée retournés"
 msgid "No database to work off"
 msgstr "Aucune base de données de travailler hors"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5128,6 +5125,9 @@ msgstr "Aucune requête envoyée"
 
 msgid "No query result, use query() first"
 msgstr "Aucun résultat de requête, utilisez query () premier"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
@@ -7657,9 +7657,6 @@ msgstr "Échec du chargement: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "Tâche Started"
-
-msgid "Task is not an imaging task"
-msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4838,9 +4838,6 @@ msgstr "Nessun dato da inserire"
 msgid "No database to work off"
 msgstr "Nessun database di lavorare off"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -4946,6 +4943,9 @@ msgstr "Nessuna query inviata"
 
 msgid "No query result, use query() first"
 msgstr "Nessun risultato della query, utilizzare query () prima"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "nessun risultato trovato"
@@ -7376,10 +7376,6 @@ msgstr "Caricamento non riuscito"
 #, fuzzy
 msgid "Task finished"
 msgstr "Attività iniziata"
-
-#, fuzzy
-msgid "Task is not an imaging task"
-msgstr "Impossibile modificare l'immagine durante l'attività"
 
 msgid "Task not created as there are no associated Tasks"
 msgstr "Attività non creata poiché non ci sono attività associate"
@@ -10001,6 +9997,10 @@ msgstr ""
 
 #~ msgid "Successful"
 #~ msgstr "Riuscito"
+
+#, fuzzy
+#~ msgid "Task is not an imaging task"
+#~ msgstr "Impossibile modificare l'immagine durante l'attività"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4790,9 +4790,6 @@ msgstr "挿入するデータがありません"
 msgid "No database to work off"
 msgstr "使用するデータベースがありません"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -4900,6 +4897,9 @@ msgstr "クエリが渡されていません"
 
 msgid "No query result, use query() first"
 msgstr "クエリ結果がありません。先に query() を使用してください"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "結果が見つかりません"
@@ -7305,10 +7305,6 @@ msgstr "タスク実行に失敗しました"
 #, fuzzy
 msgid "Task finished"
 msgstr "タスク実行に失敗しました"
-
-#, fuzzy
-msgid "Task is not an imaging task"
-msgstr "タスク実行中はイメージを変更できません"
 
 #, fuzzy
 msgid "Task not created as there are no associated Tasks"
@@ -11228,6 +11224,10 @@ msgstr ""
 
 #~ msgid "Task forced to start"
 #~ msgstr "タスクを強制開始しました"
+
+#, fuzzy
+#~ msgid "Task is not an imaging task"
+#~ msgstr "タスク実行中はイメージを変更できません"
 
 #~ msgid "Tasked Successfully"
 #~ msgstr "タスクを正常に設定しました"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4242,9 +4242,6 @@ msgstr ""
 msgid "No database to work off"
 msgstr ""
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -4339,6 +4336,9 @@ msgid "No query passed"
 msgstr ""
 
 msgid "No query result, use query() first"
+msgstr ""
+
+msgid "No report text supplied"
 msgstr ""
 
 msgid "No results found"
@@ -6475,9 +6475,6 @@ msgid "Task failed"
 msgstr ""
 
 msgid "Task finished"
-msgstr ""
-
-msgid "Task is not an imaging task"
 msgstr ""
 
 msgid "Task not created as there are no associated Tasks"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5013,9 +5013,6 @@ msgstr "Não há dados retornados"
 msgid "No database to work off"
 msgstr "Nenhum banco de dados para trabalhar fora"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5127,6 +5124,9 @@ msgstr "Sem consulta enviada"
 
 msgid "No query result, use query() first"
 msgstr "Nenhum resultado consulta, use query () primeiro"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
@@ -7656,9 +7656,6 @@ msgstr "Carga falhou: %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "tarefa iniciada"
-
-msgid "Task is not an imaging task"
-msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5013,9 +5013,6 @@ msgstr "无数据返回"
 msgid "No database to work off"
 msgstr "没有数据库工作关闭"
 
-msgid "No error text supplied"
-msgstr ""
-
 msgid "No external data to download the file from"
 msgstr ""
 
@@ -5127,6 +5124,9 @@ msgstr "没有查询发送"
 
 msgid "No query result, use query() first"
 msgstr "没有查询结果，使用query（）首先"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "未找到结果"
@@ -7656,9 +7656,6 @@ msgstr "加载失败： %s"
 #, fuzzy
 msgid "Task finished"
 msgstr "任务开始"
-
-msgid "Task is not an imaging task"
-msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
 msgstr ""

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -20,6 +20,12 @@
  * touch the task's state -- there is no Failed state and inventing one is a
  * separate decision.
  *
+ * And the two destinations a report gets that are not the event: a typed
+ * `taskLog` row, which is what correlates the report with the task, and
+ * FOG's own log file. The type matters more than it looks -- a warning is a
+ * report the machine carried on after, so treating one as an error would
+ * announce a failed deploy for a task that went on to succeed.
+ *
  * No database, no web server. The sanitizer is pure and is called directly;
  * the rest is source-level, because the constructor needs a booted FOG, a
  * host lookup and a task.
@@ -126,12 +132,99 @@ if (substr_count($src, "echo '##';") !== 1) {
     $fails[] = 'the endpoint does not answer identically on every path, so the'
         . ' response says whether the MAC had an active imaging task';
 }
-if (false !== strpos($src, "set('stateID'")) {
-    $fails[] = 'the endpoint changes the task state; taskStates has no Failed'
-        . ' and choosing one is a separate decision (#1206)';
+// The TaskLog row carries the task's state; the TASK is what must not be
+// written. Checking for the literal set('stateID') would now match the row.
+if (false !== strpos($src, '$Task->set(')
+    || false !== strpos($src, '$Task->save(')
+) {
+    $fails[] = 'the endpoint changes the task; taskStates has no Failed and'
+        . ' choosing one is a separate decision (#1206)';
 }
 if (false === strpos($src, 'error_log(')) {
     $fails[] = 'the endpoint leaves no server-side trace of a failure';
+}
+
+// ------------------------------------------------------- type, row, file
+
+$types = (new \ReflectionClass('FOG\TaskError'))->getConstant('TYPES');
+if (!is_array($types)
+    || ($types['warning'] ?? null) !== \FOG\TaskLog::TYPE_WARNING
+    || ($types['error'] ?? null) !== \FOG\TaskLog::TYPE_ERROR
+) {
+    $fails[] = 'the endpoint does not map both report types onto TaskLog types';
+}
+
+$readType = new \ReflectionMethod('FOG\TaskError', '_reportedType');
+$readType->setAccessible(true);
+// filter_input has nothing to read under CLI, so this exercises the fallback:
+// no type at all must mean error, never warning. A FOS too old to send one is
+// only ever reporting a failure.
+if ($readType->invoke(null) !== \FOG\TaskLog::TYPE_ERROR) {
+    $fails[] = 'a report with no type is not treated as an error, so an older'
+        . ' FOS reporting a real failure fires nothing';
+}
+
+// A warning must return before the notify, not fall into it.
+$warnGuard = strpos($src, 'TaskLog::TYPE_ERROR !== $type');
+$notify = strpos($src, "'HOST_IMAGE_FAIL'");
+if (false === $warnGuard || false === $notify || $warnGuard > $notify) {
+    $fails[] = 'a warning is not held back from HOST_IMAGE_FAIL, so a machine'
+        . ' that carried on announces a failed deploy';
+}
+
+// The row is written before either gate -- the imaging one included -- so a
+// failed wipe is still recorded against its task even though no event fires.
+$row = strpos($src, '_logRow(');
+$imaging = strpos($src, '$Task->isImagingTask()');
+if (false === $row || false === $imaging || $row > $imaging) {
+    $fails[] = 'the taskLog row is written only for imaging tasks, so a failed'
+        . ' wipe or inventory leaves no trace against its task';
+}
+if (false === $warnGuard || $row > $warnGuard) {
+    $fails[] = 'a warning writes no taskLog row, so the only reports FOG keeps'
+        . ' are the ones that were already fatal';
+}
+
+// The model has to be able to hold what the endpoint writes.
+$fields = (new \ReflectionClass('FOG\TaskLog'))
+    ->getDefaultProperties()['databaseFields'] ?? [];
+foreach (['type' => 'logType', 'text' => 'logText'] as $key => $column) {
+    if (($fields[$key] ?? null) !== $column) {
+        $fails[] = "TaskLog does not map $key onto $column, so the endpoint's"
+            . ' report is dropped on save';
+    }
+}
+
+// The log file goes in its own subdirectory, and that subdirectory has to be
+// one FOGLogPaths knows about or the Log Viewer can neither list nor read it
+// -- the two fail differently, which is why the class exists.
+$subdir = (new \ReflectionClass('FOG\TaskError'))->getConstant('LOG_SUBDIR');
+if (!in_array($subdir, \FOG\FOGLogPaths::FOG_SUBDIRS, true)) {
+    $fails[] = "the report log lives in '$subdir', which FOGLogPaths does not"
+        . ' list, so the Log Viewer cannot offer it';
+}
+$reachable = false;
+foreach (\FOG\FOGLogPaths::readable() as $dir) {
+    if (substr($dir, -strlen($subdir . DS)) === $subdir . DS) {
+        $reachable = true;
+    }
+}
+if (!$reachable) {
+    $fails[] = "the report log's directory is enumerable but not readable, so"
+        . ' the Log Viewer lists the file and then says Invalid Folder';
+}
+
+// The installer is what creates it, with the SELinux label: /opt/fog inherits
+// usr_t and httpd_t may read it but not write it (GH-964), so a directory
+// created without the relabel swallows every report on an enforcing host.
+$inst = file_get_contents($root . '/lib/common/functions.sh');
+if (false === strpos($inst, 'mkdir -p $servicelogs/' . $subdir)) {
+    $fails[] = 'the installer does not create the report log directory, so the'
+        . ' web tier has nowhere to write';
+}
+if (false === strpos($inst, 'setSELinuxContext "$servicelogs/' . $subdir . '" httpd_sys_rw_content_t')) {
+    $fails[] = 'the report log directory is not relabelled, so every report is'
+        . ' dropped by SELinux with nothing but an AVC to say so';
 }
 
 // The entry point has to be a real file: service/*.php are served directly,
@@ -148,5 +241,5 @@ if (count($fails) > 0) {
     exit(1);
 }
 
-echo "ok: the imaging-failure report is bounded, single-line and uniform\n";
+echo "ok: the FOS report is bounded, single-line, typed and recorded\n";
 exit(0);


### PR DESCRIPTION
#1207 gave FOS an endpoint to report an imaging failure to. It fired
HOST_IMAGE_FAIL and called error_log(), and that was the whole of it -- so a
report either reached a notification plugin or it reached the web server's
error log, mixed in with everything else the web tier writes, correlated with
nothing. Neither is a place an admin goes to ask "what did this task actually
say before it stopped".

A report now lands in three places:

  a `taskLog` row, typed and with the text in it. This is the one correlated
    with the task: it carries taskID and the state the task was in;
  /var/log/fog/fos/fosreports.log, listed by the Log Viewer like any other
    log because 'fos' is now in FOGLogPaths;
  HOST_IMAGE_FAIL, as before -- errors only, imaging tasks only.

SCHEMA 338 adds `logType` (default 'state') and `logText` (NULL) to taskLog.
Every row in that table so far is a state transition, which is exactly what
the default backfills them as, so TaskingElement::taskLog() is untouched: a
state row costs no extra column. logText is NULL rather than '' so "no body"
and "an empty body" stay distinguishable. The step is a closure, like 336,
because ADD COLUMN has no IF NOT EXISTS below MariaDB 10.0.2 and a re-run has
to converge rather than error.

TYPES. FOS now sends `type=error` or `type=warning`, because handleWarning()
reports too (FOGProject/fos#152). A warning means the machine carried on, so
it is recorded and it does not fire the failure event -- announcing a failed
deploy for a task that went on to succeed would be worse than saying nothing.
A report with no type at all is an error: an older FOS reporting a real
failure must not be downgraded into silence.

The row is written BEFORE the imaging gate, so a failed Memtest or inventory
is recorded against its task even though no imaging event can fire for it.
That gate is still there for the event itself -- firing HOST_IMAGE_FAIL for a
non-imaging task is the defect #1202 removed, in the other direction.

THE LOG FILE gets its own subdirectory, created by the installer as the web
user with httpd_sys_rw_content_t. Both halves matter. It is not the top level
because $servicelogs is root's and holds the eight daemons' logs, and rotation
renames and unlinks -- the same split ADR 0010 made for the plugin runner. And
it is not created by PHP, because /opt/fog inherits usr_t and httpd_t may READ
usr_t but not write it (GH-964), so a directory made without the relabel looks
right and silently swallows every write on an enforcing host. error_log() is
kept as the fallback, not the destination: a server whose web tree is updated
but which has not been re-installed yet has nowhere to write, and a report
that reaches no log at all is the exact failure this path exists to end.

Rotation keeps one old copy at SERVICE_LOG_SIZE -- the daemons' setting, so an
admin who has already decided how big a FOG log may get does not decide again.
One generation rather than five: this file gains a line per failed task, not a
line per poll.

VERIFIED against a throwaway copy of a real FOG database in a container, with
the web tier served from a shadow tree, so nothing live was written:

  step 338 applied through its own closure, backfilled all 52 existing rows to
    'state', and ran clean a second time;
  an error on a Deploy task wrote its row, its log line and fired
    HOST_IMAGE_FAIL to a registered listener;
  a warning on the same task wrote its row and its log line and fired nothing;
  an error on a Memtest task wrote its row and its log line and fired nothing;
  a report with no type was recorded as an error;
  an embedded newline arrived flattened to spaces, as #1207 intended;
  the file rotated to .1 once it passed SERVICE_LOG_SIZE.

The `ip` column is empty in those rows only because filter_input(INPUT_SERVER)
returns NULL under the cli-server SAPI the harness used; the same TaskLog
constructor fills it under php-fpm, which the 52 pre-existing rows show.

tests/task-error-report.test.php grows the type routing, the row's position
relative to both gates, the model mapping, the FOGLogPaths entry and the
installer's two lines. Every one of them was mutation-verified.

Downstream: none. `tasklog` is already a Route::$validClasses entry, so
OpenAPI picks the two columns up from the regenerated manifest.

---

Pairs with FOGProject/fos#152, which adds the `type` field and makes
`handleWarning()` report as well. Either side works without the other: an
older FOS sends no type and is recorded as an error, and a newer FOS talking
to an older server gets a 404 it already ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
