### PR TITLE
Name the columns in the fogstorage grant probe, so a schema step stops breaking it

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1048,18 +1048,29 @@ updateDB() {
     # holds INSERT; a failure here is read as "the grants need redoing", which
     # is what sends the installer off to ask for the database root password.
     #
-    # So the row has to be valid, and the marker cannot live in taskID. That
-    # column used to be mediumtext and took the literal '999test'; schema 336
-    # made it the int(11) it always held, and under STRICT_TRANS_TABLES -- the
-    # MariaDB default -- inserting a non-numeric string into it is error 1265,
-    # not a warning. The probe then failed on a server whose grants were
-    # perfectly correct, and every upgrade demanded a root password nobody
-    # needed to type. Reported on a 1.6 server at schema 336 while two nodes
-    # still on the old column type were unaffected.
+    # NAME THE COLUMNS. This probe has now broken twice, both times because it
+    # was a positional INSERT against a table somebody else changed, and both
+    # times the symptom was identical and misleading: an upgrade demanding a
+    # database root password on a server whose grants were perfectly correct.
     #
-    # createdBy is varchar(30), so the marker goes there and the DELETE keys
-    # on it. taskID 0 points at no task, which is what a throwaway row should.
-    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog VALUES ( 0, 0, 3, '127.0.0.1', NOW(), 'fog-install-probe');" >/dev/null 2>&1
+    #   schema 336 made taskID the int(11) it always held. The marker was the
+    #     literal '999test' in that column, and under STRICT_TRANS_TABLES --
+    #     the MariaDB default -- a non-numeric string there is error 1265, not
+    #     a warning. Fixed by moving the marker to createdBy, which left the
+    #     positional list in place;
+    #   schema 338 added logType and logText, taking the table from six
+    #     columns to eight, so the six-value list became error 1136, "Column
+    #     count doesn't match value count".
+    #
+    # A named column list cannot break that way: a column added later takes
+    # its default and this INSERT does not care. That -- not the marker's
+    # position -- is the actual fix, and it is why the previous repair did not
+    # hold.
+    #
+    # id is AUTO_INCREMENT so it is omitted. taskID 0 points at no task, which
+    # is what a throwaway row should. The marker lives in createdBy (varchar
+    # 30) and the DELETE below keys on it.
+    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog (taskID, taskStateID, ip, createTime, createdBy) VALUES (0, 3, '127.0.0.1', NOW(), 'fog-install-probe');" >/dev/null 2>&1
     connect_as_fogstorage=$?
     if [[ $connect_as_fogstorage -eq 0 ]]; then
         mysql $sqloptionsuser --password="${snmysqlpass}" --execute="DELETE FROM $mysqldbname.taskLog WHERE createdBy='fog-install-probe' AND ip='127.0.0.1';" >/dev/null 2>&1

--- a/tests/installer-db-probes-name-columns.test.php
+++ b/tests/installer-db-probes-name-columns.test.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Every INSERT the installer runs names its columns.
+ *
+ * The fogstorage grant probe writes a throwaway row to find out whether that
+ * user still holds INSERT. A failure is read as "the grants need redoing",
+ * which is what sends the installer off to demand a database root password --
+ * so a probe that fails for ANY other reason produces a prompt on a server
+ * whose grants are perfectly correct, with nothing on screen to say why.
+ *
+ * It has broken that way twice, and both times the cause was the same
+ * positional INSERT against a table somebody else changed:
+ *
+ *   schema 336 made taskLog.taskID an int(11); the marker '999test' in that
+ *     column became error 1265 under STRICT_TRANS_TABLES. Repaired by moving
+ *     the marker, which left the positional list in place;
+ *   schema 338 added taskLog.logType and taskLog.logText, so the six-value
+ *     list became error 1136, "Column count doesn't match value count".
+ *
+ * The repair that holds is naming the columns: a column added later takes its
+ * default and the INSERT does not care. This test is what makes the next
+ * schema step unable to reopen it -- the failure is invisible in review
+ * (`INSERT INTO x VALUES (...)` looks fine) and invisible at install time on
+ * any server that has not taken the schema change yet.
+ *
+ * Textual, because these are shell strings inside a 9000-line library; there
+ * is nothing to execute without a database and a root password.
+ *
+ * Usage: php tests/installer-db-probes-name-columns.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$src = file_get_contents($root . '/lib/common/functions.sh');
+
+$fails = [];
+$checks = 0;
+
+// Every INSERT INTO in the installer, with whatever follows the table name.
+preg_match_all(
+    '#INSERT\s+INTO\s+(\S+?)\s*(\(|VALUES)#i',
+    $src,
+    $matches,
+    PREG_SET_ORDER
+);
+
+foreach ($matches as $m) {
+    $checks++;
+    if ($m[2] === '(') {
+        continue;
+    }
+    $fails[] = sprintf(
+        'INSERT INTO %s has no column list, so any later ADD COLUMN on that'
+        . ' table breaks it -- and when the statement is a grant probe, the'
+        . ' user sees a demand for the database root password instead of an'
+        . ' error',
+        $m[1]
+    );
+}
+
+if ($checks < 1) {
+    $fails[] = 'no INSERT statements found at all; this test has stopped'
+        . ' testing anything and needs its pattern checked';
+}
+
+// The grant probe specifically: name it, so a rewrite that drops the probe
+// entirely does not silently pass the check above.
+if (false === strpos($src, "fog-install-probe")) {
+    $fails[] = 'the fogstorage grant probe marker is gone; if the probe was'
+        . ' replaced, point this test at whatever replaced it';
+}
+if (!preg_match(
+    '#INSERT INTO \$mysqldbname\.taskLog \([^)]*createdBy[^)]*\) VALUES#',
+    $src
+)) {
+    $fails[] = 'the fogstorage grant probe no longer names its columns, which'
+        . ' is the one thing that keeps a schema change from turning an'
+        . ' upgrade into a root-password prompt';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: all $checks installer INSERT statement(s) name their columns\n";
+exit(0);


### PR DESCRIPTION
Regression from #1208. An upgrade on a server whose grants are perfectly
correct now stops and demands the database root password:

    * Granting access to fogstorage database user.................
      To improve the overall security the installer will restrict
      permissions for the *fogstorage* database user.
      Please provide the database *root* user password.

Nothing is wrong with the grants. installFOGDB()'s probe writes a throwaway
row as fogstorage to find out whether that user still holds INSERT, and reads
ANY failure as "the grants need redoing". The probe was a positional INSERT:

    INSERT INTO taskLog VALUES ( 0, 0, 3, '127.0.0.1', NOW(), 'fog-install-probe');

#1208 added logType and logText, taking taskLog from six columns to eight, so
that statement is now error 1136, "Column count doesn't match value count".
The grants are untouched -- reaching a column-count error means the connection
and the INSERT privilege both worked, which is exactly what the probe was
asking about.

THE SECOND TIME. Schema 336 made taskID the int(11) it always held, and the
marker '999test' in that column became error 1265 under STRICT_TRANS_TABLES.
Same prompt, same misleading symptom. That was repaired by moving the marker
into createdBy -- which fixed the instance and left the positional list, so
the next ADD COLUMN reopened it. Naming the columns is the repair that holds:
a column added later takes its default and the INSERT does not care.

VERIFIED on a live 1.6 server at schema 338, both statements run as fogstorage
inside a transaction and rolled back so nothing persisted:

    positional  -> ERROR 1136 (21S01): Column count doesn't match value count
    named       -> ROW_COUNT() = 1

tests/installer-db-probes-name-columns.test.php fails on any positional INSERT
anywhere in the installer, not just this one, and separately on the probe
losing its column list or disappearing. Mutation-verified against the bug
exactly as shipped, against a new positional INSERT elsewhere, and against the
probe being deleted.

1.5 is deliberately not touched. dev-branch's copy is positional too, but its
taskLog still has the six columns that statement was written for and 1.5 is
not gaining any, so there is nothing broken there to fix.

## Why a Normal Server needs a `fogstorage` user at all

Worth stating, because the prompt makes it look like the installer is asking
for a storage node's credential on a machine that has no storage node.

It isn't. The password being asked for is the **database root** password, and
the account being repaired is `fogstorage` — a deliberately unprivileged
database user with `SELECT` on the schema and `INSERT`/`UPDATE` on the eleven
tables imaging actually writes. A Normal Server is its own master storage
node, so the node-side code paths run here and authenticate as that user; the
point of it is that the credential sitting in a node's config cannot drop
tables or read the user table.

So the account is real and the grants are wanted. What was wrong was only the
probe that decides whether they need rebuilding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
