### PR TITLE
Let 1.5 record what FOS tells it: taskLog gets a type and a body (schema 280)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -413,7 +413,23 @@ updateDB() {
     mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_STORAGENODE_MYSQLPASS', 'This setting defines the password the storage nodes should use to connect to the fog server.', \"$snmysqlstoragepass\", 'FOG Storage Nodes') ON DUPLICATE KEY UPDATE settingValue=\"$snmysqlstoragepass\"" $mysqldbname >>$error_log 2>&1
     errorStat $?
     dots "Granting access to fogstorage database user"
-    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog VALUES ( 0, '999test', 3, '127.0.0.1', NOW(), 'fog');" >/dev/null 2>&1
+    # The probe writes a throwaway row to find out whether fogstorage still
+    # holds INSERT; a failure here is read as "the grants need redoing", which
+    # is what sends the installer off to ask for the database root password.
+    #
+    # NAME THE COLUMNS. This was a positional INSERT, and schema 280 adds
+    # logType and logText to taskLog -- six values into an eight column table
+    # is error 1136, "Column count doesn't match value count", and the symptom
+    # is an upgrade demanding a database root password on a server whose
+    # grants are perfectly correct. 1.6 hit exactly this twice (schema 336,
+    # then 338) before naming the columns; see fogproject#1209. A named list
+    # cannot break that way -- a column added later takes its default and this
+    # INSERT does not care.
+    #
+    # id is AUTO_INCREMENT so it is omitted. The '999test' marker stays in
+    # taskID, which on 1.5 is still mediumtext, and the DELETE still keys on
+    # it -- this change is about the column list, not the marker.
+    mysql ${host} -s --user=fogstorage --password="${snmysqlstoragepass}" --execute="INSERT INTO $mysqldbname.taskLog (taskID, taskStateID, ip, createTime, createdBy) VALUES ('999test', 3, '127.0.0.1', NOW(), 'fog');" >/dev/null 2>&1
     connect_as_fogstorage=$?
     if [[ $connect_as_fogstorage -eq 0 ]]; then
         mysql $sqloptionsuser --password="${snmysqlpass}" --execute="DELETE FROM $mysqldbname.taskLog WHERE taskID='999test' AND ip='127.0.0.1';" >/dev/null 2>&1
@@ -872,6 +888,20 @@ installFOGServices() {
     chmod +x -R $servicedst/
     mkdir -p $servicelogs
     errorStat $?
+    # Where the web tier records what FOS told it (service/taskerror.php).
+    # Its own subdirectory rather than group-write on $servicelogs: that
+    # directory is root's and holds the daemons' logs, and rotation renames
+    # and unlinks, so shared write would let the web user delete them.
+    dots "Creating FOS report log directory"
+    mkdir -p $servicelogs/fos >>$error_log 2>&1
+    chown ${apacheuser}:${apacheuser} $servicelogs/fos >>$error_log 2>&1
+    errorStat $?
+    # Outside the dots/errorStat pair, like every other caller:
+    # setSELinuxContext prints its own line. The _rw_ type is not optional --
+    # /opt/fog inherits usr_t and httpd_t may READ usr_t but not write it, so
+    # without this the directory exists, looks right, and every report is
+    # dropped with nothing but an AVC to say so.
+    setSELinuxContext "$servicelogs/fos" httpd_sys_rw_content_t
 }
 configureUDPCast() {
     dots "Setting up UDPCast"

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -3968,3 +3968,56 @@ $this->schema[] = array(
     . "VALUES "
     . "(14, 'fog.enrollsecureboot', 'Enroll Secure Boot Key', '0', '2', NULL)",
 );
+// 280
+$this->schema[] = array(
+    // taskLog gains a type and a body, so a task can log something that is
+    // not a state change. Ported from 1.6 schema 338 (GH-1206/#1208), which
+    // is where the feature this serves lives.
+    //
+    // Every row in this table so far is one state transition: taskID,
+    // taskStateID, who, when, from where. There has never been anywhere to
+    // put WHAT happened, which is why FOS reporting a failure had nowhere to
+    // land -- and on 1.5 that gap is not academic: FOS is shared between the
+    // two lines, so a FOS carrying FOGProject/fos#152 posts a failure report
+    // to every server it boots from, 1.5 included.
+    //
+    // `logType` defaults to 'state' and the ALTER backfills every existing
+    // row with it, which is what those rows are. TaskingElement::taskLog() is
+    // deliberately left alone: the default is the correct value for it, so a
+    // state row costs no extra column.
+    //
+    // `logText` is NULL, not '', so "no body" and "an empty body" stay
+    // distinguishable -- a state row has no body at all.
+    //
+    // A closure rather than a bare ALTER because ADD COLUMN has no
+    // IF NOT EXISTS below MariaDB 10.0.2/MySQL 8.0.29, so a re-run has to
+    // converge on its own rather than error.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'taskLog' "
+            . "AND `COLUMN_NAME` IN ('logType','logText')"
+        )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = array();
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        $adds = array();
+        if (!in_array('logType', $cols)) {
+            $adds[] = "ADD `logType` VARCHAR(16) NOT NULL DEFAULT 'state'";
+        }
+        if (!in_array('logText', $cols)) {
+            $adds[] = "ADD `logText` TEXT NULL DEFAULT NULL";
+        }
+        if (count($adds) < 1) {
+            return true;
+        }
+        self::$DB->query(
+            "ALTER TABLE `taskLog` " . implode(', ', $adds)
+        );
+
+        return true;
+    },
+);

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -208,9 +208,16 @@ class StorageNode extends FOGController
         if (!$this->get('online')) {
             return;
         }
+        // Three lists have to agree and nothing checks that they do: this
+        // one and getfiles.php feed enumeration, logtoview.php authorises
+        // the read. Adding a directory to some of them yields a selector
+        // with no entry, or an entry that answers "Invalid Folder" -- so
+        // 'fos' (the FOS report log, its own subdirectory because the web
+        // tier writes it) goes into all three or none.
         $logpaths = array(
             '/var/log/apache2',
             '/var/log/fog',
+            '/var/log/fog/fos',
             '/var/log/httpd',
             '/var/log/nginx',
             '/var/log/php*',

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -54,7 +54,7 @@ class System
     {
         self::_versionCompare();
         define('FOG_VERSION', '1.5.10.2294');
-        define('FOG_SCHEMA', 279);
+        define('FOG_SCHEMA', 280);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -39,7 +39,28 @@ class TaskLog extends FOGController
         'ip' => 'ip',
         'createdTime' => 'createTime',
         'createdBy' => 'createdBy',
+        'type' => 'logType',
+        'text' => 'logText',
     );
+    /**
+     * A row recording a state transition, which is what every row was
+     * before schema 280.
+     *
+     * @var string
+     */
+    const TYPE_STATE = 'state';
+    /**
+     * A row recording that something went wrong and the task stopped.
+     *
+     * @var string
+     */
+    const TYPE_ERROR = 'error';
+    /**
+     * A row recording that something went wrong and the task carried on.
+     *
+     * @var string
+     */
+    const TYPE_WARNING = 'warning';
     /**
      * taskID is a foreign key held in a text column.
      *

--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Records that FOS could not finish a task, and tells anyone listening.
+ *
+ * PHP version 7.4+
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Records that FOS could not finish a task, and tells anyone listening.
+ *
+ * Ported from 1.6 (GH-1206, #1207/#1208). This is a feature on a maintenance
+ * branch, and the reason it belongs here anyway is that FOS is not branched:
+ * FOGProject/fos#152 makes handleError() and handleWarning() post a report to
+ * whatever server the machine booted from, 1.5 servers included. Without this
+ * that POST reaches a 404 and 1.5 keeps the behaviour it has had since the
+ * beginning -- a machine that stops mid-image and says nothing to anyone.
+ *
+ * A report lands in three places, none of which is the task's state:
+ *
+ *   a `taskLog` row, typed 'error' or 'warning', with the text in it. This
+ *     is the one that is correlated with the task -- it carries taskID and
+ *     the state the task was in, and it survives long after a log rotates;
+ *   FOG's own log file, /var/log/fog/fos/fosreports.log, which the Log
+ *     Viewer lists like any other because 'fos' was added to the three
+ *     places 1.5 keeps its log directory lists;
+ *   HOST_IMAGE_FAIL, so the notification plugins fire -- errors only, and
+ *     imaging tasks only.
+ *
+ * Deliberately narrow in the one way that matters: it does NOT change the
+ * task's state. There is no Failed state in taskStates -- the five are
+ * Queued, Checked In, In-Progress, Complete, Cancelled -- and the two ways of
+ * not adding one are both wrong on their own terms: reusing Cancelled loses
+ * the difference between "an admin stopped this" and "this broke", and adding
+ * a sixth means every place that enumerates states has to learn about it or a
+ * failed task becomes invisible to it. That is a decision with UI and API
+ * consequences, and it is even less of a thing to take on a maintenance
+ * branch than on 1.6, where it is tracked on GH-1206.
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class TaskError extends FOGBase
+{
+    /**
+     * How much of the reported text is kept.
+     *
+     * The text is written by whatever called this endpoint, and it ends up in
+     * a Slack or pushbullet message. Bounded so a caller cannot use an
+     * admin's notification channel as a paste bin.
+     *
+     * @var int
+     */
+    const MAX_REASON = 500;
+    /**
+     * The report types a caller may send, mapped to the TaskLog type.
+     *
+     * A warning is a report that FOS carried on after, so it is worth a row
+     * and a log line but is not a failure and must not fire HOST_IMAGE_FAIL.
+     * Anything unrecognised is treated as an error: a report FOG cannot
+     * classify is not a reason to throw it away.
+     *
+     * @var array
+     */
+    const TYPES = array(
+        'error' => TaskLog::TYPE_ERROR,
+        'warning' => TaskLog::TYPE_WARNING
+    );
+    /**
+     * FOG's log directory.
+     *
+     * 1.5 has no FOG_LOG_DIR constant -- every service spells this path out
+     * -- so this one does too rather than introduce a constant for a single
+     * caller. It matches the installer's $servicelogs default.
+     *
+     * @var string
+     */
+    const LOG_DIR = '/opt/fog/log';
+    /**
+     * Where the reports are written, under that directory.
+     *
+     * Its own subdirectory, not the top level, because the writer here is the
+     * web tier and the top level is root's -- the eight daemons' logs live
+     * there, and rotation renames and unlinks, so directory write on the
+     * shared log directory would let this delete them.
+     *
+     * @var string
+     */
+    const LOG_SUBDIR = 'fos';
+    /**
+     * The file within that directory.
+     *
+     * @var string
+     */
+    const LOG_FILE = 'fosreports.log';
+    /**
+     * Reports the failure.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        try {
+            $text = self::_reported('text');
+            if ('' === $text) {
+                throw new Exception(_('No report text supplied'));
+            }
+            $type = self::_reportedType();
+            $script = self::_reported('script');
+            if ('' !== $script) {
+                $text = sprintf('%s (%s)', $text, $script);
+            }
+            self::getHostItem(false);
+            $Task = self::$Host->get('task');
+            if (!$Task->isValid()) {
+                throw new Exception(_('No active task found for this host'));
+            }
+            // Recorded for EVERY task type, imaging or not. A wipe that dies
+            // on a bad disk is exactly as worth having in the task's log as a
+            // deploy that dies on a bad image, and this is the half of the
+            // report that carries no notification consequences.
+            self::_logRow($Task, $type, $text);
+            self::_record(
+                sprintf(
+                    'FOG: %s reported by host %s (task %s): %s',
+                    $type,
+                    self::$Host->get('name'),
+                    $Task->get('id'),
+                    $text
+                )
+            );
+            if (TaskLog::TYPE_ERROR !== $type) {
+                // A warning means FOS carried on. Nothing failed, so nothing
+                // gets told that something did.
+                return;
+            }
+            // HOST_IMAGE_FAIL is an imaging event, and this endpoint is
+            // reachable from a wipe or an inventory task too. The row and the
+            // log line above are written either way, so a non-imaging failure
+            // is recorded rather than lost by falling through here.
+            if (!$Task->isImagingTask()) {
+                return;
+            }
+            $Image = $Task->getImage();
+            self::$EventManager->notify(
+                'HOST_IMAGE_FAIL',
+                array(
+                    'HostName' => self::$Host->get('name'),
+                    'Host' => self::$Host,
+                    'Task' => $Task,
+                    'Image' => $Image,
+                    'ImageName' => (
+                        $Image->isValid() ?
+                        $Image->get('name') :
+                        ''
+                    ),
+                    'TaskType' => $Task->getTaskTypeText(),
+                    'Reason' => $text
+                )
+            );
+        } catch (Exception $e) {
+            // A report that cannot be matched to a task is still worth a line
+            // in the log -- it is the only trace that a machine tried to say
+            // something -- but it is not worth an answer a caller can probe
+            // with. See the ack below.
+            self::_record(
+                sprintf(
+                    'FOG: unusable report from FOS: %s',
+                    $e->getMessage()
+                )
+            );
+        }
+        /*
+         * Always the same ack, always 200, whatever happened.
+         *
+         * FOS calls this on its way out of handleError() and cannot act on
+         * the answer -- it is about to print a banner and exit either way --
+         * so there is nothing to tell it. Answering identically also means
+         * the endpoint cannot be used to ask whether a given MAC has an
+         * active imaging task, which a distinguishing response would allow
+         * anyone who can reach the web tier to do.
+         */
+        echo '##';
+        exit;
+    }
+    /**
+     * Writes the report against the task.
+     *
+     * taskStateID is the state the task was in when the report arrived, not a
+     * new state: nothing here changes the task. It is the useful half of
+     * "when did this happen" -- a failure during In-Progress and a failure
+     * while still Queued are different problems.
+     *
+     * @param Task   $Task the task being reported against
+     * @param string $type the TaskLog type constant
+     * @param string $text the report body
+     *
+     * @return void
+     */
+    private static function _logRow($Task, $type, $text)
+    {
+        self::getClass('TaskLog')
+            ->set('taskID', $Task->get('id'))
+            ->set('stateID', $Task->get('stateID'))
+            ->set('createdBy', 'fos')
+            ->set('type', $type)
+            ->set('text', $text)
+            ->save();
+    }
+    /**
+     * Reads the report type, as a TaskLog type constant.
+     *
+     * Unrecognised input becomes an error rather than being rejected. The
+     * caller is a machine that has already failed at something; the report is
+     * worth more than the label on it, and a stricter reading would throw
+     * away the report of a FOS newer than this server -- which on 1.5 is the
+     * normal case, not the exotic one, because FOS is shared.
+     *
+     * @return string
+     */
+    private static function _reportedType()
+    {
+        $sent = strtolower(self::_reported('type'));
+
+        return isset(self::TYPES[$sent]) ?
+            self::TYPES[$sent] :
+            TaskLog::TYPE_ERROR;
+    }
+    /**
+     * Reads one bounded, single-line field from the request.
+     *
+     * Control characters are removed rather than escaped: this text is not
+     * going into HTML, it is going into a chat message and a log line, and in
+     * both of those an embedded newline lets a caller forge what looks like a
+     * second message.
+     *
+     * @param string $field the field name
+     *
+     * @return string
+     */
+    private static function _reported($field)
+    {
+        $raw = filter_input(INPUT_POST, $field);
+        if (null === $raw || false === $raw) {
+            $raw = filter_input(INPUT_GET, $field);
+        }
+
+        return self::_sanitize((string)(null === $raw ? '' : $raw));
+    }
+    /**
+     * Makes one caller-supplied string safe to put in a message.
+     *
+     * Split from _reported() so it can be tested: filter_input(INPUT_POST) has
+     * nothing to read under the CLI SAPI, and this is the half with the rules
+     * in it.
+     *
+     * @param string $raw the string as it arrived
+     *
+     * @return string
+     */
+    private static function _sanitize($raw)
+    {
+        // \p{C} is every Unicode control and format character, which covers
+        // CR, LF, NUL and the terminal escapes a console-facing error string
+        // can easily contain.
+        $clean = preg_replace('#\p{C}+#u', ' ', $raw);
+        if (null === $clean) {
+            // Invalid UTF-8 makes preg_replace return null rather than throw,
+            // so fall back to the byte-wise class. Never let a malformed
+            // string become an empty one silently -- the text is the whole
+            // point of the report.
+            $clean = preg_replace('#[[:cntrl:]]+#', ' ', $raw);
+        }
+        $clean = trim((string)$clean);
+        if ('' === $clean) {
+            return '';
+        }
+        // mb_substr on invalid UTF-8 can return '', which would throw the
+        // report away; strlen-bound the bytes in that case instead.
+        $cut = mb_substr($clean, 0, self::MAX_REASON);
+        if ('' === $cut) {
+            $cut = substr($clean, 0, self::MAX_REASON);
+        }
+
+        return $cut;
+    }
+    /**
+     * Writes one line where a server operator will find it.
+     *
+     * Not FOGBase::log(): that writes a history row, and logHistory() returns
+     * without doing anything unless a user is signed in. Nobody is signed in
+     * here -- the caller is a machine in the middle of imaging.
+     *
+     * Its own file, so that "what have the machines been telling us" is one
+     * `tail` rather than a grep through everything else the web tier logs,
+     * and so the Log Viewer can offer it by name.
+     *
+     * error_log() is the fallback, not the destination. The directory is
+     * created by the installer, so a server whose web tree has been updated
+     * but which has not been re-installed has nowhere to write yet -- and a
+     * report that reaches no log at all would be the exact failure this whole
+     * path exists to end.
+     *
+     * @param string $line the line to write
+     *
+     * @return void
+     */
+    private static function _record($line)
+    {
+        $stamped = sprintf(
+            '[%s] %s' . PHP_EOL,
+            date('Y-m-d H:i:s'),
+            $line
+        );
+        $file = self::_logPath();
+        if ('' !== $file) {
+            self::_rotate($file);
+            if (false !== @file_put_contents($file, $stamped, FILE_APPEND)) {
+                return;
+            }
+        }
+        error_log($line);
+    }
+    /**
+     * The report log's path, or '' if it cannot be written.
+     *
+     * The directory is never created here. It is the installer's, which gives
+     * it to the web user with the right SELinux label -- /opt/fog inherits
+     * usr_t, and httpd_t may read usr_t but not write it, so an unlabelled
+     * mkdir would produce a directory that looks right and silently swallows
+     * every write on an enforcing host.
+     *
+     * @return string
+     */
+    private static function _logPath()
+    {
+        $dir = self::LOG_DIR . DIRECTORY_SEPARATOR . self::LOG_SUBDIR;
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return '';
+        }
+
+        return $dir . DIRECTORY_SEPARATOR . self::LOG_FILE;
+    }
+    /**
+     * Keeps one old copy once the file passes SERVICE_LOG_SIZE.
+     *
+     * The same setting the daemons rotate on, so an admin who has already
+     * decided how big a FOG log may get does not have to decide again. One
+     * generation rather than the daemons' five: this file gains a line per
+     * failed task, not a line per poll.
+     *
+     * @param string $file the log file
+     *
+     * @return void
+     */
+    private static function _rotate($file)
+    {
+        $max = (int)self::getSetting('SERVICE_LOG_SIZE');
+        if ($max < 1) {
+            return;
+        }
+        $size = @filesize($file);
+        if (false === $size || $size < $max) {
+            return;
+        }
+        @rename($file, $file . '.1');
+    }
+}

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4275,6 +4275,10 @@ msgstr "Keine Site"
 msgid "No access is allowed"
 msgstr "Kein Zugriff erlaubt"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Keinen aktiven Task gefunden für Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4390,6 +4394,9 @@ msgstr "Kein Abfrageergebnis, verwenden Sie zuerst query()"
 
 msgid "No query sent"
 msgstr "Keine Abfrage gesendet"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4275,6 +4275,10 @@ msgstr "Not Set"
 msgid "No access is allowed"
 msgstr ""
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "No Active Task found for Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4390,6 +4394,9 @@ msgstr "No query result, use query() first"
 
 msgid "No query sent"
 msgstr "No query sent"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "No results found"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4294,6 +4294,10 @@ msgstr ""
 msgid "No access is allowed"
 msgstr "No permitido aquí"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "No hay tareas activas para este equipo"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4409,6 +4413,9 @@ msgid "No query result, use query() first"
 msgstr ""
 
 msgid "No query sent"
+msgstr ""
+
+msgid "No report text supplied"
 msgstr ""
 
 msgid "No results found"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3786,6 +3786,10 @@ msgstr "Pas de Site"
 msgid "No access is allowed"
 msgstr "Aucun accès n'est autorisé"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Aucune tâche active trouvée pour Host"
+
 msgid "No activity information available for this group"
 msgstr "Aucune information sur l'activité n'est disponible pour ce groupe"
 
@@ -3891,6 +3895,9 @@ msgstr "Aucun résultat de requête, utilisez query () en premier"
 
 msgid "No query sent"
 msgstr "Aucune requête envoyée"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Aucun résultat trouvé"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3857,6 +3857,10 @@ msgstr "Nessun Sito"
 msgid "No access is allowed"
 msgstr "Nessun accesso è consentito"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Nessun compito attivo trovato per Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -3963,6 +3967,9 @@ msgstr "Nessun risultato della query, utilizzare query () prima"
 
 msgid "No query sent"
 msgstr "No query inviata"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "nessun risultato trovato"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3748,6 +3748,10 @@ msgstr "サイトなし"
 msgid "No access is allowed"
 msgstr "アクセスは許可されていません"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "このホストの実行中タスクは見つかりません"
+
 msgid "No activity information available for this group"
 msgstr "このグループで利用可能なアクティビティ情報はありません"
 
@@ -3852,6 +3856,9 @@ msgstr "クエリ結果がありません。先に query() を使用してくだ
 
 msgid "No query sent"
 msgstr "クエリが送信されていません"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "結果が見つかりません"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3725,6 +3725,9 @@ msgstr ""
 msgid "No access is allowed"
 msgstr ""
 
+msgid "No active task found for this host"
+msgstr ""
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -3828,6 +3831,9 @@ msgid "No query result, use query() first"
 msgstr ""
 
 msgid "No query sent"
+msgstr ""
+
+msgid "No report text supplied"
 msgstr ""
 
 msgid "No results found"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3768,6 +3768,10 @@ msgstr "Sem Site"
 msgid "No access is allowed"
 msgstr "Nenhum acesso é permitido"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "Nenhuma Tarefa Ativa encontrada para o Host"
+
 msgid "No activity information available for this group"
 msgstr "Nenhuma informação de atividade disponível para este grupo"
 
@@ -3873,6 +3877,9 @@ msgstr "Nenhum resultado de consulta, use query() primeiro"
 
 msgid "No query sent"
 msgstr "Nenhuma consulta enviada"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3768,6 +3768,10 @@ msgstr "没有站点"
 msgid "No access is allowed"
 msgstr "不允许访问"
 
+#, fuzzy
+msgid "No active task found for this host"
+msgstr "主机没有活动任务"
+
 msgid "No activity information available for this group"
 msgstr "该群组暂无活动信息"
 
@@ -3873,6 +3877,9 @@ msgstr "没有查询结果，请先使用 query()"
 
 msgid "No query sent"
 msgstr "无查询发送"
+
+msgid "No report text supplied"
+msgstr ""
 
 msgid "No results found"
 msgstr "无结果"

--- a/packages/web/service/taskerror.php
+++ b/packages/web/service/taskerror.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Receives a failure or warning report from FOS.
+ *
+ * PHP version 7.4+
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+/**
+ * Receives a failure or warning report from FOS.
+ *
+ * @category TaskError
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+require '../commons/base.inc.php';
+new TaskError();

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -39,9 +39,12 @@ Route::ids('storagenode', [], 'path');
 $imagePaths = json_decode(Route::getData(), true);
 Route::ids('storagenode', [], 'snapinpath');
 $snapinPaths = json_decode(Route::getData(), true);
+// Keep in step with StorageNode::_getData() and logtoview.php; see the note
+// there. '/var/log/fog/fos' is the FOS report log's own subdirectory.
 $validPaths = [
     '/var/log/apache2',
     '/var/log/fog',
+    '/var/log/fog/fos',
     '/var/log/httpd',
     '/var/log/nginx',
     '/var/log/php*'

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -66,9 +66,16 @@ function vals($reverse, $HookManager, $lines, $file)
         '#^%s$#',
         $folder
     );
+    // Anchored and exact against the requested file's dirname, so every
+    // path needs its trailing separator and BOTH spellings of FOG's log
+    // directory -- the viewer reaches a file through the symlink while
+    // /opt/fog/log is the real path. Keep in step with the two enumeration
+    // lists; see the note in StorageNode::_getData().
     $folders = array(
         '/var/log/fog/',
+        '/var/log/fog/fos/',
         '/opt/fog/log/',
+        '/opt/fog/log/fos/',
         '/var/log/httpd/',
         '/var/log/apache2/',
         '/var/log/nginx/',

--- a/tests/installer-db-probes-name-columns.test.php
+++ b/tests/installer-db-probes-name-columns.test.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Every INSERT the installer runs names its columns.
+ *
+ * The fogstorage grant probe writes a throwaway row to find out whether that
+ * user still holds INSERT. A failure is read as "the grants need redoing",
+ * which is what sends the installer off to demand a database root password --
+ * so a probe that fails for ANY other reason produces a prompt on a server
+ * whose grants are perfectly correct, with nothing on screen to say why.
+ *
+ * It was a positional INSERT into taskLog, and schema 280 adds logType and
+ * logText to that table, which would have made it error 1136, "Column count
+ * doesn't match value count". 1.6 shipped that regression before catching it
+ * (fogproject#1209) and had already been bitten once before by the same
+ * statement (its schema 336 changed a column type under it). This branch gets
+ * the repair and the gate together, so it is never bitten at all.
+ *
+ * Naming the columns is what makes it durable: a column added later takes its
+ * default and the INSERT does not care. The failure is invisible in review --
+ * `INSERT INTO x VALUES (...)` looks fine -- and invisible at install time on
+ * any server that has not taken the schema change yet, which is why it is
+ * worth a test rather than a comment.
+ *
+ * Textual, because these are shell strings inside a 9000-line library; there
+ * is nothing to execute without a database and a root password.
+ *
+ * Usage: php tests/installer-db-probes-name-columns.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$src = file_get_contents($root . '/lib/common/functions.sh');
+
+$fails = array();
+$checks = 0;
+
+preg_match_all(
+    '#INSERT\s+INTO\s+(\S+?)\s*(\(|VALUES)#i',
+    $src,
+    $matches,
+    PREG_SET_ORDER
+);
+
+foreach ($matches as $m) {
+    $checks++;
+    if ($m[2] === '(') {
+        continue;
+    }
+    $fails[] = sprintf(
+        'INSERT INTO %s has no column list, so any later ADD COLUMN on that'
+        . ' table breaks it -- and when the statement is a grant probe, the'
+        . ' user sees a demand for the database root password instead of an'
+        . ' error',
+        $m[1]
+    );
+}
+
+if ($checks < 1) {
+    $fails[] = 'no INSERT statements found at all; this test has stopped'
+        . ' testing anything and needs its pattern checked';
+}
+
+if (false === strpos($src, "999test")) {
+    $fails[] = 'the fogstorage grant probe marker is gone; if the probe was'
+        . ' replaced, point this test at whatever replaced it';
+}
+if (!preg_match(
+    '#INSERT INTO \$mysqldbname\.taskLog \([^)]*createdBy[^)]*\) VALUES#',
+    $src
+)) {
+    $fails[] = 'the fogstorage grant probe no longer names its columns, which'
+        . ' is the one thing that keeps a schema change from turning an'
+        . ' upgrade into a root-password prompt';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: all $checks installer INSERT statement(s) name their columns\n";
+exit(0);

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * The FOS report endpoint must not become an injection channel.
+ *
+ * Ported from working-1.6 (GH-1206). FOS's handleError() and handleWarning()
+ * post to service/taskerror.php, and FOS is not branched -- a FOS carrying
+ * FOGProject/fos#152 reports to 1.5 servers exactly as it does to 1.6 ones.
+ * So this branch accepts free text from an unauthenticated machine and puts
+ * it in an administrator's Slack or pushbullet message.
+ *
+ * The text is therefore bounded and flattened to one line. An embedded
+ * newline is the interesting one: in a chat message it lets a caller forge
+ * what looks like a second, separate notification, which is a far better lie
+ * than anything they could do with markup.
+ *
+ * Also pinned: the endpoint answers identically whatever happened (so it
+ * cannot be used to ask whether a MAC has an active imaging task), a warning
+ * is held back from the imaging event, the taskLog row is written before
+ * either gate, and the task's state is never written -- there is no Failed
+ * state and inventing one is a separate decision.
+ *
+ * No database and no booted FOG. FOGBase and TaskLog are stubbed so the class
+ * can be loaded and its sanitizer called for real; everything else is
+ * source-level, because the constructor needs a host lookup and a task.
+ *
+ * Usage: php tests/task-error-report.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$fails = array();
+
+// Stubs, so the file can be included without the autoloader, a database or a
+// booted FOG. Only what the class needs at load time.
+if (!class_exists('FOGBase')) {
+    abstract class FOGBase
+    {
+    }
+}
+if (!class_exists('TaskLog')) {
+    class TaskLog
+    {
+        const TYPE_STATE = 'state';
+        const TYPE_ERROR = 'error';
+        const TYPE_WARNING = 'warning';
+    }
+}
+require_once $web . '/lib/reg-task/taskerror.class.php';
+
+$sanitize = new ReflectionMethod('TaskError', '_sanitize');
+$sanitize->setAccessible(true);
+$clean = function ($raw) use ($sanitize) {
+    return $sanitize->invoke(null, $raw);
+};
+$max = constant('TaskError::MAX_REASON');
+
+// ------------------------------------------------------------- one line
+
+foreach (array(
+    "Failed to mount\nHost imaging completed successfully" => 'a newline',
+    "Failed to mount\r\nsecond line" => 'a CRLF',
+    "Failed\tto mount" => 'a tab',
+    "Failed to mount\x00truncated" => 'a NUL',
+    "Failed \x1b[31mto\x1b[0m mount" => 'a terminal escape',
+) as $raw => $what) {
+    $out = $clean($raw);
+    if (preg_match('#[\r\n\t\x00\x1b]#', $out)) {
+        $fails[] = "$what survives sanitizing, so a caller can forge a second"
+            . ' line in an administrator\'s notification';
+    }
+    if ('' === $out) {
+        $fails[] = "$what makes the whole report empty, which throws away the"
+            . ' only thing it carries';
+    }
+}
+
+// ---------------------------------------------------------------- bounds
+
+if (!is_int($max) || $max < 1) {
+    $fails[] = 'MAX_REASON is not a positive integer, so the report is unbounded';
+}
+if (mb_strlen($clean(str_repeat('A', $max * 3))) > $max) {
+    $fails[] = 'a long report is not truncated, so an unauthenticated caller'
+        . ' can use a notification channel as a paste bin';
+}
+$cut = $clean(str_repeat('é', $max * 2));
+if ('' === $cut) {
+    $fails[] = 'a multibyte report is discarded entirely';
+}
+if (mb_strlen($cut) > $max) {
+    $fails[] = 'a multibyte report is not truncated';
+}
+if ($cut !== mb_convert_encoding($cut, 'UTF-8', 'UTF-8')) {
+    $fails[] = 'truncation split a multibyte character, so the message is no'
+        . ' longer valid UTF-8';
+}
+if ('' === $clean("Failed \xC3\x28 to mount")) {
+    $fails[] = 'a report containing invalid UTF-8 is discarded, so a machine'
+        . ' with the wrong locale reports nothing at all';
+}
+if ('' !== $clean('   ') || '' !== $clean('')) {
+    $fails[] = 'an empty report is not treated as empty';
+}
+
+// ------------------------------------------------------------ the types
+
+$types = constant('TaskError::TYPES');
+if (!is_array($types)
+    || !isset($types['warning'])
+    || $types['warning'] !== TaskLog::TYPE_WARNING
+    || !isset($types['error'])
+    || $types['error'] !== TaskLog::TYPE_ERROR
+) {
+    $fails[] = 'the endpoint does not map both report types onto TaskLog types';
+}
+$readType = new ReflectionMethod('TaskError', '_reportedType');
+$readType->setAccessible(true);
+// filter_input has nothing to read under CLI, so this exercises the fallback:
+// no type at all must mean error, never warning. On 1.5 that is the normal
+// case rather than the exotic one, because FOS is shared between the lines.
+if ($readType->invoke(null) !== TaskLog::TYPE_ERROR) {
+    $fails[] = 'a report with no type is not treated as an error, so an older'
+        . ' FOS reporting a real failure fires nothing';
+}
+
+// --------------------------------------------------------------- ordering
+
+$src = file_get_contents($web . '/lib/reg-task/taskerror.class.php');
+
+$warnGuard = strpos($src, 'TaskLog::TYPE_ERROR !== $type');
+$notify = strpos($src, "'HOST_IMAGE_FAIL'");
+$row = strpos($src, '_logRow(');
+$imaging = strpos($src, '$Task->isImagingTask()');
+
+if (false === $notify) {
+    $fails[] = 'the endpoint no longer notifies HOST_IMAGE_FAIL, which is the'
+        . ' whole reason it exists';
+}
+if (false === $imaging) {
+    $fails[] = 'the endpoint no longer checks the task is an imaging one, so a'
+        . ' failed wipe fires HOST_IMAGE_FAIL';
+}
+if (false === $warnGuard || false === $notify || $warnGuard > $notify) {
+    $fails[] = 'a warning is not held back from HOST_IMAGE_FAIL, so a machine'
+        . ' that carried on announces a failed deploy';
+}
+if (false === $row || false === $imaging || $row > $imaging) {
+    $fails[] = 'the taskLog row is written only for imaging tasks, so a failed'
+        . ' wipe or inventory leaves no trace against its task';
+}
+if (false === $warnGuard || $row > $warnGuard) {
+    $fails[] = 'a warning writes no taskLog row, so the only reports FOG keeps'
+        . ' are the ones that were already fatal';
+}
+if (substr_count($src, "echo '##';") !== 1) {
+    $fails[] = 'the endpoint does not answer identically on every path, so the'
+        . ' response says whether the MAC had an active imaging task';
+}
+if (false !== strpos($src, '$Task->set(')
+    || false !== strpos($src, '$Task->save(')
+) {
+    $fails[] = 'the endpoint changes the task; taskStates has no Failed and'
+        . ' choosing one is a separate decision';
+}
+if (false === strpos($src, 'error_log(')) {
+    $fails[] = 'the endpoint leaves no fallback trace when the log file is'
+        . ' unwritable, which is every server not yet re-installed';
+}
+
+// ----------------------------------------------------------- the plumbing
+
+$model = file_get_contents($web . '/lib/fog/tasklog.class.php');
+foreach (array('type' => 'logType', 'text' => 'logText') as $key => $column) {
+    if (false === strpos($model, "'$key' => '$column'")) {
+        $fails[] = "TaskLog does not map $key onto $column, so the endpoint's"
+            . ' report is dropped on save';
+    }
+}
+
+// The log directory has to appear in all three lists or the Log Viewer fails
+// in two different ways -- no entry, or an entry answering "Invalid Folder".
+$subdir = constant('TaskError::LOG_SUBDIR');
+$lists = array(
+    'lib/fog/storagenode.class.php' => "'/var/log/fog/$subdir'",
+    'status/getfiles.php' => "'/var/log/fog/$subdir'",
+    'status/logtoview.php' => "'/var/log/fog/$subdir/'",
+);
+foreach ($lists as $file => $needle) {
+    if (false === strpos(file_get_contents($web . '/' . $file), $needle)) {
+        $fails[] = "$file does not list $needle, so the Log Viewer cannot"
+            . ' offer or read the FOS report log';
+    }
+}
+if (false === strpos(
+    file_get_contents($web . '/status/logtoview.php'),
+    "'/opt/fog/log/$subdir/'"
+)) {
+    $fails[] = 'logtoview.php lists only the symlinked spelling of the report'
+        . ' log directory; a file named by its real path is refused';
+}
+
+$inst = file_get_contents($root . '/lib/common/functions.sh');
+if (false === strpos($inst, 'mkdir -p $servicelogs/' . $subdir)) {
+    $fails[] = 'the installer does not create the report log directory, so the'
+        . ' web tier has nowhere to write';
+}
+if (false === strpos(
+    $inst,
+    'setSELinuxContext "$servicelogs/' . $subdir . '" httpd_sys_rw_content_t'
+)) {
+    $fails[] = 'the report log directory is not relabelled, so every report is'
+        . ' dropped by SELinux with nothing but an AVC to say so';
+}
+
+// The entry point has to be a real file: service/*.php are served directly.
+if (!is_file($web . '/service/taskerror.php')) {
+    $fails[] = 'service/taskerror.php does not exist, so nothing can report';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: the FOS report is bounded, single-line, typed and recorded\n";
+exit(0);


### PR DESCRIPTION
Ported from working-1.6 (#1207, #1208, #1209). This is a feature on a
maintenance branch, and the reason it belongs here anyway is that FOS is not
branched. FOGProject/fos#152 makes handleError() AND handleWarning() post a
report to whatever server the machine booted from, and a 1.5 server is just as
likely to be that server. Without this the POST reaches a 404 and 1.5 keeps
the behaviour it has had since the beginning: a machine stops mid-image and
says nothing to anyone. HOST_IMAGE_FAIL has two listeners in this tree (slack,
pushbullet) and no core caller, so neither has ever fired on any 1.5 server.

WHAT ARRIVES. service/taskerror.php takes mac, sysuuid, a type of error or
warning, the text, and the script that raised it. A report lands in three
places, none of which is the task's state:

  a `taskLog` row, typed, with the text in it -- the one correlated with the
    task, carrying taskID and the state the task was in;
  /var/log/fog/fos/fosreports.log, which the Log Viewer lists like any other;
  HOST_IMAGE_FAIL -- errors only, imaging tasks only.

SCHEMA 280 adds `logType` (default 'state') and `logText` (NULL) to taskLog.
Every row in that table so far is a state transition, which is what the
default backfills them as, so TaskingElement::taskLog() is untouched. A
closure, not a bare ALTER, because ADD COLUMN has no IF NOT EXISTS below
MariaDB 10.0.2 and a re-run has to converge.

A warning is recorded and fires nothing, because the machine carried on;
announcing a failed deploy for a task that went on to succeed would be worse
than silence. A report with NO type is an error -- on this branch that is the
normal case rather than the exotic one, because a FOS newer than the server is
what 1.5 will usually be talking to.

THE INSTALLER PROBE HAD TO COME WITH IT, and this is the part that is not
optional. installFOGDB() probes fogstorage's INSERT privilege with a throwaway
row and reads any failure as "the grants need redoing", which is what makes it
demand a database root password. That probe was positional:

    INSERT INTO taskLog VALUES ( 0, '999test', 3, '127.0.0.1', NOW(), 'fog');

Six values into what schema 280 makes an eight column table is error 1136,
"Column count doesn't match value count" -- so this schema step alone would
have made every 1.5 upgrade stop and ask for a root password nobody needs to
type, on servers whose grants are perfectly correct. 1.6 shipped exactly that
regression and had already been bitten once before by the same statement; see
#1209. Naming the columns is the repair that holds, and it lands here in the
same commit as the cause rather than after it.

THE LOG DIRECTORY is created by the installer as the web user with
httpd_sys_rw_content_t, in its own subdirectory: $servicelogs is root's and
holds the daemons' logs, and rotation renames and unlinks. error_log() stays
as the fallback so a server updated but not yet re-installed still records
something. 'fos' is added to all THREE lists 1.5 keeps -- StorageNode::
_getData(), status/getfiles.php and status/logtoview.php -- because they fail
differently: miss the first two and the selector has no entry, miss the last
and it answers "Invalid Folder".

VERIFIED against a throwaway copy of a real 1.5 database (2079 hosts, schema
278) in a container, with the web tier served from a shadow tree, so the live
1.5 install was never written to:

  step 280 applied through its own closure, backfilled all 7 existing rows to
    'state', and ran clean a second time;
  the OLD probe against the migrated table -> ERROR 1136, as predicted;
    the new one -> ROW_COUNT() = 1;
  error on a Deploy task    -> row, log line, HOST_IMAGE_FAIL to a listener;
  warning on the same task  -> row and log line, no event;
  no type at all            -> recorded as an error, event fired;
  error on a non-imaging task -> row and log line, no event;
  an embedded newline arrived flattened to spaces;
  the file rotated to .1 once it passed SERVICE_LOG_SIZE.

WHAT IS DELIBERATELY NOT PORTED. The slack and pushbullet listeners are left
exactly as they are. 1.6's #1202 rewrote them to name the image and the
reason; here they keep reading only $data['HostName'], and the extra payload
keys are simply ignored. Making them fire at all is the change this branch
needed; changing what they say is a separate one.

Two tests, both mutation-verified: task-error-report.test.php (the sanitizer
run for real against stubbed base classes, plus the type routing, the row's
position relative to both gates, and all three log-path lists) and
installer-db-probes-name-columns.test.php (any positional INSERT anywhere in
the installer).

---

Base is `dev-branch`. Pairs with FOGProject/fos#152 (merged) and mirrors
#1208 / #1209 on `working-1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
