### PR TITLE
Make a FOS failure visible: a Failed task state, and a tab that shows the task log

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5855,3 +5855,26 @@ $this->schema[] = [
         return true;
     },
 ];
+// 339
+$this->schema[] = [
+    // A task the host reported dead on gets a state of its own. GH-1206
+    // follow-up to step 338.
+    //
+    // Until now such a task stayed Queued or In-Progress forever: the report
+    // was recorded and announced, but the task list still said the machine
+    // was working on it, and the host could not be re-tasked because it still
+    // held an active task. Somebody had to notice and cancel it by hand.
+    //
+    // Not reusing Cancelled (5), which was the alternative. Cancelled means
+    // an administrator stopped it; losing the difference between "somebody
+    // stopped this" and "this broke" costs the operator the one fact they are
+    // looking at the task list to find.
+    //
+    // INSERT IGNORE, so a re-run converges and a server that somehow already
+    // has a row 6 keeps whatever it has rather than having it rewritten.
+    "INSERT IGNORE INTO `taskStates` "
+    . "(`tsID`,`tsName`,`tsDescription`,`tsOrder`,`tsIcon`) "
+    . "VALUES "
+    . "(6,'Failed','Host reported that the task could not be completed.',"
+    . "6,'exclamation-triangle')",
+];

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2948,6 +2948,15 @@ abstract class FOGBase
         return TaskState::getCancelledState();
     }
     /**
+     * Get failed state id.
+     *
+     * @return int
+     */
+    public static function getFailedState()
+    {
+        return TaskState::getFailedState();
+    }
+    /**
      * Normalises a value to a re-indexed list of positive integer ids.
      *
      * Casts to an array, intval's every element, drops anything <= 0 (blank,

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 339);
-        define('FOG_BCACHE_VER', 285);
+        define('FOG_BCACHE_VER', 286);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 338);
+        define('FOG_SCHEMA', 339);
         define('FOG_BCACHE_VER', 285);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -143,6 +143,39 @@ class TaskState extends FOGController
         );
         return $cancelledState;
     }
+    /**
+     * Gets the literal failed state
+     *
+     * Added at schema 339. Until then a task the host had died on stayed
+     * Queued or In-Progress forever: the report was recorded and announced
+     * (GH-1206) but the task list still said the machine was working on it,
+     * and the host could not be re-tasked because it still held an active
+     * task.
+     *
+     * Not Cancelled, which was the alternative and is the one thing this
+     * must not be confused with -- Cancelled means an administrator stopped
+     * it. Losing the difference between "somebody stopped this" and "this
+     * broke" is exactly the distinction an operator needs at the moment
+     * they are looking at the task list.
+     *
+     * Adding a sixth state is safe here because every "is this task live"
+     * test in the tree is an ALLOWLIST -- Host::loadTask() and
+     * getActiveTaskCount() both ask for getQueuedStates() plus
+     * getProgressState() -- so a state nobody listed is inactive by
+     * construction. That is what lets this land without touching the 156
+     * call sites that enumerate states.
+     *
+     * @return int
+     */
+    public static function getFailedState()
+    {
+        $failedState = 6;
+        self::$HookManager->processEvent(
+            'FAILED_STATE',
+            ['failedState' => &$failedState]
+        );
+        return $failedState;
+    }
 }
 
 /*

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -425,10 +425,14 @@ class TaskManagement extends FOGPage
         echo '<div class="btn-group" role="group" aria-label="'
             . _('State filter')
             . '">';
+        // 'all' rather than 'both': there are three finished states since
+        // schema 339 added Failed, so a two-way label was about to start
+        // lying. getRecentTasks() still treats any unrecognised value as
+        // all-of-them, so a page cached before this keeps working.
         echo '<input type="radio" class="btn-check" name="recent-state-filter"'
-            . ' id="recent-state-both" value="both" autocomplete="off" checked/>';
-        echo '<label class="btn btn-outline-primary" for="recent-state-both">'
-            . _('Both')
+            . ' id="recent-state-all" value="all" autocomplete="off" checked/>';
+        echo '<label class="btn btn-outline-primary" for="recent-state-all">'
+            . _('All')
             . '</label>';
         echo '<input type="radio" class="btn-check" name="recent-state-filter"'
             . ' id="recent-state-complete" value="complete" autocomplete="off"/>';
@@ -439,6 +443,11 @@ class TaskManagement extends FOGPage
             . ' id="recent-state-cancelled" value="cancelled" autocomplete="off"/>';
         echo '<label class="btn btn-outline-primary" for="recent-state-cancelled">'
             . _('Cancelled')
+            . '</label>';
+        echo '<input type="radio" class="btn-check" name="recent-state-filter"'
+            . ' id="recent-state-failed" value="failed" autocomplete="off"/>';
+        echo '<label class="btn btn-outline-primary" for="recent-state-failed">'
+            . _('Failed')
             . '</label>';
         echo '</div>';
         echo '</div>';
@@ -548,6 +557,10 @@ class TaskManagement extends FOGPage
 
         $complete = (int)self::getCompleteState();
         $cancelled = (int)self::getCancelledState();
+        // Failed has to be here or it is in no pane at all: it is not an
+        // active state, so the active pane excludes it by construction, and
+        // this is the only view of finished tasks there is.
+        $failed = (int)self::getFailedState();
         switch ($pass_vars['states'] ?? '') {
             case 'complete':
                 $states = [$complete];
@@ -555,8 +568,11 @@ class TaskManagement extends FOGPage
             case 'cancelled':
                 $states = [$cancelled];
                 break;
+            case 'failed':
+                $states = [$failed];
+                break;
             default:
-                $states = [$complete, $cancelled];
+                $states = [$complete, $cancelled, $failed];
         }
         $where = "`tasks`.`taskStateID` IN ("
             . implode(',', $states)

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -108,6 +108,15 @@ class TaskManagement extends FOGPage
         $this->_tabbed('recent');
     }
     /**
+     * Deep link: pre-select the task log tab.
+     *
+     * @return void
+     */
+    public function logs()
+    {
+        $this->_tabbed('logs');
+    }
+    /**
      * Renders the single tabbed task page.
      *
      * @param string $initialTab The tab pane id to pre-select client side.
@@ -163,6 +172,13 @@ class TaskManagement extends FOGPage
                 'id' => 'recent',
                 'generator' => function () {
                     $this->_recentPane();
+                }
+            ],
+            [
+                'name' => _('Logs'),
+                'id' => 'logs',
+                'generator' => function () {
+                    $this->_logsPane();
                 }
             ]
         ];
@@ -453,6 +469,169 @@ class TaskManagement extends FOGPage
         echo '</div>';
         echo '</div>';
         $this->render(12, 'recent-tasks-table');
+    }
+    /**
+     * Renders the task log pane.
+     *
+     * taskLog has existed since 1.2 and nothing has ever shown it. Every task
+     * state transition wrote a row and the only way to read one was SQL --
+     * which stopped being merely untidy at schema 338, when FOS reports
+     * started landing in the same table: the text a machine sends when a
+     * deploy dies was being stored and shown to nobody.
+     *
+     * Defaults to reports rather than everything. State rows are one per
+     * transition per task, so they outnumber reports by roughly five to one
+     * and would bury them on the tab that exists to surface them; 'All' is
+     * one click away.
+     *
+     * @return void
+     */
+    private function _logsPane()
+    {
+        $this->headerData = [
+            _('Time'),
+            _('Host Name'),
+            _('Task Type'),
+            _('State'),
+            _('Type'),
+            _('Message'),
+            _('Recorded By')
+        ];
+        $this->attributes = [
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+        ];
+        echo '<!-- Task Logs -->';
+        echo '<div class="row mb-3">';
+        echo '<div class="col-sm-6">';
+        echo '<label class="form-label d-block">' . _('Entry Type') . '</label>';
+        echo '<div class="btn-group" role="group" aria-label="'
+            . _('Log entry type filter')
+            . '">';
+        $types = [
+            'reports' => _('Reports'),
+            'error' => _('Errors'),
+            'warning' => _('Warnings'),
+            'state' => _('State changes'),
+            'all' => _('All')
+        ];
+        foreach ($types as $value => $label) {
+            echo '<input type="radio" class="btn-check" name="log-type-filter"'
+                . ' id="log-type-' . $value . '" value="' . $value . '"'
+                . ' autocomplete="off"'
+                . ($value == 'reports' ? ' checked' : '')
+                . '/>';
+            echo '<label class="btn btn-outline-primary" for="log-type-'
+                . $value
+                . '">'
+                . $label
+                . '</label>';
+        }
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+        $this->render(12, 'task-logs-table');
+    }
+    /**
+     * Get the task log entries.
+     *
+     * Read through a derived table because taskLog and tasks both have
+     * `taskID` and `taskStateID` columns, and complex() builds its select
+     * list as bare backticked names -- an unqualified `taskID` across that
+     * join is ambiguous and the query dies. Aliasing inside the subquery
+     * gives every column a name of its own, and MariaDB merges a derived
+     * table with no aggregate in it, so this is not a materialisation.
+     *
+     * @return void
+     */
+    public function getTaskLogs()
+    {
+        header('Content-type: application/json');
+        parse_str(
+            file_get_contents('php://input'),
+            $pass_vars
+        );
+
+        $reports = [TaskLog::TYPE_ERROR, TaskLog::TYPE_WARNING];
+        switch ($pass_vars['logtypes'] ?? '') {
+            case 'error':
+                $types = [TaskLog::TYPE_ERROR];
+                break;
+            case 'warning':
+                $types = [TaskLog::TYPE_WARNING];
+                break;
+            case 'state':
+                $types = [TaskLog::TYPE_STATE];
+                break;
+            case 'all':
+                $types = [];
+                break;
+            default:
+                $types = $reports;
+        }
+        $where = '';
+        if (count($types) > 0) {
+            $where = "`logType` IN ('" . implode("','", $types) . "')";
+        }
+
+        $from = "FROM (
+            SELECT `taskLog`.`id` AS `id`,
+                `taskLog`.`createTime` AS `logTime`,
+                `taskLog`.`createdBy` AS `logBy`,
+                `taskLog`.`logType` AS `logType`,
+                `taskLog`.`logText` AS `logText`,
+                `taskLog`.`taskID` AS `logTaskID`,
+                `taskStates`.`tsName` AS `logStateName`,
+                `taskStates`.`tsIcon` AS `logStateIcon`,
+                `taskTypes`.`ttName` AS `logTypeName`,
+                `taskTypes`.`ttIcon` AS `logTypeIcon`,
+                `hosts`.`hostID` AS `logHostID`,
+                `hosts`.`hostName` AS `logHostName`
+            FROM `taskLog`
+            LEFT OUTER JOIN `taskStates`
+            ON `taskLog`.`taskStateID` = `taskStates`.`tsID`
+            LEFT OUTER JOIN `tasks`
+            ON `taskLog`.`taskID` = `tasks`.`taskID`
+            LEFT OUTER JOIN `taskTypes`
+            ON `tasks`.`taskTypeID` = `taskTypes`.`ttID`
+            LEFT OUTER JOIN `hosts`
+            ON `tasks`.`taskHostID` = `hosts`.`hostID`
+        ) AS `%s`";
+        $logsSqlStr = "SELECT `%s` $from %s %s %s";
+        $logsFilterStr = "SELECT COUNT(`%s`) $from %s";
+        $logsTotalStr = "SELECT COUNT(`%s`) $from";
+
+        $columns = [
+            ['db' => 'id', 'dt' => 'id'],
+            ['db' => 'logTime', 'dt' => 'logtime'],
+            ['db' => 'logHostName', 'dt' => 'hostname'],
+            ['db' => 'logHostID', 'dt' => 'hostid'],
+            ['db' => 'logTypeName', 'dt' => 'tasktypename'],
+            ['db' => 'logTypeIcon', 'dt' => 'tasktypeicon'],
+            ['db' => 'logStateName', 'dt' => 'taskstatename'],
+            ['db' => 'logStateIcon', 'dt' => 'taskstateicon'],
+            ['db' => 'logType', 'dt' => 'logtype'],
+            ['db' => 'logText', 'dt' => 'logtext'],
+            ['db' => 'logBy', 'dt' => 'createdBy'],
+            ['db' => 'logTaskID', 'dt' => 'taskid']
+        ];
+        $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode(
+            FOGManagerController::complex(
+                $pass_vars,
+                'taskLogView',
+                'id',
+                $columns,
+                $logsSqlStr,
+                $logsFilterStr,
+                $logsTotalStr,
+                $where
+            )
+        ));
     }
     /**
      * Get the active tasks

--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -23,25 +23,27 @@ namespace FOG;
  * only failure FOG ever heard about was a storage node problem, through
  * Blame, which re-queues rather than fails.
  *
- * A report lands in three places, none of which is the task's state:
+ * A report lands in four places:
  *
  *   a `taskLog` row, typed 'error' or 'warning', with the text in it. This
  *     is the one that is correlated with the task -- it carries taskID and
  *     the state the task was in, and it survives long after a log rotates;
  *   FOG's own log file, /var/log/fog/fos/fosreports.log, which the Log
  *     Viewer lists like any other because 'fos' is in FOGLogPaths;
+ *   the task's state, which an error moves to Failed (schema 339). A
+ *     warning never does -- a warning means FOS carried on;
  *   HOST_IMAGE_FAIL, so the notification plugins fire -- errors only, and
  *     imaging tasks only.
  *
- * Deliberately narrow in the one way that matters: it does NOT change the
- * task's state. There is no Failed state in taskStates -- the five are Queued,
- * Checked In, In-Progress, Complete, Cancelled -- and the two ways of not
- * adding one are both wrong on their own terms: reusing Cancelled loses the
- * difference between "an admin stopped this" and "this broke", and adding a
- * sixth means every place that enumerates states has to learn about it or a
- * failed task becomes invisible to it. That is a decision with UI and API
- * consequences and it is tracked separately on #1206; making the event fire
- * does not depend on taking it.
+ * The state is written for every task type, not just imaging ones: a Memtest
+ * the host died on is as finished as a deploy. Only the notification is
+ * imaging-specific. See TaskState::getFailedState() for why this is a sixth
+ * state rather than Cancelled, and why adding one did not mean editing the
+ * places that enumerate states.
+ *
+ * Apart from that one field it writes nothing about the task. The endpoint is
+ * unauthenticated -- it is matched to a host by MAC, the way every FOS
+ * endpoint is -- so what it may change has to stay a list of one.
  *
  * @category TaskError
  * @package  FOGProject
@@ -135,6 +137,11 @@ class TaskError extends FOGBase
                 // gets told that something did.
                 return;
             }
+            // The task is finished, whatever kind it was. A Memtest or an
+            // inventory task the host died on is just as over as a deploy;
+            // only the NOTIFICATION below is imaging-specific, so the state
+            // is written before that gate rather than behind it.
+            self::_markFailed($Task);
             // Same rule as TaskQueue::_notifyImagingOutcome(): HOST_IMAGE_FAIL
             // is an imaging event, and this endpoint is reachable from a wipe
             // or an inventory task too. Firing it for one of those would be
@@ -201,6 +208,28 @@ class TaskError extends FOGBase
      *
      * @return void
      */
+    /**
+     * Moves the task to the Failed state.
+     *
+     * Guarded on the row actually existing rather than assuming schema 339
+     * has run. A web tree can be updated ahead of its database -- that is the
+     * ordinary state of an install between the files landing and the admin
+     * loading a page -- and pointing a task at a taskStates row that is not
+     * there renders blank and cannot be filtered for, which is worse than
+     * leaving the task where it was for a few minutes.
+     *
+     * @param Task $Task the task the report arrived for
+     *
+     * @return void
+     */
+    private static function _markFailed($Task)
+    {
+        $failed = TaskState::getFailedState();
+        if (!self::getClass('TaskState', $failed)->isValid()) {
+            return;
+        }
+        $Task->set('stateID', $failed)->save();
+    }
     private static function _logRow($Task, $type, $text)
     {
         self::getClass('TaskLog')

--- a/packages/web/management/js/fog/task/fog.task.list.js
+++ b/packages/web/management/js/fog/task/fog.task.list.js
@@ -55,6 +55,13 @@
       paused: false,
       table: null,
       build: buildRecent
+    },
+    logs: {
+      id: 'logs',
+      poll: false,
+      paused: false,
+      table: null,
+      build: buildLogs
     }
   };
 
@@ -416,6 +423,81 @@
     });
   }
 
+  function buildLogs(pane) {
+    // Read-only history of taskLog, which nothing has ever displayed. Message
+    // is the wide column, so it is the one that survives a narrow viewport;
+    // the icons come from the same taskStates/taskTypes rows the other panes
+    // draw from, so a Failed row is marked the same way everywhere.
+    return $('#task-logs-table').registerTable(null, {
+      order: [
+        [0, 'desc']
+      ],
+      columns: [
+        {data: 'logtime'},
+        {data: 'hostname'},
+        {data: 'tasktypename'},
+        {data: 'taskstatename'},
+        {data: 'logtype'},
+        {data: 'logtext'},
+        {data: 'createdBy'}
+      ],
+      rowId: 'id',
+      columnDefs: [
+        {
+          responsivePriority: 0,
+          targets: 0
+        },
+        {
+          responsivePriority: 1,
+          render: function(data, type, row) {
+            if (!row.hostid) {
+              return $.escapeHtml(data || '');
+            }
+            return '<a href="../management/index.php?node=host&sub=edit&id=' + row.hostid + '">' + $.escapeHtml(data) + '</a>';
+          },
+          targets: 1
+        },
+        {
+          render: function(data, type, row) {
+            return $.escapeHtml(data || '')
+              + ' <i class="fa fa-' + $.escapeHtml(row.tasktypeicon || '') + '"></i> ';
+          },
+          targets: 2
+        },
+        {
+          render: function(data, type, row) {
+            return $.escapeHtml(data || '')
+              + ' <i class="fa fa-' + $.escapeHtml(row.taskstateicon || '') + '"></i> ';
+          },
+          targets: 3
+        },
+        {
+          render: function(data) {
+            // The type is what tells an operator whether the machine stopped
+            // or carried on, so it is badged rather than left as bare text.
+            var cls = {error: 'bg-danger', warning: 'bg-warning text-dark'};
+            return '<span class="badge ' + (cls[data] || 'bg-secondary') + '">'
+              + $.escapeHtml(data || '')
+              + '</span>';
+          },
+          targets: 4
+        },
+        {
+          responsivePriority: -1,
+          targets: 5
+        }
+      ],
+      serverSide: true,
+      ajax: {
+        url: '../management/index.php?node=' + Common.node + '&sub=getTaskLogs',
+        type: 'post',
+        data: function(d) {
+          d.logtypes = $('input[name="log-type-filter"]:checked').val();
+        }
+      }
+    });
+  }
+
   // ---------------------------------------------------------------
   // PER-PANE ACTION BUTTONS (cancel / reload toggle)
   //
@@ -552,15 +634,22 @@
   }
 
   // ---------------------------------------------------------------
-  // RECENT TAB FILTERS
+  // RECENT AND LOG TAB FILTERS
 
   function reloadRecent() {
     if (panes.recent.table) {
       panes.recent.table.ajax.reload(null, true);
     }
   }
+
+  function reloadLogs() {
+    if (panes.logs.table) {
+      panes.logs.table.ajax.reload(null, true);
+    }
+  }
   $('#recent-type-filter').on('change', reloadRecent);
   $('input[name="recent-state-filter"]').on('change', reloadRecent);
+  $('input[name="log-type-filter"]').on('change', reloadLogs);
 
   // ---------------------------------------------------------------
   // RECENT TAB RE-DEPLOY (ported from the host edit tasking tab; delegated

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2166,6 +2166,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Druckertyp"
+
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
@@ -4501,6 +4505,10 @@ msgstr "Log-Viewer"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4532,6 +4540,9 @@ msgstr "Erfolgreich"
 
 msgid "Logout"
 msgstr "Logout"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -6144,6 +6155,9 @@ msgstr "Erhalten"
 msgid "Record not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7154,6 +7168,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Zustand"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Änderungen speichern"
 
 #, fuzzy
 msgid "State filter"
@@ -8853,6 +8871,9 @@ msgid "Wake On Lan"
 msgstr "Wake On Lan"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -998,9 +998,6 @@ msgstr "Boot-Optionen:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast hinzugefügt!"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1002,9 +1002,6 @@ msgstr "Boot Options:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast Name"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2167,6 +2167,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Please enter a valid hostname"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Printer Type"
+
 msgid "Equipment Loan"
 msgstr "Equipment Loan"
 
@@ -4499,6 +4503,10 @@ msgstr "Log Viewer"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "Printer update failed!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4530,6 +4538,9 @@ msgstr "Successful"
 
 msgid "Logout"
 msgstr "Logout"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -6142,6 +6153,9 @@ msgstr "Receive"
 msgid "Record not found"
 msgstr "Record not found, Error: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7152,6 +7166,10 @@ msgstr ""
 
 msgid "State"
 msgstr "State"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Save Changes"
 
 #, fuzzy
 msgid "State filter"
@@ -8849,6 +8867,9 @@ msgid "Wake On Lan"
 msgstr "Wake on lan?"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1016,9 +1016,6 @@ msgstr "Opciones de arranque:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nombre de host"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2204,6 +2204,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Por favor introduce un nombre de sesión"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Tipo de impresora"
+
 msgid "Equipment Loan"
 msgstr ""
 
@@ -4610,6 +4614,10 @@ msgstr "FOG Visor de registro"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "actualización de la impresora ha fallado!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4641,6 +4649,9 @@ msgid "Login successful!"
 msgstr "Exitoso"
 
 msgid "Logout"
+msgstr ""
+
+msgid "Logs"
 msgstr ""
 
 msgid "MAC"
@@ -6289,6 +6300,9 @@ msgstr "retirar"
 msgid "Record not found"
 msgstr "Registro no encontrado, error: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7316,6 +7330,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Estado"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Guardar cambios"
 
 #, fuzzy
 msgid "State filter"
@@ -9036,6 +9054,9 @@ msgid "Wake On Lan"
 msgstr "¿Activación de la LAN?"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -998,9 +998,6 @@ msgstr "Boot-Optionen:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast hinzugefügt!"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2166,6 +2166,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Druckertyp"
+
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
@@ -4502,6 +4506,10 @@ msgstr "Log-Viewer"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4533,6 +4541,9 @@ msgstr "Erfolgreich"
 
 msgid "Logout"
 msgstr "Logout"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -6145,6 +6156,9 @@ msgstr "Erhalten"
 msgid "Record not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7155,6 +7169,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Zustand"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Änderungen speichern"
 
 #, fuzzy
 msgid "State filter"
@@ -8854,6 +8872,9 @@ msgid "Wake On Lan"
 msgstr "Wake On Lan"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2169,6 +2169,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "S'il vous plaît entrer un nom d'hôte valide"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Type d'imprimante"
+
 msgid "Equipment Loan"
 msgstr "prêt d'équipement"
 
@@ -4501,6 +4505,10 @@ msgstr "Log Viewer"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "mise à jour de l'imprimante a échoué!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4532,6 +4540,9 @@ msgstr "Réussi"
 
 msgid "Logout"
 msgstr "Se déconnecter"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -6144,6 +6155,9 @@ msgstr "Recevoir"
 msgid "Record not found"
 msgstr "Enregistrement non trouvé, Erreur: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7154,6 +7168,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Etat"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Sauvegarder les modifications"
 
 #, fuzzy
 msgid "State filter"
@@ -8851,6 +8869,9 @@ msgid "Wake On Lan"
 msgstr "Wake on lan?"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1003,9 +1003,6 @@ msgstr "Options de démarrage:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nom de diffusion"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -970,9 +970,6 @@ msgstr "Opzioni di avvio:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Broadcast aggiunto!"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2102,6 +2102,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Si prega di inserire un nome host valido"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Tipo stampante"
+
 msgid "Equipment Loan"
 msgstr "attrezzature di prestito"
 
@@ -4333,6 +4337,10 @@ msgstr "Log Viewer"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "Aggiornamento della stampante non è riuscito!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4364,6 +4372,9 @@ msgstr "Riuscito"
 
 msgid "Logout"
 msgstr "Disconnettersi"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -5932,6 +5943,9 @@ msgstr "Ricevere"
 msgid "Record not found"
 msgstr "Record non trovato"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -6897,6 +6911,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Stato"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Salva i cambiamenti"
 
 #, fuzzy
 msgid "State filter"
@@ -8534,6 +8552,9 @@ msgid "Wake On Lan"
 msgstr "Wake On LAN"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2084,6 +2084,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "有効なホスト名を入力してください"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "プリンタータイプ"
+
 msgid "Equipment Loan"
 msgstr "機器貸出"
 
@@ -4289,6 +4293,10 @@ msgstr "ログビューアー"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "サイトの更新に失敗しました！"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4318,6 +4326,9 @@ msgstr "成功"
 
 msgid "Logout"
 msgstr "ログアウト"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC アドレス"
@@ -5887,6 +5898,9 @@ msgstr "パーセント"
 msgid "Record not found"
 msgstr "レコードが見つかりません"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -6836,6 +6850,10 @@ msgstr "処理を開始しています"
 
 msgid "State"
 msgstr "状態"
+
+#, fuzzy
+msgid "State changes"
+msgstr "変更を保存"
 
 #, fuzzy
 msgid "State filter"
@@ -8465,6 +8483,9 @@ msgid "Wake On Lan"
 msgstr "Wake on LAN"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -952,9 +952,6 @@ msgstr "ブートオプション"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "新しいブロードキャストアドレス"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -847,9 +847,6 @@ msgstr ""
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 msgid "Broadcast Address"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1835,6 +1835,9 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr ""
 
+msgid "Entry Type"
+msgstr ""
+
 msgid "Equipment Loan"
 msgstr ""
 
@@ -3799,6 +3802,9 @@ msgstr ""
 msgid "Log contents."
 msgstr ""
 
+msgid "Log entry type filter"
+msgstr ""
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -3824,6 +3830,9 @@ msgid "Login successful!"
 msgstr ""
 
 msgid "Logout"
+msgstr ""
+
+msgid "Logs"
 msgstr ""
 
 msgid "MAC"
@@ -5206,6 +5215,9 @@ msgstr ""
 msgid "Record not found"
 msgstr ""
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -6060,6 +6072,9 @@ msgid "Starting download"
 msgstr ""
 
 msgid "State"
+msgstr ""
+
+msgid "State changes"
 msgstr ""
 
 msgid "State filter"
@@ -7516,6 +7531,9 @@ msgid "Wake On Lan"
 msgstr ""
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1002,9 +1002,6 @@ msgstr "Opções de inicialização:"
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "Nome transmissão"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2168,6 +2168,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "Por favor insira um nome de host válido"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "Tipo de impressora"
+
 msgid "Equipment Loan"
 msgstr "equipamento Loan"
 
@@ -4500,6 +4504,10 @@ msgstr "Visualizador de log"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "atualização da impressora falhou!"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4531,6 +4539,9 @@ msgstr "Bem sucedido"
 
 msgid "Logout"
 msgstr "Sair"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "MAC"
@@ -6143,6 +6154,9 @@ msgstr "Receber"
 msgid "Record not found"
 msgstr "Registro não encontrado, erro: %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7153,6 +7167,10 @@ msgstr ""
 
 msgid "State"
 msgstr "Estado"
+
+#, fuzzy
+msgid "State changes"
+msgstr "Salvar alterações"
 
 #, fuzzy
 msgid "State filter"
@@ -8850,6 +8868,9 @@ msgid "Wake On Lan"
 msgstr "Wake on LAN?"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1002,9 +1002,6 @@ msgstr "启动选项："
 msgid "Boot files from"
 msgstr ""
 
-msgid "Both"
-msgstr ""
-
 #, fuzzy
 msgid "Broadcast Address"
 msgstr "广播名称"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2168,6 +2168,10 @@ msgstr ""
 msgid "Enter a valid %s name"
 msgstr "请输入一个有效的主机名"
 
+#, fuzzy
+msgid "Entry Type"
+msgstr "打印机类型"
+
 msgid "Equipment Loan"
 msgstr "器材信贷"
 
@@ -4500,6 +4504,10 @@ msgstr "日志查看器"
 msgid "Log contents."
 msgstr ""
 
+#, fuzzy
+msgid "Log entry type filter"
+msgstr "打印机更新失败！"
+
 msgid "Log out and sign in as an administrator"
 msgstr ""
 
@@ -4531,6 +4539,9 @@ msgstr "成功"
 
 msgid "Logout"
 msgstr "登出"
+
+msgid "Logs"
+msgstr ""
 
 msgid "MAC"
 msgstr "苹果电脑"
@@ -6143,6 +6154,9 @@ msgstr "接收"
 msgid "Record not found"
 msgstr "未发现记录，错误： %s"
 
+msgid "Recorded By"
+msgstr ""
+
 msgid "Redirect Login To This Provider"
 msgstr ""
 
@@ -7153,6 +7167,10 @@ msgstr ""
 
 msgid "State"
 msgstr "州"
+
+#, fuzzy
+msgid "State changes"
+msgstr "保存更改"
 
 #, fuzzy
 msgid "State filter"
@@ -8850,6 +8868,9 @@ msgid "Wake On Lan"
 msgstr "网络唤醒？"
 
 msgid "Wake Up"
+msgstr ""
+
+msgid "Warnings"
 msgstr ""
 
 msgid "We are group ID"

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -173,6 +173,24 @@ foreach (array_unique($written[1]) as $field) {
     }
 }
 
+// 5. A failed task has to be visible somewhere. It is not an active state,
+//    so the active pane excludes it by construction, and Task Management's
+//    Recent pane is the only view of finished tasks there is -- if that pane
+//    does not list Failed, the state exists and nobody can see it.
+$page = file_get_contents($web . '/lib/pages/taskmanagement.page.php');
+if (false === strpos($page, 'self::getFailedState()')) {
+    $fails[] = "Task Management's Recent pane does not know about the Failed"
+        . ' state, so a failed task appears in no pane at all';
+}
+if (!preg_match('#\$states = \[\$complete, \$cancelled, \$failed\]#', $page)) {
+    $fails[] = 'the Recent pane\'s default state set leaves out Failed, so a'
+        . ' failed task is only found by picking a filter for it';
+}
+if (false === strpos($page, 'value="failed"')) {
+    $fails[] = 'the Recent pane offers no Failed filter, so failed tasks'
+        . ' cannot be listed on their own';
+}
+
 // 4. Guarded on the row existing. The web tree can be updated before the
 //    schema step runs, and writing a stateID with no taskStates row behind it
 //    is worse than leaving the task alone.

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -16,9 +16,8 @@
  *
  * Also pinned: the endpoint answers identically whatever happened (so it
  * cannot be used to ask whether a MAC has an active imaging task), it refuses
- * to fire an imaging event for a task that is not imaging, and it does not
- * touch the task's state -- there is no Failed state and inventing one is a
- * separate decision.
+ * to fire an imaging event for a task that is not imaging, and an error --
+ * but never a warning -- moves the task to Failed (schema 339).
  *
  * And the two destinations a report gets that are not the event: a typed
  * `taskLog` row, which is what correlates the report with the task, and
@@ -39,6 +38,18 @@ $web = $root . '/packages/web';
 
 require $web . '/commons/init.php';
 new Initiator();
+
+// Every TaskState::get*State() fires a hook so a plugin can move the number,
+// and a hook manager only exists inside a booted application. Binding a stub
+// directly is deliberate: FOGBase::_init() would drag in the database.
+$hook = new class {
+    public function processEvent($event, $data = [])
+    {
+    }
+};
+$bind = new \ReflectionProperty('FOG\FOGBase', 'HookManager');
+$bind->setAccessible(true);
+$bind->setValue(null, $hook);
 
 $fails = [];
 
@@ -132,13 +143,43 @@ if (substr_count($src, "echo '##';") !== 1) {
     $fails[] = 'the endpoint does not answer identically on every path, so the'
         . ' response says whether the MAC had an active imaging task';
 }
-// The TaskLog row carries the task's state; the TASK is what must not be
-// written. Checking for the literal set('stateID') would now match the row.
-if (false !== strpos($src, '$Task->set(')
-    || false !== strpos($src, '$Task->save(')
-) {
-    $fails[] = 'the endpoint changes the task; taskStates has no Failed and'
-        . ' choosing one is a separate decision (#1206)';
+// ------------------------------------------------------------ the state
+
+// Schema 339 gave a failed task a state of its own. Three things have to hold
+// together or the state is worse than not having it.
+
+// 1. The constant and the seeded row must agree, or a failed task points at a
+//    taskStates row that does not exist: it renders blank and cannot be
+//    filtered for.
+$failed = \FOG\TaskState::getFailedState();
+if ($failed !== 6) {
+    $fails[] = "TaskState::getFailedState() returns $failed; the schema seeds"
+        . ' tsID 6, and the two have to be the same number';
+}
+$schema = file_get_contents($web . '/commons/schema.php');
+if (!preg_match('#`taskStates`.*?VALUES.*?\(' . $failed . ",'Failed'#s", $schema)) {
+    $fails[] = "no schema step seeds taskStates row $failed as Failed, so the"
+        . ' state the endpoint writes does not exist';
+}
+
+// 2. Only the state is written. The endpoint's whole discipline is that it
+//    reports rather than decides -- writing anything else about the task
+//    would make an unauthenticated caller able to edit it.
+preg_match_all('#\$Task->set\(\s*\'([^\']+)\'#', $src, $written);
+foreach (array_unique($written[1]) as $field) {
+    if ($field !== 'stateID') {
+        $fails[] = "the endpoint writes \$Task->$field; an unauthenticated"
+            . ' report may set the task state and nothing else';
+    }
+}
+
+// 4. Guarded on the row existing. The web tree can be updated before the
+//    schema step runs, and writing a stateID with no taskStates row behind it
+//    is worse than leaving the task alone.
+if (!preg_match('#getClass\(\s*\'TaskState\'.*?isValid\(\)#s', $src)) {
+    $fails[] = 'the endpoint writes the Failed state without checking the row'
+        . ' exists, so a server updated ahead of its schema gets tasks'
+        . ' pointing at a state that is not there';
 }
 if (false === strpos($src, 'error_log(')) {
     $fails[] = 'the endpoint leaves no server-side trace of a failure';
@@ -183,6 +224,25 @@ if (false === $row || false === $imaging || $row > $imaging) {
 if (false === $warnGuard || $row > $warnGuard) {
     $fails[] = 'a warning writes no taskLog row, so the only reports FOG keeps'
         . ' are the ones that were already fatal';
+}
+
+// 3. A warning must not fail the task, and the state must be written for
+//    non-imaging tasks too -- a Memtest the host died on is just as finished
+//    as a deploy; only the notification is imaging-specific.
+$mark = strpos($src, 'self::_markFailed(');
+if (false === $mark) {
+    // Checked separately so removing the call says so, rather than reporting
+    // the two ordering failures it also produces.
+    $fails[] = 'the endpoint no longer fails the task, so a host that died'
+        . ' mid-image still shows as running and cannot be re-tasked';
+}
+if (false === $mark || false === $warnGuard || $mark < $warnGuard) {
+    $fails[] = 'a warning marks the task Failed, so a machine that carried on'
+        . ' has its task killed under it';
+}
+if (false === $mark || false === $imaging || $mark > $imaging) {
+    $fails[] = 'only imaging tasks are marked Failed, so a failed Memtest or'
+        . ' inventory task still shows as running forever';
 }
 
 // The model has to be able to hold what the endpoint writes.

--- a/tests/task-log-view.test.php
+++ b/tests/task-log-view.test.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * The task log tab has to line up with the endpoint that feeds it.
+ *
+ * taskLog has been written since 1.2 and displayed never, so the columns,
+ * the table id and the filter values had no existing consumer to keep them
+ * honest. All three fail the same silent way: DataTables asks for a key the
+ * JSON does not carry and draws a blank column, or a filter radio posts a
+ * value the endpoint's switch does not know and quietly falls back to the
+ * default -- a pane that looks like it is working and is showing the wrong
+ * rows.
+ *
+ * Usage: php tests/task-log-view.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$page = file_get_contents($web . '/lib/pages/taskmanagement.page.php');
+$js = file_get_contents(
+    $web . '/management/js/fog/task/fog.task.list.js'
+);
+
+$fails = [];
+
+// ------------------------------------------------------------- the tab
+
+if (!preg_match("#'id' => 'logs'#", $page)) {
+    $fails[] = 'Task Management has no logs tab, so nothing shows taskLog';
+}
+if (!preg_match('#logs:\s*\{[^}]*build:\s*buildLogs#s', $js)) {
+    $fails[] = 'the logs pane is not in the JS pane registry, so the tab'
+        . ' renders an empty table that never initialises';
+}
+
+// The table id is the only thing tying the rendered markup to the builder.
+preg_match("#render\(\s*12,\s*'([a-z-]+)'\s*\)#", $page, $rendered);
+$tableId = '';
+foreach (['task-logs-table'] as $expected) {
+    if (false === strpos($page, "'" . $expected . "'")
+        || false === strpos($js, '#' . $expected)
+    ) {
+        $fails[] = "the logs table id '$expected' is not used by both the pane"
+            . ' and its builder, so the grid never binds';
+    }
+    $tableId = $expected;
+}
+
+// ---------------------------------------------------------- the columns
+
+// Every key the builder asks DataTables for has to be a `dt` name the
+// endpoint emits, or that column is silently blank.
+preg_match('#function buildLogs\(.*?\n  \}#s', $js, $builder);
+preg_match_all("#\{data: '([^']+)'\}#", $builder[0] ?? '', $wanted);
+preg_match(
+    '#public function getTaskLogs\(\).*?\n    \}#s',
+    $page,
+    $endpoint
+);
+preg_match_all("#'dt' => '([^']+)'#", $endpoint[0] ?? '', $emitted);
+$have = array_flip($emitted[1]);
+if (count($wanted[1]) < 1 || count($emitted[1]) < 1) {
+    $fails[] = 'could not read the logs builder or its endpoint; the column'
+        . ' contract is unchecked';
+}
+foreach ($wanted[1] as $key) {
+    if (!isset($have[$key])) {
+        $fails[] = "the logs grid asks for '$key', which getTaskLogs() does"
+            . ' not emit, so that column draws blank';
+    }
+}
+// The render callbacks reach for these off the row rather than through
+// `data`, so they are just as load-bearing and just as silent when missing.
+foreach (['hostid', 'tasktypeicon', 'taskstateicon'] as $key) {
+    if (false === strpos($builder[0] ?? '', $key)) {
+        continue;
+    }
+    if (!isset($have[$key])) {
+        $fails[] = "a logs render callback reads row.$key, which getTaskLogs()"
+            . ' does not emit';
+    }
+}
+
+// ---------------------------------------------------------- the filters
+
+// Every radio the pane offers has to be a case the endpoint handles.
+preg_match('#private function _logsPane\(\).*?\n    \}#s', $page, $pane);
+preg_match_all("#'([a-z]+)' => _\(#", $pane[0] ?? '', $offered);
+preg_match_all("#case '([a-z]+)':#", $endpoint[0] ?? '', $handled);
+$handledSet = array_flip($handled[1]);
+// 'reports' is the default arm, so it is deliberately not a case.
+$handledSet['reports'] = true;
+foreach ($offered[1] as $value) {
+    if (!isset($handledSet[$value])) {
+        $fails[] = "the logs pane offers a '$value' filter that getTaskLogs()"
+            . ' does not handle, so picking it silently shows the default';
+    }
+}
+if (count($offered[1]) < 2) {
+    $fails[] = 'could not read the logs filter list; the filter contract is'
+        . ' unchecked';
+}
+
+// The default must be the reports, not everything: state rows outnumber
+// them several-fold and would bury the thing the tab exists to show.
+if (!preg_match("#value=' \. \\\$value \. '\"'\s*\.\s*' autocomplete=\"off\"'\s*\.\s*\(\\\$value == 'reports' \? ' checked' : ''\)#s", $pane[0] ?? '')
+    && false === strpos($pane[0] ?? '', "\$value == 'reports' ? ' checked'")
+) {
+    $fails[] = 'the logs pane does not default to reports, so FOS reports are'
+        . ' buried under one state row per task transition';
+}
+if (!preg_match('#default:\s*\$types = \$reports;#', $endpoint[0] ?? '')) {
+    $fails[] = 'getTaskLogs() does not default to reports, so the pane and the'
+        . ' endpoint disagree about what is selected on arrival';
+}
+
+if ($fails) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo "  - $f\n";
+    }
+    exit(1);
+}
+echo "ok: the task log tab and its endpoint agree\n";
+exit(0);


### PR DESCRIPTION
Follow-up to #1207 / #1208. FOS reports an error, FOG records it — and then nothing about the system changed: the task stayed where it was, and the row it wrote landed in a table nothing has ever displayed.

Two commits, one job: make a FOS failure something you can see.

## 1. A Failed task state (schema 339)

A task the host died on stayed Queued or In-Progress forever. `Host::loadTask()` and `Host::getActiveTaskCount()` count those states as live, so the host could not be re-tasked until somebody noticed and cancelled the task by hand.

- `taskStates` row 6, **Failed** — "Host reported that the task could not be completed."
- `TaskState::getFailedState()`, with a `FAILED_STATE` hook like every other state getter, plus the `FOGBase` passthrough its five siblings already have
- `TaskError` moves the task to it on an **error**. A **warning** never does — a warning means FOS carried on.

Not Cancelled, which was the alternative: Cancelled means an administrator stopped it, and losing the difference between "somebody stopped this" and "this broke" costs the operator the one fact they open the task list to find.

Adding a sixth state is additive because every "is this task live" test in the tree is an **allowlist** — `getQueuedStates()` plus `getProgressState()` — so a state nobody listed is inactive by construction. Complete and Cancelled rows already persist in `tasks` (20 and 33 of them on the reference install), so a Failed row lingering is existing behavior, not new litter.

The state is written for **every task type**, not just imaging ones — a Memtest the host died on is as finished as a deploy. Only `HOST_IMAGE_FAIL` stays imaging-specific. `_markFailed()` is guarded on the `taskStates` row existing, so a web tree updated ahead of its database leaves the task alone rather than pointing it at a state that is not there. Apart from `stateID` the endpoint writes nothing about the task — it is unauthenticated, matched by MAC like every FOS endpoint, so what it may change stays a list of one.

**Recent pane:** the state would otherwise be invisible — not active, and Recent asked for Complete and Cancelled only. Its filter becomes All / Complete / Cancelled / Failed with Failed in the default. (`both` → `all`, since a two-way label was about to start lying; the endpoint still reads any unrecognised value as all-of-them.)

## 2. A tab that shows the task log

`taskLog` has been written since 1.2 and displayed never. Schema 338 started putting FOS report text in the same table, so the message a machine sends when a deploy dies was being stored and shown to nobody.

New **Logs** tab on Task Management: time, host, task type, state at the time, entry type, message, recorded by. Errors and warnings are badged, because the type is what tells you whether the machine stopped or carried on. Defaults to reports — state rows outnumber them several-fold and would bury the thing the tab exists to surface — with All / Errors / Warnings / State changes one click away.

Read through a derived table: `taskLog` and `tasks` both carry `taskID` and `taskStateID`, and `complex()` builds its select list as bare backticked names, so an unqualified name across that join is ambiguous and the query dies. Aliasing inside the subquery gives every column a name of its own; MariaDB merges a derived table with no aggregate in it.

`FOG_BCACHE_VER` bumped — `fog.task.list.js` changed.

## Verification

Against an **isolated** copy of this server's database (podman MariaDB on :13306, shadow web tree, throwaway host on a locally-administered MAC — nothing live was touched):

| case | result |
|---|---|
| error on a deploy task | state → 6, `getActiveTaskCount()` → 0, `loadTask()` invalid |
| error on a wipe task (non-imaging) | state → 6 |
| warning | state stays Queued, `taskLog` row typed `warning` |
| every endpoint path, unknown MAC included | identical `##` body |
| step 339 run twice | converges, `taskStates` still 6 rows |
| Recent pane's own WHERE | 54 rows where the old one returned 53 |
| `getTaskLogs()` through `complex()` | correct row shape, joins resolving host name and both icons |
| each log filter's WHERE | 2 reports / 1 error / 1 warning / 52 state / 54 all |

Ten new assertions across `tests/task-error-report.test.php` and the new `tests/task-log-view.test.php`, every one mutation-tested. Full suite green (56 files).

## Downstream

None — no route classes added or removed.