### PR TITLE
Give a task the host died on a state of its own (schema 281)

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4021,3 +4021,27 @@ $this->schema[] = array(
         return true;
     },
 );
+// 281
+$this->schema[] = array(
+    // A task the host reported dead on gets a state of its own. Ported from
+    // 1.6 schema 339 (GH-1206/#1211), following step 280 which gave taskLog
+    // somewhere to record the report in the first place.
+    //
+    // Until now such a task stayed Queued or In-Progress forever: the report
+    // was recorded, but the task list still said the machine was working on
+    // it, and the host could not be re-tasked because it still held an
+    // active task. Somebody had to notice and cancel it by hand.
+    //
+    // Not reusing Cancelled (5), which was the alternative. Cancelled means
+    // an administrator stopped it; losing the difference between "somebody
+    // stopped this" and "this broke" costs the operator the one fact they are
+    // looking at the task list to find.
+    //
+    // INSERT IGNORE, so a re-run converges and a server that somehow already
+    // has a row 6 keeps whatever it has rather than having it rewritten.
+    "INSERT IGNORE INTO `taskStates` "
+    . "(`tsID`,`tsName`,`tsDescription`,`tsOrder`,`tsIcon`) "
+    . "VALUES "
+    . "(6,'Failed','Host reported that the task could not be completed.',"
+    . "6,'exclamation-triangle')",
+);

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -2331,6 +2331,15 @@ abstract class FOGBase
         return TaskState::getCancelledState();
     }
     /**
+     * Get failed state id.
+     *
+     * @return int
+     */
+    public static function getFailedState()
+    {
+        return TaskState::getFailedState();
+    }
+    /**
      * Safe min() over a collection that may be empty.
      *
      * PHP 8's min()/max() throw an uncaught ValueError on an empty array

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -54,7 +54,7 @@ class System
     {
         self::_versionCompare();
         define('FOG_VERSION', '1.5.10.2294');
-        define('FOG_SCHEMA', 280);
+        define('FOG_SCHEMA', 281);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/taskstate.class.php
+++ b/packages/web/lib/fog/taskstate.class.php
@@ -146,4 +146,35 @@ class TaskState extends FOGController
             );
         return $cancelledState;
     }
+    /**
+     * Gets the literal failed state
+     *
+     * Added at schema 281. Until then a task the host had died on stayed
+     * Queued or In-Progress forever: the report was recorded (GH-1206) but
+     * the task list still said the machine was working on it, and the host
+     * could not be re-tasked because it still held an active task.
+     *
+     * Not Cancelled, which was the alternative and is the one thing this
+     * must not be confused with -- Cancelled means an administrator stopped
+     * it. Losing the difference between "somebody stopped this" and "this
+     * broke" is exactly the distinction an operator needs at the moment
+     * they are looking at the task list.
+     *
+     * Adding a sixth state is safe here because every "is this task live"
+     * test in the tree is an ALLOWLIST -- Host::loadTask() and the task
+     * page both ask for getQueuedStates() plus getProgressState() -- so a
+     * state nobody listed is inactive by construction.
+     *
+     * @return int
+     */
+    public static function getFailedState()
+    {
+        $failedState = 6;
+        self::$HookManager
+            ->processEvent(
+                'FAILED_STATE',
+                array('failedState' => &$failedState)
+            );
+        return $failedState;
+    }
 }

--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -20,7 +20,7 @@
  * that POST reaches a 404 and 1.5 keeps the behaviour it has had since the
  * beginning -- a machine that stops mid-image and says nothing to anyone.
  *
- * A report lands in three places, none of which is the task's state:
+ * A report lands in four places:
  *
  *   a `taskLog` row, typed 'error' or 'warning', with the text in it. This
  *     is the one that is correlated with the task -- it carries taskID and
@@ -28,18 +28,20 @@
  *   FOG's own log file, /var/log/fog/fos/fosreports.log, which the Log
  *     Viewer lists like any other because 'fos' was added to the three
  *     places 1.5 keeps its log directory lists;
+ *   the task's state, which an error moves to Failed (schema 281). A
+ *     warning never does -- a warning means FOS carried on;
  *   HOST_IMAGE_FAIL, so the notification plugins fire -- errors only, and
  *     imaging tasks only.
  *
- * Deliberately narrow in the one way that matters: it does NOT change the
- * task's state. There is no Failed state in taskStates -- the five are
- * Queued, Checked In, In-Progress, Complete, Cancelled -- and the two ways of
- * not adding one are both wrong on their own terms: reusing Cancelled loses
- * the difference between "an admin stopped this" and "this broke", and adding
- * a sixth means every place that enumerates states has to learn about it or a
- * failed task becomes invisible to it. That is a decision with UI and API
- * consequences, and it is even less of a thing to take on a maintenance
- * branch than on 1.6, where it is tracked on GH-1206.
+ * The state is written for every task type, not just imaging ones: a Memtest
+ * the host died on is as finished as a deploy. Only the notification is
+ * imaging-specific. See TaskState::getFailedState() for why this is a sixth
+ * state rather than Cancelled, and why adding one did not mean editing the
+ * places that enumerate states -- every one of them is an allowlist.
+ *
+ * Apart from that one field it writes nothing about the task. The endpoint is
+ * unauthenticated -- it is matched to a host by MAC, the way every FOS
+ * endpoint is -- so what it may change has to stay a list of one.
  *
  * @category TaskError
  * @package  FOGProject
@@ -142,6 +144,11 @@ class TaskError extends FOGBase
                 // gets told that something did.
                 return;
             }
+            // The task is finished, whatever kind it was. A Memtest or an
+            // inventory task the host died on is just as over as a deploy;
+            // only the NOTIFICATION below is imaging-specific, so the state
+            // is written before that gate rather than behind it.
+            self::_markFailed($Task);
             // HOST_IMAGE_FAIL is an imaging event, and this endpoint is
             // reachable from a wipe or an inventory task too. The row and the
             // log line above are written either way, so a non-imaging failure
@@ -190,6 +197,28 @@ class TaskError extends FOGBase
          */
         echo '##';
         exit;
+    }
+    /**
+     * Moves the task to the Failed state.
+     *
+     * Guarded on the row actually existing rather than assuming schema 281
+     * has run. A web tree can be updated ahead of its database -- that is the
+     * ordinary state of an install between the files landing and the admin
+     * loading a page -- and pointing a task at a taskStates row that is not
+     * there renders blank and cannot be filtered for, which is worse than
+     * leaving the task where it was for a few minutes.
+     *
+     * @param Task $Task the task the report arrived for
+     *
+     * @return void
+     */
+    private static function _markFailed($Task)
+    {
+        $failed = TaskState::getFailedState();
+        if (!self::getClass('TaskState', $failed)->isValid()) {
+            return;
+        }
+        $Task->set('stateID', $failed)->save();
     }
     /**
      * Writes the report against the task.

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -157,11 +157,62 @@ if (substr_count($src, "echo '##';") !== 1) {
     $fails[] = 'the endpoint does not answer identically on every path, so the'
         . ' response says whether the MAC had an active imaging task';
 }
-if (false !== strpos($src, '$Task->set(')
-    || false !== strpos($src, '$Task->save(')
+
+// ------------------------------------------------------------- the state
+
+// Schema 281 gave a failed task a state of its own. Read out of the source
+// rather than called: this file stubs FOGBase so the class can be included
+// without a database, and TaskState needs a hook manager.
+$stateSrc = file_get_contents($web . '/lib/fog/taskstate.class.php');
+if (!preg_match('#function getFailedState\(\).*?\$failedState = (\d+);#s', $stateSrc, $m)) {
+    $fails[] = 'TaskState has no getFailedState(), so the endpoint has no'
+        . ' state to move a dead task to';
+    $failed = 0;
+} else {
+    $failed = (int) $m[1];
+}
+$schema = file_get_contents($web . '/commons/schema.php');
+if (!$failed
+    || !preg_match('#`taskStates`.*?VALUES.*?\(' . $failed . ",'Failed'#s", $schema)
 ) {
-    $fails[] = 'the endpoint changes the task; taskStates has no Failed and'
-        . ' choosing one is a separate decision';
+    $fails[] = "no schema step seeds taskStates row $failed as Failed, so the"
+        . ' state the endpoint writes does not exist';
+}
+
+// Only the state is written. The endpoint's whole discipline is that it
+// reports rather than decides -- writing anything else about the task would
+// make an unauthenticated caller able to edit it.
+preg_match_all('#\$Task->set\(\s*\'([^\']+)\'#', $src, $written);
+foreach (array_unique($written[1]) as $field) {
+    if ($field !== 'stateID') {
+        $fails[] = "the endpoint writes \$Task->$field; an unauthenticated"
+            . ' report may set the task state and nothing else';
+    }
+}
+
+$mark = strpos($src, 'self::_markFailed(');
+if (false === $mark) {
+    $fails[] = 'the endpoint no longer fails the task, so a host that died'
+        . ' mid-image still shows as running and cannot be re-tasked';
+}
+// A warning must not fail the task, and the state must be written for
+// non-imaging tasks too -- a Memtest the host died on is just as finished as
+// a deploy; only the notification is imaging-specific.
+if (false === $mark || false === $warnGuard || $mark < $warnGuard) {
+    $fails[] = 'a warning marks the task Failed, so a machine that carried on'
+        . ' has its task killed under it';
+}
+if (false === $mark || false === $imaging || $mark > $imaging) {
+    $fails[] = 'only imaging tasks are marked Failed, so a failed Memtest or'
+        . ' inventory task still shows as running forever';
+}
+// Guarded on the row existing: a web tree can be updated ahead of its
+// database, and a stateID with no taskStates row behind it is worse than
+// leaving the task alone.
+if (!preg_match('#getClass\(\s*\'TaskState\'.*?isValid\(\)#s', $src)) {
+    $fails[] = 'the endpoint writes the Failed state without checking the row'
+        . ' exists, so a server updated ahead of its schema gets tasks'
+        . ' pointing at a state that is not there';
 }
 if (false === strpos($src, 'error_log(')) {
     $fails[] = 'the endpoint leaves no fallback trace when the log file is'


### PR DESCRIPTION
Port of #1211, completing #1210. Independent of anything else open — different base.

## The problem

A FOS error report is recorded on 1.5 since #1210, and the task itself was left exactly where it was: Queued or In-Progress, forever. `Host::loadTask()` and `Host::getActiveTaskCount()` count those states as live, so the host could not be re-tasked until somebody noticed and cancelled the task by hand.

## The change

- `taskStates` row 6, **Failed** (schema 281)
- `TaskState::getFailedState()` with a `FAILED_STATE` hook, plus the `FOGBase` passthrough its five siblings already have
- `TaskError` moves the task to it on an **error**; a **warning** never does

Not Cancelled: that means an administrator stopped it, and losing the difference between "somebody stopped this" and "this broke" costs the operator the one fact they open the task list to find.

**Why this is portable to a maintenance branch at all:** every "is this task live" test in the tree is an *allowlist* — `getQueuedStates()` plus `getProgressState()` — so a state nobody listed is inactive by construction and no call site had to learn about it. 1.5 has no history pane, so a Failed task is exactly as invisible in the UI as a Complete or Cancelled one already is; what changes is that the host is free and the task has stopped claiming otherwise. (1.6 got a Recent-pane filter and a task log tab in #1211; neither of those panes exists here.)

The state is written for every task type — a Memtest the host died on is as finished as a deploy — while `HOST_IMAGE_FAIL` stays imaging-specific. `_markFailed()` is guarded on the `taskStates` row existing, so a web tree updated ahead of its database leaves the task alone rather than pointing it at a state that is not there.

## Verification

Against an **isolated** copy of the real 1.5 database (podman MariaDB on :13306, shadow web tree, throwaway host on a locally-administered MAC, 2079 real hosts — nothing live touched):

| case | result |
|---|---|
| warning | task stays Queued, `taskLog` row typed `warning` |
| error | task → 6, `getActiveTaskCount()` → 0, `loadTask()` invalid |
| error / warning / unknown MAC | identical `##` body |
| step 281 on a database at schema 278 | applies clean |

Seven assertions mutation-tested (wrong constant, unseeded row, call removed, call moved either side of both gates, a second field written, guard removed). Full suite green.