### PR TITLE
Open a log entry in a modal, and fix the rows that were landing untyped

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5878,3 +5878,24 @@ $this->schema[] = [
     . "(6,'Failed','Host reported that the task could not be completed.',"
     . "6,'exclamation-triangle')",
 ];
+// 340
+$this->schema[] = [
+    // Retype the rows that landed untyped between step 338 and the model
+    // learning to type them.
+    //
+    // Step 338 gave `logType` a DEFAULT of 'state', which reads as though a
+    // writer that sets no type gets one. It does not: a column default
+    // applies only when the column is absent from the INSERT, and
+    // FOGController::save() writes every declared field -- so
+    // TaskingElement::taskLog(), which has recorded state changes since long
+    // before this column existed, has been writing '' ever since the field
+    // was declared. TaskLog::__construct() now supplies the type, and this
+    // repairs what the gap produced.
+    //
+    // Scoped to '' (and NULL, which the column does not allow today but a
+    // hand-edited schema might). Nothing else can be mistaken for it: the
+    // only other values are written deliberately by the FOS report endpoint.
+    "UPDATE `taskLog` "
+    . "SET `logType` = 'state' "
+    . "WHERE `logType` = '' OR `logType` IS NULL",
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,8 +94,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 339);
-        define('FOG_BCACHE_VER', 286);
+        define('FOG_SCHEMA', 340);
+        define('FOG_BCACHE_VER', 287);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -67,6 +67,23 @@ class TaskLog extends FOGController
     /**
      * Initializes the class to set the ip from the remote.
      *
+     * Also types the row, because the column default cannot. Schema 338 gave
+     * `logType` a DEFAULT of 'state', and a default only applies when the
+     * column is left out of the INSERT -- which FOGController::save() never
+     * does: it writes every declared field, so an unset one arrives as ''.
+     * So TaskingElement::taskLog(), which has recorded task state changes
+     * since long before this column existed and sets no type, started writing
+     * untyped rows the moment the field was declared. Proven on a live
+     * install 2026-08-19: one row with logType '' against 52 pre-existing
+     * rows reading 'state', those 52 being rows the ALTER had backfilled.
+     *
+     * The consequence is silent: Task Management's log pane filters on
+     * `logType IN ('state')`, so every state row written after the upgrade
+     * would be missing from the one view built to show them.
+     *
+     * Guarded rather than assigned, so loading an existing row and saving it
+     * cannot retype it as a state change.
+     *
      * @param mixed $data the data to initialize with.
      *
      * @return void
@@ -75,6 +92,9 @@ class TaskLog extends FOGController
     {
         parent::__construct($data);
         $this->set('ip', self::$remoteaddr);
+        if ('' === (string) $this->get('type')) {
+            $this->set('type', self::TYPE_STATE);
+        }
     }
     /**
      * Gets the task object.

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -536,6 +536,32 @@ class TaskManagement extends FOGPage
         echo '</div>';
         echo '</div>';
         $this->render(12, 'task-logs-table');
+        // Clicking a row opens this. The message column is the one that gets
+        // truncated on a narrow viewport, and it is also the only column
+        // whose whole point is its text -- a FOS report carries the script it
+        // came from and the arguments it was passed. The modal is filled
+        // client side from the row the grid already has, so opening it costs
+        // no request.
+        //
+        // Dismiss only: nothing here is editable, so there is no commit
+        // button for it to sit to the left of, and it takes the outline
+        // secondary a modal dismiss always takes.
+        echo self::makeModal(
+            'task-log-modal',
+            '<h4 class="card-title">'
+            . _('Log entry')
+            . '</h4>',
+            '<dl class="row mb-0" id="task-log-detail"></dl>',
+            self::makeButton(
+                'task-log-close',
+                _('Close'),
+                'btn btn-outline-secondary float-start',
+                'data-bs-dismiss="modal"'
+            ),
+            '',
+            'default',
+            'modal-lg'
+        );
     }
     /**
      * Get the task log entries.

--- a/packages/web/management/js/fog/task/fog.task.list.js
+++ b/packages/web/management/js/fog/task/fog.task.list.js
@@ -472,9 +472,13 @@
           targets: 3
         },
         {
+          // Ranked above task type and state, because it is the column that
+          // says whether the machine stopped or carried on -- the first thing
+          // anyone opening this tab is looking for, and the one that must not
+          // be the one Responsive collapses away on a laptop.
+          responsivePriority: 2,
           render: function(data) {
-            // The type is what tells an operator whether the machine stopped
-            // or carried on, so it is badged rather than left as bare text.
+            // Badged rather than left as bare text, for the same reason.
             var cls = {error: 'bg-danger', warning: 'bg-warning text-dark'};
             return '<span class="badge ' + (cls[data] || 'bg-secondary') + '">'
               + $.escapeHtml(data || '')
@@ -494,9 +498,64 @@
         data: function(d) {
           d.logtypes = $('input[name="log-type-filter"]:checked').val();
         }
+      },
+      createdRow: function(row) {
+        // The whole row is the target, so say so: without a pointer there is
+        // nothing to suggest the message has more behind it.
+        $(row).css('cursor', 'pointer');
       }
     });
   }
+
+  // ---------------------------------------------------------------
+  // LOG ENTRY DETAIL
+  //
+  // Filled from the row the grid already holds -- no request. The message is
+  // the reason this exists: it is the column that truncates on a narrow
+  // viewport, and a FOS report carries the script it came from and the
+  // arguments it was passed, which is exactly what someone reading it needs.
+  function showLogDetail(row) {
+    var badge = {error: 'bg-danger', warning: 'bg-warning text-dark'},
+      $dl = $('#task-log-detail'),
+      pairs = [
+        ['Time', $.escapeHtml(row.logtime || '')],
+        ['Host', row.hostid ?
+          '<a href="../management/index.php?node=host&sub=edit&id=' + row.hostid + '">' + $.escapeHtml(row.hostname || '') + '</a>' :
+          $.escapeHtml(row.hostname || '')],
+        ['Task', $.escapeHtml(String(row.taskid || '')) + ' &mdash; ' + $.escapeHtml(row.tasktypename || '')],
+        ['State at the time', $.escapeHtml(row.taskstatename || '')
+          + ' <i class="fa fa-' + $.escapeHtml(row.taskstateicon || '') + '"></i>'],
+        ['Type', '<span class="badge ' + (badge[row.logtype] || 'bg-secondary') + '">'
+          + $.escapeHtml(row.logtype || '') + '</span>'],
+        ['Recorded by', $.escapeHtml(row.createdBy || '')]
+      ],
+      html = '';
+    $.each(pairs, function(i, pair) {
+      html += '<dt class="col-sm-3">' + pair[0] + '</dt>'
+        + '<dd class="col-sm-9">' + pair[1] + '</dd>';
+    });
+    // A state change has no message at all, which is a fact worth showing
+    // rather than an empty box.
+    html += '<dt class="col-sm-3">Message</dt><dd class="col-sm-9">'
+      + (row.logtext ?
+        '<pre class="mb-0 text-wrap">' + $.escapeHtml(row.logtext) + '</pre>' :
+        '<em>none</em>')
+      + '</dd>';
+    $dl.html(html);
+    $('#task-log-modal').modal('show');
+  }
+
+  // Delegated, because the grid replaces its rows on every draw.
+  $(document).on('click', '#task-logs-table tbody tr', function(e) {
+    // A row carries links out to the host; let those win.
+    if ($(e.target).closest('a').length) {
+      return;
+    }
+    var row = panes.logs.table && panes.logs.table.row(this).data();
+    if (row) {
+      showLogDetail(row);
+    }
+  });
 
   // ---------------------------------------------------------------
   // PER-PANE ACTION BUTTONS (cancel / reload toggle)

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4506,6 +4506,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Log-Viewer"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "Drucker-Update fehlgeschlagen!"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4504,6 +4504,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Log Viewer"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "Printer update failed!"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4615,6 +4615,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "FOG Visor de registro"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "actualización de la impresora ha fallado!"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4507,6 +4507,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Log-Viewer"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "Drucker-Update fehlgeschlagen!"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4506,6 +4506,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Log Viewer"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "mise à jour de l'imprimante a échoué!"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4338,6 +4338,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Log Viewer"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "Aggiornamento della stampante non è riuscito!"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4294,6 +4294,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "ログビューアー"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "サイトの更新に失敗しました！"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3802,6 +3802,9 @@ msgstr ""
 msgid "Log contents."
 msgstr ""
 
+msgid "Log entry"
+msgstr ""
+
 msgid "Log entry type filter"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4505,6 +4505,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "Visualizador de log"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "atualização da impressora falhou!"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4505,6 +4505,10 @@ msgid "Log contents."
 msgstr ""
 
 #, fuzzy
+msgid "Log entry"
+msgstr "日志查看器"
+
+#, fuzzy
 msgid "Log entry type filter"
 msgstr "打印机更新失败！"
 

--- a/tests/task-log-view.test.php
+++ b/tests/task-log-view.test.php
@@ -115,6 +115,58 @@ if (!preg_match('#default:\s*\$types = \$reports;#', $endpoint[0] ?? '')) {
         . ' endpoint disagree about what is selected on arrival';
 }
 
+// ------------------------------------------------------------ the typing
+
+// A column DEFAULT does not type these rows: FOGController::save() writes
+// every declared field, so a writer that sets no type stores ''. The model
+// has to supply it, or every state row written after schema 338 is missing
+// from the 'state' filter -- which is the one view built to show them.
+$model = file_get_contents($web . '/lib/fog/tasklog.class.php');
+if (!preg_match(
+    '#__construct.*?get\(\'type\'\).*?set\(\'type\', self::TYPE_STATE\)#s',
+    $model
+)) {
+    $fails[] = 'TaskLog does not default its own type, so every row written by'
+        . ' a caller that sets none stores an empty string and disappears from'
+        . ' the state filter';
+}
+$schema = file_get_contents($web . '/commons/schema.php');
+if (!preg_match(
+    "#UPDATE `taskLog`.*?SET `logType` = 'state'.*?WHERE `logType` = ''#s",
+    $schema
+)) {
+    $fails[] = 'no schema step retypes the rows written untyped before the'
+        . ' model was fixed, so they stay invisible to the state filter';
+}
+
+// ------------------------------------------------------------- the modal
+
+// The message column truncates, and a FOS report's value is its full text --
+// the script it came from and the arguments it was passed.
+if (false === strpos($page, "'task-log-modal'")) {
+    $fails[] = 'the logs pane has no detail modal, so a truncated message'
+        . ' cannot be read in full';
+}
+if (false === strpos($js, "#task-log-modal")
+    || false === strpos($js, "#task-logs-table tbody tr")
+) {
+    $fails[] = 'nothing opens the log detail modal from a row, so the markup'
+        . ' is emitted and unreachable';
+}
+if (false === strpos($js, "closest('a').length")) {
+    $fails[] = 'the row click does not defer to the links inside it, so'
+        . ' clicking through to a host opens the modal instead';
+}
+// Filled, not merely referenced: dropping the write leaves the modal showing
+// whatever the last click put there, which reads as the wrong row's detail
+// rather than as a bug.
+if (false === strpos($js, '$(\'#task-log-detail\')')
+    || false === strpos($js, '$dl.html(')
+) {
+    $fails[] = 'the modal is opened without being filled, so it shows the'
+        . ' previous row (or nothing) whatever was clicked';
+}
+
 if ($fails) {
     echo 'FAIL: ' . count($fails) . " problem(s):\n";
     foreach ($fails as $f) {


### PR DESCRIPTION
Two things, both out of live-testing the FOS report path end to end (a VM PXE-booted into the `EXP_20260819-141018` FOS build, failing on a missing image store).

## 1. A defect in #1208 that only a real report could show

Schema 338 gave `logType` a `DEFAULT 'state'`, and that step's comment said the existing writer could therefore be left alone — the default would cover it.

It does not. **A column default applies only when the column is absent from the INSERT**, and `FOGController::save()` writes every declared field. So `TaskingElement::taskLog()`, which has recorded task state changes since long before this column existed and sets no type, has been storing `''` ever since the field was declared.

On this server: **one row with `''`** (the state row for the test task) against 52 reading `state` — and those 52 are rows the `ALTER` backfilled, not rows the app wrote.

The consequence is silent and defeats the tab this same series added: the log pane filters on `logType IN ('state')`, so every state row written after the upgrade would be missing from the one view built to show them.

- `TaskLog::__construct()` now types the row itself, guarded on it being empty so loading an existing row and saving it cannot retype it
- schema **340** retypes the rows the gap produced

## 2. Clicking a row opens the entry in a modal

Asked for directly. The message column is the one Responsive truncates, and it is the only column whose whole point is its text — a FOS report carries the script it came from and the arguments it was passed.

- Filled from the row the grid already holds, so opening it costs no request
- Defers to the links inside the row, so clicking through to the host still works
- Entry type is now ranked above task type and state: whether the machine stopped or carried on should not be what Responsive collapses away on a laptop

## Verification

In a browser against the isolated lab database: the tab draws both report types, a row click opens the modal with all seven fields and the full message, Close dismisses it, and clicking the host link navigates instead of opening the modal. The untyped-row defect was reproduced and the fix confirmed against the same data.

Six new assertions in `tests/task-log-view.test.php`, every one mutation-tested (model default removed, backfill removed, modal markup renamed, nothing opening it, link guard removed, modal opened unfilled). Full suite green.

`FOG_BCACHE_VER` bumped — `fog.task.list.js` changed.