### PR TITLE
Type the taskLog rows that were landing empty (schema 282)

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4045,3 +4045,20 @@ $this->schema[] = array(
     . "(6,'Failed','Host reported that the task could not be completed.',"
     . "6,'exclamation-triangle')",
 );
+// 282
+$this->schema[] = array(
+    // Retype the rows that landed untyped between step 280 and the model
+    // learning to type them. Ported from 1.6 schema 340 (#1213).
+    //
+    // Step 280 gave `logType` a DEFAULT of 'state', which reads as though a
+    // writer that sets no type gets one. It does not: a column default
+    // applies only when the column is absent from the INSERT, and
+    // FOGController::save() writes every declared field -- so
+    // TaskingElement::taskLog(), which has recorded state changes since long
+    // before this column existed, has been writing '' ever since the field
+    // was declared. TaskLog::__construct() now supplies the type, and this
+    // repairs what the gap produced.
+    "UPDATE `taskLog` "
+    . "SET `logType` = 'state' "
+    . "WHERE `logType` = '' OR `logType` IS NULL",
+);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -54,7 +54,7 @@ class System
     {
         self::_versionCompare();
         define('FOG_VERSION', '1.5.10.2294');
-        define('FOG_SCHEMA', 281);
+        define('FOG_SCHEMA', 282);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -93,6 +93,21 @@ class TaskLog extends FOGController
     {
         parent::__construct($data);
         $this->set('ip', self::$remoteaddr);
+        // Types the row, because the column default cannot. Schema 280 gave
+        // `logType` a DEFAULT of 'state', and a default only applies when the
+        // column is left out of the INSERT -- which FOGController::save()
+        // never does: it writes every declared field, so an unset one arrives
+        // as ''. So TaskingElement::taskLog(), which has recorded task state
+        // changes since long before this column existed and sets no type,
+        // started writing untyped rows the moment the field was declared.
+        // Found on 1.6 (#1213) against a live install; the code is the same
+        // here, so the defect is too.
+        //
+        // Guarded rather than assigned, so loading an existing row and saving
+        // it cannot retype it as a state change.
+        if ('' === (string) $this->get('type')) {
+            $this->set('type', self::TYPE_STATE);
+        }
     }
     /**
      * Gets the task object.

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -219,6 +219,27 @@ if (false === strpos($src, 'error_log(')) {
         . ' unwritable, which is every server not yet re-installed';
 }
 
+// ------------------------------------------------------------ the typing
+
+// A column DEFAULT does not type these rows: FOGController::save() writes
+// every declared field, so a writer that sets no type stores ''. The model
+// has to supply it, or every state row written after schema 280 is untyped.
+$modelSrc = file_get_contents($web . '/lib/fog/tasklog.class.php');
+if (!preg_match(
+    '#__construct.*?get\(\'type\'\).*?set\(\'type\', self::TYPE_STATE\)#s',
+    $modelSrc
+)) {
+    $fails[] = 'TaskLog does not default its own type, so every row written by'
+        . ' a caller that sets none stores an empty string';
+}
+if (!preg_match(
+    "#UPDATE `taskLog`.*?SET `logType` = 'state'.*?WHERE `logType` = ''#s",
+    $schema
+)) {
+    $fails[] = 'no schema step retypes the rows written untyped before the'
+        . ' model was fixed';
+}
+
 // ----------------------------------------------------------- the plumbing
 
 $model = file_get_contents($web . '/lib/fog/tasklog.class.php');


### PR DESCRIPTION
Port of #1213's first half. (The other half is a UI tab 1.5 does not have.)

Schema 280 gave `logType` a `DEFAULT 'state'`, and that step said the existing writer could therefore be left alone. It cannot: **a column default applies only when the column is absent from the INSERT**, and `FOGController::save()` writes every declared field — so `TaskingElement::taskLog()`, which has recorded task state changes since long before this column existed and sets no type, has been storing `''` ever since the field was declared.

Found on 1.6 against a live install, where such a row appeared the moment a task was created. The code here is identical, so the defect is too.

- `TaskLog::__construct()` types the row itself, guarded on it being empty so loading an existing row and saving it cannot retype it
- schema **282** repairs the rows the gap produced

Less visible on 1.5 than on 1.6, which has a pane that filters on the type; here it is simply the difference between a stored value that says what a row is and one that says nothing.

Two assertions, both mutation-tested. Full suite green.