### PR TITLE
Make the cancel route refuse what it cannot cancel

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -1020,8 +1020,18 @@ class OpenAPI extends FOGBase
                     $class,
                     'cancel',
                     sprintf(_('Cancel a %s task'), $class),
-                    '',
-                    self::_messageResponse()
+                    // Hand-written, because the 409 is a router decision the
+                    // generic emitter cannot see. Only cancel answers it, so
+                    // it belongs on this operation and not in the shared
+                    // _errorResponses() map every path picks up.
+                    _(
+                        'Only a task in a queued or in-progress state can be '
+                        . 'cancelled. Naming a resource whose task has already '
+                        . 'finished -- Complete, Cancelled or Failed -- answers '
+                        . '409 rather than reporting a success it did not '
+                        . 'perform.'
+                    ),
+                    self::_messageResponse() + self::_conflictResponse()
                 )
             ];
         }
@@ -1222,6 +1232,33 @@ class OpenAPI extends FOGBase
         return [
             '200' => [
                 'description' => _('Success.'),
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => ['msg' => ['type' => 'string']]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The 409 the cancel route answers when the named resource is not in a
+     * cancellable state.
+     *
+     * Carries the same {msg} object the 200 does, rather than the Error
+     * schema: the reason is written for a person, and the UI reads it with
+     * the same $.notifyFromAPI() call either way.
+     *
+     * @return array
+     */
+    private static function _conflictResponse()
+    {
+        return [
+            '409' => [
+                'description' => _('The resource is not in a cancellable state.'),
                 'content' => [
                     'application/json' => [
                         'schema' => [

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -3636,6 +3636,15 @@ class Route extends FOGBase
         try {
             $classname = strtolower($class);
             $class = new $class($id);
+            // The states a task can be cancelled FROM. This is the same
+            // allowlist every "is this task live" test in the tree uses --
+            // Host::loadTask() and getActiveTaskCount() both ask for exactly
+            // it -- so anything outside it is already finished: Complete,
+            // Cancelled, and Failed since schema 339.
+            $states = self::fastmerge(
+                (array)self::getQueuedStates(),
+                (array)self::getProgressState()
+            );
             switch ($classname) {
                 case 'group':
                     if (!$class->isValid()) {
@@ -3643,21 +3652,38 @@ class Route extends FOGBase
                             HTTPResponseCodes::HTTP_NOT_FOUND
                         );
                     }
-                    Route::listem(
+                    // Read ids, filtered by state, rather than paging through
+                    // listem(). Two separate faults lived in that call:
+                    //
+                    //  - It passed NO state filter, and every row that came
+                    //    back was cancelled regardless of state. The listing
+                    //    is not state-scoped either: the same host filter
+                    //    matches 29 rows for group 2 on the development
+                    //    server, none of them active. How much of that a real
+                    //    bodyless DELETE actually reached could not be
+                    //    reproduced outside a browser session -- listem()
+                    //    returns nothing at all to a CLI harness -- so treat
+                    //    29 as the exposure, not as a measured outcome.
+                    //  - listem() returns a PAGINATED envelope, so the work
+                    //    was bounded by a page either way. (Iterating the
+                    //    envelope rather than ->data once cancelled nothing at
+                    //    all -- that half was already fixed.)
+                    //
+                    // TaskManager::cancel() is the established bulk path and
+                    // re-applies the same state filter itself.
+                    $taskIDs = self::getIds(
                         'task',
-                        ['hostID' => $class->get('hosts')]
+                        [
+                            'hostID' => $class->get('hosts'),
+                            'stateID' => $states
+                        ]
                     );
-                    $Tasks = json_decode(
-                        Route::getData()
-                    );
-                    // ->data, not the envelope: listem() returns the paginated
-                    // wrapper. Iterating the wrapper walked its own scalar
-                    // members, so $Task->id was null on every pass and this
-                    // cancelled nothing at all -- cancelling a group's tasks
-                    // reported success and left every task running.
-                    foreach ($Tasks->data as $Task) {
-                        self::getClass('Task', $Task->id)->cancel();
+                    if (count($taskIDs) < 1) {
+                        self::_notCancellable(
+                            _('No active tasks to cancel for this group')
+                        );
                     }
+                    self::getClass('TaskManager')->cancel($taskIDs);
                     break;
                 case 'host':
                     if (!$class->isValid()) {
@@ -3665,25 +3691,90 @@ class Route extends FOGBase
                             HTTPResponseCodes::HTTP_NOT_FOUND
                         );
                     }
-                    if ($class->get('task') instanceof Task) {
-                        $class->get('task')->cancel();
+                    // isValid(), not instanceof. Host::loadTask() sets this
+                    // field to `new Task(null)` when the host has nothing
+                    // running, and that IS `instanceof Task` -- so the old
+                    // test was true unconditionally. Task::cancel() then opens
+                    // with getHost()->get('snapinjob'), and getHost() on an
+                    // empty task returns the empty STRING, so the call raised
+                    // "Call to a member function get() on string": an Error,
+                    // not an \Exception, so the catch below never saw it and
+                    // an idle host answered a bodyless 500. Reproduced against
+                    // a copy of the live database, host 154.
+                    $Task = $class->get('task');
+                    if (!($Task instanceof Task) || !$Task->isValid()) {
+                        self::_notCancellable(
+                            _('Host has no active task to cancel')
+                        );
                     }
+                    $Task->cancel();
+                    break;
+                case 'scheduledtask':
+                    // Has no stateID at all -- it carries isActive -- so it
+                    // fell into the default arm below, failed the state test
+                    // and returned 200 having done nothing. The endpoint has
+                    // therefore never cancelled a scheduled task. Its model
+                    // cancel() is a destroy(), which is what the management
+                    // page does too, and there is no state to be wrong about.
+                    if (!$class->isValid()) {
+                        self::sendResponse(
+                            HTTPResponseCodes::HTTP_NOT_FOUND
+                        );
+                    }
+                    $class->cancel();
+                    break;
+                case 'filedeletequeue':
+                    // FileDeleteQueue is the one tasking class with no model
+                    // cancel(); only the manager implements one. So a valid id
+                    // reached $class->cancel() and raised an Error -- which is
+                    // not an \Exception, so the catch below never saw it and
+                    // the caller got a bodyless 500. The daemon does set these
+                    // rows to the progress state (filedeleter.class.php), so
+                    // that is reachable, not theoretical.
+                    if (!$class->isValid()) {
+                        self::sendResponse(
+                            HTTPResponseCodes::HTTP_NOT_FOUND
+                        );
+                    }
+                    if (!in_array($class->get('stateID'), $states)) {
+                        self::_notCancellable(
+                            _('Queued deletion is not active and cannot be cancelled')
+                        );
+                    }
+                    $class->getManager()->cancel([$class->get('id')]);
                     break;
                 default:
-                    $states = self::fastmerge(
-                        (array)self::getQueuedStates(),
-                        (array)self::getProgressState()
-                    );
                     if (!$class->isValid()) {
                         $classman = $class->getManager();
                         $find = self::getsearchbody($classname);
                         $find['stateID'] = $states;
                         $ids = self::ids($classname, $find);
+                        // A search that matches nothing stays a 200. This arm
+                        // is a bulk filter, and matching no rows is a
+                        // legitimate result for one; the 409s in this method
+                        // are for a caller who named a specific resource and
+                        // is entitled to know it was not touched.
                         $classman->cancel($ids);
                     } else {
-                        if (in_array($class->get('stateID'), $states)) {
-                            $class->cancel();
+                        // Falling out of this test used to be silent: the
+                        // method returned normally and the router answered 200
+                        // "cancelled" with the state untouched. That is how a
+                        // Failed task came back from the API reporting success
+                        // and stayed Failed.
+                        if (!in_array($class->get('stateID'), $states)) {
+                            $stateName = self::getClass(
+                                'TaskState',
+                                $class->get('stateID')
+                            )->get('name');
+                            self::_notCancellable(
+                                sprintf(
+                                    '%s: %s',
+                                    _('Task is not active and cannot be cancelled'),
+                                    ($stateName ?: $class->get('stateID'))
+                                )
+                            );
                         }
+                        $class->cancel();
                     }
             }
         } catch (\Exception $e) {
@@ -3692,6 +3783,28 @@ class Route extends FOGBase
                 $e->getMessage()
             );
         }
+    }
+    /**
+     * Refuses a cancel the named resource is not in a state to accept.
+     *
+     * The body is a JSON object, not the bare reason string the older non-2xx
+     * paths in this class emit. breakHead() has always declared
+     * `Content-Type: application/json` and then echoed whatever it was given,
+     * so those replies claim a type they are not; 409 is a status no caller
+     * receives today, so it can start out matching its own header without
+     * breaking anyone. Same `{"msg": ...}` shape the 200 already uses, which
+     * is what $.notifyFromAPI() reads.
+     *
+     * @param string $msg Why the resource cannot be cancelled.
+     *
+     * @return void
+     */
+    private static function _notCancellable($msg)
+    {
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_CONFLICT,
+            json_encode(['msg' => $msg])
+        );
     }
     /**
      * Gets the json body and sets our vars.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3294,6 +3294,9 @@ msgstr "Host Aktualisierung erfolgreich!"
 msgid "Host added!"
 msgstr "Host hinzugefügt"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host ist bereits Mitglied eines aktiven Tasks"
 
@@ -4996,6 +4999,10 @@ msgstr "Kein Zugriff erlaubt"
 msgid "No active task found for this host"
 msgstr "Keinen aktiven Task gefunden für Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "Keinen aktiven Task gefunden für Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5377,6 +5384,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6118,6 +6128,10 @@ msgstr "In der Warteschlange"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7679,6 +7693,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Task finished"
 msgstr "Task gestartet"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Image ist geschützt und kann nicht gelöscht werden"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"
 
@@ -7958,6 +7976,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3295,6 +3295,9 @@ msgstr "Install / Update Successful!"
 msgid "Host added!"
 msgstr "Host added"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host is already a member of an active task"
 
@@ -4994,6 +4997,10 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr "No Active Task found for Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "No Active Task found for Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5375,6 +5382,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Error, Is an image associated with this host"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6116,6 +6126,10 @@ msgstr "Queued"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin is protected and cannot be deleted"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7675,6 +7689,10 @@ msgstr "Load failed: %s"
 msgid "Task finished"
 msgstr "Task Started"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Image is protected and cannot be deleted"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -7954,6 +7972,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3366,6 +3366,9 @@ msgstr "actualización Valoración falló"
 msgid "Host added!"
 msgstr "nombre de host"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr ""
 
@@ -5120,6 +5123,10 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr "No se encontró Clase FOGPage para este nodo"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "No se encontró Clase FOGPage para este nodo"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5508,6 +5515,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Error, es una imagen asociada con este anfitrión"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6262,6 +6272,10 @@ msgstr ""
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "está protegido, no se permite la eliminación"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7863,6 +7877,10 @@ msgstr "Carga ha fallado: %s"
 msgid "Task finished"
 msgstr "Nombre de la tarea"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "está protegido, no se permite la eliminación"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -8142,6 +8160,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3294,6 +3294,9 @@ msgstr "Host Aktualisierung erfolgreich!"
 msgid "Host added!"
 msgstr "Host hinzugefügt"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host ist bereits Mitglied eines aktiven Tasks"
 
@@ -4997,6 +5000,10 @@ msgstr "Kein Zugriff erlaubt"
 msgid "No active task found for this host"
 msgstr "Keinen aktiven Task gefunden für Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "Keinen aktiven Task gefunden für Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5378,6 +5385,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6119,6 +6129,10 @@ msgstr "In der Warteschlange"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7680,6 +7694,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Task finished"
 msgstr "Task gestartet"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Image ist geschützt und kann nicht gelöscht werden"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr "Task wird nicht erstellt, da keine zugeordneten Tasks vorhanden sind"
 
@@ -7959,6 +7977,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3297,6 +3297,9 @@ msgstr "Installation / Mise à jour réussie!"
 msgid "Host added!"
 msgstr "hôte ajouté"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host est déjà membre d'une tâche active"
 
@@ -4996,6 +4999,10 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr "Aucune tâche active trouvée pour Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "Aucune tâche active trouvée pour Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5377,6 +5384,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Erreur, est une image associée à cet hôte"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6118,6 +6128,10 @@ msgstr "Queued"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin est protégé et ne peut être supprimé"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7677,6 +7691,10 @@ msgstr "Échec du chargement: %s"
 msgid "Task finished"
 msgstr "Tâche Started"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "L'image est protégée et ne peut être supprimé"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -7956,6 +7974,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3192,6 +3192,9 @@ msgstr "Aggiornamento host completato!"
 msgid "Host added!"
 msgstr "Host aggiunto!"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host è già membro di un compito attivo"
 
@@ -4821,6 +4824,10 @@ msgstr "Nessun accesso è consentito"
 msgid "No active task found for this host"
 msgstr "Nessun compito attivo trovato per Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "Nessun compito attivo trovato per Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5186,6 +5193,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Uno o più MAC sono associati a questo host"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -5907,6 +5917,10 @@ msgstr "In coda"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin è protetto e non può essere cancellato"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7396,6 +7410,10 @@ msgstr "Caricamento non riuscito"
 msgid "Task finished"
 msgstr "Attività iniziata"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "L'immagine è protetta e non può essere cancellato"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr "Attività non creata poiché non ci sono attività associate"
 
@@ -7670,6 +7688,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3160,6 +3160,9 @@ msgstr "ホストの更新に成功しました"
 msgid "Host added!"
 msgstr "ホストを追加しました！"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "ホストは既に実行中のタスクに含まれています"
 
@@ -4773,6 +4776,10 @@ msgstr "アクセスは許可されていません"
 msgid "No active task found for this host"
 msgstr "このホストの実行中タスクは見つかりません"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "このホストの実行中タスクは見つかりません"
+
 msgid "No activity information available for this group"
 msgstr "このグループで利用可能なアクティビティ情報はありません"
 
@@ -5139,6 +5146,9 @@ msgid "One or more macs are associated with a host"
 msgstr "1 つ以上の MAC アドレスがホストに関連付けられています"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -5862,6 +5872,10 @@ msgstr "キュー済み"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "スナップインは保護されているため削除できません"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7326,6 +7340,10 @@ msgid "Task finished"
 msgstr "タスク実行に失敗しました"
 
 #, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "イメージは保護されているため削除できません"
+
+#, fuzzy
 msgid "Task not created as there are no associated Tasks"
 msgstr "関連付けられたタスクがないため、タスクは作成されませんでした"
 
@@ -7599,6 +7617,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2785,6 +2785,9 @@ msgstr ""
 msgid "Host added!"
 msgstr ""
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr ""
 
@@ -4224,6 +4227,9 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr ""
 
+msgid "No active tasks to cancel for this group"
+msgstr ""
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -4552,6 +4558,9 @@ msgid "One or more macs are associated with a host"
 msgstr ""
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -5180,6 +5189,9 @@ msgid "Queued"
 msgstr ""
 
 msgid "Queued Path Deletions"
+msgstr ""
+
+msgid "Queued deletion is not active and cannot be cancelled"
 msgstr ""
 
 msgid "RESOURCES"
@@ -6492,6 +6504,9 @@ msgstr ""
 msgid "Task finished"
 msgstr ""
 
+msgid "Task is not active and cannot be cancelled"
+msgstr ""
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -6739,6 +6754,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3296,6 +3296,9 @@ msgstr "Instalar / Atualizar sucesso!"
 msgid "Host added!"
 msgstr "hospedar acrescentou"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host já é membro de uma tarefa ativa"
 
@@ -4995,6 +4998,10 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr "Nenhuma tarefa ativa encontrada para o Host"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "Nenhuma tarefa ativa encontrada para o Host"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5376,6 +5383,9 @@ msgid "One or more macs are associated with a host"
 msgstr "Erro, é uma imagem associada com este anfitrião"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6117,6 +6127,10 @@ msgstr "Enfileiradas"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "Snapin está protegido e não pode ser excluído"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7676,6 +7690,10 @@ msgstr "Carga falhou: %s"
 msgid "Task finished"
 msgstr "tarefa iniciada"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "A imagem está protegida e não pode ser excluído"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -7955,6 +7973,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3296,6 +3296,9 @@ msgstr "安装/升级成功！"
 msgid "Host added!"
 msgstr "添加主机"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "主机已经是一个活动任务中的一员"
 
@@ -4995,6 +4998,10 @@ msgstr ""
 msgid "No active task found for this host"
 msgstr "发现主机没有活动任务"
 
+#, fuzzy
+msgid "No active tasks to cancel for this group"
+msgstr "发现主机没有活动任务"
+
 msgid "No activity information available for this group"
 msgstr ""
 
@@ -5376,6 +5383,9 @@ msgid "One or more macs are associated with a host"
 msgstr "错误，与此主机关联的图像"
 
 msgid "Online"
+msgstr ""
+
+msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6117,6 +6127,10 @@ msgstr "排队"
 
 msgid "Queued Path Deletions"
 msgstr ""
+
+#, fuzzy
+msgid "Queued deletion is not active and cannot be cancelled"
+msgstr "管理单元被保护，不能被删除"
 
 msgid "RESOURCES"
 msgstr ""
@@ -7676,6 +7690,10 @@ msgstr "加载失败： %s"
 msgid "Task finished"
 msgstr "任务开始"
 
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "图像被保护，不能被删除"
+
 msgid "Task not created as there are no associated Tasks"
 msgstr ""
 
@@ -7955,6 +7973,9 @@ msgid "The provider published no https %s"
 msgstr ""
 
 msgid "The provider returned a configuration for a different issuer"
+msgstr ""
+
+msgid "The resource is not in a cancellable state."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."

--- a/tests/cancel-route-reports-truthfully.test.php
+++ b/tests/cancel-route-reports-truthfully.test.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Route::cancel() must not report work it did not do.
+ *
+ * Every arm of this method used to have a path that returned normally --
+ * and therefore 200 -- while changing nothing, or while changing far more
+ * than was asked:
+ *
+ *  - a task in a finished state fell out of the state test and answered
+ *    "cancelled" with its state untouched (the reason this file exists: a
+ *    Failed task did exactly that);
+ *  - a group cancelled by no state filter at all and by a paginated listing,
+ *    so whatever came back was cancelled whatever state it was in -- and the
+ *    listing covers every task the member hosts have ever run;
+ *  - a host with nothing running reached Task::save() on an empty Task and
+ *    answered 406 "Required database field is empty: typeID";
+ *  - scheduledtask carries no stateID, so it failed a test it could never
+ *    pass and the endpoint never once cancelled a scheduled task;
+ *  - filedeletequeue has no model cancel(), so a valid id raised an Error,
+ *    which is not an \Exception and so escaped the catch as a bodyless 500.
+ *
+ * All five are silent in exactly the same way: the caller is told the
+ * resource was dealt with. That is what this gate pins.
+ *
+ * Usage: php tests/cancel-route-reports-truthfully.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$route = file_get_contents($web . '/lib/router/route.class.php');
+$openapi = file_get_contents($web . '/lib/fog/openapi.class.php');
+
+$fails = [];
+
+// Isolate cancel() so a match elsewhere in this 5000-line class cannot
+// stand in for the thing being tested.
+if (!preg_match(
+    '#public static function cancel\(\$class, \$id\).*?\n    \}\n#s',
+    $route,
+    $m
+)) {
+    echo "FAIL: Route::cancel() not found -- the gate cannot see its subject\n";
+    exit(1);
+}
+$cancel = $m[0];
+
+// ------------------------------------------------- the requested resource
+
+// The 409 helper, and that it is what the arms call. Reached through
+// sendResponse() directly the body would be a bare string under a JSON
+// content type, which is the older shape this deliberately does not copy.
+// Bounded to the helper's own body. An unbounded `.*?` here happily found
+// json_encode somewhere else in the 5000 lines below and passed a mutation
+// that removed it.
+if (!preg_match(
+    '#private static function _notCancellable\(\$msg\)\s*\{(.*?)\n    \}#s',
+    $route,
+    $helper
+)) {
+    $fails[] = 'Route::_notCancellable() does not exist, so the 409s are'
+        . ' hand-rolled at each call site';
+} elseif (false === strpos($helper[1], 'HTTP_CONFLICT')
+    || false === strpos($helper[1], 'json_encode')
+) {
+    $fails[] = '_notCancellable() does not answer 409 with a JSON body, so a'
+        . ' refused cancel is indistinguishable from the router\'s older'
+        . ' bare-string errors';
+}
+
+// A named task in a finished state. Without the negated test the method
+// falls through the if and returns -- 200, nothing done.
+if (!preg_match(
+    '#if \(!in_array\(\$class->get\(\'stateID\'\), \$states\)\).*?_notCancellable#s',
+    $cancel
+)) {
+    $fails[] = 'a named task outside the active states does not answer 409,'
+        . ' so cancelling a Complete/Cancelled/Failed task reports success';
+}
+
+// ------------------------------------------------------------- the group
+
+// The state filter is the whole fix. Without it the arm cancels whatever the
+// listing hands it: the same host filter matches 29 rows for group 2 on the
+// development server, none of them active.
+if (!preg_match(
+    '#case \'group\':.*?getIds\(\s*\'task\',\s*\[\s*\'hostID\'[^\]]*?\'stateID\' => \$states#s',
+    $cancel
+)) {
+    $fails[] = 'the group arm does not filter its task ids by state, so'
+        . ' cancelling a group rewrites every task its hosts ever ran';
+}
+// listem() is paginated, so it was also the reason only one page of the
+// intended work happened. Reading ids has no page.
+if (false !== strpos($cancel, 'Route::listem(')) {
+    $fails[] = 'the group arm still reads tasks through listem(), whose'
+        . ' response is a paginated envelope, so it cancels one page';
+}
+// The CONDITION, not just the presence of the refusal: pinning only the call
+// leaves `if (false) { self::_notCancellable(...) }` passing, with the
+// refusal still in the source and no longer able to happen.
+if (!preg_match('#case \'group\':(.*?)\n                    break;#s', $cancel, $grp)) {
+    $fails[] = 'the group arm is not where this gate can see it';
+} elseif (!preg_match(
+    '#if \(count\(\$taskIDs\)\s*<\s*1\)\s*\{\s*self::_notCancellable#s',
+    $grp[1]
+)) {
+    $fails[] = 'a group with no active tasks does not answer 409, so'
+        . ' cancelling an idle group reports success';
+}
+
+// --------------------------------------------------------------- the host
+
+// Host::loadTask() sets the field to `new Task(null)` when nothing is
+// running, and that IS instanceof Task -- so instanceof alone is always
+// true and proves nothing.
+if (!preg_match('#\$Task->isValid\(\)#', $cancel)) {
+    $fails[] = 'the host arm does not test the loaded task for validity, so'
+        . ' an idle host tries to save an empty Task';
+}
+
+// ------------------------------------------------- the two silent classes
+
+// scheduledtask has isActive, not stateID, so it can only ever be handled
+// by an arm of its own.
+if (!preg_match('#case \'scheduledtask\':.*?\$class->cancel\(\)#s', $cancel)) {
+    $fails[] = 'scheduledtask has no arm of its own, so it falls into the'
+        . ' state test it cannot pass and the endpoint cancels nothing';
+}
+
+// filedeletequeue is the one tasking class with no model cancel(), so the
+// manager is the only implementation there is.
+if (!preg_match(
+    '#case \'filedeletequeue\':.*?getManager\(\)->cancel\(#s',
+    $cancel
+)) {
+    $fails[] = 'filedeletequeue does not cancel through its manager, and it'
+        . ' has no model cancel() -- the call raises an uncatchable Error';
+}
+
+// ------------------------------------------------------- the bulk arm is not
+
+// The search-driven arm is a filter, and matching nothing is a legitimate
+// result for one. If this ever starts refusing, the 409 has spread from
+// "you named a thing I did not touch" to "your filter was empty", which is
+// a different and wrong contract.
+if (!preg_match(
+    '#\$find\[\'stateID\'\] = \$states;(.*?)\n                    \} else \{#s',
+    $cancel,
+    $bulk
+)) {
+    $fails[] = 'the search-driven bulk arm is not where this gate can see it,'
+        . ' so nothing checks that it still answers 200 on an empty filter';
+} elseif (false !== strpos($bulk[1], '_notCancellable')) {
+    $fails[] = 'the search-driven bulk arm now refuses an empty filter result;'
+        . ' matching no rows is a legitimate outcome for a filter, and the'
+        . ' 409 is only for a caller who named a specific resource';
+}
+
+// ------------------------------------------------------------- the document
+
+// A route that answers a status the spec does not list is a route whose
+// consumers cannot handle it. Only cancel returns 409, so it belongs on
+// that operation and not in the shared _errorResponses() map.
+if (!preg_match(
+    '#private static function _conflictResponse\(\).*?\'409\'#s',
+    $openapi
+)) {
+    $fails[] = 'openapi.class.php has no 409 response helper';
+}
+// Bounded to that one path entry, for the same reason as the helper above:
+// _conflictResponse() is defined later in this file, so an open-ended match
+// finds its own definition and passes whatever the cancel path says.
+if (!preg_match(
+    "#'/\{id\}/cancel'\] = \[(.*?)\n            \];#s",
+    $openapi,
+    $path
+)) {
+    $fails[] = 'the cancel path entry is not where this gate can see it';
+} elseif (false === strpos($path[1], '_conflictResponse()')) {
+    $fails[] = 'the cancel operation does not document its 409, so the spec'
+        . ' describes a route that always succeeds';
+}
+if (preg_match(
+    '#private static function _errorResponses\(\).*?\'409\'#s',
+    $openapi
+)) {
+    $fails[] = 'the 409 has leaked into the shared error map, so every'
+        . ' operation now claims a status only cancel can return';
+}
+
+if ($fails) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo "  - $f\n";
+    }
+    exit(1);
+}
+echo "ok: the cancel route refuses what it cannot cancel\n";
+exit(0);


### PR DESCRIPTION
`DELETE /fog/task/{id}/cancel` on a task in a finished state returned **200 `cancelled: true`** and changed nothing.

`Route::cancel()`'s default arm only acts `if (in_array($class->get('stateID'), $states))`, where `$states` is the queued + in-progress allowlist. A task outside it fell out of the `if`, the method returned normally, and the router reported success. That is how a **Failed** task — new at schema 339, and inactive *precisely because* it is not in that allowlist — came back from the API saying it had been cancelled while sitting untouched at state 6.

Found while cancelling a real one: task 64 on `fos-deploy-test`, left Failed by the FOS report field test. The API said it worked; the row still read `taskStateID 6`.

## Every arm had its own version of this

Fixing only the task case would leave the endpoint honest for one class and lying for the rest, so all of them are handled here.

| Arm | Before | After |
|---|---|---|
| named task in a finished state | 200, nothing done | **409** with the state name |
| `host` with no active task | **bodyless 500** | 409 |
| `group` | no state filter, paginated | state-filtered ids via `TaskManager::cancel()`; 409 when nothing is active |
| `scheduledtask` | 200, nothing done — **ever** | its own arm; cancels |
| `filedeletequeue` | uncatchable `Error` | goes through its manager |
| search-driven bulk | 200 on empty | **unchanged, deliberately** |

**host** — `Host::loadTask()` sets its field to `new Task(null)` when the host has nothing running, and that **is** `instanceof Task`, so the guard was true unconditionally. `Task::cancel()` opens with `getHost()->get('snapinjob')`, and `getHost()` on an empty task returns the empty *string*:

```
Uncaught Error: Call to a member function get() on string in task.class.php:272
  #0 route.class.php(3669): FOG\Task->cancel()
```

`Error` is not `\Exception`, so the `catch` below never saw it.

**group** — read tasks through `listem()` with no state filter at all and cancelled every row that came back, whatever state it was in. The same host filter matches 29 rows for group 2 on the development server, none of them active. How much of that a real bodyless `DELETE` actually reached could not be reproduced outside a browser session, so treat 29 as the exposure, not a measured outcome. Either way the arm now reads ids filtered by state and hands them to `TaskManager::cancel()` — the established bulk path, which re-applies the same filter — which also drops the pagination that bounded the work to one page.

**scheduledtask** — carries `isActive`, not `stateID`, so it failed a test it could never pass. This endpoint has never cancelled a scheduled task. Its `cancel()` is a `destroy()`, the same thing the management page does.

**filedeletequeue** — the one tasking class with no model `cancel()`. The daemon does set these rows to the progress state, so a valid id reaching `$class->cancel()` is not theoretical.

**The bulk arm stays at 200 on purpose.** It is a filter, and matching no rows is a legitimate outcome for one. The 409 is for a caller who *named* a specific resource and is entitled to know it was not touched. The test pins that distinction in both directions.

## Behaviour change

A client that fires cancel at an already-finished task used to get 200 and now gets 409. That is the point of the change, but it is a contract change and worth a look before merge.

The 409 body is JSON — `{"msg": "..."}`, the same shape the 200 uses — where the router's older non-2xx replies are a bare string under a `Content-Type` of `application/json`. 409 is a status no caller receives today, so it can start out matching its own header without breaking anyone. The existing 406 is left alone.

## Verification

Against an **isolated copy** of the live database (podman MariaDB on :13306, shadow web tree), not the live install:

```
task-finished   {"msg":"Task is not active and cannot be cancelled: Cancelled"}
host-idle       {"msg":"Host has no active task to cancel"}
group-idle      {"msg":"No active tasks to cancel for this group"}
```

All 29 of group 2's task rows byte-identical before and after every probe. The pre-fix code was run against the same database to produce the `Error` trace above.

One limit worth stating: `listem()` returns zero rows for *anything* in a CLI harness — an unfiltered task list came back empty while `getIds()` with the same filter returned 29 — so the pre-fix **group** path could not be exercised. That claim is read from the source; the host and task claims were run.

`tests/cancel-route-reports-truthfully.test.php` — eleven mutations, each reintroducing one defect, all killed. Three survived the first pass because an unbounded `.*?` ran past the region under test and matched elsewhere in the file; one because it pinned the *presence* of a refusal rather than its *condition*, so `if (false) { refuse }` passed. Both traps are fixed and commented where they bit.

Full suite: 71 passed, 0 failed.

## Spec

`openapi.class.php` documents the new status on the cancel operation only, via `_conflictResponse()`, rather than in the shared `_errorResponses()` map — no other operation can return it. The test fails if it leaks into the shared map.

## Downstream

No route class added or removed, so **FogApi**'s hardcoded class list in `Private/Get-DynmicParam.ps1` is unaffected. Its cancel calls will see the new 409.

Ported to `dev-branch` separately — 1.5 has the same silent 200 and the same empty-`Task` crash, but no `filedeletequeue` among its tasking classes and no OpenAPI document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
