### PR TITLE
Make the cancel route refuse what it cannot cancel

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1383,6 +1383,13 @@ class Route extends FOGBase
     {
         $classname = strtolower($class);
         $class = new $class($id);
+        // The states a task can be cancelled FROM. The same allowlist every
+        // "is this task live" test uses, so anything outside it -- Complete
+        // or Cancelled -- is already finished.
+        $states = self::fastmerge(
+            (array)self::getQueuedStates(),
+            (array)self::getProgressState()
+        );
         switch ($classname) {
             case 'group':
                 if (!$class->isValid()) {
@@ -1390,13 +1397,32 @@ class Route extends FOGBase
                         HTTPResponseCodes::HTTP_NOT_FOUND
                     );
                 }
+                // isValid(), not instanceof. Host::loadTask() sets this field
+                // to `new Task(null)` when the host has nothing running and
+                // that IS instanceof Task, so the test was true for every
+                // host in the group. Task::cancel() then opens with
+                // getHost()->get('snapinjob'), and getHost() on an empty task
+                // returns the empty STRING -- "Call to a member function
+                // get() on string", an Error rather than an Exception. This
+                // method has no catch at all, so one idle member killed the
+                // request outright: every host after it in the loop kept its
+                // task running, under a bodyless 500. Reproduced on the 1.6
+                // copy of this code, whose Task::cancel() is identical here.
+                $cancelled = 0;
                 foreach (self::getClass('HostManager')
                     ->find(array('id' => $class->get('hosts'))) as &$Host
                 ) {
-                    if ($Host->get('task') instanceof Task) {
-                        $Host->get('task')->cancel();
+                    $Task = $Host->get('task');
+                    if ($Task instanceof Task && $Task->isValid()) {
+                        $Task->cancel();
+                        $cancelled++;
                     }
                     unset($Host);
+                }
+                if ($cancelled < 1) {
+                    self::_notCancellable(
+                        _('No active tasks to cancel for this group')
+                    );
                 }
                 break;
             case 'host':
@@ -1405,15 +1431,31 @@ class Route extends FOGBase
                         HTTPResponseCodes::HTTP_NOT_FOUND
                     );
                 }
-                if ($class->get('task') instanceof Task) {
-                    $class->get('task')->cancel();
+                // Same empty-Task trap as the group arm above, reached one
+                // host at a time: an idle host answered a bodyless 500
+                // instead of saying it had nothing running.
+                $Task = $class->get('task');
+                if (!($Task instanceof Task) || !$Task->isValid()) {
+                    self::_notCancellable(
+                        _('Host has no active task to cancel')
+                    );
                 }
+                $Task->cancel();
+                break;
+            case 'scheduledtask':
+                // Carries isActive, not stateID, so it fell into the default
+                // arm and failed a state test it could never pass: the
+                // endpoint returned 200 and cancelled nothing, every time.
+                // Its cancel() is a destroy(), which is what the management
+                // page does, and there is no state to be wrong about.
+                if (!$class->isValid()) {
+                    self::sendResponse(
+                        HTTPResponseCodes::HTTP_NOT_FOUND
+                    );
+                }
+                $class->cancel();
                 break;
             default:
-                $states = self::fastmerge(
-                    (array)self::getQueuedStates(),
-                    (array)self::getProgressState()
-                );
                 if (!$class->isValid()) {
                     $classman = $class->getManager();
                     $find = self::getsearchbody($classname, $class);
@@ -1422,13 +1464,52 @@ class Route extends FOGBase
                         $classname,
                         $find
                     );
+                    // A search that matches nothing stays a 200. This arm is
+                    // a bulk filter and an empty result is a legitimate
+                    // outcome for one; the 409s here are for a caller who
+                    // named a specific resource.
                     $classman->cancel($ids);
                 } else {
-                    if (in_array($class->get('stateID'), $states)) {
-                        $class->cancel();
+                    // Falling out of this test used to be silent -- the
+                    // method returned normally and the caller was told the
+                    // task had been cancelled while its state sat untouched.
+                    if (!in_array($class->get('stateID'), $states)) {
+                        $stateName = self::getClass(
+                            'TaskState',
+                            $class->get('stateID')
+                        )->get('name');
+                        self::_notCancellable(
+                            sprintf(
+                                '%s: %s',
+                                _('Task is not active and cannot be cancelled'),
+                                ($stateName ? $stateName : $class->get('stateID'))
+                            )
+                        );
                     }
+                    $class->cancel();
                 }
         }
+    }
+    /**
+     * Refuses a cancel the named resource is not in a state to accept.
+     *
+     * The body is a JSON object rather than the bare reason string the older
+     * non-2xx paths here emit: breakHead() has always declared
+     * `Content-Type: application/json` and then echoed whatever it was given,
+     * so those replies claim a type they are not. 409 is a status no caller
+     * receives today, so it can start out matching its own header without
+     * breaking anyone.
+     *
+     * @param string $msg Why the resource cannot be cancelled.
+     *
+     * @return void
+     */
+    private static function _notCancellable($msg)
+    {
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_CONFLICT,
+            json_encode(array('msg' => $msg))
+        );
     }
     /**
      * Gets the json body and sets our vars.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2734,6 +2734,9 @@ msgstr "Host-Beschreibung"
 msgid "Host general"
 msgstr "Host-Kernel"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host ist bereits Mitglied eines aktiven Tasks"
 
@@ -4277,6 +4280,10 @@ msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "Keinen aktiven Task gefunden für Host"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "Keinen aktiven Task gefunden für Host"
 
 msgid "No activity information available for this group"
@@ -6390,6 +6397,10 @@ msgstr "Task-Typen"
 
 msgid "Task forced to start"
 msgstr "Task Start erzwungen"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Image ist geschützt und kann nicht gelöscht werden"
 
 msgid "Task not created as there are no associated tasks"
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2736,6 +2736,9 @@ msgstr "Host Description"
 msgid "Host general"
 msgstr "Host Kernel"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host is already a member of an active task"
 
@@ -4277,6 +4280,10 @@ msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "No Active Task found for Host"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "No Active Task found for Host"
 
 msgid "No activity information available for this group"
@@ -6388,6 +6395,10 @@ msgstr "Task Types"
 
 msgid "Task forced to start"
 msgstr "Task forced to start"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Image is protected and cannot be deleted"
 
 msgid "Task not created as there are no associated tasks"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2749,6 +2749,9 @@ msgstr "Descripción"
 msgid "Host general"
 msgstr "Equipo"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "El equipo ya es miembro de una tarea activa"
 
@@ -4296,6 +4299,10 @@ msgstr "No permitido aquí"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "No hay tareas activas para este equipo"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "No hay tareas activas para este equipo"
 
 msgid "No activity information available for this group"
@@ -6384,6 +6391,10 @@ msgstr "Tarea"
 #, fuzzy
 msgid "Task forced to start"
 msgstr "Gestión de tareas"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "Imagen protegida y no puede ser borrada"
 
 msgid "Task not created as there are no associated tasks"
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2419,6 +2419,9 @@ msgstr "Description machine"
 msgid "Host general"
 msgstr "Généralités sur la machine"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "La machine est déjà membre d'une tâche active"
 
@@ -3788,6 +3791,10 @@ msgstr "Aucun accès n'est autorisé"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "Aucune tâche active trouvée pour Host"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "Aucune tâche active trouvée pour Host"
 
 msgid "No activity information available for this group"
@@ -5640,6 +5647,10 @@ msgstr "Types de tâches"
 
 msgid "Task forced to start"
 msgstr "Tâche forcée de commencer"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "L'image est protégée et ne peut être supprimée"
 
 msgid "Task not created as there are no associated tasks"
 msgstr "Tâche non créée car il n'y a pas de tâches associées"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2480,6 +2480,9 @@ msgstr "Descrizione host"
 msgid "Host general"
 msgstr "Generale Host"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host è già membro di un compito attivo"
 
@@ -3859,6 +3862,10 @@ msgstr "Nessun accesso è consentito"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "Nessun compito attivo trovato per Host"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "Nessun compito attivo trovato per Host"
 
 msgid "No activity information available for this group"
@@ -5761,6 +5768,10 @@ msgstr "Tipi di attività"
 
 msgid "Task forced to start"
 msgstr "Task forzato a partire"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "L'immagine è protetta e non può essere cancellato"
 
 msgid "Task not created as there are no associated tasks"
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2393,6 +2393,9 @@ msgstr "ホストの説明"
 msgid "Host general"
 msgstr "ホスト全般"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "ホストは既に実行中のタスクに含まれています"
 
@@ -3750,6 +3753,10 @@ msgstr "アクセスは許可されていません"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "このホストの実行中タスクは見つかりません"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "このホストの実行中タスクは見つかりません"
 
 msgid "No activity information available for this group"
@@ -5584,6 +5591,10 @@ msgstr "タスクタイプ"
 
 msgid "Task forced to start"
 msgstr "タスクを強制開始しました"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "イメージは保護されているため削除できません"
 
 msgid "Task not created as there are no associated tasks"
 msgstr "関連付けられたタスクがないため、タスクは作成されませんでした"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2376,6 +2376,9 @@ msgstr ""
 msgid "Host general"
 msgstr ""
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr ""
 
@@ -3726,6 +3729,9 @@ msgid "No access is allowed"
 msgstr ""
 
 msgid "No active task found for this host"
+msgstr ""
+
+msgid "No active tasks to cancel for this group"
 msgstr ""
 
 msgid "No activity information available for this group"
@@ -5557,6 +5563,9 @@ msgid "Task Types"
 msgstr ""
 
 msgid "Task forced to start"
+msgstr ""
+
+msgid "Task is not active and cannot be cancelled"
 msgstr ""
 
 msgid "Task not created as there are no associated tasks"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2407,6 +2407,9 @@ msgstr "Descrição do host"
 msgid "Host general"
 msgstr "Geral do host"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "Host já é membro de uma tarefa ativa"
 
@@ -3770,6 +3773,10 @@ msgstr "Nenhum acesso é permitido"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "Nenhuma Tarefa Ativa encontrada para o Host"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "Nenhuma Tarefa Ativa encontrada para o Host"
 
 msgid "No activity information available for this group"
@@ -5611,6 +5618,10 @@ msgstr "Tipos de Tarefa"
 
 msgid "Task forced to start"
 msgstr "Tarefa forçada a iniciar"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "A imagem está protegida e não pode ser excluída"
 
 msgid "Task not created as there are no associated tasks"
 msgstr "Tarefa não criada pois não há tarefas associadas"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2407,6 +2407,9 @@ msgstr "主机描述"
 msgid "Host general"
 msgstr "主机通用"
 
+msgid "Host has no active task to cancel"
+msgstr ""
+
 msgid "Host is already a member of an active task"
 msgstr "主机已经是一个活动任务中的一员"
 
@@ -3770,6 +3773,10 @@ msgstr "不允许访问"
 
 #, fuzzy
 msgid "No active task found for this host"
+msgstr "主机没有活动任务"
+
+#, fuzzy
+msgid "No active tasks to cancel for this group"
 msgstr "主机没有活动任务"
 
 msgid "No activity information available for this group"
@@ -5611,6 +5618,10 @@ msgstr "任务类型"
 
 msgid "Task forced to start"
 msgstr "任务强行启动"
+
+#, fuzzy
+msgid "Task is not active and cannot be cancelled"
+msgstr "镜像被保护，不能被删除"
 
 msgid "Task not created as there are no associated tasks"
 msgstr "未创建任务，由于没有相关任务"

--- a/tests/cancel-route-reports-truthfully.test.php
+++ b/tests/cancel-route-reports-truthfully.test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Route::cancel() must not report work it did not do.
+ *
+ * Every arm of this method had a path that returned normally -- and so 200 --
+ * having changed nothing, or that died partway with an error saying nothing
+ * about the actual situation:
+ *
+ *  - a task in a finished state fell out of the state test and answered
+ *    "cancelled" with its state untouched;
+ *  - Host::loadTask() sets its field to `new Task(null)` when nothing is
+ *    running, and that IS `instanceof Task`, so the guard was true for every
+ *    host and cancel() went on to save a Task with no typeID. save() throws,
+ *    and cancel() has no catch -- so one idle member of a group aborted the
+ *    whole loop and every host after it kept its task running;
+ *  - scheduledtask carries isActive rather than stateID, so it failed a test
+ *    it could never pass: that endpoint has never cancelled anything.
+ *
+ * Ported from working-1.6. Narrower here by fact, not by choice: 1.5 has no
+ * filedeletequeue among its tasking classes and no OpenAPI document, so the
+ * two assertions covering those have nothing to bind to.
+ *
+ * Usage: php tests/cancel-route-reports-truthfully.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$route = file_get_contents($web . '/lib/router/route.class.php');
+
+$fails = array();
+
+// Isolate cancel() so a match elsewhere in this class cannot stand in for the
+// thing being tested.
+if (!preg_match(
+    '#public static function cancel\(\$class, \$id\).*?\n    \}\n#s',
+    $route,
+    $m
+)) {
+    echo "FAIL: Route::cancel() not found -- the gate cannot see its subject\n";
+    exit(1);
+}
+$cancel = $m[0];
+
+// ------------------------------------------------- the requested resource
+
+// Bounded to the helper's own body: an open-ended match finds json_encode
+// somewhere else in the file and passes a mutation that removed it.
+if (!preg_match(
+    '#private static function _notCancellable\(\$msg\)\s*\{(.*?)\n    \}#s',
+    $route,
+    $helper
+)) {
+    $fails[] = 'Route::_notCancellable() does not exist, so the 409s are'
+        . ' hand-rolled at each call site';
+} elseif (false === strpos($helper[1], 'HTTP_CONFLICT')
+    || false === strpos($helper[1], 'json_encode')
+) {
+    $fails[] = '_notCancellable() does not answer 409 with a JSON body, so a'
+        . ' refused cancel is indistinguishable from the router\'s older'
+        . ' bare-string errors';
+}
+
+// A named task in a finished state. Without the negated test the method
+// falls through the if and returns -- 200, nothing done.
+if (!preg_match(
+    '#if \(!in_array\(\$class->get\(\'stateID\'\), \$states\)\).*?_notCancellable#s',
+    $cancel
+)) {
+    $fails[] = 'a named task outside the active states does not answer 409,'
+        . ' so cancelling a Complete or Cancelled task reports success';
+}
+
+// ------------------------------------------------------- the empty Task
+
+// Both arms, because they fail identically and were fixed together. The
+// group arm is the worse of the two: it aborts a loop it is halfway through.
+if (substr_count($cancel, '$Task->isValid()') < 2) {
+    $fails[] = 'the host and group arms do not both test the loaded task for'
+        . ' validity -- instanceof alone is true for the empty Task that'
+        . ' Host::loadTask() leaves behind, so an idle host tries to save it';
+}
+// Bounded to the group arm. Left open-ended, the match ran on and found the
+// host arm's refusal, so dropping the group's own was invisible.
+if (!preg_match('#case \'group\':(.*?)\n                break;#s', $cancel, $grp)) {
+    $fails[] = 'the group arm is not where this gate can see it';
+} elseif (false === strpos($grp[1], '$cancelled++')
+    || !preg_match(
+        '#if \(\$cancelled\s*<\s*1\)\s*\{\s*self::_notCancellable#s',
+        $grp[1]
+    )
+) {
+    // The CONDITION, not just the presence of the call. Pinning only the
+    // call left `if (false) { self::_notCancellable(...) }` passing -- the
+    // refusal was still in the source and could no longer happen.
+    $fails[] = 'the group arm does not count what it cancelled and refuse on'
+        . ' zero, so a group with nothing running still reports success';
+}
+
+// ------------------------------------------------------- scheduledtask
+
+// It has no stateID at all, so it can only ever be handled by an arm of its
+// own.
+if (!preg_match('#case \'scheduledtask\':.*?\$class->cancel\(\)#s', $cancel)) {
+    $fails[] = 'scheduledtask has no arm of its own, so it falls into the'
+        . ' state test it cannot pass and the endpoint cancels nothing';
+}
+
+// ---------------------------------------------------- the bulk arm is not
+
+// The search-driven arm is a filter, and matching nothing is a legitimate
+// result for one. If this starts refusing, the 409 has spread from "you
+// named a thing I did not touch" to "your filter was empty".
+if (!preg_match(
+    '#\$find\[\'stateID\'\] = \$states;(.*?)\n                \} else \{#s',
+    $cancel,
+    $bulk
+)) {
+    $fails[] = 'the search-driven bulk arm is not where this gate can see it,'
+        . ' so nothing checks that it still answers 200 on an empty filter';
+} elseif (false !== strpos($bulk[1], '_notCancellable')) {
+    $fails[] = 'the search-driven bulk arm now refuses an empty filter result;'
+        . ' matching no rows is a legitimate outcome for a filter';
+}
+
+if ($fails) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo "  - $f\n";
+    }
+    exit(1);
+}
+echo "ok: the cancel route refuses what it cannot cancel\n";
+exit(0);


### PR DESCRIPTION
Port of #1215.

`DELETE /fog/task/{id}/cancel` on a task in a finished state returns **200 `cancelled: true`** and changes nothing. `Route::cancel()`'s default arm only acts `if (in_array($class->get('stateID'), $states))`, so a task outside the queued + in-progress allowlist falls out of the `if`, the method returns normally, and the router reports success.

## The other arms fail differently here — and worse

| Arm | Before | After |
|---|---|---|
| named task in a finished state | 200, nothing done | **409** with the state name |
| `host` with no active task | **bodyless 500** | 409 |
| `group` with an idle member | **bodyless 500 partway through the loop** | idle members skipped; 409 if none were active |
| `scheduledtask` | 200, nothing done — **ever** | its own arm; cancels |
| search-driven bulk | 200 on empty | **unchanged, deliberately** |

`Host::loadTask()` sets its field to `new Task(null)` when the host has nothing running, and that **is** `instanceof Task`, so the guard was true for every host. `Task::cancel()` opens with `getHost()->get('snapinjob')`, and `getHost()` on an empty task returns the empty *string*:

```
Uncaught Error: Call to a member function get() on string in task.class.php:272
```

`Error` is not `\Exception`, and `cancel()` has **no catch at all** on this branch — so one idle host killed the request outright. In the group arm that means every host after it in the loop kept its task running, under a bodyless 500.

`scheduledtask` carries `isActive`, not `stateID`, so it failed a state test it could never pass. This endpoint has never cancelled a scheduled task on 1.5.

**The bulk arm stays at 200 on purpose.** It is a filter, and matching no rows is a legitimate outcome for one. The 409 is for a caller who *named* a specific resource and is entitled to know it was not touched. The test pins that distinction in both directions.

## Narrower than #1215, by fact rather than choice

- No `filedeletequeue` among this branch's tasking classes, so that arm has nothing to fix.
- No `openapi.class.php`, so there is no document to update.
- The group arm here already cancelled through `Host::get('task')` rather than an unfiltered `listem()`, so it never had 1.6's missing-state-filter fault. Its problem is the empty `Task`, not the state filter.

## Behaviour change

A client that fires cancel at an already-finished task used to get 200 and now gets 409. That is the point of the change, but it is a contract change on the patched line and worth a look before merge.

The 409 body is JSON — `{"msg": "..."}` — where the router's older non-2xx replies are a bare string under a `Content-Type` of `application/json`. 409 is a status no caller receives today, so it can start out matching its own header without breaking anyone. The existing paths are left alone.

## Verification

The empty-`Task` crash was reproduced on **1.6**, against an isolated copy of the live database. `Task::cancel()`, `Task::getHost()` and `Host::loadTask()` are identical on this branch, so the port is verified by that plus reading — not by a 1.5 run.

`tests/cancel-route-reports-truthfully.test.php` — seven mutations, each reintroducing one defect, all killed. One survived the first pass because the assertion pinned the *presence* of the refusal rather than its *condition*, so `if (false) { refuse }` passed; that is fixed and commented.

Full suite: 14 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
