### PR TITLE
Let a stored FOS report be longer than the notification it triggers

### DIFF
--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -54,15 +54,43 @@ namespace FOG;
 class TaskError extends FOGBase
 {
     /**
-     * How much of the reported text is kept.
+     * How much of the report reaches a NOTIFICATION, in characters.
      *
-     * The text is written by whatever called this endpoint, and it ends up in
-     * a Slack/ntfy/pushbullet message. Bounded so a caller cannot use an
-     * admin's notification channel as a paste bin.
+     * The text is written by whatever called this endpoint, and this half of
+     * it ends up in a Slack/ntfy/pushbullet message. Bounded so a caller
+     * cannot use an admin's notification channel as a paste bin.
+     *
+     * Characters, not bytes, and deliberately: nothing downstream of here has
+     * a byte budget, and cutting a multibyte reason by bytes would silently
+     * make it a third as long for anyone not writing in ASCII.
      *
      * @var int
      */
     const MAX_REASON = 500;
+    /**
+     * How much of the report is STORED and logged, in bytes.
+     *
+     * Split from MAX_REASON because the two have opposite pressures. A push
+     * notification wants to stay short enough to read on a phone; a stored
+     * diagnostic wants the whole of what FOS had to say, and 500 characters
+     * is not a failure trace. `taskLog`.`logText` is TEXT, so the row can
+     * hold 65535 bytes and this could have been that.
+     *
+     * It is not, because of what this endpoint is: unauthenticated, matched
+     * to a host by MAC (see the class docblock). Taking the column's whole
+     * capacity would multiply what one unauthenticated request can write by
+     * 130 for no diagnostic gain -- a `fog.download` trace with its context
+     * runs to a few KB, not 64. So: generous against any real report,
+     * bounded against a caller with something else in mind.
+     *
+     * Bytes rather than characters because the limit that actually exists is
+     * the column's, and that one is in bytes: sql_mode carries
+     * STRICT_TRANS_TABLES, so an oversized value fails the INSERT rather
+     * than truncating, and the report would be lost entirely.
+     *
+     * @var int
+     */
+    const MAX_TEXT = 8192;
     /**
      * The report types a caller may send, mapped to the TaskLog type.
      *
@@ -111,7 +139,13 @@ class TaskError extends FOGBase
             $type = self::_reportedType();
             $script = self::_reported('script');
             if ('' !== $script) {
-                $text = sprintf('%s (%s)', $text, $script);
+                // Re-bounded after composing: both halves arrive already cut
+                // to MAX_TEXT, so joining them could otherwise hand the
+                // column twice what it was promised.
+                $text = self::_limit(
+                    sprintf('%s (%s)', $text, $script),
+                    self::MAX_TEXT
+                );
             }
             self::getHostItem(false);
             $Task = self::$Host->get('task');
@@ -166,7 +200,11 @@ class TaskError extends FOGBase
                         ''
                     ),
                     'TaskType' => $Task->getTaskTypeText(),
-                    'Reason' => $text
+                    // The short half. The row and the log line above keep the
+                    // whole report; a phone notification gets the opening of
+                    // it. Cut here rather than at the top so that widening
+                    // what is stored never widens what is pushed.
+                    'Reason' => mb_substr($text, 0, self::MAX_REASON)
                 ]
             );
         } catch (\Exception $e) {
@@ -304,12 +342,37 @@ class TaskError extends FOGBase
         if ('' === $clean) {
             return '';
         }
-        // mb_substr on invalid UTF-8 can return '', which would throw the
-        // report away; strlen-bound the bytes in that case instead.
-        $cut = mb_substr($clean, 0, self::MAX_REASON);
-        if ('' === $cut) {
-            $cut = substr($clean, 0, self::MAX_REASON);
+
+        return self::_limit($clean, self::MAX_TEXT);
+    }
+    /**
+     * Cuts a string to a byte budget without splitting a character.
+     *
+     * mb_strcut, not mb_substr: the budget being spent is the column's, and
+     * that is counted in bytes. mb_substr counts characters, so a cut at
+     * 8192 characters can be 24576 bytes in utf8mb3 -- three times what was
+     * promised, and under STRICT_TRANS_TABLES that is a failed INSERT and a
+     * lost report rather than a truncated one.
+     *
+     * @param string $str the string to bound
+     * @param int    $max the budget, in bytes
+     *
+     * @return string
+     */
+    private static function _limit($str, $max)
+    {
+        if (strlen($str) <= $max) {
+            return $str;
         }
+        // mb_strcut on invalid UTF-8 can return '', which would throw the
+        // report away; byte-cut it in that case instead. Never let a
+        // malformed string become an empty one -- the text is the whole
+        // point of the report.
+        $cut = mb_strcut($str, 0, $max);
+        if ('' === $cut) {
+            $cut = substr($str, 0, $max);
+        }
+
         return $cut;
     }
     /**

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -58,7 +58,10 @@ $sanitize->setAccessible(true);
 $clean = function ($raw) use ($sanitize) {
     return $sanitize->invoke(null, $raw);
 };
-$max = (new \ReflectionClass('FOG\TaskError'))->getConstant('MAX_REASON');
+$refl = new \ReflectionClass('FOG\TaskError');
+$maxReason = $refl->getConstant('MAX_REASON');
+$maxText = $refl->getConstant('MAX_TEXT');
+$max = $maxText;
 
 // ------------------------------------------------------------- one line
 
@@ -82,24 +85,46 @@ foreach ([
 
 // ---------------------------------------------------------------- bounds
 
-if (!is_int($max) || $max < 1) {
-    $fails[] = 'MAX_REASON is not a positive integer, so the report is unbounded';
+// Two bounds, not one, and they must not collapse back into each other. The
+// stored row and the push notification pull in opposite directions: a phone
+// message wants to stay readable, a diagnostic wants the whole trace. If
+// MAX_TEXT ever stops being the larger of the two, the split has been undone
+// and widening storage has quietly started widening what gets pushed.
+foreach (['MAX_REASON' => $maxReason, 'MAX_TEXT' => $maxText] as $name => $val) {
+    if (!is_int($val) || $val < 1) {
+        $fails[] = "$name is not a positive integer, so the report is unbounded";
+    }
 }
-$long = str_repeat('A', $max * 3);
-if (mb_strlen($clean($long)) > $max) {
-    $fails[] = 'a long report is not truncated, so an unauthenticated caller'
-        . ' can use a notification channel as a paste bin';
+if ($maxText <= $maxReason) {
+    $fails[] = 'MAX_TEXT is not larger than MAX_REASON, so splitting them'
+        . ' bought nothing -- the stored report is still notification-sized';
+}
+// The column is TEXT: 65535 BYTES. Bounding above that would mean an
+// oversized report fails its INSERT under STRICT_TRANS_TABLES and is lost
+// entirely, rather than being stored short.
+if ($maxText > 65535) {
+    $fails[] = 'MAX_TEXT exceeds what taskLog.logText can hold, so a large'
+        . ' report fails the INSERT instead of being truncated';
 }
 
-// A multibyte string must not be cut into an invalid sequence, and must not
-// be thrown away either.
-$mb = str_repeat('é', $max * 2);
+// Bytes, not characters -- that is the budget the column actually spends.
+$long = str_repeat('A', $maxText * 2);
+if (strlen($clean($long)) > $maxText) {
+    $fails[] = 'a long report is not truncated, so an unauthenticated caller'
+        . ' can write whatever it likes into the task log';
+}
+
+// A multibyte string must not be cut into an invalid sequence, must not be
+// thrown away, and must not be cut by CHARACTERS: 8192 utf8mb3 characters is
+// 24576 bytes, three times the budget, which the column would reject.
+$mb = str_repeat('é', $maxText);
 $cut = $clean($mb);
 if ('' === $cut) {
     $fails[] = 'a multibyte report is discarded entirely';
 }
-if (mb_strlen($cut) > $max) {
-    $fails[] = 'a multibyte report is not truncated';
+if (strlen($cut) > $maxText) {
+    $fails[] = 'a multibyte report is bounded by characters rather than bytes,'
+        . ' so it can exceed the column and fail the INSERT';
 }
 if ($cut !== mb_convert_encoding($cut, 'UTF-8', 'UTF-8')) {
     $fails[] = 'truncation split a multibyte character, so the message is no'
@@ -122,6 +147,38 @@ if ('' !== $clean('   ') || '' !== $clean('')) {
 // --------------------------------------------------------------- the class
 
 $src = file_get_contents($web . '/lib/reg-task/taskerror.class.php');
+
+// The split only exists if the SHORT bound is applied at the notification and
+// nowhere earlier. Cut at the top instead and both halves shrink together,
+// which is the state this change was undoing.
+if (false === strpos(
+    $src,
+    "'Reason' => mb_substr(\$text, 0, self::MAX_REASON)"
+)) {
+    $fails[] = 'the notification payload is not cut to MAX_REASON at the'
+        . ' notify() call, so widening what is stored also widens what is'
+        . ' pushed to an administrator\'s phone';
+}
+// _logRow gets the WHOLE text. If MAX_REASON reaches it, the stored row is
+// notification-sized again and the extra capacity is unreachable.
+// `self::` and the semicolon on purpose: without them this also matches the
+// method's own SIGNATURE, `_logRow($Task, $type, $text)`, so narrowing the
+// argument at the call site passed clean.
+if (false === strpos($src, 'self::_logRow($Task, $type, $text);')) {
+    $fails[] = 'the stored row is no longer written from the full report text';
+}
+// text and script arrive bounded separately, so the join has to be re-bounded
+// or the column is handed twice what it was promised.
+if (!preg_match(
+    '#sprintf\(\'%s \(%s\)\', \$text, \$script\)#s',
+    $src
+) || !preg_match(
+    '#\$text = self::_limit\(\s*sprintf#s',
+    $src
+)) {
+    $fails[] = 'the composed text+script is not re-bounded, so a report with a'
+        . ' script name can be twice MAX_TEXT';
+}
 
 if (false === strpos($src, '$Task->isImagingTask()')) {
     $fails[] = 'the endpoint no longer checks the task is an imaging one, so a'


### PR DESCRIPTION
`MAX_REASON` bounded the FOS report at 500 characters in `_sanitize()` — before the text branched — so one number governed two things that want opposite answers:

| | wants | bound |
|---|---|---|
| push notification (Slack / ntfy / pushbullet) | short enough to read on a phone | `MAX_REASON` **500 characters** |
| `taskLog.logText` row + `fosreports.log` | the whole of what FOS had to say | `MAX_TEXT` **8192 bytes** |

500 characters is not a failure trace. Now they're separate, and `MAX_REASON` is applied at the `notify()` call rather than at the top — so widening what is stored can never again widen what lands on someone's phone.

## Why bytes for one and characters for the other

`MAX_REASON` stays in **characters**: nothing downstream of it has a byte budget, and cutting a multibyte reason by bytes would silently make it a third as long for anyone not writing in ASCII.

`MAX_TEXT` is in **bytes**, because the only real limit here is the column's and that one is in bytes. `logText` is `TEXT` — 65535 bytes — and `sql_mode` carries `STRICT_TRANS_TABLES`, so an oversized value **fails the INSERT rather than truncating**, and the report is lost rather than shortened. `mb_substr` counts characters, so an 8192-character cut is 24576 bytes of utf8mb3 — three times the budget. The new `_limit()` uses `mb_strcut`, which spends the budget the column actually charges for and still never splits a character.

## Why 8192 and not the column's 65535

Because of what this endpoint is: **unauthenticated, matched to a host by MAC** (it says so in its own class docblock). Taking the whole column would multiply what one unauthenticated request can write by 130 for no diagnostic gain — a `fog.download` trace with its context runs to a few KB, not 64. Generous against any real report, bounded against a caller with something else in mind.

**Nothing needs migrating.** The column has always been `TEXT`; only the PHP constant was tight.

`text` and `script` arrive sanitized separately and are then joined, so the composed string is re-bounded — otherwise a report carrying a script name could hand the column twice what it was promised.

## Verification

End to end against an **isolated copy** of the live database (podman MariaDB, shadow tree), not the live install:

```
MAX_REASON=500 chars   MAX_TEXT=8192 bytes   ratio=16.4x
raw=14400 bytes -> stored=8192 bytes (8192 chars), pushed=500 chars
multibyte: raw=18000 bytes/9000 chars -> stored=8192 bytes/4096 chars  validUTF8=yes
row 343: stored=8192 bytes  identical=yes
```

That last line is a full-size report written through the real ORM and read back byte-identical — no INSERT failure, which is the thing the byte-bounding exists to prevent. The probe row was cleaned up.

`tests/task-error-report.test.php` gains the split's invariants: `MAX_TEXT` larger than `MAX_REASON`, `MAX_TEXT` within the column, byte-bounding rather than character-bounding, and the three call sites that make the split real. Seven mutations, all killed — one survived the first pass because the assertion matched `_logRow`'s own *signature* as well as its call, so narrowing the argument passed clean; it now pins `self::` and the semicolon.

Full suite: 71 passed, 0 failed.

## Not in this change

Control characters are still collapsed to spaces for **all** paths, so a stored trace is one long line. That guard exists because an embedded newline lets a caller forge a second line in a chat message or a log file — which is true of the notification and `fosreports.log`, and not true of a database row rendered in the log modal. Splitting that the way this splits length is a separate change, and it pulls in the modal's `white-space` and the grid's preview column.

Ported to `dev-branch` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
