### PR TITLE
Pin the plugins release that reports why imaging failed

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.10');
+        define('FOG_PLUGINS_VERSION', 'v1.6.11');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1242,6 +1242,10 @@ msgid "Capture"
 msgstr "Upload"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "Export vollständig"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Erstellt"
 
@@ -1934,6 +1938,10 @@ msgstr "Remotedatei wird gelöscht"
 
 msgid "Deploy"
 msgstr "Verteilung"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
@@ -3127,6 +3135,18 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3657,6 +3677,10 @@ msgstr "Image Task vollständig"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Imaging Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8095,6 +8119,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Dieser Host ist bereits vorhanden."
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Dieser Host ist bereits vorhanden."
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9092,6 +9128,10 @@ msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
 
 #, fuzzy
+msgid "an unnamed image"
+msgstr "Ungültiges Image"
+
+#, fuzzy
 msgid "and below"
 msgstr "Nur Teilstruktur"
 
@@ -9164,10 +9204,6 @@ msgstr "Client"
 #, fuzzy
 msgid "clients"
 msgstr "Client"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "Abgeschlossen"
 
 #, fuzzy
 msgid "confirm"
@@ -9414,10 +9450,6 @@ msgid "images to a storage group"
 msgstr "bildet ab zu einer Speichergruppe"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Laden fehlgeschlagen: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "Minuten"
 
@@ -9574,6 +9606,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10554,6 +10589,10 @@ msgstr ""
 
 #~ msgid "but"
 #~ msgstr "aber "
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "Abgeschlossen"
 
 #~ msgid "e.g."
 #~ msgstr "z.B."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1245,6 +1245,10 @@ msgid "Capture"
 msgstr "Create"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "Complete"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Created"
 
@@ -1936,6 +1940,10 @@ msgstr "Menu create failed"
 
 msgid "Deploy"
 msgstr "Deploy"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Download Failed"
 
 msgid "Deploy Method"
 msgstr "Deploy Method"
@@ -3128,6 +3136,18 @@ msgstr "Home"
 msgid "Host"
 msgstr "Host"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host Created"
@@ -3658,6 +3678,10 @@ msgstr "after task completion"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Imaging Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Load failed: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8090,6 +8114,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Printer already exists"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Printer already exists"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9087,6 +9123,10 @@ msgstr " ago"
 msgid "all current storage nodes"
 msgstr "Invalid storage node"
 
+#, fuzzy
+msgid "an unnamed image"
+msgstr "Invalid image"
+
 msgid "and below"
 msgstr ""
 
@@ -9158,10 +9198,6 @@ msgstr "Client"
 #, fuzzy
 msgid "clients"
 msgstr "Client"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "Completed"
 
 #, fuzzy
 msgid "confirm"
@@ -9408,10 +9444,6 @@ msgid "images to a storage group"
 msgstr "Primary Storage Group"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Load failed: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "minutes"
 
@@ -9567,6 +9599,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10519,6 +10554,10 @@ msgstr ""
 
 #~ msgid "before me"
 #~ msgstr "before me"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "Completed"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1262,6 +1262,10 @@ msgid "Capture"
 msgstr "Creado"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "impresora iPrint"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Creado"
 
@@ -1964,6 +1968,10 @@ msgstr "Menú Error de creación"
 #, fuzzy
 msgid "Deploy"
 msgstr "última Desplegado"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Descarga fracasó"
 
 #, fuzzy
 msgid "Deploy Method"
@@ -3187,6 +3195,18 @@ msgstr "nombre de host"
 msgid "Host"
 msgstr "Anfitrión"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creado"
@@ -3740,6 +3760,10 @@ msgstr "después de la realización de tareas"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Transferencia de imágenes Entrar"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Carga ha fallado: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8279,6 +8303,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Impresora ya existe"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Impresora ya existe"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9273,6 +9309,10 @@ msgstr " hace"
 msgid "all current storage nodes"
 msgstr "nodo de almacenamiento no válido"
 
+#, fuzzy
+msgid "an unnamed image"
+msgstr "carpeta no válida"
+
 msgid "and below"
 msgstr ""
 
@@ -9344,10 +9384,6 @@ msgstr "Clientela"
 #, fuzzy
 msgid "clients"
 msgstr "Clientela"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "suprimido"
 
 #, fuzzy
 msgid "confirm"
@@ -9597,10 +9633,6 @@ msgid "images to a storage group"
 msgstr "Grupo de almacenamiento primaria"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Carga ha fallado: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "minutos"
 
@@ -9754,6 +9786,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10699,6 +10734,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "before me"
 #~ msgstr "Nombre del núcleo"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "suprimido"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1242,6 +1242,10 @@ msgid "Capture"
 msgstr "Upload"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "Export vollständig"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Erstellt"
 
@@ -1934,6 +1938,10 @@ msgstr "Remotedatei wird gelöscht"
 
 msgid "Deploy"
 msgstr "Verteilung"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
@@ -3127,6 +3135,18 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3657,6 +3677,10 @@ msgstr "Image Task vollständig"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Imaging Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8096,6 +8120,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Dieser Host ist bereits vorhanden."
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Dieser Host ist bereits vorhanden."
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9093,6 +9129,10 @@ msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
 
 #, fuzzy
+msgid "an unnamed image"
+msgstr "Ungültiges Image"
+
+#, fuzzy
 msgid "and below"
 msgstr "Nur Teilstruktur"
 
@@ -9165,10 +9205,6 @@ msgstr "Client"
 #, fuzzy
 msgid "clients"
 msgstr "Client"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "Abgeschlossen"
 
 #, fuzzy
 msgid "confirm"
@@ -9415,10 +9451,6 @@ msgid "images to a storage group"
 msgstr "bildet ab zu einer Speichergruppe"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Laden fehlgeschlagen: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "Minuten"
 
@@ -9575,6 +9607,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10555,6 +10590,10 @@ msgstr ""
 
 #~ msgid "but"
 #~ msgstr "aber "
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "Abgeschlossen"
 
 #~ msgid "e.g."
 #~ msgstr "z.B."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1246,6 +1246,10 @@ msgid "Capture"
 msgstr "Créer"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "Achevée"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Créé"
 
@@ -1938,6 +1942,10 @@ msgstr "Menu create a échoué"
 
 msgid "Deploy"
 msgstr "Déployer"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Échec du téléchargement"
 
 msgid "Deploy Method"
 msgstr "Déployer Méthode"
@@ -3130,6 +3138,18 @@ msgstr "Accueil"
 msgid "Host"
 msgstr "Hôte"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "hôte Créé"
@@ -3660,6 +3680,10 @@ msgstr "après l'achèvement des tâches"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Imaging Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Échec du chargement: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8092,6 +8116,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Imprimante existe déjà"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Imprimante existe déjà"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9089,6 +9125,10 @@ msgstr " depuis"
 msgid "all current storage nodes"
 msgstr "nœud de stockage non valide"
 
+#, fuzzy
+msgid "an unnamed image"
+msgstr "Invalid image"
+
 msgid "and below"
 msgstr ""
 
@@ -9160,10 +9200,6 @@ msgstr "Client"
 #, fuzzy
 msgid "clients"
 msgstr "Client"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "Terminé"
 
 #, fuzzy
 msgid "confirm"
@@ -9410,10 +9446,6 @@ msgid "images to a storage group"
 msgstr "Groupe de stockage primaire"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Échec du chargement: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "minutes"
 
@@ -9569,6 +9601,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10525,6 +10560,10 @@ msgstr ""
 
 #~ msgid "before me"
 #~ msgstr "avant moi"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "Terminé"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1202,6 +1202,10 @@ msgstr "Snap-in aggiornato!"
 msgid "Capture"
 msgstr "Catturare"
 
+#, fuzzy
+msgid "Capture Complete"
+msgstr "Esportazione Completata"
+
 msgid "Captured"
 msgstr "Catturato"
 
@@ -1872,6 +1876,10 @@ msgstr "Eliminazione di file remoti"
 
 msgid "Deploy"
 msgstr "Distribuisci"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Scaricamento fallito"
 
 msgid "Deploy Method"
 msgstr "Metodo Deploy"
@@ -3033,6 +3041,18 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Host"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creazione Host con successo"
@@ -3541,6 +3561,10 @@ msgstr "Attività di immagine completata"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "Imaging Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Caricamento non riuscito"
 
 #, fuzzy
 msgid "Imaging History"
@@ -7802,6 +7826,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Questo host esiste già"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Questo host esiste già"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -8763,6 +8799,10 @@ msgid "all current storage nodes"
 msgstr "tutti i nodi di archiviazione attivi"
 
 #, fuzzy
+msgid "an unnamed image"
+msgstr "immagine non valido"
+
+#, fuzzy
 msgid "and below"
 msgstr "Sottoalbero e inferiore"
 
@@ -8831,10 +8871,6 @@ msgstr "client"
 #, fuzzy
 msgid "clients"
 msgstr "client"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "Completato"
 
 #, fuzzy
 msgid "confirm"
@@ -9063,10 +9099,6 @@ msgid "images to a storage group"
 msgstr "Immagini in un gruppo di archiviazione"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Caricamento non riuscito"
-
-#, fuzzy
 msgid "in"
 msgstr "minuti"
 
@@ -9215,6 +9247,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10151,6 +10186,10 @@ msgstr ""
 
 #~ msgid "but"
 #~ msgstr "ma"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "Completato"
 
 #~ msgid "e.g."
 #~ msgstr "es."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1183,6 +1183,10 @@ msgstr "スナップインを更新しました！"
 msgid "Capture"
 msgstr "キャプチャ"
 
+#, fuzzy
+msgid "Capture Complete"
+msgstr "エクスポートが完了しました"
+
 msgid "Captured"
 msgstr "キャプチャ済み"
 
@@ -1854,6 +1858,10 @@ msgstr "リモートファイルを削除しています"
 
 msgid "Deploy"
 msgstr "展開"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "ダウンロードに失敗しました"
 
 msgid "Deploy Method"
 msgstr "展開方法"
@@ -3003,6 +3011,18 @@ msgstr "ホーム"
 msgid "Host"
 msgstr "ホスト"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "承認に成功しました"
@@ -3507,6 +3527,10 @@ msgstr "イメージ処理が完了しました"
 
 msgid "Imaging Duration"
 msgstr "イメージ処理時間"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "イメージ処理に失敗しました。"
 
 #, fuzzy
 msgid "Imaging History"
@@ -7732,6 +7756,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "このホストは既に存在します"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "このホストは既に存在します"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -8689,6 +8725,10 @@ msgid "all current storage nodes"
 msgstr "現在のすべてのストレージノード"
 
 #, fuzzy
+msgid "an unnamed image"
+msgstr "無効なイメージ"
+
+#, fuzzy
 msgid "and below"
 msgstr "サブツリー以下"
 
@@ -8756,10 +8796,6 @@ msgstr "クライアント"
 
 msgid "clients"
 msgstr "クライアント"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "イメージ処理が完了しました。"
 
 msgid "confirm"
 msgstr ""
@@ -8987,10 +9023,6 @@ msgid "images to a storage group"
 msgstr "イメージをストレージグループへ"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "イメージ処理に失敗しました。"
-
-#, fuzzy
 msgid "in"
 msgstr "分"
 
@@ -9138,6 +9170,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -11644,6 +11679,10 @@ msgstr ""
 
 #~ msgid "before me"
 #~ msgstr "自分より前"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "イメージ処理が完了しました。"
 
 #~ msgid "config files that run on the client computers."
 #~ msgstr "クライアントコンピューター上で実行される設定ファイル。"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1050,6 +1050,9 @@ msgstr ""
 msgid "Capture"
 msgstr ""
 
+msgid "Capture Complete"
+msgstr ""
+
 msgid "Captured"
 msgstr ""
 
@@ -1634,6 +1637,9 @@ msgid "Deleting remote file"
 msgstr ""
 
 msgid "Deploy"
+msgstr ""
+
+msgid "Deploy Complete"
 msgstr ""
 
 msgid "Deploy Method"
@@ -2650,6 +2656,18 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 msgid "Host Approval Success"
 msgstr ""
 
@@ -3097,6 +3115,9 @@ msgid "Imaging Completed"
 msgstr ""
 
 msgid "Imaging Duration"
+msgstr ""
+
+msgid "Imaging Failed"
 msgstr ""
 
 msgid "Imaging History"
@@ -6861,6 +6882,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr ""
 
+#, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr ""
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -7723,6 +7756,9 @@ msgstr ""
 msgid "all current storage nodes"
 msgstr ""
 
+msgid "an unnamed image"
+msgstr ""
+
 msgid "and below"
 msgstr ""
 
@@ -7787,9 +7823,6 @@ msgid "client"
 msgstr ""
 
 msgid "clients"
-msgstr ""
-
-msgid "completed imaging"
 msgstr ""
 
 msgid "confirm"
@@ -7994,9 +8027,6 @@ msgstr ""
 msgid "images to a storage group"
 msgstr ""
 
-msgid "imaging failed"
-msgstr ""
-
 msgid "in"
 msgstr ""
 
@@ -8139,6 +8169,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1245,6 +1245,10 @@ msgid "Capture"
 msgstr "Crio"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "Completo"
+
+#, fuzzy
 msgid "Captured"
 msgstr "Criado"
 
@@ -1937,6 +1941,10 @@ msgstr "Menu Criar falhou"
 
 msgid "Deploy"
 msgstr "implantar"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "Falha no download"
 
 msgid "Deploy Method"
 msgstr "Método Deploy"
@@ -3129,6 +3137,18 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Anfitrião"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "host criado"
@@ -3659,6 +3679,10 @@ msgstr "após a conclusão da tarefa"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "imagiologia Log"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "Carga falhou: %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8091,6 +8115,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "Impressora já existe"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "Impressora já existe"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9088,6 +9124,10 @@ msgstr " atrás"
 msgid "all current storage nodes"
 msgstr "nó de armazenamento inválido"
 
+#, fuzzy
+msgid "an unnamed image"
+msgstr "imagem inválido"
+
 msgid "and below"
 msgstr ""
 
@@ -9159,10 +9199,6 @@ msgstr "Cliente"
 #, fuzzy
 msgid "clients"
 msgstr "Cliente"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "concluído"
 
 #, fuzzy
 msgid "confirm"
@@ -9409,10 +9445,6 @@ msgid "images to a storage group"
 msgstr "Grupo de armazenamento primário"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "Carga falhou: %s"
-
-#, fuzzy
 msgid "in"
 msgstr "minutos"
 
@@ -9568,6 +9600,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10524,6 +10559,10 @@ msgstr ""
 
 #~ msgid "before me"
 #~ msgstr "antes de mim"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "concluído"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1245,6 +1245,10 @@ msgid "Capture"
 msgstr "创建"
 
 #, fuzzy
+msgid "Capture Complete"
+msgstr "完成"
+
+#, fuzzy
 msgid "Captured"
 msgstr "创建"
 
@@ -1937,6 +1941,10 @@ msgstr "菜单创建失败"
 
 msgid "Deploy"
 msgstr "部署"
+
+#, fuzzy
+msgid "Deploy Complete"
+msgstr "下载失败"
 
 msgid "Deploy Method"
 msgstr "部署方法"
@@ -3129,6 +3137,18 @@ msgstr "家"
 msgid "Host"
 msgstr "主办"
 
+#, php-format
+msgid "Host %1$s failed imaging %2$s: %3$s"
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished capturing image %2$s."
+msgstr ""
+
+#, php-format
+msgid "Host %1$s finished deploying image %2$s."
+msgstr ""
+
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "主机创建"
@@ -3659,6 +3679,10 @@ msgstr "任务完成后，"
 #, fuzzy
 msgid "Imaging Duration"
 msgstr "成像测井"
+
+#, fuzzy
+msgid "Imaging Failed"
+msgstr "加载失败： %s"
 
 #, fuzzy
 msgid "Imaging History"
@@ -8091,6 +8115,18 @@ msgstr ""
 msgid "This host already exists"
 msgstr "打印机已经存在"
 
+#, fuzzy, php-format
+msgid "This host failed imaging %1$s: %2$s"
+msgstr "打印机已经存在"
+
+#, php-format
+msgid "This host has finished capturing image %s."
+msgstr ""
+
+#, php-format
+msgid "This host has finished deploying image %s."
+msgstr ""
+
 msgid "This identity is linked to a different FOG account"
 msgstr ""
 
@@ -9088,6 +9124,10 @@ msgstr "前"
 msgid "all current storage nodes"
 msgstr "无效的存储节点"
 
+#, fuzzy
+msgid "an unnamed image"
+msgstr "图片无效"
+
 msgid "and below"
 msgstr ""
 
@@ -9159,10 +9199,6 @@ msgstr "客户"
 #, fuzzy
 msgid "clients"
 msgstr "客户"
-
-#, fuzzy
-msgid "completed imaging"
-msgstr "完成"
 
 #, fuzzy
 msgid "confirm"
@@ -9409,10 +9445,6 @@ msgid "images to a storage group"
 msgstr "主存储组"
 
 #, fuzzy
-msgid "imaging failed"
-msgstr "加载失败： %s"
-
-#, fuzzy
 msgid "in"
 msgstr "分钟"
 
@@ -9568,6 +9600,9 @@ msgid "no node in the group answered the probe"
 msgstr ""
 
 msgid "no reason given"
+msgstr ""
+
+msgid "no reason was reported"
 msgstr ""
 
 msgid "no response from server"
@@ -10524,6 +10559,10 @@ msgstr ""
 
 #~ msgid "before me"
 #~ msgstr "我面前"
+
+#, fuzzy
+#~ msgid "completed imaging"
+#~ msgstr "完成"
 
 #, fuzzy
 #~ msgid "multicast tasks!"


### PR DESCRIPTION
`v1.6.11` carries FOGProject/fog-plugins#21, which merged the morning **after** `v1.6.10` was cut and so has never reached a server.

That change matters more than its own PR made it sound, because the FOS reporting work landed in between. #1206 / #1211 / #1217 / #1223 give a failed task a stored, multi-line report of what FOS actually said, and `TaskError` sends the flattened opening of it as `HOST_IMAGE_FAIL`'s `Reason` — but **every bundled listener on `v1.6.10` ignores that key.**

Found while doing the end-to-end live test of the FOS report path. A report whose stored row read

```
fog.download: failed to restore partition 2
  partclone.ntfs: /dev/sda2 is busy
  ERROR: win11-split part 2 checksum mismatch
  exit code 1 (fog.download)
```

pushed, in its entirety: **`fos-deploy-test Failed` / `This host has failed to image`**. So the whole point of storing the trace — somebody seeing it — stopped at the server.

## Why it is one line of code and eleven files

The sha256 is fetched from the release alongside the tarball rather than pinned here, so `bin/fetch-plugins.sh` needs nothing but the constant. The other ten files are the pre-commit hook's `xgettext` pass: `v1.6.11`'s listeners introduce new strings (`Deploy Complete`, `Capture Complete`, `Imaging Failed`, `an unnamed image`, `no reason was reported`), and the pin bump is exactly the moment those become part of what FOG ships, so the catalog picking them up is correct rather than incidental.

## Verified end to end on this pin

```
$ bash bin/fetch-plugins.sh --version
v1.6.11
$ bash bin/fetch-plugins.sh
Fetching plugins v1.6.11
Plugins at v1.6.11
```

Checksum verified by the script, and all three `imagefail` listeners in the fetched tree read `Reason`.

## The 1.5 line

`dev-branch` keeps its plugins in-tree and has no pin, so its equivalent is a code change rather than a version bump: #1226 (merged). `ntfy` has no listener there, so that one is two files rather than three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mJVe4CpK3rRbi9H5GubXd
