### PR TITLE
Address this server by its certificate's name when netboot is HTTPS

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1329,6 +1329,12 @@ while [[ -z $blGo ]]; do
                     installUtilities
                     updateStorageNodeCredentials
                     recordGitUpdateSettings
+                    # Beside recordGitUpdateSettings because it is the same kind
+                    # of write -- a record, not a control -- and this is the
+                    # earliest point where both halves it needs are in place: the
+                    # schema is deployed, and configureHttpd has put the served
+                    # certificate on disk for _resolveNetbootHost to read.
+                    recordNetbootWebHost
                     setupFogReporting
                     # Last, so it is the part still on screen. An admin who
                     # asked for HTTPS and got HTTP netboot has to be told; the

--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -85,6 +85,16 @@ directories**, not one.
 | 4 | `${boot-url}/service/secureboot/MOK.der` (`imgfetch`), `mmx64.efi` / `arm64-efi/mmaa64.efi` (`chain`) | `BootMenu`'s Secure Boot entries |
 | 5 | `web=<proto>://<host><webroot>/` | handed to **FOS**, not fetched by iPXE |
 
+>[!important]
+>**`<host>` is not one value.** Step 1's host is written by the installer; steps
+>2, 4 and 5's come from the `FOG_WEB_HOST` DB row, read by `BootMenu`; step 3's
+>is inherited from step 1 because the URLs are relative. Nothing used to compare
+>the two — step 1 was `$hostname` and could be a short label, while
+>`FOG_WEB_HOST` was seeded from `$ipaddress` and never rewritten, so an HTTPS
+>netboot install could fail at step 1, at step 2, or at both, for different
+>reasons. Both are now derived from the served certificate's name and
+>`FOG_WEB_HOST` is recorded from it; see `docs/adr/0018`.
+
 **The rule: exclude every path iPXE itself fetches — `service/ipxe/` and
 `service/secureboot/`.**
 

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -466,8 +466,21 @@ Override either way with `--netboot-proto http|https`.
 
 **Public Let's Encrypt for netboot** works only on an FQDN in a domain you
 control — it need not be publicly reachable, DNS-01 is enough — and only on
-that exact FQDN, not a short hostname and not an IP. Set `FOG_WEB_HOST` to
-that FQDN or the generated boot URLs will not match the certificate.
+that exact FQDN, not a short hostname and not an IP.
+
+You no longer have to set `FOG_WEB_HOST` yourself: the installer resolves the
+netboot name from the certificate the vhost actually serves and records it into
+that setting, so both hops of a boot use one name. Under `netbootproto=https`
+the row is therefore a **record, not a control** — it is rewritten on every
+install run and an edit through FOG Settings will not survive. Plain-HTTP
+netboot is untouched, and `FOG_WEB_HOST` stays yours to set there.
+
+If the served certificate carries no name the netboot URL could use, the install
+**stops** and prints the names it does carry, rather than writing a
+`default.ipxe` that cannot boot. Note that `--extra-server-name` cannot rescue
+this case: it only feeds FOG's own SAN list, and a Let's Encrypt leaf was issued
+outside FOG. Re-issue the certificate for the name you need, or fall back with
+`--netboot-proto http`. See `docs/adr/0018`.
 
 ## Secure Boot
 

--- a/docs/adr/0018-netboot-addresses-this-server-by-its-certificate-name.md
+++ b/docs/adr/0018-netboot-addresses-this-server-by-its-certificate-name.md
@@ -1,0 +1,141 @@
+# Netboot addresses this server by the name in its certificate
+
+## Status
+
+accepted
+
+## Context
+
+A PXE boot over HTTPS fetches from this server twice, and until now the two
+fetches got their host from two unrelated places with nothing comparing them.
+
+| Hop | URL | Host came from |
+| --- | --- | --- |
+| 1 | `default.ipxe` → `service/ipxe/boot.php` | shell `$hostname` |
+| 2..n | `${boot-url}/service/ipxe/*`, `web=`, Secure Boot `MOK.der` / `mmx64.efi` | the `FOG_WEB_HOST` DB row |
+| kernel / init | relative, so it inherits hop 1's host | — |
+
+`configureDefaultiPXEfile()` used `$ipaddress` for the entire prior life of that
+line. When HTTPS netboot arrived it became `${hostname:-$ipaddress}`, guarded
+only by `validip` — so the *only* rejected value was an IPv4 literal.
+`validhostname()` accepts a single label, and a short name therefore passed every
+check on the path.
+
+That produced `https://fog/fog/service/ipxe/boot.php` against a Let's Encrypt
+certificate issued to `fog.arrowheaddental.com`. iPXE has no `--insecure` and
+fails the handshake on a name mismatch, so the boot stopped before it fetched
+anything.
+
+**The guard was wrong in a way that testing could not see.**
+`_defaultServerNames()` puts *both* the FQDN and the short `${hostname%%.*}` into
+the SAN list, so on a FOG-issued leaf a short name is a genuine SAN and
+`$hostname` works. But `_createWebLeaf()` returns early when `acmeLeaf` or
+`publicWebCert` is set — FOG's SAN list is never applied to a publicly-issued
+leaf, which carries only the names its issuer was asked for. Since
+`publicWebCert` is one of exactly two triggers for HTTPS netboot (ADR 0015), the
+short-name case is not an edge case: it is roughly half the population that
+selects HTTPS netboot at all.
+
+Meanwhile `FOG_WEB_HOST` is seeded from `$ipaddress` on a fresh schema deploy and
+was never written again — the string does not appear anywhere in `lib/` or
+`bin/`. So a fresh `--install-mode public-cert` install pointed hops 2..n at
+`https://<address>/`, which no public CA will ever certify.
+
+The requirement was written down — `docs/PKI_ZONES.md`: *"only on that exact
+FQDN, not a short hostname and not an IP"* — and enforced nowhere. The installer
+already had the right helper: `_servedCertName()` reads the CN off the leaf the
+vhost actually serves, and the vhost's `ServerName` and every installer HTTPS
+self-call had been moved onto it. The netboot URL was the one self-reference that
+was missed.
+
+## Decision
+
+**One name for the whole boot, taken from the certificate.**
+
+`_resolveNetbootHost()` resolves it once into `$netboothost`, which is
+deliberately not `local`: `configureDefaultiPXEfile` and `recordNetbootWebHost`
+read the same variable and so cannot disagree. It is idempotent and silent on a
+second call.
+
+1. The name is `_servedCertName()` — the CN of the leaf the vhost serves, the
+   same value the self-calls verify against.
+2. It is then **checked against that certificate** by `_certServesName()`, which
+   applies *iPXE's* rule rather than OpenSSL's: per ADR 0016, iPXE's
+   `x509_check_name()` honours a `commonName` only when the certificate carries
+   no `subjectAltName` at all. Once any SAN exists the CN is ignored. IP SANs are
+   ignored throughout — they cannot satisfy a URL built from a name.
+3. A failure to satisfy this is **fatal, before anything is written**. An install
+   that completes having laid down an unbootable `default.ipxe` is strictly worse
+   than one that stops and says which names the certificate does carry.
+4. `FOG_WEB_HOST` is **recorded** from the same value by
+   `recordNetbootWebHost()`, so hops 2..n agree with hop 1 by construction.
+
+Plain-HTTP netboot is untouched and still uses `$ipaddress`. It never cared about
+names, and rewriting it would change the boot URL of every ordinary install.
+
+### `FOG_WEB_HOST` becomes a record, but only under HTTPS netboot
+
+This is the part an admin can be surprised by, so it is stated plainly: when
+`netbootproto=https`, `FOG_WEB_HOST` is overwritten on every install run and an
+edit through the Settings tab will not survive. It joins `FOG_GIT_PATH`,
+`FOG_EXTRA_SERVER_NAMES` and `SERVICE_LOG_PATH` as a record rather than a
+control, for the same reason `SERVICE_LOG_PATH` became one: two things that must
+agree, kept in step by deriving one from the other instead of hoping.
+
+The gate matters. On a plain-HTTP install `FOG_WEB_HOST` is a name plenty of
+admins set deliberately, no certificate has to match it, and rewriting it would
+be a regression dressed as a fix. So the recorder returns immediately unless
+netboot is HTTPS.
+
+## Consequences
+
+- HTTPS netboot works on a publicly-issued certificate without the admin having
+  to know that `$hostname` and `FOG_WEB_HOST` are separate values that both had
+  to be right.
+- A server whose certificate genuinely cannot cover a usable name now fails the
+  install instead of shipping a broken TFTP tree. That is a louder failure than
+  before on exactly the installs that were already broken.
+- `--extra-server-name` is explicitly *not* offered as a remedy in the failure
+  message. It only feeds FOG's own SAN list, and the branch fires mostly on
+  installs whose leaf FOG did not issue.
+- A wildcard-only match is accepted **with a printed note**, because whether
+  iPXE's `x509_check_name()` honours a wildcard SAN is unverified — `fog-ipxe`
+  is an overlay and carries no upstream `crypto/x509.c` to read. Verify against
+  upstream and tighten or relax then.
+- `tests/netboot-host.test.sh` pins all of it, including the case most likely to
+  be "simplified" later: that the CN must be ignored once any SAN exists. There
+  was previously no test over the netboot host at all —
+  `install-settings-resolution.test.sh` covers which *protocol* is chosen but
+  never calls the function that writes the URL, which is why this shipped.
+
+## Alternatives rejected
+
+**Require an FQDN shape instead of checking the certificate.** Extending the
+existing guard to reject a single label is a two-line change and would have fixed
+the reported symptom. It still accepts a dotted name the certificate does not
+carry — `fog.internal.lan` when the leaf says `fog.arrowheaddental.com` — which
+fails identically and is harder to diagnose, because the install claims to have
+validated something.
+
+**Read `FOG_WEB_HOST` in the installer and use it for hop 1.** Makes the two hops
+agree, but agrees on the wrong thing: the row is an IP on every fresh install, is
+admin-editable with no validation, and the installer has no access to it today.
+It would move the mismatch rather than remove it.
+
+**Derive hops 2..n from `$_SERVER['HTTP_HOST']` instead of `FOG_WEB_HOST`.** The
+elegant option — hop 1 sets the identity and the rest inherit it, exactly as the
+*protocol* already self-derives from `$_SERVER['HTTPS']`. Rejected as too broad
+for a bug fix: it changes the boot URLs of every existing install, including HTTP
+ones where `FOG_WEB_HOST` deliberately differs from the address iPXE dialled, and
+it puts a client-supplied header into generated boot URLs.
+
+**Warn instead of failing.** Leaves an install that completes cleanly and cannot
+boot — the precise failure mode the original IP guard was made fatal to prevent.
+
+## References
+
+- ADR 0015 — the settings this builds on: `netbootproto`, `publicWebCert`,
+  `rebuildIpxeWithMyCA` as independent keys.
+- ADR 0016 — why iPXE's name checking is the rule to mirror.
+- `docs/PKI_ZONES.md` — the Let's Encrypt netboot caveat this enforces.
+- `docs/HTTPPROTO_COVERAGE_AUDIT.md` §A2 — the full set of URLs iPXE fetches.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -575,6 +575,30 @@ recordGitUpdateSettings() {
     mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('SERVICE_LOG_PATH', 'Where the linux side fog services write their logs. Recorded automatically by installfog.sh from the install path -- editing it here has no effect. To move the logs, re-run the installer with a different base path.', \"${servicelogs%/}/\", 'FOG Linux Service Logs') ON DUPLICATE KEY UPDATE settingValue=\"${servicelogs%/}/\", settingDesc=VALUES(settingDesc)" $mysqldbname >>$error_log 2>&1
     errorStat $?
 }
+# Keeps FOG_WEB_HOST in step with the name netboot uses.
+#
+# A boot is two hops with two host sources. default.ipxe names the server for
+# the fetch of boot.php; BootMenu builds everything after it -- the iPXE menu,
+# the kernel's web= argument, the Secure Boot MOK.der and mmx64.efi -- from this
+# row. The row is seeded from $ipaddress on a fresh schema deploy and was then
+# never written again, so a fresh public-cert install pointed all of those at
+# https://<address>/ and nothing compared the two. Recording it makes them agree
+# by construction, the same argument as SERVICE_LOG_PATH above.
+#
+# Under HTTPS netboot ONLY, and that guard is load-bearing. On a plain-HTTP
+# install FOG_WEB_HOST is a name plenty of admins set deliberately and no
+# certificate has to match it, so rewriting it there would be a regression
+# dressed as a fix.
+recordNetbootWebHost() {
+    [[ $netbootproto == https ]] || return 0
+    _resolveNetbootHost || return 1
+    [[ -n $netboothost ]] || return 0
+    dots "Pointing FOG_WEB_HOST at the netboot certificate name"
+    mysql $sqloptionsuser --password="${snmysqlpass}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_WEB_HOST', 'This setting defines the hostname or ip address of the web server used with fog. Under HTTPS netboot it is recorded automatically from the served certificate name, because every boot URL iPXE fetches after boot.php is built from it -- an edit here is overwritten on the next install.', \"$netboothost\", 'Web Server') ON DUPLICATE KEY UPDATE settingValue=\"$netboothost\", settingDesc=VALUES(settingDesc)" $mysqldbname >>$error_log 2>&1
+    errorStat $?
+    echo "   FOG_WEB_HOST is now $netboothost. Every boot URL after boot.php is"
+    echo "   built from it, and HTTPS netboot needs them to match the certificate."
+}
 backupDB() {
     # ---------------------------------------------------------
     # External Unprivileged Database Implementation
@@ -1891,37 +1915,25 @@ configureDefaultiPXEfile() {
     # (FOGBase::$httpproto reads $_SERVER['HTTPS']), so chaining over HTTP here
     # makes the whole boot sequence HTTP with no PHP change.
     _resolveNetbootProto
-    # HTTPS netboot has to address this server by NAME, never by IP.
+    # HTTPS netboot has to address this server by a name its CERTIFICATE
+    # carries -- not by IP, and not merely by "a name".
     #
-    # A certificate is issued to a name. Public CAs will not issue for a
-    # private IP at all, and even where the chain itself validates, iPXE still
-    # fails the handshake on a name mismatch -- so an https:// URL built from
-    # $ipaddress cannot work, whatever the certificate is. HTTP does not care,
-    # which is why this has never mattered before.
+    # A certificate is issued to a name. Public CAs will not issue for a private
+    # IP at all, and even where the chain itself validates, iPXE still fails the
+    # handshake on a name mismatch -- so an https:// URL built from $ipaddress
+    # cannot work, whatever the certificate is. HTTP does not care, which is why
+    # this has never mattered before.
+    #
+    # $hostname is NOT good enough, which is the bug this replaces. It is a
+    # short label on plenty of servers and validhostname() accepts one; that is
+    # harmless against a FOG-issued leaf, because _defaultServerNames() puts the
+    # short form in the SAN list, and impossible against a publicly-issued one.
+    # _resolveNetbootHost asks the certificate instead, and is shared with
+    # recordNetbootWebHost so the two hops of a boot cannot name different hosts.
     local nbhost="$ipaddress"
     if [[ $netbootproto == https ]]; then
-        nbhost="${hostname:-$ipaddress}"
-        # validip echoes 0 for a valid IPv4 literal, 1 otherwise.
-        if [[ -z $hostname || $(validip "$nbhost") -eq 0 ]]; then
-            echo "Failed"
-            echo
-            echo " ###################################################################"
-            echo " # HTTPS netboot needs a hostname, and this server has only an IP.  #"
-            echo " #                                                                 #"
-            echo " # A certificate is issued to a NAME. Public CAs will not issue for #"
-            echo " # a private IP, and iPXE fails the handshake on a name mismatch    #"
-            echo " # even after the chain validates -- so every PXE client would stop #"
-            echo " # at the TLS handshake.                                            #"
-            echo " #                                                                 #"
-            echo " # Set a resolvable hostname with --hostname, or put netboot back   #"
-            echo " # on HTTP with --netboot-proto http.                               #"
-            echo " ###################################################################"
-            echo
-            # Fatal on purpose. Writing this file with an IP would produce an
-            # install that completes cleanly and cannot boot anything.
-            [[ -z $exitFail ]] && exit 1
-            return 1
-        fi
+        _resolveNetbootHost || return 1
+        nbhost="$netboothost"
     fi
     echo -e "#!ipxe\nset arch \${buildarch}\niseq \${arch} i386 && cpuid --ext 29 && set arch x86_64 ||\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nparam sysuuid \${uuid}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain ${netbootproto}://${nbhost}${webroot}service/ipxe/boot.php##params" > "$tftpdirdst/default.ipxe"
     errorStat $?
@@ -4660,6 +4672,151 @@ _servedCertName() {
     done
     [[ -n $hostname ]] && { echo "$hostname"; return 0; }
     echo "$ipaddress"
+}
+# The DNS names a certificate carries as subjectAltName entries.
+#
+# Echoes one per line, nothing at all when the certificate has no
+# subjectAltName extension -- and that difference is load-bearing, because it is
+# what decides whether the commonName counts as a host name (see
+# _certServesName below).
+#
+# -text and awk rather than `openssl x509 -ext subjectAltName`: -ext arrived in
+# OpenSSL 1.1.1 and this has to work wherever the installer runs. The
+# continuation match is not decoration either -- openssl wraps a long SAN list
+# across lines, and reading only the first would silently drop names.
+_certDnsNames() {
+    local cert="$1"
+    [[ -n $cert && -f $cert ]] || return 0
+    openssl x509 -noout -text -in "$cert" 2>/dev/null \
+        | awk '/X509v3 Subject Alternative Name/ { grab = 1; next }
+               grab && /^[[:space:]]+(DNS|IP|IP Address|email|URI|DirName|othername|Registered ID):/ { print; next }
+               grab { exit }' \
+        | tr ',' '\n' \
+        | sed -n 's/^[[:space:]]*DNS:[[:space:]]*//p'
+}
+# Does the certificate at $1 serve the name in $2?
+#
+# By iPXE's rule, not OpenSSL's. Per docs/adr/0016, iPXE's x509_check_name()
+# accepts a commonName as a host name ONLY when the certificate carries no
+# subjectAltName at all. Mirroring that exactly matters: a check laxer than the
+# validator we are trying to satisfy is worse than no check, because it blesses
+# an install that completes cleanly and then cannot boot anything.
+#
+# IP SANs are deliberately ignored. They cannot help a URL built from a name,
+# and iPXE matches addresses and names separately anyway.
+#
+# Echoes "exact" or "wildcard" and returns 0 on a match; echoes nothing and
+# returns 1 otherwise. The two are distinguished because whether iPXE honours a
+# wildcard SAN is UNVERIFIED -- fog-ipxe is an overlay and carries no upstream
+# crypto/x509.c to read -- so the caller reports a wildcard match rather than
+# trusting it silently.
+_certServesName() {
+    local cert="$1" name="$2" sans cn n bare
+    [[ -n $cert && -f $cert && -n $name ]] || return 1
+    name=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+    sans=$(_certDnsNames "$cert")
+    if [[ -z $sans ]]; then
+        cn=$(openssl x509 -noout -subject -nameopt multiline -in "$cert" 2>/dev/null \
+            | awk -F' = ' '/commonName/{print $2; exit}' \
+            | tr '[:upper:]' '[:lower:]')
+        [[ -n $cn && $cn == "$name" ]] && { echo exact; return 0; }
+        return 1
+    fi
+    # Exact matches first, so one anywhere in the list beats a wildcard that
+    # also happens to cover the name.
+    while IFS= read -r n; do
+        n=$(echo "$n" | tr '[:upper:]' '[:lower:]')
+        [[ -n $n && $n == "$name" ]] && { echo exact; return 0; }
+    done <<< "$sans"
+    while IFS= read -r n; do
+        n=$(echo "$n" | tr '[:upper:]' '[:lower:]')
+        [[ $n == '*.'* ]] || continue
+        # One label, and a real one. Comparing what is left after the first dot
+        # rather than glob-matching '*.example.org' is what keeps this from
+        # accepting deep.sub.example.org, which a glob would.
+        bare="${n#\*.}"
+        [[ $name == *.* && ${name#*.} == "$bare" ]] && { echo wildcard; return 0; }
+    done <<< "$sans"
+    return 1
+}
+# The single name HTTPS netboot addresses this server by. Sets $netboothost.
+#
+# Not local, on purpose. A boot is two hops with two host sources: default.ipxe
+# names the server for the fetch of boot.php, and BootMenu builds every URL
+# after it from the FOG_WEB_HOST row. Those two used to be $hostname and a DB
+# setting with nothing comparing them, which is the defect this fixes -- so
+# configureDefaultiPXEfile and recordNetbootWebHost read one variable and cannot
+# disagree.
+#
+# Idempotent and silent on a second call, because the recorder asks after
+# configureDefaultiPXEfile already has.
+#
+# Why the certificate and not $hostname: $hostname is a short label on plenty of
+# servers, and validhostname() accepts one. That is harmless on a FOG-issued
+# leaf -- _defaultServerNames() puts the short form in the SAN list -- and
+# cannot work on a publicly-issued one, which carries only the names its issuer
+# was asked for. publicWebCert is one of exactly two triggers for HTTPS netboot,
+# so the short-name case is not an edge case here; it is half the population.
+_resolveNetbootHost() {
+    local cert match="" reason=""
+    [[ -n $netboothost ]] && return 0
+    netboothost=$(_servedCertName)
+    cert=$(_vhostCertPath)
+    [[ -n $cert && -f $cert ]] || cert="$sslpubcert"
+    [[ -n $cert && -f $cert ]] || cert="$sslfullchain"
+    [[ -n $cert && -f $cert ]] || cert=""
+    # validip echoes 0 for a valid IPv4 literal, 1 otherwise.
+    if [[ -z $netboothost || $(validip "$netboothost") -eq 0 ]]; then
+        reason="address"
+    elif [[ -n $cert ]] && ! match=$(_certServesName "$cert" "$netboothost"); then
+        reason="mismatch"
+    fi
+    if [[ -n $reason ]]; then
+        echo "Failed"
+        echo
+        echo " ##################################################################"
+        echo " # HTTPS netboot has to address this server by a name its          #"
+        echo " # certificate carries. iPXE has no --insecure and fails the       #"
+        echo " # handshake on a name mismatch, so every PXE client would stop    #"
+        echo " # before it fetched anything.                                    #"
+        echo " ##################################################################"
+        echo
+        if [[ $reason == address ]]; then
+            echo "   This server has no name to use, only the address ${netboothost:-$ipaddress}."
+            echo
+            echo "   Set a resolvable name with --hostname, or put netboot back on"
+            echo "   HTTP with --netboot-proto http."
+        else
+            echo "   Resolved name: $netboothost"
+            echo "   Certificate:   $cert"
+            echo "   It carries:    $(_certDnsNames "$cert" | tr '\n' ' ')"
+            echo
+            echo "   Re-issue the certificate for $netboothost, or put netboot back"
+            echo "   on HTTP with --netboot-proto http."
+            echo
+            # Deliberately NOT offered above: --extra-server-name. It only feeds
+            # FOG's own SAN list, and _createWebLeaf() returns early on an
+            # acmeLeaf/publicWebCert install, so it cannot change a leaf issued
+            # outside FOG -- which is the install this branch mostly fires on.
+            echo "   Note: --extra-server-name cannot help here. It only affects a"
+            echo "   leaf FOG issues, and this certificate was issued elsewhere."
+        fi
+        echo
+        # Fatal on purpose, and before anything is written: an install that
+        # completes having laid down an unbootable default.ipxe is worse than one
+        # that stops and says why.
+        [[ -z $exitFail ]] && exit 1
+        return 1
+    fi
+    if [[ $match == wildcard ]]; then
+        echo
+        echo "   Note: $netboothost matches only a WILDCARD name in the served"
+        echo "   certificate. Whether iPXE honours a wildcard SAN is unverified,"
+        echo "   so if netboot stops at the TLS handshake, re-issue with"
+        echo "   $netboothost as an explicit name."
+        echo
+    fi
+    return 0
 }
 # The --cacert arguments for an HTTPS call this server makes to ITSELF.
 #

--- a/tests/netboot-host.test.sh
+++ b/tests/netboot-host.test.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+# Guards the host that HTTPS netboot addresses this server by.
+#
+#   tests/netboot-host.test.sh
+#
+# iPXE validates TLS strictly and has no --insecure, so the name in the netboot
+# URL has to be a name the served certificate actually carries. There was no
+# test over this at all: install-settings-resolution.test.sh covers which
+# PROTOCOL is chosen but never calls the function that writes the URL, so
+# nothing could see the host.
+#
+# What went wrong without one. configureDefaultiPXEfile() used $ipaddress for
+# the whole prior life of the line; when a name was introduced it was
+# ${hostname:-$ipaddress}, guarded only by validip -- and validhostname()
+# accepts a single label, so a short "fog" passed every check and produced
+# https://fog/fog/service/ipxe/boot.php against a certificate issued to
+# fog.arrowheaddental.com. iPXE stopped at the handshake.
+#
+# That failed only on the path the change was written for. _defaultServerNames()
+# puts both the FQDN and the short ${hostname%%.*} in the SAN list, so a short
+# name is a real SAN on a FOG-issued certificate. But _createWebLeaf() returns
+# early when acmeLeaf/publicWebCert is set, so a publicly-issued leaf carries
+# only the names its issuer was asked for -- and publicWebCert is one of exactly
+# two things that select HTTPS netboot.
+#
+# The properties pinned here, in the order they are easiest to break again:
+#
+#   1. the name comes from the CERTIFICATE, not from $hostname (A2, I);
+#   2. a commonName is honoured only when there is no subjectAltName at all,
+#      which is iPXE's own rule -- see docs/adr/0016 (D, E). E is the one most
+#      likely to be "simplified" by someone who reads D;
+#   3. an install that cannot satisfy this FAILS rather than writing an
+#      unbootable default.ipxe (K, L, P);
+#   4. HTTP netboot is untouched and still uses the address (O).
+#
+# Needs openssl. Runs entirely on generated fixtures -- no install, no network,
+# no root, no database.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()    { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()   { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+rc()    { [[ $1 -eq $2 ]] && ok "$3" || bad "$3 (expected rc $2, got $1)"; }
+has()   { [[ $1 == *"$2"* ]] && ok "$3" || bad "$3 (not found in '$1')"; }
+hasnt() { [[ $1 != *"$2"* ]] && ok "$3" || bad "$3 (unexpectedly present in '$1')"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# A leaf with an explicit SAN set, via a config file rather than -addext:
+# -addext needs OpenSSL 1.1.1, and the point of this suite is to run wherever
+# the installer does. An empty $3 means NO subjectAltName extension at all,
+# which is a different case from an empty one and is what D exercises.
+mkleaf() {
+    local out=$1 cn=$2 sans=$3 cnf="$WORK/$1.cnf"
+    {
+        echo "[req]"
+        echo "distinguished_name = dn"
+        echo "prompt = no"
+        echo "[dn]"
+        echo "CN = $cn"
+        if [[ -n $sans ]]; then
+            echo "[v3]"
+            echo "subjectAltName = $sans"
+        fi
+    } > "$cnf"
+    local -a ext=()
+    [[ -n $sans ]] && ext=(-extensions v3)
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 -config "$cnf" "${ext[@]}" \
+        -keyout "$WORK/$out.key" -out "$WORK/$out.pem" >/dev/null 2>&1
+}
+
+# The publicly-issued shape: exactly the name its issuer was asked for. No short
+# name, no IP. This is the reported failure.
+mkleaf public   "fog.example.org" "DNS:fog.example.org"
+# The FOG-issued shape: _defaultServerNames() adds the short form and the IPs.
+mkleaf fogpki   "fog.example.org" "DNS:fog.example.org,DNS:fog,IP:10.0.0.1"
+# CN only, no SAN extension whatsoever.
+mkleaf cnonly   "fog.example.org" ""
+# A CN that is NOT among its own SANs. Once a SAN exists the CN must be ignored.
+mkleaf cnliar   "fog"             "DNS:other.example.org"
+mkleaf wildcard "*.example.org"   "DNS:*.example.org"
+
+reset_env() {
+    etcconf=""; sslpubcert=""; sslfullchain=""
+    hostname=""; ipaddress=""; ipaddresses=""; extraServerNames=""
+    netboothost=""; netbootproto=""; netbootProtoForced=""; snetbootproto=""
+    publicWebCert="no"; rebuildIpxeWithMyCA="no"
+    webroot="/fog/"
+    tftpdirdst="$WORK/tftp"
+    error_log="$WORK/error.log"
+    # Without this the fatal paths call `exit 1` and take the test script with
+    # them. functions.sh honours it on every one of them.
+    exitFail=1
+}
+
+echo "== _certServesName: does the certificate carry this name? =="
+
+out=$(_certServesName "$WORK/public.pem" "fog.example.org"); status=$?
+check "$out" "exact" "A: the FQDN in the SAN list matches"
+rc $status 0 "A2: ...and returns success"
+
+out=$(_certServesName "$WORK/public.pem" "fog"); status=$?
+rc $status 1 "B: the SHORT name does NOT match a public leaf -- the reported bug"
+
+out=$(_certServesName "$WORK/fogpki.pem" "fog"); status=$?
+check "$out" "exact" "C: the short name DOES match a FOG-issued leaf (it is a SAN)"
+
+out=$(_certServesName "$WORK/cnonly.pem" "fog.example.org"); status=$?
+check "$out" "exact" "D: with no SAN at all, the commonName is honoured (ADR 0016)"
+
+out=$(_certServesName "$WORK/cnliar.pem" "fog"); status=$?
+rc $status 1 "E: once ANY SAN exists the commonName is ignored -- do not 'simplify' this"
+
+out=$(_certServesName "$WORK/wildcard.pem" "fog.example.org"); status=$?
+check "$out" "wildcard" "F: a wildcard SAN matches one label, and says so"
+
+out=$(_certServesName "$WORK/wildcard.pem" "deep.sub.example.org"); status=$?
+rc $status 1 "G: a wildcard does NOT match across a dot"
+
+out=$(_certServesName "$WORK/nope.pem" "fog.example.org"); status=$?
+rc $status 1 "H: an unreadable certificate matches nothing"
+
+echo "== _resolveNetbootHost: one name for the whole boot =="
+
+# I. The reported case: a public leaf for the FQDN, and $hostname holding the
+#    short name. The certificate wins.
+reset_env
+sslpubcert="$WORK/public.pem"
+hostname="fog"; ipaddress="10.0.0.1"
+_resolveNetbootHost >/dev/null 2>&1; status=$?
+rc $status 0 "I: resolves against a public leaf"
+check "$netboothost" "fog.example.org" "I2: the name is the CERTIFICATE's, not \$hostname"
+
+# J. No certificate to read -- a storage node's configureMinHttpd path, or
+#    --no-vhost. Fall back to the name, never to the address.
+reset_env
+hostname="fog.example.org"; ipaddress="10.0.0.1"
+_resolveNetbootHost >/dev/null 2>&1; status=$?
+rc $status 0 "J: no readable certificate is not fatal on its own"
+check "$netboothost" "fog.example.org" "J2: ...it falls back to \$hostname"
+
+# K. No certificate AND no name: the address is all there is, and an https URL
+#    built from it cannot work whatever the certificate says.
+reset_env
+ipaddress="10.0.0.5"
+_resolveNetbootHost >/dev/null 2>&1; status=$?
+rc $status 1 "K: an address-only server is fatal under HTTPS netboot"
+
+# L. A certificate that does not serve the name resolved from it.
+reset_env
+sslpubcert="$WORK/cnliar.pem"
+hostname="fog"; ipaddress="10.0.0.1"
+_resolveNetbootHost >/dev/null 2>&1; status=$?
+rc $status 1 "L: a name the certificate does not carry is fatal"
+
+# M. Idempotent: the recorder calls this after configureDefaultiPXEfile already
+#    has, and must get the same answer without re-announcing it.
+reset_env
+sslpubcert="$WORK/public.pem"
+hostname="fog"; ipaddress="10.0.0.1"
+_resolveNetbootHost >/dev/null 2>&1
+second=$(_resolveNetbootHost 2>&1)
+check "$netboothost" "fog.example.org" "M: a second call keeps the same name"
+check "$second" "" "M2: ...and says nothing the second time"
+
+echo "== configureDefaultiPXEfile: what actually reaches default.ipxe =="
+
+# N. End to end. This is the artifact that broke; assert the file, not just the
+#    resolver.
+reset_env
+mkdir -p "$tftpdirdst"
+sslpubcert="$WORK/public.pem"
+hostname="fog"; ipaddress="10.0.0.1"
+snetbootproto="https"
+configureDefaultiPXEfile >/dev/null 2>&1
+written=$(cat "$tftpdirdst/default.ipxe" 2>/dev/null)
+has   "$written" "https://fog.example.org/fog/service/ipxe/boot.php" \
+    "N: default.ipxe chains to the certificate's name"
+hasnt "$written" "https://fog/" \
+    "N2: ...and not to the short hostname"
+
+# O. HTTP netboot is deliberately untouched. It never cared about names, and
+#    changing it would rewrite the boot URL of every ordinary install.
+reset_env
+mkdir -p "$tftpdirdst"
+rm -f "$tftpdirdst/default.ipxe"
+sslpubcert="$WORK/public.pem"
+hostname="fog"; ipaddress="10.0.0.1"
+snetbootproto="http"
+configureDefaultiPXEfile >/dev/null 2>&1
+written=$(cat "$tftpdirdst/default.ipxe" 2>/dev/null)
+has "$written" "http://10.0.0.1/fog/service/ipxe/boot.php" \
+    "O: HTTP netboot still uses the address"
+
+# P. The fatal case must not leave a file behind for TFTP to serve. An install
+#    that aborts having already written an unbootable default.ipxe is the worst
+#    of both outcomes.
+reset_env
+mkdir -p "$tftpdirdst"
+rm -f "$tftpdirdst/default.ipxe"
+ipaddress="10.0.0.5"
+snetbootproto="https"
+configureDefaultiPXEfile >/dev/null 2>&1
+if [[ ! -f $tftpdirdst/default.ipxe ]]; then
+    ok "P: an aborted resolution writes no default.ipxe"
+else
+    bad "P: default.ipxe was written despite an unusable host ($(cat "$tftpdirdst/default.ipxe"))"
+fi
+
+echo "== the recorder keeps FOG_WEB_HOST in step =="
+
+# Q. Hops 2..n come from the FOG_WEB_HOST DB row, which the installer never used
+#    to write -- it is seeded from $ipaddress on a fresh schema deploy and then
+#    left alone, so a fresh public-cert install pointed them at https://<IP>/.
+#    Source-level, because asserting the row needs a database.
+if grep -q "recordNetbootWebHost" "$REPO/bin/installfog.sh"; then
+    ok "Q: installfog.sh records FOG_WEB_HOST"
+else
+    bad "Q: nothing keeps FOG_WEB_HOST in step with the netboot name"
+fi
+
+# R. Gated on HTTPS netboot. Rewriting FOG_WEB_HOST on every plain-HTTP install
+#    would stomp a name plenty of admins set deliberately.
+if awk '/^recordNetbootWebHost\(\)/,/^}/' "$FUNCS" | grep -q 'netbootproto == https'; then
+    ok "R: the rewrite only happens under HTTPS netboot"
+else
+    bad "R: FOG_WEB_HOST would be rewritten on HTTP installs too"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## The report

An HTTPS netboot with a Let's Encrypt certificate and Secure Boot handed iPXE:

```
chain https://fog/fog/service/ipxe/boot.php##params
```

— the server's **short** hostname, against a certificate issued to
`fog.arrowheaddental.com`. iPXE has no `--insecure` and fails the handshake on a
name mismatch, so the boot stopped before it fetched anything.

## Root cause

`configureDefaultiPXEfile()` used `$ipaddress` for the entire prior life of that
line. When HTTPS netboot arrived it became `${hostname:-$ipaddress}`, guarded
only by `validip` — so the **only** rejected value was an IPv4 literal, and
`validhostname()` accepts a single label. A short name passed every check.

**The guard was wrong in a way testing could not see.** `_defaultServerNames()`
puts *both* the FQDN and the short `${hostname%%.*}` into the SAN list, so on a
FOG-issued leaf a short name is a genuine SAN and `$hostname` works fine. But
`_createWebLeaf()` returns early when `acmeLeaf`/`publicWebCert` is set — FOG's
SAN list is never applied to a publicly-issued leaf, which carries only the names
its issuer was asked for. Since `publicWebCert` is one of exactly two triggers for
HTTPS netboot, this is not an edge case: it is most of the population that selects
HTTPS netboot at all.

The installer already had the right helper, and this was the one self-reference
that missed it. `_servedCertName()` reads the CN off the leaf the vhost actually
serves, and the vhost's `ServerName` plus every installer HTTPS self-call had
already been moved onto it.

### The second half was worse than the reported case

A boot has two hops with two host sources, and nothing compared them:

| Hop | URL | Host came from |
|---|---|---|
| 1 | `default.ipxe` → `boot.php` | shell `$hostname` |
| 2..n | `${boot-url}/service/ipxe/*`, `web=`, Secure Boot `MOK.der` / `mmx64.efi` | `FOG_WEB_HOST` DB row |
| kernel / init | relative — inherits hop 1 | — |

`FOG_WEB_HOST` is seeded from `$ipaddress` on a fresh schema deploy and was then
**never written again** — the string appears nowhere in `lib/` or `bin/`. So a
fresh `--install-mode public-cert` install pointed all of hops 2..n at
`https://<address>/`, which no public CA will ever certify. The reported install
only broke at hop 1 because its admin had typed the FQDN into FOG Settings by
hand.

## The fix

- **`_resolveNetbootHost()`** resolves the name once into `$netboothost`
  (deliberately not `local`), so `configureDefaultiPXEfile` and
  `recordNetbootWebHost` cannot disagree. Idempotent and silent on a second call.
- **`_certServesName()`** checks it against that certificate using *iPXE's* rule,
  not OpenSSL's: per ADR 0016 a `commonName` counts only when there is no
  `subjectAltName` at all, so once any SAN exists the CN is ignored. IP SANs are
  ignored throughout — they cannot satisfy a URL built from a name.
- **Fatal before anything is written**, listing the names the certificate does
  carry. An install that completes having laid down an unbootable `default.ipxe`
  is worse than one that stops and says why. `--extra-server-name` is
  deliberately *not* offered as the remedy — it only feeds FOG's own SAN list.
- **`recordNetbootWebHost()`** records `FOG_WEB_HOST` from the same resolved name,
  reusing `recordGitUpdateSettings()`'s existing `INSERT … ON DUPLICATE KEY`
  pattern.
- A **wildcard-only** match is accepted with a printed note rather than trusted
  silently: whether iPXE's `x509_check_name()` honours a wildcard SAN is
  unverified, as `fog-ipxe` is an overlay with no upstream `crypto/x509.c` to read.

Plain-HTTP netboot is untouched and still uses `$ipaddress`.

## Behaviour change worth flagging

Under `netbootproto=https` **only**, `FOG_WEB_HOST` becomes a record rather than
a control — rewritten on every install run, so an edit via FOG Settings will not
survive. It joins `FOG_GIT_PATH`, `FOG_EXTRA_SERVER_NAMES` and `SERVICE_LOG_PATH`.

That gate is load-bearing. On a plain-HTTP install `FOG_WEB_HOST` is a name plenty
of admins set deliberately, no certificate has to match it, and rewriting it there
would be a regression dressed as a fix.

## Tests

`tests/netboot-host.test.sh` is new because there was **no** coverage of the
netboot host at all — `install-settings-resolution.test.sh` covers which
*protocol* is chosen but never calls the function that writes the URL, which is
why this shipped. 23 assertions, on generated fixtures only (no install, no
network, no root, no DB). It asserts the reported URL end to end and pins the case
most likely to be "simplified" later: that the CN must be ignored once any SAN
exists.

Verified against the baseline by stashing the change and re-running: the suite
goes from **57 passed / 15 failed** to **58 / 14**, the two failure lists
differing only by this test. The remaining 14 are pre-existing openssl-fixture
and PHP failures on the dev machine, unrelated to this change.

## Docs

- `docs/adr/0018-netboot-addresses-this-server-by-its-certificate-name.md` — new,
  including the `FOG_WEB_HOST` record/control change and the rejected
  alternatives (FQDN-shape check only; reading `FOG_WEB_HOST` for hop 1; deriving
  hops 2..n from `$_SERVER['HTTP_HOST']`; warning instead of failing).
- `docs/PKI_ZONES.md` — its prose said *"Set `FOG_WEB_HOST` to that FQDN or the
  generated boot URLs will not match the certificate"* and nothing enforced it.
  Now describes what the installer does instead.
- `docs/HTTPPROTO_COVERAGE_AUDIT.md` §A2 — the step table listed the URLs without
  saying that `<host>` is two different values.

## Not in scope

- `bootmenu.class.php:477-478` hardcodes `/fog/` in `$_booturl`, so Secure Boot and
  `advanced.php` URLs ignore `FOG_WEB_ROOT` — already recorded in
  `HTTPPROTO_COVERAGE_AUDIT.md` as a GH-529 leftover. Independent bug, harmless
  at the default webroot.
- No REST route changed, so `OpenAPI::document()` needs no edit and there is no
  downstream FogApi class-list sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
