### PR TITLE
Apply the site boundary to the API, not just to the management pages

### DIFF
--- a/packages/web/lib/plugins/site/class/site.class.php
+++ b/packages/web/lib/plugins/site/class/site.class.php
@@ -323,4 +323,119 @@ class Site extends FOGController
         }
         return $this;
     }
+    /**
+     * Whether this user's view is bounded by site membership.
+     *
+     * @param int $userID The user to test.
+     *
+     * @return bool
+     */
+    public static function userIsRestricted($userID)
+    {
+        $userID = (int)$userID;
+        if ($userID < 1) {
+            return false;
+        }
+        $flags = self::getSubObjectIDs(
+            'SiteUserRestriction',
+            array('userID' => $userID),
+            'isRestricted'
+        );
+        return (bool)(isset($flags[0]) ? $flags[0] : false);
+    }
+    /**
+     * The sites this user belongs to.
+     *
+     * @param int $userID The user to look up.
+     *
+     * @return array
+     */
+    public static function userSiteIDs($userID)
+    {
+        return (array)self::getSubObjectIDs(
+            'SiteUserAssociation',
+            array('userID' => (int)$userID),
+            'siteID'
+        );
+    }
+    /**
+     * The hosts belonging to any of these sites.
+     *
+     * @param array $siteIDs The sites.
+     *
+     * @return array
+     */
+    public static function hostIDsForSites($siteIDs)
+    {
+        return (array)self::getSubObjectIDs(
+            'SiteHostAssociation',
+            array('siteID' => (array)$siteIDs),
+            'hostID'
+        );
+    }
+    /**
+     * The groups holding one or more hosts of these sites.
+     *
+     * @param array $siteIDs The sites.
+     *
+     * @return array
+     */
+    public static function groupIDsForSites($siteIDs)
+    {
+        $hostIDs = self::hostIDsForSites($siteIDs);
+        if (count($hostIDs) < 1) {
+            return array();
+        }
+        return (array)self::getSubObjectIDs(
+            'GroupAssociation',
+            array('hostID' => $hostIDs),
+            'groupID'
+        );
+    }
+    /**
+     * The object ids $userID may see for $classname.
+     *
+     * THE RETURN IS A TRI-STATE and the distinction is the whole point:
+     *
+     *   null          no boundary applies -- leave the caller's set alone
+     *   array(...)    narrow to exactly these ids
+     *   array()       a real answer meaning "nothing", NOT "no boundary"
+     *
+     * null is the only value that means "unbounded". Treating an empty
+     * array as unbounded -- which is what any `if (!$ids)` test does -- is
+     * how a user entitled to nothing ends up seeing everything, so callers
+     * must test `null ===` and nothing looser.
+     *
+     * This is the single statement of the membership rule. The management
+     * pages reach it through AddSiteFilterSearch and the API reaches it
+     * through AddSiteAPI; if the two ever disagree about who may see what,
+     * the boundary is decorative.
+     *
+     * @param string $classname The class being listed or fetched.
+     * @param int    $userID    The acting user.
+     *
+     * @return array|null
+     */
+    public static function scopedObjectIDs($classname, $userID)
+    {
+        $classname = strtolower((string)$classname);
+        // Only what the plugin actually associates. Everything else --
+        // images, snapins, storage nodes, the association tables -- has no
+        // site boundary to apply, and returning an id list for one would
+        // narrow lookups the plugin knows nothing about.
+        if (!in_array($classname, array('host', 'group'), true)) {
+            return null;
+        }
+        $userID = (int)$userID;
+        if (!self::userIsRestricted($userID)) {
+            return null;
+        }
+        $siteIDs = self::userSiteIDs($userID);
+        if (count($siteIDs) < 1) {
+            return array();
+        }
+        return 'group' === $classname
+            ? self::groupIDsForSites($siteIDs)
+            : self::hostIDsForSites($siteIDs);
+    }
 }

--- a/packages/web/lib/plugins/site/hooks/addsiteapi.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsiteapi.hook.php
@@ -81,6 +81,13 @@ class AddSiteAPI extends Hook
                     $this,
                     'adjustMassInfo'
                 )
+            )
+            ->register(
+                'API_SCOPE_IDS',
+                array(
+                    $this,
+                    'scopeIDs'
+                )
             );
     }
     /**
@@ -188,6 +195,53 @@ class AddSiteAPI extends Hook
                 
                 break;
         }
+    }
+    /**
+     * Narrows an API read to the acting user's sites.
+     *
+     * Until this existed the plugin's boundary was a management-page
+     * feature: the only filtering hook is AddSiteFilterSearch, registered
+     * on HOST_DATA and GROUP_DATA, and both handlers switch on the global
+     * $node/$sub the pages set. Nothing under api/ fires those events, so
+     * a site-restricted user saw their site in the grid and every host on
+     * the server through /fog/host/list -- on the same credentials, and
+     * without an API token, because Route skips API auth entirely when a
+     * management session is already valid.
+     *
+     * Sets $arguments['ids'] only when a boundary actually applies. Left
+     * alone it stays null, which is the caller's "no narrowing" value; an
+     * EMPTY array set here is a real answer meaning the user may see
+     * nothing. See Site::scopedObjectIDs() for why those must not be
+     * collapsed.
+     *
+     * @param mixed $arguments The arguments to modify.
+     *
+     * @return void
+     */
+    public function scopeIDs($arguments)
+    {
+        if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+            return;
+        }
+        // No acting user means no boundary to apply -- the service daemons
+        // and the status endpoints reach Route::ids()/names() with nobody
+        // logged in, and narrowing those to a site would break imaging
+        // rather than protect anything.
+        if (!self::$FOGUser || !self::$FOGUser->isValid()) {
+            return;
+        }
+        $scope = Site::scopedObjectIDs(
+            $arguments['classname'],
+            self::$FOGUser->get('id')
+        );
+        if (null === $scope) {
+            return;
+        }
+        $arguments['ids'] = array_values(
+            array_unique(
+                array_map('intval', (array)$scope)
+            )
+        );
     }
     /**
      * This function changes the getter to enact on this particular item.

--- a/packages/web/lib/plugins/site/hooks/addsitefiltersearch.hook.php
+++ b/packages/web/lib/plugins/site/hooks/addsitefiltersearch.hook.php
@@ -85,11 +85,17 @@ class AddSiteFilterSearch extends Hook
             case 'host':
                 switch ($sub) {
                     case 'search':
+                        // Narrowed against $siteHosts rather than by a
+                        // second SiteHostAssociation lookup of its own:
+                        // the membership rule lives in Site now, and two
+                        // statements of who may see what is a boundary
+                        // that is decorative the first time they differ.
                         $hostsID = self::getClass('HostManager')->search('');
-                        $hosts = self::getSubObjectIDs(
-                            'SiteHostAssociation',
-                            array('hostID' => $hostsID,'siteID'=>$siteIDbyUser),
-                            'hostID'
+                        $hosts = array_values(
+                            array_intersect(
+                                array_map('intval', (array)$hostsID),
+                                array_map('intval', (array)$siteHosts)
+                            )
                         );
                         break;
                     case 'list':
@@ -212,12 +218,7 @@ class AddSiteFilterSearch extends Hook
      */
     public function isRestricted($userid)
     {
-        $userRestrictions = self::getSubObjectIDs(
-            'SiteUserRestriction',
-            array('userID' => $userid),
-            'isRestricted'
-        );
-        return $userRestrictions[0];
+        return Site::userIsRestricted($userid);
     }
     /**
      * Get site IDs where the user is associated.
@@ -228,12 +229,7 @@ class AddSiteFilterSearch extends Hook
      */
     public function getSiteIDbyUser($userID)
     {
-        $find = array('userID' => $userID);
-        return self::getSubObjectIDs(
-            'SiteUserAssociation',
-            $find,
-            'siteID'
-        );
+        return Site::userSiteIDs($userID);
     }
 
     /**
@@ -245,12 +241,7 @@ class AddSiteFilterSearch extends Hook
      */
     public function getHostIDbySite($siteIDs)
     {
-        $find = array('siteID' => $siteIDs);
-        return self::getSubObjectIDs(
-            'SiteHostAssociation',
-            $find,
-            'hostID'
-        );
+        return Site::hostIDsForSites($siteIDs);
     }
     /**
      * Get the group IDs which have one or more hosts of the user locations.
@@ -261,11 +252,6 @@ class AddSiteFilterSearch extends Hook
      */
     public function getGroupIDbySite($siteIDbyUser)
     {
-        $siteHosts = $this->getHostIDbySite($siteIDbyUser);
-        return self::getSubObjectIDs(
-            'GroupAssociation',
-            array('hostID' => $siteHosts),
-            'groupID'
-        );
+        return Site::groupIDsForSites($siteIDbyUser);
     }
 }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -447,6 +447,18 @@ class Route extends FOGBase
                 ? self::$matches['params']['class']
                 : ''
             );
+            /**
+             * Object boundary for a per-object route. Inert unless a
+             * plugin answers API_SCOPE_IDS.
+             */
+            self::_requireObjectScope(
+                isset(self::$matches['params']['class'])
+                ? self::$matches['params']['class']
+                : '',
+                isset(self::$matches['params']['id'])
+                ? self::$matches['params']['id']
+                : 0
+            );
             call_user_func_array(
                 self::$matches['target'],
                 array_values(self::$matches['params'])
@@ -506,6 +518,103 @@ class Route extends FOGBase
         if (in_array($name, $allowed, true)
             && in_array(strtolower((string)$class), self::$nonAdminClasses, true)
         ) {
+            return;
+        }
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_FORBIDDEN
+        );
+    }
+    /**
+     * The object ids the acting user may see for this class, or null when
+     * no boundary applies.
+     *
+     * THE RETURN IS A TRI-STATE and every caller below depends on it:
+     *
+     *   null          no boundary -- leave the result set alone
+     *   array(...)    narrow to exactly these ids
+     *   array()       a real answer meaning "nothing"
+     *
+     * null is the ONLY value meaning unbounded. `if (!$ids)` is true for
+     * both null and array(), so a caller written that way shows every
+     * object to the one user entitled to none. Test `null ===`.
+     *
+     * Inert in core: nothing here knows what a site is. The site plugin
+     * answers the event; with the plugin absent or the user unrestricted
+     * the value stays null and the read behaves exactly as it always did.
+     *
+     * @param string $classname The class being read.
+     *
+     * @return array|null
+     */
+    private static function _scopeIDs($classname)
+    {
+        $ids = null;
+        self::$HookManager
+            ->processEvent(
+                'API_SCOPE_IDS',
+                array(
+                    'classname' => &$classname,
+                    'ids' => &$ids
+                )
+            );
+        return is_array($ids) ? array_values($ids) : null;
+    }
+    /**
+     * Narrows a filter set to the ids the acting user may see.
+     *
+     * Folded into the WHERE rather than applied to the rows afterwards, so
+     * a route that only ever produces ids -- names() and ids() -- is
+     * bounded by the query itself. An intersection that comes out empty is
+     * passed through as an empty array on purpose: _buildWhere() compiles
+     * that to `WHERE 1=0` rather than dropping the term, which is the
+     * difference between "you may see nothing" and "here is everything".
+     *
+     * @param string $classname  The class being read.
+     * @param array  $whereItems The caller's filter.
+     *
+     * @return array
+     */
+    private static function _scopeWhereItems($classname, $whereItems)
+    {
+        $scope = self::_scopeIDs($classname);
+        if (null === $scope) {
+            return $whereItems;
+        }
+        $whereItems = (array)$whereItems;
+        if (isset($whereItems['id'])) {
+            $whereItems['id'] = array_values(
+                array_intersect(
+                    array_map('intval', (array)$whereItems['id']),
+                    $scope
+                )
+            );
+            return $whereItems;
+        }
+        $whereItems['id'] = $scope;
+        return $whereItems;
+    }
+    /**
+     * Denies a per-object route whose target is outside the acting user's
+     * scope.
+     *
+     * At dispatch rather than in each handler, for the same reason
+     * _requireAuthorized() is: one place to audit, and it covers indiv,
+     * update, delete, task and cancel without each of them remembering.
+     * Routes carrying no id are unaffected.
+     *
+     * @param string $class The class the route is acting on, if any.
+     * @param int    $id    The target object id, if any.
+     *
+     * @return void
+     */
+    private static function _requireObjectScope($class, $id)
+    {
+        $id = (int)$id;
+        if ($id < 1) {
+            return;
+        }
+        $scope = self::_scopeIDs(strtolower((string)$class));
+        if (null === $scope || in_array($id, $scope, true)) {
             return;
         }
         self::sendResponse(
@@ -638,6 +747,10 @@ class Route extends FOGBase
             $find,
             self::getsearchbody($classname)
         );
+        // Object boundary. Applied to the rows rather than the query
+        // because this route has no LIMIT -- every match is built and
+        // returned -- so filtering here is exact and keeps 'count' honest.
+        $scope = self::_scopeIDs($classname);
         switch ($classname) {
             case 'plugin':
                 self::$data['count_active'] = 0;
@@ -669,6 +782,11 @@ class Route extends FOGBase
                         '_api_'
                     );
                     if (!$bypass && false != $test) {
+                        continue;
+                    }
+                    if (null !== $scope
+                        && !in_array((int)$class->get('id'), $scope, true)
+                    ) {
                         continue;
                     }
                     self::$data[$classname.'s'][] = self::getter(
@@ -726,8 +844,14 @@ class Route extends FOGBase
         self::$data = array();
         self::$data['count'] = 0;
         self::$data[$classname.'s'] = array();
+        $scope = self::_scopeIDs($classname);
         foreach ($classman->search($item, true) as &$class) {
             if (false != stripos($class->get('name'), '_api_')) {
+                continue;
+            }
+            if (null !== $scope
+                && !in_array((int)$class->get('id'), $scope, true)
+            ) {
                 continue;
             }
             self::$data[$classname.'s'][] = self::getter(
@@ -2101,6 +2225,7 @@ class Route extends FOGBase
         );
 
         $whereItems = self::handleWhereItems($whereItems, $class);
+        $whereItems = self::_scopeWhereItems($classname, $whereItems);
 
         $sql = 'SELECT `'
             . $classVars['databaseFields']['id']
@@ -2188,6 +2313,8 @@ class Route extends FOGBase
                 );
             }
         }
+
+        $whereItems = self::_scopeWhereItems($classname, $whereItems);
 
         $sql = 'SELECT `'
             . $classVars['databaseFields'][$getField]

--- a/tests/site-api-scope.test.php
+++ b/tests/site-api-scope.test.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * The site boundary must reach the API, and the tri-state must not be
+ * collapsed.
+ *
+ * The bug this guards: the site plugin's only filtering hook was
+ * registered on HOST_DATA and GROUP_DATA, whose handlers switch on the
+ * global $node/$sub the management pages set. Nothing under api/ fires
+ * those events, so a site-restricted user saw their site in the grid and
+ * every host on the server through /fog/host/list -- on the same
+ * credentials, and without an API token, because Route skips API auth
+ * entirely when a management session is already valid.
+ *
+ * Proven end to end against the 1.5 lab (2079 hosts, a user entitled to
+ * 2) before this landed: list 126, search 68, names 2079, ids 2079 for
+ * the restricted user, identical to the administrator's. After: 2 on
+ * every route, the administrator unchanged, and a restricted user
+ * belonging to NO site gets 0 rather than 2079. The driver is
+ * scripts/background_scripts/probe_site_api_scope.php.
+ *
+ * Static by design. Route extends FOGBase, so exercising these paths for
+ * real needs the full bootstrap, a database, the site plugin installed
+ * and a restricted user -- that is the probe's job. What runs anywhere,
+ * including in the pre-commit hook, is the shape: that each read route
+ * still consults the boundary, that the dispatcher still gates
+ * per-object routes, that nobody has rewritten a `null ===` test into a
+ * falsy one, and that the membership rule is stated once.
+ *
+ * Usage: php tests/site-api-scope.test.php [path/to/packages/web]
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = rtrim($argv[1] ?? dirname(__DIR__) . '/packages/web', '/');
+if (!is_dir($root)) {
+    fwrite(STDERR, "FAIL: no such directory: $root\n");
+    exit(1);
+}
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+function readFile_($path, array &$failures, &$checks)
+{
+    $src = @file_get_contents($path);
+    check('readable: ' . basename($path), false !== $src, $failures, $checks);
+    return (string)$src;
+}
+
+/**
+ * The body of a named method, brace-matched from its signature. Needed
+ * because "the file mentions _scopeIDs somewhere" is not the assertion --
+ * "listem() consults it" is, and a file-wide grep passes even after the
+ * call is deleted from the one method that mattered.
+ */
+function methodBody($src, $name)
+{
+    $sig = strpos($src, 'function ' . $name . '(');
+    if (false === $sig) {
+        return '';
+    }
+    $open = strpos($src, '{', $sig);
+    if (false === $open) {
+        return '';
+    }
+    $depth = 0;
+    $len = strlen($src);
+    for ($i = $open; $i < $len; $i++) {
+        if ('{' === $src[$i]) {
+            $depth++;
+        } elseif ('}' === $src[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                return substr($src, $open, $i - $open + 1);
+            }
+        }
+    }
+    return '';
+}
+
+$route = readFile_($root . '/lib/router/route.class.php', $failures, $checks);
+$site = readFile_($root . '/lib/plugins/site/class/site.class.php', $failures, $checks);
+$apiHook = readFile_(
+    $root . '/lib/plugins/site/hooks/addsiteapi.hook.php',
+    $failures,
+    $checks
+);
+$uiHook = readFile_(
+    $root . '/lib/plugins/site/hooks/addsitefiltersearch.hook.php',
+    $failures,
+    $checks
+);
+
+/*
+ * 1. Every route that answers "which objects are there" consults the
+ *    boundary. listem() and search() build objects and filter the rows;
+ *    names() and ids() only ever produce ids, so they fold it into the
+ *    WHERE instead. listdetails() is not listed because it delegates to
+ *    listem() -- and that delegation is asserted, so it cannot quietly
+ *    stop delegating.
+ */
+foreach (['listem', 'search'] as $fn) {
+    check(
+        "$fn() consults the object boundary",
+        false !== strpos(methodBody($route, $fn), '_scopeIDs('),
+        $failures,
+        $checks
+    );
+}
+foreach (['names', 'ids'] as $fn) {
+    check(
+        "$fn() folds the object boundary into its WHERE",
+        false !== strpos(methodBody($route, $fn), '_scopeWhereItems('),
+        $failures,
+        $checks
+    );
+}
+check(
+    'listdetails() still delegates to listem(), which carries the boundary',
+    false !== strpos(methodBody($route, 'listdetails'), 'self::listem('),
+    $failures,
+    $checks
+);
+
+/*
+ * 2. The per-object routes -- indiv, update, delete, task, cancel -- are
+ *    gated once at dispatch, next to the uType check, for the same reason
+ *    that one is there: one place to audit.
+ */
+check(
+    'runMatches() gates per-object routes on the boundary',
+    false !== strpos(methodBody($route, 'runMatches'), '_requireObjectScope('),
+    $failures,
+    $checks
+);
+
+/*
+ * 3. The tri-state. null means "no boundary", an ARRAY narrows, and an
+ *    EMPTY array is a real answer meaning "nothing". `if (!$scope)` and
+ *    `empty($scope)` are true for both null and array(), so either one
+ *    shows every host to the one user entitled to none -- the failure is
+ *    silent, it looks like the feature working, and it is the whole
+ *    reason these tests exist. Every test against a scope value must be
+ *    an explicit null comparison.
+ */
+$looseScope = [];
+if (preg_match_all(
+    '/(?:if\s*\(\s*!\s*\$scope\b|empty\s*\(\s*\$scope\s*\)|if\s*\(\s*\$scope\s*\))/',
+    $route,
+    $m
+)) {
+    $looseScope = $m[0];
+}
+check(
+    'route.class.php tests $scope against null, never for falsiness'
+    . (count($looseScope) ? ' (found: ' . implode(', ', $looseScope) . ')' : ''),
+    count($looseScope) < 1,
+    $failures,
+    $checks
+);
+// Counted, not merely present. The regex above catches `if (!$scope)`
+// but not `if ($scope && ...)` spanning two lines, and the whole failure
+// mode here is a comparison quietly losing its `null` half.
+check(
+    'the row filters compare against null exactly twice (listem, search)',
+    2 === preg_match_all('/null !== \$scope/', $route, $mn),
+    $failures,
+    $checks
+);
+check(
+    'the WHERE narrowing and the dispatch gate each short-circuit on null',
+    2 === preg_match_all('/null === \$scope/', $route, $mn2),
+    $failures,
+    $checks
+);
+check(
+    '_scopeIDs() distinguishes an array from null rather than from empty',
+    false !== strpos(methodBody($route, '_scopeIDs'), 'is_array($ids)'),
+    $failures,
+    $checks
+);
+check(
+    'the deny-all branch returns an empty ARRAY, not null',
+    (bool)preg_match(
+        '/count\(\$siteIDs\)\s*<\s*1\s*\)\s*\{\s*return\s+array\(\)\s*;/',
+        $site
+    ),
+    $failures,
+    $checks
+);
+check(
+    'scopedObjectIDs() returns null only for an unbounded class or user',
+    2 === preg_match_all('/\n\s*return null;/', $site, $m2),
+    $failures,
+    $checks
+);
+
+/*
+ * 4. An empty intersection must reach _buildWhere() as an empty array,
+ *    because that is what compiles to `WHERE 1=0`. Dropping the term
+ *    instead -- which is what happens if the caller "tidies up" an empty
+ *    filter -- returns the whole table.
+ */
+check(
+    '_buildWhere() still compiles an empty IN set to 1=0',
+    false !== strpos(methodBody($route, '_buildWhere'), "return ' WHERE 1=0';"),
+    $failures,
+    $checks
+);
+
+/*
+ * 5. The plugin answers the event, and answers it from the same rule the
+ *    management pages use. Two statements of "who may see what" is a
+ *    boundary that is decorative the first time they disagree, which is
+ *    why the UI hook's helpers were made to delegate rather than copied.
+ */
+check(
+    'the site plugin registers on API_SCOPE_IDS',
+    false !== strpos($apiHook, "'API_SCOPE_IDS'"),
+    $failures,
+    $checks
+);
+check(
+    'the API hook asks Site for the boundary rather than restating it',
+    false !== strpos($apiHook, 'Site::scopedObjectIDs('),
+    $failures,
+    $checks
+);
+check(
+    'the API hook applies no boundary when nobody is logged in (daemons)',
+    false !== strpos($apiHook, 'self::$FOGUser->isValid()'),
+    $failures,
+    $checks
+);
+// SiteHostAssociation is read twice in the management hook and only one
+// of those is the boundary. The grid shows each row's site name, which is
+// a per-host lookup by hostID and stays. What must not come back is a
+// lookup keyed on siteID -- that is the membership question, and Site
+// answers it for both paths now.
+check(
+    'the management hook asks no membership question of its own',
+    !preg_match("/'siteID'\s*=>/", $uiHook),
+    $failures,
+    $checks
+);
+check(
+    'Site owns the SiteHostAssociation membership lookup',
+    false !== strpos($site, "'SiteHostAssociation'"),
+    $failures,
+    $checks
+);
+foreach (
+    [
+        'SiteUserRestriction' => 'Site::userIsRestricted()',
+        'SiteUserAssociation' => 'Site::userSiteIDs()',
+        'GroupAssociation' => 'Site::groupIDsForSites()'
+    ] as $table => $owner
+) {
+    check(
+        "the management hook reads $table through $owner, not its own query",
+        false === strpos($uiHook, "'$table'"),
+        $failures,
+        $checks
+    );
+    check(
+        "Site owns the $table lookup",
+        false !== strpos($site, "'$table'"),
+        $failures,
+        $checks
+    );
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+echo "ok  $checks checks passed\n";


### PR DESCRIPTION
## The bug

The `site` plugin's only filtering hook is registered on `HOST_DATA` and `GROUP_DATA`. Both handlers open with `global $node; global $sub;` and switch on them — the management pages. Nothing under `api/` fires those events.

The plugin's *other* hook (`addsiteapi.hook.php`) is registered on `API_VALID_CLASSES`, `API_GETTER` and the two data mappings. It *adds* `site` and `sitehostassociation` as API classes and stamps `siteID` onto host payloads. It filters nothing.

So a site-restricted user saw their site in the grid and **every host on the server** through `/fog/host/list`.

Reachable without an API token and without `uAllowAPI`: `Route::__construct()` skips `_testToken()`/`_testAuth()` entirely when `self::$FOGUser->isValid()`, so the same browser session that renders the filtered grid returns the unfiltered set one URL away. With API credentials, `_requireAuthorized()` allows a non-admin `list`, `listdetails`, `search`, `names`, `ids`, `indiv` and `active` on `host` and `group`. Both require `FOG_API_ENABLED`, which is off by default.

Not a regression — the API was never site-scoped on this line. 1.6 does not share it: object scope there lives in the query and the per-object routes are gated at dispatch.

## The fix

Core gains one seam and stays ignorant of sites. `API_SCOPE_IDS` asks whoever is listening which object ids the acting user may see. With no plugin, an unrestricted user, or nobody logged in, the answer stays `null` and every read behaves exactly as before.

| Applied in | How | Why there |
|---|---|---|
| `listem()`, `search()` | filters the rows | neither route has a `LIMIT`, so this is exact and keeps `count` honest |
| `names()`, `ids()` | folds into the `WHERE` | those two only ever produce ids |
| `runMatches()` | gates `indiv`/`update`/`delete`/`task`/`cancel` | one place to audit, beside the `uType` check and for the same reason |

**The return is a tri-state and that is the design.** `null` = no boundary, an array narrows, an **empty array** is a real answer meaning "nothing". `if (!$ids)` is true for both `null` and `array()`, so a caller written that way shows all 2079 hosts to the one user entitled to none. An empty intersection is handed to `_buildWhere()` as an empty array on purpose — that compiles to `WHERE 1=0` rather than dropping the term.

The membership rule moves to `Site` as static methods and **both** hooks call it. Two statements of who may see what is a boundary that is decorative the first time they disagree.

### Behaviour changes, both toward the safe answer

- `getGroupIDbySite()` returns nothing for a user with no hosts, instead of querying `GroupAssociation` with an empty `hostID` set.
- `isRestricted()` on a user with no restriction row returns `false` instead of an undefined-index notice.

## Verification

Against the 1.5 lab — 2079 hosts, a user entitled to 2:

| Route | shipped | patched | admin (patched) |
|---|---|---|---|
| `list host` | 126 | **2** | 126 |
| `search host "a"` | 68 | **2** | 68 |
| `names host` | 2079 | **2** | 2079 |
| `ids host` | 2079 | **2** | 2079 |
| `ids host` (field=name) | 2079 | **2** | 2079 |

Also verified:

- A caller's own filter is **intersected**, not replaced: `ids?id=1,99999` → `[1]` for both users.
- A restricted user belonging to **no site** gets `0` on every route, not 2079.
- With **nobody logged in** — the daemons and `status/*.php`, which reach `Route::ids()` constantly — `_scopeIDs()` returns `null` and `ids('host')` still answers 2079.
- The per-object gate allows host 1 (in scope) and denies host 7075 (out of scope).
- The management hook's own helpers return the same answers after being made to delegate.

Driver, fixture and teardown: `scripts/background_scripts/{probe,fixture,teardown}_site_api_scope.*`

## Tests

`tests/site-api-scope.test.php` — 28 checks, static so it runs in the pre-commit hook. Pins that each read route still consults the boundary, the dispatcher still gates per-object routes, the `null` comparisons keep both halves, the deny-all branch still returns an array, `_buildWhere()` still compiles an empty `IN` to `1=0`, and the membership rule is stated once.

Eight mutations checked, all caught: `listem()` ignoring the boundary, `names()` dropping the `WHERE` narrowing, the dispatch gate removed, the tri-state tested for falsiness (two forms), deny-all returning `null`, the plugin no longer answering the event, and the boundary applied with nobody logged in.

Full suite: 16 passed, 0 failed.

## Downstream

None. `API_SCOPE_IDS` is a new event with one listener; `Route::$validClasses` is unchanged, so FogApi's hardcoded class list needs no sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GN7hADN5QLzoxXWDA6xeUk