### PR TITLE
Survive a class file list that has gone stale, and stop making one

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -8555,6 +8555,32 @@ configureHttpd() {
     dots "Copying new files to web folder"
     cp -Rf $webdirsrc/* $webdirdest/
     errorStat $?
+    # The web root was rm -rf'd above and rebuilt, so any file the new release
+    # DROPPED is genuinely gone. Initiator::classFileList() caches the scanned
+    # class-file list to $fogprogramdir/cache with a 300 second TTL, and that
+    # cache does not know the tree just changed underneath it.
+    #
+    # Left alone, every request for the rest of the TTL walks a list naming
+    # files that no longer exist. startClassFromFiles() used to die on the
+    # first one, which is an uncaught ReflectionException inside LoadGlobals --
+    # a bodyless 500 on every page, including the "Checking web server serves
+    # FOG" probe a few steps below, which then reports a failed install. It
+    # heals itself when the TTL expires, so it reads as a flaky install rather
+    # than as this.
+    #
+    # Observed with fog-plugins v1.6.11, which drops ldap/hooks/addldapapi.hook.php.
+    #
+    # startClassFromFiles() now skips a vanished file instead of dying, so this
+    # is the second of two guards rather than the only one -- but a stale list
+    # still means a hook that quietly does not load, and that is a feature
+    # silently not happening. Clearing it here means the very next request
+    # rescans.
+    #
+    # Only the file lists. The same directory holds the settings-cache flush
+    # signal (see the cache block in configureFOGService) which must survive.
+    dots "Dropping the stale class file list"
+    rm -f $fogprogramdir/cache/filelist.*.json >>$error_log 2>&1
+    errorStat $?
     for i in $(find $backupPath/fog_web_${version}.BACKUP/management/other/ -maxdepth 1 -type f -not -name gpl-3.0.txt -a -not -name index.php -a -not -name 'ca.*' 2>>$error_log); do
         cp -Rf $i ${webdirdest}/management/other/ >>$error_log 2>&1
     done

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -3590,7 +3590,65 @@ abstract class FOGBase
             if (class_exists($className, false)) {
                 continue;
             }
-            self::getClass($className);
+            // The file list is a TTL-cached snapshot (Initiator::
+            // classFileList), so it is ALLOWED to be stale -- that is the
+            // documented design, and forgetClassFileList() exists because of
+            // it. This was the one consumer that treated staleness as fatal:
+            // a file named by the cache and since removed produced an
+            // include_once warning and then an uncaught ReflectionException
+            // out of getClass(), which is a bodyless 500 on every page of the
+            // site for the rest of the TTL.
+            //
+            // Not hypothetical. An install swaps the whole of lib/plugins for
+            // a new pinned release; if that release drops a hook -- ldap lost
+            // addldapapi.hook.php in fog-plugins v1.6.11 -- every request in
+            // the remaining TTL window dies in LoadGlobals, and the installer
+            // reports "Checking web server serves FOG ... Failed!" with an
+            // empty body. It then heals itself, which is why it reads as a
+            // flaky install rather than a bug.
+            //
+            // Skipped and logged rather than swallowed: a listener that does
+            // not load is a feature that silently stops happening, so it has
+            // to leave a trace.
+            //
+            // error_log(), not self::error(). _writeLog() is gated on
+            // `self::$mySchema >= FOG_SCHEMA` and on a globalSettings lookup,
+            // and this runs inside LoadGlobals during an install -- which is
+            // to say it would be silently dropped in exactly the situation it
+            // exists to report. The PHP error log is also where the fatal
+            // this replaces showed up, so both lines land in one place for
+            // whoever is reading. Precedent: authorization.class.php,
+            // hostmanager.class.php.
+            if (!is_file($file)) {
+                error_log(
+                    sprintf(
+                        'FOG startClassFromFiles: %s is in the cached class'
+                        . ' file list but no longer exists; skipping %s.'
+                        . ' Harmless if a plugin was just updated -- the list'
+                        . ' refreshes on its own.',
+                        $file,
+                        $className
+                    )
+                );
+                continue;
+            }
+            // Second guard, different cause: the file is present but does not
+            // declare the class its name promises. Same consequence if it
+            // throws here -- the whole boot dies -- and the same reasoning
+            // applies, so it is reported rather than fatal.
+            try {
+                self::getClass($className);
+            } catch (\ReflectionException $e) {
+                error_log(
+                    sprintf(
+                        'FOG startClassFromFiles: %s does not declare %s'
+                        . ' (%s); skipping it.',
+                        $file,
+                        $className,
+                        $e->getMessage()
+                    )
+                );
+            }
             unset($file);
         }
     }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -727,9 +727,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
-msgid "All methods of binding have failed"
-msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandbreite sollte numerisch und größer als 0 sein."
@@ -739,12 +736,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
 
 #, fuzzy
 msgid "Already created"
@@ -1062,10 +1053,6 @@ msgid "CA Certificate Path"
 msgstr "Neuen Standort erstellen"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Pfad"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
 
@@ -1165,10 +1152,6 @@ msgstr "Stornierter Task"
 msgid "Cancelled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Anmeldung am LDAP-Server nicht möglich"
-
 msgid "Cannot change image when in tasking"
 msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
@@ -1213,9 +1196,6 @@ msgstr "Snapin erstellen fehlgeschlagen"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin erfolgreich hinzugefügt"
-
-msgid "Capone Deploy"
-msgstr "Capone Verteilung"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1294,9 +1274,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "Kanalaufruf ist ungültig"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1526,22 +1503,7 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
 msgid "Could not read tmp file."
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -1551,10 +1513,6 @@ msgstr "Konnte nicht registriert werden."
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1881,10 +1839,6 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Standard ist deaktiviert"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -1949,9 +1903,6 @@ msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Beschreibung"
@@ -2117,10 +2068,6 @@ msgid "Edit Capone"
 msgstr "Snapins exportieren"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Snapins exportieren"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Gruppeneinstellungen Module"
 
@@ -2141,9 +2088,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Standort senden aktivieren"
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2285,10 +2229,6 @@ msgstr "Konfiguration exportieren"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP-Server"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "Standorte exportieren"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2629,10 +2569,6 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Filter"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Suche nach zugeordneten Images"
 
@@ -2738,10 +2674,6 @@ msgstr "Funktion"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funktion"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Methode ist nicht vorhanden"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2909,18 +2841,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -2991,10 +2911,6 @@ msgid "Group Update Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
@@ -3009,10 +2925,6 @@ msgstr "Gruppe hinzugefügt!"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3139,18 +3051,6 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3233,17 +3133,6 @@ msgstr "Host Kernel Argumente"
 msgid "Host List"
 msgstr "Hostliste"
 
-msgid "Host Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Standort aktualisiert"
-
 msgid "Host Login History"
 msgstr "Host-Login-Verlauf"
 
@@ -3300,10 +3189,6 @@ msgstr "Host Snapinverlauf"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3608,22 +3493,6 @@ msgid "Image Used"
 msgstr "genutzte Images"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows-Schlüssel importieren"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows-Schlüssel erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows-Schlüssel aktualisiert"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image hinzugefügt"
 
@@ -3736,10 +3605,6 @@ msgid "Import Failed"
 msgstr "Image aktualisiert"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Standorte importieren"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Benutzer importieren"
 
@@ -3756,28 +3621,12 @@ msgid "Import Reports"
 msgstr "Berichte importieren"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppen importieren"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Import erfolgreich"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Import erfolgreich"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Taskstatus exportieren"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task-Typen importieren"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows-Schlüssel importieren"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3974,10 +3823,6 @@ msgstr "Ungültige Einheit"
 msgid "Invalid Windows product key"
 msgstr "Host Produktschlüssel"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Wählen Sie ein gültiges Abbild"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4018,9 +3863,6 @@ msgstr "Ungültiger Schlüssel wurde angefordert"
 
 msgid "Invalid key being set"
 msgstr "Ungültiger Schlüssel wurde gesetzt"
-
-msgid "Invalid method called"
-msgstr "Ungültige Methode aufgerufen"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4141,9 +3983,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "indem es die max. Bandbreiteneinstellung desjenigen Knotens"
 
-msgid "It tells the client to download snapins from"
-msgstr "Es weist den Client an, Snapins vom hostdefinierten "
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4189,10 +4028,6 @@ msgid "Key"
 msgstr "DMI-Schlüssel"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Schlüsselfeldname muss eine Zeichenfolge sein."
 
@@ -4216,10 +4051,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "sofort abbrechen"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4337,10 +4168,6 @@ msgstr "LDAP-Server aktualisiert"
 msgid "LDAP Server updated!"
 msgstr "LDAP-Server aktualisiert"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
 msgid "Language"
 msgstr "Sprache"
 
@@ -4372,9 +4199,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4442,14 +4266,6 @@ msgid "List All Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task Status"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task-Typen"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installierte Plugins"
 
@@ -4477,10 +4293,6 @@ msgstr "Laden von Daten zum Feld %s"
 
 msgid "Location"
 msgstr "Ort"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Standort Zugehörigkeiten"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4515,9 +4327,6 @@ msgstr "Standort erfolgreich aktualisiert"
 #, fuzzy
 msgid "Location added!"
 msgstr "Standort hinzugefügt"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4902,10 +4711,6 @@ msgstr "NAME"
 msgid "NOT"
 msgstr "NICHT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "HINWEIS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4938,16 +4743,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -5019,9 +4817,6 @@ msgstr "Kein Image angegeben"
 
 msgid "No Printer Management"
 msgstr "Keine Druckerverwaltung"
-
-msgid "No access is allowed"
-msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5901,10 +5696,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6128,9 +5919,6 @@ msgstr "Drucker aktualisiert!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client-Management"
@@ -6330,10 +6118,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Ergebnis"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6579,19 +6363,8 @@ msgid "Search Base DN"
 msgstr "Suche Basis DN"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Suche DN"
-
-msgid "Search DN did not return any results"
-msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
-
-#, fuzzy
 msgid "Search Key"
 msgstr "Suche"
-
-#, fuzzy
-msgid "Search Method"
-msgstr "Suchmethode"
 
 #, fuzzy
 msgid "Search Scope"
@@ -6599,9 +6372,6 @@ msgstr "Suchbereich"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Die Suche lieferte kein passendes Ergebnis"
 
 #, fuzzy
 msgid "Search settings"
@@ -6979,9 +6749,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7503,10 +7270,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppe aktualisiert"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppen exportieren"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppen exportieren"
 
@@ -7657,9 +7420,6 @@ msgstr "Task Status erfolgreich aktualisiert"
 msgid "Task State Updated!"
 msgstr "Task Status aktualisiert!"
 
-msgid "Task States"
-msgstr "Task Status"
-
 msgid "Task Type"
 msgstr "Task-Typ"
 
@@ -7709,9 +7469,6 @@ msgstr "Task-Typ ist nicht gültig"
 
 msgid "Task Type is not valid"
 msgstr "Task-Typ ist nicht gültig"
-
-msgid "Task Types"
-msgstr "Task-Typen"
 
 #, fuzzy
 msgid "Task failed"
@@ -7820,12 +7577,6 @@ msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 msgid "The API is disabled"
 msgstr "Standard ist deaktiviert"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -7844,9 +7595,6 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "läuft nicht mehr"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7887,9 +7635,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7960,9 +7705,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -8160,9 +7902,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -8217,10 +7956,6 @@ msgstr "IP(s) dieses Servers"
 msgid "This setting"
 msgstr "Diese Einstellung"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Diese Einstellung definiert das Senden"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8272,9 +8007,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8739,10 +8471,6 @@ msgid "User Create Success"
 msgstr "Benutzer erfolgreich erstellt"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Benutzer DN"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Gruppen"
 
@@ -8826,9 +8554,6 @@ msgstr "Benutzeraktualisierung erfolgreich!"
 msgid "User added!"
 msgstr "Benutzer hinzugefügt"
 
-msgid "User call is invalid"
-msgstr "Benutzeraufruf ist ungültig"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Benutzer hinzugefügt"
@@ -8841,9 +8566,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8855,10 +8577,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 #, fuzzy
 msgid "User updated!"
 msgstr "Benutzer aktualisiert"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8880,15 +8598,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Benutzername"
-
 msgid "Users"
 msgstr "Benutzer"
-
-msgid "Using the group match function"
-msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
 msgid "VB Script"
 msgstr ""
@@ -8955,10 +8666,6 @@ msgstr "Wir sind Knoten-ID "
 msgid "We are node name"
 msgstr "Wir sind Knotenname "
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8981,9 +8688,6 @@ msgstr "wurde abgebrochen"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
@@ -9000,10 +8704,6 @@ msgstr "Fenstergröße muss größer sein als 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows-Schlüssel beschreibung"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows Keys"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9046,15 +8746,8 @@ msgid "Windows Key updated!"
 msgstr "Windows-Schlüssel aktualisiert"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows Keys"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Produktschlüssel"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
 
 msgid "Wipes"
 msgstr ""
@@ -9178,17 +8871,11 @@ msgstr "vor mir auf diesem Knoten"
 msgid "between"
 msgstr "zwischen"
 
-msgid "between different sites"
-msgstr "Stellen hin und her wechseln."
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "die Client Computer in den FOG"
-
-msgid "but bind password is not set"
-msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 msgid "but has recently failed for this host"
@@ -9230,9 +8917,6 @@ msgstr ""
 
 msgid "day"
 msgstr "Tag"
-
-msgid "deploy task occurs for it"
-msgstr "es eine Verteilungs-Task gibt."
 
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
@@ -9303,9 +8987,6 @@ msgstr "Dateigröße"
 msgid "fog-admins"
 msgstr "Domänen-Name"
 
-msgid "for Microsoft Windows to images"
-msgstr "MS Windows den Images zuordnet."
-
 #, fuzzy
 msgid "found"
 msgstr "gefunden"
@@ -9341,14 +9022,6 @@ msgstr "wurde erfolgreich zerstört"
 
 msgid "has been successfully updated"
 msgstr "wurde erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "wurde abgeschlossen"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Ungültiges Snapin-Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9528,10 +9201,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "die Client Computer in den FOG"
 
-#, fuzzy
-msgid "key"
-msgstr "aktiviert werden."
-
 msgid "keys"
 msgstr ""
 
@@ -9544,9 +9213,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "auf 1 MBit/s begrenzen, "
-
-msgid "location url based on the host that checks in"
-msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 msgid "logged in"
 msgstr ""
@@ -9581,9 +9247,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
 #, fuzzy
 msgid "must be specified"
@@ -9743,9 +9406,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "mit Clients haben, die zwischen verschiedenen "
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9802,9 +9462,6 @@ msgstr "den folgenden Terminalbefehlen tun"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
-
-msgid "the host defined location where available"
-msgstr "Speicherort herunterzuladen, sofern verfügbar."
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9863,9 +9520,6 @@ msgstr "um den angeforderten Kernel herunterzuladen."
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "um den angeforderten Kernel herunterzuladen."
-
-msgid "to operate in an environment where there may be"
-msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
 
 msgid "to review."
 msgstr "um zu überprüfen."
@@ -9934,13 +9588,6 @@ msgstr "Windows"
 
 msgid "wipe out all of your images stored on"
 msgstr "alle Images auf sämtlichen"
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "Schlüssel beim Host."
 
 #, fuzzy
 msgid "with this group"
@@ -10083,6 +9730,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
@@ -10095,12 +9751,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Pfad"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Anmeldung am LDAP-Server nicht möglich"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Verteilung"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Kanalaufruf ist ungültig"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Client Einstellungen"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10122,6 +9808,14 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
+#, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Snapins exportieren"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
@@ -10138,6 +9832,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Standorte exportieren"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Standorte exportieren"
 
 #~ msgid "Export Printers"
@@ -10184,8 +9882,28 @@ msgstr ""
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Methode ist nicht vorhanden"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10207,8 +9925,16 @@ msgstr ""
 #~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10234,6 +9960,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hostliste"
@@ -10249,6 +9986,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10287,6 +10028,22 @@ msgstr ""
 #~ msgstr "Host aktualisiert!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows-Schlüssel erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows-Schlüssel aktualisiert"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts importieren"
 
@@ -10295,6 +10052,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Standorte importieren"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Standorte importieren"
 
 #~ msgid "Import Printers"
@@ -10323,12 +10084,50 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Alle Speicherknoten"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppen importieren"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Taskstatus exportieren"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task-Typen importieren"
+
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Ungültiger Typ"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Wählen Sie ein gültiges Abbild"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Ungültige Methode aufgerufen"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "Es weist den Client an, Snapins vom hostdefinierten "
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP-Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10347,11 +10146,37 @@ msgstr ""
 #~ msgstr "Alle %s auflisten"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task Status"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task-Typen"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Standort Zugehörigkeiten"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "zugeordneter Host"
 
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "HINWEIS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10387,8 +10212,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Bitte geben Sie einen Namen für einen Admin oder einen mobilen Lookup ein."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
@@ -10399,6 +10231,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Ausgewählte entfernen?"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Ergebnis"
 
 #~ msgid "Results"
 #~ msgstr "Ergebnisse"
@@ -10459,8 +10295,25 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Suche DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Suchmethode"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Die Suche lieferte kein passendes Ergebnis"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Site Zugehörigkeit"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10474,8 +10327,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppen exportieren"
+
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#~ msgid "Task States"
+#~ msgstr "Task Status"
+
+#~ msgid "Task Types"
+#~ msgstr "Task-Typen"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10488,6 +10351,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10505,9 +10371,19 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Es gibt keine Snapins auf diesem Server."
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Diese Einstellung definiert das Senden"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
@@ -10531,6 +10407,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Benutzer DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10576,6 +10456,38 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Site aktualisiert!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "Benutzeraufruf ist ungültig"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Benutzername"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows Keys"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows Keys"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Sie haben Version"
@@ -10591,24 +10503,67 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "vor mir"
 
+#~ msgid "between different sites"
+#~ msgstr "Stellen hin und her wechseln."
+
 #~ msgid "but"
 #~ msgstr "aber "
+
+#~ msgid "but bind password is not set"
+#~ msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Abgeschlossen"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "es eine Verteilungs-Task gibt."
+
 #~ msgid "e.g."
 #~ msgstr "z.B."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "MS Windows den Images zuordnet."
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "wurde abgeschlossen"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Ungültiges Snapin-Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "aktiviert werden."
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Aktive Multicast-Tasks"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
+
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "mit Clients haben, die zwischen verschiedenen "
+
+#~ msgid "the host defined location where available"
+#~ msgstr "Speicherort herunterzuladen, sofern verfügbar."
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
+
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "Schlüssel beim Host."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -731,9 +731,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Install / Update Successful!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandwidth should be numeric and greater than 0"
@@ -742,12 +739,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1066,10 +1057,6 @@ msgid "CA Certificate Path"
 msgstr "Create New %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Path"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Private key failed"
 
@@ -1169,10 +1156,6 @@ msgstr "Cancelled task"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelled due to new tasking."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Cannot connect to database"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1216,9 +1199,6 @@ msgstr "Snapin updated"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin updated"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1297,9 +1277,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "Channel call is invalid"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1528,22 +1505,7 @@ msgstr "Could not read tmp file."
 msgid "Could not read snapin file"
 msgstr "Could not read tmp file."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Could not read tmp file."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Could not read tmp file."
-
 msgid "Could not read tmp file."
-msgstr "Could not read tmp file."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Could not read tmp file."
 
 #, fuzzy
@@ -1553,10 +1515,6 @@ msgstr "Could not create printer"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1883,10 +1841,6 @@ msgid "Default Width"
 msgstr "Default Width"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Donations are disabled"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Unable to open file for reading"
 
@@ -1951,9 +1905,6 @@ msgstr "Download Failed"
 
 msgid "Deploy Method"
 msgstr "Deploy Method"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Description"
@@ -2119,10 +2070,6 @@ msgid "Edit Capone"
 msgstr "Export Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Update Settings"
 
@@ -2141,9 +2088,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2286,10 +2230,6 @@ msgstr "Export Configuration"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP Server"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "Host Location"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2630,10 +2570,6 @@ msgid "Files Deleted List"
 msgstr "Delete file data"
 
 #, fuzzy
-msgid "Filter"
-msgstr "File"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "No snapins associated"
 
@@ -2739,10 +2675,6 @@ msgstr "Action"
 #, fuzzy
 msgid "Function Error"
 msgstr "Action"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Method does not exist"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2910,18 +2842,6 @@ msgid "Group Kernel Arguments"
 msgstr "Group Kernel Arguments"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Location"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Location Updated"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login History"
 
@@ -2993,10 +2913,6 @@ msgid "Group Update Fail"
 msgstr "Group create failed"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Group create failed"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Group create failed"
 
@@ -3011,10 +2927,6 @@ msgstr "Group added"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Group is Invalid"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "User update failed"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3140,18 +3052,6 @@ msgstr "Home"
 msgid "Host"
 msgstr "Host"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host Created"
@@ -3234,17 +3134,6 @@ msgstr "Host Kernel Arguments"
 msgid "Host List"
 msgstr "Host List"
 
-msgid "Host Location"
-msgstr "Host Location"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Location Updated"
-
 msgid "Host Login History"
 msgstr "Host Login History"
 
@@ -3301,10 +3190,6 @@ msgstr "Snapin History"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host Update Failed"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host Update Failed"
 
 #, fuzzy
@@ -3609,22 +3494,6 @@ msgid "Image Used"
 msgstr "Imaged"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "User Management"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "User Management"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "User Management"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image Name"
 
@@ -3737,10 +3606,6 @@ msgid "Import Failed"
 msgstr "Image updated"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Host Location"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Import Users"
 
@@ -3757,28 +3622,12 @@ msgid "Import Reports"
 msgstr "Import Hosts"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Import Groups"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Successful"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Successful"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Task States"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task Types"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3975,10 +3824,6 @@ msgstr "Invalid URL"
 msgid "Invalid Windows product key"
 msgstr "Host Product Key"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Select a valid image"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4019,9 +3864,6 @@ msgstr "Invalid key being removed"
 
 msgid "Invalid key being set"
 msgstr "Invalid key being set"
-
-msgid "Invalid method called"
-msgstr "Invalid method called"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4142,9 +3984,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4190,10 +4029,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Image Association"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Event must be a string"
 
@@ -4216,9 +4051,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Kill"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4336,10 +4168,6 @@ msgstr "LDAP Server Name"
 msgid "LDAP Server updated!"
 msgstr "LDAP Server Name"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP Server"
-
 msgid "Language"
 msgstr "Language"
 
@@ -4371,9 +4199,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4441,14 +4266,6 @@ msgid "List All Plugins"
 msgstr "Install Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task States"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task Types"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installed Plugins"
 
@@ -4475,10 +4292,6 @@ msgstr "Loading data to field %s"
 
 msgid "Location"
 msgstr "Location"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Image Association"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4513,9 +4326,6 @@ msgstr "Install / Update Successful!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Location Name"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4900,10 +4710,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NOT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NOT"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4936,16 +4742,9 @@ msgstr "Event must be a string"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Event must be a string"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Event must be a string"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "User update failed"
 
 msgid "Network Information"
 msgstr "Network Information"
@@ -5017,9 +4816,6 @@ msgstr "No Image specified"
 
 msgid "No Printer Management"
 msgstr "No Printer Management"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5899,10 +5695,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Port is not valid ldap/ldaps ports"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6126,9 +5918,6 @@ msgstr "Printer updated!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client Management"
@@ -6328,10 +6117,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Results"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6577,18 +6362,7 @@ msgid "Search Base DN"
 msgstr "Search"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Search"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Search"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Search"
 
 #, fuzzy
@@ -6596,9 +6370,6 @@ msgid "Search Scope"
 msgstr "Search"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6977,9 +6748,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7501,10 +7269,6 @@ msgid "Subnet Group updated!"
 msgstr "Group added"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Export Groups"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Export Groups"
 
@@ -7653,9 +7417,6 @@ msgstr "User created"
 msgid "Task State Updated!"
 msgstr "Task State added, editing"
 
-msgid "Task States"
-msgstr "Task States"
-
 msgid "Task Type"
 msgstr "Task Type"
 
@@ -7705,9 +7466,6 @@ msgstr "Task type is not valid"
 
 msgid "Task Type is not valid"
 msgstr "Task Type is not valid"
-
-msgid "Task Types"
-msgstr "Task Types"
 
 #, fuzzy
 msgid "Task failed"
@@ -7816,12 +7574,6 @@ msgstr "This setting defines "
 msgid "The API is disabled"
 msgstr "Donations are disabled"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "There are no groups on this server."
@@ -7840,9 +7592,6 @@ msgstr "Could not read temp file"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " no longer exists"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7883,9 +7632,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7955,9 +7701,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8155,9 +7898,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | This is not the primary group"
@@ -8212,10 +7952,6 @@ msgstr ""
 msgid "This setting"
 msgstr "This setting defines "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "This setting defines "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8267,10 +8003,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "There are no snapins associated with this host"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8735,10 +8467,6 @@ msgid "User Create Success"
 msgstr "User created"
 
 #, fuzzy
-msgid "User DN"
-msgstr "User Name"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Groups"
 
@@ -8822,9 +8550,6 @@ msgstr "Install / Update Successful!"
 msgid "User added!"
 msgstr "Printer Name"
 
-msgid "User call is invalid"
-msgstr "User call is invalid"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Printer Name"
@@ -8837,9 +8562,6 @@ msgstr "User update failed"
 msgid "User group updated!"
 msgstr "User updated"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Record not found, Error: %s"
@@ -8851,10 +8573,6 @@ msgstr "User update failed"
 #, fuzzy
 msgid "User updated!"
 msgstr "User updated"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Please enter a name for this LDAP server."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8876,15 +8594,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Username"
-
 msgid "Users"
 msgstr "Users"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8951,10 +8662,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Storage Node Name"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Cannot connect to database"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8977,9 +8684,6 @@ msgstr "has been successfully updated"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -8995,10 +8699,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Host Description"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9041,16 +8741,8 @@ msgid "Windows Key updated!"
 msgstr "User Management"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Product Key"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "An image already exists with this name!"
 
 msgid "Wipes"
 msgstr ""
@@ -9172,16 +8864,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9223,9 +8909,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9297,9 +8980,6 @@ msgstr "filesize"
 msgid "fog-admins"
 msgstr "Domain name"
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 #, fuzzy
 msgid "found"
 msgstr "Not found"
@@ -9335,14 +9015,6 @@ msgstr "has been successfully updated"
 
 msgid "has been successfully updated"
 msgstr "has been successfully updated"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "has been destroyed"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Invalid Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9521,10 +9193,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9536,9 +9204,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9573,9 +9238,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9735,9 +9397,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9794,9 +9453,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Storage Group Updated"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9855,9 +9511,6 @@ msgstr "No key being requested"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "No key being requested"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "to review."
@@ -9926,13 +9579,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "not within this"
 
 #, fuzzy
 msgid "with this group"
@@ -10084,12 +9730,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Path"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Cannot connect to database"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Channel call is invalid"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Settings"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Could not read tmp file."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10112,6 +9788,14 @@ msgstr ""
 #~ msgstr "No hash available"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Donations are disabled"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Export Hosts"
 
@@ -10124,6 +9808,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Host Location"
 
 #~ msgid "Export Printers"
@@ -10170,8 +9858,28 @@ msgstr ""
 #~ msgstr "I am not the fog web server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "File"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reboot"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Method does not exist"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Location Updated"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10190,8 +9898,16 @@ msgstr ""
 #~ msgstr "Group added"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Group create failed"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Group create failed"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "User update failed"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10217,6 +9933,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "User update failed"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Location Updated"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Host List"
@@ -10232,6 +9959,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Snapin History"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host Update Failed"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10266,6 +9997,22 @@ msgstr ""
 #~ msgstr "User updated"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "User Management"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "User Management"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "User Management"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Import Hosts"
 
@@ -10274,6 +10021,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Host Location"
 
 #~ msgid "Import Printers"
@@ -10302,12 +10053,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "All Storage Nodes"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Import Groups"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Task States"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task Types"
+
 #~ msgid "Import Users"
 #~ msgstr "Import Users"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Invalid type"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Select a valid image"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Invalid method called"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Image Association"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10326,8 +10108,28 @@ msgstr ""
 #~ msgstr "List All %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task States"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task Types"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Image Association"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No node associated"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NOT"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "User update failed"
 
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "No FOGPage Class found for this node"
@@ -10362,8 +10164,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Please enter a name for this location."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Port is not valid ldap/ldaps ports"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Registered"
 #~ msgstr "Registered"
@@ -10371,6 +10180,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remove selected snapins"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Results"
 
 #~ msgid "Results"
 #~ msgstr "Results"
@@ -10431,8 +10244,19 @@ msgstr ""
 #~ msgstr "Printer update failed!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Search"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Search"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Image Association"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10446,8 +10270,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Created"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Export Groups"
+
 #~ msgid "Successful"
 #~ msgstr "Successful"
+
+#~ msgid "Task States"
+#~ msgstr "Task States"
+
+#~ msgid "Task Types"
+#~ msgstr "Task Types"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10477,6 +10311,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | This is not the master node"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "This setting defines "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "There are no snapins associated with this host"
+
 #~ msgid "Total Rows"
 #~ msgstr "Total Rows"
 
@@ -10499,6 +10341,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Update Printer"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "User Name"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10544,6 +10390,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Service Updated!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "User call is invalid"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Please enter a name for this LDAP server."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Username"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Cannot connect to database"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "An image already exists with this name!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Latest Version"
@@ -10564,6 +10437,18 @@ msgstr ""
 #~ msgstr "Completed"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "has been destroyed"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Invalid Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Active Multicast Tasks"
 
@@ -10574,3 +10459,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "not within this"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -746,9 +746,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "actualización de servicio no pudo"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr ""
 
@@ -756,12 +753,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1082,10 +1073,6 @@ msgid "CA Certificate Path"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Camino"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "clave privada fracasó"
 
@@ -1186,10 +1173,6 @@ msgstr "tarea Cancelado"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelada debido a las nuevas tareas a la vez."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Error: No se pudo descargar kernel"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1232,10 +1215,6 @@ msgstr "Nombre snapin"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Nombre snapin"
-
-#, fuzzy
-msgid "Capone Deploy"
-msgstr "última Desplegado"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1313,10 +1292,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-#, fuzzy
-msgid "Channel call is invalid"
-msgstr "La imagen no está habilitada"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1548,22 +1523,7 @@ msgstr "No se pudo leer el archivo tmp."
 msgid "Could not read snapin file"
 msgstr "No se pudo leer el archivo tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "No se pudo leer el archivo tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "No se pudo leer el archivo tmp."
-
 msgid "Could not read tmp file."
-msgstr "No se pudo leer el archivo tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
@@ -1573,10 +1533,6 @@ msgstr "No se pudo crear la impresora"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1909,10 +1865,6 @@ msgid "Default Width"
 msgstr "Ancho por defecto"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Ancho por defecto"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "No se puede abrir archivo para lectura"
 
@@ -1980,9 +1932,6 @@ msgstr "Descarga fracasó"
 #, fuzzy
 msgid "Deploy Method"
 msgstr "última Desplegado"
-
-msgid "Depth"
-msgstr ""
 
 #, fuzzy
 msgid "Description"
@@ -2153,10 +2102,6 @@ msgid "Edit Capone"
 msgstr "snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Descripción del Grupo"
 
@@ -2176,9 +2121,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2326,10 +2268,6 @@ msgstr "Configuración"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "servidor TFTP"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "Lista de host"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2685,10 +2623,6 @@ msgid "Files Deleted List"
 msgstr "Eliminar los datos del archivo"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Archivo"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "No hay snapins asociados"
 
@@ -2794,10 +2728,6 @@ msgstr "Acción"
 #, fuzzy
 msgid "Function Error"
 msgstr "Acción"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Método no existe"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2966,18 +2896,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Lista de host"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "actualización de servicio no pudo"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "información de LDAP actualizado!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Camino snapin"
 
@@ -3050,10 +2968,6 @@ msgid "Group Update Fail"
 msgstr "Grupo Error de creación"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Grupo Error de creación"
 
@@ -3068,10 +2982,6 @@ msgstr "grupo añadió"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "tipo de tarea no es válida"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "actualización Valoración falló"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3199,18 +3109,6 @@ msgstr "nombre de host"
 msgid "Host"
 msgstr "Anfitrión"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creado"
@@ -3300,18 +3198,6 @@ msgid "Host List"
 msgstr "Hospedadores"
 
 #, fuzzy
-msgid "Host Location"
-msgstr "Lista de host"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "actualización de servicio no pudo"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "información de LDAP actualizado!"
-
-#, fuzzy
 msgid "Host Login History"
 msgstr "Camino snapin"
 
@@ -3372,10 +3258,6 @@ msgstr "Camino snapin"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "actualización Valoración falló"
 
 #, fuzzy
@@ -3687,22 +3569,6 @@ msgid "Image Used"
 msgstr "Nombre de la imagen"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Impresora TCP / IP Port"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Actualizar impresora"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Nombre del núcleo"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nombre de la imagen"
 
@@ -3821,10 +3687,6 @@ msgid "Import Failed"
 msgstr "imagen actualizada"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Lista de host"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Importar"
 
@@ -3841,28 +3703,12 @@ msgid "Import Reports"
 msgstr "Importar"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "grupo está"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Exitoso"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Exitoso"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Tipo de tarea"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Tipo de tarea"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Impresora TCP / IP Port"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -4064,10 +3910,6 @@ msgstr "carpeta no válida"
 msgid "Invalid Windows product key"
 msgstr "Clave del producto Grupo"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Seleccionar una imagen válida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4109,10 +3951,6 @@ msgstr "Clave no válida se retira"
 
 msgid "Invalid key being set"
 msgstr "está estableciendo tecla no válida"
-
-#, fuzzy
-msgid "Invalid method called"
-msgstr "Valor no válido Tiempo de espera"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4237,9 +4075,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4289,10 +4124,6 @@ msgid "Key"
 msgstr "DMI clave"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Asociación para la imagen"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Evento debe ser una cadena"
 
@@ -4315,9 +4146,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Matar"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4439,10 +4267,6 @@ msgstr "Impresora actualiza!"
 msgid "LDAP Server updated!"
 msgstr "Impresora actualiza!"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "servidor TFTP"
-
 msgid "Language"
 msgstr ""
 
@@ -4475,9 +4299,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4548,14 +4369,6 @@ msgid "List All Plugins"
 msgstr "Nombre de la impresora"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Nombre de la tarea"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipo de tarea"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "No disponible"
 
@@ -4582,10 +4395,6 @@ msgstr "La carga de datos de campo de %s"
 #, fuzzy
 msgid "Location"
 msgstr "Acción"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Asociación para la imagen"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4622,9 +4431,6 @@ msgstr "actualización de servicio no pudo"
 #, fuzzy
 msgid "Location added!"
 msgstr "Nombre de dominio"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -5025,10 +4831,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NO"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NO"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -5061,16 +4863,9 @@ msgstr "Evento debe ser una cadena"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Evento debe ser una cadena"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Evento debe ser una cadena"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "actualización Valoración falló"
 
 msgid "Network Information"
 msgstr "Información de la red"
@@ -5143,9 +4938,6 @@ msgstr "Sin imagen especificada"
 
 msgid "No Printer Management"
 msgstr "Sin administración de la impresora"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -6040,10 +5832,6 @@ msgstr ""
 msgid "Port"
 msgstr "Puerto"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Por favor seleccione una opción"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6272,10 +6060,6 @@ msgid "Providers"
 msgstr ""
 
 #, fuzzy
-msgid "Pushbullet Accounts"
-msgstr "Añadir nueva cuenta de usuario"
-
-#, fuzzy
 msgid "Pushbullet Management"
 msgstr "Gestión de usuarios"
 
@@ -6478,10 +6262,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "resultados"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6730,18 +6510,7 @@ msgid "Search Base DN"
 msgstr "Buscar"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Buscar"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Buscar"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Buscar"
 
 #, fuzzy
@@ -6749,9 +6518,6 @@ msgid "Search Scope"
 msgstr "Buscar"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -7131,9 +6897,6 @@ msgid "Skipping, not a PluginTask"
 msgstr ""
 
 msgid "Skipping, will need manual removal"
-msgstr ""
-
-msgid "Slack Accounts"
 msgstr ""
 
 #, fuzzy
@@ -7683,10 +7446,6 @@ msgid "Subnet Group updated!"
 msgstr "grupo añadió"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Exportar"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Exportar"
 
@@ -7838,10 +7597,6 @@ msgstr "creado por el usuario"
 msgid "Task State Updated!"
 msgstr "Nombre de la tarea"
 
-#, fuzzy
-msgid "Task States"
-msgstr "Nombre de la tarea"
-
 msgid "Task Type"
 msgstr "Tipo de tarea"
 
@@ -7892,10 +7647,6 @@ msgstr "tipo de tarea no es válida"
 #, fuzzy
 msgid "Task Type is not valid"
 msgstr "tipo de tarea no es válida"
-
-#, fuzzy
-msgid "Task Types"
-msgstr "Tipo de tarea"
 
 #, fuzzy
 msgid "Task failed"
@@ -8003,12 +7754,6 @@ msgstr ""
 msgid "The API is disabled"
 msgstr "Ancho por defecto"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "No hay grupos en este servidor."
@@ -8025,9 +7770,6 @@ msgid "The FOG account could not be created"
 msgstr "No se pudo leer el archivo temporal"
 
 msgid "The FOG account for this identity no longer exists"
-msgstr ""
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
 msgstr ""
 
 msgid "The ID token carries no subject"
@@ -8069,9 +7811,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -8142,9 +7881,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8344,9 +8080,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 msgid "This is not the master for this group"
 msgstr ""
 
@@ -8398,10 +8131,6 @@ msgstr ""
 msgid "This setting"
 msgstr ""
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Este ajuste define "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8449,10 +8178,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "No hay snapins asociados con este anfitrión"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8918,10 +8643,6 @@ msgid "User Create Success"
 msgstr "creado por el usuario"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nombre de usuario"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Grupo"
 
@@ -9007,10 +8728,6 @@ msgid "User added!"
 msgstr "Nombre de la impresora"
 
 #, fuzzy
-msgid "User call is invalid"
-msgstr "imagen asignado"
-
-#, fuzzy
 msgid "User group added!"
 msgstr "Nombre de la impresora"
 
@@ -9021,9 +8738,6 @@ msgstr "actualización Valoración falló"
 #, fuzzy
 msgid "User group updated!"
 msgstr "el usuario actualiza"
-
-msgid "User matched none of the mapped groups"
-msgstr ""
 
 #, fuzzy
 msgid "User not found"
@@ -9036,10 +8750,6 @@ msgstr "actualización Valoración falló"
 #, fuzzy
 msgid "User updated!"
 msgstr "el usuario actualiza"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Error: No se pudo descargar kernel"
 
 #, fuzzy
 msgid "User/Channel"
@@ -9063,15 +8773,8 @@ msgid "Username must end with a number or letter."
 msgstr ""
 
 #, fuzzy
-msgid "Username was blank"
-msgstr "Nombre de usuario"
-
-#, fuzzy
 msgid "Users"
 msgstr "Usuario"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -9137,10 +8840,6 @@ msgstr ""
 msgid "We are node name"
 msgstr ""
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Error: No se pudo descargar kernel"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -9163,9 +8862,6 @@ msgstr "se ha actualizado correctamente"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -9181,10 +8877,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Descripción de la impresora"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Nombre del núcleo"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9227,16 +8919,8 @@ msgid "Windows Key updated!"
 msgstr "Nombre del núcleo"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Nombre del núcleo"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Clave del producto Grupo"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Una imagen ya existe con este nombre!"
 
 msgid "Wipes"
 msgstr ""
@@ -9358,16 +9042,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9409,9 +9087,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9484,9 +9159,6 @@ msgstr "tamaño del archivo"
 msgid "fog-admins"
 msgstr "Nombre de dominio"
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 #, fuzzy
 msgid "found"
 msgstr "Extraviado"
@@ -9522,14 +9194,6 @@ msgstr "se ha actualizado correctamente"
 
 msgid "has been successfully updated"
 msgstr "se ha actualizado correctamente"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "Deben estar cifrados"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "tarea no válido"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9709,10 +9373,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI clave"
-
 msgid "keys"
 msgstr ""
 
@@ -9724,9 +9384,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9760,9 +9417,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9921,9 +9575,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "snapin"
@@ -9981,9 +9632,6 @@ msgstr ""
 msgid "the group has no enabled master node"
 msgstr "Nombre del grupo de almacenamiento"
 
-msgid "the host defined location where available"
-msgstr ""
-
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
 
@@ -10039,9 +9687,6 @@ msgstr "se requiere ninguna clave"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "se requiere ninguna clave"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "para revisar."
@@ -10110,13 +9755,6 @@ msgstr "windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "no dentro de este"
 
 #, fuzzy
 msgid "with this group"
@@ -10269,12 +9907,44 @@ msgstr ""
 #~ msgstr "Guardar cambios"
 
 #, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Camino"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Capone Deploy"
+#~ msgstr "última Desplegado"
+
+#, fuzzy
+#~ msgid "Channel call is invalid"
+#~ msgstr "La imagen no está habilitada"
+
+#, fuzzy
 #~ msgid "Check that database is running"
 #~ msgstr "Compruebe que la base de datos se está ejecutando"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Configuración Tecla"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10297,6 +9967,14 @@ msgstr ""
 #~ msgstr "No se dispone de hash"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Ancho por defecto"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Editar anfitrión"
 
@@ -10311,6 +9989,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export LDAPs"
 #~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "Export Locations"
+#~ msgstr "Lista de host"
 
 #, fuzzy
 #~ msgid "Export Printers"
@@ -10357,8 +10039,28 @@ msgstr ""
 #~ msgstr "No se pudo crear Sesión"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Archivo"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reiniciar"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Método no existe"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "información de LDAP actualizado!"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10377,8 +10079,16 @@ msgstr ""
 #~ msgstr "grupo añadió"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Error de creación"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Grupo Error de creación"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10405,6 +10115,18 @@ msgstr ""
 #~ msgstr "actualización Valoración falló"
 
 #, fuzzy
+#~ msgid "Host Location"
+#~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "información de LDAP actualizado!"
+
+#, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hospedadores"
 
@@ -10419,6 +10141,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Camino snapin"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10457,6 +10183,22 @@ msgstr ""
 #~ msgstr "el usuario actualiza"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Impresora TCP / IP Port"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "actualización Valoración falló"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Actualizar impresora"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Importar"
 
@@ -10467,6 +10209,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import LDAP Settings"
 #~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "Import Locations"
+#~ msgstr "Lista de host"
 
 #, fuzzy
 #~ msgid "Import Printers"
@@ -10497,12 +10243,44 @@ msgstr ""
 #~ msgstr "nodo de almacenamiento"
 
 #, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "grupo está"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
 #~ msgid "Import Users"
 #~ msgstr "Importar"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Impresora TCP / IP Port"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "tipo no válido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Seleccionar una imagen válida"
+
+#, fuzzy
+#~ msgid "Invalid method called"
+#~ msgstr "Valor no válido Tiempo de espera"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "servidor TFTP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10513,8 +10291,28 @@ msgstr ""
 #~ msgstr "Versión del sistema"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Nombre de la tarea"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No nodo asociado"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NO"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10544,8 +10342,16 @@ msgstr ""
 #~ msgid "Pause"
 #~ msgstr "Usuario"
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Por favor seleccione una opción"
+
 #~ msgid "Printer Alias"
 #~ msgstr "impresora Alias"
+
+#, fuzzy
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Añadir nueva cuenta de usuario"
 
 #~ msgid "Registered"
 #~ msgstr "Registrado"
@@ -10553,6 +10359,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remoto"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "resultados"
 
 #~ msgid "Results"
 #~ msgstr "resultados"
@@ -10610,6 +10420,14 @@ msgstr ""
 #~ msgstr "actualización de la impresora ha fallado!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Buscar"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Buscar"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Asociación para la imagen"
 
@@ -10625,8 +10443,20 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "nodo de almacenamiento"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Exportar"
+
 #~ msgid "Successful"
 #~ msgstr "Exitoso"
+
+#, fuzzy
+#~ msgid "Task States"
+#~ msgstr "Nombre de la tarea"
+
+#, fuzzy
+#~ msgid "Task Types"
+#~ msgstr "Tipo de tarea"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10656,6 +10486,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "La dirección MAC ya está en uso por otro host"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Este ajuste define "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "No hay snapins asociados con este anfitrión"
+
 #~ msgid "Total Rows"
 #~ msgstr "Filas totales"
 
@@ -10678,6 +10516,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Eliminar todos los elementos seleccionados"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nombre de usuario"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10724,6 +10566,34 @@ msgstr ""
 #~ msgstr "Servicio de Actualización!"
 
 #, fuzzy
+#~ msgid "User call is invalid"
+#~ msgstr "imagen asignado"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nombre de usuario"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Una imagen ya existe con este nombre!"
+
+#, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Ultima versión"
 
@@ -10744,9 +10614,25 @@ msgstr ""
 #~ msgstr "suprimido"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "Deben estar cifrados"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "tarea no válido"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI clave"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "MulticastTask"
 
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versión"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "no dentro de este"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -727,9 +727,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
-msgid "All methods of binding have failed"
-msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandbreite sollte numerisch und größer als 0 sein."
@@ -739,12 +736,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
 
 #, fuzzy
 msgid "Already created"
@@ -1062,10 +1053,6 @@ msgid "CA Certificate Path"
 msgstr "Neuen Standort erstellen"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Pfad"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
 
@@ -1165,10 +1152,6 @@ msgstr "Stornierter Task"
 msgid "Cancelled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Anmeldung am LDAP-Server nicht möglich"
-
 msgid "Cannot change image when in tasking"
 msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
@@ -1213,9 +1196,6 @@ msgstr "Snapin erstellen fehlgeschlagen"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin erfolgreich hinzugefügt"
-
-msgid "Capone Deploy"
-msgstr "Capone Verteilung"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1294,9 +1274,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "Kanalaufruf ist ungültig"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1526,22 +1503,7 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
 msgid "Could not read tmp file."
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -1551,10 +1513,6 @@ msgstr "Konnte nicht registriert werden."
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1881,10 +1839,6 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Standard ist deaktiviert"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -1949,9 +1903,6 @@ msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Beschreibung"
@@ -2117,10 +2068,6 @@ msgid "Edit Capone"
 msgstr "Snapins exportieren"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Snapins exportieren"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Gruppeneinstellungen Module"
 
@@ -2141,9 +2088,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Standort senden aktivieren"
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2285,10 +2229,6 @@ msgstr "Konfiguration exportieren"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP-Server"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "Standorte exportieren"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2629,10 +2569,6 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Filter"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Suche nach zugeordneten Images"
 
@@ -2738,10 +2674,6 @@ msgstr "Funktion"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funktion"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Methode ist nicht vorhanden"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2909,18 +2841,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -2991,10 +2911,6 @@ msgid "Group Update Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
@@ -3009,10 +2925,6 @@ msgstr "Gruppe hinzugefügt!"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3139,18 +3051,6 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3233,17 +3133,6 @@ msgstr "Host Kernel Argumente"
 msgid "Host List"
 msgstr "Hostliste"
 
-msgid "Host Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Standort aktualisiert"
-
 msgid "Host Login History"
 msgstr "Host-Login-Verlauf"
 
@@ -3300,10 +3189,6 @@ msgstr "Host Snapinverlauf"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3608,22 +3493,6 @@ msgid "Image Used"
 msgstr "genutzte Images"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows-Schlüssel importieren"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows-Schlüssel erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows-Schlüssel aktualisiert"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image hinzugefügt"
 
@@ -3736,10 +3605,6 @@ msgid "Import Failed"
 msgstr "Image aktualisiert"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Standorte importieren"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Benutzer importieren"
 
@@ -3756,28 +3621,12 @@ msgid "Import Reports"
 msgstr "Berichte importieren"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppen importieren"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Import erfolgreich"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Import erfolgreich"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Taskstatus exportieren"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task-Typen importieren"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows-Schlüssel importieren"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3975,10 +3824,6 @@ msgstr "Ungültige Einheit"
 msgid "Invalid Windows product key"
 msgstr "Host Produktschlüssel"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Wählen Sie ein gültiges Abbild"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4019,9 +3864,6 @@ msgstr "Ungültiger Schlüssel wurde angefordert"
 
 msgid "Invalid key being set"
 msgstr "Ungültiger Schlüssel wurde gesetzt"
-
-msgid "Invalid method called"
-msgstr "Ungültige Methode aufgerufen"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4142,9 +3984,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "indem es die max. Bandbreiteneinstellung desjenigen Knotens"
 
-msgid "It tells the client to download snapins from"
-msgstr "Es weist den Client an, Snapins vom hostdefinierten "
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4190,10 +4029,6 @@ msgid "Key"
 msgstr "DMI-Schlüssel"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Schlüsselfeldname muss eine Zeichenfolge sein."
 
@@ -4217,10 +4052,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "sofort abbrechen"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4338,10 +4169,6 @@ msgstr "LDAP-Server aktualisiert"
 msgid "LDAP Server updated!"
 msgstr "LDAP-Server aktualisiert"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
 msgid "Language"
 msgstr "Sprache"
 
@@ -4373,9 +4200,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4443,14 +4267,6 @@ msgid "List All Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task Status"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task-Typen"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installierte Plugins"
 
@@ -4478,10 +4294,6 @@ msgstr "Laden von Daten zum Feld %s"
 
 msgid "Location"
 msgstr "Ort"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Standort Zugehörigkeiten"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4516,9 +4328,6 @@ msgstr "Standort erfolgreich aktualisiert"
 #, fuzzy
 msgid "Location added!"
 msgstr "Standort hinzugefügt"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4903,10 +4712,6 @@ msgstr "NAME"
 msgid "NOT"
 msgstr "NICHT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "HINWEIS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4939,16 +4744,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -5020,9 +4818,6 @@ msgstr "Kein Image angegeben"
 
 msgid "No Printer Management"
 msgstr "Keine Druckerverwaltung"
-
-msgid "No access is allowed"
-msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5902,10 +5697,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6129,9 +5920,6 @@ msgstr "Drucker aktualisiert!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client-Management"
@@ -6331,10 +6119,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Ergebnis"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6580,19 +6364,8 @@ msgid "Search Base DN"
 msgstr "Suche Basis DN"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Suche DN"
-
-msgid "Search DN did not return any results"
-msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
-
-#, fuzzy
 msgid "Search Key"
 msgstr "Suche"
-
-#, fuzzy
-msgid "Search Method"
-msgstr "Suchmethode"
 
 #, fuzzy
 msgid "Search Scope"
@@ -6600,9 +6373,6 @@ msgstr "Suchbereich"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Die Suche lieferte kein passendes Ergebnis"
 
 #, fuzzy
 msgid "Search settings"
@@ -6980,9 +6750,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7504,10 +7271,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppe aktualisiert"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppen exportieren"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppen exportieren"
 
@@ -7658,9 +7421,6 @@ msgstr "Task Status erfolgreich aktualisiert"
 msgid "Task State Updated!"
 msgstr "Task Status aktualisiert!"
 
-msgid "Task States"
-msgstr "Task Status"
-
 msgid "Task Type"
 msgstr "Task-Typ"
 
@@ -7710,9 +7470,6 @@ msgstr "Task-Typ ist nicht gültig"
 
 msgid "Task Type is not valid"
 msgstr "Task-Typ ist nicht gültig"
-
-msgid "Task Types"
-msgstr "Task-Typen"
 
 #, fuzzy
 msgid "Task failed"
@@ -7821,12 +7578,6 @@ msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 msgid "The API is disabled"
 msgstr "Standard ist deaktiviert"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -7845,9 +7596,6 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "läuft nicht mehr"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7888,9 +7636,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7961,9 +7706,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -8161,9 +7903,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -8218,10 +7957,6 @@ msgstr "IP(s) dieses Servers"
 msgid "This setting"
 msgstr "Diese Einstellung"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Diese Einstellung definiert das Senden"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8273,9 +8008,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8740,10 +8472,6 @@ msgid "User Create Success"
 msgstr "Benutzer erfolgreich erstellt"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Benutzer DN"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Gruppen"
 
@@ -8827,9 +8555,6 @@ msgstr "Benutzeraktualisierung erfolgreich!"
 msgid "User added!"
 msgstr "Benutzer hinzugefügt"
 
-msgid "User call is invalid"
-msgstr "Benutzeraufruf ist ungültig"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Benutzer hinzugefügt"
@@ -8842,9 +8567,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8856,10 +8578,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 #, fuzzy
 msgid "User updated!"
 msgstr "Benutzer aktualisiert"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8881,15 +8599,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Benutzername"
-
 msgid "Users"
 msgstr "Benutzer"
-
-msgid "Using the group match function"
-msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
 msgid "VB Script"
 msgstr ""
@@ -8956,10 +8667,6 @@ msgstr "Wir sind Knoten-ID "
 msgid "We are node name"
 msgstr "Wir sind Knotenname "
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8982,9 +8689,6 @@ msgstr "wurde abgebrochen"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
@@ -9001,10 +8705,6 @@ msgstr "Fenstergröße muss größer sein als 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows-Schlüssel beschreibung"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows Keys"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9047,15 +8747,8 @@ msgid "Windows Key updated!"
 msgstr "Windows-Schlüssel aktualisiert"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows Keys"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Produktschlüssel"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
 
 msgid "Wipes"
 msgstr ""
@@ -9179,17 +8872,11 @@ msgstr "vor mir auf diesem Knoten"
 msgid "between"
 msgstr "zwischen"
 
-msgid "between different sites"
-msgstr "Stellen hin und her wechseln."
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "die Client Computer in den FOG"
-
-msgid "but bind password is not set"
-msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 msgid "but has recently failed for this host"
@@ -9231,9 +8918,6 @@ msgstr ""
 
 msgid "day"
 msgstr "Tag"
-
-msgid "deploy task occurs for it"
-msgstr "es eine Verteilungs-Task gibt."
 
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
@@ -9304,9 +8988,6 @@ msgstr "Dateigröße"
 msgid "fog-admins"
 msgstr "Domänen-Name"
 
-msgid "for Microsoft Windows to images"
-msgstr "MS Windows den Images zuordnet."
-
 #, fuzzy
 msgid "found"
 msgstr "gefunden"
@@ -9342,14 +9023,6 @@ msgstr "wurde erfolgreich zerstört"
 
 msgid "has been successfully updated"
 msgstr "wurde erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "wurde abgeschlossen"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Ungültiges Snapin-Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9529,10 +9202,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "die Client Computer in den FOG"
 
-#, fuzzy
-msgid "key"
-msgstr "aktiviert werden."
-
 msgid "keys"
 msgstr ""
 
@@ -9545,9 +9214,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "auf 1 MBit/s begrenzen, "
-
-msgid "location url based on the host that checks in"
-msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 msgid "logged in"
 msgstr ""
@@ -9582,9 +9248,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
 #, fuzzy
 msgid "must be specified"
@@ -9744,9 +9407,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "mit Clients haben, die zwischen verschiedenen "
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9803,9 +9463,6 @@ msgstr "den folgenden Terminalbefehlen tun"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
-
-msgid "the host defined location where available"
-msgstr "Speicherort herunterzuladen, sofern verfügbar."
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9864,9 +9521,6 @@ msgstr "um den angeforderten Kernel herunterzuladen."
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "um den angeforderten Kernel herunterzuladen."
-
-msgid "to operate in an environment where there may be"
-msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
 
 msgid "to review."
 msgstr "um zu überprüfen."
@@ -9935,13 +9589,6 @@ msgstr "Windows"
 
 msgid "wipe out all of your images stored on"
 msgstr "alle Images auf sämtlichen"
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "Schlüssel beim Host."
 
 #, fuzzy
 msgid "with this group"
@@ -10084,6 +9731,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
@@ -10096,12 +9752,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Pfad"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Anmeldung am LDAP-Server nicht möglich"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Verteilung"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Kanalaufruf ist ungültig"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Client Einstellungen"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10123,6 +9809,14 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
+#, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Snapins exportieren"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
@@ -10139,6 +9833,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Standorte exportieren"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Standorte exportieren"
 
 #~ msgid "Export Printers"
@@ -10185,8 +9883,28 @@ msgstr ""
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Methode ist nicht vorhanden"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10208,8 +9926,16 @@ msgstr ""
 #~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10235,6 +9961,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hostliste"
@@ -10250,6 +9987,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10288,6 +10029,22 @@ msgstr ""
 #~ msgstr "Host aktualisiert!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows-Schlüssel erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows-Schlüssel aktualisiert"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts importieren"
 
@@ -10296,6 +10053,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Standorte importieren"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Standorte importieren"
 
 #~ msgid "Import Printers"
@@ -10324,12 +10085,50 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Alle Speicherknoten"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppen importieren"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Taskstatus exportieren"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task-Typen importieren"
+
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Ungültiger Typ"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Wählen Sie ein gültiges Abbild"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Ungültige Methode aufgerufen"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "Es weist den Client an, Snapins vom hostdefinierten "
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP-Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10348,11 +10147,37 @@ msgstr ""
 #~ msgstr "Alle %s auflisten"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task Status"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task-Typen"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Standort Zugehörigkeiten"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "zugeordneter Host"
 
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "HINWEIS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10388,8 +10213,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Bitte geben Sie einen Namen für einen Admin oder einen mobilen Lookup ein."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
@@ -10400,6 +10232,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Ausgewählte entfernen?"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Ergebnis"
 
 #~ msgid "Results"
 #~ msgstr "Ergebnisse"
@@ -10460,8 +10296,25 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Suche DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Suchmethode"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Die Suche lieferte kein passendes Ergebnis"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Site Zugehörigkeit"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10475,8 +10328,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppen exportieren"
+
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#~ msgid "Task States"
+#~ msgstr "Task Status"
+
+#~ msgid "Task Types"
+#~ msgstr "Task-Typen"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10489,6 +10352,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10506,9 +10372,19 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Es gibt keine Snapins auf diesem Server."
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Diese Einstellung definiert das Senden"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
@@ -10532,6 +10408,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Benutzer DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10577,6 +10457,38 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Site aktualisiert!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "Benutzeraufruf ist ungültig"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Benutzername"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows Keys"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows Keys"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Sie haben Version"
@@ -10592,24 +10504,67 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "vor mir"
 
+#~ msgid "between different sites"
+#~ msgstr "Stellen hin und her wechseln."
+
 #~ msgid "but"
 #~ msgstr "aber "
+
+#~ msgid "but bind password is not set"
+#~ msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Abgeschlossen"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "es eine Verteilungs-Task gibt."
+
 #~ msgid "e.g."
 #~ msgstr "z.B."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "MS Windows den Images zuordnet."
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "wurde abgeschlossen"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Ungültiges Snapin-Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "aktiviert werden."
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Aktive Multicast-Tasks"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
+
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "mit Clients haben, die zwischen verschiedenen "
+
+#~ msgid "the host defined location where available"
+#~ msgstr "Speicherort herunterzuladen, sofern verfügbar."
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
+
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "Schlüssel beim Host."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -732,9 +732,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Installation / Mise à jour réussie!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "La bande passante doit être numérique et supérieur à 0"
@@ -743,12 +740,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1067,10 +1058,6 @@ msgid "CA Certificate Path"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Chemin"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "La clé privée a échoué"
 
@@ -1170,10 +1157,6 @@ msgstr "tâche Annulé"
 msgid "Cancelled due to new tasking."
 msgstr "Annulé en raison de nouvelles tâches."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Impossible de se connecter à la base de données"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1217,9 +1200,6 @@ msgstr "snapin mise à jour"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "snapin mise à jour"
-
-msgid "Capone Deploy"
-msgstr "Capone Déployer"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1298,9 +1278,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "appel de canal est invalide"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1530,22 +1507,7 @@ msgstr "Impossible de lire le fichier tmp."
 msgid "Could not read snapin file"
 msgstr "Impossible de lire le fichier tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Impossible de lire le fichier tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Impossible de lire le fichier tmp."
-
 msgid "Could not read tmp file."
-msgstr "Impossible de lire le fichier tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
@@ -1555,10 +1517,6 @@ msgstr "Impossible de créer l'imprimante"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1885,10 +1843,6 @@ msgid "Default Width"
 msgstr "Par défaut Largeur"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Les dons sont désactivés"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
@@ -1953,9 +1907,6 @@ msgstr "Échec du téléchargement"
 
 msgid "Deploy Method"
 msgstr "Déployer Méthode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "La description"
@@ -2121,10 +2072,6 @@ msgid "Edit Capone"
 msgstr "Export SnapIns"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export SnapIns"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "hôte description de"
 
@@ -2143,9 +2090,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2288,10 +2232,6 @@ msgstr "Exporter la configuration"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "Serveur LDAP"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "hôte Lieu"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2632,10 +2572,6 @@ msgid "Files Deleted List"
 msgstr "Supprimer les données de fichiers"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Fichier"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Aucun snapins associés"
 
@@ -2741,10 +2677,6 @@ msgstr "action"
 #, fuzzy
 msgid "Function Error"
 msgstr "action"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Méthode n'existe pas"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2912,18 +2844,6 @@ msgid "Group Kernel Arguments"
 msgstr "Arguments Groupe Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "hôte Lieu"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Emplacement Mise à jour"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Historique de connexion"
 
@@ -2995,10 +2915,6 @@ msgid "Group Update Fail"
 msgstr "Groupe create a échoué"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Groupe create a échoué"
 
@@ -3013,10 +2929,6 @@ msgstr "Groupe ajouté"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Groupe est non valide"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "mise à jour de l'utilisateur a échoué"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3142,18 +3054,6 @@ msgstr "Accueil"
 msgid "Host"
 msgstr "Hôte"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "hôte Créé"
@@ -3236,17 +3136,6 @@ msgstr "Hôte Arguments Kernel"
 msgid "Host List"
 msgstr "Liste des hôtes"
 
-msgid "Host Location"
-msgstr "hôte Lieu"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Emplacement Mise à jour"
-
 msgid "Host Login History"
 msgstr "Hôte Connexion Histoire"
 
@@ -3303,10 +3192,6 @@ msgstr "snapin Histoire"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Mise à jour de l'hôte a échoué"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
@@ -3611,22 +3496,6 @@ msgid "Image Used"
 msgstr "imager"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nom de l'image"
 
@@ -3739,10 +3608,6 @@ msgid "Import Failed"
 msgstr "image mise à jour"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "hôte Lieu"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Importer des utilisateurs"
 
@@ -3759,28 +3624,12 @@ msgid "Import Reports"
 msgstr "Hôtes d'importation"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Importer des groupes"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Réussi"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Réussi"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Unis Groupe"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Types de tâches"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3977,10 +3826,6 @@ msgstr "URL invalide"
 msgid "Invalid Windows product key"
 msgstr "Hôte clé de produit"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Sélectionnez une image valide"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4021,9 +3866,6 @@ msgstr "clé non valide étant retirée"
 
 msgid "Invalid key being set"
 msgstr "Clé non valide étant réglée"
-
-msgid "Invalid method called"
-msgstr "Méthode invalide appelé"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4144,9 +3986,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4192,10 +4031,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Association Image"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Événement doit être une chaîne"
 
@@ -4218,9 +4053,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Tuer"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4338,10 +4170,6 @@ msgstr "Serveur LDAP Nom"
 msgid "LDAP Server updated!"
 msgstr "Serveur LDAP Nom"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "Serveur LDAP"
-
 msgid "Language"
 msgstr "La langue"
 
@@ -4373,9 +4201,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4443,14 +4268,6 @@ msgid "List All Plugins"
 msgstr "Installer Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Unis Groupe"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Types de tâches"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Plugins installés"
 
@@ -4477,10 +4294,6 @@ msgstr "Chargement des données à champ %s"
 
 msgid "Location"
 msgstr "Emplacement"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Association Image"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4515,9 +4328,6 @@ msgstr "Installation / Mise à jour réussie!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Nom de la localisation"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4902,10 +4712,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NE PAS"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NE PAS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4938,16 +4744,9 @@ msgstr "Événement doit être une chaîne"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Événement doit être une chaîne"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Événement doit être une chaîne"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "mise à jour de l'utilisateur a échoué"
 
 msgid "Network Information"
 msgstr "Réseau d'information"
@@ -5019,9 +4818,6 @@ msgstr "Pas d'image spécifiée"
 
 msgid "No Printer Management"
 msgstr "Pas de gestion de l'imprimante"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5901,10 +5697,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Port est pas ldap valide / LDAPS ports"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6128,9 +5920,6 @@ msgstr "Imprimante mis à jour!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Comptes Pushbullet"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "La gestion des clients"
@@ -6330,10 +6119,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Résultats"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6579,18 +6364,7 @@ msgid "Search Base DN"
 msgstr "Chercher"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Chercher"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Chercher"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Chercher"
 
 #, fuzzy
@@ -6598,9 +6372,6 @@ msgid "Search Scope"
 msgstr "Chercher"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6979,9 +6750,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Comptes Slack"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7503,10 +7271,6 @@ msgid "Subnet Group updated!"
 msgstr "Groupe ajouté"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Groupes d'exportation"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Groupes d'exportation"
 
@@ -7655,9 +7419,6 @@ msgstr "utilisateur créé"
 msgid "Task State Updated!"
 msgstr "État Tâche ajouté, édition"
 
-msgid "Task States"
-msgstr "Unis Groupe"
-
 msgid "Task Type"
 msgstr "type de tâche"
 
@@ -7707,9 +7468,6 @@ msgstr "Type de tâche n'est pas valide"
 
 msgid "Task Type is not valid"
 msgstr "Type de tâche n'est pas valide"
-
-msgid "Task Types"
-msgstr "Types de tâches"
 
 #, fuzzy
 msgid "Task failed"
@@ -7818,12 +7576,6 @@ msgstr "Ce paramètre définit "
 msgid "The API is disabled"
 msgstr "Les dons sont désactivés"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Il n'y a pas de groupes sur ce serveur."
@@ -7842,9 +7594,6 @@ msgstr "Impossible de lire le fichier temporaire"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " n'existe plus"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7885,9 +7634,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7957,9 +7703,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8157,9 +7900,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | Cela ne veut pas le groupe principal"
@@ -8214,10 +7954,6 @@ msgstr ""
 msgid "This setting"
 msgstr "Ce paramètre définit "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Ce paramètre définit "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8269,10 +8005,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "Il n'y a pas snapins associés à cet hôte"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8737,10 +8469,6 @@ msgid "User Create Success"
 msgstr "utilisateur créé"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nom d'utilisateur"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Groupes"
 
@@ -8824,9 +8552,6 @@ msgstr "Installation / Mise à jour réussie!"
 msgid "User added!"
 msgstr "Nom de l'imprimante"
 
-msgid "User call is invalid"
-msgstr "appel de l'utilisateur est invalide"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Nom de l'imprimante"
@@ -8839,9 +8564,6 @@ msgstr "mise à jour de l'utilisateur a échoué"
 msgid "User group updated!"
 msgstr "mis à jour l'utilisateur"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Enregistrement non trouvé, Erreur: %s"
@@ -8853,10 +8575,6 @@ msgstr "mise à jour de l'utilisateur a échoué"
 #, fuzzy
 msgid "User updated!"
 msgstr "mis à jour l'utilisateur"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "S'il vous plaît entrez un nom pour ce serveur LDAP."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8878,15 +8596,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nom d'utilisateur"
-
 msgid "Users"
 msgstr "Utilisateurs"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8953,10 +8664,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Nom du nœud de stockage"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Impossible de se connecter à la base de données"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8979,9 +8686,6 @@ msgstr "a été mis à jour avec succès"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -8997,10 +8701,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "hôte description de"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9043,16 +8743,8 @@ msgid "Windows Key updated!"
 msgstr "Gestion des utilisateurs"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Hôte clé de produit"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Une image existe déjà avec ce nom!"
 
 msgid "Wipes"
 msgstr ""
@@ -9174,16 +8866,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9225,9 +8911,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9299,9 +8982,6 @@ msgstr "taille du fichier"
 msgid "fog-admins"
 msgstr "Nom de domaine"
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 #, fuzzy
 msgid "found"
 msgstr "Pas trouvé"
@@ -9337,14 +9017,6 @@ msgstr "a été mis à jour avec succès"
 
 msgid "has been successfully updated"
 msgstr "a été mis à jour avec succès"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "a été détruit"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Invalid Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9523,10 +9195,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9538,9 +9206,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9575,9 +9240,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9737,9 +9399,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "snapin"
@@ -9796,9 +9455,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Groupe de stockage Mise à jour"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9857,9 +9513,6 @@ msgstr "Aucune clé demandée"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "Aucune clé demandée"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "réviser."
@@ -9928,13 +9581,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "pas dans ce"
 
 #, fuzzy
 msgid "with this group"
@@ -10086,12 +9732,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Chemin"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Impossible de se connecter à la base de données"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Déployer"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "appel de canal est invalide"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Paramètres"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10114,6 +9790,14 @@ msgstr ""
 #~ msgstr "Pas de hachage disponible"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Les dons sont désactivés"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Les hôtes à l'exportation"
 
@@ -10126,6 +9810,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "hôte Lieu"
 
 #~ msgid "Export Printers"
@@ -10172,8 +9860,28 @@ msgstr ""
 #~ msgstr "Je ne suis pas le serveur web de brouillard"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Fichier"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Réinitialiser"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Méthode n'existe pas"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Emplacement Mise à jour"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10192,8 +9900,16 @@ msgstr ""
 #~ msgstr "Groupe ajouté"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Groupe create a échoué"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Groupe create a échoué"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "mise à jour de l'utilisateur a échoué"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10219,6 +9935,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "mise à jour de l'utilisateur a échoué"
 
+#~ msgid "Host Location"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Emplacement Mise à jour"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Liste des hôtes"
@@ -10234,6 +9961,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "snapin Histoire"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10272,6 +10003,22 @@ msgstr ""
 #~ msgstr "mis à jour l'utilisateur"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hôtes d'importation"
 
@@ -10280,6 +10027,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "hôte Lieu"
 
 #~ msgid "Import Printers"
@@ -10308,12 +10059,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Tous les nœuds de stockage"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Importer des groupes"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Unis Groupe"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Types de tâches"
+
 #~ msgid "Import Users"
 #~ msgstr "Importer des utilisateurs"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Type non valide"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Sélectionnez une image valide"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Méthode invalide appelé"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Association Image"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "Serveur LDAP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10332,8 +10114,28 @@ msgstr ""
 #~ msgstr "Lister tous les %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Unis Groupe"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Types de tâches"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Association Image"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "Aucun noeud associé"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NE PAS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "mise à jour de l'utilisateur a échoué"
 
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "Non FOGPage Classe trouvé pour ce noeud"
@@ -10368,8 +10170,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "S'il vous plaît entrer un nom pour cet emplacement."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Port est pas ldap valide / LDAPS ports"
+
 #~ msgid "Printer Alias"
 #~ msgstr "imprimante Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Comptes Pushbullet"
 
 #~ msgid "Registered"
 #~ msgstr "Inscrit"
@@ -10377,6 +10186,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Retirer snapins sélectionnés"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Résultats"
 
 #~ msgid "Results"
 #~ msgstr "Résultats"
@@ -10437,8 +10250,19 @@ msgstr ""
 #~ msgstr "mise à jour de l'imprimante a échoué!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Chercher"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Chercher"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Association Image"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Comptes Slack"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10452,8 +10276,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nœud de stockage Créé"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Groupes d'exportation"
+
 #~ msgid "Successful"
 #~ msgstr "Réussi"
+
+#~ msgid "Task States"
+#~ msgstr "Unis Groupe"
+
+#~ msgid "Task Types"
+#~ msgstr "Types de tâches"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10483,6 +10317,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | Cela ne veut pas le nœud maître"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Ce paramètre définit "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Il n'y a pas snapins associés à cet hôte"
+
 #~ msgid "Total Rows"
 #~ msgstr "Nombre de lignes"
 
@@ -10505,6 +10347,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Supprimer les imprimantes sélectionnées"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nom d'utilisateur"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10550,6 +10396,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Service de mise à jour!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "appel de l'utilisateur est invalide"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "S'il vous plaît entrez un nom pour ce serveur LDAP."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nom d'utilisateur"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Impossible de se connecter à la base de données"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Une image existe déjà avec ce nom!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Dernière version"
@@ -10570,6 +10443,18 @@ msgstr ""
 #~ msgstr "Terminé"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "a été détruit"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Invalid Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Tâches Multicast actifs"
 
@@ -10580,3 +10465,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "pas dans ce"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -705,9 +705,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Impostazioni iPXE aggiornate correttamente!"
 
-msgid "All methods of binding have failed"
-msgstr "Tutti i metodi di associazione sono falliti"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Larghezza di banda deve essere numerico e maggiore di 0"
@@ -717,12 +714,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Consente la modifica/creazione di Task States per FOG."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Consente la modifica / creazione di tipi di attività FOG."
 
 msgid "Already created"
 msgstr "Già creato"
@@ -1027,10 +1018,6 @@ msgid "CA Certificate Path"
 msgstr "Crea nuova posizione"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Percorso"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Chiave privata non è riuscita"
 
@@ -1130,9 +1117,6 @@ msgstr "compito Annullato"
 msgid "Cancelled due to new tasking."
 msgstr "Annullato a causa della nuova tasking."
 
-msgid "Cannot bind to the LDAP server"
-msgstr "Impossibile legare al server LDAP"
-
 msgid "Cannot change image when in tasking"
 msgstr "Impossibile modificare l'immagine durante l'attività"
 
@@ -1175,9 +1159,6 @@ msgstr "Creazione Snapin fallita"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Creazione Snapin completata"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1254,9 +1235,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "chiamata canale non è valido"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1471,22 +1449,7 @@ msgstr "Impossibile leggere il file tmp."
 msgid "Could not read snapin file"
 msgstr "Impossibile leggere il file snapin"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Impossibile leggere il file tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Impossibile leggere il file tmp."
-
 msgid "Could not read tmp file."
-msgstr "Impossibile leggere il file tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Impossibile leggere il file tmp."
 
 msgid "Could not register"
@@ -1495,10 +1458,6 @@ msgstr "Non posso registrare"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1822,9 +1781,6 @@ msgstr "Predefinito: frequenza aggiornamento"
 msgid "Default Width"
 msgstr "Larghezza predefinita"
 
-msgid "Default is disabled"
-msgstr "Il valore predefinito è disabilitato"
-
 #, fuzzy
 msgid "Default nested group depth"
 msgstr "Impossibile aprire il file per la lettura"
@@ -1887,9 +1843,6 @@ msgstr "Scaricamento fallito"
 
 msgid "Deploy Method"
 msgstr "Metodo Deploy"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Descrizione"
@@ -2053,10 +2006,6 @@ msgid "Edit Capone"
 msgstr "Export Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Impostazioni modulo del gruppo"
 
@@ -2077,9 +2026,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Abilita invio posizione "
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2218,9 +2164,6 @@ msgstr "Esporta configurazione"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP Servers"
-
-msgid "Export Locations"
-msgstr "Esporta luoghi"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2550,9 +2493,6 @@ msgstr "Impossibile per distruggere il nodo di archiviazione"
 msgid "Files Deleted List"
 msgstr "Cancellare i file"
 
-msgid "Filter"
-msgstr "Filtro"
-
 msgid "Finding any images associated"
 msgstr "Trovare tutte le immagini associate"
 
@@ -2654,9 +2594,6 @@ msgstr "Funzione"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funzione"
-
-msgid "Function does not exist"
-msgstr "La funzione non esiste"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2822,18 +2759,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argomenti Gruppo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Luoghi"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Modifica posizione riuscita"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Posizione aggiornata!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Accesso Storia"
 
@@ -2902,10 +2827,6 @@ msgid "Group Update Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
@@ -2917,10 +2838,6 @@ msgstr "Gruppo aggiunto!"
 
 msgid "Group is not valid"
 msgstr "Gruppo non valido"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Aggiornamento utente non riuscita"
 
 msgid "Group update failed!"
 msgstr "Aggiornamento del gruppo non riuscito!"
@@ -3045,18 +2962,6 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Host"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creazione Host con successo"
@@ -3136,17 +3041,6 @@ msgstr "Host argomenti del kernel"
 msgid "Host List"
 msgstr "Lista Host"
 
-msgid "Host Location"
-msgstr "Host Luoghi"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Modifica posizione riuscita"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Posizione aggiornata!"
-
 msgid "Host Login History"
 msgstr "Host Accesso Storia"
 
@@ -3200,10 +3094,6 @@ msgid "Host Snapin History"
 msgstr "Storia Snapin Host"
 
 msgid "Host Update Fail"
-msgstr "Aggiornamento Host completato"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Aggiornamento Host completato"
 
 #, fuzzy
@@ -3495,22 +3385,6 @@ msgstr "Modifica immagine riuscita"
 msgid "Image Used"
 msgstr "Immagine utilizzata"
 
-#, fuzzy
-msgid "Image Windows Key"
-msgstr "Importa chiavi Windows"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Chiave di Windows Aggiornata"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Chiave di Windows Aggiornata"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Chiave di Windows Aggiornata"
-
 msgid "Image added!"
 msgstr "Immagine aggiunta!"
 
@@ -3617,9 +3491,6 @@ msgstr "Importa database"
 msgid "Import Failed"
 msgstr "immagine aggiornata"
 
-msgid "Import Locations"
-msgstr "Importa luoghi"
-
 #, fuzzy
 msgid "Import OUs"
 msgstr "Importa utenti"
@@ -3636,25 +3507,12 @@ msgid "Import Reports"
 msgstr "Importa Report"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppi di importazione"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Importazione riuscita"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Importazione riuscita"
-
-msgid "Import Task States"
-msgstr "Importa Stato delle attività"
-
-msgid "Import Task Types"
-msgstr "Importa tipi di attività"
-
-msgid "Import Windows Keys"
-msgstr "Importa chiavi Windows"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3841,10 +3699,6 @@ msgstr "Unità non valida"
 msgid "Invalid Windows product key"
 msgstr "Host Product Key"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Selezionare un'immagine valida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -3882,9 +3736,6 @@ msgstr "chiave non valida richiesta"
 
 msgid "Invalid key being set"
 msgstr "chiave non valido stato impostato"
-
-msgid "Invalid method called"
-msgstr "metodo valido chiamato"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4001,9 +3852,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "funziona ottenendo l'impostazione massima della larghezza di banda del nodo"
 
-msgid "It tells the client to download snapins from"
-msgstr "indica al client di scaricare gli snapins da"
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4047,10 +3895,6 @@ msgstr "I kernel / INIT dalla posizione"
 msgid "Key"
 msgstr "Chiave"
 
-#, fuzzy
-msgid "Key Association"
-msgstr "Associazione Sito"
-
 msgid "Key field must be a string"
 msgstr "Campo chiave deve essere una stringa"
 
@@ -4073,10 +3917,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Uccidere"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 msgid "LDAP Connection  Name"
 msgstr "Nome connessione LDAP"
@@ -4188,9 +4028,6 @@ msgstr "LDAP Server modificato!"
 msgid "LDAP Server updated!"
 msgstr "LDAP Server modificato!"
 
-msgid "LDAP Servers"
-msgstr "LDAP Servers"
-
 msgid "Language"
 msgstr "Lingua"
 
@@ -4220,9 +4057,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 msgid "Level must be an integer"
@@ -4283,14 +4117,6 @@ msgid "List All Plugins"
 msgstr "installare plugin"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Stati attività"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipi di attività"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "plugin installati"
 
@@ -4316,9 +4142,6 @@ msgstr "Caricamento dei dati campo"
 
 msgid "Location"
 msgstr "Luogo"
-
-msgid "Location Association"
-msgstr "Associazione Posizione"
 
 msgid "Location Create Fail"
 msgstr "Creazione posizione fallita"
@@ -4349,9 +4172,6 @@ msgstr "Modifica posizione riuscita"
 
 msgid "Location added!"
 msgstr "Posizione aggiunta!"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Luoghi è un plugin che consente al server FOG"
 
 msgid "Location update failed!"
 msgstr "Aggiornamento posizione non riuscito"
@@ -4729,9 +4549,6 @@ msgstr "NOME"
 msgid "NOT"
 msgstr "NON"
 
-msgid "NOTE"
-msgstr "NOTE"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4764,16 +4581,9 @@ msgstr "Nuova chiave deve essere una stringa"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Nuova chiave deve essere una stringa"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Nuova chiave deve essere una stringa"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Aggiornamento utente non riuscita"
 
 msgid "Network Information"
 msgstr "Informationi di rete"
@@ -4844,9 +4654,6 @@ msgstr "Nessuna immagine specificata"
 
 msgid "No Printer Management"
 msgstr "No Printer Management"
-
-msgid "No access is allowed"
-msgstr "Nessun accesso è consentito"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5699,9 +5506,6 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr "La porta non è la porta ldap / ldaps valida"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5917,9 +5721,6 @@ msgstr "aggiornato stampante!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Conti"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "client Management"
@@ -6113,9 +5914,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-msgid "Result"
-msgstr "Risultati"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6353,27 +6151,15 @@ msgstr "Ricerca"
 msgid "Search Base DN"
 msgstr "Cerca Base DN"
 
-msgid "Search DN"
-msgstr "Search DN"
-
-msgid "Search DN did not return any results"
-msgstr "Ricerca DN non ha restituito alcun risultato"
-
 #, fuzzy
 msgid "Search Key"
 msgstr "Ricerca"
-
-msgid "Search Method"
-msgstr "Metodo di ricerca"
 
 msgid "Search Scope"
 msgstr "Scope di ricerca"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Risultati di ricerca che restituiscono false"
 
 #, fuzzy
 msgid "Search settings"
@@ -6742,9 +6528,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7234,10 +7017,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppo aggiornato!"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppi Export"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppi Export"
 
@@ -7380,9 +7159,6 @@ msgstr "Aggiunta stato attività riuscito!"
 msgid "Task State Updated!"
 msgstr "Aggiunta stato attività aggiormato!"
 
-msgid "Task States"
-msgstr "Stati attività"
-
 msgid "Task Type"
 msgstr "Tipo attività"
 
@@ -7426,9 +7202,6 @@ msgstr "Tipo di attività non è valido"
 
 msgid "Task Type is not valid"
 msgstr "Task Type non è valido"
-
-msgid "Task Types"
-msgstr "Tipi di attività"
 
 #, fuzzy
 msgid "Task failed"
@@ -7533,12 +7306,6 @@ msgstr "L'impostazione \"nodo master\" definisce quale"
 msgid "The API is disabled"
 msgstr "Il valore predefinito è disabilitato"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Non ci sono gruppi su questo server"
@@ -7557,9 +7324,6 @@ msgstr "Impossibile leggere il file temporaneo"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "non è più in esecuzione"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7600,9 +7364,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7672,9 +7433,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "La chiave verrà assegnata agli host registrati quando una"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -7867,9 +7625,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Ciò è particolarmente utile se si dispone di più"
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Questo non è il gruppo primario"
@@ -7922,9 +7677,6 @@ msgstr "IP di questo server"
 msgid "This setting"
 msgstr "Questa impostazione"
 
-msgid "This setting defines sending the"
-msgstr "Questa impostazione definisce l'invio"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -7975,9 +7727,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Queste immagini devono essere attivate con le relative"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8430,9 +8179,6 @@ msgstr "Creazione utente fallita"
 msgid "User Create Success"
 msgstr "Creazione utente riuscita"
 
-msgid "User DN"
-msgstr "User DN"
-
 #, fuzzy
 msgid "User Group"
 msgstr "gruppi"
@@ -8513,9 +8259,6 @@ msgstr "Utente aggiornato con successo"
 msgid "User added!"
 msgstr "Utente aggiunto!"
 
-msgid "User call is invalid"
-msgstr "chiamata dell'utente non è valido"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Utente aggiunto!"
@@ -8528,9 +8271,6 @@ msgstr "Aggiornamento utente non riuscita"
 msgid "User group updated!"
 msgstr "Utente aggiornato"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Record non trovato"
@@ -8540,9 +8280,6 @@ msgstr "Aggiornamento utente non riuscita"
 
 msgid "User updated!"
 msgstr "Utente aggiornato"
-
-msgid "User was not authorized by the LDAP server"
-msgstr "L'utente non è stato autorizzato dal server LDAP"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8564,15 +8301,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nome utente"
-
 msgid "Users"
 msgstr "utenti"
-
-msgid "Using the group match function"
-msgstr "Utilizzo della funzione di corrispondenza gruppo"
 
 msgid "VB Script"
 msgstr ""
@@ -8634,9 +8364,6 @@ msgstr "Siamo ID nodo"
 msgid "We are node name"
 msgstr "Siamo il nome del nodo"
 
-msgid "We cannot connect to LDAP server"
-msgstr "Non è possibile connettersi al server LDAP"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8659,9 +8386,6 @@ msgstr "è stato cancellato"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Quando il plugin viene rimosso, il tasto assegnato rimarrà"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Dove ottenere aiuto"
@@ -8678,10 +8402,6 @@ msgstr "La finestra dati deve essere maggiore di 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Descrizione chiave di Windows"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Chiave Windows"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -8721,15 +8441,9 @@ msgstr "Chiave di Windows Aggiornata"
 msgid "Windows Key updated!"
 msgstr "Chiave di Windows Aggiornata"
 
-msgid "Windows Keys"
-msgstr "Chiave Windows"
-
 #, fuzzy
 msgid "Windows Product key"
 msgstr "Host Product Key"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Tasti di Windows è un plugin che associa le chiavi di prodotto"
 
 msgid "Wipes"
 msgstr ""
@@ -8847,17 +8561,11 @@ msgstr "prima di me su questo nodo"
 msgid "between"
 msgstr "fra"
 
-msgid "between different sites"
-msgstr "tra diversi siti"
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "avvia i computer client"
-
-msgid "but bind password is not set"
-msgstr "Ma la bind password non è impostata"
 
 msgid "but has recently failed for this host"
 msgstr "ma è fallito di recente per questo host"
@@ -8897,9 +8605,6 @@ msgstr ""
 
 msgid "day"
 msgstr "giorno"
-
-msgid "deploy task occurs for it"
-msgstr "attività di distribuzione avviene per esso"
 
 msgid "directive in php.ini"
 msgstr "direttiva in php.ini"
@@ -8966,9 +8671,6 @@ msgstr "dimensione del file"
 msgid "fog-admins"
 msgstr "Nome del dominio"
 
-msgid "for Microsoft Windows to images"
-msgstr "per Microsoft Windows per immagini"
-
 msgid "found"
 msgstr "trovato"
 
@@ -9000,14 +8702,6 @@ msgstr "è stato distrutta con successo"
 
 msgid "has been successfully updated"
 msgstr "è stato aggiornato con successo"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "è stato completato"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Non valido Snapin Tasking"
 
 msgid "has failed to destroy"
 msgstr "è fallita la distruzione"
@@ -9174,9 +8868,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "avvia i computer client"
 
-msgid "key"
-msgstr "chiave"
-
 msgid "keys"
 msgstr ""
 
@@ -9189,9 +8880,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "limitata a 1Mbps su quel nodo"
-
-msgid "location url based on the host that checks in"
-msgstr "Url di posizione basata sull'host che controlla e"
 
 msgid "logged in"
 msgstr ""
@@ -9223,9 +8911,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "più posti per ottenere l'immagine"
 
 msgid "must be specified"
 msgstr "deve essere specificato"
@@ -9378,9 +9063,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "siti con client che si muovono avanti e indietro"
-
 msgid "snapin"
 msgstr "snapin"
 
@@ -9433,9 +9115,6 @@ msgstr "il seguente comando in un terminale"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aggiornamento Gruppo di archiviazione fallito"
-
-msgid "the host defined location where available"
-msgstr "la posizione definita dall'host, se disponibile"
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9490,9 +9169,6 @@ msgstr "pr ottenere il Kernel richiesto"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "pr ottenere il Kernel richiesto"
-
-msgid "to operate in an environment where there may be"
-msgstr "per operare in un ambiente in cui ci possa essere"
 
 msgid "to review."
 msgstr "da revisionare"
@@ -9558,12 +9234,6 @@ msgstr "finestra"
 
 msgid "wipe out all of your images stored on"
 msgstr "cancellare tutte le immagini archiviate in"
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
-msgstr "con l'host"
 
 msgid "with this group"
 msgstr "con questo gruppo"
@@ -9701,6 +9371,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Gruppo amministrativo"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Tutti i metodi di associazione sono falliti"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Consente la modifica/creazione di Task States per FOG."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Consente la modifica / creazione di tipi di attività FOG."
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Esiste già un ruolo con questo nome!"
@@ -9713,12 +9392,41 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Percorso"
+
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Impossibile legare al server LDAP"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "chiamata canale non è valido"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Controllare che database è in esecuzione"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Impostazioni Client"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -9740,6 +9448,13 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Percorso non disponibile"
 
+#~ msgid "Default is disabled"
+#~ msgstr "Il valore predefinito è disabilitato"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export Snapins"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Event e data non sono impostati"
 
@@ -9756,6 +9471,9 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Esporta luoghi"
+
+#~ msgid "Export Locations"
 #~ msgstr "Esporta luoghi"
 
 #~ msgid "Export Printers"
@@ -9800,9 +9518,27 @@ msgstr ""
 #~ msgid "Files do not match on server"
 #~ msgstr "Io non sono il server web fog"
 
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Riavvio"
+
+#~ msgid "Function does not exist"
+#~ msgstr "La funzione non esiste"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Modifica posizione riuscita"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Posizione aggiornata!"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -9824,8 +9560,16 @@ msgstr ""
 #~ msgstr "Gruppo aggiornato!"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Aggiornamento gruppo non riuscito"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Aggiornamento utente non riuscita"
 
 #~ msgid "Group module settings"
 #~ msgstr "Impostazioni modulo del gruppo"
@@ -9849,6 +9593,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aggiornamento ruolo non riuscito"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Modifica posizione riuscita"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Posizione aggiornata!"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Lista Host"
@@ -9864,6 +9619,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Storia Snapin Host"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Aggiornamento Host completato"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -9901,6 +9660,22 @@ msgstr ""
 #~ msgstr "Host aggiornato!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Importa chiavi Windows"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Importa Host"
 
@@ -9909,6 +9684,9 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Importa luoghi"
+
+#~ msgid "Import Locations"
 #~ msgstr "Importa luoghi"
 
 #~ msgid "Import Printers"
@@ -9936,11 +9714,45 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Tutti i nodi di storage"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppi di importazione"
+
+#~ msgid "Import Task States"
+#~ msgstr "Importa Stato delle attività"
+
+#~ msgid "Import Task Types"
+#~ msgstr "Importa tipi di attività"
+
 #~ msgid "Import Users"
 #~ msgstr "Importa utenti"
 
+#~ msgid "Import Windows Keys"
+#~ msgstr "Importa chiavi Windows"
+
 #~ msgid "Invalid Type"
 #~ msgstr "Tipo non valido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Selezionare un'immagine valida"
+
+#~ msgid "Invalid method called"
+#~ msgstr "metodo valido chiamato"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "indica al client di scaricare gli snapins da"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Associazione Sito"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP Servers"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -9958,11 +9770,35 @@ msgstr ""
 #~ msgstr "Elencare tutti %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Stati attività"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipi di attività"
+
+#~ msgid "Location Association"
+#~ msgstr "Associazione Posizione"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Luoghi è un plugin che consente al server FOG"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "Host associato"
 
+#~ msgid "NOTE"
+#~ msgstr "NOTE"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Aggiornamento utente non riuscita"
+
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "Nessun FOGPage Classe trovato per questo nodo"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Nessun accesso è consentito"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -9996,8 +9832,14 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Inserisci un nome di amministratore o di ricerca per cellulari"
 
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "La porta non è la porta ldap / ldaps valida"
+
 #~ msgid "Printer Alias"
 #~ msgstr "stampante Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Conti"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Registro deve essere gestito da hook o eventi"
@@ -10008,6 +9850,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Rimuovi i selezionati"
+
+#~ msgid "Result"
+#~ msgstr "Risultati"
 
 #~ msgid "Results"
 #~ msgstr "risultati"
@@ -10064,8 +9909,23 @@ msgstr ""
 #~ msgid "Rule update failed!"
 #~ msgstr "Aggiornamento della stampante non è riuscito!"
 
+#~ msgid "Search DN"
+#~ msgstr "Search DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Ricerca DN non ha restituito alcun risultato"
+
+#~ msgid "Search Method"
+#~ msgstr "Metodo di ricerca"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Risultati di ricerca che restituiscono false"
+
 #~ msgid "Site Association"
 #~ msgstr "Associazione Sito"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin creato"
@@ -10077,8 +9937,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Creato"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppi Export"
+
 #~ msgid "Successful"
 #~ msgstr "Riuscito"
+
+#~ msgid "Task States"
+#~ msgstr "Stati attività"
+
+#~ msgid "Task Types"
+#~ msgstr "Tipi di attività"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10091,6 +9961,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Questo host esiste già"
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "La chiave verrà assegnata agli host registrati quando una"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10106,9 +9979,18 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Non ci sono snapins su questo server"
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Ciò è particolarmente utile se si dispone di più"
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Questo non è il nodo master"
+
+#~ msgid "This setting defines sending the"
+#~ msgstr "Questa impostazione definisce l'invio"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Queste immagini devono essere attivate con le relative"
 
 #~ msgid "Total Rows"
 #~ msgstr "Righe totali"
@@ -10130,6 +10012,9 @@ msgstr ""
 
 #~ msgid "Update/Remove printers"
 #~ msgstr "Aggiorna/Rimuovi stampanti"
+
+#~ msgid "User DN"
+#~ msgstr "User DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10175,6 +10060,35 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Sito aggiornato!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "chiamata dell'utente non è valido"
+
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "L'utente non è stato autorizzato dal server LDAP"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nome utente"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Utilizzo della funzione di corrispondenza gruppo"
+
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Non è possibile connettersi al server LDAP"
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Quando il plugin viene rimosso, il tasto assegnato rimarrà"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Chiave Windows"
+
+#~ msgid "Windows Keys"
+#~ msgstr "Chiave Windows"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Tasti di Windows è un plugin che associa le chiavi di prodotto"
+
 #~ msgid "You have version"
 #~ msgstr "Hai l'ultima versione"
 
@@ -10188,22 +10102,63 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "prima di me"
 
+#~ msgid "between different sites"
+#~ msgstr "tra diversi siti"
+
 #~ msgid "but"
 #~ msgstr "ma"
+
+#~ msgid "but bind password is not set"
+#~ msgstr "Ma la bind password non è impostata"
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Completato"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "attività di distribuzione avviene per esso"
+
 #~ msgid "e.g."
 #~ msgstr "es."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "per Microsoft Windows per immagini"
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "è stato completato"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Non valido Snapin Tasking"
+
+#~ msgid "key"
+#~ msgstr "chiave"
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "Url di posizione basata sull'host che controlla e"
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Compiti multicast attivi"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "più posti per ottenere l'immagine"
+
 #~ msgid "no database to"
 #~ msgstr "Nessun database a"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "siti con client che si muovono avanti e indietro"
+
+#~ msgid "the host defined location where available"
+#~ msgstr "la posizione definita dall'host, se disponibile"
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "per operare in un ambiente in cui ci possa essere"
+
 #~ msgid "version"
 #~ msgstr "versione"
+
+#~ msgid "with the host"
+#~ msgstr "con l'host"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -689,9 +689,6 @@ msgstr "ホストに同じイメージが割り当てられていません"
 msgid "All items imported successfully"
 msgstr "項目を正常に削除しました！"
 
-msgid "All methods of binding have failed"
-msgstr "すべてのバインド方法に失敗しました"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "帯域幅は 0 より大きい数値で指定してください"
@@ -701,12 +698,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "現在 FOG に登録されているタスク状態の編集および作成を許可します。"
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "現在 FOG に登録されているタスクタイプの編集および作成を許可します。"
 
 msgid "Already created"
 msgstr "既に作成されています"
@@ -1009,10 +1000,6 @@ msgid "CA Certificate Path"
 msgstr "新しいロケーションを作成"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "パス"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "秘密鍵の処理に失敗しました"
 
@@ -1111,9 +1098,6 @@ msgstr "キャンセルされたタスク"
 msgid "Cancelled due to new tasking."
 msgstr "新しいタスクによりキャンセルされました。"
 
-msgid "Cannot bind to the LDAP server"
-msgstr "LDAP サーバーにバインドできません"
-
 msgid "Cannot change image when in tasking"
 msgstr "タスク実行中はイメージを変更できません"
 
@@ -1156,9 +1140,6 @@ msgstr "スナップインの作成に失敗しました"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "スナップインを作成しました"
-
-msgid "Capone Deploy"
-msgstr "Capone 展開"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1236,9 +1217,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "チャネル呼び出しが無効です"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1453,22 +1431,7 @@ msgstr "一時ファイルを読み取れませんでした。"
 msgid "Could not read snapin file"
 msgstr "スナップインファイルを読み取れませんでした"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "一時ファイルを読み取れませんでした。"
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "一時ファイルを読み取れませんでした。"
-
 msgid "Could not read tmp file."
-msgstr "一時ファイルを読み取れませんでした。"
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "一時ファイルを読み取れませんでした。"
 
 msgid "Could not register"
@@ -1477,10 +1440,6 @@ msgstr "登録できませんでした"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1804,9 +1763,6 @@ msgstr "既定の更新レート"
 msgid "Default Width"
 msgstr "既定の幅"
 
-msgid "Default is disabled"
-msgstr "既定では無効です"
-
 #, fuzzy
 msgid "Default nested group depth"
 msgstr "更新できません"
@@ -1869,9 +1825,6 @@ msgstr "ダウンロードに失敗しました"
 
 msgid "Deploy Method"
 msgstr "展開方法"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "説明"
@@ -2034,10 +1987,6 @@ msgid "Edit Capone"
 msgstr "ノードを編集"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "ノードを編集"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "ノードを編集"
 
@@ -2058,10 +2007,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "ロケーション送信を有効化"
-
-#, fuzzy
-msgid "Enable Sending via Location"
-msgstr "スナップインロケーション"
 
 msgid "Enable on all hosts"
 msgstr ""
@@ -2199,9 +2144,6 @@ msgstr "構成をエクスポート"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP サーバー"
-
-msgid "Export Locations"
-msgstr "ロケーションをエクスポート"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2523,9 +2465,6 @@ msgstr "ストレージノードの破棄に失敗しました"
 msgid "Files Deleted List"
 msgstr "ルールの削除に失敗しました"
 
-msgid "Filter"
-msgstr "フィルター"
-
 msgid "Finding any images associated"
 msgstr "関連付けられたイメージを検索しています"
 
@@ -2628,9 +2567,6 @@ msgstr "関数"
 #, fuzzy
 msgid "Function Error"
 msgstr "関数"
-
-msgid "Function does not exist"
-msgstr "関数が存在しません"
 
 msgid "GNU General Public License"
 msgstr "GNU General Public License"
@@ -2793,18 +2729,6 @@ msgid "Group Kernel Arguments"
 msgstr "グループカーネル引数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "ロケーションを更新しました"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "ロケーションを更新しました！"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "ログイン履歴"
 
@@ -2873,10 +2797,6 @@ msgid "Group Update Fail"
 msgstr "グループの更新に失敗しました"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "グループの更新に失敗しました"
 
@@ -2888,10 +2808,6 @@ msgstr "グループを追加しました！"
 
 msgid "Group is not valid"
 msgstr "グループが無効です"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "ユーザーの更新に失敗しました！"
 
 msgid "Group update failed!"
 msgstr "グループの更新に失敗しました！"
@@ -3015,18 +2931,6 @@ msgstr "ホーム"
 msgid "Host"
 msgstr "ホスト"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "承認に成功しました"
@@ -3104,17 +3008,6 @@ msgstr "ホストカーネル引数"
 msgid "Host List"
 msgstr "ホスト一覧"
 
-msgid "Host Location"
-msgstr "ホスト ロケーション"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "ロケーションを更新しました"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "ロケーションを更新しました！"
-
 msgid "Host Login History"
 msgstr "ホストログイン履歴"
 
@@ -3168,10 +3061,6 @@ msgid "Host Snapin History"
 msgstr "ホストスナップイン履歴"
 
 msgid "Host Update Fail"
-msgstr "ホストの更新に失敗しました"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "ホストの更新に失敗しました"
 
 #, fuzzy
@@ -3464,22 +3353,6 @@ msgstr "イメージを更新しました"
 msgid "Image Used"
 msgstr "使用中のイメージ"
 
-#, fuzzy
-msgid "Image Windows Key"
-msgstr "新しい Windows キー"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows キーの更新に失敗しました"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows キーの更新に成功しました"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows キーを更新しました！"
-
 msgid "Image added!"
 msgstr "イメージを追加しました！"
 
@@ -3581,9 +3454,6 @@ msgstr "データベースをインポート"
 msgid "Import Failed"
 msgstr "インポートに失敗しました"
 
-msgid "Import Locations"
-msgstr "ロケーションをインポート"
-
 #, fuzzy
 msgid "Import OUs"
 msgstr "ユーザーをインポート"
@@ -3600,24 +3470,11 @@ msgid "Import Reports"
 msgstr "レポートをインポート"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "サブネットグループをインポート"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "インポートに成功しました"
 
 msgid "Import Succeeded With Warnings"
 msgstr ""
-
-msgid "Import Task States"
-msgstr "タスク状態をインポート"
-
-msgid "Import Task Types"
-msgstr "タスクタイプをインポート"
-
-msgid "Import Windows Keys"
-msgstr "Windows キーをインポート"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3801,10 +3658,6 @@ msgstr "無効な URL"
 msgid "Invalid Windows product key"
 msgstr "指定されたプロダクトキーが無効です"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "有効な LDAP ポートを選択してください"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -3843,9 +3696,6 @@ msgstr "要求されたキーが無効です"
 
 msgid "Invalid key being set"
 msgstr "設定しようとしているキーが無効です"
-
-msgid "Invalid method called"
-msgstr "無効なメソッドが呼び出されました"
 
 msgid "Invalid path"
 msgstr "無効なパス"
@@ -3957,9 +3807,6 @@ msgstr "ユーザー名は 41 文字未満で指定してください"
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "ノードの最大帯域幅設定を取得して動作します"
 
-msgid "It tells the client to download snapins from"
-msgstr "クライアントに次の場所からスナップインをダウンロードするよう指示します"
-
 #, fuzzy
 msgid "It will operate based on the fields the area typcially requires."
 msgstr "通常その領域で必要とされるフィールドに基づいて動作します"
@@ -4004,10 +3851,6 @@ msgstr "ロケーションからのカーネル/Init"
 msgid "Key"
 msgstr "キー"
 
-#, fuzzy
-msgid "Key Association"
-msgstr "ルールの関連付け"
-
 msgid "Key field must be a string"
 msgstr "キーフィールドは文字列で指定してください"
 
@@ -4029,10 +3872,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "強制終了"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4143,9 +3982,6 @@ msgstr "LDAP サーバーを更新しました！"
 msgid "LDAP Server updated!"
 msgstr "LDAP サーバーを更新しました！"
 
-msgid "LDAP Servers"
-msgstr "LDAP サーバー"
-
 msgid "Language"
 msgstr "言語"
 
@@ -4178,9 +4014,6 @@ msgstr "各ホストの現在の値を維持する場合は、フィールドを
 #, fuzzy
 msgid "Leave blank to keep the current password"
 msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
-
-msgid "Level"
-msgstr ""
 
 msgid "Level must be an integer"
 msgstr "レベルは整数である必要があります"
@@ -4240,14 +4073,6 @@ msgid "List All Plugins"
 msgstr "プラグインをインストール"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "タスク状態"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "タスクタイプ"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "インストール済みプラグイン"
 
@@ -4273,9 +4098,6 @@ msgstr "フィールドにデータを読み込んでいます"
 
 msgid "Location"
 msgstr "ロケーション"
-
-msgid "Location Association"
-msgstr "ロケーションの関連付け"
 
 msgid "Location Create Fail"
 msgstr "ロケーションの作成に失敗しました"
@@ -4305,9 +4127,6 @@ msgstr "ロケーションを更新しました"
 
 msgid "Location added!"
 msgstr "ロケーションを追加しました！"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "ロケーションは、FOG サーバーで利用できるプラグインです"
 
 msgid "Location update failed!"
 msgstr "ロケーションの更新に失敗しました！"
@@ -4681,9 +4500,6 @@ msgstr "名前"
 msgid "NOT"
 msgstr "NOT"
 
-msgid "NOTE"
-msgstr "注意"
-
 #, fuzzy
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr "フォーラムは、最も一般的で迅速なサポートを受ける方法です"
@@ -4718,16 +4534,9 @@ msgstr "新しいキーは文字列である必要があります"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "ユーザー名は 41 文字未満で指定してください"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "ユーザー名は 41 文字未満で指定してください"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "ユーザーの更新に失敗しました！"
 
 msgid "Network Information"
 msgstr "ネットワーク情報"
@@ -4796,9 +4605,6 @@ msgstr "イメージが指定されていません"
 
 msgid "No Printer Management"
 msgstr "プリンター管理なし"
-
-msgid "No access is allowed"
-msgstr "アクセスは許可されていません"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5658,9 +5464,6 @@ msgstr ""
 msgid "Port"
 msgstr "ポート"
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr "ポートは有効な ldap/ldaps ポートではありません"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5873,9 +5676,6 @@ msgstr "プリンターを更新しました！"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet アカウント"
-
 msgid "Pushbullet Management"
 msgstr "Pushbullet 管理"
 
@@ -6066,9 +5866,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-msgid "Result"
-msgstr "結果"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6301,27 +6098,15 @@ msgstr "検索"
 msgid "Search Base DN"
 msgstr "検索ベース DN"
 
-msgid "Search DN"
-msgstr "検索 DN"
-
-msgid "Search DN did not return any results"
-msgstr "検索 DN は結果を返しませんでした"
-
 #, fuzzy
 msgid "Search Key"
 msgstr "検索"
-
-msgid "Search Method"
-msgstr "検索方法"
 
 msgid "Search Scope"
 msgstr "検索範囲"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "検索結果が false を返しました"
 
 #, fuzzy
 msgid "Search settings"
@@ -6680,9 +6465,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack アカウント"
 
 msgid "Slack Management"
 msgstr "Slack 管理"
@@ -7169,9 +6951,6 @@ msgstr "サブネットグループの更新に失敗しました！"
 msgid "Subnet Group updated!"
 msgstr "サブネットグループを更新しました！"
 
-msgid "Subnet Groups"
-msgstr "サブネットグループ"
-
 msgid "Subnets"
 msgstr "サブネット"
 
@@ -7310,9 +7089,6 @@ msgstr "タスク状態を更新しました"
 msgid "Task State Updated!"
 msgstr "タスク状態を更新しました！"
 
-msgid "Task States"
-msgstr "タスク状態"
-
 msgid "Task Type"
 msgstr "タスクタイプ"
 
@@ -7355,9 +7131,6 @@ msgstr "タスクタイプが無効です"
 
 msgid "Task Type is not valid"
 msgstr "タスクタイプが無効です"
-
-msgid "Task Types"
-msgstr "タスクタイプ"
 
 #, fuzzy
 msgid "Task failed"
@@ -7462,12 +7235,6 @@ msgstr "「マスターノード」設定は、どのノードを"
 msgid "The API is disabled"
 msgstr "既定では無効です"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "このサーバーにはグループがありません"
@@ -7486,9 +7253,6 @@ msgstr "強制終了できませんでした"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "選択したプリンターを追加"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7529,9 +7293,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7600,9 +7361,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "キーは、登録済みホストに次の場合割り当てられます"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -7797,9 +7555,6 @@ msgstr "これは一度だけ実行されるタスクであり、現在実行さ
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "複数ある場合に特に便利です"
-
 msgid "This is not the master for this group"
 msgstr "このグループのマスターノードではありません"
 
@@ -7850,9 +7605,6 @@ msgstr "このサーバーの IP アドレス"
 
 msgid "This setting"
 msgstr "この設定"
-
-msgid "This setting defines sending the"
-msgstr "この設定では送信方法を定義します"
 
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
@@ -7905,9 +7657,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "これらのイメージは関連付けられた"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8360,9 +8109,6 @@ msgstr "ユーザーの作成に失敗しました"
 msgid "User Create Success"
 msgstr "ユーザーの作成に成功しました"
 
-msgid "User DN"
-msgstr "ユーザー DN"
-
 #, fuzzy
 msgid "User Group"
 msgstr "グループ"
@@ -8443,9 +8189,6 @@ msgstr "ユーザーの更新に成功しました"
 msgid "User added!"
 msgstr "ユーザーを追加しました！"
 
-msgid "User call is invalid"
-msgstr "無効なユーザー呼び出しです"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "ユーザーを追加しました！"
@@ -8458,9 +8201,6 @@ msgstr "ユーザーの更新に失敗しました！"
 msgid "User group updated!"
 msgstr "ユーザーを更新しました！"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "レコードが見つかりません"
@@ -8470,9 +8210,6 @@ msgstr "ユーザーの更新に失敗しました！"
 
 msgid "User updated!"
 msgstr "ユーザーを更新しました！"
-
-msgid "User was not authorized by the LDAP server"
-msgstr "LDAP サーバーでユーザー認証に失敗しました"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8496,15 +8233,8 @@ msgstr "ユーザー名は 3 文字以上で指定してください"
 msgid "Username must end with a number or letter."
 msgstr "ユーザー名は英数字またはアンダースコアで開始する必要があります"
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "ユーザー名"
-
 msgid "Users"
 msgstr "ユーザー"
-
-msgid "Using the group match function"
-msgstr "グループ照合機能を使用しています"
 
 msgid "VB Script"
 msgstr ""
@@ -8565,9 +8295,6 @@ msgstr "現在のノード ID"
 msgid "We are node name"
 msgstr "現在のノード名"
 
-msgid "We cannot connect to LDAP server"
-msgstr "LDAP サーバーに接続できません"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8590,9 +8317,6 @@ msgstr "強制終了されました"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "プラグインを削除しても、割り当てられたキーは保持されます"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "ヘルプの入手先"
@@ -8609,9 +8333,6 @@ msgstr "ウィンドウサイズは 1 より大きい必要があります"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows キー全般"
-
-msgid "Windows Key"
-msgstr "Windows キー"
 
 msgid "Windows Key Create Fail"
 msgstr "Windows キーの作成に失敗しました"
@@ -8644,15 +8365,9 @@ msgstr "Windows キーを更新しました！"
 msgid "Windows Key updated!"
 msgstr "Windows キーを更新しました！"
 
-msgid "Windows Keys"
-msgstr "Windows キー"
-
 #, fuzzy
 msgid "Windows Product key"
 msgstr "ホスト プロダクトキー"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows キーは、プロダクトキーを関連付けるプラグインです"
 
 msgid "Wipes"
 msgstr ""
@@ -8773,18 +8488,12 @@ msgstr "このノードで自分より前"
 msgid "between"
 msgstr "～の間"
 
-msgid "between different sites"
-msgstr "異なるサイト間"
-
 #, fuzzy
 msgid "blank for default"
 msgstr "空欄の場合は既定値"
 
 msgid "boot the client computers"
 msgstr "クライアントコンピューターを起動"
-
-msgid "but bind password is not set"
-msgstr "ただし、バインドパスワードが設定されていません"
 
 msgid "but has recently failed for this host"
 msgstr "ただし、このホストでは最近失敗しています"
@@ -8818,9 +8527,6 @@ msgstr ""
 
 msgid "day"
 msgstr "日"
-
-msgid "deploy task occurs for it"
-msgstr "展開タスクが実行されたとき"
 
 msgid "directive in php.ini"
 msgstr "php.ini のディレクティブ"
@@ -8888,9 +8594,6 @@ msgstr "ファイルサイズ"
 msgid "fog-admins"
 msgstr "ドメイン名"
 
-msgid "for Microsoft Windows to images"
-msgstr "Microsoft Windows 用にイメージへ"
-
 msgid "found"
 msgstr "見つかりました"
 
@@ -8922,14 +8625,6 @@ msgstr "正常に削除されました"
 
 msgid "has been successfully updated"
 msgstr "正常に更新されました"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "完了しました"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "スナップインタスクが完了しました。"
 
 msgid "has failed to destroy"
 msgstr "削除に失敗しました"
@@ -9097,9 +8792,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "クライアントコンピューターを起動するためのカーネル"
 
-msgid "key"
-msgstr "キー"
-
 msgid "keys"
 msgstr ""
 
@@ -9113,9 +8805,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "そのノードで 1 Mbps に制限されます"
-
-msgid "location url based on the host that checks in"
-msgstr "チェックインしたホストに基づくロケーション URL"
 
 msgid "logged in"
 msgstr "ログイン済み"
@@ -9146,9 +8835,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "イメージの取得元が複数ある"
 
 msgid "must be specified"
 msgstr "指定する必要があります"
@@ -9303,9 +8989,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "クライアントが行き来する複数のサイト"
-
 msgid "snapin"
 msgstr "スナップイン"
 
@@ -9358,9 +9041,6 @@ msgstr "ターミナルで次のコマンドを実行してください"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "ストレージグループに到達可能なマスターノードがありません"
-
-msgid "the host defined location where available"
-msgstr "利用可能な場合は、ホストで定義されたロケーション"
 
 #, fuzzy
 msgid "the initrd (initial ramdisk) which is alongside the"
@@ -9415,9 +9095,6 @@ msgstr "要求されたカーネルを取得するため"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "要求された Initrd を取得するため"
-
-msgid "to operate in an environment where there may be"
-msgstr "次のような環境でも動作できるように"
 
 msgid "to review."
 msgstr "確認してください。"
@@ -9482,12 +9159,6 @@ msgstr "ウィンドウ"
 
 msgid "wipe out all of your images stored on"
 msgstr "保存されているすべてのイメージを削除します"
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
-msgstr "ホストと"
 
 msgid "with this group"
 msgstr "このグループと"
@@ -9682,8 +9353,17 @@ msgstr ""
 #~ msgid "All Pending MACs approved"
 #~ msgstr "保留中のすべての MAC アドレスを承認しました"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "すべてのバインド方法に失敗しました"
+
 #~ msgid "All snapins"
 #~ msgstr "すべてのスナップイン"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "現在 FOG に登録されているタスク状態の編集および作成を許可します。"
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "現在 FOG に登録されているタスクタイプの編集および作成を許可します。"
 
 #~ msgid "Although there are multiple levels already"
 #~ msgstr "既に複数のレベルがありますが"
@@ -9739,11 +9419,18 @@ msgstr ""
 #~ msgid "Boot Exit settings"
 #~ msgstr "ブート終了設定"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "パス"
+
 #~ msgid "Cannot add Primary mac as additional mac"
 #~ msgstr "プライマリ MAC アドレスを追加 MAC アドレスとして追加できません"
 
 #~ msgid "Cannot add a pre-existing primary mac"
 #~ msgstr "既存のプライマリ MAC アドレスを追加できません"
+
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "LDAP サーバーにバインドできません"
 
 #~ msgid "Cannot cancel tasks this way"
 #~ msgstr "この方法ではタスクをキャンセルできません"
@@ -9756,6 +9443,12 @@ msgstr ""
 
 #~ msgid "Cannot view from browser"
 #~ msgstr "ブラウザーから表示できません"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone 展開"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "チャネル呼び出しが無効です"
 
 #~ msgid "Chat is also available on the forums for more realtime help"
 #~ msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"
@@ -9823,6 +9516,22 @@ msgstr ""
 #~ msgid "Conflicting path/file"
 #~ msgstr "競合するパス/ファイル"
 
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
 #~ msgid "Create New Access Control Role"
 #~ msgstr "新しいアクセス制御ロールを作成"
 
@@ -9881,6 +9590,9 @@ msgstr ""
 #~ msgid "Date of checkout"
 #~ msgstr "貸出日"
 
+#~ msgid "Default is disabled"
+#~ msgstr "既定では無効です"
+
 #~ msgid "Default log out time (in minutes)"
 #~ msgstr "既定のログアウト時間（分）"
 
@@ -9929,6 +9641,10 @@ msgstr ""
 #~ msgid "ESC is defaulted"
 #~ msgstr "ESC が既定です"
 
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "ノードを編集"
+
 #~ msgid "Edit Host"
 #~ msgstr "ホストを編集"
 
@@ -9946,6 +9662,10 @@ msgstr ""
 
 #~ msgid "Enable Nested Group Matching (Active Directory only)"
 #~ msgstr "ネストされたグループ照合を有効化（Active Directory のみ）"
+
+#, fuzzy
+#~ msgid "Enable Sending via Location"
+#~ msgstr "スナップインロケーション"
 
 #~ msgid "End Date"
 #~ msgstr "終了日"
@@ -10021,6 +9741,9 @@ msgstr ""
 
 #~ msgid "Export LDAPs"
 #~ msgstr "LDAP をエクスポート"
+
+#~ msgid "Export Locations"
+#~ msgstr "ロケーションをエクスポート"
 
 #~ msgid "Export PDF"
 #~ msgstr "PDF をエクスポート"
@@ -10147,6 +9870,9 @@ msgstr ""
 #~ msgid "Filesize"
 #~ msgstr "ファイルサイズ"
 
+#~ msgid "Filter"
+#~ msgstr "フィルター"
+
 #~ msgid "For example, a GPO policy to push"
 #~ msgstr "たとえば、配布するための GPO ポリシー"
 
@@ -10165,6 +9891,9 @@ msgstr ""
 #~ msgid "Full Inventory Export"
 #~ msgstr "完全なインベントリをエクスポート"
 
+#~ msgid "Function does not exist"
+#~ msgstr "関数が存在しません"
+
 #~ msgid "Generate"
 #~ msgstr "生成"
 
@@ -10176,6 +9905,18 @@ msgstr ""
 
 #~ msgid "Group FOG Client Module configuration"
 #~ msgstr "グループ FOG クライアントモジュール設定"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "グループの関連付け"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "ロケーションを更新しました"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "ロケーションを更新しました！"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10206,11 +9947,19 @@ msgstr ""
 #~ msgstr "サイトを更新しました！"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "グループの更新に失敗しました"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "グループの更新に失敗しました"
 
 #~ msgid "Group general"
 #~ msgstr "グループ全般"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "ユーザーの更新に失敗しました！"
 
 #~ msgid "Groups are not allowed to schedule upload tasks"
 #~ msgstr "グループではアップロードタスクをスケジュールできません"
@@ -10275,6 +10024,17 @@ msgstr ""
 #~ msgid "Host Listing Export"
 #~ msgstr "ホスト一覧をエクスポート"
 
+#~ msgid "Host Location"
+#~ msgstr "ホスト ロケーション"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "ロケーションを更新しました"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "ロケーションを更新しました！"
+
 #~ msgid "Host MAC"
 #~ msgstr "ホスト MAC アドレス"
 
@@ -10315,6 +10075,10 @@ msgstr ""
 
 #~ msgid "Host Unassociated Snapins"
 #~ msgstr "ホストに関連付けられていないスナップイン"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "ホストの更新に失敗しました"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10398,6 +10162,22 @@ msgstr ""
 #~ msgid "Image Size: ON SERVER"
 #~ msgstr "イメージサイズ: サーバー上"
 
+#, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "新しい Windows キー"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows キーの更新に失敗しました"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows キーの更新に成功しました"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows キーを更新しました！"
+
 #~ msgid "Image to DMI Mappings"
 #~ msgstr "イメージと DMI のマッピング"
 
@@ -10428,11 +10208,27 @@ msgstr ""
 #~ msgid "Import LDAPs"
 #~ msgstr "LDAP をインポート"
 
+#~ msgid "Import Locations"
+#~ msgstr "ロケーションをインポート"
+
 #~ msgid "Import Printers"
 #~ msgstr "プリンターをインポート"
 
 #~ msgid "Import Sites"
 #~ msgstr "サイトをインポート"
+
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "サブネットグループをインポート"
+
+#~ msgid "Import Task States"
+#~ msgstr "タスク状態をインポート"
+
+#~ msgid "Import Task Types"
+#~ msgstr "タスクタイプをインポート"
+
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows キーをインポート"
 
 #~ msgid "Included Items"
 #~ msgstr "含まれる項目"
@@ -10470,6 +10266,10 @@ msgstr ""
 #~ msgid "Invalid Type"
 #~ msgstr "無効なタイプ"
 
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "有効な LDAP ポートを選択してください"
+
 #~ msgid "Invalid data found"
 #~ msgstr "無効なデータが見つかりました"
 
@@ -10478,6 +10278,9 @@ msgstr ""
 
 #~ msgid "Invalid image assigned to host"
 #~ msgstr "ホストに割り当てられたイメージが無効です"
+
+#~ msgid "Invalid method called"
+#~ msgstr "無効なメソッドが呼び出されました"
 
 #~ msgid "Invalid numeric entry"
 #~ msgstr "無効な数値入力です"
@@ -10512,6 +10315,9 @@ msgstr ""
 #~ msgid "It is primarily geared for the smart installer methodology now"
 #~ msgstr "現在は主にスマートインストーラー方式向けに設計されています"
 
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "クライアントに次の場所からスナップインをダウンロードするよう指示します"
+
 #~ msgid "Items must be an array"
 #~ msgstr "項目は配列である必要があります"
 
@@ -10524,14 +10330,25 @@ msgstr ""
 #~ msgid "Kernel Name"
 #~ msgstr "カーネル名"
 
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "ルールの関連付け"
+
 #~ msgid "Key Name"
 #~ msgstr "キー名"
 
 #~ msgid "Key must be a string"
 #~ msgstr "キーは文字列で指定してください"
 
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
 #~ msgid "LDAP General"
 #~ msgstr "LDAP 全般"
+
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP サーバー"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10552,6 +10369,14 @@ msgstr ""
 #~ msgid "Linux"
 #~ msgstr "Linux"
 
+#, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "タスク状態"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "タスクタイプ"
+
 #, php-format
 #~ msgid "List all roles"
 #~ msgstr "すべてのロールを一覧表示"
@@ -10559,8 +10384,14 @@ msgstr ""
 #~ msgid "Load MAC Vendors"
 #~ msgstr "MAC ベンダーを読み込み"
 
+#~ msgid "Location Association"
+#~ msgstr "ロケーションの関連付け"
+
 #~ msgid "Location General"
 #~ msgstr "ロケーション全般"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "ロケーションは、FOG サーバーで利用できるプラグインです"
 
 #~ msgid "Location/Deployed"
 #~ msgstr "ロケーション/展開済み"
@@ -10665,6 +10496,9 @@ msgstr ""
 #~ msgid "Must use an"
 #~ msgstr "次を使用する必要があります"
 
+#~ msgid "NOTE"
+#~ msgstr "注意"
+
 #~ msgid "NOTICE"
 #~ msgstr "通知"
 
@@ -10676,6 +10510,10 @@ msgstr ""
 
 #~ msgid "Needs action string of ask, get, or list"
 #~ msgstr "action には ask、get、list のいずれかの文字列が必要です"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "ユーザーの更新に失敗しました！"
 
 #~ msgid "New Client and Utilities"
 #~ msgstr "新しいクライアントとユーティリティ"
@@ -10736,6 +10574,9 @@ msgstr ""
 
 #~ msgid "No Site"
 #~ msgstr "サイトなし"
+
+#~ msgid "No access is allowed"
+#~ msgstr "アクセスは許可されていません"
 
 #~ msgid "No complete time recorded"
 #~ msgstr "完了時刻は記録されていません"
@@ -10973,6 +10814,9 @@ msgstr ""
 #~ msgid "Please wait until a slot is open"
 #~ msgstr "空きスロットができるまでお待ちください"
 
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "ポートは有効な ldap/ldaps ポートではありません"
+
 #~ msgid "Postfix requires an action of login, logout, or start to operate"
 #~ msgstr "Postfix を動作させるには login、logout、または start アクションが必要です"
 
@@ -10993,6 +10837,9 @@ msgstr ""
 
 #~ msgid "Printer name already exists"
 #~ msgstr "このプリンター名は既に存在します"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet アカウント"
 
 #~ msgid "Quarantine"
 #~ msgstr "隔離"
@@ -11066,6 +10913,9 @@ msgstr ""
 #~ msgid "Requires templates to process"
 #~ msgstr "処理するテンプレートが必要です"
 
+#~ msgid "Result"
+#~ msgstr "結果"
+
 #~ msgid "Results"
 #~ msgstr "結果"
 
@@ -11130,8 +10980,20 @@ msgstr ""
 #~ msgid "Schedule with shutdown"
 #~ msgstr "シャットダウンを含めてスケジュール"
 
+#~ msgid "Search DN"
+#~ msgstr "検索 DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "検索 DN は結果を返しませんでした"
+
+#~ msgid "Search Method"
+#~ msgstr "検索方法"
+
 #~ msgid "Search pattern"
 #~ msgstr "検索パターン"
+
+#~ msgid "Search results returned false"
+#~ msgstr "検索結果が false を返しました"
 
 #~ msgid "Select Image"
 #~ msgstr "イメージを選択"
@@ -11201,6 +11063,9 @@ msgstr ""
 
 #~ msgid "Site Control Management"
 #~ msgstr "サイト制御管理"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack アカウント"
 
 #~ msgid "Snapin Args"
 #~ msgstr "スナップイン引数"
@@ -11277,6 +11142,9 @@ msgstr ""
 #~ msgid "Storage Node update failed!"
 #~ msgstr "ストレージノードの更新に失敗しました！"
 
+#~ msgid "Subnet Groups"
+#~ msgstr "サブネットグループ"
+
 #~ msgid "SubnetGroup General"
 #~ msgstr "サブネットグループ全般"
 
@@ -11301,8 +11169,14 @@ msgstr ""
 #~ msgid "Task State General"
 #~ msgstr "タスク状態全般"
 
+#~ msgid "Task States"
+#~ msgstr "タスク状態"
+
 #~ msgid "Task Type General"
 #~ msgstr "タスクタイプ全般"
+
+#~ msgid "Task Types"
+#~ msgstr "タスクタイプ"
 
 #~ msgid "Task forced to start"
 #~ msgstr "タスクを強制開始しました"
@@ -11338,6 +11212,9 @@ msgstr ""
 
 #~ msgid "The following errors occurred"
 #~ msgstr "次のエラーが発生しました"
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "キーは、登録済みホストに次の場合割り当てられます"
 
 #~ msgid "The old client is what was distributed with"
 #~ msgstr "旧クライアントは次のバージョンまで配布されていました"
@@ -11376,6 +11253,9 @@ msgstr ""
 
 #~ msgid "This file will only work on Windows"
 #~ msgstr "このファイルは Windows でのみ使用できます"
+
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "複数ある場合に特に便利です"
 
 #~ msgid "This is ipxe script commands to operate with"
 #~ msgstr "iPXE を制御するためのスクリプトコマンドです"
@@ -11438,8 +11318,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "| これはマスターノードではありません"
 
+#~ msgid "This setting defines sending the"
+#~ msgstr "この設定では送信方法を定義します"
+
 #~ msgid "This setting turns off all FOG Printer Management"
 #~ msgstr "この設定は FOG のプリンター管理機能をすべて無効にします"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "これらのイメージは関連付けられた"
 
 #~ msgid "Timeout"
 #~ msgstr "タイムアウト"
@@ -11531,6 +11417,9 @@ msgstr ""
 #~ msgid "User Change Password"
 #~ msgstr "ユーザーパスワードを変更"
 
+#~ msgid "User DN"
+#~ msgstr "ユーザー DN"
+
 #~ msgid "User General"
 #~ msgstr "ユーザー全般"
 
@@ -11572,8 +11461,14 @@ msgstr ""
 #~ msgid "User Tracking"
 #~ msgstr "ユーザー追跡"
 
+#~ msgid "User call is invalid"
+#~ msgstr "無効なユーザー呼び出しです"
+
 #~ msgid "User name"
 #~ msgstr "ユーザー名"
+
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "LDAP サーバーでユーザー認証に失敗しました"
 
 #~ msgid "User/Channel to post to"
 #~ msgstr "投稿先のユーザー/Channel"
@@ -11583,6 +11478,13 @@ msgstr ""
 
 #~ msgid "Username does not meet requirements"
 #~ msgstr "ユーザー名が要件を満たしていません"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "ユーザー名"
+
+#~ msgid "Using the group match function"
+#~ msgstr "グループ照合機能を使用しています"
 
 #~ msgid "Valid Host Colors"
 #~ msgstr "有効なホストカラー"
@@ -11614,11 +11516,26 @@ msgstr ""
 #~ msgid "Wake on lan?"
 #~ msgstr "Wake on LAN を実行しますか？"
 
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "LDAP サーバーに接続できません"
+
 #~ msgid "Web root"
 #~ msgstr "Web ルート"
 
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "プラグインを削除しても、割り当てられたキーは保持されます"
+
+#~ msgid "Windows Key"
+#~ msgstr "Windows キー"
+
 #~ msgid "Windows Key for Image"
 #~ msgstr "イメージ用 Windows キー"
+
+#~ msgid "Windows Keys"
+#~ msgstr "Windows キー"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows キーは、プロダクトキーを関連付けるプラグインです"
 
 #~ msgid "Working with node"
 #~ msgstr "ノードを処理しています"
@@ -11684,6 +11601,12 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "自分より前"
 
+#~ msgid "between different sites"
+#~ msgstr "異なるサイト間"
+
+#~ msgid "but bind password is not set"
+#~ msgstr "ただし、バインドパスワードが設定されていません"
+
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "イメージ処理が完了しました。"
@@ -11703,6 +11626,9 @@ msgstr ""
 #~ msgid "deleted"
 #~ msgstr "削除済み"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "展開タスクが実行されたとき"
+
 #~ msgid "download the module and use it on the next"
 #~ msgstr "モジュールをダウンロードし、次回以降に使用します"
 
@@ -11715,6 +11641,9 @@ msgstr ""
 #~ msgid "faster"
 #~ msgstr "高速"
 
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "Microsoft Windows 用にイメージへ"
+
 #~ msgid "for the advanced menu parameters"
 #~ msgstr "詳細メニューパラメーター用"
 
@@ -11723,6 +11652,14 @@ msgstr ""
 
 #~ msgid "has been started on port"
 #~ msgstr "次のポートで開始されました"
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "完了しました"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "スナップインタスクが完了しました。"
 
 #~ msgid "help with any aspect of FOG"
 #~ msgstr "FOG に関するあらゆるサポート"
@@ -11772,6 +11709,12 @@ msgstr ""
 #~ msgid "it will enforce login to gain access to the advanced"
 #~ msgstr "詳細メニューへアクセスするにはログインが必要になります"
 
+#~ msgid "key"
+#~ msgstr "キー"
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "チェックインしたホストに基づくロケーション URL"
+
 #~ msgid "may see the issue and help and/or use the solutions"
 #~ msgstr "問題を確認し、支援したり解決策を利用したりできます"
 
@@ -11790,6 +11733,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "マルチキャストタスク"
+
+#~ msgid "multiple places to get your image"
+#~ msgstr "イメージの取得元が複数ある"
 
 #~ msgid "no login will appear"
 #~ msgstr "ログイン画面は表示されません"
@@ -11834,6 +11780,9 @@ msgstr ""
 #~ msgid "see the forums or lookup the commands and scripts available"
 #~ msgstr "フォーラムを参照するか、利用可能なコマンドやスクリプトを確認してください"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "クライアントが行き来する複数のサイト"
+
 #~ msgid "successfully removed!"
 #~ msgstr "正常に削除しました！"
 
@@ -11848,6 +11797,9 @@ msgstr ""
 
 #~ msgid "the base FOG install"
 #~ msgstr "FOG の基本インストール"
+
+#~ msgid "the host defined location where available"
+#~ msgstr "利用可能な場合は、ホストで定義されたロケーション"
 
 #~ msgid "the main and the host"
 #~ msgstr "メイン設定とホスト設定"
@@ -11866,6 +11818,9 @@ msgstr ""
 
 #~ msgid "to be booted if no keys are pressed when the menu is"
 #~ msgstr "メニュー表示中にキーが押されなかった場合に起動する"
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "次のような環境でも動作できるように"
 
 #~ msgid "to signify if this is a user or channel to send to"
 #~ msgstr "送信先がユーザーかチャンネルかを指定します"
@@ -11890,6 +11845,9 @@ msgstr ""
 
 #~ msgid "with modules and config"
 #~ msgstr "モジュールと構成を含めて"
+
+#~ msgid "with the host"
+#~ msgstr "ホストと"
 
 #~ msgid "would you like to install it now"
 #~ msgstr "今すぐインストールしますか？"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -610,9 +610,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr ""
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr ""
 
@@ -620,12 +617,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 msgid "Already created"
@@ -898,9 +889,6 @@ msgstr ""
 msgid "CA Certificate Path"
 msgstr ""
 
-msgid "CA Path"
-msgstr ""
-
 msgid "CA private key"
 msgstr ""
 
@@ -989,9 +977,6 @@ msgstr ""
 msgid "Cancelled due to new tasking."
 msgstr ""
 
-msgid "Cannot bind to the LDAP server"
-msgstr ""
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1028,9 +1013,6 @@ msgid "Capone Create Fail"
 msgstr ""
 
 msgid "Capone Create Success"
-msgstr ""
-
-msgid "Capone Deploy"
 msgstr ""
 
 msgid "Capone Management"
@@ -1094,9 +1076,6 @@ msgid "Changing this setting takes effect after you reload the page. A hard refr
 msgstr ""
 
 msgid "Channel"
-msgstr ""
-
-msgid "Channel call is invalid"
 msgstr ""
 
 msgid "Channel not found"
@@ -1294,19 +1273,7 @@ msgstr ""
 msgid "Could not read snapin file"
 msgstr ""
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-msgid "Could not read the group mappings"
-msgstr ""
-
-msgid "Could not read the recorded grants"
-msgstr ""
-
 msgid "Could not read tmp file."
-msgstr ""
-
-msgid "Could not record the granted targets"
 msgstr ""
 
 msgid "Could not register"
@@ -1314,9 +1281,6 @@ msgstr ""
 
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
-msgstr ""
-
-msgid "Could not seed the granted targets"
 msgstr ""
 
 msgid "Could not send data from file"
@@ -1591,9 +1555,6 @@ msgstr ""
 msgid "Default Width"
 msgstr ""
 
-msgid "Default is disabled"
-msgstr ""
-
 msgid "Default nested group depth"
 msgstr ""
 
@@ -1647,9 +1608,6 @@ msgid "Deploy Complete"
 msgstr ""
 
 msgid "Deploy Method"
-msgstr ""
-
-msgid "Depth"
 msgstr ""
 
 msgid "Description"
@@ -1790,9 +1748,6 @@ msgstr ""
 msgid "Edit Capone"
 msgstr ""
 
-msgid "Edit Capone ID"
-msgstr ""
-
 msgid "Editing Capone ID"
 msgstr ""
 
@@ -1809,9 +1764,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 msgid "Enable on all hosts"
@@ -1940,9 +1892,6 @@ msgid "Export Configuration"
 msgstr ""
 
 msgid "Export LDAP Servers"
-msgstr ""
-
-msgid "Export Locations"
 msgstr ""
 
 msgid "Export OUs"
@@ -2232,9 +2181,6 @@ msgstr ""
 msgid "Files Deleted List"
 msgstr ""
 
-msgid "Filter"
-msgstr ""
-
 msgid "Finding any images associated"
 msgstr ""
 
@@ -2329,9 +2275,6 @@ msgid "Function"
 msgstr ""
 
 msgid "Function Error"
-msgstr ""
-
-msgid "Function does not exist"
 msgstr ""
 
 msgid "GNU General Public License"
@@ -2473,15 +2416,6 @@ msgstr ""
 msgid "Group Kernel Arguments"
 msgstr ""
 
-msgid "Group Location"
-msgstr ""
-
-msgid "Group Location Update Success"
-msgstr ""
-
-msgid "Group Location Updated!"
-msgstr ""
-
 msgid "Group Login History"
 msgstr ""
 
@@ -2539,9 +2473,6 @@ msgstr ""
 msgid "Group Update Fail"
 msgstr ""
 
-msgid "Group Update Location Fail"
-msgstr ""
-
 msgid "Group Update OU Fail"
 msgstr ""
 
@@ -2552,9 +2483,6 @@ msgid "Group added!"
 msgstr ""
 
 msgid "Group is not valid"
-msgstr ""
-
-msgid "Group membership search failed"
 msgstr ""
 
 msgid "Group update failed!"
@@ -2660,18 +2588,6 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 msgid "Host Approval Success"
 msgstr ""
 
@@ -2738,15 +2654,6 @@ msgstr ""
 msgid "Host List"
 msgstr ""
 
-msgid "Host Location"
-msgstr ""
-
-msgid "Host Location Update Success"
-msgstr ""
-
-msgid "Host Location Updated!"
-msgstr ""
-
 msgid "Host Login History"
 msgstr ""
 
@@ -2793,9 +2700,6 @@ msgid "Host Snapin History"
 msgstr ""
 
 msgid "Host Update Fail"
-msgstr ""
-
-msgid "Host Update Location Fail"
 msgstr ""
 
 msgid "Host Update OU Fail"
@@ -3061,18 +2965,6 @@ msgstr ""
 msgid "Image Used"
 msgstr ""
 
-msgid "Image Windows Key"
-msgstr ""
-
-msgid "Image Windows Key Update Fail"
-msgstr ""
-
-msgid "Image Windows Key Update Success"
-msgstr ""
-
-msgid "Image Windows Key Updated!"
-msgstr ""
-
 msgid "Image added!"
 msgstr ""
 
@@ -3163,9 +3055,6 @@ msgstr ""
 msgid "Import Failed"
 msgstr ""
 
-msgid "Import Locations"
-msgstr ""
-
 msgid "Import OUs"
 msgstr ""
 
@@ -3178,22 +3067,10 @@ msgstr ""
 msgid "Import Reports"
 msgstr ""
 
-msgid "Import Subnet Groups"
-msgstr ""
-
 msgid "Import Succeeded"
 msgstr ""
 
 msgid "Import Succeeded With Warnings"
-msgstr ""
-
-msgid "Import Task States"
-msgstr ""
-
-msgid "Import Task Types"
-msgstr ""
-
-msgid "Import Windows Keys"
 msgstr ""
 
 msgid "Import a new Plugin"
@@ -3362,10 +3239,6 @@ msgid "Invalid Windows product key"
 msgstr ""
 
 #, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr ""
-
-#, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
 
@@ -3400,9 +3273,6 @@ msgid "Invalid key being requested"
 msgstr ""
 
 msgid "Invalid key being set"
-msgstr ""
-
-msgid "Invalid method called"
 msgstr ""
 
 msgid "Invalid path"
@@ -3504,9 +3374,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -3546,9 +3413,6 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-msgid "Key Association"
-msgstr ""
-
 msgid "Key field must be a string"
 msgstr ""
 
@@ -3568,9 +3432,6 @@ msgid "Keys cached"
 msgstr ""
 
 msgid "Kill"
-msgstr ""
-
-msgid "LDAP"
 msgstr ""
 
 msgid "LDAP Connection  Name"
@@ -3663,9 +3524,6 @@ msgstr ""
 msgid "LDAP Server updated!"
 msgstr ""
 
-msgid "LDAP Servers"
-msgstr ""
-
 msgid "Language"
 msgstr ""
 
@@ -3694,9 +3552,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 msgid "Level must be an integer"
@@ -3752,12 +3607,6 @@ msgstr ""
 msgid "List All Plugins"
 msgstr ""
 
-msgid "List All Task States"
-msgstr ""
-
-msgid "List All Task Types"
-msgstr ""
-
 msgid "List Available Plugins"
 msgstr ""
 
@@ -3780,9 +3629,6 @@ msgid "Loading data to field"
 msgstr ""
 
 msgid "Location"
-msgstr ""
-
-msgid "Location Association"
 msgstr ""
 
 msgid "Location Create Fail"
@@ -3810,9 +3656,6 @@ msgid "Location Update Success"
 msgstr ""
 
 msgid "Location added!"
-msgstr ""
-
-msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 msgid "Location update failed!"
@@ -4142,9 +3985,6 @@ msgstr ""
 msgid "NOT"
 msgstr ""
 
-msgid "NOTE"
-msgstr ""
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4172,13 +4012,7 @@ msgstr ""
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr ""
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 msgid "Nested group depth must be between 1 and 100"
-msgstr ""
-
-msgid "Nested group search failed"
 msgstr ""
 
 msgid "Network Information"
@@ -4244,9 +4078,6 @@ msgid "No Image specified"
 msgstr ""
 
 msgid "No Printer Management"
-msgstr ""
-
-msgid "No access is allowed"
 msgstr ""
 
 msgid "No active task found for this host"
@@ -4999,9 +4830,6 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr ""
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5191,9 +5019,6 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr ""
-
 msgid "Pushbullet Management"
 msgstr ""
 
@@ -5367,9 +5192,6 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
-msgstr ""
-
-msgid "Result"
 msgstr ""
 
 msgid "Resume Reload"
@@ -5580,25 +5402,13 @@ msgstr ""
 msgid "Search Base DN"
 msgstr ""
 
-msgid "Search DN"
-msgstr ""
-
-msgid "Search DN did not return any results"
-msgstr ""
-
 msgid "Search Key"
-msgstr ""
-
-msgid "Search Method"
 msgstr ""
 
 msgid "Search Scope"
 msgstr ""
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 msgid "Search settings"
@@ -5911,9 +5721,6 @@ msgid "Skipping, not a PluginTask"
 msgstr ""
 
 msgid "Skipping, will need manual removal"
-msgstr ""
-
-msgid "Slack Accounts"
 msgstr ""
 
 msgid "Slack Management"
@@ -6348,9 +6155,6 @@ msgstr ""
 msgid "Subnet Group updated!"
 msgstr ""
 
-msgid "Subnet Groups"
-msgstr ""
-
 msgid "Subnets"
 msgstr ""
 
@@ -6478,9 +6282,6 @@ msgstr ""
 msgid "Task State Updated!"
 msgstr ""
 
-msgid "Task States"
-msgstr ""
-
 msgid "Task Type"
 msgstr ""
 
@@ -6518,9 +6319,6 @@ msgid "Task Type is invalid"
 msgstr ""
 
 msgid "Task Type is not valid"
-msgstr ""
-
-msgid "Task Types"
 msgstr ""
 
 msgid "Task failed"
@@ -6611,12 +6409,6 @@ msgstr ""
 msgid "The API is disabled"
 msgstr ""
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 msgid "The CA private key is not on this server"
 msgstr ""
 
@@ -6630,9 +6422,6 @@ msgid "The FOG account could not be created"
 msgstr ""
 
 msgid "The FOG account for this identity no longer exists"
-msgstr ""
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
 msgstr ""
 
 msgid "The ID token carries no subject"
@@ -6672,9 +6461,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 msgid "The count."
@@ -6738,9 +6524,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -6923,9 +6706,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 msgid "This is not the master for this group"
 msgstr ""
 
@@ -6975,9 +6755,6 @@ msgstr ""
 msgid "This setting"
 msgstr ""
 
-msgid "This setting defines sending the"
-msgstr ""
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -7024,9 +6801,6 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
-msgstr ""
-
-msgid "Those images should be activated with the associated"
 msgstr ""
 
 msgid "Throughput sample."
@@ -7426,9 +7200,6 @@ msgstr ""
 msgid "User Create Success"
 msgstr ""
 
-msgid "User DN"
-msgstr ""
-
 msgid "User Group"
 msgstr ""
 
@@ -7495,9 +7266,6 @@ msgstr ""
 msgid "User added!"
 msgstr ""
 
-msgid "User call is invalid"
-msgstr ""
-
 msgid "User group added!"
 msgstr ""
 
@@ -7507,9 +7275,6 @@ msgstr ""
 msgid "User group updated!"
 msgstr ""
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 msgid "User not found"
 msgstr ""
 
@@ -7517,9 +7282,6 @@ msgid "User update failed!"
 msgstr ""
 
 msgid "User updated!"
-msgstr ""
-
-msgid "User was not authorized by the LDAP server"
 msgstr ""
 
 msgid "User/Channel"
@@ -7540,13 +7302,7 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-msgid "Username was blank"
-msgstr ""
-
 msgid "Users"
-msgstr ""
-
-msgid "Using the group match function"
 msgstr ""
 
 msgid "VB Script"
@@ -7606,9 +7362,6 @@ msgstr ""
 msgid "We are node name"
 msgstr ""
 
-msgid "We cannot connect to LDAP server"
-msgstr ""
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -7630,9 +7383,6 @@ msgstr ""
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -7646,9 +7396,6 @@ msgid "Window size must be greater than 1"
 msgstr ""
 
 msgid "Windows 10 Professional"
-msgstr ""
-
-msgid "Windows Key"
 msgstr ""
 
 msgid "Windows Key Create Fail"
@@ -7681,13 +7428,7 @@ msgstr ""
 msgid "Windows Key updated!"
 msgstr ""
 
-msgid "Windows Keys"
-msgstr ""
-
 msgid "Windows Product key"
-msgstr ""
-
-msgid "Windows keys is a plugin that associates product keys"
 msgstr ""
 
 msgid "Wipes"
@@ -7802,16 +7543,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 msgid "but has recently failed for this host"
@@ -7845,9 +7580,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -7908,9 +7640,6 @@ msgstr ""
 msgid "fog-admins"
 msgstr ""
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 msgid "found"
 msgstr ""
 
@@ -7939,12 +7668,6 @@ msgid "has been successfully destroyed"
 msgstr ""
 
 msgid "has been successfully updated"
-msgstr ""
-
-msgid "has completed on"
-msgstr ""
-
-msgid "has completed snapin tasking"
 msgstr ""
 
 msgid "has failed to destroy"
@@ -8097,9 +7820,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-msgid "key"
-msgstr ""
-
 msgid "keys"
 msgstr ""
 
@@ -8111,9 +7831,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -8144,9 +7861,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 msgid "must be specified"
@@ -8293,9 +8007,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 msgid "snapin"
 msgstr ""
 
@@ -8347,9 +8058,6 @@ msgstr ""
 msgid "the group has no enabled master node"
 msgstr ""
 
-msgid "the host defined location where available"
-msgstr ""
-
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
 
@@ -8397,9 +8105,6 @@ msgid "to get the requested Kernel"
 msgstr ""
 
 msgid "to get the requested initrd"
-msgstr ""
-
-msgid "to operate in an environment where there may be"
 msgstr ""
 
 msgid "to review."
@@ -8460,12 +8165,6 @@ msgid "window"
 msgstr ""
 
 msgid "wipe out all of your images stored on"
-msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
 msgstr ""
 
 msgid "with this group"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -731,9 +731,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Instalar / Atualizar sucesso!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "A largura de banda deve ser numérico e maior do que 0"
@@ -742,12 +739,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1066,10 +1057,6 @@ msgid "CA Certificate Path"
 msgstr "Criar novo %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Caminho"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "chave privada falhou"
 
@@ -1169,10 +1156,6 @@ msgstr "tarefa cancelada"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelado devido à nova tarefa."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Não é possível conectar ao banco de dados"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1216,9 +1199,6 @@ msgstr "Snapin atualizada"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin atualizada"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1297,9 +1277,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "chamada de canal é inválido"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1529,22 +1506,7 @@ msgstr "Não foi possível ler o arquivo tmp."
 msgid "Could not read snapin file"
 msgstr "Não foi possível ler o arquivo tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Não foi possível ler o arquivo tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Não foi possível ler o arquivo tmp."
-
 msgid "Could not read tmp file."
-msgstr "Não foi possível ler o arquivo tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
@@ -1554,10 +1516,6 @@ msgstr "Não foi possível criar impressora"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1884,10 +1842,6 @@ msgid "Default Width"
 msgstr "Largura padrão"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "As doações são deficientes"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Não é possível abrir arquivo para leitura"
 
@@ -1952,9 +1906,6 @@ msgstr "Falha no download"
 
 msgid "Deploy Method"
 msgstr "Método Deploy"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Descrição"
@@ -2120,10 +2071,6 @@ msgid "Edit Capone"
 msgstr "exportação Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "exportação Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "anfitrião Descrição"
 
@@ -2142,9 +2089,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2287,10 +2231,6 @@ msgstr "Configuração de exportação"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "Servidor LDAP"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "anfitrião Localização"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2631,10 +2571,6 @@ msgid "Files Deleted List"
 msgstr "Apagar dados de arquivo"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Arquivo"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Não snapins associado"
 
@@ -2740,10 +2676,6 @@ msgstr "Açao"
 #, fuzzy
 msgid "Function Error"
 msgstr "Açao"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "O método não existe"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2911,18 +2843,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos Grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "anfitrião Localização"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Localização Atualizado"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "História de login"
 
@@ -2994,10 +2914,6 @@ msgid "Group Update Fail"
 msgstr "Grupo Criar falhou"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Grupo Criar falhou"
 
@@ -3012,10 +2928,6 @@ msgstr "grupo adicionado"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Grupo é inválido"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "atualização do utilizador falhou"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3141,18 +3053,6 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Anfitrião"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "host criado"
@@ -3235,17 +3135,6 @@ msgstr "Hospedar argumentos do kernel"
 msgid "Host List"
 msgstr "Lista de Host"
 
-msgid "Host Location"
-msgstr "anfitrião Localização"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Localização Atualizado"
-
 msgid "Host Login History"
 msgstr "Hospedar Entrada História"
 
@@ -3302,10 +3191,6 @@ msgstr "História Snapin"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Anfitrião Update Failed"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Anfitrião Update Failed"
 
 #, fuzzy
@@ -3610,22 +3495,6 @@ msgid "Image Used"
 msgstr "fotografada"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nome da imagem"
 
@@ -3738,10 +3607,6 @@ msgid "Import Failed"
 msgstr "imagem atualizada"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "anfitrião Localização"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "importar usuários"
 
@@ -3758,28 +3623,12 @@ msgid "Import Reports"
 msgstr "Hosts de importação"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Grupos de importação"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Bem sucedido"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Bem sucedido"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Unidos Task"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Tipos de tarefa"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3976,10 +3825,6 @@ msgstr "URL inválida"
 msgid "Invalid Windows product key"
 msgstr "Hospedar de Chave de Produto"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Selecione uma imagem válida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4020,9 +3865,6 @@ msgstr "Chave inválida a ser removido"
 
 msgid "Invalid key being set"
 msgstr "Chave inválida sendo definido"
-
-msgid "Invalid method called"
-msgstr "Método inválido chamada"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4143,9 +3985,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4191,10 +4030,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Associação imagem"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Evento deve ser uma string"
 
@@ -4217,9 +4052,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Matar"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4337,10 +4169,6 @@ msgstr "Nome do servidor LDAP"
 msgid "LDAP Server updated!"
 msgstr "Nome do servidor LDAP"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "Servidor LDAP"
-
 msgid "Language"
 msgstr "Língua"
 
@@ -4372,9 +4200,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4442,14 +4267,6 @@ msgid "List All Plugins"
 msgstr "instalar Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Unidos Task"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipos de tarefa"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Plugins instalados"
 
@@ -4476,10 +4293,6 @@ msgstr "Carregamento de dados para o campo %s"
 
 msgid "Location"
 msgstr "Localização"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Associação imagem"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4514,9 +4327,6 @@ msgstr "Instalar / Atualizar sucesso!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Localização Nome"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4901,10 +4711,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NÃO"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NÃO"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4937,16 +4743,9 @@ msgstr "Evento deve ser uma string"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Evento deve ser uma string"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Evento deve ser uma string"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "atualização do utilizador falhou"
 
 msgid "Network Information"
 msgstr "Informações de rede"
@@ -5018,9 +4817,6 @@ msgstr "Sem Imagem do especificado"
 
 msgid "No Printer Management"
 msgstr "Sem gerenciamento de impressoras"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5900,10 +5696,6 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "A porta não é válida ldap / ldaps portos"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6127,9 +5919,6 @@ msgstr "Impressora atualizado!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Contas Pushbullet"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Gestão de Clientes"
@@ -6329,10 +6118,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Resultados"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6578,18 +6363,7 @@ msgid "Search Base DN"
 msgstr "Pesquisa"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Pesquisa"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Pesquisa"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Pesquisa"
 
 #, fuzzy
@@ -6597,9 +6371,6 @@ msgid "Search Scope"
 msgstr "Pesquisa"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6978,9 +6749,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Contas Slack"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7502,10 +7270,6 @@ msgid "Subnet Group updated!"
 msgstr "grupo adicionado"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Grupos de exportação"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Grupos de exportação"
 
@@ -7654,9 +7418,6 @@ msgstr "usuário criado"
 msgid "Task State Updated!"
 msgstr "Estado tarefa adicional, a edição"
 
-msgid "Task States"
-msgstr "Unidos Task"
-
 msgid "Task Type"
 msgstr "Tipo de tarefa"
 
@@ -7706,9 +7467,6 @@ msgstr "tipo de tarefa não é válido"
 
 msgid "Task Type is not valid"
 msgstr "Tipo de tarefa não é válido"
-
-msgid "Task Types"
-msgstr "Tipos de tarefa"
 
 #, fuzzy
 msgid "Task failed"
@@ -7817,12 +7575,6 @@ msgstr "Esta configuração define "
 msgid "The API is disabled"
 msgstr "As doações são deficientes"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Não existem grupos neste servidor."
@@ -7841,9 +7593,6 @@ msgstr "Não foi possível ler arquivo temporário"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " não existe mais"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7884,9 +7633,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7956,9 +7702,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8156,9 +7899,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | Este não é o grupo primário"
@@ -8213,10 +7953,6 @@ msgstr ""
 msgid "This setting"
 msgstr "Esta configuração define "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Esta configuração define "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8268,10 +8004,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "Não há snapins associados a este alojamento"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8736,10 +8468,6 @@ msgid "User Create Success"
 msgstr "usuário criado"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nome de usuário"
-
-#, fuzzy
 msgid "User Group"
 msgstr "grupos"
 
@@ -8823,9 +8551,6 @@ msgstr "Instalar / Atualizar sucesso!"
 msgid "User added!"
 msgstr "Nome da impressora"
 
-msgid "User call is invalid"
-msgstr "chamada do usuário é inválido"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Nome da impressora"
@@ -8838,9 +8563,6 @@ msgstr "atualização do utilizador falhou"
 msgid "User group updated!"
 msgstr "usuário atualizada"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Registro não encontrado, erro: %s"
@@ -8852,10 +8574,6 @@ msgstr "atualização do utilizador falhou"
 #, fuzzy
 msgid "User updated!"
 msgstr "usuário atualizada"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Por favor, indique um nome para este servidor LDAP."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8877,15 +8595,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nome de usuário"
-
 msgid "Users"
 msgstr "usuários"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8952,10 +8663,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Nome Storage Node"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Não é possível conectar ao banco de dados"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8978,9 +8685,6 @@ msgstr "foi atualizado com sucesso"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -8996,10 +8700,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "anfitrião Descrição"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9042,16 +8742,8 @@ msgid "Windows Key updated!"
 msgstr "Gerenciamento de usuários"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Hospedar de Chave de Produto"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Uma imagem já existe com este nome!"
 
 msgid "Wipes"
 msgstr ""
@@ -9173,16 +8865,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9224,9 +8910,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9298,9 +8981,6 @@ msgstr "tamanho do arquivo"
 msgid "fog-admins"
 msgstr "Nome do domínio"
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 #, fuzzy
 msgid "found"
 msgstr "Não encontrado"
@@ -9336,14 +9016,6 @@ msgstr "foi atualizado com sucesso"
 
 msgid "has been successfully updated"
 msgstr "foi atualizado com sucesso"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "foi destruído"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Inválida Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9522,10 +9194,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9537,9 +9205,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9574,9 +9239,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9736,9 +9398,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9795,9 +9454,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Grupo de armazenamento Atualizado"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9856,9 +9512,6 @@ msgstr "Nenhuma chave que está sendo solicitado"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "Nenhuma chave que está sendo solicitado"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "rever."
@@ -9927,13 +9580,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "não dentro desta"
 
 #, fuzzy
 msgid "with this group"
@@ -10085,12 +9731,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Caminho"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Não é possível conectar ao banco de dados"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "chamada de canal é inválido"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Configurações"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10113,6 +9789,14 @@ msgstr ""
 #~ msgstr "Nenhum de hash disponíveis"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "As doações são deficientes"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Hosts de exportação"
 
@@ -10125,6 +9809,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "anfitrião Localização"
 
 #~ msgid "Export Printers"
@@ -10171,8 +9859,28 @@ msgstr ""
 #~ msgstr "Eu não sou o servidor web nevoeiro"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Arquivo"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "reinicialização"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "O método não existe"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Localização Atualizado"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10191,8 +9899,16 @@ msgstr ""
 #~ msgstr "grupo adicionado"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Criar falhou"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Grupo Criar falhou"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "atualização do utilizador falhou"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10218,6 +9934,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "atualização do utilizador falhou"
 
+#~ msgid "Host Location"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Localização Atualizado"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Lista de Host"
@@ -10233,6 +9960,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "História Snapin"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Anfitrião Update Failed"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10271,6 +10002,22 @@ msgstr ""
 #~ msgstr "usuário atualizada"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts de importação"
 
@@ -10279,6 +10026,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "anfitrião Localização"
 
 #~ msgid "Import Printers"
@@ -10307,12 +10058,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Todos os nós de armazenamento"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Grupos de importação"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Unidos Task"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Tipos de tarefa"
+
 #~ msgid "Import Users"
 #~ msgstr "importar usuários"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "tipo inválido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Selecione uma imagem válida"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Método inválido chamada"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "Servidor LDAP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10331,8 +10113,28 @@ msgstr ""
 #~ msgstr "Listar todos os %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Unidos Task"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipos de tarefa"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No nó associado"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NÃO"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "atualização do utilizador falhou"
 
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "Sem FOGPage classe encontrada para este nó"
@@ -10367,8 +10169,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Por favor, indique um nome para este local."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "A porta não é válida ldap / ldaps portos"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Contas Pushbullet"
 
 #~ msgid "Registered"
 #~ msgstr "Registrado"
@@ -10376,6 +10185,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remover snapins selecionados"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Resultados"
 
 #~ msgid "Results"
 #~ msgstr "Resultados"
@@ -10436,8 +10249,19 @@ msgstr ""
 #~ msgstr "atualização da impressora falhou!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Pesquisa"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Pesquisa"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Associação imagem"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Contas Slack"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10451,8 +10275,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nó de Armazenamento Criado"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Grupos de exportação"
+
 #~ msgid "Successful"
 #~ msgstr "Bem sucedido"
+
+#~ msgid "Task States"
+#~ msgstr "Unidos Task"
+
+#~ msgid "Task Types"
+#~ msgstr "Tipos de tarefa"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10482,6 +10316,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | Este não é o nó mestre"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Esta configuração define "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Não há snapins associados a este alojamento"
+
 #~ msgid "Total Rows"
 #~ msgstr "total de linhas"
 
@@ -10504,6 +10346,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Remover impressoras selecionadas"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nome de usuário"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10549,6 +10395,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Serviço Atualizado!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "chamada do usuário é inválido"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Por favor, indique um nome para este servidor LDAP."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nome de usuário"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Não é possível conectar ao banco de dados"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Uma imagem já existe com este nome!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Última versão"
@@ -10569,6 +10442,18 @@ msgstr ""
 #~ msgstr "concluído"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "foi destruído"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Inválida Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Tarefas Multicast ativos"
 
@@ -10579,3 +10464,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versão"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "não dentro desta"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -731,9 +731,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "安装/升级成功！"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "带宽应该是数字和大于0"
@@ -742,12 +739,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1066,10 +1057,6 @@ msgid "CA Certificate Path"
 msgstr "新建%s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "路径"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "私钥失败"
 
@@ -1169,10 +1156,6 @@ msgstr "取消任务"
 msgid "Cancelled due to new tasking."
 msgstr "由于新的任务取消。"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "无法连接到数据库"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1216,9 +1199,6 @@ msgstr "更新管理单元"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "更新管理单元"
-
-msgid "Capone Deploy"
-msgstr "卡波恩部署"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1297,9 +1277,6 @@ msgstr ""
 
 msgid "Channel"
 msgstr ""
-
-msgid "Channel call is invalid"
-msgstr "通道调用无效"
 
 #, fuzzy
 msgid "Channel not found"
@@ -1529,22 +1506,7 @@ msgstr "无法读取tmp文件。"
 msgid "Could not read snapin file"
 msgstr "无法读取tmp文件。"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "无法读取tmp文件。"
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "无法读取tmp文件。"
-
 msgid "Could not read tmp file."
-msgstr "无法读取tmp文件。"
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
@@ -1554,10 +1516,6 @@ msgstr "无法创建打印机"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1884,10 +1842,6 @@ msgid "Default Width"
 msgstr "默认宽度"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "捐款将被禁用"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "无法打开文件进行读取"
 
@@ -1952,9 +1906,6 @@ msgstr "下载失败"
 
 msgid "Deploy Method"
 msgstr "部署方法"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "描述"
@@ -2120,10 +2071,6 @@ msgid "Edit Capone"
 msgstr "出口Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "出口Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "主机描述"
 
@@ -2142,9 +2089,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2287,10 +2231,6 @@ msgstr "导出配置"
 #, fuzzy
 msgid "Export LDAP Servers"
 msgstr "LDAP服务器"
-
-#, fuzzy
-msgid "Export Locations"
-msgstr "主机位置"
 
 #, fuzzy
 msgid "Export OUs"
@@ -2631,10 +2571,6 @@ msgid "Files Deleted List"
 msgstr "删除的文件数据"
 
 #, fuzzy
-msgid "Filter"
-msgstr "文件"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "没有snapins相关"
 
@@ -2740,10 +2676,6 @@ msgstr "行动"
 #, fuzzy
 msgid "Function Error"
 msgstr "行动"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "方法不存在"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2911,18 +2843,6 @@ msgid "Group Kernel Arguments"
 msgstr "集团内核参数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "主机位置"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "更新位置"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "登录历史记录"
 
@@ -2994,10 +2914,6 @@ msgid "Group Update Fail"
 msgstr "集团创建失败"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "集团创建失败"
 
@@ -3012,10 +2928,6 @@ msgstr "集团补充"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "集团是无效的"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "用户更新失败"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3141,18 +3053,6 @@ msgstr "家"
 msgid "Host"
 msgstr "主办"
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "主机创建"
@@ -3235,17 +3135,6 @@ msgstr "主机内核参数"
 msgid "Host List"
 msgstr "主机列表"
 
-msgid "Host Location"
-msgstr "主机位置"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "更新位置"
-
 msgid "Host Login History"
 msgstr "主机登录历史"
 
@@ -3302,10 +3191,6 @@ msgstr "历史管理单元"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "主机更新失败"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "主机更新失败"
 
 #, fuzzy
@@ -3610,22 +3495,6 @@ msgid "Image Used"
 msgstr "成像"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8的"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "用户管理"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "用户管理"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "用户管理"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "图片名称"
 
@@ -3738,10 +3607,6 @@ msgid "Import Failed"
 msgstr "图片更新"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "主机位置"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "导入用户"
 
@@ -3758,28 +3623,12 @@ msgid "Import Reports"
 msgstr "进口主机"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "导入组"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "成功"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "成功"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "任务的国家"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "任务类型"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8的"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3976,10 +3825,6 @@ msgstr "无效的网址"
 msgid "Invalid Windows product key"
 msgstr "主机产品密钥"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "选择一个有效的图像"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4020,9 +3865,6 @@ msgstr "关键无效被删除"
 
 msgid "Invalid key being set"
 msgstr "无效的关键字设定"
-
-msgid "Invalid method called"
-msgstr "所谓的无效方法"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4143,9 +3985,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4191,10 +4030,6 @@ msgid "Key"
 msgstr "DMI关键"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "图像协会"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "事件必须是字符串"
 
@@ -4217,9 +4052,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "杀"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4337,10 +4169,6 @@ msgstr "LDAP服务器名称"
 msgid "LDAP Server updated!"
 msgstr "LDAP服务器名称"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP服务器"
-
 msgid "Language"
 msgstr "语言"
 
@@ -4372,9 +4200,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4442,14 +4267,6 @@ msgid "List All Plugins"
 msgstr "安装插件"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "任务的国家"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "任务类型"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "已安装的插件"
 
@@ -4476,10 +4293,6 @@ msgstr "加载数据到现场%s"
 
 msgid "Location"
 msgstr "位置"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "图像协会"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4514,9 +4327,6 @@ msgstr "安装/升级成功！"
 #, fuzzy
 msgid "Location added!"
 msgstr "地点名称"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4901,10 +4711,6 @@ msgstr ""
 msgid "NOT"
 msgstr "不"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "不"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4937,16 +4743,9 @@ msgstr "事件必须是字符串"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "事件必须是字符串"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "事件必须是字符串"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "用户更新失败"
 
 msgid "Network Information"
 msgstr "网络信息"
@@ -5018,9 +4817,6 @@ msgstr "没有指定的Image"
 
 msgid "No Printer Management"
 msgstr "没有打印机管理"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5900,10 +5696,6 @@ msgstr ""
 msgid "Port"
 msgstr "港口"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "端口是无效的LDAP / LDAPS端口"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6127,9 +5919,6 @@ msgstr "打印机更新！"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet账户"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "客户管理"
@@ -6329,10 +6118,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "结果"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6578,18 +6363,7 @@ msgid "Search Base DN"
 msgstr "搜索"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "搜索"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "搜索"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "搜索"
 
 #, fuzzy
@@ -6597,9 +6371,6 @@ msgid "Search Scope"
 msgstr "搜索"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6978,9 +6749,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "斯莱克账户"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7502,10 +7270,6 @@ msgid "Subnet Group updated!"
 msgstr "集团补充"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "出口组"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "出口组"
 
@@ -7654,9 +7418,6 @@ msgstr "用户创建"
 msgid "Task State Updated!"
 msgstr "任务状态添加，编辑"
 
-msgid "Task States"
-msgstr "任务的国家"
-
 msgid "Task Type"
 msgstr "任务类型"
 
@@ -7706,9 +7467,6 @@ msgstr "任务类型无效"
 
 msgid "Task Type is not valid"
 msgstr "任务类型是无效"
-
-msgid "Task Types"
-msgstr "任务类型"
 
 #, fuzzy
 msgid "Task failed"
@@ -7817,12 +7575,6 @@ msgstr "此设置定义"
 msgid "The API is disabled"
 msgstr "捐款将被禁用"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "有此服务器上没有组。"
@@ -7841,9 +7593,6 @@ msgstr "无法读取临时文件"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "不复存在"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7884,9 +7633,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7956,9 +7702,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8156,9 +7899,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "|这不是主要组"
@@ -8213,10 +7953,6 @@ msgstr ""
 msgid "This setting"
 msgstr "此设置定义"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "此设置定义"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8268,10 +8004,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "没有与此主机关联snapins"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8736,10 +8468,6 @@ msgid "User Create Success"
 msgstr "用户创建"
 
 #, fuzzy
-msgid "User DN"
-msgstr "用户名"
-
-#, fuzzy
 msgid "User Group"
 msgstr "组"
 
@@ -8823,9 +8551,6 @@ msgstr "安装/升级成功！"
 msgid "User added!"
 msgstr "打印机名称"
 
-msgid "User call is invalid"
-msgstr "用户调用无效"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "打印机名称"
@@ -8838,9 +8563,6 @@ msgstr "用户更新失败"
 msgid "User group updated!"
 msgstr "用户更新"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "未发现记录，错误： %s"
@@ -8852,10 +8574,6 @@ msgstr "用户更新失败"
 #, fuzzy
 msgid "User updated!"
 msgstr "用户更新"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "这个LDAP服务器输入名称。"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8877,15 +8595,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "用户名"
-
 msgid "Users"
 msgstr "用户"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8952,10 +8663,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "存储节点名称"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "无法连接到数据库"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8978,9 +8685,6 @@ msgstr "已成功更新"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -8996,10 +8700,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "主机描述"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8的"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9042,16 +8742,8 @@ msgid "Windows Key updated!"
 msgstr "用户管理"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8的"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "主机产品密钥"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "图像已经存在具有此名称！"
 
 msgid "Wipes"
 msgstr ""
@@ -9173,16 +8865,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9224,9 +8910,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9298,9 +8981,6 @@ msgstr "文件大小"
 msgid "fog-admins"
 msgstr "域名"
 
-msgid "for Microsoft Windows to images"
-msgstr ""
-
 #, fuzzy
 msgid "found"
 msgstr "未找到"
@@ -9336,14 +9016,6 @@ msgstr "已成功更新"
 
 msgid "has been successfully updated"
 msgstr "已成功更新"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "已被破坏"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "无效的管理单元任务处理"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9522,10 +9194,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI关键"
-
 msgid "keys"
 msgstr ""
 
@@ -9537,9 +9205,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9574,9 +9239,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9736,9 +9398,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "管理单元"
@@ -9795,9 +9454,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "存储组更新"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9856,9 +9512,6 @@ msgstr "没有要求的关键"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "没有要求的关键"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "回顾。"
@@ -9927,13 +9580,6 @@ msgstr "Windows 7的"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "不在此"
 
 #, fuzzy
 msgid "with this group"
@@ -10085,12 +9731,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "路径"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "无法连接到数据库"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "卡波恩部署"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "通道调用无效"
+
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "设置"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "无法读取tmp文件。"
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10113,6 +9789,14 @@ msgstr ""
 #~ msgstr "没有可用的散列"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "捐款将被禁用"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "主机出口"
 
@@ -10125,6 +9809,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "主机位置"
 
 #~ msgid "Export Printers"
@@ -10171,8 +9859,28 @@ msgstr ""
 #~ msgstr "我不是雾Web服务器"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "文件"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "重启"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "方法不存在"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "更新位置"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10191,8 +9899,16 @@ msgstr ""
 #~ msgstr "集团补充"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "集团创建失败"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "集团创建失败"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "用户更新失败"
 
 #, fuzzy
 #~ msgid "Group module settings"
@@ -10218,6 +9934,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "用户更新失败"
 
+#~ msgid "Host Location"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "更新位置"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "主机列表"
@@ -10233,6 +9960,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "历史管理单元"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "主机更新失败"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10271,6 +10002,22 @@ msgstr ""
 #~ msgstr "用户更新"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "用户管理"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "用户管理"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "用户管理"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "进口主机"
 
@@ -10279,6 +10026,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "主机位置"
 
 #~ msgid "Import Printers"
@@ -10307,12 +10058,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "所有存储节点"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "导入组"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "任务的国家"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "任务类型"
+
 #~ msgid "Import Users"
 #~ msgstr "导入用户"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "无效类型"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "选择一个有效的图像"
+
+#~ msgid "Invalid method called"
+#~ msgstr "所谓的无效方法"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "图像协会"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP服务器"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10331,8 +10113,28 @@ msgstr ""
 #~ msgstr "列表中的所有%s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "任务的国家"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "任务类型"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "图像协会"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "无关联的节点"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "不"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "用户更新失败"
 
 #~ msgid "No FOGPage Class found for this node"
 #~ msgstr "没有FOGPage类中找到此节点"
@@ -10367,8 +10169,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "这个位置输入名称。"
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "端口是无效的LDAP / LDAPS端口"
+
 #~ msgid "Printer Alias"
 #~ msgstr "打印机别名"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet账户"
 
 #~ msgid "Registered"
 #~ msgstr "注册"
@@ -10376,6 +10185,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "删除选定snapins"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "结果"
 
 #~ msgid "Results"
 #~ msgstr "结果"
@@ -10436,8 +10249,19 @@ msgstr ""
 #~ msgstr "打印机更新失败！"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "搜索"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "搜索"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "图像协会"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "斯莱克账户"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10451,8 +10275,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "存储节点创建"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "出口组"
+
 #~ msgid "Successful"
 #~ msgstr "成功"
+
+#~ msgid "Task States"
+#~ msgstr "任务的国家"
+
+#~ msgid "Task Types"
+#~ msgstr "任务类型"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10482,6 +10316,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "|这不是主节点"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "此设置定义"
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "没有与此主机关联snapins"
+
 #~ msgid "Total Rows"
 #~ msgstr "共行"
 
@@ -10504,6 +10346,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "删除选定的打印机"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "用户名"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10549,6 +10395,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "服务更新！"
 
+#~ msgid "User call is invalid"
+#~ msgstr "用户调用无效"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "这个LDAP服务器输入名称。"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "用户名"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "无法连接到数据库"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "图像已经存在具有此名称！"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "最新版本"
@@ -10569,6 +10442,18 @@ msgstr ""
 #~ msgstr "完成"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "已被破坏"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "无效的管理单元任务处理"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI关键"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "活动组播任务"
 
@@ -10579,3 +10464,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "版"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "不在此"

--- a/tests/stale-class-file-list.test.php
+++ b/tests/stale-class-file-list.test.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * A class-file list that has gone stale must not take the site down.
+ *
+ * Initiator::classFileList() caches the scanned file list to FOG_CACHE_DIR
+ * with a 300 second TTL. Staleness is DESIGNED IN -- forgetClassFileList()
+ * exists precisely because the cache can describe a tree that has since
+ * changed, and its own docblock says so. Every consumer therefore has to
+ * tolerate it.
+ *
+ * startClassFromFiles() was the one that did not. Handed a path the cache
+ * named and the tree no longer has, it ran include_once on nothing and then
+ * getClass(), whose ReflectionClass throws -- uncaught, inside
+ * EventManager::load(), inside LoadGlobals. That is a bodyless 500 on every
+ * page for the rest of the TTL.
+ *
+ * Not hypothetical. An install rm -rf's the web root and rebuilds it, so a
+ * plugin release that DROPS a file really removes it: fog-plugins v1.6.11
+ * drops ldap/hooks/addldapapi.hook.php, and an install landing it inside the
+ * TTL window fails its own "Checking web server serves FOG" probe with an
+ * empty body. It then heals when the TTL expires, which is why it reads as a
+ * flaky install rather than as a bug.
+ *
+ * Two guards, both checked here because either alone leaves a hole:
+ *
+ *   the installer drops $fogprogramdir/cache/filelist.*.json after replacing
+ *   the web root, so the window does not exist;
+ *
+ *   startClassFromFiles() skips a vanished file and says so, so a stale list
+ *   from any other cause -- an admin deleting a plugin by hand, an NFS lag --
+ *   costs one missing listener rather than the whole server.
+ *
+ * Behavioural for the second, source-level for the first: the installer half
+ * is one line of shell inside a 9000-line function that needs a live install
+ * to run, and the comment says which is which rather than dressing one up as
+ * the other.
+ *
+ * Usage: php tests/stale-class-file-list.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/*
+ * 1. The loader tolerates a path that is no longer there.
+ *
+ *    Driven for real: a temp file is created, named to startClassFromFiles()
+ *    exactly as the cache would name it, then deleted before the call. What
+ *    is asserted is that the call RETURNS -- before the fix it threw, and a
+ *    throw here is a dead server.
+ */
+$webroot = $root . '/packages/web';
+require_once $webroot . '/commons/init.php';
+new Initiator();
+
+$tmp = sys_get_temp_dir() . '/fog-stale-filelist-' . getmypid();
+@mkdir($tmp, 0700, true);
+$gone = $tmp . '/nosuchhook.hook.php';
+file_put_contents($gone, "<?php\n");
+unlink($gone);
+
+$threw = null;
+// The error_log line is the point of the guard, so it is captured rather than
+// left to scroll past: "skipped" and "skipped silently" are different answers
+// and only one of them is acceptable for a listener that stops running.
+$errLog = $tmp . '/php-errors.log';
+$prevLog = ini_get('error_log');
+ini_set('error_log', $errLog);
+try {
+    FOGBase::startClassFromFiles([$gone], -strlen('.hook.php'));
+} catch (\Throwable $e) {
+    $threw = get_class($e) . ': ' . $e->getMessage();
+}
+ini_set('error_log', (string)$prevLog);
+
+check(
+    'a file named by the cache and since deleted does not throw'
+    . (null === $threw ? '' : " (threw $threw)"),
+    null === $threw,
+    $failures,
+    $checks
+);
+$logged = is_file($errLog) ? (string)file_get_contents($errLog) : '';
+check(
+    'the skip is reported, so a listener that stops running leaves a trace',
+    false !== strpos($logged, 'startClassFromFiles')
+    && false !== strpos($logged, 'nosuchhook'),
+    $failures,
+    $checks
+);
+// error_log(), not self::error(): _writeLog() is gated on
+// `self::$mySchema >= FOG_SCHEMA` and a globalSettings read, and this path
+// runs inside LoadGlobals during an install -- exactly when that gate is
+// closed. A guard that reports nothing in the only situation it fires in is
+// not a guard.
+$src = (string)file_get_contents(
+    $webroot . '/lib/fog/fogbase.class.php'
+);
+$body = '';
+if (preg_match(
+    '/function startClassFromFiles\(.*?\n    \}/s',
+    $src,
+    $m
+)) {
+    $body = $m[0];
+}
+check(
+    'startClassFromFiles() is what was measured, and it guards on is_file',
+    '' !== $body && false !== strpos($body, 'if (!is_file($file))'),
+    $failures,
+    $checks
+);
+// Matched at the start of a statement, not anywhere in the text: the
+// comment above the guard NAMES self::error() to explain why it is not used,
+// and a bare strpos() reads its own rationale as the thing it forbids.
+check(
+    'it reports through error_log(), which is not gated on the schema',
+    (bool)preg_match('/\n\s*error_log\(/', $body)
+    && !preg_match('/\n\s*self::error\(/', $body),
+    $failures,
+    $checks
+);
+check(
+    'a file present but not declaring its class is also survivable',
+    false !== strpos($body, 'catch (\\ReflectionException $e)'),
+    $failures,
+    $checks
+);
+
+@unlink($errLog);
+@rmdir($tmp);
+
+/*
+ * 2. The installer drops the cached list after replacing the web root.
+ *
+ *    Source-level, and deliberately anchored to the copy it must follow: the
+ *    ordering is the whole content of the fix. Dropping the cache BEFORE the
+ *    new tree is in place just rebuilds it from the old one.
+ */
+$fn = (string)file_get_contents($root . '/lib/common/functions.sh');
+$copy = strpos($fn, 'cp -Rf $webdirsrc/* $webdirdest/');
+$drop = strpos($fn, 'rm -f $fogprogramdir/cache/filelist.*.json');
+check(
+    'the installer drops the cached class file list',
+    false !== $drop,
+    $failures,
+    $checks
+);
+check(
+    'it does so AFTER the new web root is in place, not before',
+    false !== $copy && false !== $drop && $drop > $copy,
+    $failures,
+    $checks
+);
+// Narrow on purpose. The same directory carries the settings-cache flush
+// signal that configureFOGService sets up; a blanket wipe of
+// $fogprogramdir/cache would take it with them.
+check(
+    'it removes the file lists only, not everything in the cache directory',
+    false === strpos($fn, 'rm -rf $fogprogramdir/cache/*')
+    && false === strpos($fn, 'rm -f $fogprogramdir/cache/*'),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+echo "ok  $checks checks passed\n";


### PR DESCRIPTION
Found live: `installfog.sh` reported

```
 * Checking web server serves FOG..............................Failed!
   Reason: the server answered HTTP 500.  (curl exit 22, 0 bytes of body)
```

on a server that was fine.

## What happens

```
PHP Warning: include_once(.../lib/plugins/ldap/hooks/addldapapi.hook.php):
             Failed to open stream: No such file or directory
PHP Fatal error: Uncaught ReflectionException: Class "addldapapi" does not exist
  #2 eventmanager.class.php(404): FOGBase::startClassFromFiles()
  #3 loadglobals.class.php(60): EventManager->load()
```

An install `rm -rf`s the web root and rebuilds it, so a plugin release that **drops** a file really removes it — `fog-plugins` **v1.6.11 drops `ldap/hooks/addldapapi.hook.php`**. `Initiator::classFileList()` caches the scanned file list for **300 seconds** and does not know the tree changed underneath it, so every request in the rest of that window walks a list naming a file that is gone.

`startClassFromFiles()` died on the first one, uncaught, inside `LoadGlobals` — which is every entry point. Bodyless 500 on the whole site, including the installer's own probe a few steps later. It heals when the TTL expires, which is why it reads as a flaky install rather than as a bug.

**Staleness is designed in.** `forgetClassFileList()` exists precisely because the cache can describe a tree that has since changed, and its docblock says so — it is just never called by the installer, only by the plugin uploader. Every consumer has to tolerate a stale list; this was the one that treated it as fatal.

## Two guards, because either alone leaves a hole

| | |
|---|---|
| **Installer** | drops `$fogprogramdir/cache/filelist.*.json` **after** replacing the web root, so the window does not exist. Ordering is the whole content of the fix — dropping it first just rebuilds it from the old tree. File lists only: that directory also carries the settings-cache flush signal. |
| **Loader** | `startClassFromFiles()` skips a vanished file, and catches `ReflectionException` around `getClass()` for the other cause — a file present that does not declare the class its name promises. Covers staleness from any source: an admin deleting a plugin by hand, NFS lag, a half-finished copy. |

Reported through `error_log()`, **not** `self::error()`: `_writeLog()` is gated on `self::$mySchema >= FOG_SCHEMA` and a `globalSettings` read, and this path runs inside `LoadGlobals` during an install — exactly when that gate is closed. It would be dropped in the only situation it fires in. The PHP error log is also where the fatal it replaces appeared, so both lines land in one place.

Skipped and **reported**, not swallowed — a listener that does not load is a feature that silently stops happening.

## Verification

Against a real stale cache, the same cache file either side, whole experiment inside the TTL:

```
cache names the deleted file: 1
PRE-FIX   PHP Fatal error: Uncaught ReflectionException:
          Class "addldapapi" does not exist ... fogbase.class.php:588
POST-FIX  FOG startClassFromFiles: ... no longer exists; skipping addldapapi.
          BOOTED OK
```

`tests/stale-class-file-list.test.php` — 8 checks. Behavioural for the loader (a real file created, deleted, then passed to `startClassFromFiles()`, asserting it returns *and* logs); source-level for the installer half, which needs a live install to run, and the comment says which is which rather than dressing one up as the other.

Five mutations checked, all caught: removing the `is_file` guard, removing the `ReflectionException` catch, skipping silently, the installer not dropping the cache, and the installer wiping the whole cache directory instead of just the file lists.

Full suite: 76 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GN7hADN5QLzoxXWDA6xeUk