### PR TITLE
Repair the schema manifest, and keep a FOS report readable after its task

### DIFF
--- a/bin/schema-manifest.php
+++ b/bin/schema-manifest.php
@@ -228,6 +228,45 @@ if ($cmd === 'generate') {
             $def = preg_replace('/\s*AUTO_INCREMENT\b/i', '', $m[2]);
             $cols[$m[1]] = trim($def);
         }
+        // Refuse to emit a table whose two blocks disagree.
+        //
+        // They are derived from one $raw and so cannot normally differ, but
+        // they are derived by DIFFERENT means -- the create is $raw with its
+        // whitespace collapsed, the columns are $raw parsed a line at a time
+        // -- and only the columns parse can fail quietly. If a server ever
+        // prints SHOW CREATE TABLE in a shape that regex does not match,
+        // $cols comes out empty, every `columns` block ships empty, and
+        // SchemaReconciler silently loses its ability to add a missing
+        // column to ANY table: plan() pass 3 skips a table whose `columns`
+        // is empty. That is the failure taskLog had alone in 407be1a53,
+        // multiplied by the whole schema, and nothing downstream would say
+        // so -- the manifest would still be valid PHP and the create
+        // strings would still execute on a fresh install.
+        //
+        // Names only. The definitions legitimately differ: the create keeps
+        // AUTO_INCREMENT and the column definitions drop it. Comparing the
+        // two blocks properly is tests/schema-manifest-consistent.test.php's
+        // job, and it works on the committed file, which is where the
+        // hand-edits that actually drifted happen.
+        if (!count($cols)) {
+            fwrite(
+                STDERR,
+                "Refusing to write: parsed no columns for `$table`.\n"
+                . "SHOW CREATE TABLE output was not in the expected shape.\n"
+            );
+            exit(1);
+        }
+        foreach (array_keys($cols) as $name) {
+            if (false !== strpos($create, '`' . $name . '`')) {
+                continue;
+            }
+            fwrite(
+                STDERR,
+                "Refusing to write: `$table`.`$name` was parsed as a column"
+                . " but does not appear in the CREATE statement.\n"
+            );
+            exit(1);
+        }
         $tables[$table] = ['create' => $create, 'columns' => $cols];
     }
 

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -758,7 +758,7 @@ return [
             ],
         ],
         'taskLog' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` int(11) NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, `logType` varchar(16) NOT NULL DEFAULT \'state\', `logText` text DEFAULT NULL, PRIMARY KEY (`id`), KEY `taskID` (`taskID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `taskLog` ( `id` mediumint(9) NOT NULL AUTO_INCREMENT, `taskID` int(11) NOT NULL, `taskStateID` mediumint(9) NOT NULL, `ip` varchar(15) NOT NULL, `createTime` timestamp NOT NULL DEFAULT current_timestamp(), `createdBy` varchar(30) NOT NULL, `logType` varchar(16) NOT NULL DEFAULT \'state\', `logText` text DEFAULT NULL, `logHostID` int(11) DEFAULT NULL, `logHostName` varchar(16) NOT NULL DEFAULT \'\', `logTaskTypeName` varchar(30) NOT NULL DEFAULT \'\', PRIMARY KEY (`id`), KEY `taskID` (`taskID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'id' => 'mediumint(9) NOT NULL',
                 'taskID' => 'int(11) NOT NULL',
@@ -766,6 +766,11 @@ return [
                 'ip' => 'varchar(15) NOT NULL',
                 'createTime' => 'timestamp NOT NULL DEFAULT current_timestamp()',
                 'createdBy' => 'varchar(30) NOT NULL',
+                'logType' => 'varchar(16) NOT NULL DEFAULT \'state\'',
+                'logText' => 'text DEFAULT NULL',
+                'logHostID' => 'int(11) DEFAULT NULL',
+                'logHostName' => 'varchar(16) NOT NULL DEFAULT \'\'',
+                'logTaskTypeName' => 'varchar(30) NOT NULL DEFAULT \'\'',
             ],
         ],
         'tasks' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5899,3 +5899,104 @@ $this->schema[] = [
     . "SET `logType` = 'state' "
     . "WHERE `logType` = '' OR `logType` IS NULL",
 ];
+// 341
+$this->schema[] = [
+    // A report keeps enough identity to be read after its task is gone.
+    //
+    // taskLog stores no host and no task type of its own; Task Management's
+    // log pane reaches all three through LEFT OUTER JOINs against `tasks`.
+    // Nothing deletes taskLog rows, so a report's TEXT survives forever --
+    // but Route::deletemass('host') cascades to `task`, and taskLog is in no
+    // cascade at all, so deleting a host destroys its tasks and leaves the
+    // reports behind with NULL where the host name was. On the install this
+    // was written against, 9 of 56 rows were already orphaned that way.
+    //
+    // Host name is the first thing anyone searches a failure by, and it is
+    // the field that cannot be recovered afterwards -- by the time the join
+    // fails, the host row is gone too. The point of GH-1206 is that a failure
+    // message is findable later instead of arriving as a phone photo of a
+    // wrapped console, and a foreign key to a routinely-deleted row cannot
+    // deliver that.
+    //
+    // The alternative was to block deleting a task that has reports, which
+    // inverts the dependency -- a diagnostic artifact would then constrain
+    // operational cleanup, and to be consistent it would have to block HOST
+    // deletion too, since that is the path that actually removes tasks.
+    // Refusing to delete a host because it once failed to image is a worse
+    // product than losing a host name.
+    //
+    // The state a row records is NOT copied: taskLog already stores
+    // taskStateID itself, so the taskStates join survives the task. Neither
+    // is the image, which this view has never shown.
+    //
+    // Nullable/empty and written only by the FOS report endpoint. 53 of those
+    // 56 rows are state transitions written by TaskingElement::taskLog() on
+    // every transition; they are meaningless without their task anyway, and
+    // making that path do three extra lookups per transition buys nothing.
+    // Same reasoning that gave logText no value on a state row in step 338.
+    //
+    // Two column shapes on purpose, and they follow what the writer can
+    // actually produce. FOGController::save() omits an unset OPTIONAL column
+    // whose key ends in "id" -- so logHostID gets its DEFAULT of NULL -- but
+    // for every other key an unset value is written as '', never NULL (the
+    // trap step 340 had to repair for logType, and the reason
+    // TaskLog::__construct() types its own rows). Declaring logHostName NOT
+    // NULL DEFAULT '' says what the ORM will really store rather than
+    // describing a NULL the writer cannot produce.
+    //
+    // A closure rather than a bare ALTER for the same reason steps 336 and
+    // 338 are: ADD COLUMN has no IF NOT EXISTS below MariaDB 10.0.2/MySQL
+    // 8.0.29, so a re-run has to converge on its own rather than error.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'taskLog' "
+            . "AND `COLUMN_NAME` IN "
+            . "('logHostID','logHostName','logTaskTypeName')"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        $adds = [];
+        if (!in_array('logHostID', $cols)) {
+            $adds[] = "ADD `logHostID` INT(11) NULL DEFAULT NULL";
+        }
+        if (!in_array('logHostName', $cols)) {
+            // varchar(16) matches hosts.hostName, which is capped at the
+            // NetBIOS limit and cannot outgrow this copy.
+            $adds[] = "ADD `logHostName` VARCHAR(16) NOT NULL DEFAULT ''";
+        }
+        if (!in_array('logTaskTypeName', $cols)) {
+            // varchar(30) matches taskTypes.ttName.
+            $adds[] = "ADD `logTaskTypeName` VARCHAR(30) NOT NULL DEFAULT ''";
+        }
+        if (count($adds) > 0) {
+            self::$DB->query(
+                "ALTER TABLE `taskLog` " . implode(', ', $adds)
+            );
+        }
+
+        // Backfill the reports whose task is still there, so the history is
+        // not split between rows that know their host and rows that do not.
+        // Restricted to report rows and to rows not already filled, so a
+        // re-run is a no-op and a later hand-correction is not overwritten.
+        self::$DB->query(
+            "UPDATE `taskLog` "
+            . "JOIN `tasks` ON `tasks`.`taskID` = `taskLog`.`taskID` "
+            . "LEFT JOIN `hosts` "
+            . "ON `hosts`.`hostID` = `tasks`.`taskHostID` "
+            . "LEFT JOIN `taskTypes` "
+            . "ON `taskTypes`.`ttID` = `tasks`.`taskTypeID` "
+            . "SET `taskLog`.`logHostID` = `tasks`.`taskHostID`, "
+            . "`taskLog`.`logHostName` = COALESCE(`hosts`.`hostName`, ''), "
+            . "`taskLog`.`logTaskTypeName` = COALESCE(`taskTypes`.`ttName`, '') "
+            . "WHERE `taskLog`.`logType` <> '" . TaskLog::TYPE_STATE . "' "
+            . "AND `taskLog`.`logHostID` IS NULL"
+        );
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 340);
+        define('FOG_SCHEMA', 341);
         define('FOG_BCACHE_VER', 288);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -33,6 +33,19 @@ class TaskLog extends FOGController
     /**
      * The task log fields and common names.
      *
+     * hostID/hostName/taskTypeName are a copy of who the report was about,
+     * kept because the row outlives what it points at. taskLog reaches host
+     * and task type through `tasks`; nothing deletes taskLog rows, but
+     * Route::deletemass('host') cascades to `task` and taskLog is in no
+     * cascade -- so deleting a host destroys its tasks and leaves the
+     * reports with nothing to join to, losing the host name at the same
+     * moment the host row that could supply it goes. Host name is the first
+     * thing anyone searches a failure by, so schema 341 stores it here.
+     *
+     * Only the FOS report endpoint fills them. A state row leaves them
+     * empty: it is an annotation on a task and means nothing without it,
+     * and TaskingElement::taskLog() runs on every transition.
+     *
      * @var array
      */
     protected $databaseFields = [
@@ -43,7 +56,10 @@ class TaskLog extends FOGController
         'createdTime' => 'createTime',
         'createdBy' => 'createdBy',
         'type' => 'logType',
-        'text' => 'logText'
+        'text' => 'logText',
+        'hostID' => 'logHostID',
+        'hostName' => 'logHostName',
+        'taskTypeName' => 'logTaskTypeName'
     ];
     /**
      * A row recording a state transition, which is what every row was

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -564,6 +564,73 @@ class TaskManagement extends FOGPage
         );
     }
     /**
+     * The derived table every task-log query reads from.
+     *
+     * The row's own copy of the host and task type wins; the joins
+     * through `tasks` are the fallback for rows written before schema
+     * 341, and for state rows, which never carry one.
+     *
+     * That order is deliberate and not just a null-check: a report is a
+     * historical record, so the name the host had WHEN IT FAILED is the
+     * answer, not the name it has been renamed to since.
+     *
+     * The state a row records needs none of this -- taskLog stores
+     * taskStateID itself, so that join survives its task.
+     *
+     * `logHostID` still comes from the `hosts` join, because the grid
+     * links the name with it and a link to a deleted host is worse than
+     * no link. Resolving the join through the STORED id first is what
+     * keeps that link working once the task is gone but the host is not.
+     *
+     * `reportType` resolves the stored type name back to its icon;
+     * taskTypes.ttName is UNIQUE, so it matches at most one row.
+     *
+     * Its own method so tests/tasklog-report-retention.test.php can run the
+     * real statement rather than a copy of it that drifts.
+     *
+     * @return string a FROM clause with one %s for the derived table alias
+     */
+    private static function _logQueryFrom()
+    {
+        return "FROM (
+            SELECT `taskLog`.`id` AS `id`,
+                `taskLog`.`createTime` AS `logTime`,
+                `taskLog`.`createdBy` AS `logBy`,
+                `taskLog`.`logType` AS `logType`,
+                `taskLog`.`logText` AS `logText`,
+                `taskLog`.`taskID` AS `logTaskID`,
+                `taskStates`.`tsName` AS `logStateName`,
+                `taskStates`.`tsIcon` AS `logStateIcon`,
+                COALESCE(
+                    NULLIF(`taskLog`.`logTaskTypeName`, ''),
+                    `taskTypes`.`ttName`
+                ) AS `logTypeName`,
+                COALESCE(
+                    `reportType`.`ttIcon`,
+                    `taskTypes`.`ttIcon`
+                ) AS `logTypeIcon`,
+                `hosts`.`hostID` AS `logHostID`,
+                COALESCE(
+                    NULLIF(`taskLog`.`logHostName`, ''),
+                    `hosts`.`hostName`
+                ) AS `logHostName`
+            FROM `taskLog`
+            LEFT OUTER JOIN `taskStates`
+            ON `taskLog`.`taskStateID` = `taskStates`.`tsID`
+            LEFT OUTER JOIN `tasks`
+            ON `taskLog`.`taskID` = `tasks`.`taskID`
+            LEFT OUTER JOIN `taskTypes`
+            ON `tasks`.`taskTypeID` = `taskTypes`.`ttID`
+            LEFT OUTER JOIN `taskTypes` AS `reportType`
+            ON `reportType`.`ttName` = NULLIF(`taskLog`.`logTaskTypeName`, '')
+            LEFT OUTER JOIN `hosts`
+            ON `hosts`.`hostID` = COALESCE(
+                `taskLog`.`logHostID`,
+                `tasks`.`taskHostID`
+            )
+        ) AS `%s`";
+    }
+    /**
      * Get the task log entries.
      *
      * Read through a derived table because taskLog and tasks both have
@@ -605,29 +672,7 @@ class TaskManagement extends FOGPage
             $where = "`logType` IN ('" . implode("','", $types) . "')";
         }
 
-        $from = "FROM (
-            SELECT `taskLog`.`id` AS `id`,
-                `taskLog`.`createTime` AS `logTime`,
-                `taskLog`.`createdBy` AS `logBy`,
-                `taskLog`.`logType` AS `logType`,
-                `taskLog`.`logText` AS `logText`,
-                `taskLog`.`taskID` AS `logTaskID`,
-                `taskStates`.`tsName` AS `logStateName`,
-                `taskStates`.`tsIcon` AS `logStateIcon`,
-                `taskTypes`.`ttName` AS `logTypeName`,
-                `taskTypes`.`ttIcon` AS `logTypeIcon`,
-                `hosts`.`hostID` AS `logHostID`,
-                `hosts`.`hostName` AS `logHostName`
-            FROM `taskLog`
-            LEFT OUTER JOIN `taskStates`
-            ON `taskLog`.`taskStateID` = `taskStates`.`tsID`
-            LEFT OUTER JOIN `tasks`
-            ON `taskLog`.`taskID` = `tasks`.`taskID`
-            LEFT OUTER JOIN `taskTypes`
-            ON `tasks`.`taskTypeID` = `taskTypes`.`ttID`
-            LEFT OUTER JOIN `hosts`
-            ON `tasks`.`taskHostID` = `hosts`.`hostID`
-        ) AS `%s`";
+        $from = self::_logQueryFrom();
         $logsSqlStr = "SELECT `%s` $from %s %s %s";
         $logsFilterStr = "SELECT COUNT(`%s`) $from %s";
         $logsTotalStr = "SELECT COUNT(`%s`) $from";

--- a/packages/web/lib/reg-task/taskerror.class.php
+++ b/packages/web/lib/reg-task/taskerror.class.php
@@ -280,12 +280,21 @@ class TaskError extends FOGBase
     }
     private static function _logRow($Task, $type, $text)
     {
+        // Host and task type are copied onto the row, not left to the join.
+        // Route::deletemass('host') cascades to `task`, taskLog is in no
+        // cascade, so the report outlives everything it points at -- and by
+        // the time the join fails the host row is gone too, which makes this
+        // the last moment the name can be recorded at all. See TaskLog's
+        // $databaseFields and schema step 341.
         self::getClass('TaskLog')
             ->set('taskID', $Task->get('id'))
             ->set('stateID', $Task->get('stateID'))
             ->set('createdBy', 'fos')
             ->set('type', $type)
             ->set('text', $text)
+            ->set('hostID', self::$Host->get('id'))
+            ->set('hostName', self::$Host->get('name'))
+            ->set('taskTypeName', $Task->getTaskTypeText())
             ->save();
     }
     /**

--- a/tests/fixtures/route-column-contract.txt
+++ b/tests/fixtures/route-column-contract.txt
@@ -540,6 +540,10 @@ tasklog	5	createTime	createdTime	f	-
 tasklog	6	createdBy	createdBy	-	-
 tasklog	7	logType	type	-	-
 tasklog	8	logText	text	-	-
+tasklog	9	logHostID	hostID	-	-
+tasklog	10	logHostID	hostLink	f	host
+tasklog	11	logHostName	hostName	-	-
+tasklog	12	logTaskTypeName	taskTypeName	-	-
 taskstate	0	tsID	id	-	-
 taskstate	1	tsID	DT_RowId	f	-
 taskstate	2	tsName	name	-	-

--- a/tests/schema-executes.test.php
+++ b/tests/schema-executes.test.php
@@ -387,8 +387,13 @@ foreach ($steps as $updates) {
 }
 
 $manifest = include $manifestFile;
+// ['tables'], not the top level: the manifest is ['renames' => …,
+// 'tables' => …], so walking it directly finds no 'create' anywhere and
+// collects nothing. This half of the file had therefore never run -- with a
+// DSN set it failed on the "expected both to be non-empty" guard below, and
+// the guard was doing its job; nobody had a DSN.
 $manifestDdl = [];
-foreach ((array)$manifest as $table => $spec) {
+foreach ((array)($manifest['tables'] ?? []) as $table => $spec) {
     if (!empty($spec['create'])) {
         $manifestDdl[] = $spec['create'];
     }
@@ -415,6 +420,23 @@ try {
 }
 
 $server = $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+// This test needs to build two scratch databases from nothing, so it needs a
+// user that may CREATE DATABASE -- which a FOG service account deliberately
+// is not: fogmaster holds ALL PRIVILEGES on its own database and nothing
+// above it. Probed once here rather than letting the first CREATE throw an
+// uncaught PDOException mid-run, which reads as a broken test rather than an
+// unsuitable account. Same shape as the no-DSN skip above.
+try {
+    $pdo->exec(sprintf('CREATE DATABASE IF NOT EXISTS `%s`', $stepDb));
+    $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $stepDb));
+} catch (\PDOException $e) {
+    printf(
+        "SKIP  %s may not CREATE DATABASE; schema execution not checked\n",
+        false === $user ? 'root' : $user
+    );
+    exit(0);
+}
 
 /**
  * Run a list of statements into a freshly created database.

--- a/tests/schema-manifest-consistent.test.php
+++ b/tests/schema-manifest-consistent.test.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * A manifest table's `create` and its `columns` must describe the same table.
+ *
+ * commons/schema-expected.php holds two descriptions of every table, and
+ * SchemaReconciler uses them for different jobs: `create` builds a table that
+ * is absent, `columns` adds columns to a table that exists. The generator
+ * derives both from one `SHOW CREATE TABLE`, so they agree by construction --
+ * right up until somebody edits the file by hand, which the header asks
+ * nobody to do and which has happened.
+ *
+ * 407be1a53 added `logType` and `logText` to taskLog's `create` and not to its
+ * `columns`. The consequences were entirely silent:
+ *
+ *  - plan() pass 3 iterates `columns` and skips a table whose `columns` is
+ *    empty, so the reconciler could never add those two to a taskLog that
+ *    already existed -- and an existing table is the only kind it repairs.
+ *  - the INSERT then failed with 1054 Unknown column, on any sql_mode.
+ *  - PDODB::$throwOnQueryError is false, so query() recorded the error and
+ *    returned normally; FOGController::save() caught its own insertId=0
+ *    exception and returned false; TaskError::_logRow() ignores that return.
+ *    So nothing threw, TaskError's catch never ran, the endpoint answered its
+ *    usual 200, the notification fired, and the report was simply not there.
+ *  - OpenAPI::_entitySchema() reads column types from the same `columns`
+ *    block, so the published API document described both fields as
+ *    "No type information available for this column."
+ *
+ * Nothing compared the two blocks, so nothing noticed. tests/schema-executes
+ * executes the `create` strings into an empty database, which is exactly the
+ * case where `columns` is never consulted.
+ *
+ * Checks both directions and the definition text, because all three are ways
+ * for the blocks to disagree and only one of them was the bug we had:
+ *
+ *   a column in `create` and not in `columns`  -> reconciler cannot add it
+ *   a column in `columns` and not in `create`  -> ALTER for a column a fresh
+ *                                                 install will never have
+ *   the same column defined differently        -> a fresh install and a
+ *                                                 repaired one diverge
+ *
+ * Needs no database: both blocks are in the committed file, which is the
+ * thing that drifted.
+ *
+ * Usage: php tests/schema-manifest-consistent.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+$manifestFile = dirname(__DIR__) . '/packages/web/commons/schema-expected.php';
+if (!is_readable($manifestFile)) {
+    fwrite(STDERR, "FAIL: cannot read $manifestFile\n");
+    exit(1);
+}
+$manifest = include $manifestFile;
+
+$t = new FogChecks();
+
+/**
+ * The column definitions a single-line CREATE TABLE declares.
+ *
+ * Hand-rolled rather than reusing the generator's parser: that one reads the
+ * multi-line output of SHOW CREATE TABLE, one column per line, and the
+ * committed `create` has had its whitespace collapsed. Splitting on top-level
+ * commas is what that collapse costs.
+ *
+ * @param string $create The CREATE TABLE statement.
+ *
+ * @return array Column name => definition, in declaration order.
+ */
+function manifestCreateColumns($create)
+{
+    $open = strpos($create, '(');
+    if (false === $open) {
+        return [];
+    }
+    // Walk to the paren that closes the column list, skipping quoted text so
+    // a default like DEFAULT '(' cannot end it early.
+    $depth = 0;
+    $end = null;
+    $len = strlen($create);
+    for ($i = $open; $i < $len; $i++) {
+        $ch = $create[$i];
+        if ("'" === $ch) {
+            for ($i++; $i < $len; $i++) {
+                if ('\\' === $create[$i]) {
+                    $i++;
+                    continue;
+                }
+                if ("'" === $create[$i]) {
+                    break;
+                }
+            }
+            continue;
+        }
+        if ('(' === $ch) {
+            $depth++;
+        } elseif (')' === $ch) {
+            $depth--;
+            if (0 === $depth) {
+                $end = $i;
+                break;
+            }
+        }
+    }
+    if (null === $end) {
+        return [];
+    }
+    $body = substr($create, $open + 1, $end - $open - 1);
+
+    $parts = [];
+    $buf = '';
+    $depth = 0;
+    $len = strlen($body);
+    for ($i = 0; $i < $len; $i++) {
+        $ch = $body[$i];
+        if ("'" === $ch) {
+            $buf .= $ch;
+            for ($i++; $i < $len; $i++) {
+                $buf .= $body[$i];
+                if ('\\' === $body[$i]) {
+                    $i++;
+                    $buf .= $body[$i];
+                    continue;
+                }
+                if ("'" === $body[$i]) {
+                    break;
+                }
+            }
+            continue;
+        }
+        if ('(' === $ch) {
+            $depth++;
+        }
+        if (')' === $ch) {
+            $depth--;
+        }
+        if (',' === $ch && 0 === $depth) {
+            $parts[] = trim($buf);
+            $buf = '';
+            continue;
+        }
+        $buf .= $ch;
+    }
+    if ('' !== trim($buf)) {
+        $parts[] = trim($buf);
+    }
+
+    $columns = [];
+    foreach ($parts as $part) {
+        // Key and constraint clauses sit in the same comma list.
+        if (preg_match(
+            '/^(PRIMARY|UNIQUE|KEY|CONSTRAINT|FULLTEXT|SPATIAL|INDEX|CHECK)\b/i',
+            $part
+        )) {
+            continue;
+        }
+        if (!preg_match('/^`(\w+)`\s+(.+)$/s', $part, $m)) {
+            continue;
+        }
+        // The generator drops AUTO_INCREMENT from a column definition: it is
+        // only valid on a key column and ADD COLUMN has no key yet. Dropped
+        // here too, or every table's id column would read as a difference.
+        $columns[$m[1]] = trim(preg_replace('/\s*AUTO_INCREMENT\b/i', '', $m[2]));
+    }
+    return $columns;
+}
+
+$tables = $manifest['tables'] ?? [];
+$t->check('the manifest ships a tables block', count($tables) > 0);
+
+foreach ($tables as $table => $spec) {
+    $fromCreate = manifestCreateColumns($spec['create'] ?? '');
+    $declared = (array)($spec['columns'] ?? []);
+
+    // Both halves have to be non-empty for the comparison to mean anything.
+    // A parser that quietly returned nothing would otherwise make every
+    // table below agree with itself.
+    if (!$t->check("$table: `create` parses into columns", count($fromCreate) > 0)) {
+        continue;
+    }
+    $t->check("$table: `columns` is not empty", count($declared) > 0);
+
+    foreach (array_diff(array_keys($fromCreate), array_keys($declared)) as $c) {
+        $t->check(
+            "$table.$c is in `create` but missing from `columns`"
+            . ' -- the reconciler can never add it',
+            false
+        );
+    }
+    foreach (array_diff(array_keys($declared), array_keys($fromCreate)) as $c) {
+        $t->check(
+            "$table.$c is in `columns` but missing from `create`"
+            . ' -- a fresh install would never have it',
+            false
+        );
+    }
+    foreach (array_intersect_key($fromCreate, $declared) as $c => $def) {
+        $t->check(
+            "$table.$c is defined the same way in both blocks"
+            . " (create: '$def', columns: '{$declared[$c]}')",
+            $def === $declared[$c]
+        );
+    }
+}
+
+$t->finish();

--- a/tests/tasklog-report-retention.test.php
+++ b/tests/tasklog-report-retention.test.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * A FOS report stays readable after its task, and its host, are gone.
+ *
+ * The point of GH-1206 is that a failure message is stored and findable
+ * later instead of arriving as a phone photo of a wrapped console. taskLog
+ * stored no host and no task type of its own and reached both through LEFT
+ * OUTER JOINs against `tasks` -- and while nothing deletes taskLog rows,
+ * Route::deletemass('host') cascades to `task` and taskLog is in no cascade
+ * at all. So deleting a host destroyed its tasks and left the reports behind
+ * with NULL where the host name had been, at the same moment the host row
+ * that could have supplied it went too. On the install this was written
+ * against, 9 of 56 rows were already orphaned that way.
+ *
+ * Schema 341 copies hostID, host name and task type name onto the row at
+ * write time, and TaskManagement::_logQueryFrom() prefers the copy. Two
+ * things are asserted here and they fail differently:
+ *
+ *   the WRITER puts the identity on the row       (TaskError::_logRow)
+ *   the READER prefers it and falls back cleanly  (_logQueryFrom)
+ *
+ * The reader half runs the real statement -- the method exists so this test
+ * cannot drift from a copy of the SQL -- against TEMPORARY tables, which
+ * live on one connection and vanish with it. Every CREATE is asserted to be
+ * TEMPORARY before it is issued, because a plain CREATE TABLE here would
+ * leave a table behind in whatever database FOG_TEST_DSN names.
+ *
+ * Needs a database only for that half: the join semantics ARE the fix, and a
+ * fake connection cannot show them. Skips without FOG_TEST_DSN, the same
+ * convention tests/schema-executes.test.php uses. Unlike that one this needs
+ * no CREATE DATABASE, so an ordinary FOG database user can run it.
+ *
+ * Usage:
+ *   php tests/tasklog-report-retention.test.php
+ *   FOG_TEST_DSN='mysql:host=127.0.0.1;dbname=fog' FOG_TEST_USER=... \
+ *     FOG_TEST_PASS=... php tests/tasklog-report-retention.test.php
+ *
+ * Exit status 0 = pass or skip, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('tasklog-retention');
+$db = FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+/*
+ * 1. The writer. Driven for real against a fake connection, so this half
+ *    needs no database: what is asserted is the INSERT that comes out.
+ *
+ *    TaskError::_logRow() is private static and TaskError's constructor IS
+ *    the endpoint -- it reads the request, writes, notifies and exits -- so
+ *    the method is invoked directly rather than by building the class.
+ */
+$t->check(
+    'TaskLog declares the three identity fields',
+    (function () {
+        $p = new \ReflectionProperty('FOG\TaskLog', 'databaseFields');
+        $p->setAccessible(true);
+        $fields = $p->getValue(FOGCore::getClass('TaskLog'));
+        return isset($fields['hostID'], $fields['hostName'], $fields['taskTypeName'])
+            && 'logHostID' === $fields['hostID']
+            && 'logHostName' === $fields['hostName']
+            && 'logTaskTypeName' === $fields['taskTypeName'];
+    })()
+);
+
+$host = FOGCore::getClass('Host')
+    ->set('id', 42)
+    ->set('name', 'lab-07');
+
+/**
+ * A Task whose type resolves without a database.
+ *
+ * Task::getTaskTypeText() reads through the TaskType relationship, which a
+ * fake connection cannot populate. Overridden so this half stays about what
+ * _logRow() DOES with the type, not about how a task finds one.
+ */
+class RetentionTask extends \FOG\Task
+{
+    public function getTaskTypeText()
+    {
+        return 'Deploy';
+    }
+}
+
+$task = (new RetentionTask())
+    ->set('id', 7)
+    ->set('stateID', 3);
+
+FogTestHarness::setStatic('FOGBase', 'Host', $host);
+
+// The values arrive as bound parameters, so the SQL text alone cannot show
+// that the right thing was written. The responder sees both.
+$insert = '';
+$bound = [];
+$db->responder = function ($sql, $params) use (&$insert, &$bound) {
+    if (false !== stripos($sql, 'INSERT INTO `taskLog`')) {
+        $insert = $sql;
+        $bound = (array)$params;
+    }
+    return null;
+};
+
+$m = new \ReflectionMethod('FOG\TaskError', '_logRow');
+$m->setAccessible(true);
+$m->invoke(null, $task, 'error', 'partclone died');
+$db->responder = null;
+
+if ($t->check('_logRow() issues an INSERT against taskLog', '' !== $insert)) {
+    $expected = [
+        'logHostID' => 42,
+        'logHostName' => 'lab-07',
+        'logTaskTypeName' => 'Deploy',
+    ];
+    foreach ($expected as $column => $value) {
+        $t->check(
+            "the INSERT names `$column`",
+            false !== strpos($insert, '`' . $column . '`')
+        );
+        $t->check(
+            "`$column` is written as " . var_export($value, true),
+            in_array($value, $bound, false)
+            && in_array($value, $bound, true)
+        );
+    }
+}
+
+/*
+ * 2. The reader.
+ */
+$dsn = getenv('FOG_TEST_DSN');
+if (false === $dsn || '' === $dsn) {
+    echo "SKIP  no FOG_TEST_DSN set; the read path was not exercised\n";
+    // The writer checks above still ran; report them rather than throwing
+    // the work away, but do not fail the suite for a missing database.
+    if (count($t->failures)) {
+        $t->finish();
+    }
+    echo 'ok  ' . $t->count . " checks passed (writer half only)\n";
+    exit(0);
+}
+if (!in_array('mysql', \PDO::getAvailableDrivers(), true)) {
+    fwrite(STDERR, "FAIL: FOG_TEST_DSN is set but pdo_mysql is missing.\n");
+    exit(1);
+}
+$user = getenv('FOG_TEST_USER');
+$pass = getenv('FOG_TEST_PASS');
+$pdo = new \PDO(
+    $dsn,
+    false === $user ? 'root' : $user,
+    false === $pass ? '' : $pass,
+    [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+);
+
+/**
+ * Issues one statement, refusing any CREATE that is not TEMPORARY.
+ *
+ * The guard is not decoration. The manifest's create string is a plain
+ * CREATE TABLE, and running it here as-is would leave a real `taskLog`
+ * shadow behind in whatever database the DSN names -- which may well be a
+ * live one, since this test deliberately needs no CREATE DATABASE right.
+ *
+ * @param \PDO   $pdo the connection
+ * @param string $sql the statement
+ *
+ * @return void
+ */
+function retentionExec($pdo, $sql)
+{
+    if (preg_match('/^\s*CREATE\s+(?!TEMPORARY\b)/i', $sql)) {
+        fwrite(STDERR, "FAIL: refusing a non-TEMPORARY CREATE:\n$sql\n");
+        exit(1);
+    }
+    $pdo->exec($sql);
+}
+
+// taskLog comes from the manifest, so the columns under test are the ones
+// the release actually ships rather than a hand-written copy.
+$manifest = include dirname(__DIR__) . '/packages/web/commons/schema-expected.php';
+$create = $manifest['tables']['taskLog']['create'] ?? '';
+$create = preg_replace('/^CREATE TABLE IF NOT EXISTS /i', 'CREATE TEMPORARY TABLE ', $create);
+$t->check(
+    'the manifest create for taskLog could be made TEMPORARY',
+    0 === stripos($create, 'CREATE TEMPORARY TABLE')
+);
+
+// The joined tables only need the columns the query touches.
+retentionExec($pdo, 'CREATE TEMPORARY TABLE `taskStates` ('
+    . '`tsID` int(11) NOT NULL, `tsName` varchar(30) NOT NULL,'
+    . '`tsIcon` varchar(255) NOT NULL)');
+retentionExec($pdo, 'CREATE TEMPORARY TABLE `tasks` ('
+    . '`taskID` int(11) NOT NULL, `taskHostID` int(11) NOT NULL,'
+    . '`taskTypeID` mediumint(9) NOT NULL)');
+retentionExec($pdo, 'CREATE TEMPORARY TABLE `hosts` ('
+    . '`hostID` int(11) NOT NULL, `hostName` varchar(16) NOT NULL)');
+// ttName is UNIQUE on the real table and the reportType join relies on it.
+retentionExec($pdo, 'CREATE TEMPORARY TABLE `taskTypes` ('
+    . '`ttID` mediumint(9) NOT NULL, `ttName` varchar(30) NOT NULL UNIQUE,'
+    . '`ttIcon` varchar(30) NOT NULL)');
+retentionExec($pdo, $create);
+
+$pdo->exec("INSERT INTO `taskStates` VALUES (3,'In Progress','fa-play'),(7,'Failed','fa-times')");
+$pdo->exec("INSERT INTO `taskTypes` VALUES (1,'Deploy','fa-download'),(2,'Upload','fa-upload')");
+$pdo->exec("INSERT INTO `hosts` VALUES (100,'alpha'),(102,'gamma')");
+$pdo->exec("INSERT INTO `tasks` VALUES (10,100,1)");
+$pdo->exec(
+    "INSERT INTO `taskLog`"
+    . " (`taskID`,`taskStateID`,`ip`,`createdBy`,`logType`,`logText`,"
+    . "`logHostID`,`logHostName`,`logTaskTypeName`) VALUES"
+    // task alive, host alive
+    . " (10,7,'127.0.0.1','fos','error','live',100,'alpha','Deploy'),"
+    // task deleted, host still there -- the link must survive
+    . " (55,7,'127.0.0.1','fos','error','task gone',102,'gamma','Upload'),"
+    // task deleted and host deleted -- the report is all that is left
+    . " (56,7,'127.0.0.1','fos','error','both gone',999,'deadhost','Deploy'),"
+    // written before schema 341: nothing stored, joins must still answer
+    . " (10,7,'127.0.0.1','fos','error','pre-341',NULL,'',''),"
+    // a state row: never carries an identity of its own
+    . " (10,3,'127.0.0.1','fog','state',NULL,NULL,'',''),"
+    // the host has since been RENAMED: host 100 is 'alpha' now and the
+    // report was written when it was 'oldname'. The stored copy has to win,
+    // or the fallback is really just a null-check and the record is not
+    // historical at all.
+    . " (10,7,'127.0.0.1','fos','error','renamed',100,'oldname','Deploy')"
+);
+
+$fromMethod = new \ReflectionMethod('FOG\TaskManagement', '_logQueryFrom');
+$fromMethod->setAccessible(true);
+$from = sprintf($fromMethod->invoke(null), 'v');
+$rows = $pdo->query(
+    'SELECT `logText`,`logStateName`,`logTypeName`,`logTypeIcon`,'
+    . '`logHostID`,`logHostName` ' . $from . ' ORDER BY `id`'
+)->fetchAll(\PDO::FETCH_ASSOC);
+
+$by = [];
+foreach ($rows as $row) {
+    $by[$row['logText']] = $row;
+}
+
+$t->check('all six fixture rows came back', 6 === count($rows));
+
+// The ordering inside the COALESCE, not just its presence.
+$t->check(
+    'a report keeps the host name it was written with, not the current one',
+    'oldname' === ($by['renamed']['logHostName'] ?? null)
+);
+$t->check(
+    'a renamed host still links, because the id did not change',
+    100 === (int)($by['renamed']['logHostID'] ?? 0)
+);
+
+// The case the whole change exists for.
+$t->check(
+    'a report whose task is gone keeps its host name',
+    'gamma' === ($by['task gone']['logHostName'] ?? null)
+);
+$t->check(
+    'a report whose task is gone keeps its task type and icon',
+    'Upload' === ($by['task gone']['logTypeName'] ?? null)
+    && 'fa-upload' === ($by['task gone']['logTypeIcon'] ?? null)
+);
+$t->check(
+    'a report whose task is gone still links to its host',
+    102 === (int)($by['task gone']['logHostID'] ?? 0)
+);
+
+// Host deleted too: the name is all that is left, and it must not pretend
+// to be a link.
+$t->check(
+    'a report whose host is gone keeps the name it had',
+    'deadhost' === ($by['both gone']['logHostName'] ?? null)
+);
+$t->check(
+    'a report whose host is gone offers no host link',
+    // array_key_exists, not ??: the column IS there and its value is NULL,
+    // which is the whole point, and ?? cannot tell those apart.
+    array_key_exists('logHostID', (array)($by['both gone'] ?? []))
+    && null === $by['both gone']['logHostID']
+);
+
+// Falling back has to keep working, or this is a fix that breaks the rows it
+// was meant to protect.
+$t->check(
+    'a pre-341 report still resolves through the joins',
+    'alpha' === ($by['pre-341']['logHostName'] ?? null)
+    && 'Deploy' === ($by['pre-341']['logTypeName'] ?? null)
+    && 100 === (int)($by['pre-341']['logHostID'] ?? 0)
+);
+$t->check(
+    'a live report reads the same as it always did',
+    'alpha' === ($by['live']['logHostName'] ?? null)
+    && 'Deploy' === ($by['live']['logTypeName'] ?? null)
+    && 'Failed' === ($by['live']['logStateName'] ?? null)
+);
+// taskLog carries taskStateID itself, so this one never needed the task.
+// Indexed by position: the state row's logText is NULL, which is not a key.
+$t->check(
+    'a state row still resolves its state',
+    'In Progress' === ($rows[4]['logStateName'] ?? null)
+);
+
+$t->finish();


### PR DESCRIPTION
Two follow-ups on the FOS report feature (#1206–#1223).

## 1. `schema-expected.php` had drifted, silently

407be1a53 added `logType` and `logText` to `taskLog`'s `create` string and not to its `columns` array. The file header asks nobody to hand-edit that block; nothing checked that they agreed.

`SchemaReconciler::plan()` pass 3 adds missing columns only from `columns`, and skips a table whose `columns` is empty — so the reconciler could never heal a `taskLog` that already existed, and an existing table is the only kind it repairs.

**The failure is quieter than it looks, and not strict-mode dependent.** Naming a column that doesn't exist is error **1054**, on any `sql_mode`. And nothing throws:

| Expected | Actual |
|---|---|
| `PDODB::query()` throws | `$throwOnQueryError` is `false` and nothing sets it true — it records `->error` and returns |
| TaskError's catch writes "unusable report from FOS" | Never fires. `save()` catches its own `insertId=0` exception and returns `false`; `_logRow()` ignores the return |

So the endpoint answered its usual `200 ##`, `fosreports.log` got the normal success line, the task was marked Failed, `HOST_IMAGE_FAIL` fired — and the report simply was not in the database. `PDODB`'s own `error()` writes to a file gated on `FOG_LOG_ERROR`, which is `0` by default, so the SQL error went nowhere at all.

Proven by shadowing `taskLog` with a `TEMPORARY` table of the six old columns:

```
save() returned: false
DB->error: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'logType' in 'INSERT INTO'
rows now in shadow taskLog: 0
```

Second consumer, same gap: `OpenAPI::_entitySchema()` reads column types from `columns`, so the published API document described both fields as *"No type information available for this column."* Fixed as a side effect.

**Audited all 67 tables** in both directions and on the definition text. `taskLog` was the only divergence. Corrected **in place** rather than regenerated — regeneration rewrites 67 `create` strings and 507 column definitions from whatever the generating server has, which is not a reviewable diff for a two-column bug. Verified the edit is byte-identical to what `schema-manifest.php generate` produces.

Guards, since "nothing compared the two blocks" was the actual defect:

- `tests/schema-manifest-consistent.test.php` — compares them for every table, both directions and the definition text. No database, so it gates CI. Mutation-verified against all four ways they can disagree.
- `bin/schema-manifest.php` now refuses to write a table it parsed no columns for. It can't disagree with itself today, but the two blocks come from one `$raw` by different means and only the column parse can fail quietly — a `SHOW CREATE TABLE` shape that regex stops matching would ship **every** `columns` block empty and disable the reconciler for the whole schema.

## 2. A report lost its identity when its task was cleared

`taskLog` stores no host and no task type of its own. Nothing deletes `taskLog` rows — but `Route::deletemass('host')` cascades to `task`, and `taskLog` is in no cascade at all. Deleting a host destroys its tasks and leaves the reports with NULL where the host name was, at the same moment the host row that could have supplied it goes. **On the install this was written against, 9 of 56 rows were already orphaned.**

Narrower than first stated: `taskLog` stores `taskStateID` itself, so state survives; the image was never in this view. What is lost is host name, host id and task type.

Schema **341** copies `logHostID`, `logHostName` and `logTaskTypeName` onto the row at write time and backfills reports whose task still exists. `_logQueryFrom()` prefers the copy, falling back to the joins for pre-341 rows and state rows. That order is deliberate: a report is a historical record, so the name the host had **when it failed** is the answer, not what it has been renamed to since.

**Why not block deleting a task that has reports:** it inverts the dependency — a diagnostic artifact would constrain operational cleanup — and to be consistent it would have to block *host* deletion too, since that's the path that actually removes tasks. Refusing to delete a host because it once failed to image is a worse product than losing a host name.

Only the FOS report endpoint fills the columns. 53 of those 56 rows are state transitions written on every transition; they mean nothing without their task, and three extra lookups per transition buys nothing — the same reasoning that gave `logText` no value on a state row in step 338.

Two column shapes, following what the writer can actually produce: `save()` omits an unset **optional** column whose key ends in `id`, so `logHostID` lands NULL, but writes `''` for every other unset field (the trap step 340 had to repair for `logType`).

`logHostID` still comes from the `hosts` join, because the grid links the name with it and a link to a deleted host is worse than no link. Resolving that join through the stored id first keeps the link working once the task is gone but the host is not.

## Tests

`tests/tasklog-report-retention.test.php` drives the writer against a fake connection, and with `FOG_TEST_DSN` runs the real statement over six shapes:

| Fixture | Asserted |
|---|---|
| task alive, host alive | reads as it always did |
| task deleted, host alive | keeps name, type, icon — **and still links** |
| task deleted, host deleted | keeps the name it had, offers no link |
| pre-341 row | still resolves through the joins |
| state row | still resolves its state |
| host renamed since | keeps the name it was written with |

Seven mutations verified. It needs no `CREATE DATABASE`, so an ordinary FOG database user can run it.

**Also fixed, found on the way:** `tests/schema-executes.test.php` walked the manifest's top level instead of `['tables']`, so it collected no manifest statements and failed its own non-empty guard whenever a DSN was set — that half had never run. It now also skips cleanly when the account may not `CREATE DATABASE` instead of dying on an uncaught `PDOException`.

`sh tests/run-all.sh` — 80 passed, 0 failed, with and without a DSN.

## Downstream

None — no route class added or removed.