### PR TITLE
fix(tests): make the schema replay model what the updater really does (#1241)

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,8 +62,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.3704');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '1241.0-feature.3705');
+        define('FOG_CHANNEL', 'Feature');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element
         // count. DatabaseManager::init() and schemaNeedsDeploy() test

--- a/tests/schema-executes.test.php
+++ b/tests/schema-executes.test.php
@@ -375,7 +375,14 @@ foreach ($steps as $updates) {
             continue;
         }
         if (is_string($update)) {
-            if (preg_match('/^\s*(CREATE|ALTER|DROP)/i', $update)) {
+            // RENAME is DDL and it is load-bearing. schema.php performs the
+            // table-rebuild dance three times -- groupMembers, globalSettings
+            // and users -- as CREATE `x_new` / INSERT / DROP `x` / RENAME
+            // `x_new` TO `x`. Omitting RENAME executed the DROP and not the
+            // rename, so all three tables vanished mid-replay and every later
+            // ALTER against them failed 1146. That was 8 of the 12 failures
+            // this test was reporting, and none of them were the schema's.
+            if (preg_match('/^\s*(CREATE|ALTER|DROP|RENAME)/i', $update)) {
                 $stepDdl[] = $update;
             }
             continue;
@@ -412,6 +419,87 @@ if (!$stepDdl || !$manifestDdl) {
     exit(1);
 }
 
+
+/**
+ * The "this is already how we want it" error codes, read from the production
+ * code that defines them.
+ *
+ * Both real paths tolerate a set of errors that mean the target state is
+ * already reached: SchemaUpdaterPage::update() has a local $skiperrs, and
+ * SchemaReconciler has a private static $_skiperrs whose docblock says it
+ * "mirrors the updater's own tolerance list". Replaying decades of migrations
+ * against a schema whose step 0 has since been updated to the end state HITS
+ * those codes by design -- `ALTER TABLE groups ADD COLUMN groupInit` is 1060
+ * on a fresh database because step 0 now creates the column outright.
+ *
+ * They are PARSED rather than copied. A hardcoded third copy would be one
+ * more thing to drift, and drift is what this whole test exists to catch; a
+ * copy that fell behind would make the test either reject valid schemas or
+ * accept broken ones, silently, and the test would be the last place anyone
+ * looked. Failing loudly when the list cannot be found is deliberate for the
+ * same reason -- a tolerance list that quietly reads as empty turns every
+ * fresh-install replay red, and one that quietly reads as everything turns
+ * this test into decoration.
+ *
+ * @param string $file    file to read
+ * @param string $varname variable name, without the sigil
+ *
+ * @return array list of integer error codes
+ */
+function fogParseSkipErrs($file, $varname)
+{
+    if (!is_readable($file)) {
+        fwrite(STDERR, "FAIL: cannot read $file to learn the tolerated errors.\n");
+        exit(1);
+    }
+    $src = file_get_contents($file);
+    if (!preg_match('/\$' . preg_quote($varname, '/') . '\s*=\s*\[(.*?)\]\s*;/s', $src, $m)) {
+        fwrite(
+            STDERR,
+            "FAIL: no \$$varname list found in $file.\n"
+            . "  This test mirrors the tolerance the real updater applies; if\n"
+            . "  that list moved or was renamed, point this at the new one --\n"
+            . "  do not hardcode a copy here.\n"
+        );
+        exit(1);
+    }
+    preg_match_all('/\b(\d{4})\b/', $m[1], $codes);
+    $out = array_map('intval', $codes[1]);
+    if (!$out) {
+        fwrite(STDERR, "FAIL: \$$varname in $file parsed as empty.\n");
+        exit(1);
+    }
+    sort($out);
+    return $out;
+}
+
+$updaterSkip = fogParseSkipErrs(
+    $root . '/lib/pages/schemaupdaterpage.page.php',
+    'skiperrs'
+);
+$reconcilerSkip = fogParseSkipErrs(
+    $root . '/lib/fog/schemareconciler.class.php',
+    '_skiperrs'
+);
+
+// The reconciler's docblock claims it mirrors the updater's list. Two hand-kept
+// copies of one constant is exactly the drift this test is for, so the claim is
+// checked rather than trusted -- and it is checked HERE, where a database is
+// already in hand, rather than being someone's job to remember.
+if ($updaterSkip !== $reconcilerSkip) {
+    fwrite(
+        STDERR,
+        "FAIL: the two tolerance lists have drifted apart.\n"
+        . '  SchemaUpdaterPage::update()  $skiperrs:  ' . implode(', ', $updaterSkip) . "\n"
+        . '  SchemaReconciler            $_skiperrs:  ' . implode(', ', $reconcilerSkip) . "\n\n"
+        . "  SchemaReconciler's docblock says it mirrors the updater's list.\n"
+        . "  One of the two paths now tolerates something the other does not,\n"
+        . "  so the same statement can succeed on a fresh install and fail a\n"
+        . "  reconcile, or the reverse.\n"
+    );
+    exit(1);
+}
+
 try {
     $pdo = new \PDO($dsn, $user, $pass, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
 } catch (\PDOException $e) {
@@ -444,10 +532,11 @@ try {
  * @param \PDO   $pdo        open connection
  * @param string $database   scratch database name, dropped and recreated
  * @param array  $statements statements to execute in order
+ * @param array  $tolerated  MySQL error numbers that mean "already so"
  *
  * @return array list of ['sql' => string, 'error' => string] for each failure
  */
-function fogRunInto($pdo, $database, array $statements)
+function fogRunInto($pdo, $database, array $statements, array $tolerated = [])
 {
     $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $database));
     $pdo->exec(sprintf('CREATE DATABASE `%s`', $database));
@@ -465,6 +554,12 @@ function fogRunInto($pdo, $database, array $statements)
         try {
             $pdo->exec($sql);
         } catch (\PDOException $e) {
+            // The driver-specific code, not the SQLSTATE: $skiperrs is a list
+            // of MySQL error numbers, and errorInfo[1] is where PDO puts them.
+            $code = isset($e->errorInfo[1]) ? (int)$e->errorInfo[1] : 0;
+            if (in_array($code, $tolerated, true)) {
+                continue;
+            }
             $failures[] = [
                 'sql' => preg_replace('/\s+/', ' ', substr($sql, 0, 220)),
                 'error' => $e->getMessage(),
@@ -500,11 +595,25 @@ function fogCollations($pdo, $database)
 $problems = [];
 $report = [];
 
+// Each pass carries the tolerance its own real path applies. They are equal
+// today -- checked above -- but they are read separately so that if one path
+// ever legitimately diverges, each half of this test still models the path it
+// is named after rather than whichever list happened to be picked.
 foreach ([
-    ['label' => 'schema.php steps (fresh install path)', 'db' => $stepDb, 'sql' => $stepDdl],
-    ['label' => 'schema-expected.php (reconciler path)', 'db' => $manifestDb, 'sql' => $manifestDdl],
+    [
+        'label' => 'schema.php steps (fresh install path)',
+        'db' => $stepDb,
+        'sql' => $stepDdl,
+        'skip' => $updaterSkip,
+    ],
+    [
+        'label' => 'schema-expected.php (reconciler path)',
+        'db' => $manifestDb,
+        'sql' => $manifestDdl,
+        'skip' => $reconcilerSkip,
+    ],
 ] as $pass) {
-    $failures = fogRunInto($pdo, $pass['db'], $pass['sql']);
+    $failures = fogRunInto($pdo, $pass['db'], $pass['sql'], $pass['skip']);
     $collations = fogCollations($pdo, $pass['db']);
 
     $report[] = sprintf(


### PR DESCRIPTION
Closes #1241 (the second half of it — the CI `pipefail` half is FOGProject/fog-workflows#27).

**The answer to the open question: it was the harness, not the schema.** All 12 failures were the test's, and two things the real paths do that the test did not.

## 1. `RENAME TABLE` was not in the DDL filter — 8 of the 12

`schema.php` performs the table-rebuild dance three times, for the three tables that were going missing:

```php
"CREATE TABLE `users_new` (…)",
"INSERT IGNORE INTO `users_new` SELECT * FROM `users`",
"DROP TABLE `users`",
"RENAME TABLE `users_new` TO `users`",
```

The filter was `/^\s*(CREATE|ALTER|DROP)/i`. So the replay executed the **DROP** and skipped the **RENAME** — `users`, `globalSettings` and `groupMembers` each vanished mid-replay, and every later `ALTER` against them failed 1146. Three `RENAME TABLE` statements in the file, three tables reported missing.

## 2. The tolerance list was not applied at all — the other 4

`SchemaUpdaterPage::update()` carries `$skiperrs` — `1050, 1054, 1060, 1061, 1062, 1091` — errors that mean "the thing is already how we want it". `SchemaReconciler` carries `$_skiperrs`, whose docblock says it "mirrors the updater's own tolerance list".

Replaying two hundred migrations against a schema whose step 0 has since been updated to the end state hits those codes **by design**. `ALTER TABLE groups ADD COLUMN groupInit` returns 1060 on a fresh database precisely because step 0 now creates the column outright. The remaining four failures were two 1091s and two 1060s — both on the list.

### The list is parsed, not copied

A third hand-kept copy is one more thing to drift, and drift is what this whole test exists to catch. A stale copy would make the test reject valid schemas or accept broken ones — silently, in the last place anyone would look. It fails loudly if the list cannot be found, for the same reason: a tolerance list that quietly reads as empty reddens every replay, and one that quietly reads as *everything* turns the test into decoration.

### And since both are read, they are compared

`SchemaReconciler`'s docblock *claims* to mirror the updater's list. That claim is now checked rather than trusted — here, where a database is already in hand, rather than being someone's job to remember. Two hand-kept copies of one constant that can diverge is how the same statement comes to succeed on a fresh install and fail a reconcile.

## Result

```
ok  schema executes on 10.5.29-MariaDB-ubu2004
  schema.php steps (fresh install path)  282 statements, 68 tables, 1 collation(s)
  schema-expected.php (reconciler path)   67 statements, 67 tables, 1 collation(s)
    10 closure step(s) skipped (data migrations, no DDL)
```

Mutation-verified — all four killed:

| Mutation | Caught by |
|---|---|
| `RENAME` dropped from the filter | 7 statements fail again |
| the two tolerance lists made to disagree | `the two tolerance lists have drifted apart` |
| `$skiperrs` renamed out from under the parser | `no $skiperrs list found in …` |
| tolerance disabled at the point of use | 4 statements fail again |

## What a working test found immediately

Neither is fixed here. Both are real.

**MariaDB 11.8 — a *fresh* install is already split.** 66 tables `utf8mb3_uca1400_ai_ci`, 2 `utf8mb3_general_ci`. #1152 said "A fresh install on 11.4+ is self-consistent and is not affected" — it is not, because #1147 pinned two tables explicitly and the other 71 inherit. #1240 fixes it, and this is the assertion that proves it: the collation check has never once been exercised, because the CI step was swallowing the result.

**MySQL 8.0 — one statement genuinely cannot run**, in both paths:

```
1067 Invalid default value for 'fdqCompletedDate'
  ALTER TABLE `fileDeleteQueue` MODIFY COLUMN `fdqCompletedDate` DATETIME DEFAULT '0000-00-00 00:00:00'
```

`'0000-00-00 00:00:00'` is rejected under MySQL 8.0's stock `sql_mode` (`NO_ZERO_DATE`, `STRICT_TRANS_TABLES`), and 1067 is on neither tolerance list — so the whole schema update throws, the version is never recorded, and every request 308-redirects to `?node=schema`. FOG relaxes `sql_mode` only inside `_convertEngine()`, and restores it immediately, so nothing covers this.

Filed as its own issue: it needs a schema step to repair existing installs, and numbering one while #1240's step 342 is in flight would collide.

## Sequencing

Independent of #1240 — different files, no shared lines. Merge in either order.

The schema CI legs stay `tolerated` (fog-workflows#27) until the MySQL 8.0 issue is fixed; with this merged they would otherwise redden every PR over a defect that predates all of this.
