### PR TITLE
fix(schema): drop the zero-date default so MySQL 8.0 can install (#1243)

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -86,13 +86,13 @@ return [
             ],
         ],
         'fileDeleteQueue' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `fileDeleteQueue` ( `fdqID` int(11) NOT NULL AUTO_INCREMENT, `fdqPathName` varchar(255) NOT NULL, `fdqStorageGroupID` int(11) NOT NULL, `fdqCreateDate` datetime DEFAULT current_timestamp(), `fdqCompletedDate` datetime DEFAULT \'0000-00-00 00:00:00\', `fdqCreateBy` varchar(40) DEFAULT NULL, `fdqState` int(11) NOT NULL, `fdqPathType` varchar(255) NOT NULL, PRIMARY KEY (`fdqID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `fileDeleteQueue` ( `fdqID` int(11) NOT NULL AUTO_INCREMENT, `fdqPathName` varchar(255) NOT NULL, `fdqStorageGroupID` int(11) NOT NULL, `fdqCreateDate` datetime DEFAULT current_timestamp(), `fdqCompletedDate` datetime DEFAULT NULL, `fdqCreateBy` varchar(40) DEFAULT NULL, `fdqState` int(11) NOT NULL, `fdqPathType` varchar(255) NOT NULL, PRIMARY KEY (`fdqID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'fdqID' => 'int(11) NOT NULL',
                 'fdqPathName' => 'varchar(255) NOT NULL',
                 'fdqStorageGroupID' => 'int(11) NOT NULL',
                 'fdqCreateDate' => 'datetime DEFAULT current_timestamp()',
-                'fdqCompletedDate' => 'datetime DEFAULT \'0000-00-00 00:00:00\'',
+                'fdqCompletedDate' => 'datetime DEFAULT NULL',
                 'fdqCreateBy' => 'varchar(40) DEFAULT NULL',
                 'fdqState' => 'int(11) NOT NULL',
                 'fdqPathType' => 'varchar(255) NOT NULL',

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4171,7 +4171,15 @@ $this->schema[] = [
     'ALTER TABLE `fileDeleteQueue` CHANGE COLUMN `fqdCreateDate` `fdqCreateDate` DATETIME',
     'ALTER TABLE `fileDeleteQueue` CHANGE COLUMN `fqdCompletedDate` `fdqCompletedDate` DATETIME',
     'ALTER TABLE `fileDeleteQueue` CHANGE COLUMN `fqdCreateBy` `fdqCreateBy` VARCHAR(40)',
-    "ALTER TABLE `fileDeleteQueue` MODIFY COLUMN `fdqCompletedDate` DATETIME DEFAULT '0000-00-00 00:00:00'",
+    // GH-1243: NULL, not a zero date. '0000-00-00 00:00:00' is not a legal
+    // DATETIME default under MySQL 8.0's stock sql_mode (NO_ZERO_DATE,
+    // STRICT_TRANS_TABLES) -- it is error 1067, which is on neither
+    // tolerance list, so the whole schema update threw and FOG could not be
+    // installed on MySQL at all. NULL says the same thing ("not completed
+    // yet") and every supported server accepts it. Editing this historical
+    // step is safe: it has already run everywhere it was going to, and step
+    // 343 is what repairs those installs.
+    "ALTER TABLE `fileDeleteQueue` MODIFY COLUMN `fdqCompletedDate` DATETIME NULL DEFAULT NULL",
     "ALTER TABLE `fileDeleteQueue` MODIFY COLUMN `fdqCreateDate` DATETIME DEFAULT CURRENT_TIMESTAMP",
 ];
 // 289
@@ -6081,4 +6089,39 @@ $this->schema[] = [
 
         return true;
     },
+];
+// 343
+$this->schema[] = [
+    // GH-1243: repair the zero-date default on installs that already have it.
+    //
+    // `fdqCompletedDate` was declared DATETIME DEFAULT '0000-00-00 00:00:00'
+    // in step 288. That is not a legal default under MySQL 8.0's stock
+    // sql_mode -- NO_ZERO_DATE and STRICT_TRANS_TABLES are both on by
+    // default -- so the statement answers 1067, which is on neither
+    // SchemaUpdaterPage::update()'s $skiperrs nor SchemaReconciler's
+    // $_skiperrs. The whole update therefore threw before the schema version
+    // was recorded, after which DatabaseManager::establish() 308-redirects
+    // every request to ?node=schema: FOG could not be installed on MySQL at
+    // all. MariaDB's default sql_mode has never included either flag, which
+    // is why no MariaDB install ever saw it.
+    //
+    // Step 288 is edited too, so a fresh install never creates the bad
+    // default. This step is for the installs that already did.
+    //
+    // The rows are cleared BEFORE the column is altered. Nothing reads this
+    // value -- FileDeleteQueueManager only ever writes it, on cancel() and
+    // complete() -- so a zero date here means "never completed", which is
+    // what NULL says without needing a sql_mode that tolerates it. Doing it
+    // in this order also means the MODIFY never has to convert an illegal
+    // value in place, which is itself an error on a strict server.
+    //
+    // YEAR() rather than comparing against the literal '0000-00-00 00:00:00':
+    // a strict server rejects the literal in the comparison as well, so a
+    // WHERE written the obvious way would fail on exactly the servers this
+    // exists for.
+    "UPDATE `fileDeleteQueue` SET `fdqCompletedDate` = NULL "
+    . "WHERE `fdqCompletedDate` IS NOT NULL "
+    . "AND YEAR(`fdqCompletedDate`) = 0",
+    "ALTER TABLE `fileDeleteQueue` "
+    . "MODIFY COLUMN `fdqCompletedDate` DATETIME NULL DEFAULT NULL",
 ];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,8 +62,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.3712');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '1243.0-feature.3713');
+        define('FOG_CHANNEL', 'Feature');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element
         // count. DatabaseManager::init() and schemaNeedsDeploy() test
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 342);
+        define('FOG_SCHEMA', 343);
         define('FOG_BCACHE_VER', 288);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/tests/schema-portable-collation.test.php
+++ b/tests/schema-portable-collation.test.php
@@ -205,6 +205,57 @@ if (count($bare)) {
     exit(1);
 }
 
-echo 'ok  no non-portable collations, and no inherited ones, in '
+/*
+ * GH-1243: and no zero dates.
+ *
+ * '0000-00-00 00:00:00' is not a legal DATE/DATETIME default under MySQL
+ * 8.0's stock sql_mode, which has NO_ZERO_DATE and STRICT_TRANS_TABLES on by
+ * default. It answers 1067, which is on neither SchemaUpdaterPage::update()'s
+ * $skiperrs nor SchemaReconciler's $_skiperrs, so the whole schema update
+ * throws, the version is never recorded, and every request 308-redirects to
+ * ?node=schema. MariaDB's default sql_mode has never carried either flag,
+ * which is why one such default sat in the tree for years and only MySQL
+ * ever objected -- the same shape as the collation checks above, where the
+ * server that would refuse it is not the server anyone was writing on.
+ *
+ * Textual for the same reason as the rest of this file. The executable
+ * version of this check is tests/schema-executes.test.php against a real
+ * mysql:8.0, which is where it was actually found -- this gate is here so it
+ * cannot come back without a database in the room.
+ */
+$zerodates = [];
+foreach ($files as $path) {
+    $lines = preg_split('/\r?\n/', file_get_contents($path));
+    foreach ($lines as $i => $line) {
+        if (isComment($line)) {
+            continue;
+        }
+        if (!preg_match('/0000-00-00/', $line)) {
+            continue;
+        }
+        $zerodates[] = sprintf(
+            '%s:%d',
+            str_replace(dirname(__DIR__) . '/', '', $path),
+            $i + 1
+        );
+    }
+}
+
+if (count($zerodates)) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($zerodates) . " zero date(s) in checked-in schema"
+        . " DDL:\n"
+        . '  ' . implode("\n  ", $zerodates) . "\n\n"
+        . "  '0000-00-00' is rejected outright by MySQL 8.0's stock sql_mode\n"
+        . "  (NO_ZERO_DATE, STRICT_TRANS_TABLES) with error 1067, which\n"
+        . "  neither tolerance list skips -- so the schema update throws and\n"
+        . "  the install is left permanently redirecting to ?node=schema.\n\n"
+        . "  Use NULL. 'Not yet' is an absent value, not a date.\n"
+    );
+    exit(1);
+}
+
+echo 'ok  no non-portable collations, no inherited ones and no zero dates in '
     . count($files) . " schema file(s)\n";
 exit(0);


### PR DESCRIPTION
Closes #1243.

`fileDeleteQueue.fdqCompletedDate` was declared `DATETIME DEFAULT '0000-00-00 00:00:00'` in step 288. That is not a legal DATETIME default under MySQL 8.0's stock `sql_mode`:

```
ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,
ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
```

It answers **1067**, which is on neither `SchemaUpdaterPage::update()`'s `$skiperrs` nor `SchemaReconciler::$_skiperrs` — so the whole update threw before `$newSchema->save()`, after which `DatabaseManager::establish()` 308-redirects every request to `?node=schema`. **FOG could not be installed on MySQL at all**, in either path. MariaDB's default `sql_mode` has never carried either flag, which is why this sat in the tree for years and only MySQL ever objected.

## The fix

`NULL` says the same thing. Nothing reads this column — `FileDeleteQueueManager` only ever *writes* it, in `cancel()` and `complete()`, both with a real timestamp — so a zero date here means "never completed", which is exactly what NULL means, without needing a permissive server to express it.

Option 3 from the issue (add 1067 to the tolerance lists) is rejected: that tolerates the statement *failing*, so the column keeps whatever definition it already had and the two vendors stay divergent. Those lists are for "already how we want it", not "cannot do it here".

**Step 288 is edited** so a fresh install never creates the bad default. Editing a historical step is safe — it has already run everywhere it was going to.

**Step 343 repairs installs that already ran it**, and clears the rows *before* altering the column. The other order asks the server to convert an illegal value in place, which is itself an error on a strict server. The `WHERE` uses `YEAR(…) = 0` rather than comparing against the literal, because a strict server rejects that literal *in a comparison* too — the obvious spelling would fail on exactly the servers this exists for.

The manifest carried the same literal twice and is fixed in the same commit. Leaving it would have fixed the updater path and left the reconciler path broken.

## Verification

`tests/schema-executes.test.php`, all three servers, **283 statements, 68 tables, one collation** each:

| Server | before | after |
|---|---|---|
| mysql:8.0.46 | 1 of 282 failed, **both paths** | ok |
| mariadb:10.5.29 | ok | ok |
| mariadb:11.8.8 | ok | ok |

Step 343 against an install built the old way (`scripts/background_scripts/verify_zerodate_repair_1243.sh`):

```
before   default '0000-00-00 00:00:00';  rows a,b zero-dated, c a real timestamp
after    default NULL;                   a,b NULL;  c untouched
re-run   0 rows changed, column unchanged
```

## Gate

`tests/schema-portable-collation.test.php` gains a zero-date check, next to the two collation ones it already carries — the same class of bug, where the server that would refuse the statement is not the server anyone is writing on. The executable version is `schema-executes.test.php` against a real mysql:8.0, which is where it was found; this gate is so it cannot come back without a database in the room.

Mutation-verified, all three killed: restoring the literal in `schema.php`, restoring it in the manifest, and leaving `FOG_SCHEMA` at 342.

## Not fixed here, and bigger than this

While building the step-343 fixture I could not insert a zero-date row on **stock MariaDB 10.5** either:

```
ERROR 1292 (22007): Incorrect datetime value: '' for column 'fdqCompletedDate'
```

`FOGController::save()` writes `''` for any unset optional field whose key does not end in `id` (fogcontroller.class.php, the `$val = '';` arm), and `''` into a DATETIME is 1292 on **any** strict server — MariaDB has defaulted to `STRICT_TRANS_TABLES` since 10.2.4, so this is not a MySQL-only concern. The schema declares **50 DATETIME columns**, 22 of them `NOT NULL`.

So this PR makes the schema *install* on MySQL 8.0. It does not establish that FOG *runs* there, and I would not claim it does. Filed separately with the evidence.

## Sequencing

Depends on #1240 (step 342) being merged, which it is — this is step 343 on top.
