### PR TITLE
fix(tests): repair the two suite failures CI had been hiding

### DIFF
--- a/tests/relationship-filter-in-join.test.php
+++ b/tests/relationship-filter-in-join.test.php
@@ -111,8 +111,34 @@ $classes = [
     'UserTracking',
     'OUAssociation',
 ];
+
+/*
+ * OUAssociation is the one name here that a plugin owns
+ * (lib/plugins/ou/class/ouassociation.class.php), and plugins are FETCHED by
+ * bin/fetch-plugins.sh rather than tracked -- so lib/plugins does not exist
+ * at all in a fresh clone, a fresh worktree, or on a CI runner. Failing on it
+ * there says "a class lost its path to Host" when the truth is "nobody ran
+ * fetch-plugins", which is not a regression and not actionable.
+ *
+ * A missing CORE class still fails, which is the assertion this list was
+ * written for. Only the plugin-provided ones are excused, and only when the
+ * plugin tree is genuinely absent -- if the tree IS there and the class is
+ * not, that is a real regression and still fails.
+ *
+ * This is why every fogproject pull request reported 79/2 rather than 80/1
+ * once fog-workflows GH-27 turned pipefail on: the suite had been failing in
+ * CI from the day it was added, and `run-all.sh | tee` was discarding the
+ * status. See GH-1241 for the same swallow in the schema job.
+ */
+$pluginOwned = ['OUAssociation'];
+$pluginsFetched = is_dir(dirname(__DIR__) . '/packages/web/lib/plugins');
 foreach ($classes as $class) {
     if (!class_exists($class)) {
+        if (in_array($class, $pluginOwned, true) && !$pluginsFetched) {
+            echo "  SKIP  $class is plugin-provided and lib/plugins is not"
+                . " fetched here\n";
+            continue;
+        }
         $t->check("$class exists, so its join is actually being checked", false);
         continue;
     }

--- a/tests/web-chain-feedback.test.sh
+++ b/tests/web-chain-feedback.test.sh
@@ -104,7 +104,14 @@ is "$(ncerts "$fullchain")" "2" "a normal run assembles leaf + intermediate"
 sslpubcert="$fullchain"
 for _ in 1 2 3 4 5; do _writeWebChainFiles; done
 is "$(ncerts "$fullchain")" "2" "five runs against its own output stay at leaf + intermediate"
-is "$(openssl x509 -in "$fullchain" -noout -subject 2>/dev/null)" \
+# -nameopt RFC2253 pins the formatting. Without it openssl prints whatever its
+# own default is, and that is not stable across versions: 3.0.13 (ubuntu-24.04,
+# which is what the CI runner has) prints "subject=CN = fogserver" with spaces,
+# 3.5.7 prints "subject=CN=fogserver" without them. The test passed on the
+# machine it was written on and failed on the runner -- invisibly, because
+# `run-all.sh | tee` was discarding the suite's exit status until fog-workflows
+# GH-27. RFC2253 is a specified format rather than a default, so both agree.
+is "$(openssl x509 -in "$fullchain" -noout -subject -nameopt RFC2253 2>/dev/null)" \
    "subject=CN=fogserver" "the leaf is still first in the bundle"
 
 # An already-grown bundle collapses rather than needing a migration.


### PR DESCRIPTION
FOGProject/fog-workflows#27 turned on `pipefail`, and the `tests (PHP 7.4)` and `tests (PHP 8.3)` checks went red on every branch immediately.

**Neither failure is new.** The step was

```yaml
run: sh tests/run-all.sh | tee "$RUNNER_TEMP/suite.txt"
```

under `bash -e {0}` with no `pipefail`, so the pipeline's status was `tee`'s and the job passed whatever `run-all.sh` returned. Both of these have been failing in CI since the day that workflow was added — `79 passed, 2 failed`, reported as green. Same swallow as the schema job (#1241).

## `relationship-filter-in-join.test.php`

It asserted `class_exists('OUAssociation')`. That is the one name in its list a **plugin** owns — `lib/plugins/ou/class/ouassociation.class.php` — and plugins are fetched by `bin/fetch-plugins.sh` rather than tracked, so `lib/plugins` does not exist at all in a fresh clone, a fresh worktree, or on a runner.

The test's own comment says the list is spelled out "so that a class LOSING its path to Host shows up as a skipped name here, not as silence" — which is right, and worth keeping. It was just reporting "a class lost its path to Host" when the truth was "nobody ran fetch-plugins".

It now skips that one name, **and only when the plugin tree is genuinely absent**. With the tree present and the class missing it still fails, which is the assertion the list exists for. A missing *core* class fails either way.

## `web-chain-feedback.test.sh`

It compared `openssl x509 -noout -subject` against a literal. That output is not stable across openssl versions:

| openssl | prints |
|---|---|
| 3.0.13 (ubuntu-24.04, i.e. the runner) | `subject=CN = fogserver` |
| 3.5.7 (my box) | `subject=CN=fogserver` |

So it passed where it was written and failed on the runner. `-nameopt RFC2253` asks for a specified format rather than a default, and both versions then agree.

## Verified, not assumed

| Condition | Result |
|---|---|
| `lib/plugins` present, class present | **18 checks pass** — OUAssociation genuinely exercised |
| `lib/plugins` present, class removed | **still FAILS** — the regression it guards is still guarded |
| `lib/plugins` absent | `SKIP`, 16 checks |
| `web-chain-feedback` in `ubuntu:24.04` @ openssl 3.0.13 | 9 passed |
| same container, `-nameopt` taken back out | 8 passed, 1 failed — the fix is what carries it |

Local suite: `81 passed, 0 failed`.

## Why this goes in first

#1244 cannot merge until these are green, and neither has anything to do with that PR's schema change.
