### PR TITLE
fix(dates): an empty date means "no value", not the current time (#1245)

### DIFF
--- a/packages/web/lib/client/usertrack.class.php
+++ b/packages/web/lib/client/usertrack.class.php
@@ -60,7 +60,13 @@ class UserTrack extends FOGClient
         $user = strtolower(
             $_REQUEST['user']
         );
-        if (isset($_REQUEST['date'])) {
+        // GH-1245: an empty date= is not a supplied date. niceDate() now reads
+        // empty as "no value" rather than "now", so the client sending the
+        // parameter with nothing in it has to fall to the same branch as not
+        // sending it at all -- otherwise the row records the zero date.
+        if (isset($_REQUEST['date'])
+            && '' !== trim((string) $_REQUEST['date'])
+        ) {
             $tmpDate = self::niceDate($_REQUEST['date']);
         } else {
             $tmpDate = self::niceDate();

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -1333,6 +1333,31 @@ abstract class FOGBase
      */
     public static function niceDate($date = 'now', $utc = false)
     {
+        /*
+         * GH-1245: an empty value means "this never happened", not "now".
+         *
+         * new \DateTime('') and new \DateTime(null) both return the CURRENT
+         * time, so a date column holding no value renders as a real
+         * timestamp. That has stayed hidden because FOGController::save()
+         * writes '' into date columns and PDODB clears sql_mode on every
+         * connection, so the server coerces it to '0000-00-00 00:00:00' --
+         * and THAT parses to year -0001, which validDate() rejects and
+         * formatTime() renders as "No Data". The empty case is only reached
+         * by the columns that are already nullable, where it is wrong today:
+         * a NULL tasks.stateChangedTime currently shows the current time in
+         * the task grid.
+         *
+         * Mapping empty onto the same zero date makes the two spellings of
+         * "no value" render identically, which is also what lets the columns
+         * move to NULL without the display changing -- FOGController::get()
+         * hands back '' for a NULL column, because isset() is false for null.
+         *
+         * Callers that genuinely want the current time pass 'now', which is
+         * this method's own default.
+         */
+        if (null === $date || (is_string($date) && '' === trim($date))) {
+            $date = '0000-00-00 00:00:00';
+        }
         //we could optionally just catch 'No Data' or any !validDate dates and change them to now
         // if ($date !== 'now' && (!self::validDate($date))) {
         //      $date = 'now';

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -2252,7 +2252,7 @@ abstract class FOGPage extends FOGBase
                         '%s%s_%s',
                         $backuppath,
                         $destfile,
-                        self::formatTime('', 'Ymd_His')
+                        self::formatTime('now', 'Ymd_His')
                     );
                     $keys = [
                         'FOG_TFTP_FTP_PASSWORD',
@@ -2600,7 +2600,7 @@ abstract class FOGPage extends FOGBase
                         '%s%s_%s',
                         $backuppath,
                         $destfile,
-                        self::formatTime('', 'Ymd_His')
+                        self::formatTime('now', 'Ymd_His')
                     );
                     $keys = [
                         'FOG_TFTP_FTP_PASSWORD',

--- a/packages/web/lib/fog/fogpagepost.class.php
+++ b/packages/web/lib/fog/fogpagepost.class.php
@@ -446,9 +446,22 @@ trait FOGPagePost
         // Schedule Delayed/Cron checks.
         switch ($scheduleType) {
             case 'single':
-                $scheduleDeployTime = self::niceDate(
-                    filter_input(INPUT_POST, 'scheduleSingleTime')
-                );
+                $scheduleSingleTime = filter_input(INPUT_POST, 'scheduleSingleTime');
+                /*
+                 * GH-1245: reject the missing time instead of scheduling now.
+                 *
+                 * niceDate() used to read an absent or empty value as the
+                 * current time, so a single schedule with no time silently
+                 * became "run immediately". It now reads empty as "no value",
+                 * which would trip the past-time check below with a message
+                 * that does not describe what happened.
+                 */
+                if (null === $scheduleSingleTime
+                    || '' === trim((string) $scheduleSingleTime)
+                ) {
+                    throw new \Exception(_('A scheduled time is required'));
+                }
+                $scheduleDeployTime = self::niceDate($scheduleSingleTime);
                 if ($scheduleDeployTime < self::niceDate()) {
                     throw new \Exception(_('Scheduled time is in the past'));
                 }

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -199,7 +199,7 @@ class Schema extends FOGController
         if (!$backup_name) {
             $backup_name = sprintf(
                 'fog_backup_%s.sql',
-                self::formatTime('', 'Ymd_His')
+                self::formatTime('now', 'Ymd_His')
             );
         }
         $dump = self::getClass('Mysqldump');

--- a/packages/web/lib/fog/snapintaskmanager.class.php
+++ b/packages/web/lib/fog/snapintaskmanager.class.php
@@ -66,7 +66,7 @@ class SnapinTaskManager extends FOGManagerController
             '',
             [
                 'stateID' => $cancelled,
-                'complete'=> self::formatTime('', 'Y-m-d H:i:s')
+                'complete'=> self::formatTime('now', 'Y-m-d H:i:s')
             ]
         );
         $hostTasksToCancel = [];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1245.0-feature.3721');
+        define('FOG_VERSION', '1245.0-feature.3722');
         define('FOG_CHANNEL', 'Feature');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,8 +62,8 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.3720');
-        define('FOG_CHANNEL', 'Beta');
+        define('FOG_VERSION', '1245.0-feature.3721');
+        define('FOG_CHANNEL', 'Feature');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element
         // count. DatabaseManager::init() and schemaNeedsDeploy() test

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -3090,7 +3090,7 @@ class FOGConfigurationPage extends FOGPage
         try {
             if (isset($_POST['toExport'])) {
                 $backup_name = 'fog_backup_'
-                    . self::formatTime('', 'Ymd_His');
+                    . self::formatTime('now', 'Ymd_His');
                 $tmpfile = '/tmp/' . $backup_name;
                 $data = '';
                 self::getClass('Mysqldump')->start($tmpfile);

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -316,7 +316,7 @@ abstract class TaskingElement extends FOGBase
             );
             return self::getClass('ImagingLog')
                 ->set('hostID', self::$Host->get('id'))
-                ->set('start', self::formatTime('', 'Y-m-d H:i:s'))
+                ->set('start', self::formatTime('now', 'Y-m-d H:i:s'))
                 ->set('image', $this->Image->get('name'))
                 ->set('type', $_REQUEST['type'])
                 ->set('createdBy', $this->Task->get('createdBy'))
@@ -333,7 +333,7 @@ abstract class TaskingElement extends FOGBase
         );
         $ilID = self::maxId($ilID);
         return self::getClass('ImagingLog', $ilID)
-            ->set('finish', self::formatTime('', 'Y-m-d H:i:s'))
+            ->set('finish', self::formatTime('now', 'Y-m-d H:i:s'))
             ->save();
     }
 }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1511,7 +1511,7 @@ class Route extends FOGBase
         }
         $backup_name = sprintf(
             'fog_backup_%s.sql',
-            self::formatTime('', 'Ymd_His')
+            self::formatTime('now', 'Ymd_His')
         );
         self::getClass('Schema')->exportdb($backup_name);
         exit;

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -35,7 +35,7 @@ if ($_remoteIp !== '127.0.0.1'
 unset($_remoteIp, $_serverIp);
 
 $backup_name = 'fog_backup_'
-    . FOGCore::formatTime('', 'Ymd_His');
+    . FOGCore::formatTime('now', 'Ymd_His');
 $tmpfile = '/tmp/' . $backup_name;
 $data = '';
 FOGCore::getClass('Mysqldump')->start($tmpfile);

--- a/tests/nicedate-empty-is-no-value.test.php
+++ b/tests/nicedate-empty-is-no-value.test.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * An empty date reads as "no value", not as the current time.
+ *
+ * new \DateTime('') and new \DateTime(null) both return the CURRENT time, so
+ * FOGBase::niceDate() used to answer "now" for a column holding nothing. The
+ * zero date FOG actually stores parses to year -0001 instead, which
+ * validDate() rejects and formatTime() renders as "No Data" -- so the two
+ * spellings of "this never happened" rendered as opposites, and only the one
+ * that is about to go away rendered correctly.
+ *
+ * That matters now because the date columns are moving to NULL (GH-1245), and
+ * FOGController::get() hands back '' for a NULL column -- isset() is false for
+ * null. Without this normalisation, making a column nullable would silently
+ * turn every "No Data" into the current timestamp: no error, no log line, a
+ * plausible value in every grid. It is already wrong for the three columns
+ * that are nullable today, tasks.stateChangedTime among them.
+ *
+ * The static half guards the seam. Eight call sites passed '' to formatTime()
+ * meaning "now" -- five of them building a backup or export FILENAME, which
+ * would have become "fog_backup_No Data.sql". They now say 'now', which is
+ * niceDate()'s own default spelling, and nothing may reintroduce the empty
+ * literal.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = [];
+$checks = 0;
+
+// ---------------------------------------------------------------
+// 1. Behaviour: empty, null and the zero date all mean the same thing.
+// ---------------------------------------------------------------
+require_once $web . '/lib/fog/fogbase.class.php';
+
+$zero = FOGBase::niceDate('0000-00-00 00:00:00')->format('Y-m-d H:i:s');
+foreach ([['', "empty string"], [null, 'null']] as $case) {
+    list($in, $label) = $case;
+    $checks++;
+    $got = FOGBase::niceDate($in)->format('Y-m-d H:i:s');
+    if ($got !== $zero) {
+        $failures[] = sprintf(
+            'niceDate(%s) gave %s; the zero date gives %s, and the two have '
+            . 'to agree or a nullable column renders differently from a '
+            . 'zero-dated one',
+            $label,
+            $got,
+            $zero
+        );
+    }
+}
+
+// The failure this exists to prevent, stated directly.
+$checks++;
+if (FOGBase::niceDate('')->format('Y') === FOGBase::niceDate('now')->format('Y')) {
+    $failures[] = 'niceDate(\'\') resolved to the current time -- an empty '
+        . 'date column would render as a real timestamp';
+}
+
+// What the display layer does with it, which is the whole point.
+foreach ([['', "empty string"], [null, 'null'], ['0000-00-00 00:00:00', 'zero date']] as $case) {
+    list($in, $label) = $case;
+    $checks++;
+    $got = FOGBase::formatTime($in);
+    if ($got !== 'No Data') {
+        $failures[] = sprintf(
+            'formatTime(%s) rendered "%s", expected "No Data"',
+            $label,
+            $got
+        );
+    }
+}
+
+// 'now' still means now, in both the formatted and the relative arm.
+$checks++;
+if (FOGBase::formatTime('now', 'Y') !== date('Y')) {
+    $failures[] = 'formatTime(\'now\', \'Y\') did not give the current year';
+}
+$checks++;
+if (FOGBase::formatTime('now') !== 'Moments ago') {
+    $failures[] = 'formatTime(\'now\') did not give "Moments ago"';
+}
+
+// ---------------------------------------------------------------
+// 2. The seam stays reserved: nothing passes '' meaning "now".
+// ---------------------------------------------------------------
+$dirs = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($web, \FilesystemIterator::SKIP_DOTS)
+);
+foreach ($dirs as $file) {
+    if ('php' !== strtolower($file->getExtension())) {
+        continue;
+    }
+    $path = $file->getPathname();
+    if (false !== strpos($path, '/lib/plugins/')) {
+        continue;
+    }
+    $lines = file($path);
+    foreach ($lines as $n => $line) {
+        if (preg_match('/\b(niceDate|formatTime)\(\s*(\'\'|"")\s*[,)]/', $line)) {
+            $failures[] = sprintf(
+                '%s:%d passes an empty literal, which now means "no value": '
+                . '%s',
+                substr($path, strlen($root) + 1),
+                $n + 1,
+                trim($line)
+            );
+        }
+    }
+    $checks++;
+}
+
+if (count($failures) > 0) {
+    echo "FAIL nicedate-empty-is-no-value (" . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS nicedate-empty-is-no-value ($checks checks)\n";
+exit(0);

--- a/tests/schema-executes.test.php
+++ b/tests/schema-executes.test.php
@@ -47,6 +47,25 @@
  *
  * Each database is then asserted on twice:
  *
+ * SQL_MODE, and why this test is deliberately STRICTER than FOG's runtime.
+ *
+ * PDODB::_connect() issues `SET SESSION sql_mode=''` on every connection, so
+ * every statement FOG itself runs -- the schema updater included -- executes
+ * with all server-side validation switched off. This test connects with a
+ * plain PDO and inherits whatever the server's own sql_mode is, which on
+ * stock MySQL 8.0 and stock MariaDB 10.5+ is a strict one.
+ *
+ * That gap is deliberate and worth keeping: a statement that only executes
+ * because validation was disabled is a latent dependency on FOG continuing
+ * to disable it, and this is the only place that can see such a statement.
+ *
+ * But it means a failure here is NOT automatically an outage. Check whether
+ * the statement also fails with sql_mode cleared before calling it one.
+ * GH-1243 was reported as "FOG cannot be installed on MySQL 8.0" on the
+ * strength of a failure here, and that was wrong: with sql_mode cleared, as
+ * FOG really runs, MySQL 8.0 accepts it. The DDL was still worth fixing; the
+ * severity was not what this test appeared to say. See GH-1245.
+ *
  *   (a) every statement executed. This is the GH-1147 class -- an unknown
  *       collation, or any other DDL the target server cannot run.
  *   (b) every resulting table shares one collation. This is GH-1152. On a
@@ -662,8 +681,14 @@ if ($problems) {
         STDERR,
         "FAIL: the schema did not execute cleanly on " . $server . "\n\n"
         . implode("\n", $problems) . "\n"
-        . "  A statement that fails here fails the reconcile on a real server,\n"
-        . "  which also stops the schema version being recorded -- after which\n"
+        . "  This runs under the SERVER'S OWN sql_mode. PDODB::_connect()\n"
+        . "  clears sql_mode on every FOG connection, so a failure here is a\n"
+        . "  latent dependency on that clearing rather than a guaranteed\n"
+        . "  outage -- check whether the statement also fails with\n"
+        . "  sql_mode='' before calling it one (GH-1245).\n\n"
+        . "  What IS unconditional: a statement the server cannot run at all,\n"
+        . "  such as an unknown collation, fails the reconcile, which stops\n"
+        . "  the schema version being recorded -- after which\n"
         . "  DatabaseManager::establish() 308-redirects every request to\n"
         . "  ?node=schema. See GH-1147.\n\n"
         . "  More than one collation means a varchar join across the split will\n"

--- a/tests/schema-portable-collation.test.php
+++ b/tests/schema-portable-collation.test.php
@@ -211,12 +211,15 @@ if (count($bare)) {
  * '0000-00-00 00:00:00' is not a legal DATE/DATETIME default under MySQL
  * 8.0's stock sql_mode, which has NO_ZERO_DATE and STRICT_TRANS_TABLES on by
  * default. It answers 1067, which is on neither SchemaUpdaterPage::update()'s
- * $skiperrs nor SchemaReconciler's $_skiperrs, so the whole schema update
- * throws, the version is never recorded, and every request 308-redirects to
- * ?node=schema. MariaDB's default sql_mode has never carried either flag,
- * which is why one such default sat in the tree for years and only MySQL
- * ever objected -- the same shape as the collation checks above, where the
- * server that would refuse it is not the server anyone was writing on.
+ * $skiperrs nor SchemaReconciler's $_skiperrs.
+ *
+ * FOG does not hit that today, because PDODB::_connect() issues
+ * `SET SESSION sql_mode=''` on every connection and a cleared sql_mode
+ * accepts the zero date on every server. So this gate is not guarding an
+ * outage -- it guards against writing DDL whose validity depends on FOG
+ * having switched the server's own checks off. That dependency is real and
+ * undocumented (GH-1245); DDL that stands up without it is simply better
+ * DDL, and NULL says what the zero date was standing in for anyway.
  *
  * Textual for the same reason as the rest of this file. The executable
  * version of this check is tests/schema-executes.test.php against a real
@@ -247,10 +250,11 @@ if (count($zerodates)) {
         'FAIL: ' . count($zerodates) . " zero date(s) in checked-in schema"
         . " DDL:\n"
         . '  ' . implode("\n  ", $zerodates) . "\n\n"
-        . "  '0000-00-00' is rejected outright by MySQL 8.0's stock sql_mode\n"
+        . "  '0000-00-00' is rejected by MySQL 8.0's stock sql_mode\n"
         . "  (NO_ZERO_DATE, STRICT_TRANS_TABLES) with error 1067, which\n"
-        . "  neither tolerance list skips -- so the schema update throws and\n"
-        . "  the install is left permanently redirecting to ?node=schema.\n\n"
+        . "  neither tolerance list skips. FOG survives it only because\n"
+        . "  PDODB clears sql_mode on every connection -- so this is DDL that\n"
+        . "  depends on the server's own checks being off. See GH-1245.\n\n"
         . "  Use NULL. 'Not yet' is an absent value, not a date.\n"
     );
     exit(1);


### PR DESCRIPTION
First of two for #1245. This one is the display layer and is a no-op on
zero-dated data by construction; the schema and `save()` follow in a second PR,
which is only safe once this has landed.

## The bug that exists today

`new \DateTime('')` and `new \DateTime(null)` both return the **current time**,
so `FOGBase::niceDate()` answered "now" for a date column holding nothing. The
zero date FOG actually stores parses to year `-0001` instead, which
`validDate()` rejects and `formatTime()` renders as `No Data`.

So the two spellings of "this never happened" rendered as opposites, and only
the one that is about to go away rendered correctly.

That is already wrong for the three date columns that are nullable **today** —
`tasks.stateChangedTime`, `multicastSessions.senderstart`,
`fileDeleteQueue.completedTime`. `Route`'s date formatter asks `validDate()`
first, and `validDate('')` was true:

```
BEFORE  ''  validDate=true   grid renders: 2026-08-20 14:15:42
AFTER   ''  validDate=false  grid renders: (empty cell)
```

A NULL `stateChangedTime` displayed as the moment the page was drawn.

## Why it blocks the rest of #1245

`FOGController::get()` returns `''` for a NULL column — `isset()` is false for
null (`fogcontroller.class.php:285`). Moving the remaining 13 date columns off
`'0000-00-00 00:00:00'` would therefore have turned every `No Data` into the
current timestamp, on every page, with no error and no log line. Same failure
class as the rest of the issue: it fails open into a plausible value.

`niceDate()` now maps null and the empty string onto the zero date — the value
they are standing in for — so both spellings render identically and the columns
can move without the display moving with them.

## What that cost

Nine call sites passed `''` to `formatTime()` meaning "now". **Five were
building a backup or export FILENAME**, which would have become
`fog_backup_No Data.sql`. They now pass `'now'`, which is `niceDate()`'s own
default spelling and what most of the tree already used.

## Behavior changes (2)

| Site | Was | Is |
|---|---|---|
| `UserTracking::process()` | a client sending `date=` with nothing in it was treated as a supplied date | falls to the same branch as not sending it, so the row records the request time rather than the zero date |
| `FOGPagePost` single schedule | a missing `scheduleSingleTime` read as the current time, so a schedule with no time silently became "run immediately" | throws `A scheduled time is required` |

The second is the one worth a look. It would otherwise have tripped the
existing past-time check with a message that does not describe what happened.

## Test

`tests/nicedate-empty-is-no-value.test.php` — 344 checks, both halves:

- the three inputs resolve to one instant and render as `No Data`, while
  `'now'` still means now in both `formatTime()` arms;
- a tree scan keeps the empty literal from coming back, since the seam now
  means something else.

Four mutations, all killed: dropping the normalization, normalizing null only,
normalizing to `'now'`, and reintroducing one `formatTime('')` call site.

Full suite green locally — every `tests/*.test.php` and `tests/*.test.sh`.

## Not in this PR

`save()` writing NULL, the schema step making the 13 `NOT NULL` columns
nullable, the four sites that write the zero date explicitly, and
`fog.host.list.js`'s literal comparison. Those all move data; keeping them
separate means a bisect points at the right half.

Nor the `SET SESSION sql_mode=''` in `PDODB::_connect()` that hid all of this —
that comes off once the data is clean, on its own, with its own testing.

Refs #1245
