### PR TITLE
fix(orm): resolve plugin column types from the catalog (#1245)

### DIFF
--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -490,7 +490,68 @@ abstract class FOGController extends FOGBase
                 }
             }
         }
-        return self::$columnTypes[strtolower($table)][strtolower($column)] ?? '';
+        $t = strtolower($table);
+        if (!isset(self::$columnTypes[$t])) {
+            self::_loadPluginColumnTypes($t);
+        }
+        return self::$columnTypes[$t][strtolower($column)] ?? '';
+    }
+
+    /**
+     * Loads one table's columns from the server's own catalog.
+     *
+     * commons/schema-expected.php describes core's 67 tables and nothing
+     * else, so a plugin's table is not in it -- and GH-1245's first cut
+     * therefore answered '' for every plugin column, which is precisely the
+     * bug it set out to fix. That was invisible while PDODB cleared sql_mode;
+     * with the clear gone the server refuses the write instead of coercing
+     * it, so saving an LDAP server without a port is error 1366 rather than a
+     * silently stored 0. On the maintainer's own 1.6 install that is 18
+     * tables, 16 enum/set and 44 integer columns.
+     *
+     * Not solved by adding plugin tables to the manifest: the manifest is
+     * generated from core's schema and the reconciler uses it to decide what
+     * to CREATE, so a plugin table listed there would be created for
+     * everyone whether the plugin is installed or not.
+     *
+     * Asked once per table per request, and only for a table the manifest
+     * does not cover -- core never gets here. An empty result is cached too,
+     * so a table that genuinely does not exist is asked about once and then
+     * behaves exactly as it did before this method existed.
+     *
+     * The definition is rebuilt as "<type> NOT NULL" rather than returned
+     * raw, so columnIsNullable() reads it with the same regex it applies to
+     * the manifest's strings and there is only one notion of "nullable".
+     *
+     * @param string $table the table, already lowercased
+     *
+     * @return void
+     */
+    private static function _loadPluginColumnTypes($table)
+    {
+        self::$columnTypes[$table] = [];
+        try {
+            $rows = self::$DB->query(
+                "SELECT `COLUMN_NAME` AS `c`, `COLUMN_TYPE` AS `ty`, "
+                . "`IS_NULLABLE` AS `n` FROM `information_schema`.`COLUMNS` "
+                . "WHERE `TABLE_SCHEMA` = DATABASE() "
+                . "AND LOWER(`TABLE_NAME`) = :table",
+                [],
+                [':table' => $table]
+            )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        } catch (\Exception $e) {
+            // A catalog FOG cannot read leaves every column looking unknown,
+            // which is the behaviour that shipped before GH-1245 rather than
+            // a broken one.
+            return;
+        }
+        foreach ((array) $rows as $row) {
+            if (!isset($row['c'], $row['ty'])) {
+                continue;
+            }
+            self::$columnTypes[$table][strtolower($row['c'])] = trim($row['ty'])
+                . (isset($row['n']) && strtoupper($row['n']) === 'NO' ? ' NOT NULL' : '');
+        }
     }
 
     /**

--- a/tests/empty-values-match-column-types.test.php
+++ b/tests/empty-values-match-column-types.test.php
@@ -183,6 +183,58 @@ if ($reachable < 200) {
 }
 
 // ---------------------------------------------------------------
+// A table the manifest does not describe is asked about, not guessed at.
+//
+// schema-expected.php describes core's tables and nothing else, so every
+// plugin column used to come back '' -- which is the exact bug this file
+// exists to prevent, reintroduced one layer down. Invisible while PDODB
+// cleared sql_mode; with the clear gone the server refuses the write, so
+// saving an LDAP server without a port is error 1366. On the maintainer's own
+// install that is 18 tables, 16 enum/set and 44 integer columns.
+// ---------------------------------------------------------------
+$controllerSrc = evStripComments(
+    file_get_contents($web . '/lib/fog/fogcontroller.class.php')
+);
+$squashed = preg_replace('#\s+#', '', $controllerSrc);
+
+$checks++;
+if (strpos($squashed, 'if(!isset(self::$columnTypes[$t])){self::_loadPluginColumnTypes($t);}') === false) {
+    $failures[] = 'FOGController::columnType() no longer falls back to the '
+        . 'server catalog for a table the manifest does not describe, so '
+        . "every plugin column answers '' again -- GH-1245's own bug, one "
+        . 'layer down';
+}
+
+$checks++;
+if (strpos($squashed, 'information_schema') === false) {
+    $failures[] = 'FOGController no longer reads information_schema at all';
+}
+
+// The rebuilt definition has to carry NOT NULL, or columnIsNullable() -- which
+// greps the manifest's definition strings for it -- reads every plugin column
+// as nullable and binds a NULL the server refuses.
+$checks++;
+// The needle is whitespace-squashed, so ' NOT NULL' reads as 'NOTNULL'.
+if (strpos($squashed, "==='NO'?'NOTNULL':''") === false) {
+    $failures[] = '_loadPluginColumnTypes() no longer appends NOT NULL to the '
+        . 'definition it builds, so columnIsNullable() reads every plugin '
+        . 'column as nullable';
+}
+
+// Cached before the query, so a table that does not exist is asked about once
+// rather than on every field of every save.
+$checks++;
+$at = strpos($squashed, 'staticfunction_loadPluginColumnTypes($table){');
+$body = false === $at ? '' : substr($squashed, $at, 400);
+$seed = false === $at ? false : strpos($body, 'self::$columnTypes[$table]=[];');
+$query = false === $at ? false : strpos($body, 'self::$DB->query(');
+if (false === $seed || false === $query || $seed > $query) {
+    $failures[] = '_loadPluginColumnTypes() no longer seeds its cache entry '
+        . 'before querying, so a table that does not exist is looked up again '
+        . 'for every field of every save';
+}
+
+// ---------------------------------------------------------------
 // The clear does not come back.
 // ---------------------------------------------------------------
 $checks++;


### PR DESCRIPTION
Follow-on to #1251. Found while verifying that PR on the running servers, which
is the only reason it surfaced at all.

#1251 taught `FOGController::save()` to write a value each column's **type** can
hold, reading those types from `commons/schema-expected.php`. That manifest
describes core's 67 tables and nothing else — so every **plugin** column came
back with no type, and `emptyValueFor()` answers `''` for an unknown column.
Which is precisely the bug #1251 set out to fix, reintroduced one layer down.

It was invisible before, because `PDODB` cleared `sql_mode` and the server
coerced the `''` silently. #1251 removed the clear, so the server now refuses
the write:

| column | type | before this PR | server says |
|---|---|---|---|
| `LDAPServers.lsPort` | `int(11) NOT NULL` | `''` | **1366** Incorrect integer value |
| `LDAPServers.lsSearchScope` | `enum('0','1','2') NOT NULL` | `''` | **1265** Data truncated |
| `location.lStorageNodeProto` | `enum('http','https') NOT NULL` | `''` | **1265** |

`lsPort` is the sharp one: its key does not end in `id`, so it takes the `''`
arm rather than the foreign-key arm. On my own 1.6 install that is **18 plugin
tables carrying 16 enum/set and 44 integer columns**, many `NOT NULL` with no
default.

## The fix

`columnType()` asks `information_schema` for a table the manifest does not
describe. Core never reaches it. Asked once per table per request, and the
**empty** result is cached too, so a table that genuinely does not exist is
looked up once and then behaves exactly as it did before this method existed.

Not solved by adding plugin tables to the manifest: `SchemaReconciler` uses it
to decide what to `CREATE`, so a plugin table listed there would be created for
everyone whether the plugin is installed or not.

The definition is rebuilt as `"<type> NOT NULL"` rather than returned raw, so
`columnIsNullable()` reads it with the same regex it applies to the manifest's
strings — one notion of nullable rather than two.

**`dev-branch` needs no equivalent.** Its version of this lookup (#1252) reads
every table in the schema from `information_schema` in one query, so plugin
tables were always covered there.

## Verified

Against the live 1.6 database through the real stack, read only, via a shadow
tree (the deployed tree's md5 confirmed unchanged afterwards):

```
  hosts.hostEnforce            enum('0','1') NOT NULL DEFAULT '1'    -> '0'
  hosts.hostLastDeploy         datetime DEFAULT NULL                 -> NULL
  LDAPServers.lsPort           int(11) NOT NULL                      -> 0
  LDAPServers.lsSearchScope    enum('0','1','2') NOT NULL            -> '0'
  LDAPServers.lsNestedGroups   enum('off','chain','expand') NOT NULL -> 'off'
  OIDCProviders.opEnabled      enum('0','1') NOT NULL                -> '0'
  location.lStorageNodeProto   enum('http','https') NOT NULL         -> 'http'
  location.lTftpEnabled        enum('0','1') NOT NULL                -> '0'
  nosuchtable.nosuchcolumn     (unknown)                             -> ''
```

Core still resolves from the manifest; a table that does not exist still answers
`''`, which is the pre-#1251 behaviour.

The refusals in the table above were confirmed on a throwaway MariaDB 11.8 under
this server's own `sql_mode`
(`STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION`)
rather than reasoned about.

## No repair step

A plugin enum holding the error value reads back as `''` exactly as it did
before, and the next `save()` of that row rewrites it with the first member — so
it self-heals. Both 1.5 lab servers and this one currently hold **zero** rows
with it, checked directly.

## Gate

`tests/empty-values-match-column-types.test.php` gained four checks — the
fallback call, the `NOT NULL` suffix, the cache seeding, and the catalog read
itself. All four go red under their own mutation. Suite: 84 tests, 0 failures.

## Downstream

None. No route class added or removed, no route shape changed.
