### PR TITLE
fix(replication): report a refused FTP login as a login failure (#1254)

### DIFF
--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -69,6 +69,17 @@ class FOGFTP
      */
     private $_currentLoginHash;
     /**
+     * Which stage of connect() failed, if one did.
+     *
+     * Either 'connect' (the socket never came up) or 'login' (the server
+     * answered and refused the credentials). connect() returns a bare false
+     * for both, so without this the caller cannot tell a network problem from
+     * a wrong password -- and every caller guessed "network".
+     *
+     * @var string
+     */
+    private $_lastFailure = '';
+    /**
      * Sets the variable for us to use later.
      *
      * @param string $key   The key to set.
@@ -126,6 +137,7 @@ class FOGFTP
         $autologin = true,
         $connectmethod = 'ftp_connect'
     ) {
+        $this->_lastFailure = '';
         try {
             $this->_currentConnectionHash = password_hash(
                 print_r($this->data, 1),
@@ -158,21 +170,33 @@ class FOGFTP
                     $timeout = $this->timeout;
                 }
             }
+            $this->_lastFailure = 'connect';
             $this->_link = $connectmethod($host, $port, $timeout);
             if ($this->_link === false) {
                 trigger_error(_('FTP Connection Failed'), E_USER_NOTICE);
                 $this->ftperror($this->data);
             }
             if ($autologin) {
+                $this->_lastFailure = 'login';
                 $this->login();
                 $this->pasv($this->passive);
             }
+            $this->_lastFailure = '';
             $this->_lastConnectionHash = $this->_currentConnectionHash;
         } catch (\Exception $e) {
             FOGCore::error($e->getMessage());
             return false;
         }
         return $this;
+    }
+    /**
+     * Which stage of the last connect() failed.
+     *
+     * @return string 'connect', 'login', or '' when the last attempt succeeded
+     */
+    public function lastFailure()
+    {
+        return $this->_lastFailure;
     }
     /**
      * Deletes the item passed

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -522,9 +522,24 @@ abstract class FOGService extends FOGBase
             );
             $nodename = $StorageNode->name;
             if (!self::$FOGFTP->connect()) {
-                self::outall(
-                    ' * ' . _('Cannot connect to') . ' ' . $nodename
-                );
+                // A refused login used to be reported as "Cannot connect",
+                // which points at the network when the cause is nearly always
+                // a stale password for this node. Each master keeps its own
+                // copy of every peer's credential and nothing syncs them, so
+                // say which of the two actually failed.
+                if (self::$FOGFTP->lastFailure() === 'login') {
+                    self::outall(
+                        ' * ' . _('FTP login rejected by') . ' ' . $nodename
+                        . ' ' . _('for user') . ' ' . $username
+                    );
+                    self::outall(
+                        ' | ' . _('Check the password stored for this node')
+                    );
+                } else {
+                    self::outall(
+                        ' * ' . _('Cannot connect to') . ' ' . $nodename
+                    );
+                }
                 continue;
             }
             $encpassword = urlencode($password);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -731,9 +731,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
-msgid "All methods of binding have failed"
-msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandbreite sollte numerisch und größer als 0 sein."
@@ -743,12 +740,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
 
 #, fuzzy
 msgid "Already created"
@@ -1066,10 +1057,6 @@ msgid "CA Certificate Path"
 msgstr "Neuen Standort erstellen"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Pfad"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
 
@@ -1169,10 +1156,6 @@ msgstr "Stornierter Task"
 msgid "Cancelled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Anmeldung am LDAP-Server nicht möglich"
-
 msgid "Cannot change image when in tasking"
 msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
@@ -1217,9 +1200,6 @@ msgstr "Snapin erstellen fehlgeschlagen"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin erfolgreich hinzugefügt"
-
-msgid "Capone Deploy"
-msgstr "Capone Verteilung"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1299,9 +1279,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "Kanalaufruf ist ungültig"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -1326,6 +1303,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1530,22 +1511,7 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
 msgid "Could not read tmp file."
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -1555,10 +1521,6 @@ msgstr "Konnte nicht registriert werden."
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1885,10 +1847,6 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Standard ist deaktiviert"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -1953,9 +1911,6 @@ msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Beschreibung"
@@ -2121,10 +2076,6 @@ msgid "Edit Capone"
 msgstr "Snapins exportieren"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Snapins exportieren"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Gruppeneinstellungen Module"
 
@@ -2145,9 +2096,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Standort senden aktivieren"
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2291,10 +2239,6 @@ msgid "Export LDAP Servers"
 msgstr "LDAP-Server"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "Standorte exportieren"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Benutzer exportieren"
 
@@ -2396,6 +2340,9 @@ msgstr "FTP-Verbindung fehlgeschlagen"
 
 msgid "FTP Path"
 msgstr "FTP-Pfad"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "fehlgeschlagen"
@@ -2633,10 +2580,6 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Filter"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Suche nach zugeordneten Images"
 
@@ -2742,10 +2685,6 @@ msgstr "Funktion"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funktion"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Methode ist nicht vorhanden"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2913,18 +2852,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -2995,10 +2922,6 @@ msgid "Group Update Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
@@ -3013,10 +2936,6 @@ msgstr "Gruppe hinzugefügt!"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3143,18 +3062,6 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Dieser Host ist bereits vorhanden."
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3237,17 +3144,6 @@ msgstr "Host Kernel Argumente"
 msgid "Host List"
 msgstr "Hostliste"
 
-msgid "Host Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Standort aktualisiert"
-
 msgid "Host Login History"
 msgstr "Host-Login-Verlauf"
 
@@ -3304,10 +3200,6 @@ msgstr "Host Snapinverlauf"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3612,22 +3504,6 @@ msgid "Image Used"
 msgstr "genutzte Images"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows-Schlüssel importieren"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows-Schlüssel erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows-Schlüssel aktualisiert"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image hinzugefügt"
 
@@ -3740,10 +3616,6 @@ msgid "Import Failed"
 msgstr "Image aktualisiert"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Standorte importieren"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Benutzer importieren"
 
@@ -3760,28 +3632,12 @@ msgid "Import Reports"
 msgstr "Berichte importieren"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppen importieren"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Import erfolgreich"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Import erfolgreich"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Taskstatus exportieren"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task-Typen importieren"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows-Schlüssel importieren"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3978,10 +3834,6 @@ msgstr "Ungültige Einheit"
 msgid "Invalid Windows product key"
 msgstr "Host Produktschlüssel"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Wählen Sie ein gültiges Abbild"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4022,9 +3874,6 @@ msgstr "Ungültiger Schlüssel wurde angefordert"
 
 msgid "Invalid key being set"
 msgstr "Ungültiger Schlüssel wurde gesetzt"
-
-msgid "Invalid method called"
-msgstr "Ungültige Methode aufgerufen"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4145,9 +3994,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "indem es die max. Bandbreiteneinstellung desjenigen Knotens"
 
-msgid "It tells the client to download snapins from"
-msgstr "Es weist den Client an, Snapins vom hostdefinierten "
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4193,10 +4039,6 @@ msgid "Key"
 msgstr "DMI-Schlüssel"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Schlüsselfeldname muss eine Zeichenfolge sein."
 
@@ -4220,10 +4062,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "sofort abbrechen"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4341,10 +4179,6 @@ msgstr "LDAP-Server aktualisiert"
 msgid "LDAP Server updated!"
 msgstr "LDAP-Server aktualisiert"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
 msgid "Language"
 msgstr "Sprache"
 
@@ -4376,9 +4210,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4446,14 +4277,6 @@ msgid "List All Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task Status"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task-Typen"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installierte Plugins"
 
@@ -4481,10 +4304,6 @@ msgstr "Laden von Daten zum Feld %s"
 
 msgid "Location"
 msgstr "Ort"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Standort Zugehörigkeiten"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4519,9 +4338,6 @@ msgstr "Standort erfolgreich aktualisiert"
 #, fuzzy
 msgid "Location added!"
 msgstr "Standort hinzugefügt"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4906,10 +4722,6 @@ msgstr "NAME"
 msgid "NOT"
 msgstr "NICHT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "HINWEIS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4942,16 +4754,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -5023,9 +4828,6 @@ msgstr "Kein Image angegeben"
 
 msgid "No Printer Management"
 msgstr "Keine Druckerverwaltung"
-
-msgid "No access is allowed"
-msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5905,10 +5707,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6132,9 +5930,6 @@ msgstr "Drucker aktualisiert!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client-Management"
@@ -6334,10 +6129,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Ergebnis"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6583,19 +6374,8 @@ msgid "Search Base DN"
 msgstr "Suche Basis DN"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Suche DN"
-
-msgid "Search DN did not return any results"
-msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
-
-#, fuzzy
 msgid "Search Key"
 msgstr "Suche"
-
-#, fuzzy
-msgid "Search Method"
-msgstr "Suchmethode"
 
 #, fuzzy
 msgid "Search Scope"
@@ -6603,9 +6383,6 @@ msgstr "Suchbereich"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Die Suche lieferte kein passendes Ergebnis"
 
 #, fuzzy
 msgid "Search settings"
@@ -6983,9 +6760,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7507,10 +7281,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppe aktualisiert"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppen exportieren"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppen exportieren"
 
@@ -7661,9 +7431,6 @@ msgstr "Task Status erfolgreich aktualisiert"
 msgid "Task State Updated!"
 msgstr "Task Status aktualisiert!"
 
-msgid "Task States"
-msgstr "Task Status"
-
 msgid "Task Type"
 msgstr "Task-Typ"
 
@@ -7713,9 +7480,6 @@ msgstr "Task-Typ ist nicht gültig"
 
 msgid "Task Type is not valid"
 msgstr "Task-Typ ist nicht gültig"
-
-msgid "Task Types"
-msgstr "Task-Typen"
 
 #, fuzzy
 msgid "Task failed"
@@ -7824,12 +7588,6 @@ msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 msgid "The API is disabled"
 msgstr "Standard ist deaktiviert"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -7848,9 +7606,6 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "läuft nicht mehr"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7891,9 +7646,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7964,9 +7716,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -8164,9 +7913,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -8221,10 +7967,6 @@ msgstr "IP(s) dieses Servers"
 msgid "This setting"
 msgstr "Diese Einstellung"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Diese Einstellung definiert das Senden"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8276,9 +8018,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8743,10 +8482,6 @@ msgid "User Create Success"
 msgstr "Benutzer erfolgreich erstellt"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Benutzer DN"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Gruppen"
 
@@ -8830,9 +8565,6 @@ msgstr "Benutzeraktualisierung erfolgreich!"
 msgid "User added!"
 msgstr "Benutzer hinzugefügt"
 
-msgid "User call is invalid"
-msgstr "Benutzeraufruf ist ungültig"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Benutzer hinzugefügt"
@@ -8845,9 +8577,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8859,10 +8588,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 #, fuzzy
 msgid "User updated!"
 msgstr "Benutzer aktualisiert"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8884,15 +8609,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Benutzername"
-
 msgid "Users"
 msgstr "Benutzer"
-
-msgid "Using the group match function"
-msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
 msgid "VB Script"
 msgstr ""
@@ -8959,10 +8677,6 @@ msgstr "Wir sind Knoten-ID "
 msgid "We are node name"
 msgstr "Wir sind Knotenname "
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8985,9 +8699,6 @@ msgstr "wurde abgebrochen"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
@@ -9004,10 +8715,6 @@ msgstr "Fenstergröße muss größer sein als 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows-Schlüssel beschreibung"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows Keys"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9050,15 +8757,8 @@ msgid "Windows Key updated!"
 msgstr "Windows-Schlüssel aktualisiert"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows Keys"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Produktschlüssel"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
 
 msgid "Wipes"
 msgstr ""
@@ -9182,17 +8882,11 @@ msgstr "vor mir auf diesem Knoten"
 msgid "between"
 msgstr "zwischen"
 
-msgid "between different sites"
-msgstr "Stellen hin und her wechseln."
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "die Client Computer in den FOG"
-
-msgid "but bind password is not set"
-msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 msgid "but has recently failed for this host"
@@ -9234,9 +8928,6 @@ msgstr ""
 
 msgid "day"
 msgstr "Tag"
-
-msgid "deploy task occurs for it"
-msgstr "es eine Verteilungs-Task gibt."
 
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
@@ -9307,8 +8998,8 @@ msgstr "Dateigröße"
 msgid "fog-admins"
 msgstr "Domänen-Name"
 
-msgid "for Microsoft Windows to images"
-msgstr "MS Windows den Images zuordnet."
+msgid "for user"
+msgstr ""
 
 #, fuzzy
 msgid "found"
@@ -9345,14 +9036,6 @@ msgstr "wurde erfolgreich zerstört"
 
 msgid "has been successfully updated"
 msgstr "wurde erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "wurde abgeschlossen"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Ungültiges Snapin-Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9532,10 +9215,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "die Client Computer in den FOG"
 
-#, fuzzy
-msgid "key"
-msgstr "aktiviert werden."
-
 msgid "keys"
 msgstr ""
 
@@ -9548,9 +9227,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "auf 1 MBit/s begrenzen, "
-
-msgid "location url based on the host that checks in"
-msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 msgid "logged in"
 msgstr ""
@@ -9585,9 +9261,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
 #, fuzzy
 msgid "must be specified"
@@ -9747,9 +9420,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "mit Clients haben, die zwischen verschiedenen "
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9806,9 +9476,6 @@ msgstr "den folgenden Terminalbefehlen tun"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
-
-msgid "the host defined location where available"
-msgstr "Speicherort herunterzuladen, sofern verfügbar."
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9867,9 +9534,6 @@ msgstr "um den angeforderten Kernel herunterzuladen."
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "um den angeforderten Kernel herunterzuladen."
-
-msgid "to operate in an environment where there may be"
-msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
 
 msgid "to review."
 msgstr "um zu überprüfen."
@@ -9938,13 +9602,6 @@ msgstr "Windows"
 
 msgid "wipe out all of your images stored on"
 msgstr "alle Images auf sämtlichen"
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "Schlüssel beim Host."
 
 #, fuzzy
 msgid "with this group"
@@ -10087,6 +9744,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
@@ -10099,12 +9765,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Pfad"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Anmeldung am LDAP-Server nicht möglich"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Verteilung"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Kanalaufruf ist ungültig"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Client Einstellungen"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10126,6 +9822,14 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
+#, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Snapins exportieren"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
@@ -10142,6 +9846,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Standorte exportieren"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Standorte exportieren"
 
 #~ msgid "Export Printers"
@@ -10188,8 +9896,28 @@ msgstr ""
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Methode ist nicht vorhanden"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10211,12 +9939,32 @@ msgstr ""
 #~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "Gruppeneinstellungen Module"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Dieser Host ist bereits vorhanden."
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10238,6 +9986,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hostliste"
@@ -10253,6 +10012,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10291,6 +10054,22 @@ msgstr ""
 #~ msgstr "Host aktualisiert!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows-Schlüssel erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows-Schlüssel aktualisiert"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts importieren"
 
@@ -10299,6 +10078,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Standorte importieren"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Standorte importieren"
 
 #~ msgid "Import Printers"
@@ -10327,12 +10110,50 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Alle Speicherknoten"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppen importieren"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Taskstatus exportieren"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task-Typen importieren"
+
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Ungültiger Typ"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Wählen Sie ein gültiges Abbild"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Ungültige Methode aufgerufen"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "Es weist den Client an, Snapins vom hostdefinierten "
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP-Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10351,11 +10172,34 @@ msgstr ""
 #~ msgstr "Alle %s auflisten"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task Status"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task-Typen"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Standort Zugehörigkeiten"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "zugeordneter Host"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "HINWEIS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10391,8 +10235,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Bitte geben Sie einen Namen für einen Admin oder einen mobilen Lookup ein."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
@@ -10403,6 +10254,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Ausgewählte entfernen?"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Ergebnis"
 
 #~ msgid "Results"
 #~ msgstr "Ergebnisse"
@@ -10463,8 +10318,25 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Suche DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Suchmethode"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Die Suche lieferte kein passendes Ergebnis"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Site Zugehörigkeit"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10478,8 +10350,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppen exportieren"
+
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#~ msgid "Task States"
+#~ msgstr "Task Status"
+
+#~ msgid "Task Types"
+#~ msgstr "Task-Typen"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10492,6 +10374,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10509,9 +10394,19 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Es gibt keine Snapins auf diesem Server."
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Diese Einstellung definiert das Senden"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
@@ -10535,6 +10430,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Benutzer DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10580,6 +10479,38 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Site aktualisiert!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "Benutzeraufruf ist ungültig"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Benutzername"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows Keys"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows Keys"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Sie haben Version"
@@ -10595,24 +10526,67 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "vor mir"
 
+#~ msgid "between different sites"
+#~ msgstr "Stellen hin und her wechseln."
+
 #~ msgid "but"
 #~ msgstr "aber "
+
+#~ msgid "but bind password is not set"
+#~ msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Abgeschlossen"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "es eine Verteilungs-Task gibt."
+
 #~ msgid "e.g."
 #~ msgstr "z.B."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "MS Windows den Images zuordnet."
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "wurde abgeschlossen"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Ungültiges Snapin-Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "aktiviert werden."
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Aktive Multicast-Tasks"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
+
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "mit Clients haben, die zwischen verschiedenen "
+
+#~ msgid "the host defined location where available"
+#~ msgstr "Speicherort herunterzuladen, sofern verfügbar."
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
+
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "Schlüssel beim Host."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -735,9 +735,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Install / Update Successful!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandwidth should be numeric and greater than 0"
@@ -746,12 +743,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1070,10 +1061,6 @@ msgid "CA Certificate Path"
 msgstr "Create New %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Path"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Private key failed"
 
@@ -1173,10 +1160,6 @@ msgstr "Cancelled task"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelled due to new tasking."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Cannot connect to database"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1220,9 +1203,6 @@ msgstr "Snapin updated"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin updated"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1302,9 +1282,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "Channel call is invalid"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Record not found, Error: %s"
@@ -1329,6 +1306,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "No FOGPage Class found for this node"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1532,22 +1513,7 @@ msgstr "Could not read tmp file."
 msgid "Could not read snapin file"
 msgstr "Could not read tmp file."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Could not read tmp file."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Could not read tmp file."
-
 msgid "Could not read tmp file."
-msgstr "Could not read tmp file."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Could not read tmp file."
 
 #, fuzzy
@@ -1557,10 +1523,6 @@ msgstr "Could not create printer"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1887,10 +1849,6 @@ msgid "Default Width"
 msgstr "Default Width"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Donations are disabled"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Unable to open file for reading"
 
@@ -1955,9 +1913,6 @@ msgstr "Download Failed"
 
 msgid "Deploy Method"
 msgstr "Deploy Method"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Description"
@@ -2123,10 +2078,6 @@ msgid "Edit Capone"
 msgstr "Export Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Update Settings"
 
@@ -2145,9 +2096,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2292,10 +2240,6 @@ msgid "Export LDAP Servers"
 msgstr "LDAP Server"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "Host Location"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Export Users"
 
@@ -2397,6 +2341,9 @@ msgstr "FTP Connection has failed"
 
 msgid "FTP Path"
 msgstr "FTP Path"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "Failed"
@@ -2634,10 +2581,6 @@ msgid "Files Deleted List"
 msgstr "Delete file data"
 
 #, fuzzy
-msgid "Filter"
-msgstr "File"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "No snapins associated"
 
@@ -2743,10 +2686,6 @@ msgstr "Action"
 #, fuzzy
 msgid "Function Error"
 msgstr "Action"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Method does not exist"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2914,18 +2853,6 @@ msgid "Group Kernel Arguments"
 msgstr "Group Kernel Arguments"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Location"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Location Updated"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login History"
 
@@ -2997,10 +2924,6 @@ msgid "Group Update Fail"
 msgstr "Group create failed"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Group create failed"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Group create failed"
 
@@ -3015,10 +2938,6 @@ msgstr "Group added"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Group is Invalid"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "User update failed"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3144,18 +3063,6 @@ msgstr "Home"
 msgid "Host"
 msgstr "Host"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Printer already exists"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Printer already exists"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Printer already exists"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host Created"
@@ -3238,17 +3145,6 @@ msgstr "Host Kernel Arguments"
 msgid "Host List"
 msgstr "Host List"
 
-msgid "Host Location"
-msgstr "Host Location"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Location Updated"
-
 msgid "Host Login History"
 msgstr "Host Login History"
 
@@ -3305,10 +3201,6 @@ msgstr "Snapin History"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host Update Failed"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host Update Failed"
 
 #, fuzzy
@@ -3613,22 +3505,6 @@ msgid "Image Used"
 msgstr "Imaged"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "User Management"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "User Management"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "User Management"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image Name"
 
@@ -3741,10 +3617,6 @@ msgid "Import Failed"
 msgstr "Image updated"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Host Location"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Import Users"
 
@@ -3761,28 +3633,12 @@ msgid "Import Reports"
 msgstr "Import Hosts"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Import Groups"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Successful"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Successful"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Task States"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task Types"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3979,10 +3835,6 @@ msgstr "Invalid URL"
 msgid "Invalid Windows product key"
 msgstr "Host Product Key"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Select a valid image"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4023,9 +3875,6 @@ msgstr "Invalid key being removed"
 
 msgid "Invalid key being set"
 msgstr "Invalid key being set"
-
-msgid "Invalid method called"
-msgstr "Invalid method called"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4146,9 +3995,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4194,10 +4040,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Image Association"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Event must be a string"
 
@@ -4220,9 +4062,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Kill"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4340,10 +4179,6 @@ msgstr "LDAP Server Name"
 msgid "LDAP Server updated!"
 msgstr "LDAP Server Name"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP Server"
-
 msgid "Language"
 msgstr "Language"
 
@@ -4375,9 +4210,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4445,14 +4277,6 @@ msgid "List All Plugins"
 msgstr "Install Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task States"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task Types"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installed Plugins"
 
@@ -4479,10 +4303,6 @@ msgstr "Loading data to field %s"
 
 msgid "Location"
 msgstr "Location"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Image Association"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4517,9 +4337,6 @@ msgstr "Install / Update Successful!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Location Name"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4904,10 +4721,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NOT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NOT"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4940,16 +4753,9 @@ msgstr "Event must be a string"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Event must be a string"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Event must be a string"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "User update failed"
 
 msgid "Network Information"
 msgstr "Network Information"
@@ -5021,9 +4827,6 @@ msgstr "No Image specified"
 
 msgid "No Printer Management"
 msgstr "No Printer Management"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5903,10 +5706,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Port is not valid ldap/ldaps ports"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6130,9 +5929,6 @@ msgstr "Printer updated!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client Management"
@@ -6332,10 +6128,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Results"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6581,18 +6373,7 @@ msgid "Search Base DN"
 msgstr "Search"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Search"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Search"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Search"
 
 #, fuzzy
@@ -6600,9 +6381,6 @@ msgid "Search Scope"
 msgstr "Search"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6981,9 +6759,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7505,10 +7280,6 @@ msgid "Subnet Group updated!"
 msgstr "Group added"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Export Groups"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Export Groups"
 
@@ -7657,9 +7428,6 @@ msgstr "User created"
 msgid "Task State Updated!"
 msgstr "Task State added, editing"
 
-msgid "Task States"
-msgstr "Task States"
-
 msgid "Task Type"
 msgstr "Task Type"
 
@@ -7709,9 +7477,6 @@ msgstr "Task type is not valid"
 
 msgid "Task Type is not valid"
 msgstr "Task Type is not valid"
-
-msgid "Task Types"
-msgstr "Task Types"
 
 #, fuzzy
 msgid "Task failed"
@@ -7820,12 +7585,6 @@ msgstr "This setting defines "
 msgid "The API is disabled"
 msgstr "Donations are disabled"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "There are no groups on this server."
@@ -7844,9 +7603,6 @@ msgstr "Could not read temp file"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " no longer exists"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7887,9 +7643,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7959,9 +7712,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8159,9 +7909,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | This is not the primary group"
@@ -8216,10 +7963,6 @@ msgstr ""
 msgid "This setting"
 msgstr "This setting defines "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "This setting defines "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8271,10 +8014,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "There are no snapins associated with this host"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8739,10 +8478,6 @@ msgid "User Create Success"
 msgstr "User created"
 
 #, fuzzy
-msgid "User DN"
-msgstr "User Name"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Groups"
 
@@ -8826,9 +8561,6 @@ msgstr "Install / Update Successful!"
 msgid "User added!"
 msgstr "Printer Name"
 
-msgid "User call is invalid"
-msgstr "User call is invalid"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Printer Name"
@@ -8841,9 +8573,6 @@ msgstr "User update failed"
 msgid "User group updated!"
 msgstr "User updated"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Record not found, Error: %s"
@@ -8855,10 +8584,6 @@ msgstr "User update failed"
 #, fuzzy
 msgid "User updated!"
 msgstr "User updated"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Please enter a name for this LDAP server."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8880,15 +8605,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Username"
-
 msgid "Users"
 msgstr "Users"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8955,10 +8673,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Storage Node Name"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Cannot connect to database"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8981,9 +8695,6 @@ msgstr "has been successfully updated"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -8999,10 +8710,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Host Description"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9045,16 +8752,8 @@ msgid "Windows Key updated!"
 msgstr "User Management"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Product Key"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "An image already exists with this name!"
 
 msgid "Wipes"
 msgstr ""
@@ -9176,16 +8875,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9227,9 +8920,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9301,7 +8991,7 @@ msgstr "filesize"
 msgid "fog-admins"
 msgstr "Domain name"
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 #, fuzzy
@@ -9339,14 +9029,6 @@ msgstr "has been successfully updated"
 
 msgid "has been successfully updated"
 msgstr "has been successfully updated"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "has been destroyed"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Invalid Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9525,10 +9207,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9540,9 +9218,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9577,9 +9252,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9739,9 +9411,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9798,9 +9467,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Storage Group Updated"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9859,9 +9525,6 @@ msgstr "No key being requested"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "No key being requested"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "to review."
@@ -9930,13 +9593,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "not within this"
 
 #, fuzzy
 msgid "with this group"
@@ -10088,12 +9744,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Path"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Cannot connect to database"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Channel call is invalid"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Settings"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Could not read tmp file."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Could not read tmp file."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10116,6 +9802,14 @@ msgstr ""
 #~ msgstr "No hash available"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Donations are disabled"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Export Hosts"
 
@@ -10128,6 +9822,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Host Location"
 
 #~ msgid "Export Printers"
@@ -10174,8 +9872,28 @@ msgstr ""
 #~ msgstr "I am not the fog web server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "File"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reboot"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Method does not exist"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Location Updated"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10194,12 +9912,32 @@ msgstr ""
 #~ msgstr "Group added"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Group create failed"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Group create failed"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "User update failed"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "Update Settings"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Printer already exists"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Printer already exists"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Printer already exists"
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10221,6 +9959,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "User update failed"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Location Updated"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Host List"
@@ -10236,6 +9985,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Snapin History"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host Update Failed"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10270,6 +10023,22 @@ msgstr ""
 #~ msgstr "User updated"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "User Management"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "User Management"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "User Management"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Import Hosts"
 
@@ -10278,6 +10047,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Host Location"
 
 #~ msgid "Import Printers"
@@ -10306,12 +10079,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "All Storage Nodes"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Import Groups"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Task States"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task Types"
+
 #~ msgid "Import Users"
 #~ msgstr "Import Users"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Invalid type"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Select a valid image"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Invalid method called"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Image Association"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10330,11 +10134,28 @@ msgstr ""
 #~ msgstr "List All %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task States"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task Types"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Image Association"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No node associated"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "No FOGPage Class found for this node"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NOT"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "User update failed"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10366,8 +10187,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Please enter a name for this location."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Port is not valid ldap/ldaps ports"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Registered"
 #~ msgstr "Registered"
@@ -10375,6 +10203,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remove selected snapins"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Results"
 
 #~ msgid "Results"
 #~ msgstr "Results"
@@ -10435,8 +10267,19 @@ msgstr ""
 #~ msgstr "Printer update failed!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Search"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Search"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Image Association"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10450,8 +10293,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Created"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Export Groups"
+
 #~ msgid "Successful"
 #~ msgstr "Successful"
+
+#~ msgid "Task States"
+#~ msgstr "Task States"
+
+#~ msgid "Task Types"
+#~ msgstr "Task Types"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10481,6 +10334,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | This is not the master node"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "This setting defines "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "There are no snapins associated with this host"
+
 #~ msgid "Total Rows"
 #~ msgstr "Total Rows"
 
@@ -10503,6 +10364,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Update Printer"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "User Name"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10548,6 +10413,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Service Updated!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "User call is invalid"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Please enter a name for this LDAP server."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Username"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Cannot connect to database"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "An image already exists with this name!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Latest Version"
@@ -10568,6 +10460,18 @@ msgstr ""
 #~ msgstr "Completed"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "has been destroyed"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Invalid Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Active Multicast Tasks"
 
@@ -10578,3 +10482,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "not within this"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -750,9 +750,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "actualización de servicio no pudo"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr ""
 
@@ -760,12 +757,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1086,10 +1077,6 @@ msgid "CA Certificate Path"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Camino"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "clave privada fracasó"
 
@@ -1190,10 +1177,6 @@ msgstr "tarea Cancelado"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelada debido a las nuevas tareas a la vez."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Error: No se pudo descargar kernel"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1236,10 +1219,6 @@ msgstr "Nombre snapin"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Nombre snapin"
-
-#, fuzzy
-msgid "Capone Deploy"
-msgstr "última Desplegado"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1319,10 +1298,6 @@ msgid "Channel"
 msgstr ""
 
 #, fuzzy
-msgid "Channel call is invalid"
-msgstr "La imagen no está habilitada"
-
-#, fuzzy
 msgid "Channel not found"
 msgstr "Registro no encontrado, error: %s"
 
@@ -1344,6 +1319,9 @@ msgid "Check %s over before installing it."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid "Check the password stored for this node"
 msgstr ""
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
@@ -1552,22 +1530,7 @@ msgstr "No se pudo leer el archivo tmp."
 msgid "Could not read snapin file"
 msgstr "No se pudo leer el archivo tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "No se pudo leer el archivo tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "No se pudo leer el archivo tmp."
-
 msgid "Could not read tmp file."
-msgstr "No se pudo leer el archivo tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
@@ -1577,10 +1540,6 @@ msgstr "No se pudo crear la impresora"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1913,10 +1872,6 @@ msgid "Default Width"
 msgstr "Ancho por defecto"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Ancho por defecto"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "No se puede abrir archivo para lectura"
 
@@ -1984,9 +1939,6 @@ msgstr "Descarga fracasó"
 #, fuzzy
 msgid "Deploy Method"
 msgstr "última Desplegado"
-
-msgid "Depth"
-msgstr ""
 
 #, fuzzy
 msgid "Description"
@@ -2157,10 +2109,6 @@ msgid "Edit Capone"
 msgstr "snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Descripción del Grupo"
 
@@ -2180,9 +2128,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2332,10 +2277,6 @@ msgid "Export LDAP Servers"
 msgstr "servidor TFTP"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "Lista de host"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Exportar"
 
@@ -2442,6 +2383,9 @@ msgstr "Añadir fallidos SNAPin!"
 #, fuzzy
 msgid "FTP Path"
 msgstr "Camino"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "Ha fallado"
@@ -2689,10 +2633,6 @@ msgid "Files Deleted List"
 msgstr "Eliminar los datos del archivo"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Archivo"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "No hay snapins asociados"
 
@@ -2798,10 +2738,6 @@ msgstr "Acción"
 #, fuzzy
 msgid "Function Error"
 msgstr "Acción"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Método no existe"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2970,18 +2906,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Lista de host"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "actualización de servicio no pudo"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "información de LDAP actualizado!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Camino snapin"
 
@@ -3054,10 +2978,6 @@ msgid "Group Update Fail"
 msgstr "Grupo Error de creación"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Grupo Error de creación"
 
@@ -3072,10 +2992,6 @@ msgstr "grupo añadió"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "tipo de tarea no es válida"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "actualización Valoración falló"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3203,18 +3119,6 @@ msgstr "nombre de host"
 msgid "Host"
 msgstr "Anfitrión"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Impresora ya existe"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Impresora ya existe"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Impresora ya existe"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creado"
@@ -3304,18 +3208,6 @@ msgid "Host List"
 msgstr "Hospedadores"
 
 #, fuzzy
-msgid "Host Location"
-msgstr "Lista de host"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "actualización de servicio no pudo"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "información de LDAP actualizado!"
-
-#, fuzzy
 msgid "Host Login History"
 msgstr "Camino snapin"
 
@@ -3376,10 +3268,6 @@ msgstr "Camino snapin"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "actualización Valoración falló"
 
 #, fuzzy
@@ -3691,22 +3579,6 @@ msgid "Image Used"
 msgstr "Nombre de la imagen"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Impresora TCP / IP Port"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "actualización Valoración falló"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Actualizar impresora"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Nombre del núcleo"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nombre de la imagen"
 
@@ -3825,10 +3697,6 @@ msgid "Import Failed"
 msgstr "imagen actualizada"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Lista de host"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Importar"
 
@@ -3845,28 +3713,12 @@ msgid "Import Reports"
 msgstr "Importar"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "grupo está"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Exitoso"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Exitoso"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Tipo de tarea"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Tipo de tarea"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Impresora TCP / IP Port"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -4068,10 +3920,6 @@ msgstr "carpeta no válida"
 msgid "Invalid Windows product key"
 msgstr "Clave del producto Grupo"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Seleccionar una imagen válida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4113,10 +3961,6 @@ msgstr "Clave no válida se retira"
 
 msgid "Invalid key being set"
 msgstr "está estableciendo tecla no válida"
-
-#, fuzzy
-msgid "Invalid method called"
-msgstr "Valor no válido Tiempo de espera"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4241,9 +4085,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4293,10 +4134,6 @@ msgid "Key"
 msgstr "DMI clave"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Asociación para la imagen"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Evento debe ser una cadena"
 
@@ -4319,9 +4156,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Matar"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4443,10 +4277,6 @@ msgstr "Impresora actualiza!"
 msgid "LDAP Server updated!"
 msgstr "Impresora actualiza!"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "servidor TFTP"
-
 msgid "Language"
 msgstr ""
 
@@ -4479,9 +4309,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4552,14 +4379,6 @@ msgid "List All Plugins"
 msgstr "Nombre de la impresora"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Nombre de la tarea"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipo de tarea"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "No disponible"
 
@@ -4586,10 +4405,6 @@ msgstr "La carga de datos de campo de %s"
 #, fuzzy
 msgid "Location"
 msgstr "Acción"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Asociación para la imagen"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4626,9 +4441,6 @@ msgstr "actualización de servicio no pudo"
 #, fuzzy
 msgid "Location added!"
 msgstr "Nombre de dominio"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -5029,10 +4841,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NO"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NO"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -5065,16 +4873,9 @@ msgstr "Evento debe ser una cadena"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Evento debe ser una cadena"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Evento debe ser una cadena"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "actualización Valoración falló"
 
 msgid "Network Information"
 msgstr "Información de la red"
@@ -5147,9 +4948,6 @@ msgstr "Sin imagen especificada"
 
 msgid "No Printer Management"
 msgstr "Sin administración de la impresora"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -6044,10 +5842,6 @@ msgstr ""
 msgid "Port"
 msgstr "Puerto"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Por favor seleccione una opción"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6276,10 +6070,6 @@ msgid "Providers"
 msgstr ""
 
 #, fuzzy
-msgid "Pushbullet Accounts"
-msgstr "Añadir nueva cuenta de usuario"
-
-#, fuzzy
 msgid "Pushbullet Management"
 msgstr "Gestión de usuarios"
 
@@ -6482,10 +6272,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "resultados"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6734,18 +6520,7 @@ msgid "Search Base DN"
 msgstr "Buscar"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Buscar"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Buscar"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Buscar"
 
 #, fuzzy
@@ -6753,9 +6528,6 @@ msgid "Search Scope"
 msgstr "Buscar"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -7136,10 +6908,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-#, fuzzy
-msgid "Slack Accounts"
-msgstr "Añadir nueva cuenta de usuario"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7688,10 +7456,6 @@ msgid "Subnet Group updated!"
 msgstr "grupo añadió"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Exportar"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Exportar"
 
@@ -7843,10 +7607,6 @@ msgstr "creado por el usuario"
 msgid "Task State Updated!"
 msgstr "Nombre de la tarea"
 
-#, fuzzy
-msgid "Task States"
-msgstr "Nombre de la tarea"
-
 msgid "Task Type"
 msgstr "Tipo de tarea"
 
@@ -7897,10 +7657,6 @@ msgstr "tipo de tarea no es válida"
 #, fuzzy
 msgid "Task Type is not valid"
 msgstr "tipo de tarea no es válida"
-
-#, fuzzy
-msgid "Task Types"
-msgstr "Tipo de tarea"
 
 #, fuzzy
 msgid "Task failed"
@@ -8008,12 +7764,6 @@ msgstr ""
 msgid "The API is disabled"
 msgstr "Ancho por defecto"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "No hay grupos en este servidor."
@@ -8030,9 +7780,6 @@ msgid "The FOG account could not be created"
 msgstr "No se pudo leer el archivo temporal"
 
 msgid "The FOG account for this identity no longer exists"
-msgstr ""
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
 msgstr ""
 
 msgid "The ID token carries no subject"
@@ -8074,9 +7821,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -8147,9 +7891,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8349,9 +8090,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 msgid "This is not the master for this group"
 msgstr ""
 
@@ -8403,10 +8141,6 @@ msgstr ""
 msgid "This setting"
 msgstr ""
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Este ajuste define "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8454,10 +8188,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "No hay snapins asociados con este anfitrión"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8923,10 +8653,6 @@ msgid "User Create Success"
 msgstr "creado por el usuario"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nombre de usuario"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Grupo"
 
@@ -9012,10 +8738,6 @@ msgid "User added!"
 msgstr "Nombre de la impresora"
 
 #, fuzzy
-msgid "User call is invalid"
-msgstr "imagen asignado"
-
-#, fuzzy
 msgid "User group added!"
 msgstr "Nombre de la impresora"
 
@@ -9026,9 +8748,6 @@ msgstr "actualización Valoración falló"
 #, fuzzy
 msgid "User group updated!"
 msgstr "el usuario actualiza"
-
-msgid "User matched none of the mapped groups"
-msgstr ""
 
 #, fuzzy
 msgid "User not found"
@@ -9041,10 +8760,6 @@ msgstr "actualización Valoración falló"
 #, fuzzy
 msgid "User updated!"
 msgstr "el usuario actualiza"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Error: No se pudo descargar kernel"
 
 #, fuzzy
 msgid "User/Channel"
@@ -9068,15 +8783,8 @@ msgid "Username must end with a number or letter."
 msgstr ""
 
 #, fuzzy
-msgid "Username was blank"
-msgstr "Nombre de usuario"
-
-#, fuzzy
 msgid "Users"
 msgstr "Usuario"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -9142,10 +8850,6 @@ msgstr ""
 msgid "We are node name"
 msgstr ""
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Error: No se pudo descargar kernel"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -9168,9 +8872,6 @@ msgstr "se ha actualizado correctamente"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -9186,10 +8887,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Descripción de la impresora"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Nombre del núcleo"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9232,16 +8929,8 @@ msgid "Windows Key updated!"
 msgstr "Nombre del núcleo"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Nombre del núcleo"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Clave del producto Grupo"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Una imagen ya existe con este nombre!"
 
 msgid "Wipes"
 msgstr ""
@@ -9363,16 +9052,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9414,9 +9097,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9489,7 +9169,7 @@ msgstr "tamaño del archivo"
 msgid "fog-admins"
 msgstr "Nombre de dominio"
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 #, fuzzy
@@ -9527,14 +9207,6 @@ msgstr "se ha actualizado correctamente"
 
 msgid "has been successfully updated"
 msgstr "se ha actualizado correctamente"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "Deben estar cifrados"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "tarea no válido"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9714,10 +9386,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI clave"
-
 msgid "keys"
 msgstr ""
 
@@ -9729,9 +9397,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9765,9 +9430,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9926,9 +9588,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "snapin"
@@ -9986,9 +9645,6 @@ msgstr ""
 msgid "the group has no enabled master node"
 msgstr "Nombre del grupo de almacenamiento"
 
-msgid "the host defined location where available"
-msgstr ""
-
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
 
@@ -10044,9 +9700,6 @@ msgstr "se requiere ninguna clave"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "se requiere ninguna clave"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "para revisar."
@@ -10115,13 +9768,6 @@ msgstr "windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "no dentro de este"
 
 #, fuzzy
 msgid "with this group"
@@ -10274,12 +9920,44 @@ msgstr ""
 #~ msgstr "Guardar cambios"
 
 #, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Camino"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Capone Deploy"
+#~ msgstr "última Desplegado"
+
+#, fuzzy
+#~ msgid "Channel call is invalid"
+#~ msgstr "La imagen no está habilitada"
+
+#, fuzzy
 #~ msgid "Check that database is running"
 #~ msgstr "Compruebe que la base de datos se está ejecutando"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Configuración Tecla"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10302,6 +9980,14 @@ msgstr ""
 #~ msgstr "No se dispone de hash"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Ancho por defecto"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Editar anfitrión"
 
@@ -10316,6 +10002,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Export LDAPs"
 #~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "Export Locations"
+#~ msgstr "Lista de host"
 
 #, fuzzy
 #~ msgid "Export Printers"
@@ -10362,8 +10052,28 @@ msgstr ""
 #~ msgstr "No se pudo crear Sesión"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Archivo"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reiniciar"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Método no existe"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "información de LDAP actualizado!"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10382,12 +10092,32 @@ msgstr ""
 #~ msgstr "grupo añadió"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Error de creación"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Grupo Error de creación"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "actualización Valoración falló"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "Descripción del Grupo"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Impresora ya existe"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Impresora ya existe"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Impresora ya existe"
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10410,6 +10140,18 @@ msgstr ""
 #~ msgstr "actualización Valoración falló"
 
 #, fuzzy
+#~ msgid "Host Location"
+#~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "información de LDAP actualizado!"
+
+#, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hospedadores"
 
@@ -10424,6 +10166,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Camino snapin"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10462,6 +10208,22 @@ msgstr ""
 #~ msgstr "el usuario actualiza"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Impresora TCP / IP Port"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "actualización Valoración falló"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Actualizar impresora"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Importar"
 
@@ -10472,6 +10234,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import LDAP Settings"
 #~ msgstr "snapins"
+
+#, fuzzy
+#~ msgid "Import Locations"
+#~ msgstr "Lista de host"
 
 #, fuzzy
 #~ msgid "Import Printers"
@@ -10502,12 +10268,44 @@ msgstr ""
 #~ msgstr "nodo de almacenamiento"
 
 #, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "grupo está"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
 #~ msgid "Import Users"
 #~ msgstr "Importar"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Impresora TCP / IP Port"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "tipo no válido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Seleccionar una imagen válida"
+
+#, fuzzy
+#~ msgid "Invalid method called"
+#~ msgstr "Valor no válido Tiempo de espera"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "servidor TFTP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10518,8 +10316,28 @@ msgstr ""
 #~ msgstr "Versión del sistema"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Nombre de la tarea"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipo de tarea"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Asociación para la imagen"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No nodo asociado"
+
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NO"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "actualización Valoración falló"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10549,8 +10367,16 @@ msgstr ""
 #~ msgid "Pause"
 #~ msgstr "Usuario"
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Por favor seleccione una opción"
+
 #~ msgid "Printer Alias"
 #~ msgstr "impresora Alias"
+
+#, fuzzy
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Añadir nueva cuenta de usuario"
 
 #~ msgid "Registered"
 #~ msgstr "Registrado"
@@ -10558,6 +10384,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remoto"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "resultados"
 
 #~ msgid "Results"
 #~ msgstr "resultados"
@@ -10615,8 +10445,20 @@ msgstr ""
 #~ msgstr "actualización de la impresora ha fallado!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Buscar"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Buscar"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Asociación para la imagen"
+
+#, fuzzy
+#~ msgid "Slack Accounts"
+#~ msgstr "Añadir nueva cuenta de usuario"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10630,8 +10472,20 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "nodo de almacenamiento"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Exportar"
+
 #~ msgid "Successful"
 #~ msgstr "Exitoso"
+
+#, fuzzy
+#~ msgid "Task States"
+#~ msgstr "Nombre de la tarea"
+
+#, fuzzy
+#~ msgid "Task Types"
+#~ msgstr "Tipo de tarea"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10661,6 +10515,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "La dirección MAC ya está en uso por otro host"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Este ajuste define "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "No hay snapins asociados con este anfitrión"
+
 #~ msgid "Total Rows"
 #~ msgstr "Filas totales"
 
@@ -10683,6 +10545,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Eliminar todos los elementos seleccionados"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nombre de usuario"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10729,6 +10595,34 @@ msgstr ""
 #~ msgstr "Servicio de Actualización!"
 
 #, fuzzy
+#~ msgid "User call is invalid"
+#~ msgstr "imagen asignado"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nombre de usuario"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Error: No se pudo descargar kernel"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Nombre del núcleo"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Una imagen ya existe con este nombre!"
+
+#, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Ultima versión"
 
@@ -10749,9 +10643,25 @@ msgstr ""
 #~ msgstr "suprimido"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "Deben estar cifrados"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "tarea no válido"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI clave"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "MulticastTask"
 
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versión"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "no dentro de este"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -731,9 +731,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
-msgid "All methods of binding have failed"
-msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Bandbreite sollte numerisch und größer als 0 sein."
@@ -743,12 +740,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
 
 #, fuzzy
 msgid "Already created"
@@ -1066,10 +1057,6 @@ msgid "CA Certificate Path"
 msgstr "Neuen Standort erstellen"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Pfad"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
 
@@ -1169,10 +1156,6 @@ msgstr "Stornierter Task"
 msgid "Cancelled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Anmeldung am LDAP-Server nicht möglich"
-
 msgid "Cannot change image when in tasking"
 msgstr "Das Image kann während eines Tasks nicht geändert werden"
 
@@ -1217,9 +1200,6 @@ msgstr "Snapin erstellen fehlgeschlagen"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin erfolgreich hinzugefügt"
-
-msgid "Capone Deploy"
-msgstr "Capone Verteilung"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1299,9 +1279,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "Kanalaufruf ist ungültig"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -1326,6 +1303,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1530,22 +1511,7 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
 msgid "Could not read tmp file."
-msgstr "Tmp-Datei konnte nicht gelesen werden."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -1555,10 +1521,6 @@ msgstr "Konnte nicht registriert werden."
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1885,10 +1847,6 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Standard ist deaktiviert"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Datei kann zum Lesen nicht geöffnet werden"
 
@@ -1953,9 +1911,6 @@ msgstr "Download fehlgeschlagen"
 
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Beschreibung"
@@ -2121,10 +2076,6 @@ msgid "Edit Capone"
 msgstr "Snapins exportieren"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Snapins exportieren"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Gruppeneinstellungen Module"
 
@@ -2145,9 +2096,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Standort senden aktivieren"
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2291,10 +2239,6 @@ msgid "Export LDAP Servers"
 msgstr "LDAP-Server"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "Standorte exportieren"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Benutzer exportieren"
 
@@ -2396,6 +2340,9 @@ msgstr "FTP-Verbindung fehlgeschlagen"
 
 msgid "FTP Path"
 msgstr "FTP-Pfad"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "fehlgeschlagen"
@@ -2633,10 +2580,6 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Filter"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Suche nach zugeordneten Images"
 
@@ -2742,10 +2685,6 @@ msgstr "Funktion"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funktion"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Methode ist nicht vorhanden"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2913,18 +2852,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -2995,10 +2922,6 @@ msgid "Group Update Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
@@ -3013,10 +2936,6 @@ msgstr "Gruppe hinzugefügt!"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3143,18 +3062,6 @@ msgstr "Startseite"
 msgid "Host"
 msgstr "Host"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Dieser Host ist bereits vorhanden."
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Dieser Host ist bereits vorhanden."
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Host erfolgreich erstellt"
@@ -3237,17 +3144,6 @@ msgstr "Host Kernel Argumente"
 msgid "Host List"
 msgstr "Hostliste"
 
-msgid "Host Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Standort aktualisiert"
-
 msgid "Host Login History"
 msgstr "Host-Login-Verlauf"
 
@@ -3304,10 +3200,6 @@ msgstr "Host Snapinverlauf"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
@@ -3612,22 +3504,6 @@ msgid "Image Used"
 msgstr "genutzte Images"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows-Schlüssel importieren"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows-Schlüssel erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows-Schlüssel aktualisiert"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Image hinzugefügt"
 
@@ -3740,10 +3616,6 @@ msgid "Import Failed"
 msgstr "Image aktualisiert"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "Standorte importieren"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Benutzer importieren"
 
@@ -3760,28 +3632,12 @@ msgid "Import Reports"
 msgstr "Berichte importieren"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppen importieren"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Import erfolgreich"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Import erfolgreich"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Taskstatus exportieren"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Task-Typen importieren"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows-Schlüssel importieren"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3979,10 +3835,6 @@ msgstr "Ungültige Einheit"
 msgid "Invalid Windows product key"
 msgstr "Host Produktschlüssel"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Wählen Sie ein gültiges Abbild"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4023,9 +3875,6 @@ msgstr "Ungültiger Schlüssel wurde angefordert"
 
 msgid "Invalid key being set"
 msgstr "Ungültiger Schlüssel wurde gesetzt"
-
-msgid "Invalid method called"
-msgstr "Ungültige Methode aufgerufen"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4146,9 +3995,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "indem es die max. Bandbreiteneinstellung desjenigen Knotens"
 
-msgid "It tells the client to download snapins from"
-msgstr "Es weist den Client an, Snapins vom hostdefinierten "
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4194,10 +4040,6 @@ msgid "Key"
 msgstr "DMI-Schlüssel"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Site Zugehörigkeit"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Schlüsselfeldname muss eine Zeichenfolge sein."
 
@@ -4221,10 +4063,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "sofort abbrechen"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4342,10 +4180,6 @@ msgstr "LDAP-Server aktualisiert"
 msgid "LDAP Server updated!"
 msgstr "LDAP-Server aktualisiert"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP-Server"
-
 msgid "Language"
 msgstr "Sprache"
 
@@ -4377,9 +4211,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4447,14 +4278,6 @@ msgid "List All Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Task Status"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Task-Typen"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Installierte Plugins"
 
@@ -4482,10 +4305,6 @@ msgstr "Laden von Daten zum Feld %s"
 
 msgid "Location"
 msgstr "Ort"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Standort Zugehörigkeiten"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4520,9 +4339,6 @@ msgstr "Standort erfolgreich aktualisiert"
 #, fuzzy
 msgid "Location added!"
 msgstr "Standort hinzugefügt"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4907,10 +4723,6 @@ msgstr "NAME"
 msgid "NOT"
 msgstr "NICHT"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "HINWEIS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4943,16 +4755,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Benutzer-Update fehlgeschlagen"
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -5024,9 +4829,6 @@ msgstr "Kein Image angegeben"
 
 msgid "No Printer Management"
 msgstr "Keine Druckerverwaltung"
-
-msgid "No access is allowed"
-msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5906,10 +5708,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6133,9 +5931,6 @@ msgstr "Drucker aktualisiert!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Accounts"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Client-Management"
@@ -6335,10 +6130,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Ergebnis"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6584,19 +6375,8 @@ msgid "Search Base DN"
 msgstr "Suche Basis DN"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Suche DN"
-
-msgid "Search DN did not return any results"
-msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
-
-#, fuzzy
 msgid "Search Key"
 msgstr "Suche"
-
-#, fuzzy
-msgid "Search Method"
-msgstr "Suchmethode"
 
 #, fuzzy
 msgid "Search Scope"
@@ -6604,9 +6384,6 @@ msgstr "Suchbereich"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Die Suche lieferte kein passendes Ergebnis"
 
 #, fuzzy
 msgid "Search settings"
@@ -6984,9 +6761,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7508,10 +7282,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppe aktualisiert"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppen exportieren"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppen exportieren"
 
@@ -7662,9 +7432,6 @@ msgstr "Task Status erfolgreich aktualisiert"
 msgid "Task State Updated!"
 msgstr "Task Status aktualisiert!"
 
-msgid "Task States"
-msgstr "Task Status"
-
 msgid "Task Type"
 msgstr "Task-Typ"
 
@@ -7714,9 +7481,6 @@ msgstr "Task-Typ ist nicht gültig"
 
 msgid "Task Type is not valid"
 msgstr "Task-Typ ist nicht gültig"
-
-msgid "Task Types"
-msgstr "Task-Typen"
 
 #, fuzzy
 msgid "Task failed"
@@ -7825,12 +7589,6 @@ msgstr "Die Einstellung 'ist Masterknoten' definiert,"
 msgid "The API is disabled"
 msgstr "Standard ist deaktiviert"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -7849,9 +7607,6 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "läuft nicht mehr"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7892,9 +7647,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7965,9 +7717,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -8165,9 +7914,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -8222,10 +7968,6 @@ msgstr "IP(s) dieses Servers"
 msgid "This setting"
 msgstr "Diese Einstellung"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Diese Einstellung definiert das Senden"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8277,9 +8019,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8744,10 +8483,6 @@ msgid "User Create Success"
 msgstr "Benutzer erfolgreich erstellt"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Benutzer DN"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Gruppen"
 
@@ -8831,9 +8566,6 @@ msgstr "Benutzeraktualisierung erfolgreich!"
 msgid "User added!"
 msgstr "Benutzer hinzugefügt"
 
-msgid "User call is invalid"
-msgstr "Benutzeraufruf ist ungültig"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Benutzer hinzugefügt"
@@ -8846,9 +8578,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 msgid "User group updated!"
 msgstr "Benutzer aktualisiert"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
@@ -8860,10 +8589,6 @@ msgstr "Benutzer-Update fehlgeschlagen"
 #, fuzzy
 msgid "User updated!"
 msgstr "Benutzer aktualisiert"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8885,15 +8610,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Benutzername"
-
 msgid "Users"
 msgstr "Benutzer"
-
-msgid "Using the group match function"
-msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
 msgid "VB Script"
 msgstr ""
@@ -8960,10 +8678,6 @@ msgstr "Wir sind Knoten-ID "
 msgid "We are node name"
 msgstr "Wir sind Knotenname "
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8986,9 +8700,6 @@ msgstr "wurde abgebrochen"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Wo bekomme ich Hilfe?"
@@ -9005,10 +8716,6 @@ msgstr "Fenstergröße muss größer sein als 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows-Schlüssel beschreibung"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows Keys"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9051,15 +8758,8 @@ msgid "Windows Key updated!"
 msgstr "Windows-Schlüssel aktualisiert"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows Keys"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Host Produktschlüssel"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
 
 msgid "Wipes"
 msgstr ""
@@ -9183,17 +8883,11 @@ msgstr "vor mir auf diesem Knoten"
 msgid "between"
 msgstr "zwischen"
 
-msgid "between different sites"
-msgstr "Stellen hin und her wechseln."
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "die Client Computer in den FOG"
-
-msgid "but bind password is not set"
-msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 msgid "but has recently failed for this host"
@@ -9235,9 +8929,6 @@ msgstr ""
 
 msgid "day"
 msgstr "Tag"
-
-msgid "deploy task occurs for it"
-msgstr "es eine Verteilungs-Task gibt."
 
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
@@ -9308,8 +8999,8 @@ msgstr "Dateigröße"
 msgid "fog-admins"
 msgstr "Domänen-Name"
 
-msgid "for Microsoft Windows to images"
-msgstr "MS Windows den Images zuordnet."
+msgid "for user"
+msgstr ""
 
 #, fuzzy
 msgid "found"
@@ -9346,14 +9037,6 @@ msgstr "wurde erfolgreich zerstört"
 
 msgid "has been successfully updated"
 msgstr "wurde erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "wurde abgeschlossen"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Ungültiges Snapin-Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9533,10 +9216,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "die Client Computer in den FOG"
 
-#, fuzzy
-msgid "key"
-msgstr "aktiviert werden."
-
 msgid "keys"
 msgstr ""
 
@@ -9549,9 +9228,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "auf 1 MBit/s begrenzen, "
-
-msgid "location url based on the host that checks in"
-msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 msgid "logged in"
 msgstr ""
@@ -9586,9 +9262,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
 
 #, fuzzy
 msgid "must be specified"
@@ -9748,9 +9421,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "mit Clients haben, die zwischen verschiedenen "
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9807,9 +9477,6 @@ msgstr "den folgenden Terminalbefehlen tun"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aktualisierung der Speichergruppe fehlgeschlagen"
-
-msgid "the host defined location where available"
-msgstr "Speicherort herunterzuladen, sofern verfügbar."
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9868,9 +9535,6 @@ msgstr "um den angeforderten Kernel herunterzuladen."
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "um den angeforderten Kernel herunterzuladen."
-
-msgid "to operate in an environment where there may be"
-msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
 
 msgid "to review."
 msgstr "um zu überprüfen."
@@ -9939,13 +9603,6 @@ msgstr "Windows"
 
 msgid "wipe out all of your images stored on"
 msgstr "alle Images auf sämtlichen"
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "Schlüssel beim Host."
 
 #, fuzzy
 msgid "with this group"
@@ -10088,6 +9745,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Alle Methoden der Bindung sind fehlgeschlagen"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Ermöglicht das Bearbeiten / Erstellen von Taskstatus, die FOG zurzeit hat."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Erlaubt das Bearbeiten/Erstellen von Task-Typen, die der FOG derzeit hat"
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
@@ -10100,12 +9766,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Pfad"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Anmeldung am LDAP-Server nicht möglich"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Verteilung"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "Kanalaufruf ist ungültig"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Client Einstellungen"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10127,6 +9823,14 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
+#, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Snapins exportieren"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Ereignis und Daten sind nicht gesetzt"
 
@@ -10143,6 +9847,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Standorte exportieren"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "Standorte exportieren"
 
 #~ msgid "Export Printers"
@@ -10189,8 +9897,28 @@ msgstr ""
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Methode ist nicht vorhanden"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10212,12 +9940,32 @@ msgstr ""
 #~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "Gruppeneinstellungen Module"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Dieser Host ist bereits vorhanden."
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10239,6 +9987,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Hostliste"
@@ -10254,6 +10013,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Host Snapinverlauf"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Host-Update fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10292,6 +10055,22 @@ msgstr ""
 #~ msgstr "Host aktualisiert!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows-Schlüssel aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows-Schlüssel erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows-Schlüssel aktualisiert"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts importieren"
 
@@ -10300,6 +10079,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Standorte importieren"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "Standorte importieren"
 
 #~ msgid "Import Printers"
@@ -10328,12 +10111,50 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Alle Speicherknoten"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppen importieren"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Taskstatus exportieren"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Task-Typen importieren"
+
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows-Schlüssel importieren"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Ungültiger Typ"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Wählen Sie ein gültiges Abbild"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Ungültige Methode aufgerufen"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "Es weist den Client an, Snapins vom hostdefinierten "
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Site Zugehörigkeit"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP-Server"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10352,11 +10173,34 @@ msgstr ""
 #~ msgstr "Alle %s auflisten"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Task Status"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Task-Typen"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Standort Zugehörigkeiten"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "zugeordneter Host"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "HINWEIS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Benutzer-Update fehlgeschlagen"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Kein Zugriff erlaubt"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10392,8 +10236,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Bitte geben Sie einen Namen für einen Admin oder einen mobilen Lookup ein."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Dieser Port ist kein gültiger LDAP/LADPS Port"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Drucker-Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Accounts"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
@@ -10404,6 +10255,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Ausgewählte entfernen?"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Ergebnis"
 
 #~ msgid "Results"
 #~ msgstr "Ergebnisse"
@@ -10464,8 +10319,25 @@ msgstr ""
 #~ msgstr "Drucker-Update fehlgeschlagen!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Suche DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Suche DN hat keine Ergebnisse zurückgegeben"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Suchmethode"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Die Suche lieferte kein passendes Ergebnis"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Site Zugehörigkeit"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10479,8 +10351,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppen exportieren"
+
 #~ msgid "Successful"
 #~ msgstr "Erfolgreich"
+
+#~ msgid "Task States"
+#~ msgstr "Task Status"
+
+#~ msgid "Task Types"
+#~ msgstr "Task-Typen"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10493,6 +10375,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10510,9 +10395,19 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Es gibt keine Snapins auf diesem Server."
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Dies ist besonders nützlich, wenn Sie mehrere Standorte "
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Diese Einstellung definiert das Senden"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Diese Images sollten mit dem zugehörigen Schlüssel"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
@@ -10536,6 +10431,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Drucker Aktualisieren/Entfernen"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Benutzer DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10581,6 +10480,38 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Site aktualisiert!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "Benutzeraufruf ist ungültig"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Der Benutzer war nicht vom LDAP-Server autorisiert"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Benutzername"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Wenn das Plugin entfernt wird, verbleibt der zugewiesene"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows Keys"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows Keys"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows Keys ist ein Plugin, das Produktschlüssel für"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Sie haben Version"
@@ -10596,24 +10527,67 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "vor mir"
 
+#~ msgid "between different sites"
+#~ msgstr "Stellen hin und her wechseln."
+
 #~ msgid "but"
 #~ msgstr "aber "
+
+#~ msgid "but bind password is not set"
+#~ msgstr "aber das Anmeldekennwort ist nicht festgelegt."
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Abgeschlossen"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "es eine Verteilungs-Task gibt."
+
 #~ msgid "e.g."
 #~ msgstr "z.B."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "MS Windows den Images zuordnet."
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "wurde abgeschlossen"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Ungültiges Snapin-Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "aktiviert werden."
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "der Standort-URL basierend auf dem Host, der eincheckt."
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Aktive Multicast-Tasks"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "Orte gibt, an denen Sie Ihr Image abrufen können"
+
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "mit Clients haben, die zwischen verschiedenen "
+
+#~ msgid "the host defined location where available"
+#~ msgstr "Speicherort herunterzuladen, sofern verfügbar."
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "in einer Umgebung arbeiten kann, in der es mehrere"
+
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "Schlüssel beim Host."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -736,9 +736,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Installation / Mise à jour réussie!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "La bande passante doit être numérique et supérieur à 0"
@@ -747,12 +744,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1071,10 +1062,6 @@ msgid "CA Certificate Path"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Chemin"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "La clé privée a échoué"
 
@@ -1174,10 +1161,6 @@ msgstr "tâche Annulé"
 msgid "Cancelled due to new tasking."
 msgstr "Annulé en raison de nouvelles tâches."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Impossible de se connecter à la base de données"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1221,9 +1204,6 @@ msgstr "snapin mise à jour"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "snapin mise à jour"
-
-msgid "Capone Deploy"
-msgstr "Capone Déployer"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1303,9 +1283,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "appel de canal est invalide"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Enregistrement non trouvé, Erreur: %s"
@@ -1330,6 +1307,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Non FOGPage Classe trouvé pour ce noeud"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1534,22 +1515,7 @@ msgstr "Impossible de lire le fichier tmp."
 msgid "Could not read snapin file"
 msgstr "Impossible de lire le fichier tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Impossible de lire le fichier tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Impossible de lire le fichier tmp."
-
 msgid "Could not read tmp file."
-msgstr "Impossible de lire le fichier tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
@@ -1559,10 +1525,6 @@ msgstr "Impossible de créer l'imprimante"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1889,10 +1851,6 @@ msgid "Default Width"
 msgstr "Par défaut Largeur"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "Les dons sont désactivés"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Impossible d'ouvrir le fichier pour la lecture"
 
@@ -1957,9 +1915,6 @@ msgstr "Échec du téléchargement"
 
 msgid "Deploy Method"
 msgstr "Déployer Méthode"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "La description"
@@ -2125,10 +2080,6 @@ msgid "Edit Capone"
 msgstr "Export SnapIns"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export SnapIns"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "hôte description de"
 
@@ -2147,9 +2098,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2294,10 +2242,6 @@ msgid "Export LDAP Servers"
 msgstr "Serveur LDAP"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "hôte Lieu"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Les utilisateurs d'exportation"
 
@@ -2399,6 +2343,9 @@ msgstr "Connexion FTP a échoué"
 
 msgid "FTP Path"
 msgstr "Chemin FTP"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "Échoué"
@@ -2636,10 +2583,6 @@ msgid "Files Deleted List"
 msgstr "Supprimer les données de fichiers"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Fichier"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Aucun snapins associés"
 
@@ -2745,10 +2688,6 @@ msgstr "action"
 #, fuzzy
 msgid "Function Error"
 msgstr "action"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "Méthode n'existe pas"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2916,18 +2855,6 @@ msgid "Group Kernel Arguments"
 msgstr "Arguments Groupe Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "hôte Lieu"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Emplacement Mise à jour"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Historique de connexion"
 
@@ -2999,10 +2926,6 @@ msgid "Group Update Fail"
 msgstr "Groupe create a échoué"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Groupe create a échoué"
 
@@ -3017,10 +2940,6 @@ msgstr "Groupe ajouté"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Groupe est non valide"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "mise à jour de l'utilisateur a échoué"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3146,18 +3065,6 @@ msgstr "Accueil"
 msgid "Host"
 msgstr "Hôte"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Imprimante existe déjà"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Imprimante existe déjà"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Imprimante existe déjà"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "hôte Créé"
@@ -3240,17 +3147,6 @@ msgstr "Hôte Arguments Kernel"
 msgid "Host List"
 msgstr "Liste des hôtes"
 
-msgid "Host Location"
-msgstr "hôte Lieu"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Emplacement Mise à jour"
-
 msgid "Host Login History"
 msgstr "Hôte Connexion Histoire"
 
@@ -3307,10 +3203,6 @@ msgstr "snapin Histoire"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Mise à jour de l'hôte a échoué"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
@@ -3615,22 +3507,6 @@ msgid "Image Used"
 msgstr "imager"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Gestion des utilisateurs"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nom de l'image"
 
@@ -3743,10 +3619,6 @@ msgid "Import Failed"
 msgstr "image mise à jour"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "hôte Lieu"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "Importer des utilisateurs"
 
@@ -3763,28 +3635,12 @@ msgid "Import Reports"
 msgstr "Hôtes d'importation"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Importer des groupes"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Réussi"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Réussi"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Unis Groupe"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Types de tâches"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3981,10 +3837,6 @@ msgstr "URL invalide"
 msgid "Invalid Windows product key"
 msgstr "Hôte clé de produit"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Sélectionnez une image valide"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4025,9 +3877,6 @@ msgstr "clé non valide étant retirée"
 
 msgid "Invalid key being set"
 msgstr "Clé non valide étant réglée"
-
-msgid "Invalid method called"
-msgstr "Méthode invalide appelé"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4148,9 +3997,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4196,10 +4042,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Association Image"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Événement doit être une chaîne"
 
@@ -4222,9 +4064,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Tuer"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4342,10 +4181,6 @@ msgstr "Serveur LDAP Nom"
 msgid "LDAP Server updated!"
 msgstr "Serveur LDAP Nom"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "Serveur LDAP"
-
 msgid "Language"
 msgstr "La langue"
 
@@ -4377,9 +4212,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4447,14 +4279,6 @@ msgid "List All Plugins"
 msgstr "Installer Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Unis Groupe"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Types de tâches"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Plugins installés"
 
@@ -4481,10 +4305,6 @@ msgstr "Chargement des données à champ %s"
 
 msgid "Location"
 msgstr "Emplacement"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Association Image"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4519,9 +4339,6 @@ msgstr "Installation / Mise à jour réussie!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Nom de la localisation"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4906,10 +4723,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NE PAS"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NE PAS"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4942,16 +4755,9 @@ msgstr "Événement doit être une chaîne"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Événement doit être une chaîne"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Événement doit être une chaîne"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "mise à jour de l'utilisateur a échoué"
 
 msgid "Network Information"
 msgstr "Réseau d'information"
@@ -5023,9 +4829,6 @@ msgstr "Pas d'image spécifiée"
 
 msgid "No Printer Management"
 msgstr "Pas de gestion de l'imprimante"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5905,10 +5708,6 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "Port est pas ldap valide / LDAPS ports"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6132,9 +5931,6 @@ msgstr "Imprimante mis à jour!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Comptes Pushbullet"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "La gestion des clients"
@@ -6334,10 +6130,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Résultats"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6583,18 +6375,7 @@ msgid "Search Base DN"
 msgstr "Chercher"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Chercher"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Chercher"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Chercher"
 
 #, fuzzy
@@ -6602,9 +6383,6 @@ msgid "Search Scope"
 msgstr "Chercher"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6983,9 +6761,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Comptes Slack"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7507,10 +7282,6 @@ msgid "Subnet Group updated!"
 msgstr "Groupe ajouté"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Groupes d'exportation"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Groupes d'exportation"
 
@@ -7659,9 +7430,6 @@ msgstr "utilisateur créé"
 msgid "Task State Updated!"
 msgstr "État Tâche ajouté, édition"
 
-msgid "Task States"
-msgstr "Unis Groupe"
-
 msgid "Task Type"
 msgstr "type de tâche"
 
@@ -7711,9 +7479,6 @@ msgstr "Type de tâche n'est pas valide"
 
 msgid "Task Type is not valid"
 msgstr "Type de tâche n'est pas valide"
-
-msgid "Task Types"
-msgstr "Types de tâches"
 
 #, fuzzy
 msgid "Task failed"
@@ -7822,12 +7587,6 @@ msgstr "Ce paramètre définit "
 msgid "The API is disabled"
 msgstr "Les dons sont désactivés"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Il n'y a pas de groupes sur ce serveur."
@@ -7846,9 +7605,6 @@ msgstr "Impossible de lire le fichier temporaire"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " n'existe plus"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7889,9 +7645,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7961,9 +7714,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8161,9 +7911,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | Cela ne veut pas le groupe principal"
@@ -8218,10 +7965,6 @@ msgstr ""
 msgid "This setting"
 msgstr "Ce paramètre définit "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Ce paramètre définit "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8273,10 +8016,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "Il n'y a pas snapins associés à cet hôte"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8741,10 +8480,6 @@ msgid "User Create Success"
 msgstr "utilisateur créé"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nom d'utilisateur"
-
-#, fuzzy
 msgid "User Group"
 msgstr "Groupes"
 
@@ -8828,9 +8563,6 @@ msgstr "Installation / Mise à jour réussie!"
 msgid "User added!"
 msgstr "Nom de l'imprimante"
 
-msgid "User call is invalid"
-msgstr "appel de l'utilisateur est invalide"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Nom de l'imprimante"
@@ -8843,9 +8575,6 @@ msgstr "mise à jour de l'utilisateur a échoué"
 msgid "User group updated!"
 msgstr "mis à jour l'utilisateur"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Enregistrement non trouvé, Erreur: %s"
@@ -8857,10 +8586,6 @@ msgstr "mise à jour de l'utilisateur a échoué"
 #, fuzzy
 msgid "User updated!"
 msgstr "mis à jour l'utilisateur"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "S'il vous plaît entrez un nom pour ce serveur LDAP."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8882,15 +8607,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nom d'utilisateur"
-
 msgid "Users"
 msgstr "Utilisateurs"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8957,10 +8675,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Nom du nœud de stockage"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Impossible de se connecter à la base de données"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8983,9 +8697,6 @@ msgstr "a été mis à jour avec succès"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -9001,10 +8712,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "hôte description de"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9047,16 +8754,8 @@ msgid "Windows Key updated!"
 msgstr "Gestion des utilisateurs"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Hôte clé de produit"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Une image existe déjà avec ce nom!"
 
 msgid "Wipes"
 msgstr ""
@@ -9178,16 +8877,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9229,9 +8922,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9303,7 +8993,7 @@ msgstr "taille du fichier"
 msgid "fog-admins"
 msgstr "Nom de domaine"
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 #, fuzzy
@@ -9341,14 +9031,6 @@ msgstr "a été mis à jour avec succès"
 
 msgid "has been successfully updated"
 msgstr "a été mis à jour avec succès"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "a été détruit"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Invalid Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9527,10 +9209,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9542,9 +9220,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9579,9 +9254,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9741,9 +9413,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "snapin"
@@ -9800,9 +9469,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Groupe de stockage Mise à jour"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9861,9 +9527,6 @@ msgstr "Aucune clé demandée"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "Aucune clé demandée"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "réviser."
@@ -9932,13 +9595,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "pas dans ce"
 
 #, fuzzy
 msgid "with this group"
@@ -10090,12 +9746,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Chemin"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Impossible de se connecter à la base de données"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Déployer"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "appel de canal est invalide"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Paramètres"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10118,6 +9804,14 @@ msgstr ""
 #~ msgstr "Pas de hachage disponible"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "Les dons sont désactivés"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export SnapIns"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Les hôtes à l'exportation"
 
@@ -10130,6 +9824,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "hôte Lieu"
 
 #~ msgid "Export Printers"
@@ -10176,8 +9874,28 @@ msgstr ""
 #~ msgstr "Je ne suis pas le serveur web de brouillard"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Fichier"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Réinitialiser"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "Méthode n'existe pas"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Emplacement Mise à jour"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10196,12 +9914,32 @@ msgstr ""
 #~ msgstr "Groupe ajouté"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Groupe create a échoué"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Groupe create a échoué"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "mise à jour de l'utilisateur a échoué"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "hôte description de"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Imprimante existe déjà"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Imprimante existe déjà"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Imprimante existe déjà"
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10223,6 +9961,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "mise à jour de l'utilisateur a échoué"
 
+#~ msgid "Host Location"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Emplacement Mise à jour"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Liste des hôtes"
@@ -10238,6 +9987,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "snapin Histoire"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Mise à jour de l'hôte a échoué"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10276,6 +10029,22 @@ msgstr ""
 #~ msgstr "mis à jour l'utilisateur"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Gestion des utilisateurs"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hôtes d'importation"
 
@@ -10284,6 +10053,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "hôte Lieu"
 
 #~ msgid "Import Printers"
@@ -10312,12 +10085,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Tous les nœuds de stockage"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Importer des groupes"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Unis Groupe"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Types de tâches"
+
 #~ msgid "Import Users"
 #~ msgstr "Importer des utilisateurs"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "Type non valide"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Sélectionnez une image valide"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Méthode invalide appelé"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Association Image"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "Serveur LDAP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10336,11 +10140,28 @@ msgstr ""
 #~ msgstr "Lister tous les %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Unis Groupe"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Types de tâches"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Association Image"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "Aucun noeud associé"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "Non FOGPage Classe trouvé pour ce noeud"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NE PAS"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "mise à jour de l'utilisateur a échoué"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10372,8 +10193,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "S'il vous plaît entrer un nom pour cet emplacement."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "Port est pas ldap valide / LDAPS ports"
+
 #~ msgid "Printer Alias"
 #~ msgstr "imprimante Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Comptes Pushbullet"
 
 #~ msgid "Registered"
 #~ msgstr "Inscrit"
@@ -10381,6 +10209,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Retirer snapins sélectionnés"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Résultats"
 
 #~ msgid "Results"
 #~ msgstr "Résultats"
@@ -10441,8 +10273,19 @@ msgstr ""
 #~ msgstr "mise à jour de l'imprimante a échoué!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Chercher"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Chercher"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Association Image"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Comptes Slack"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10456,8 +10299,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nœud de stockage Créé"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Groupes d'exportation"
+
 #~ msgid "Successful"
 #~ msgstr "Réussi"
+
+#~ msgid "Task States"
+#~ msgstr "Unis Groupe"
+
+#~ msgid "Task Types"
+#~ msgstr "Types de tâches"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10487,6 +10340,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | Cela ne veut pas le nœud maître"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Ce paramètre définit "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Il n'y a pas snapins associés à cet hôte"
+
 #~ msgid "Total Rows"
 #~ msgstr "Nombre de lignes"
 
@@ -10509,6 +10370,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Supprimer les imprimantes sélectionnées"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nom d'utilisateur"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10554,6 +10419,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Service de mise à jour!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "appel de l'utilisateur est invalide"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "S'il vous plaît entrez un nom pour ce serveur LDAP."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nom d'utilisateur"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Impossible de se connecter à la base de données"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Une image existe déjà avec ce nom!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Dernière version"
@@ -10574,6 +10466,18 @@ msgstr ""
 #~ msgstr "Terminé"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "a été détruit"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Invalid Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Tâches Multicast actifs"
 
@@ -10584,3 +10488,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "pas dans ce"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -709,9 +709,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Impostazioni iPXE aggiornate correttamente!"
 
-msgid "All methods of binding have failed"
-msgstr "Tutti i metodi di associazione sono falliti"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "Larghezza di banda deve essere numerico e maggiore di 0"
@@ -721,12 +718,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "Consente la modifica/creazione di Task States per FOG."
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "Consente la modifica / creazione di tipi di attività FOG."
 
 msgid "Already created"
 msgstr "Già creato"
@@ -1031,10 +1022,6 @@ msgid "CA Certificate Path"
 msgstr "Crea nuova posizione"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Percorso"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "Chiave privata non è riuscita"
 
@@ -1134,9 +1121,6 @@ msgstr "compito Annullato"
 msgid "Cancelled due to new tasking."
 msgstr "Annullato a causa della nuova tasking."
 
-msgid "Cannot bind to the LDAP server"
-msgstr "Impossibile legare al server LDAP"
-
 msgid "Cannot change image when in tasking"
 msgstr "Impossibile modificare l'immagine durante l'attività"
 
@@ -1179,9 +1163,6 @@ msgstr "Creazione Snapin fallita"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Creazione Snapin completata"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1259,9 +1240,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "chiamata canale non è valido"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Record non trovato"
@@ -1286,6 +1264,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Nessun FOGPage Classe trovato per questo nodo"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1475,22 +1457,7 @@ msgstr "Impossibile leggere il file tmp."
 msgid "Could not read snapin file"
 msgstr "Impossibile leggere il file snapin"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Impossibile leggere il file tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Impossibile leggere il file tmp."
-
 msgid "Could not read tmp file."
-msgstr "Impossibile leggere il file tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Impossibile leggere il file tmp."
 
 msgid "Could not register"
@@ -1499,10 +1466,6 @@ msgstr "Non posso registrare"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1826,9 +1789,6 @@ msgstr "Predefinito: frequenza aggiornamento"
 msgid "Default Width"
 msgstr "Larghezza predefinita"
 
-msgid "Default is disabled"
-msgstr "Il valore predefinito è disabilitato"
-
 #, fuzzy
 msgid "Default nested group depth"
 msgstr "Impossibile aprire il file per la lettura"
@@ -1891,9 +1851,6 @@ msgstr "Scaricamento fallito"
 
 msgid "Deploy Method"
 msgstr "Metodo Deploy"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Descrizione"
@@ -2057,10 +2014,6 @@ msgid "Edit Capone"
 msgstr "Export Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "Export Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "Impostazioni modulo del gruppo"
 
@@ -2081,9 +2034,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "Abilita invio posizione "
-
-msgid "Enable Sending via Location"
-msgstr ""
 
 #, fuzzy
 msgid "Enable on all hosts"
@@ -2223,9 +2173,6 @@ msgstr "Esporta configurazione"
 msgid "Export LDAP Servers"
 msgstr "LDAP Servers"
 
-msgid "Export Locations"
-msgstr "Esporta luoghi"
-
 #, fuzzy
 msgid "Export OUs"
 msgstr "Esporta utenti"
@@ -2325,6 +2272,9 @@ msgstr "Connessione FTP non è riuscita"
 
 msgid "FTP Path"
 msgstr "Percorso FTP"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "Fallito"
@@ -2554,9 +2504,6 @@ msgstr "Impossibile per distruggere il nodo di archiviazione"
 msgid "Files Deleted List"
 msgstr "Cancellare i file"
 
-msgid "Filter"
-msgstr "Filtro"
-
 msgid "Finding any images associated"
 msgstr "Trovare tutte le immagini associate"
 
@@ -2658,9 +2605,6 @@ msgstr "Funzione"
 #, fuzzy
 msgid "Function Error"
 msgstr "Funzione"
-
-msgid "Function does not exist"
-msgstr "La funzione non esiste"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2826,18 +2770,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argomenti Gruppo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Luoghi"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Modifica posizione riuscita"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Posizione aggiornata!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Accesso Storia"
 
@@ -2906,10 +2838,6 @@ msgid "Group Update Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
@@ -2921,10 +2849,6 @@ msgstr "Gruppo aggiunto!"
 
 msgid "Group is not valid"
 msgstr "Gruppo non valido"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "Aggiornamento utente non riuscita"
 
 msgid "Group update failed!"
 msgstr "Aggiornamento del gruppo non riuscito!"
@@ -3049,18 +2973,6 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Host"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Questo host esiste già"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Questo host esiste già"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Questo host esiste già"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "Creazione Host con successo"
@@ -3140,17 +3052,6 @@ msgstr "Host argomenti del kernel"
 msgid "Host List"
 msgstr "Lista Host"
 
-msgid "Host Location"
-msgstr "Host Luoghi"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Modifica posizione riuscita"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Posizione aggiornata!"
-
 msgid "Host Login History"
 msgstr "Host Accesso Storia"
 
@@ -3204,10 +3105,6 @@ msgid "Host Snapin History"
 msgstr "Storia Snapin Host"
 
 msgid "Host Update Fail"
-msgstr "Aggiornamento Host completato"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Aggiornamento Host completato"
 
 #, fuzzy
@@ -3499,22 +3396,6 @@ msgstr "Modifica immagine riuscita"
 msgid "Image Used"
 msgstr "Immagine utilizzata"
 
-#, fuzzy
-msgid "Image Windows Key"
-msgstr "Importa chiavi Windows"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Chiave di Windows Aggiornata"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Chiave di Windows Aggiornata"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Chiave di Windows Aggiornata"
-
 msgid "Image added!"
 msgstr "Immagine aggiunta!"
 
@@ -3621,9 +3502,6 @@ msgstr "Importa database"
 msgid "Import Failed"
 msgstr "immagine aggiornata"
 
-msgid "Import Locations"
-msgstr "Importa luoghi"
-
 #, fuzzy
 msgid "Import OUs"
 msgstr "Importa utenti"
@@ -3640,25 +3518,12 @@ msgid "Import Reports"
 msgstr "Importa Report"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Gruppi di importazione"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Importazione riuscita"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Importazione riuscita"
-
-msgid "Import Task States"
-msgstr "Importa Stato delle attività"
-
-msgid "Import Task Types"
-msgstr "Importa tipi di attività"
-
-msgid "Import Windows Keys"
-msgstr "Importa chiavi Windows"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3845,10 +3710,6 @@ msgstr "Unità non valida"
 msgid "Invalid Windows product key"
 msgstr "Host Product Key"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Selezionare un'immagine valida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -3886,9 +3747,6 @@ msgstr "chiave non valida richiesta"
 
 msgid "Invalid key being set"
 msgstr "chiave non valido stato impostato"
-
-msgid "Invalid method called"
-msgstr "metodo valido chiamato"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4005,9 +3863,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "funziona ottenendo l'impostazione massima della larghezza di banda del nodo"
 
-msgid "It tells the client to download snapins from"
-msgstr "indica al client di scaricare gli snapins da"
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4051,10 +3906,6 @@ msgstr "I kernel / INIT dalla posizione"
 msgid "Key"
 msgstr "Chiave"
 
-#, fuzzy
-msgid "Key Association"
-msgstr "Associazione Sito"
-
 msgid "Key field must be a string"
 msgstr "Campo chiave deve essere una stringa"
 
@@ -4077,10 +3928,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Uccidere"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 msgid "LDAP Connection  Name"
 msgstr "Nome connessione LDAP"
@@ -4192,9 +4039,6 @@ msgstr "LDAP Server modificato!"
 msgid "LDAP Server updated!"
 msgstr "LDAP Server modificato!"
 
-msgid "LDAP Servers"
-msgstr "LDAP Servers"
-
 msgid "Language"
 msgstr "Lingua"
 
@@ -4224,9 +4068,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 msgid "Level must be an integer"
@@ -4287,14 +4128,6 @@ msgid "List All Plugins"
 msgstr "installare plugin"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Stati attività"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipi di attività"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "plugin installati"
 
@@ -4320,9 +4153,6 @@ msgstr "Caricamento dei dati campo"
 
 msgid "Location"
 msgstr "Luogo"
-
-msgid "Location Association"
-msgstr "Associazione Posizione"
 
 msgid "Location Create Fail"
 msgstr "Creazione posizione fallita"
@@ -4353,9 +4183,6 @@ msgstr "Modifica posizione riuscita"
 
 msgid "Location added!"
 msgstr "Posizione aggiunta!"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "Luoghi è un plugin che consente al server FOG"
 
 msgid "Location update failed!"
 msgstr "Aggiornamento posizione non riuscito"
@@ -4733,9 +4560,6 @@ msgstr "NOME"
 msgid "NOT"
 msgstr "NON"
 
-msgid "NOTE"
-msgstr "NOTE"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4768,16 +4592,9 @@ msgstr "Nuova chiave deve essere una stringa"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Nuova chiave deve essere una stringa"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Nuova chiave deve essere una stringa"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "Aggiornamento utente non riuscita"
 
 msgid "Network Information"
 msgstr "Informationi di rete"
@@ -4848,9 +4665,6 @@ msgstr "Nessuna immagine specificata"
 
 msgid "No Printer Management"
 msgstr "No Printer Management"
-
-msgid "No access is allowed"
-msgstr "Nessun accesso è consentito"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5703,9 +5517,6 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr "La porta non è la porta ldap / ldaps valida"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5921,9 +5732,6 @@ msgstr "aggiornato stampante!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet Conti"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "client Management"
@@ -6117,9 +5925,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-msgid "Result"
-msgstr "Risultati"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6357,27 +6162,15 @@ msgstr "Ricerca"
 msgid "Search Base DN"
 msgstr "Cerca Base DN"
 
-msgid "Search DN"
-msgstr "Search DN"
-
-msgid "Search DN did not return any results"
-msgstr "Ricerca DN non ha restituito alcun risultato"
-
 #, fuzzy
 msgid "Search Key"
 msgstr "Ricerca"
-
-msgid "Search Method"
-msgstr "Metodo di ricerca"
 
 msgid "Search Scope"
 msgstr "Scope di ricerca"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "Risultati di ricerca che restituiscono false"
 
 #, fuzzy
 msgid "Search settings"
@@ -6746,9 +6539,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack Accounts"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7238,10 +7028,6 @@ msgid "Subnet Group updated!"
 msgstr "Gruppo aggiornato!"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Gruppi Export"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Gruppi Export"
 
@@ -7384,9 +7170,6 @@ msgstr "Aggiunta stato attività riuscito!"
 msgid "Task State Updated!"
 msgstr "Aggiunta stato attività aggiormato!"
 
-msgid "Task States"
-msgstr "Stati attività"
-
 msgid "Task Type"
 msgstr "Tipo attività"
 
@@ -7430,9 +7213,6 @@ msgstr "Tipo di attività non è valido"
 
 msgid "Task Type is not valid"
 msgstr "Task Type non è valido"
-
-msgid "Task Types"
-msgstr "Tipi di attività"
 
 #, fuzzy
 msgid "Task failed"
@@ -7537,12 +7317,6 @@ msgstr "L'impostazione \"nodo master\" definisce quale"
 msgid "The API is disabled"
 msgstr "Il valore predefinito è disabilitato"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Non ci sono gruppi su questo server"
@@ -7561,9 +7335,6 @@ msgstr "Impossibile leggere il file temporaneo"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "non è più in esecuzione"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7604,9 +7375,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7676,9 +7444,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "La chiave verrà assegnata agli host registrati quando una"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -7871,9 +7636,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "Ciò è particolarmente utile se si dispone di più"
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "Questo non è il gruppo primario"
@@ -7926,9 +7688,6 @@ msgstr "IP di questo server"
 msgid "This setting"
 msgstr "Questa impostazione"
 
-msgid "This setting defines sending the"
-msgstr "Questa impostazione definisce l'invio"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -7979,9 +7738,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "Queste immagini devono essere attivate con le relative"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8434,9 +8190,6 @@ msgstr "Creazione utente fallita"
 msgid "User Create Success"
 msgstr "Creazione utente riuscita"
 
-msgid "User DN"
-msgstr "User DN"
-
 #, fuzzy
 msgid "User Group"
 msgstr "gruppi"
@@ -8517,9 +8270,6 @@ msgstr "Utente aggiornato con successo"
 msgid "User added!"
 msgstr "Utente aggiunto!"
 
-msgid "User call is invalid"
-msgstr "chiamata dell'utente non è valido"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Utente aggiunto!"
@@ -8532,9 +8282,6 @@ msgstr "Aggiornamento utente non riuscita"
 msgid "User group updated!"
 msgstr "Utente aggiornato"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Record non trovato"
@@ -8544,9 +8291,6 @@ msgstr "Aggiornamento utente non riuscita"
 
 msgid "User updated!"
 msgstr "Utente aggiornato"
-
-msgid "User was not authorized by the LDAP server"
-msgstr "L'utente non è stato autorizzato dal server LDAP"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8568,15 +8312,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nome utente"
-
 msgid "Users"
 msgstr "utenti"
-
-msgid "Using the group match function"
-msgstr "Utilizzo della funzione di corrispondenza gruppo"
 
 msgid "VB Script"
 msgstr ""
@@ -8638,9 +8375,6 @@ msgstr "Siamo ID nodo"
 msgid "We are node name"
 msgstr "Siamo il nome del nodo"
 
-msgid "We cannot connect to LDAP server"
-msgstr "Non è possibile connettersi al server LDAP"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8663,9 +8397,6 @@ msgstr "è stato cancellato"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "Quando il plugin viene rimosso, il tasto assegnato rimarrà"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "Dove ottenere aiuto"
@@ -8682,10 +8413,6 @@ msgstr "La finestra dati deve essere maggiore di 1"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Descrizione chiave di Windows"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Chiave Windows"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -8725,15 +8452,9 @@ msgstr "Chiave di Windows Aggiornata"
 msgid "Windows Key updated!"
 msgstr "Chiave di Windows Aggiornata"
 
-msgid "Windows Keys"
-msgstr "Chiave Windows"
-
 #, fuzzy
 msgid "Windows Product key"
 msgstr "Host Product Key"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Tasti di Windows è un plugin che associa le chiavi di prodotto"
 
 msgid "Wipes"
 msgstr ""
@@ -8851,17 +8572,11 @@ msgstr "prima di me su questo nodo"
 msgid "between"
 msgstr "fra"
 
-msgid "between different sites"
-msgstr "tra diversi siti"
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
 msgstr "avvia i computer client"
-
-msgid "but bind password is not set"
-msgstr "Ma la bind password non è impostata"
 
 msgid "but has recently failed for this host"
 msgstr "ma è fallito di recente per questo host"
@@ -8901,9 +8616,6 @@ msgstr ""
 
 msgid "day"
 msgstr "giorno"
-
-msgid "deploy task occurs for it"
-msgstr "attività di distribuzione avviene per esso"
 
 msgid "directive in php.ini"
 msgstr "direttiva in php.ini"
@@ -8970,8 +8682,8 @@ msgstr "dimensione del file"
 msgid "fog-admins"
 msgstr "Nome del dominio"
 
-msgid "for Microsoft Windows to images"
-msgstr "per Microsoft Windows per immagini"
+msgid "for user"
+msgstr ""
 
 msgid "found"
 msgstr "trovato"
@@ -9004,14 +8716,6 @@ msgstr "è stato distrutta con successo"
 
 msgid "has been successfully updated"
 msgstr "è stato aggiornato con successo"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "è stato completato"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Non valido Snapin Tasking"
 
 msgid "has failed to destroy"
 msgstr "è fallita la distruzione"
@@ -9178,9 +8882,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "avvia i computer client"
 
-msgid "key"
-msgstr "chiave"
-
 msgid "keys"
 msgstr ""
 
@@ -9193,9 +8894,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "limitata a 1Mbps su quel nodo"
-
-msgid "location url based on the host that checks in"
-msgstr "Url di posizione basata sull'host che controlla e"
 
 msgid "logged in"
 msgstr ""
@@ -9227,9 +8925,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "più posti per ottenere l'immagine"
 
 msgid "must be specified"
 msgstr "deve essere specificato"
@@ -9382,9 +9077,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "siti con client che si muovono avanti e indietro"
-
 msgid "snapin"
 msgstr "snapin"
 
@@ -9437,9 +9129,6 @@ msgstr "il seguente comando in un terminale"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Aggiornamento Gruppo di archiviazione fallito"
-
-msgid "the host defined location where available"
-msgstr "la posizione definita dall'host, se disponibile"
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9494,9 +9183,6 @@ msgstr "pr ottenere il Kernel richiesto"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "pr ottenere il Kernel richiesto"
-
-msgid "to operate in an environment where there may be"
-msgstr "per operare in un ambiente in cui ci possa essere"
 
 msgid "to review."
 msgstr "da revisionare"
@@ -9562,12 +9248,6 @@ msgstr "finestra"
 
 msgid "wipe out all of your images stored on"
 msgstr "cancellare tutte le immagini archiviate in"
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
-msgstr "con l'host"
 
 msgid "with this group"
 msgstr "con questo gruppo"
@@ -9705,6 +9385,15 @@ msgstr ""
 #~ msgid "Administrator Group"
 #~ msgstr "Gruppo amministrativo"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "Tutti i metodi di associazione sono falliti"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "Consente la modifica/creazione di Task States per FOG."
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "Consente la modifica / creazione di tipi di attività FOG."
+
 #, fuzzy
 #~ msgid "An accesscontrol already exists with this name!"
 #~ msgstr "Esiste già un ruolo con questo nome!"
@@ -9717,12 +9406,41 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Percorso"
+
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Impossibile legare al server LDAP"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "chiamata canale non è valido"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Controllare che database è in esecuzione"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Impostazioni Client"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -9744,6 +9462,13 @@ msgstr ""
 #~ msgid "Database connection unavailable"
 #~ msgstr "Percorso non disponibile"
 
+#~ msgid "Default is disabled"
+#~ msgstr "Il valore predefinito è disabilitato"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "Export Snapins"
+
 #~ msgid "Event and data are not set"
 #~ msgstr "Event e data non sono impostati"
 
@@ -9760,6 +9485,9 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "Esporta luoghi"
+
+#~ msgid "Export Locations"
 #~ msgstr "Esporta luoghi"
 
 #~ msgid "Export Printers"
@@ -9804,9 +9532,27 @@ msgstr ""
 #~ msgid "Files do not match on server"
 #~ msgstr "Io non sono il server web fog"
 
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Riavvio"
+
+#~ msgid "Function does not exist"
+#~ msgstr "La funzione non esiste"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Modifica posizione riuscita"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Posizione aggiornata!"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -9828,11 +9574,31 @@ msgstr ""
 #~ msgstr "Gruppo aggiornato!"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Aggiornamento gruppo non riuscito"
 
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "Aggiornamento utente non riuscita"
+
 #~ msgid "Group module settings"
 #~ msgstr "Impostazioni modulo del gruppo"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Questo host esiste già"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Questo host esiste già"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Questo host esiste già"
 
 #~ msgid "Host Associated"
 #~ msgstr "Host associato"
@@ -9853,6 +9619,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "Aggiornamento ruolo non riuscito"
 
+#~ msgid "Host Location"
+#~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Modifica posizione riuscita"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Posizione aggiornata!"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Lista Host"
@@ -9868,6 +9645,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "Storia Snapin Host"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Aggiornamento Host completato"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -9905,6 +9686,22 @@ msgstr ""
 #~ msgstr "Host aggiornato!"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Importa chiavi Windows"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Chiave di Windows Aggiornata"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Importa Host"
 
@@ -9913,6 +9710,9 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "Importa luoghi"
+
+#~ msgid "Import Locations"
 #~ msgstr "Importa luoghi"
 
 #~ msgid "Import Printers"
@@ -9940,11 +9740,45 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Tutti i nodi di storage"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Gruppi di importazione"
+
+#~ msgid "Import Task States"
+#~ msgstr "Importa Stato delle attività"
+
+#~ msgid "Import Task Types"
+#~ msgstr "Importa tipi di attività"
+
 #~ msgid "Import Users"
 #~ msgstr "Importa utenti"
 
+#~ msgid "Import Windows Keys"
+#~ msgstr "Importa chiavi Windows"
+
 #~ msgid "Invalid Type"
 #~ msgstr "Tipo non valido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Selezionare un'immagine valida"
+
+#~ msgid "Invalid method called"
+#~ msgstr "metodo valido chiamato"
+
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "indica al client di scaricare gli snapins da"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Associazione Sito"
+
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP Servers"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -9962,11 +9796,32 @@ msgstr ""
 #~ msgstr "Elencare tutti %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Stati attività"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipi di attività"
+
+#~ msgid "Location Association"
+#~ msgstr "Associazione Posizione"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "Luoghi è un plugin che consente al server FOG"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "Host associato"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "Nessun FOGPage Classe trovato per questo nodo"
+#~ msgid "NOTE"
+#~ msgstr "NOTE"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "Aggiornamento utente non riuscita"
+
+#~ msgid "No access is allowed"
+#~ msgstr "Nessun accesso è consentito"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10000,8 +9855,14 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Inserisci un nome di amministratore o di ricerca per cellulari"
 
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "La porta non è la porta ldap / ldaps valida"
+
 #~ msgid "Printer Alias"
 #~ msgstr "stampante Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet Conti"
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Registro deve essere gestito da hook o eventi"
@@ -10012,6 +9873,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Rimuovi i selezionati"
+
+#~ msgid "Result"
+#~ msgstr "Risultati"
 
 #~ msgid "Results"
 #~ msgstr "risultati"
@@ -10068,8 +9932,23 @@ msgstr ""
 #~ msgid "Rule update failed!"
 #~ msgstr "Aggiornamento della stampante non è riuscito!"
 
+#~ msgid "Search DN"
+#~ msgstr "Search DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "Ricerca DN non ha restituito alcun risultato"
+
+#~ msgid "Search Method"
+#~ msgstr "Metodo di ricerca"
+
+#~ msgid "Search results returned false"
+#~ msgstr "Risultati di ricerca che restituiscono false"
+
 #~ msgid "Site Association"
 #~ msgstr "Associazione Sito"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack Accounts"
 
 #~ msgid "Snapin Created"
 #~ msgstr "Snapin creato"
@@ -10081,8 +9960,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Creato"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Gruppi Export"
+
 #~ msgid "Successful"
 #~ msgstr "Riuscito"
+
+#~ msgid "Task States"
+#~ msgstr "Stati attività"
+
+#~ msgid "Task Types"
+#~ msgstr "Tipi di attività"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"
@@ -10095,6 +9984,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Questo host esiste già"
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "La chiave verrà assegnata agli host registrati quando una"
 
 #, fuzzy
 #~ msgid "There are no "
@@ -10110,9 +10002,18 @@ msgstr ""
 #~ msgid "There are no snapins on this server"
 #~ msgstr "Non ci sono snapins su questo server"
 
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "Ciò è particolarmente utile se si dispone di più"
+
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Questo non è il nodo master"
+
+#~ msgid "This setting defines sending the"
+#~ msgstr "Questa impostazione definisce l'invio"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Queste immagini devono essere attivate con le relative"
 
 #~ msgid "Total Rows"
 #~ msgstr "Righe totali"
@@ -10134,6 +10035,9 @@ msgstr ""
 
 #~ msgid "Update/Remove printers"
 #~ msgstr "Aggiorna/Rimuovi stampanti"
+
+#~ msgid "User DN"
+#~ msgstr "User DN"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10179,6 +10083,35 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Sito aggiornato!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "chiamata dell'utente non è valido"
+
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "L'utente non è stato autorizzato dal server LDAP"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nome utente"
+
+#~ msgid "Using the group match function"
+#~ msgstr "Utilizzo della funzione di corrispondenza gruppo"
+
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Non è possibile connettersi al server LDAP"
+
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "Quando il plugin viene rimosso, il tasto assegnato rimarrà"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Chiave Windows"
+
+#~ msgid "Windows Keys"
+#~ msgstr "Chiave Windows"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Tasti di Windows è un plugin che associa le chiavi di prodotto"
+
 #~ msgid "You have version"
 #~ msgstr "Hai l'ultima versione"
 
@@ -10192,22 +10125,63 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "prima di me"
 
+#~ msgid "between different sites"
+#~ msgstr "tra diversi siti"
+
 #~ msgid "but"
 #~ msgstr "ma"
+
+#~ msgid "but bind password is not set"
+#~ msgstr "Ma la bind password non è impostata"
 
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "Completato"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "attività di distribuzione avviene per esso"
+
 #~ msgid "e.g."
 #~ msgstr "es."
+
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "per Microsoft Windows per immagini"
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "è stato completato"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Non valido Snapin Tasking"
+
+#~ msgid "key"
+#~ msgstr "chiave"
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "Url di posizione basata sull'host che controlla e"
 
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Compiti multicast attivi"
 
+#~ msgid "multiple places to get your image"
+#~ msgstr "più posti per ottenere l'immagine"
+
 #~ msgid "no database to"
 #~ msgstr "Nessun database a"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "siti con client che si muovono avanti e indietro"
+
+#~ msgid "the host defined location where available"
+#~ msgstr "la posizione definita dall'host, se disponibile"
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "per operare in un ambiente in cui ci possa essere"
+
 #~ msgid "version"
 #~ msgstr "versione"
+
+#~ msgid "with the host"
+#~ msgstr "con l'host"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -693,9 +693,6 @@ msgstr "ホストに同じイメージが割り当てられていません"
 msgid "All items imported successfully"
 msgstr "項目を正常に削除しました！"
 
-msgid "All methods of binding have failed"
-msgstr "すべてのバインド方法に失敗しました"
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "帯域幅は 0 より大きい数値で指定してください"
@@ -705,12 +702,6 @@ msgstr ""
 
 msgid "Allow API"
 msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr "現在 FOG に登録されているタスク状態の編集および作成を許可します。"
-
-msgid "Allows editing/creating of Task Types fog currently has."
-msgstr "現在 FOG に登録されているタスクタイプの編集および作成を許可します。"
 
 msgid "Already created"
 msgstr "既に作成されています"
@@ -1013,10 +1004,6 @@ msgid "CA Certificate Path"
 msgstr "新しいロケーションを作成"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "パス"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "秘密鍵の処理に失敗しました"
 
@@ -1115,9 +1102,6 @@ msgstr "キャンセルされたタスク"
 msgid "Cancelled due to new tasking."
 msgstr "新しいタスクによりキャンセルされました。"
 
-msgid "Cannot bind to the LDAP server"
-msgstr "LDAP サーバーにバインドできません"
-
 msgid "Cannot change image when in tasking"
 msgstr "タスク実行中はイメージを変更できません"
 
@@ -1160,9 +1144,6 @@ msgstr "スナップインの作成に失敗しました"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "スナップインを作成しました"
-
-msgid "Capone Deploy"
-msgstr "Capone 展開"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1241,9 +1222,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "チャネル呼び出しが無効です"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "アイコンファイルが見つかりません"
@@ -1268,6 +1246,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "このノードの FOGPage クラスが見つかりません"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1457,22 +1439,7 @@ msgstr "一時ファイルを読み取れませんでした。"
 msgid "Could not read snapin file"
 msgstr "スナップインファイルを読み取れませんでした"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "一時ファイルを読み取れませんでした。"
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "一時ファイルを読み取れませんでした。"
-
 msgid "Could not read tmp file."
-msgstr "一時ファイルを読み取れませんでした。"
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "一時ファイルを読み取れませんでした。"
 
 msgid "Could not register"
@@ -1481,10 +1448,6 @@ msgstr "登録できませんでした"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1808,9 +1771,6 @@ msgstr "既定の更新レート"
 msgid "Default Width"
 msgstr "既定の幅"
 
-msgid "Default is disabled"
-msgstr "既定では無効です"
-
 #, fuzzy
 msgid "Default nested group depth"
 msgstr "更新できません"
@@ -1873,9 +1833,6 @@ msgstr "ダウンロードに失敗しました"
 
 msgid "Deploy Method"
 msgstr "展開方法"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "説明"
@@ -2038,10 +1995,6 @@ msgid "Edit Capone"
 msgstr "ノードを編集"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "ノードを編集"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "ノードを編集"
 
@@ -2062,10 +2015,6 @@ msgstr ""
 #, fuzzy
 msgid "Enable Domain Joining"
 msgstr "ロケーション送信を有効化"
-
-#, fuzzy
-msgid "Enable Sending via Location"
-msgstr "スナップインロケーション"
 
 msgid "Enable on all hosts"
 msgstr ""
@@ -2204,9 +2153,6 @@ msgstr "構成をエクスポート"
 msgid "Export LDAP Servers"
 msgstr "LDAP サーバー"
 
-msgid "Export Locations"
-msgstr "ロケーションをエクスポート"
-
 #, fuzzy
 msgid "Export OUs"
 msgstr "ユーザーをエクスポート"
@@ -2303,6 +2249,9 @@ msgstr "FTP 接続に失敗しました"
 
 msgid "FTP Path"
 msgstr "FTP パス"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "失敗しました"
@@ -2527,9 +2476,6 @@ msgstr "ストレージノードの破棄に失敗しました"
 msgid "Files Deleted List"
 msgstr "ルールの削除に失敗しました"
 
-msgid "Filter"
-msgstr "フィルター"
-
 msgid "Finding any images associated"
 msgstr "関連付けられたイメージを検索しています"
 
@@ -2632,9 +2578,6 @@ msgstr "関数"
 #, fuzzy
 msgid "Function Error"
 msgstr "関数"
-
-msgid "Function does not exist"
-msgstr "関数が存在しません"
 
 msgid "GNU General Public License"
 msgstr "GNU General Public License"
@@ -2797,18 +2740,6 @@ msgid "Group Kernel Arguments"
 msgstr "グループカーネル引数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "ロケーションを更新しました"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "ロケーションを更新しました！"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "ログイン履歴"
 
@@ -2877,10 +2808,6 @@ msgid "Group Update Fail"
 msgstr "グループの更新に失敗しました"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "グループの更新に失敗しました"
 
@@ -2892,10 +2819,6 @@ msgstr "グループを追加しました！"
 
 msgid "Group is not valid"
 msgstr "グループが無効です"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "ユーザーの更新に失敗しました！"
 
 msgid "Group update failed!"
 msgstr "グループの更新に失敗しました！"
@@ -3019,18 +2942,6 @@ msgstr "ホーム"
 msgid "Host"
 msgstr "ホスト"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "このホストは既に存在します"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "このホストは既に存在します"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "このホストは既に存在します"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "承認に成功しました"
@@ -3108,17 +3019,6 @@ msgstr "ホストカーネル引数"
 msgid "Host List"
 msgstr "ホスト一覧"
 
-msgid "Host Location"
-msgstr "ホスト ロケーション"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "ロケーションを更新しました"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "ロケーションを更新しました！"
-
 msgid "Host Login History"
 msgstr "ホストログイン履歴"
 
@@ -3172,10 +3072,6 @@ msgid "Host Snapin History"
 msgstr "ホストスナップイン履歴"
 
 msgid "Host Update Fail"
-msgstr "ホストの更新に失敗しました"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "ホストの更新に失敗しました"
 
 #, fuzzy
@@ -3468,22 +3364,6 @@ msgstr "イメージを更新しました"
 msgid "Image Used"
 msgstr "使用中のイメージ"
 
-#, fuzzy
-msgid "Image Windows Key"
-msgstr "新しい Windows キー"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Windows キーの更新に失敗しました"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Windows キーの更新に成功しました"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Windows キーを更新しました！"
-
 msgid "Image added!"
 msgstr "イメージを追加しました！"
 
@@ -3585,9 +3465,6 @@ msgstr "データベースをインポート"
 msgid "Import Failed"
 msgstr "インポートに失敗しました"
 
-msgid "Import Locations"
-msgstr "ロケーションをインポート"
-
 #, fuzzy
 msgid "Import OUs"
 msgstr "ユーザーをインポート"
@@ -3604,24 +3481,11 @@ msgid "Import Reports"
 msgstr "レポートをインポート"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "サブネットグループをインポート"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "インポートに成功しました"
 
 msgid "Import Succeeded With Warnings"
 msgstr ""
-
-msgid "Import Task States"
-msgstr "タスク状態をインポート"
-
-msgid "Import Task Types"
-msgstr "タスクタイプをインポート"
-
-msgid "Import Windows Keys"
-msgstr "Windows キーをインポート"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3805,10 +3669,6 @@ msgstr "無効な URL"
 msgid "Invalid Windows product key"
 msgstr "指定されたプロダクトキーが無効です"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "有効な LDAP ポートを選択してください"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -3847,9 +3707,6 @@ msgstr "要求されたキーが無効です"
 
 msgid "Invalid key being set"
 msgstr "設定しようとしているキーが無効です"
-
-msgid "Invalid method called"
-msgstr "無効なメソッドが呼び出されました"
 
 msgid "Invalid path"
 msgstr "無効なパス"
@@ -3961,9 +3818,6 @@ msgstr "ユーザー名は 41 文字未満で指定してください"
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr "ノードの最大帯域幅設定を取得して動作します"
 
-msgid "It tells the client to download snapins from"
-msgstr "クライアントに次の場所からスナップインをダウンロードするよう指示します"
-
 #, fuzzy
 msgid "It will operate based on the fields the area typcially requires."
 msgstr "通常その領域で必要とされるフィールドに基づいて動作します"
@@ -4008,10 +3862,6 @@ msgstr "ロケーションからのカーネル/Init"
 msgid "Key"
 msgstr "キー"
 
-#, fuzzy
-msgid "Key Association"
-msgstr "ルールの関連付け"
-
 msgid "Key field must be a string"
 msgstr "キーフィールドは文字列で指定してください"
 
@@ -4033,10 +3883,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "強制終了"
-
-#, fuzzy
-msgid "LDAP"
-msgstr "OpenLDAP"
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4147,9 +3993,6 @@ msgstr "LDAP サーバーを更新しました！"
 msgid "LDAP Server updated!"
 msgstr "LDAP サーバーを更新しました！"
 
-msgid "LDAP Servers"
-msgstr "LDAP サーバー"
-
 msgid "Language"
 msgstr "言語"
 
@@ -4182,9 +4025,6 @@ msgstr "各ホストの現在の値を維持する場合は、フィールドを
 #, fuzzy
 msgid "Leave blank to keep the current password"
 msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
-
-msgid "Level"
-msgstr ""
 
 msgid "Level must be an integer"
 msgstr "レベルは整数である必要があります"
@@ -4244,14 +4084,6 @@ msgid "List All Plugins"
 msgstr "プラグインをインストール"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "タスク状態"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "タスクタイプ"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "インストール済みプラグイン"
 
@@ -4277,9 +4109,6 @@ msgstr "フィールドにデータを読み込んでいます"
 
 msgid "Location"
 msgstr "ロケーション"
-
-msgid "Location Association"
-msgstr "ロケーションの関連付け"
 
 msgid "Location Create Fail"
 msgstr "ロケーションの作成に失敗しました"
@@ -4309,9 +4138,6 @@ msgstr "ロケーションを更新しました"
 
 msgid "Location added!"
 msgstr "ロケーションを追加しました！"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr "ロケーションは、FOG サーバーで利用できるプラグインです"
 
 msgid "Location update failed!"
 msgstr "ロケーションの更新に失敗しました！"
@@ -4685,9 +4511,6 @@ msgstr "名前"
 msgid "NOT"
 msgstr "NOT"
 
-msgid "NOTE"
-msgstr "注意"
-
 #, fuzzy
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr "フォーラムは、最も一般的で迅速なサポートを受ける方法です"
@@ -4722,16 +4545,9 @@ msgstr "新しいキーは文字列である必要があります"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "ユーザー名は 41 文字未満で指定してください"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "ユーザー名は 41 文字未満で指定してください"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "ユーザーの更新に失敗しました！"
 
 msgid "Network Information"
 msgstr "ネットワーク情報"
@@ -4800,9 +4616,6 @@ msgstr "イメージが指定されていません"
 
 msgid "No Printer Management"
 msgstr "プリンター管理なし"
-
-msgid "No access is allowed"
-msgstr "アクセスは許可されていません"
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5662,9 +5475,6 @@ msgstr ""
 msgid "Port"
 msgstr "ポート"
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr "ポートは有効な ldap/ldaps ポートではありません"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5877,9 +5687,6 @@ msgstr "プリンターを更新しました！"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet アカウント"
-
 msgid "Pushbullet Management"
 msgstr "Pushbullet 管理"
 
@@ -6070,9 +5877,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-msgid "Result"
-msgstr "結果"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6305,27 +6109,15 @@ msgstr "検索"
 msgid "Search Base DN"
 msgstr "検索ベース DN"
 
-msgid "Search DN"
-msgstr "検索 DN"
-
-msgid "Search DN did not return any results"
-msgstr "検索 DN は結果を返しませんでした"
-
 #, fuzzy
 msgid "Search Key"
 msgstr "検索"
-
-msgid "Search Method"
-msgstr "検索方法"
 
 msgid "Search Scope"
 msgstr "検索範囲"
 
 msgid "Search every class at once"
 msgstr ""
-
-msgid "Search results returned false"
-msgstr "検索結果が false を返しました"
 
 #, fuzzy
 msgid "Search settings"
@@ -6684,9 +6476,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Slack アカウント"
 
 msgid "Slack Management"
 msgstr "Slack 管理"
@@ -7173,9 +6962,6 @@ msgstr "サブネットグループの更新に失敗しました！"
 msgid "Subnet Group updated!"
 msgstr "サブネットグループを更新しました！"
 
-msgid "Subnet Groups"
-msgstr "サブネットグループ"
-
 msgid "Subnets"
 msgstr "サブネット"
 
@@ -7314,9 +7100,6 @@ msgstr "タスク状態を更新しました"
 msgid "Task State Updated!"
 msgstr "タスク状態を更新しました！"
 
-msgid "Task States"
-msgstr "タスク状態"
-
 msgid "Task Type"
 msgstr "タスクタイプ"
 
@@ -7359,9 +7142,6 @@ msgstr "タスクタイプが無効です"
 
 msgid "Task Type is not valid"
 msgstr "タスクタイプが無効です"
-
-msgid "Task Types"
-msgstr "タスクタイプ"
 
 #, fuzzy
 msgid "Task failed"
@@ -7466,12 +7246,6 @@ msgstr "「マスターノード」設定は、どのノードを"
 msgid "The API is disabled"
 msgstr "既定では無効です"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "このサーバーにはグループがありません"
@@ -7490,9 +7264,6 @@ msgstr "強制終了できませんでした"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "選択したプリンターを追加"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7533,9 +7304,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7604,9 +7372,6 @@ msgstr ""
 
 msgid "The issuer must be a full URL"
 msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
-msgstr "キーは、登録済みホストに次の場合割り当てられます"
 
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
@@ -7801,9 +7566,6 @@ msgstr "これは一度だけ実行されるタスクであり、現在実行さ
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr "複数ある場合に特に便利です"
-
 msgid "This is not the master for this group"
 msgstr "このグループのマスターノードではありません"
 
@@ -7854,9 +7616,6 @@ msgstr "このサーバーの IP アドレス"
 
 msgid "This setting"
 msgstr "この設定"
-
-msgid "This setting defines sending the"
-msgstr "この設定では送信方法を定義します"
 
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
@@ -7909,9 +7668,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-msgid "Those images should be activated with the associated"
-msgstr "これらのイメージは関連付けられた"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8364,9 +8120,6 @@ msgstr "ユーザーの作成に失敗しました"
 msgid "User Create Success"
 msgstr "ユーザーの作成に成功しました"
 
-msgid "User DN"
-msgstr "ユーザー DN"
-
 #, fuzzy
 msgid "User Group"
 msgstr "グループ"
@@ -8447,9 +8200,6 @@ msgstr "ユーザーの更新に成功しました"
 msgid "User added!"
 msgstr "ユーザーを追加しました！"
 
-msgid "User call is invalid"
-msgstr "無効なユーザー呼び出しです"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "ユーザーを追加しました！"
@@ -8462,9 +8212,6 @@ msgstr "ユーザーの更新に失敗しました！"
 msgid "User group updated!"
 msgstr "ユーザーを更新しました！"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "レコードが見つかりません"
@@ -8474,9 +8221,6 @@ msgstr "ユーザーの更新に失敗しました！"
 
 msgid "User updated!"
 msgstr "ユーザーを更新しました！"
-
-msgid "User was not authorized by the LDAP server"
-msgstr "LDAP サーバーでユーザー認証に失敗しました"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8500,15 +8244,8 @@ msgstr "ユーザー名は 3 文字以上で指定してください"
 msgid "Username must end with a number or letter."
 msgstr "ユーザー名は英数字またはアンダースコアで開始する必要があります"
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "ユーザー名"
-
 msgid "Users"
 msgstr "ユーザー"
-
-msgid "Using the group match function"
-msgstr "グループ照合機能を使用しています"
 
 msgid "VB Script"
 msgstr ""
@@ -8569,9 +8306,6 @@ msgstr "現在のノード ID"
 msgid "We are node name"
 msgstr "現在のノード名"
 
-msgid "We cannot connect to LDAP server"
-msgstr "LDAP サーバーに接続できません"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8594,9 +8328,6 @@ msgstr "強制終了されました"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr "プラグインを削除しても、割り当てられたキーは保持されます"
-
 #, fuzzy
 msgid "Where to get help and guides"
 msgstr "ヘルプの入手先"
@@ -8613,9 +8344,6 @@ msgstr "ウィンドウサイズは 1 より大きい必要があります"
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "Windows キー全般"
-
-msgid "Windows Key"
-msgstr "Windows キー"
 
 msgid "Windows Key Create Fail"
 msgstr "Windows キーの作成に失敗しました"
@@ -8648,15 +8376,9 @@ msgstr "Windows キーを更新しました！"
 msgid "Windows Key updated!"
 msgstr "Windows キーを更新しました！"
 
-msgid "Windows Keys"
-msgstr "Windows キー"
-
 #, fuzzy
 msgid "Windows Product key"
 msgstr "ホスト プロダクトキー"
-
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Windows キーは、プロダクトキーを関連付けるプラグインです"
 
 msgid "Wipes"
 msgstr ""
@@ -8777,18 +8499,12 @@ msgstr "このノードで自分より前"
 msgid "between"
 msgstr "～の間"
 
-msgid "between different sites"
-msgstr "異なるサイト間"
-
 #, fuzzy
 msgid "blank for default"
 msgstr "空欄の場合は既定値"
 
 msgid "boot the client computers"
 msgstr "クライアントコンピューターを起動"
-
-msgid "but bind password is not set"
-msgstr "ただし、バインドパスワードが設定されていません"
 
 msgid "but has recently failed for this host"
 msgstr "ただし、このホストでは最近失敗しています"
@@ -8822,9 +8538,6 @@ msgstr ""
 
 msgid "day"
 msgstr "日"
-
-msgid "deploy task occurs for it"
-msgstr "展開タスクが実行されたとき"
 
 msgid "directive in php.ini"
 msgstr "php.ini のディレクティブ"
@@ -8892,8 +8605,9 @@ msgstr "ファイルサイズ"
 msgid "fog-admins"
 msgstr "ドメイン名"
 
-msgid "for Microsoft Windows to images"
-msgstr "Microsoft Windows 用にイメージへ"
+#, fuzzy
+msgid "for user"
+msgstr "ユーザーを作成しますか？"
 
 msgid "found"
 msgstr "見つかりました"
@@ -8926,14 +8640,6 @@ msgstr "正常に削除されました"
 
 msgid "has been successfully updated"
 msgstr "正常に更新されました"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "完了しました"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "スナップインタスクが完了しました。"
 
 msgid "has failed to destroy"
 msgstr "削除に失敗しました"
@@ -9101,9 +8807,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr "クライアントコンピューターを起動するためのカーネル"
 
-msgid "key"
-msgstr "キー"
-
 msgid "keys"
 msgstr ""
 
@@ -9117,9 +8820,6 @@ msgstr ""
 
 msgid "limited to 1Mbps on that node"
 msgstr "そのノードで 1 Mbps に制限されます"
-
-msgid "location url based on the host that checks in"
-msgstr "チェックインしたホストに基づくロケーション URL"
 
 msgid "logged in"
 msgstr "ログイン済み"
@@ -9150,9 +8850,6 @@ msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
 msgstr ""
-
-msgid "multiple places to get your image"
-msgstr "イメージの取得元が複数ある"
 
 msgid "must be specified"
 msgstr "指定する必要があります"
@@ -9307,9 +9004,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr "クライアントが行き来する複数のサイト"
-
 msgid "snapin"
 msgstr "スナップイン"
 
@@ -9362,9 +9056,6 @@ msgstr "ターミナルで次のコマンドを実行してください"
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "ストレージグループに到達可能なマスターノードがありません"
-
-msgid "the host defined location where available"
-msgstr "利用可能な場合は、ホストで定義されたロケーション"
 
 #, fuzzy
 msgid "the initrd (initial ramdisk) which is alongside the"
@@ -9419,9 +9110,6 @@ msgstr "要求されたカーネルを取得するため"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "要求された Initrd を取得するため"
-
-msgid "to operate in an environment where there may be"
-msgstr "次のような環境でも動作できるように"
 
 msgid "to review."
 msgstr "確認してください。"
@@ -9486,12 +9174,6 @@ msgstr "ウィンドウ"
 
 msgid "wipe out all of your images stored on"
 msgstr "保存されているすべてのイメージを削除します"
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
-msgstr "ホストと"
 
 msgid "with this group"
 msgstr "このグループと"
@@ -9686,8 +9368,17 @@ msgstr ""
 #~ msgid "All Pending MACs approved"
 #~ msgstr "保留中のすべての MAC アドレスを承認しました"
 
+#~ msgid "All methods of binding have failed"
+#~ msgstr "すべてのバインド方法に失敗しました"
+
 #~ msgid "All snapins"
 #~ msgstr "すべてのスナップイン"
+
+#~ msgid "Allows editing/creating of Task States fog currently has."
+#~ msgstr "現在 FOG に登録されているタスク状態の編集および作成を許可します。"
+
+#~ msgid "Allows editing/creating of Task Types fog currently has."
+#~ msgstr "現在 FOG に登録されているタスクタイプの編集および作成を許可します。"
 
 #~ msgid "Although there are multiple levels already"
 #~ msgstr "既に複数のレベルがありますが"
@@ -9743,11 +9434,18 @@ msgstr ""
 #~ msgid "Boot Exit settings"
 #~ msgstr "ブート終了設定"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "パス"
+
 #~ msgid "Cannot add Primary mac as additional mac"
 #~ msgstr "プライマリ MAC アドレスを追加 MAC アドレスとして追加できません"
 
 #~ msgid "Cannot add a pre-existing primary mac"
 #~ msgstr "既存のプライマリ MAC アドレスを追加できません"
+
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "LDAP サーバーにバインドできません"
 
 #~ msgid "Cannot cancel tasks this way"
 #~ msgstr "この方法ではタスクをキャンセルできません"
@@ -9760,6 +9458,12 @@ msgstr ""
 
 #~ msgid "Cannot view from browser"
 #~ msgstr "ブラウザーから表示できません"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone 展開"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "チャネル呼び出しが無効です"
 
 #~ msgid "Chat is also available on the forums for more realtime help"
 #~ msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"
@@ -9827,6 +9531,22 @@ msgstr ""
 #~ msgid "Conflicting path/file"
 #~ msgstr "競合するパス/ファイル"
 
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "一時ファイルを読み取れませんでした。"
+
 #~ msgid "Create New Access Control Role"
 #~ msgstr "新しいアクセス制御ロールを作成"
 
@@ -9842,9 +9562,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Create and associate"
 #~ msgstr "関連付けられたノードがありません"
-
-#~ msgid "Create user?"
-#~ msgstr "ユーザーを作成しますか？"
 
 #~ msgid "Cross platform"
 #~ msgstr "クロスプラットフォーム"
@@ -9884,6 +9601,9 @@ msgstr ""
 
 #~ msgid "Date of checkout"
 #~ msgstr "貸出日"
+
+#~ msgid "Default is disabled"
+#~ msgstr "既定では無効です"
 
 #~ msgid "Default log out time (in minutes)"
 #~ msgstr "既定のログアウト時間（分）"
@@ -9933,6 +9653,10 @@ msgstr ""
 #~ msgid "ESC is defaulted"
 #~ msgstr "ESC が既定です"
 
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "ノードを編集"
+
 #~ msgid "Edit Host"
 #~ msgstr "ホストを編集"
 
@@ -9950,6 +9674,10 @@ msgstr ""
 
 #~ msgid "Enable Nested Group Matching (Active Directory only)"
 #~ msgstr "ネストされたグループ照合を有効化（Active Directory のみ）"
+
+#, fuzzy
+#~ msgid "Enable Sending via Location"
+#~ msgstr "スナップインロケーション"
 
 #~ msgid "End Date"
 #~ msgstr "終了日"
@@ -10025,6 +9753,9 @@ msgstr ""
 
 #~ msgid "Export LDAPs"
 #~ msgstr "LDAP をエクスポート"
+
+#~ msgid "Export Locations"
+#~ msgstr "ロケーションをエクスポート"
 
 #~ msgid "Export PDF"
 #~ msgstr "PDF をエクスポート"
@@ -10151,6 +9882,9 @@ msgstr ""
 #~ msgid "Filesize"
 #~ msgstr "ファイルサイズ"
 
+#~ msgid "Filter"
+#~ msgstr "フィルター"
+
 #~ msgid "For example, a GPO policy to push"
 #~ msgstr "たとえば、配布するための GPO ポリシー"
 
@@ -10169,6 +9903,9 @@ msgstr ""
 #~ msgid "Full Inventory Export"
 #~ msgstr "完全なインベントリをエクスポート"
 
+#~ msgid "Function does not exist"
+#~ msgstr "関数が存在しません"
+
 #~ msgid "Generate"
 #~ msgstr "生成"
 
@@ -10180,6 +9917,18 @@ msgstr ""
 
 #~ msgid "Group FOG Client Module configuration"
 #~ msgstr "グループ FOG クライアントモジュール設定"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "グループの関連付け"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "ロケーションを更新しました"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "ロケーションを更新しました！"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10210,11 +9959,19 @@ msgstr ""
 #~ msgstr "サイトを更新しました！"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "グループの更新に失敗しました"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "グループの更新に失敗しました"
 
 #~ msgid "Group general"
 #~ msgstr "グループ全般"
+
+#, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "ユーザーの更新に失敗しました！"
 
 #~ msgid "Groups are not allowed to schedule upload tasks"
 #~ msgstr "グループではアップロードタスクをスケジュールできません"
@@ -10258,6 +10015,18 @@ msgstr ""
 #~ msgid "Home Phone"
 #~ msgstr "自宅電話番号"
 
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "このホストは既に存在します"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "このホストは既に存在します"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "このホストは既に存在します"
+
 #~ msgid "Host AD Domain"
 #~ msgstr "ホスト AD ドメイン"
 
@@ -10278,6 +10047,17 @@ msgstr ""
 
 #~ msgid "Host Listing Export"
 #~ msgstr "ホスト一覧をエクスポート"
+
+#~ msgid "Host Location"
+#~ msgstr "ホスト ロケーション"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "ロケーションを更新しました"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "ロケーションを更新しました！"
 
 #~ msgid "Host MAC"
 #~ msgstr "ホスト MAC アドレス"
@@ -10319,6 +10099,10 @@ msgstr ""
 
 #~ msgid "Host Unassociated Snapins"
 #~ msgstr "ホストに関連付けられていないスナップイン"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "ホストの更新に失敗しました"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10402,6 +10186,22 @@ msgstr ""
 #~ msgid "Image Size: ON SERVER"
 #~ msgstr "イメージサイズ: サーバー上"
 
+#, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "新しい Windows キー"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Windows キーの更新に失敗しました"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Windows キーの更新に成功しました"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Windows キーを更新しました！"
+
 #~ msgid "Image to DMI Mappings"
 #~ msgstr "イメージと DMI のマッピング"
 
@@ -10432,11 +10232,27 @@ msgstr ""
 #~ msgid "Import LDAPs"
 #~ msgstr "LDAP をインポート"
 
+#~ msgid "Import Locations"
+#~ msgstr "ロケーションをインポート"
+
 #~ msgid "Import Printers"
 #~ msgstr "プリンターをインポート"
 
 #~ msgid "Import Sites"
 #~ msgstr "サイトをインポート"
+
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "サブネットグループをインポート"
+
+#~ msgid "Import Task States"
+#~ msgstr "タスク状態をインポート"
+
+#~ msgid "Import Task Types"
+#~ msgstr "タスクタイプをインポート"
+
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows キーをインポート"
 
 #~ msgid "Included Items"
 #~ msgstr "含まれる項目"
@@ -10474,6 +10290,10 @@ msgstr ""
 #~ msgid "Invalid Type"
 #~ msgstr "無効なタイプ"
 
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "有効な LDAP ポートを選択してください"
+
 #~ msgid "Invalid data found"
 #~ msgstr "無効なデータが見つかりました"
 
@@ -10482,6 +10302,9 @@ msgstr ""
 
 #~ msgid "Invalid image assigned to host"
 #~ msgstr "ホストに割り当てられたイメージが無効です"
+
+#~ msgid "Invalid method called"
+#~ msgstr "無効なメソッドが呼び出されました"
 
 #~ msgid "Invalid numeric entry"
 #~ msgstr "無効な数値入力です"
@@ -10516,6 +10339,9 @@ msgstr ""
 #~ msgid "It is primarily geared for the smart installer methodology now"
 #~ msgstr "現在は主にスマートインストーラー方式向けに設計されています"
 
+#~ msgid "It tells the client to download snapins from"
+#~ msgstr "クライアントに次の場所からスナップインをダウンロードするよう指示します"
+
 #~ msgid "Items must be an array"
 #~ msgstr "項目は配列である必要があります"
 
@@ -10528,14 +10354,25 @@ msgstr ""
 #~ msgid "Kernel Name"
 #~ msgstr "カーネル名"
 
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "ルールの関連付け"
+
 #~ msgid "Key Name"
 #~ msgstr "キー名"
 
 #~ msgid "Key must be a string"
 #~ msgstr "キーは文字列で指定してください"
 
+#, fuzzy
+#~ msgid "LDAP"
+#~ msgstr "OpenLDAP"
+
 #~ msgid "LDAP General"
 #~ msgstr "LDAP 全般"
+
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP サーバー"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10556,6 +10393,14 @@ msgstr ""
 #~ msgid "Linux"
 #~ msgstr "Linux"
 
+#, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "タスク状態"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "タスクタイプ"
+
 #, php-format
 #~ msgid "List all roles"
 #~ msgstr "すべてのロールを一覧表示"
@@ -10563,8 +10408,14 @@ msgstr ""
 #~ msgid "Load MAC Vendors"
 #~ msgstr "MAC ベンダーを読み込み"
 
+#~ msgid "Location Association"
+#~ msgstr "ロケーションの関連付け"
+
 #~ msgid "Location General"
 #~ msgstr "ロケーション全般"
+
+#~ msgid "Location is a plugin that allows your FOG Server"
+#~ msgstr "ロケーションは、FOG サーバーで利用できるプラグインです"
 
 #~ msgid "Location/Deployed"
 #~ msgstr "ロケーション/展開済み"
@@ -10669,6 +10520,9 @@ msgstr ""
 #~ msgid "Must use an"
 #~ msgstr "次を使用する必要があります"
 
+#~ msgid "NOTE"
+#~ msgstr "注意"
+
 #~ msgid "NOTICE"
 #~ msgstr "通知"
 
@@ -10680,6 +10534,10 @@ msgstr ""
 
 #~ msgid "Needs action string of ask, get, or list"
 #~ msgstr "action には ask、get、list のいずれかの文字列が必要です"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "ユーザーの更新に失敗しました！"
 
 #~ msgid "New Client and Utilities"
 #~ msgstr "新しいクライアントとユーティリティ"
@@ -10732,14 +10590,14 @@ msgstr ""
 #~ msgid "New User"
 #~ msgstr "新しいユーザー"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "このノードの FOGPage クラスが見つかりません"
-
 #~ msgid "No Menu"
 #~ msgstr "メニューなし"
 
 #~ msgid "No Site"
 #~ msgstr "サイトなし"
+
+#~ msgid "No access is allowed"
+#~ msgstr "アクセスは許可されていません"
 
 #~ msgid "No complete time recorded"
 #~ msgstr "完了時刻は記録されていません"
@@ -10977,6 +10835,9 @@ msgstr ""
 #~ msgid "Please wait until a slot is open"
 #~ msgstr "空きスロットができるまでお待ちください"
 
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "ポートは有効な ldap/ldaps ポートではありません"
+
 #~ msgid "Postfix requires an action of login, logout, or start to operate"
 #~ msgstr "Postfix を動作させるには login、logout、または start アクションが必要です"
 
@@ -10997,6 +10858,9 @@ msgstr ""
 
 #~ msgid "Printer name already exists"
 #~ msgstr "このプリンター名は既に存在します"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet アカウント"
 
 #~ msgid "Quarantine"
 #~ msgstr "隔離"
@@ -11070,6 +10934,9 @@ msgstr ""
 #~ msgid "Requires templates to process"
 #~ msgstr "処理するテンプレートが必要です"
 
+#~ msgid "Result"
+#~ msgstr "結果"
+
 #~ msgid "Results"
 #~ msgstr "結果"
 
@@ -11134,8 +11001,20 @@ msgstr ""
 #~ msgid "Schedule with shutdown"
 #~ msgstr "シャットダウンを含めてスケジュール"
 
+#~ msgid "Search DN"
+#~ msgstr "検索 DN"
+
+#~ msgid "Search DN did not return any results"
+#~ msgstr "検索 DN は結果を返しませんでした"
+
+#~ msgid "Search Method"
+#~ msgstr "検索方法"
+
 #~ msgid "Search pattern"
 #~ msgstr "検索パターン"
+
+#~ msgid "Search results returned false"
+#~ msgstr "検索結果が false を返しました"
 
 #~ msgid "Select Image"
 #~ msgstr "イメージを選択"
@@ -11205,6 +11084,9 @@ msgstr ""
 
 #~ msgid "Site Control Management"
 #~ msgstr "サイト制御管理"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Slack アカウント"
 
 #~ msgid "Snapin Args"
 #~ msgstr "スナップイン引数"
@@ -11281,6 +11163,9 @@ msgstr ""
 #~ msgid "Storage Node update failed!"
 #~ msgstr "ストレージノードの更新に失敗しました！"
 
+#~ msgid "Subnet Groups"
+#~ msgstr "サブネットグループ"
+
 #~ msgid "SubnetGroup General"
 #~ msgstr "サブネットグループ全般"
 
@@ -11305,8 +11190,14 @@ msgstr ""
 #~ msgid "Task State General"
 #~ msgstr "タスク状態全般"
 
+#~ msgid "Task States"
+#~ msgstr "タスク状態"
+
 #~ msgid "Task Type General"
 #~ msgstr "タスクタイプ全般"
+
+#~ msgid "Task Types"
+#~ msgstr "タスクタイプ"
 
 #~ msgid "Task forced to start"
 #~ msgstr "タスクを強制開始しました"
@@ -11342,6 +11233,9 @@ msgstr ""
 
 #~ msgid "The following errors occurred"
 #~ msgstr "次のエラーが発生しました"
+
+#~ msgid "The key will be assigned to registered hosts when a"
+#~ msgstr "キーは、登録済みホストに次の場合割り当てられます"
 
 #~ msgid "The old client is what was distributed with"
 #~ msgstr "旧クライアントは次のバージョンまで配布されていました"
@@ -11380,6 +11274,9 @@ msgstr ""
 
 #~ msgid "This file will only work on Windows"
 #~ msgstr "このファイルは Windows でのみ使用できます"
+
+#~ msgid "This is especially useful if you have multiple"
+#~ msgstr "複数ある場合に特に便利です"
 
 #~ msgid "This is ipxe script commands to operate with"
 #~ msgstr "iPXE を制御するためのスクリプトコマンドです"
@@ -11442,8 +11339,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "| これはマスターノードではありません"
 
+#~ msgid "This setting defines sending the"
+#~ msgstr "この設定では送信方法を定義します"
+
 #~ msgid "This setting turns off all FOG Printer Management"
 #~ msgstr "この設定は FOG のプリンター管理機能をすべて無効にします"
+
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "これらのイメージは関連付けられた"
 
 #~ msgid "Timeout"
 #~ msgstr "タイムアウト"
@@ -11535,6 +11438,9 @@ msgstr ""
 #~ msgid "User Change Password"
 #~ msgstr "ユーザーパスワードを変更"
 
+#~ msgid "User DN"
+#~ msgstr "ユーザー DN"
+
 #~ msgid "User General"
 #~ msgstr "ユーザー全般"
 
@@ -11576,8 +11482,14 @@ msgstr ""
 #~ msgid "User Tracking"
 #~ msgstr "ユーザー追跡"
 
+#~ msgid "User call is invalid"
+#~ msgstr "無効なユーザー呼び出しです"
+
 #~ msgid "User name"
 #~ msgstr "ユーザー名"
+
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "LDAP サーバーでユーザー認証に失敗しました"
 
 #~ msgid "User/Channel to post to"
 #~ msgstr "投稿先のユーザー/Channel"
@@ -11587,6 +11499,13 @@ msgstr ""
 
 #~ msgid "Username does not meet requirements"
 #~ msgstr "ユーザー名が要件を満たしていません"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "ユーザー名"
+
+#~ msgid "Using the group match function"
+#~ msgstr "グループ照合機能を使用しています"
 
 #~ msgid "Valid Host Colors"
 #~ msgstr "有効なホストカラー"
@@ -11618,11 +11537,26 @@ msgstr ""
 #~ msgid "Wake on lan?"
 #~ msgstr "Wake on LAN を実行しますか？"
 
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "LDAP サーバーに接続できません"
+
 #~ msgid "Web root"
 #~ msgstr "Web ルート"
 
+#~ msgid "When the plugin is removed, the assigned key will remain"
+#~ msgstr "プラグインを削除しても、割り当てられたキーは保持されます"
+
+#~ msgid "Windows Key"
+#~ msgstr "Windows キー"
+
 #~ msgid "Windows Key for Image"
 #~ msgstr "イメージ用 Windows キー"
+
+#~ msgid "Windows Keys"
+#~ msgstr "Windows キー"
+
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Windows キーは、プロダクトキーを関連付けるプラグインです"
 
 #~ msgid "Working with node"
 #~ msgstr "ノードを処理しています"
@@ -11688,6 +11622,12 @@ msgstr ""
 #~ msgid "before me"
 #~ msgstr "自分より前"
 
+#~ msgid "between different sites"
+#~ msgstr "異なるサイト間"
+
+#~ msgid "but bind password is not set"
+#~ msgstr "ただし、バインドパスワードが設定されていません"
+
 #, fuzzy
 #~ msgid "completed imaging"
 #~ msgstr "イメージ処理が完了しました。"
@@ -11707,6 +11647,9 @@ msgstr ""
 #~ msgid "deleted"
 #~ msgstr "削除済み"
 
+#~ msgid "deploy task occurs for it"
+#~ msgstr "展開タスクが実行されたとき"
+
 #~ msgid "download the module and use it on the next"
 #~ msgstr "モジュールをダウンロードし、次回以降に使用します"
 
@@ -11719,6 +11662,9 @@ msgstr ""
 #~ msgid "faster"
 #~ msgstr "高速"
 
+#~ msgid "for Microsoft Windows to images"
+#~ msgstr "Microsoft Windows 用にイメージへ"
+
 #~ msgid "for the advanced menu parameters"
 #~ msgstr "詳細メニューパラメーター用"
 
@@ -11727,6 +11673,14 @@ msgstr ""
 
 #~ msgid "has been started on port"
 #~ msgstr "次のポートで開始されました"
+
+#, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "完了しました"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "スナップインタスクが完了しました。"
 
 #~ msgid "help with any aspect of FOG"
 #~ msgstr "FOG に関するあらゆるサポート"
@@ -11776,6 +11730,12 @@ msgstr ""
 #~ msgid "it will enforce login to gain access to the advanced"
 #~ msgstr "詳細メニューへアクセスするにはログインが必要になります"
 
+#~ msgid "key"
+#~ msgstr "キー"
+
+#~ msgid "location url based on the host that checks in"
+#~ msgstr "チェックインしたホストに基づくロケーション URL"
+
 #~ msgid "may see the issue and help and/or use the solutions"
 #~ msgstr "問題を確認し、支援したり解決策を利用したりできます"
 
@@ -11794,6 +11754,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "マルチキャストタスク"
+
+#~ msgid "multiple places to get your image"
+#~ msgstr "イメージの取得元が複数ある"
 
 #~ msgid "no login will appear"
 #~ msgstr "ログイン画面は表示されません"
@@ -11838,6 +11801,9 @@ msgstr ""
 #~ msgid "see the forums or lookup the commands and scripts available"
 #~ msgstr "フォーラムを参照するか、利用可能なコマンドやスクリプトを確認してください"
 
+#~ msgid "sites with clients moving back and forth"
+#~ msgstr "クライアントが行き来する複数のサイト"
+
 #~ msgid "successfully removed!"
 #~ msgstr "正常に削除しました！"
 
@@ -11852,6 +11818,9 @@ msgstr ""
 
 #~ msgid "the base FOG install"
 #~ msgstr "FOG の基本インストール"
+
+#~ msgid "the host defined location where available"
+#~ msgstr "利用可能な場合は、ホストで定義されたロケーション"
 
 #~ msgid "the main and the host"
 #~ msgstr "メイン設定とホスト設定"
@@ -11870,6 +11839,9 @@ msgstr ""
 
 #~ msgid "to be booted if no keys are pressed when the menu is"
 #~ msgstr "メニュー表示中にキーが押されなかった場合に起動する"
+
+#~ msgid "to operate in an environment where there may be"
+#~ msgstr "次のような環境でも動作できるように"
 
 #~ msgid "to signify if this is a user or channel to send to"
 #~ msgstr "送信先がユーザーかチャンネルかを指定します"
@@ -11894,6 +11866,9 @@ msgstr ""
 
 #~ msgid "with modules and config"
 #~ msgstr "モジュールと構成を含めて"
+
+#~ msgid "with the host"
+#~ msgstr "ホストと"
 
 #~ msgid "would you like to install it now"
 #~ msgstr "今すぐインストールしますか？"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -613,9 +613,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr ""
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr ""
 
@@ -623,12 +620,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 msgid "Already created"
@@ -901,9 +892,6 @@ msgstr ""
 msgid "CA Certificate Path"
 msgstr ""
 
-msgid "CA Path"
-msgstr ""
-
 msgid "CA private key"
 msgstr ""
 
@@ -992,9 +980,6 @@ msgstr ""
 msgid "Cancelled due to new tasking."
 msgstr ""
 
-msgid "Cannot bind to the LDAP server"
-msgstr ""
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1031,9 +1016,6 @@ msgid "Capone Create Fail"
 msgstr ""
 
 msgid "Capone Create Success"
-msgstr ""
-
-msgid "Capone Deploy"
 msgstr ""
 
 msgid "Capone Management"
@@ -1099,9 +1081,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr ""
-
 msgid "Channel not found"
 msgstr ""
 
@@ -1122,6 +1101,9 @@ msgid "Check %s over before installing it."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
+msgstr ""
+
+msgid "Check the password stored for this node"
 msgstr ""
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
@@ -1297,19 +1279,7 @@ msgstr ""
 msgid "Could not read snapin file"
 msgstr ""
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-msgid "Could not read the group mappings"
-msgstr ""
-
-msgid "Could not read the recorded grants"
-msgstr ""
-
 msgid "Could not read tmp file."
-msgstr ""
-
-msgid "Could not record the granted targets"
 msgstr ""
 
 msgid "Could not register"
@@ -1317,9 +1287,6 @@ msgstr ""
 
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
-msgstr ""
-
-msgid "Could not seed the granted targets"
 msgstr ""
 
 msgid "Could not send data from file"
@@ -1594,9 +1561,6 @@ msgstr ""
 msgid "Default Width"
 msgstr ""
 
-msgid "Default is disabled"
-msgstr ""
-
 msgid "Default nested group depth"
 msgstr ""
 
@@ -1650,9 +1614,6 @@ msgid "Deploy Complete"
 msgstr ""
 
 msgid "Deploy Method"
-msgstr ""
-
-msgid "Depth"
 msgstr ""
 
 msgid "Description"
@@ -1793,9 +1754,6 @@ msgstr ""
 msgid "Edit Capone"
 msgstr ""
 
-msgid "Edit Capone ID"
-msgstr ""
-
 msgid "Editing Capone ID"
 msgstr ""
 
@@ -1812,9 +1770,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 msgid "Enable on all hosts"
@@ -1945,9 +1900,6 @@ msgstr ""
 msgid "Export LDAP Servers"
 msgstr ""
 
-msgid "Export Locations"
-msgstr ""
-
 msgid "Export OUs"
 msgstr ""
 
@@ -2036,6 +1988,9 @@ msgid "FTP Connection Failed"
 msgstr ""
 
 msgid "FTP Path"
+msgstr ""
+
+msgid "FTP login rejected by"
 msgstr ""
 
 msgid "Failed"
@@ -2235,9 +2190,6 @@ msgstr ""
 msgid "Files Deleted List"
 msgstr ""
 
-msgid "Filter"
-msgstr ""
-
 msgid "Finding any images associated"
 msgstr ""
 
@@ -2332,9 +2284,6 @@ msgid "Function"
 msgstr ""
 
 msgid "Function Error"
-msgstr ""
-
-msgid "Function does not exist"
 msgstr ""
 
 msgid "GNU General Public License"
@@ -2476,15 +2425,6 @@ msgstr ""
 msgid "Group Kernel Arguments"
 msgstr ""
 
-msgid "Group Location"
-msgstr ""
-
-msgid "Group Location Update Success"
-msgstr ""
-
-msgid "Group Location Updated!"
-msgstr ""
-
 msgid "Group Login History"
 msgstr ""
 
@@ -2542,9 +2482,6 @@ msgstr ""
 msgid "Group Update Fail"
 msgstr ""
 
-msgid "Group Update Location Fail"
-msgstr ""
-
 msgid "Group Update OU Fail"
 msgstr ""
 
@@ -2555,9 +2492,6 @@ msgid "Group added!"
 msgstr ""
 
 msgid "Group is not valid"
-msgstr ""
-
-msgid "Group membership search failed"
 msgstr ""
 
 msgid "Group update failed!"
@@ -2663,18 +2597,6 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr ""
-
-#, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr ""
-
 msgid "Host Approval Success"
 msgstr ""
 
@@ -2741,15 +2663,6 @@ msgstr ""
 msgid "Host List"
 msgstr ""
 
-msgid "Host Location"
-msgstr ""
-
-msgid "Host Location Update Success"
-msgstr ""
-
-msgid "Host Location Updated!"
-msgstr ""
-
 msgid "Host Login History"
 msgstr ""
 
@@ -2796,9 +2709,6 @@ msgid "Host Snapin History"
 msgstr ""
 
 msgid "Host Update Fail"
-msgstr ""
-
-msgid "Host Update Location Fail"
 msgstr ""
 
 msgid "Host Update OU Fail"
@@ -3064,18 +2974,6 @@ msgstr ""
 msgid "Image Used"
 msgstr ""
 
-msgid "Image Windows Key"
-msgstr ""
-
-msgid "Image Windows Key Update Fail"
-msgstr ""
-
-msgid "Image Windows Key Update Success"
-msgstr ""
-
-msgid "Image Windows Key Updated!"
-msgstr ""
-
 msgid "Image added!"
 msgstr ""
 
@@ -3166,9 +3064,6 @@ msgstr ""
 msgid "Import Failed"
 msgstr ""
 
-msgid "Import Locations"
-msgstr ""
-
 msgid "Import OUs"
 msgstr ""
 
@@ -3181,22 +3076,10 @@ msgstr ""
 msgid "Import Reports"
 msgstr ""
 
-msgid "Import Subnet Groups"
-msgstr ""
-
 msgid "Import Succeeded"
 msgstr ""
 
 msgid "Import Succeeded With Warnings"
-msgstr ""
-
-msgid "Import Task States"
-msgstr ""
-
-msgid "Import Task Types"
-msgstr ""
-
-msgid "Import Windows Keys"
 msgstr ""
 
 msgid "Import a new Plugin"
@@ -3365,10 +3248,6 @@ msgid "Invalid Windows product key"
 msgstr ""
 
 #, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr ""
-
-#, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
 
@@ -3403,9 +3282,6 @@ msgid "Invalid key being requested"
 msgstr ""
 
 msgid "Invalid key being set"
-msgstr ""
-
-msgid "Invalid method called"
 msgstr ""
 
 msgid "Invalid path"
@@ -3507,9 +3383,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -3549,9 +3422,6 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-msgid "Key Association"
-msgstr ""
-
 msgid "Key field must be a string"
 msgstr ""
 
@@ -3571,9 +3441,6 @@ msgid "Keys cached"
 msgstr ""
 
 msgid "Kill"
-msgstr ""
-
-msgid "LDAP"
 msgstr ""
 
 msgid "LDAP Connection  Name"
@@ -3666,9 +3533,6 @@ msgstr ""
 msgid "LDAP Server updated!"
 msgstr ""
 
-msgid "LDAP Servers"
-msgstr ""
-
 msgid "Language"
 msgstr ""
 
@@ -3697,9 +3561,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 msgid "Level must be an integer"
@@ -3755,12 +3616,6 @@ msgstr ""
 msgid "List All Plugins"
 msgstr ""
 
-msgid "List All Task States"
-msgstr ""
-
-msgid "List All Task Types"
-msgstr ""
-
 msgid "List Available Plugins"
 msgstr ""
 
@@ -3783,9 +3638,6 @@ msgid "Loading data to field"
 msgstr ""
 
 msgid "Location"
-msgstr ""
-
-msgid "Location Association"
 msgstr ""
 
 msgid "Location Create Fail"
@@ -3813,9 +3665,6 @@ msgid "Location Update Success"
 msgstr ""
 
 msgid "Location added!"
-msgstr ""
-
-msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 msgid "Location update failed!"
@@ -4145,9 +3994,6 @@ msgstr ""
 msgid "NOT"
 msgstr ""
 
-msgid "NOTE"
-msgstr ""
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4175,13 +4021,7 @@ msgstr ""
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr ""
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 msgid "Nested group depth must be between 1 and 100"
-msgstr ""
-
-msgid "Nested group search failed"
 msgstr ""
 
 msgid "Network Information"
@@ -4247,9 +4087,6 @@ msgid "No Image specified"
 msgstr ""
 
 msgid "No Printer Management"
-msgstr ""
-
-msgid "No access is allowed"
 msgstr ""
 
 msgid "No active task found for this host"
@@ -5002,9 +4839,6 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
-msgid "Port is not valid ldap/ldaps port"
-msgstr ""
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -5194,9 +5028,6 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr ""
-
 msgid "Pushbullet Management"
 msgstr ""
 
@@ -5370,9 +5201,6 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
-msgstr ""
-
-msgid "Result"
 msgstr ""
 
 msgid "Resume Reload"
@@ -5583,25 +5411,13 @@ msgstr ""
 msgid "Search Base DN"
 msgstr ""
 
-msgid "Search DN"
-msgstr ""
-
-msgid "Search DN did not return any results"
-msgstr ""
-
 msgid "Search Key"
-msgstr ""
-
-msgid "Search Method"
 msgstr ""
 
 msgid "Search Scope"
 msgstr ""
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 msgid "Search settings"
@@ -5914,9 +5730,6 @@ msgid "Skipping, not a PluginTask"
 msgstr ""
 
 msgid "Skipping, will need manual removal"
-msgstr ""
-
-msgid "Slack Accounts"
 msgstr ""
 
 msgid "Slack Management"
@@ -6351,9 +6164,6 @@ msgstr ""
 msgid "Subnet Group updated!"
 msgstr ""
 
-msgid "Subnet Groups"
-msgstr ""
-
 msgid "Subnets"
 msgstr ""
 
@@ -6481,9 +6291,6 @@ msgstr ""
 msgid "Task State Updated!"
 msgstr ""
 
-msgid "Task States"
-msgstr ""
-
 msgid "Task Type"
 msgstr ""
 
@@ -6521,9 +6328,6 @@ msgid "Task Type is invalid"
 msgstr ""
 
 msgid "Task Type is not valid"
-msgstr ""
-
-msgid "Task Types"
 msgstr ""
 
 msgid "Task failed"
@@ -6614,12 +6418,6 @@ msgstr ""
 msgid "The API is disabled"
 msgstr ""
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 msgid "The CA private key is not on this server"
 msgstr ""
 
@@ -6633,9 +6431,6 @@ msgid "The FOG account could not be created"
 msgstr ""
 
 msgid "The FOG account for this identity no longer exists"
-msgstr ""
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
 msgstr ""
 
 msgid "The ID token carries no subject"
@@ -6675,9 +6470,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 msgid "The count."
@@ -6741,9 +6533,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -6926,9 +6715,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 msgid "This is not the master for this group"
 msgstr ""
 
@@ -6978,9 +6764,6 @@ msgstr ""
 msgid "This setting"
 msgstr ""
 
-msgid "This setting defines sending the"
-msgstr ""
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -7027,9 +6810,6 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
-msgstr ""
-
-msgid "Those images should be activated with the associated"
 msgstr ""
 
 msgid "Throughput sample."
@@ -7429,9 +7209,6 @@ msgstr ""
 msgid "User Create Success"
 msgstr ""
 
-msgid "User DN"
-msgstr ""
-
 msgid "User Group"
 msgstr ""
 
@@ -7498,9 +7275,6 @@ msgstr ""
 msgid "User added!"
 msgstr ""
 
-msgid "User call is invalid"
-msgstr ""
-
 msgid "User group added!"
 msgstr ""
 
@@ -7510,9 +7284,6 @@ msgstr ""
 msgid "User group updated!"
 msgstr ""
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 msgid "User not found"
 msgstr ""
 
@@ -7520,9 +7291,6 @@ msgid "User update failed!"
 msgstr ""
 
 msgid "User updated!"
-msgstr ""
-
-msgid "User was not authorized by the LDAP server"
 msgstr ""
 
 msgid "User/Channel"
@@ -7543,13 +7311,7 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-msgid "Username was blank"
-msgstr ""
-
 msgid "Users"
-msgstr ""
-
-msgid "Using the group match function"
 msgstr ""
 
 msgid "VB Script"
@@ -7609,9 +7371,6 @@ msgstr ""
 msgid "We are node name"
 msgstr ""
 
-msgid "We cannot connect to LDAP server"
-msgstr ""
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -7633,9 +7392,6 @@ msgstr ""
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -7649,9 +7405,6 @@ msgid "Window size must be greater than 1"
 msgstr ""
 
 msgid "Windows 10 Professional"
-msgstr ""
-
-msgid "Windows Key"
 msgstr ""
 
 msgid "Windows Key Create Fail"
@@ -7684,13 +7437,7 @@ msgstr ""
 msgid "Windows Key updated!"
 msgstr ""
 
-msgid "Windows Keys"
-msgstr ""
-
 msgid "Windows Product key"
-msgstr ""
-
-msgid "Windows keys is a plugin that associates product keys"
 msgstr ""
 
 msgid "Wipes"
@@ -7805,16 +7552,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 msgid "but has recently failed for this host"
@@ -7848,9 +7589,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -7911,7 +7649,7 @@ msgstr ""
 msgid "fog-admins"
 msgstr ""
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 msgid "found"
@@ -7942,12 +7680,6 @@ msgid "has been successfully destroyed"
 msgstr ""
 
 msgid "has been successfully updated"
-msgstr ""
-
-msgid "has completed on"
-msgstr ""
-
-msgid "has completed snapin tasking"
 msgstr ""
 
 msgid "has failed to destroy"
@@ -8100,9 +7832,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-msgid "key"
-msgstr ""
-
 msgid "keys"
 msgstr ""
 
@@ -8114,9 +7843,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -8147,9 +7873,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 msgid "must be specified"
@@ -8296,9 +8019,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 msgid "snapin"
 msgstr ""
 
@@ -8350,9 +8070,6 @@ msgstr ""
 msgid "the group has no enabled master node"
 msgstr ""
 
-msgid "the host defined location where available"
-msgstr ""
-
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
 
@@ -8400,9 +8117,6 @@ msgid "to get the requested Kernel"
 msgstr ""
 
 msgid "to get the requested initrd"
-msgstr ""
-
-msgid "to operate in an environment where there may be"
 msgstr ""
 
 msgid "to review."
@@ -8463,12 +8177,6 @@ msgid "window"
 msgstr ""
 
 msgid "wipe out all of your images stored on"
-msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-msgid "with the host"
 msgstr ""
 
 msgid "with this group"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -735,9 +735,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "Instalar / Atualizar sucesso!"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "A largura de banda deve ser numérico e maior do que 0"
@@ -746,12 +743,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1070,10 +1061,6 @@ msgid "CA Certificate Path"
 msgstr "Criar novo %s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "Caminho"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "chave privada falhou"
 
@@ -1173,10 +1160,6 @@ msgstr "tarefa cancelada"
 msgid "Cancelled due to new tasking."
 msgstr "Cancelado devido à nova tarefa."
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "Não é possível conectar ao banco de dados"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1220,9 +1203,6 @@ msgstr "Snapin atualizada"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "Snapin atualizada"
-
-msgid "Capone Deploy"
-msgstr "Capone Deploy"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1302,9 +1282,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "chamada de canal é inválido"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "Registro não encontrado, erro: %s"
@@ -1329,6 +1306,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Sem FOGPage classe encontrada para este nó"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1533,22 +1514,7 @@ msgstr "Não foi possível ler o arquivo tmp."
 msgid "Could not read snapin file"
 msgstr "Não foi possível ler o arquivo tmp."
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "Não foi possível ler o arquivo tmp."
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "Não foi possível ler o arquivo tmp."
-
 msgid "Could not read tmp file."
-msgstr "Não foi possível ler o arquivo tmp."
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
@@ -1558,10 +1524,6 @@ msgstr "Não foi possível criar impressora"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1888,10 +1850,6 @@ msgid "Default Width"
 msgstr "Largura padrão"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "As doações são deficientes"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "Não é possível abrir arquivo para leitura"
 
@@ -1956,9 +1914,6 @@ msgstr "Falha no download"
 
 msgid "Deploy Method"
 msgstr "Método Deploy"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "Descrição"
@@ -2124,10 +2079,6 @@ msgid "Edit Capone"
 msgstr "exportação Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "exportação Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "anfitrião Descrição"
 
@@ -2146,9 +2097,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2293,10 +2241,6 @@ msgid "Export LDAP Servers"
 msgstr "Servidor LDAP"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "anfitrião Localização"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "Usuários de exportação"
 
@@ -2398,6 +2342,9 @@ msgstr "Conexão FTP falhou"
 
 msgid "FTP Path"
 msgstr "Caminho FTP"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "fracassado"
@@ -2635,10 +2582,6 @@ msgid "Files Deleted List"
 msgstr "Apagar dados de arquivo"
 
 #, fuzzy
-msgid "Filter"
-msgstr "Arquivo"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "Não snapins associado"
 
@@ -2744,10 +2687,6 @@ msgstr "Açao"
 #, fuzzy
 msgid "Function Error"
 msgstr "Açao"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "O método não existe"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2915,18 +2854,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos Grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "anfitrião Localização"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Localização Atualizado"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "História de login"
 
@@ -2998,10 +2925,6 @@ msgid "Group Update Fail"
 msgstr "Grupo Criar falhou"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "Grupo Criar falhou"
 
@@ -3016,10 +2939,6 @@ msgstr "grupo adicionado"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "Grupo é inválido"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "atualização do utilizador falhou"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3145,18 +3064,6 @@ msgstr "Casa"
 msgid "Host"
 msgstr "Anfitrião"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "Impressora já existe"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "Impressora já existe"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "Impressora já existe"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "host criado"
@@ -3239,17 +3146,6 @@ msgstr "Hospedar argumentos do kernel"
 msgid "Host List"
 msgstr "Lista de Host"
 
-msgid "Host Location"
-msgstr "anfitrião Localização"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "Localização Atualizado"
-
 msgid "Host Login History"
 msgstr "Hospedar Entrada História"
 
@@ -3306,10 +3202,6 @@ msgstr "História Snapin"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "Anfitrião Update Failed"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "Anfitrião Update Failed"
 
 #, fuzzy
@@ -3614,22 +3506,6 @@ msgid "Image Used"
 msgstr "fotografada"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "Gerenciamento de usuários"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "Nome da imagem"
 
@@ -3742,10 +3618,6 @@ msgid "Import Failed"
 msgstr "imagem atualizada"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "anfitrião Localização"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "importar usuários"
 
@@ -3762,28 +3634,12 @@ msgid "Import Reports"
 msgstr "Hosts de importação"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "Grupos de importação"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "Bem sucedido"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "Bem sucedido"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "Unidos Task"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "Tipos de tarefa"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3980,10 +3836,6 @@ msgstr "URL inválida"
 msgid "Invalid Windows product key"
 msgstr "Hospedar de Chave de Produto"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "Selecione uma imagem válida"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4024,9 +3876,6 @@ msgstr "Chave inválida a ser removido"
 
 msgid "Invalid key being set"
 msgstr "Chave inválida sendo definido"
-
-msgid "Invalid method called"
-msgstr "Método inválido chamada"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4147,9 +3996,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4195,10 +4041,6 @@ msgid "Key"
 msgstr "DMI Key"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "Associação imagem"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "Evento deve ser uma string"
 
@@ -4221,9 +4063,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "Matar"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4341,10 +4180,6 @@ msgstr "Nome do servidor LDAP"
 msgid "LDAP Server updated!"
 msgstr "Nome do servidor LDAP"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "Servidor LDAP"
-
 msgid "Language"
 msgstr "Língua"
 
@@ -4376,9 +4211,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4446,14 +4278,6 @@ msgid "List All Plugins"
 msgstr "instalar Plugins"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "Unidos Task"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "Tipos de tarefa"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "Plugins instalados"
 
@@ -4480,10 +4304,6 @@ msgstr "Carregamento de dados para o campo %s"
 
 msgid "Location"
 msgstr "Localização"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "Associação imagem"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4518,9 +4338,6 @@ msgstr "Instalar / Atualizar sucesso!"
 #, fuzzy
 msgid "Location added!"
 msgstr "Localização Nome"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4905,10 +4722,6 @@ msgstr ""
 msgid "NOT"
 msgstr "NÃO"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "NÃO"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4941,16 +4754,9 @@ msgstr "Evento deve ser uma string"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "Evento deve ser uma string"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "Evento deve ser uma string"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "atualização do utilizador falhou"
 
 msgid "Network Information"
 msgstr "Informações de rede"
@@ -5022,9 +4828,6 @@ msgstr "Sem Imagem do especificado"
 
 msgid "No Printer Management"
 msgstr "Sem gerenciamento de impressoras"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5904,10 +5707,6 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "A porta não é válida ldap / ldaps portos"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6131,9 +5930,6 @@ msgstr "Impressora atualizado!"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Contas Pushbullet"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "Gestão de Clientes"
@@ -6333,10 +6129,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "Resultados"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6582,18 +6374,7 @@ msgid "Search Base DN"
 msgstr "Pesquisa"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "Pesquisa"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "Pesquisa"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "Pesquisa"
 
 #, fuzzy
@@ -6601,9 +6382,6 @@ msgid "Search Scope"
 msgstr "Pesquisa"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6982,9 +6760,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "Contas Slack"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7506,10 +7281,6 @@ msgid "Subnet Group updated!"
 msgstr "grupo adicionado"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "Grupos de exportação"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "Grupos de exportação"
 
@@ -7658,9 +7429,6 @@ msgstr "usuário criado"
 msgid "Task State Updated!"
 msgstr "Estado tarefa adicional, a edição"
 
-msgid "Task States"
-msgstr "Unidos Task"
-
 msgid "Task Type"
 msgstr "Tipo de tarefa"
 
@@ -7710,9 +7478,6 @@ msgstr "tipo de tarefa não é válido"
 
 msgid "Task Type is not valid"
 msgstr "Tipo de tarefa não é válido"
-
-msgid "Task Types"
-msgstr "Tipos de tarefa"
 
 #, fuzzy
 msgid "Task failed"
@@ -7821,12 +7586,6 @@ msgstr "Esta configuração define "
 msgid "The API is disabled"
 msgstr "As doações são deficientes"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "Não existem grupos neste servidor."
@@ -7845,9 +7604,6 @@ msgstr "Não foi possível ler arquivo temporário"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr " não existe mais"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7888,9 +7644,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7960,9 +7713,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8160,9 +7910,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr " | Este não é o grupo primário"
@@ -8217,10 +7964,6 @@ msgstr ""
 msgid "This setting"
 msgstr "Esta configuração define "
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "Esta configuração define "
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8272,10 +8015,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "Não há snapins associados a este alojamento"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8740,10 +8479,6 @@ msgid "User Create Success"
 msgstr "usuário criado"
 
 #, fuzzy
-msgid "User DN"
-msgstr "Nome de usuário"
-
-#, fuzzy
 msgid "User Group"
 msgstr "grupos"
 
@@ -8827,9 +8562,6 @@ msgstr "Instalar / Atualizar sucesso!"
 msgid "User added!"
 msgstr "Nome da impressora"
 
-msgid "User call is invalid"
-msgstr "chamada do usuário é inválido"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "Nome da impressora"
@@ -8842,9 +8574,6 @@ msgstr "atualização do utilizador falhou"
 msgid "User group updated!"
 msgstr "usuário atualizada"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "Registro não encontrado, erro: %s"
@@ -8856,10 +8585,6 @@ msgstr "atualização do utilizador falhou"
 #, fuzzy
 msgid "User updated!"
 msgstr "usuário atualizada"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "Por favor, indique um nome para este servidor LDAP."
 
 #, fuzzy
 msgid "User/Channel"
@@ -8881,15 +8606,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "Nome de usuário"
-
 msgid "Users"
 msgstr "usuários"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8956,10 +8674,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "Nome Storage Node"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "Não é possível conectar ao banco de dados"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8982,9 +8696,6 @@ msgstr "foi atualizado com sucesso"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -9000,10 +8711,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "anfitrião Descrição"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9046,16 +8753,8 @@ msgid "Windows Key updated!"
 msgstr "Gerenciamento de usuários"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "Hospedar de Chave de Produto"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "Uma imagem já existe com este nome!"
 
 msgid "Wipes"
 msgstr ""
@@ -9177,16 +8876,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9228,9 +8921,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9302,7 +8992,7 @@ msgstr "tamanho do arquivo"
 msgid "fog-admins"
 msgstr "Nome do domínio"
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 #, fuzzy
@@ -9340,14 +9030,6 @@ msgstr "foi atualizado com sucesso"
 
 msgid "has been successfully updated"
 msgstr "foi atualizado com sucesso"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "foi destruído"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "Inválida Snapin Tasking"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9526,10 +9208,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI Key"
-
 msgid "keys"
 msgstr ""
 
@@ -9541,9 +9219,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9578,9 +9253,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9740,9 +9412,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "Snapin"
@@ -9799,9 +9468,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "Grupo de armazenamento Atualizado"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9860,9 +9526,6 @@ msgstr "Nenhuma chave que está sendo solicitado"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "Nenhuma chave que está sendo solicitado"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "rever."
@@ -9931,13 +9594,6 @@ msgstr "Windows 7"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "não dentro desta"
 
 #, fuzzy
 msgid "with this group"
@@ -10089,12 +9745,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "Caminho"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "Não é possível conectar ao banco de dados"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "Capone Deploy"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "chamada de canal é inválido"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "Configurações"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10117,6 +9803,14 @@ msgstr ""
 #~ msgstr "Nenhum de hash disponíveis"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "As doações são deficientes"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "exportação Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "Hosts de exportação"
 
@@ -10129,6 +9823,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "anfitrião Localização"
 
 #~ msgid "Export Printers"
@@ -10175,8 +9873,28 @@ msgstr ""
 #~ msgstr "Eu não sou o servidor web nevoeiro"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Arquivo"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "reinicialização"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "O método não existe"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Localização Atualizado"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10195,12 +9913,32 @@ msgstr ""
 #~ msgstr "grupo adicionado"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Criar falhou"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "Grupo Criar falhou"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "atualização do utilizador falhou"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "anfitrião Descrição"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "Impressora já existe"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "Impressora já existe"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "Impressora já existe"
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10222,6 +9960,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "atualização do utilizador falhou"
 
+#~ msgid "Host Location"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "Localização Atualizado"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "Lista de Host"
@@ -10237,6 +9986,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "História Snapin"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "Anfitrião Update Failed"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10275,6 +10028,22 @@ msgstr ""
 #~ msgstr "usuário atualizada"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "Gerenciamento de usuários"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "Hosts de importação"
 
@@ -10283,6 +10052,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "anfitrião Localização"
 
 #~ msgid "Import Printers"
@@ -10311,12 +10084,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "Todos os nós de armazenamento"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "Grupos de importação"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "Unidos Task"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "Tipos de tarefa"
+
 #~ msgid "Import Users"
 #~ msgstr "importar usuários"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "tipo inválido"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "Selecione uma imagem válida"
+
+#~ msgid "Invalid method called"
+#~ msgstr "Método inválido chamada"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "Servidor LDAP"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10335,11 +10139,28 @@ msgstr ""
 #~ msgstr "Listar todos os %s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "Unidos Task"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "Tipos de tarefa"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "Associação imagem"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "No nó associado"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "Sem FOGPage classe encontrada para este nó"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "NÃO"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "atualização do utilizador falhou"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10371,8 +10192,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "Por favor, indique um nome para este local."
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "A porta não é válida ldap / ldaps portos"
+
 #~ msgid "Printer Alias"
 #~ msgstr "Printer Alias"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Contas Pushbullet"
 
 #~ msgid "Registered"
 #~ msgstr "Registrado"
@@ -10380,6 +10208,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "Remover snapins selecionados"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "Resultados"
 
 #~ msgid "Results"
 #~ msgstr "Resultados"
@@ -10440,8 +10272,19 @@ msgstr ""
 #~ msgstr "atualização da impressora falhou!"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "Pesquisa"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "Pesquisa"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "Associação imagem"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "Contas Slack"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10455,8 +10298,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nó de Armazenamento Criado"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "Grupos de exportação"
+
 #~ msgid "Successful"
 #~ msgstr "Bem sucedido"
+
+#~ msgid "Task States"
+#~ msgstr "Unidos Task"
+
+#~ msgid "Task Types"
+#~ msgstr "Tipos de tarefa"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10486,6 +10339,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr " | Este não é o nó mestre"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "Esta configuração define "
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "Não há snapins associados a este alojamento"
+
 #~ msgid "Total Rows"
 #~ msgstr "total de linhas"
 
@@ -10508,6 +10369,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "Remover impressoras selecionadas"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "Nome de usuário"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10553,6 +10418,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "Serviço Atualizado!"
 
+#~ msgid "User call is invalid"
+#~ msgstr "chamada do usuário é inválido"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "Por favor, indique um nome para este servidor LDAP."
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "Nome de usuário"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "Não é possível conectar ao banco de dados"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "Uma imagem já existe com este nome!"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "Última versão"
@@ -10573,6 +10465,18 @@ msgstr ""
 #~ msgstr "concluído"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "foi destruído"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "Inválida Snapin Tasking"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI Key"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "Tarefas Multicast ativos"
 
@@ -10583,3 +10487,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versão"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "não dentro desta"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -735,9 +735,6 @@ msgstr ""
 msgid "All items imported successfully"
 msgstr "安装/升级成功！"
 
-msgid "All methods of binding have failed"
-msgstr ""
-
 #, fuzzy
 msgid "All ports must be numeric, greater than 0, and less than 65536"
 msgstr "带宽应该是数字和大于0"
@@ -746,12 +743,6 @@ msgid "All rights reserved."
 msgstr ""
 
 msgid "Allow API"
-msgstr ""
-
-msgid "Allows editing/creating of Task States fog currently has."
-msgstr ""
-
-msgid "Allows editing/creating of Task Types fog currently has."
 msgstr ""
 
 #, fuzzy
@@ -1070,10 +1061,6 @@ msgid "CA Certificate Path"
 msgstr "新建%s"
 
 #, fuzzy
-msgid "CA Path"
-msgstr "路径"
-
-#, fuzzy
 msgid "CA private key"
 msgstr "私钥失败"
 
@@ -1173,10 +1160,6 @@ msgstr "取消任务"
 msgid "Cancelled due to new tasking."
 msgstr "由于新的任务取消。"
 
-#, fuzzy
-msgid "Cannot bind to the LDAP server"
-msgstr "无法连接到数据库"
-
 msgid "Cannot change image when in tasking"
 msgstr ""
 
@@ -1220,9 +1203,6 @@ msgstr "更新管理单元"
 #, fuzzy
 msgid "Capone Create Success"
 msgstr "更新管理单元"
-
-msgid "Capone Deploy"
-msgstr "卡波恩部署"
 
 #, fuzzy
 msgid "Capone Management"
@@ -1302,9 +1282,6 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-msgid "Channel call is invalid"
-msgstr "通道调用无效"
-
 #, fuzzy
 msgid "Channel not found"
 msgstr "未发现记录，错误： %s"
@@ -1329,6 +1306,10 @@ msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
+
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "没有FOGPage类中找到此节点"
 
 msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
@@ -1533,22 +1514,7 @@ msgstr "无法读取tmp文件。"
 msgid "Could not read snapin file"
 msgstr "无法读取tmp文件。"
 
-msgid "Could not read the directory to confirm it supports nested group chaining, saving the chain strategy unverified"
-msgstr ""
-
-#, fuzzy
-msgid "Could not read the group mappings"
-msgstr "无法读取tmp文件。"
-
-#, fuzzy
-msgid "Could not read the recorded grants"
-msgstr "无法读取tmp文件。"
-
 msgid "Could not read tmp file."
-msgstr "无法读取tmp文件。"
-
-#, fuzzy
-msgid "Could not record the granted targets"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
@@ -1558,10 +1524,6 @@ msgstr "无法创建打印机"
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
-
-#, fuzzy
-msgid "Could not seed the granted targets"
-msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not send data from file"
@@ -1888,10 +1850,6 @@ msgid "Default Width"
 msgstr "默认宽度"
 
 #, fuzzy
-msgid "Default is disabled"
-msgstr "捐款将被禁用"
-
-#, fuzzy
 msgid "Default nested group depth"
 msgstr "无法打开文件进行读取"
 
@@ -1956,9 +1914,6 @@ msgstr "下载失败"
 
 msgid "Deploy Method"
 msgstr "部署方法"
-
-msgid "Depth"
-msgstr ""
 
 msgid "Description"
 msgstr "描述"
@@ -2124,10 +2079,6 @@ msgid "Edit Capone"
 msgstr "出口Snapins"
 
 #, fuzzy
-msgid "Edit Capone ID"
-msgstr "出口Snapins"
-
-#, fuzzy
 msgid "Editing Capone ID"
 msgstr "主机描述"
 
@@ -2146,9 +2097,6 @@ msgid "Empty filename in upload"
 msgstr ""
 
 msgid "Enable Domain Joining"
-msgstr ""
-
-msgid "Enable Sending via Location"
 msgstr ""
 
 #, fuzzy
@@ -2293,10 +2241,6 @@ msgid "Export LDAP Servers"
 msgstr "LDAP服务器"
 
 #, fuzzy
-msgid "Export Locations"
-msgstr "主机位置"
-
-#, fuzzy
 msgid "Export OUs"
 msgstr "导出用户"
 
@@ -2398,6 +2342,9 @@ msgstr "FTP连接失败"
 
 msgid "FTP Path"
 msgstr "FTP路径"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Failed"
 msgstr "失败"
@@ -2635,10 +2582,6 @@ msgid "Files Deleted List"
 msgstr "删除的文件数据"
 
 #, fuzzy
-msgid "Filter"
-msgstr "文件"
-
-#, fuzzy
 msgid "Finding any images associated"
 msgstr "没有snapins相关"
 
@@ -2744,10 +2687,6 @@ msgstr "行动"
 #, fuzzy
 msgid "Function Error"
 msgstr "行动"
-
-#, fuzzy
-msgid "Function does not exist"
-msgstr "方法不存在"
 
 msgid "GNU General Public License"
 msgstr ""
@@ -2915,18 +2854,6 @@ msgid "Group Kernel Arguments"
 msgstr "集团内核参数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "主机位置"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "更新位置"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "登录历史记录"
 
@@ -2998,10 +2925,6 @@ msgid "Group Update Fail"
 msgstr "集团创建失败"
 
 #, fuzzy
-msgid "Group Update Location Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
 msgid "Group Update OU Fail"
 msgstr "集团创建失败"
 
@@ -3016,10 +2939,6 @@ msgstr "集团补充"
 #, fuzzy
 msgid "Group is not valid"
 msgstr "集团是无效的"
-
-#, fuzzy
-msgid "Group membership search failed"
-msgstr "用户更新失败"
 
 #, fuzzy
 msgid "Group update failed!"
@@ -3145,18 +3064,6 @@ msgstr "家"
 msgid "Host"
 msgstr "主办"
 
-#, fuzzy, php-format
-msgid "Host %1$s failed imaging %2$s: %3$s"
-msgstr "打印机已经存在"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished capturing image %2$s."
-msgstr "打印机已经存在"
-
-#, fuzzy, php-format
-msgid "Host %1$s finished deploying image %2$s."
-msgstr "打印机已经存在"
-
 #, fuzzy
 msgid "Host Approval Success"
 msgstr "主机创建"
@@ -3239,17 +3146,6 @@ msgstr "主机内核参数"
 msgid "Host List"
 msgstr "主机列表"
 
-msgid "Host Location"
-msgstr "主机位置"
-
-#, fuzzy
-msgid "Host Location Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Host Location Updated!"
-msgstr "更新位置"
-
 msgid "Host Login History"
 msgstr "主机登录历史"
 
@@ -3306,10 +3202,6 @@ msgstr "历史管理单元"
 
 #, fuzzy
 msgid "Host Update Fail"
-msgstr "主机更新失败"
-
-#, fuzzy
-msgid "Host Update Location Fail"
 msgstr "主机更新失败"
 
 #, fuzzy
@@ -3614,22 +3506,6 @@ msgid "Image Used"
 msgstr "成像"
 
 #, fuzzy
-msgid "Image Windows Key"
-msgstr "Windows 8的"
-
-#, fuzzy
-msgid "Image Windows Key Update Fail"
-msgstr "用户管理"
-
-#, fuzzy
-msgid "Image Windows Key Update Success"
-msgstr "用户管理"
-
-#, fuzzy
-msgid "Image Windows Key Updated!"
-msgstr "用户管理"
-
-#, fuzzy
 msgid "Image added!"
 msgstr "图片名称"
 
@@ -3742,10 +3618,6 @@ msgid "Import Failed"
 msgstr "图片更新"
 
 #, fuzzy
-msgid "Import Locations"
-msgstr "主机位置"
-
-#, fuzzy
 msgid "Import OUs"
 msgstr "导入用户"
 
@@ -3762,28 +3634,12 @@ msgid "Import Reports"
 msgstr "进口主机"
 
 #, fuzzy
-msgid "Import Subnet Groups"
-msgstr "导入组"
-
-#, fuzzy
 msgid "Import Succeeded"
 msgstr "成功"
 
 #, fuzzy
 msgid "Import Succeeded With Warnings"
 msgstr "成功"
-
-#, fuzzy
-msgid "Import Task States"
-msgstr "任务的国家"
-
-#, fuzzy
-msgid "Import Task Types"
-msgstr "任务类型"
-
-#, fuzzy
-msgid "Import Windows Keys"
-msgstr "Windows 8的"
 
 #, fuzzy
 msgid "Import a new Plugin"
@@ -3980,10 +3836,6 @@ msgstr "无效的网址"
 msgid "Invalid Windows product key"
 msgstr "主机产品密钥"
 
-#, fuzzy, php-format
-msgid "Invalid certificate verification level: %s"
-msgstr "选择一个有效的图像"
-
 #, php-format
 msgid "Invalid cron expression (expected 5 fields, got %d): \"%s\""
 msgstr ""
@@ -4024,9 +3876,6 @@ msgstr "关键无效被删除"
 
 msgid "Invalid key being set"
 msgstr "无效的关键字设定"
-
-msgid "Invalid method called"
-msgstr "所谓的无效方法"
 
 #, fuzzy
 msgid "Invalid path"
@@ -4147,9 +3996,6 @@ msgstr ""
 msgid "It operates by getting the max bandwidth setting of the node"
 msgstr ""
 
-msgid "It tells the client to download snapins from"
-msgstr ""
-
 msgid "It will operate based on the fields the area typcially requires."
 msgstr ""
 
@@ -4195,10 +4041,6 @@ msgid "Key"
 msgstr "DMI关键"
 
 #, fuzzy
-msgid "Key Association"
-msgstr "图像协会"
-
-#, fuzzy
 msgid "Key field must be a string"
 msgstr "事件必须是字符串"
 
@@ -4221,9 +4063,6 @@ msgstr ""
 
 msgid "Kill"
 msgstr "杀"
-
-msgid "LDAP"
-msgstr ""
 
 #, fuzzy
 msgid "LDAP Connection  Name"
@@ -4341,10 +4180,6 @@ msgstr "LDAP服务器名称"
 msgid "LDAP Server updated!"
 msgstr "LDAP服务器名称"
 
-#, fuzzy
-msgid "LDAP Servers"
-msgstr "LDAP服务器"
-
 msgid "Language"
 msgstr "语言"
 
@@ -4376,9 +4211,6 @@ msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
 msgid "Leave blank to keep the current password"
-msgstr ""
-
-msgid "Level"
 msgstr ""
 
 #, fuzzy
@@ -4446,14 +4278,6 @@ msgid "List All Plugins"
 msgstr "安装插件"
 
 #, fuzzy
-msgid "List All Task States"
-msgstr "任务的国家"
-
-#, fuzzy
-msgid "List All Task Types"
-msgstr "任务类型"
-
-#, fuzzy
 msgid "List Available Plugins"
 msgstr "已安装的插件"
 
@@ -4480,10 +4304,6 @@ msgstr "加载数据到现场%s"
 
 msgid "Location"
 msgstr "位置"
-
-#, fuzzy
-msgid "Location Association"
-msgstr "图像协会"
 
 #, fuzzy
 msgid "Location Create Fail"
@@ -4518,9 +4338,6 @@ msgstr "安装/升级成功！"
 #, fuzzy
 msgid "Location added!"
 msgstr "地点名称"
-
-msgid "Location is a plugin that allows your FOG Server"
-msgstr ""
 
 #, fuzzy
 msgid "Location update failed!"
@@ -4905,10 +4722,6 @@ msgstr ""
 msgid "NOT"
 msgstr "不"
 
-#, fuzzy
-msgid "NOTE"
-msgstr "不"
-
 msgid "NOTE: Forums are the most command fastest method of getting help with any aspect of FOG."
 msgstr ""
 
@@ -4941,16 +4754,9 @@ msgstr "事件必须是字符串"
 msgid "Nested depth must be between 0 and 100, or blank to inherit"
 msgstr "事件必须是字符串"
 
-msgid "Nested group depth cap reached, so group membership may be incomplete"
-msgstr ""
-
 #, fuzzy
 msgid "Nested group depth must be between 1 and 100"
 msgstr "事件必须是字符串"
-
-#, fuzzy
-msgid "Nested group search failed"
-msgstr "用户更新失败"
 
 msgid "Network Information"
 msgstr "网络信息"
@@ -5022,9 +4828,6 @@ msgstr "没有指定的Image"
 
 msgid "No Printer Management"
 msgstr "没有打印机管理"
-
-msgid "No access is allowed"
-msgstr ""
 
 #, fuzzy
 msgid "No active task found for this host"
@@ -5904,10 +5707,6 @@ msgstr ""
 msgid "Port"
 msgstr "港口"
 
-#, fuzzy
-msgid "Port is not valid ldap/ldaps port"
-msgstr "端口是无效的LDAP / LDAPS端口"
-
 msgid "Post-Logout Redirect URI"
 msgstr ""
 
@@ -6131,9 +5930,6 @@ msgstr "打印机更新！"
 msgid "Providers"
 msgstr ""
 
-msgid "Pushbullet Accounts"
-msgstr "Pushbullet账户"
-
 #, fuzzy
 msgid "Pushbullet Management"
 msgstr "客户管理"
@@ -6333,10 +6129,6 @@ msgstr ""
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
 msgstr ""
-
-#, fuzzy
-msgid "Result"
-msgstr "结果"
 
 msgid "Resume Reload"
 msgstr ""
@@ -6582,18 +6374,7 @@ msgid "Search Base DN"
 msgstr "搜索"
 
 #, fuzzy
-msgid "Search DN"
-msgstr "搜索"
-
-msgid "Search DN did not return any results"
-msgstr ""
-
-#, fuzzy
 msgid "Search Key"
-msgstr "搜索"
-
-#, fuzzy
-msgid "Search Method"
 msgstr "搜索"
 
 #, fuzzy
@@ -6601,9 +6382,6 @@ msgid "Search Scope"
 msgstr "搜索"
 
 msgid "Search every class at once"
-msgstr ""
-
-msgid "Search results returned false"
 msgstr ""
 
 #, fuzzy
@@ -6982,9 +6760,6 @@ msgstr ""
 
 msgid "Skipping, will need manual removal"
 msgstr ""
-
-msgid "Slack Accounts"
-msgstr "斯莱克账户"
 
 #, fuzzy
 msgid "Slack Management"
@@ -7506,10 +7281,6 @@ msgid "Subnet Group updated!"
 msgstr "集团补充"
 
 #, fuzzy
-msgid "Subnet Groups"
-msgstr "出口组"
-
-#, fuzzy
 msgid "Subnets"
 msgstr "出口组"
 
@@ -7658,9 +7429,6 @@ msgstr "用户创建"
 msgid "Task State Updated!"
 msgstr "任务状态添加，编辑"
 
-msgid "Task States"
-msgstr "任务的国家"
-
 msgid "Task Type"
 msgstr "任务类型"
 
@@ -7710,9 +7478,6 @@ msgstr "任务类型无效"
 
 msgid "Task Type is not valid"
 msgstr "任务类型是无效"
-
-msgid "Task Types"
-msgstr "任务类型"
 
 #, fuzzy
 msgid "Task failed"
@@ -7821,12 +7586,6 @@ msgstr "此设置定义"
 msgid "The API is disabled"
 msgstr "捐款将被禁用"
 
-msgid "The CA certificate path is too long (255 characters max)"
-msgstr ""
-
-msgid "The CA certificate path must be absolute"
-msgstr ""
-
 #, fuzzy
 msgid "The CA private key is not on this server"
 msgstr "有此服务器上没有组。"
@@ -7845,9 +7604,6 @@ msgstr "无法读取临时文件"
 #, fuzzy
 msgid "The FOG account for this identity no longer exists"
 msgstr "不复存在"
-
-msgid "The FOG schema update must be run before this plugin can be updated: users.uAuthSource does not exist yet."
-msgstr ""
 
 msgid "The ID token carries no subject"
 msgstr ""
@@ -7888,9 +7644,6 @@ msgid "The archive is larger than the %s limit."
 msgstr ""
 
 msgid "The archive must hold exactly one plugin directory."
-msgstr ""
-
-msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
 #, fuzzy
@@ -7960,9 +7713,6 @@ msgid "The issuer URL must use https"
 msgstr ""
 
 msgid "The issuer must be a full URL"
-msgstr ""
-
-msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
 #, php-format
@@ -8160,9 +7910,6 @@ msgstr ""
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."
 msgstr ""
 
-msgid "This is especially useful if you have multiple"
-msgstr ""
-
 #, fuzzy
 msgid "This is not the master for this group"
 msgstr "|这不是主要组"
@@ -8217,10 +7964,6 @@ msgstr ""
 msgid "This setting"
 msgstr "此设置定义"
 
-#, fuzzy
-msgid "This setting defines sending the"
-msgstr "此设置定义"
-
 msgid "This setting defines the number of items to display when listing/searching elements. The default value is 10."
 msgstr ""
 
@@ -8272,10 +8015,6 @@ msgstr ""
 
 msgid "This would leave no account able to administer FOG."
 msgstr ""
-
-#, fuzzy
-msgid "Those images should be activated with the associated"
-msgstr "没有与此主机关联snapins"
 
 msgid "Throughput sample."
 msgstr ""
@@ -8740,10 +8479,6 @@ msgid "User Create Success"
 msgstr "用户创建"
 
 #, fuzzy
-msgid "User DN"
-msgstr "用户名"
-
-#, fuzzy
 msgid "User Group"
 msgstr "组"
 
@@ -8827,9 +8562,6 @@ msgstr "安装/升级成功！"
 msgid "User added!"
 msgstr "打印机名称"
 
-msgid "User call is invalid"
-msgstr "用户调用无效"
-
 #, fuzzy
 msgid "User group added!"
 msgstr "打印机名称"
@@ -8842,9 +8574,6 @@ msgstr "用户更新失败"
 msgid "User group updated!"
 msgstr "用户更新"
 
-msgid "User matched none of the mapped groups"
-msgstr ""
-
 #, fuzzy
 msgid "User not found"
 msgstr "未发现记录，错误： %s"
@@ -8856,10 +8585,6 @@ msgstr "用户更新失败"
 #, fuzzy
 msgid "User updated!"
 msgstr "用户更新"
-
-#, fuzzy
-msgid "User was not authorized by the LDAP server"
-msgstr "这个LDAP服务器输入名称。"
 
 #, fuzzy
 msgid "User/Channel"
@@ -8881,15 +8606,8 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
-#, fuzzy
-msgid "Username was blank"
-msgstr "用户名"
-
 msgid "Users"
 msgstr "用户"
-
-msgid "Using the group match function"
-msgstr ""
 
 msgid "VB Script"
 msgstr ""
@@ -8956,10 +8674,6 @@ msgstr ""
 msgid "We are node name"
 msgstr "存储节点名称"
 
-#, fuzzy
-msgid "We cannot connect to LDAP server"
-msgstr "无法连接到数据库"
-
 msgid "Web CA private key"
 msgstr ""
 
@@ -8982,9 +8696,6 @@ msgstr "已成功更新"
 msgid "What to do next"
 msgstr ""
 
-msgid "When the plugin is removed, the assigned key will remain"
-msgstr ""
-
 msgid "Where to get help and guides"
 msgstr ""
 
@@ -9000,10 +8711,6 @@ msgstr ""
 #, fuzzy
 msgid "Windows 10 Professional"
 msgstr "主机描述"
-
-#, fuzzy
-msgid "Windows Key"
-msgstr "Windows 8的"
 
 #, fuzzy
 msgid "Windows Key Create Fail"
@@ -9046,16 +8753,8 @@ msgid "Windows Key updated!"
 msgstr "用户管理"
 
 #, fuzzy
-msgid "Windows Keys"
-msgstr "Windows 8的"
-
-#, fuzzy
 msgid "Windows Product key"
 msgstr "主机产品密钥"
-
-#, fuzzy
-msgid "Windows keys is a plugin that associates product keys"
-msgstr "图像已经存在具有此名称！"
 
 msgid "Wipes"
 msgstr ""
@@ -9177,16 +8876,10 @@ msgstr ""
 msgid "between"
 msgstr ""
 
-msgid "between different sites"
-msgstr ""
-
 msgid "blank for default"
 msgstr ""
 
 msgid "boot the client computers"
-msgstr ""
-
-msgid "but bind password is not set"
 msgstr ""
 
 #, fuzzy
@@ -9228,9 +8921,6 @@ msgid "cycles since last line"
 msgstr ""
 
 msgid "day"
-msgstr ""
-
-msgid "deploy task occurs for it"
 msgstr ""
 
 msgid "directive in php.ini"
@@ -9302,7 +8992,7 @@ msgstr "文件大小"
 msgid "fog-admins"
 msgstr "域名"
 
-msgid "for Microsoft Windows to images"
+msgid "for user"
 msgstr ""
 
 #, fuzzy
@@ -9340,14 +9030,6 @@ msgstr "已成功更新"
 
 msgid "has been successfully updated"
 msgstr "已成功更新"
-
-#, fuzzy
-msgid "has completed on"
-msgstr "已被破坏"
-
-#, fuzzy
-msgid "has completed snapin tasking"
-msgstr "无效的管理单元任务处理"
 
 #, fuzzy
 msgid "has failed to destroy"
@@ -9526,10 +9208,6 @@ msgstr ""
 msgid "kernel to boot the client computers"
 msgstr ""
 
-#, fuzzy
-msgid "key"
-msgstr "DMI关键"
-
 msgid "keys"
 msgstr ""
 
@@ -9541,9 +9219,6 @@ msgid "lets this account use a FOG password again; sign-in through %s may stop w
 msgstr ""
 
 msgid "limited to 1Mbps on that node"
-msgstr ""
-
-msgid "location url based on the host that checks in"
 msgstr ""
 
 msgid "logged in"
@@ -9578,9 +9253,6 @@ msgid "multipart/form-data, not JSON. The file goes to the master storage node o
 msgstr ""
 
 msgid "multipart/form-data, not JSON. Transport only -- no snapin row is created or touched, so this is how a caller pre-stages files to attach later. The field name must be snapinfiles[] even for a single file. Every file is validated before any transfer begins, but a failure part way through a batch leaves the earlier files in place."
-msgstr ""
-
-msgid "multiple places to get your image"
 msgstr ""
 
 #, fuzzy
@@ -9740,9 +9412,6 @@ msgstr ""
 msgid "signing out of FOG also signs out of this provider"
 msgstr ""
 
-msgid "sites with clients moving back and forth"
-msgstr ""
-
 #, fuzzy
 msgid "snapin"
 msgstr "管理单元"
@@ -9799,9 +9468,6 @@ msgstr ""
 #, fuzzy
 msgid "the group has no enabled master node"
 msgstr "存储组更新"
-
-msgid "the host defined location where available"
-msgstr ""
 
 msgid "the initrd (initial ramdisk) which is alongside the"
 msgstr ""
@@ -9860,9 +9526,6 @@ msgstr "没有要求的关键"
 #, fuzzy
 msgid "to get the requested initrd"
 msgstr "没有要求的关键"
-
-msgid "to operate in an environment where there may be"
-msgstr ""
 
 msgid "to review."
 msgstr "回顾。"
@@ -9931,13 +9594,6 @@ msgstr "Windows 7的"
 
 msgid "wipe out all of your images stored on"
 msgstr ""
-
-msgid "with status code"
-msgstr ""
-
-#, fuzzy
-msgid "with the host"
-msgstr "不在此"
 
 #, fuzzy
 msgid "with this group"
@@ -10089,12 +9745,42 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
 
+#, fuzzy
+#~ msgid "CA Path"
+#~ msgstr "路径"
+
+#, fuzzy
+#~ msgid "Cannot bind to the LDAP server"
+#~ msgstr "无法连接到数据库"
+
+#~ msgid "Capone Deploy"
+#~ msgstr "卡波恩部署"
+
+#~ msgid "Channel call is invalid"
+#~ msgstr "通道调用无效"
+
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"
 
 #, fuzzy
 #~ msgid "Client Module Settings"
 #~ msgstr "设置"
+
+#, fuzzy
+#~ msgid "Could not read the group mappings"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not read the recorded grants"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not record the granted targets"
+#~ msgstr "无法读取tmp文件。"
+
+#, fuzzy
+#~ msgid "Could not seed the granted targets"
+#~ msgstr "无法读取tmp文件。"
 
 #, fuzzy
 #~ msgid "Create New Accesscontrol"
@@ -10117,6 +9803,14 @@ msgstr ""
 #~ msgstr "没有可用的散列"
 
 #, fuzzy
+#~ msgid "Default is disabled"
+#~ msgstr "捐款将被禁用"
+
+#, fuzzy
+#~ msgid "Edit Capone ID"
+#~ msgstr "出口Snapins"
+
+#, fuzzy
 #~ msgid "Export Host Exts"
 #~ msgstr "主机出口"
 
@@ -10129,6 +9823,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Export LDAPs"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Export Locations"
 #~ msgstr "主机位置"
 
 #~ msgid "Export Printers"
@@ -10175,8 +9873,28 @@ msgstr ""
 #~ msgstr "我不是雾Web服务器"
 
 #, fuzzy
+#~ msgid "Filter"
+#~ msgstr "文件"
+
+#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "重启"
+
+#, fuzzy
+#~ msgid "Function does not exist"
+#~ msgstr "方法不存在"
+
+#, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "更新位置"
 
 #, fuzzy
 #~ msgid "Group Mappings"
@@ -10195,12 +9913,32 @@ msgstr ""
 #~ msgstr "集团补充"
 
 #, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "集团创建失败"
+
+#, fuzzy
 #~ msgid "Group Update Site Fail"
 #~ msgstr "集团创建失败"
 
 #, fuzzy
+#~ msgid "Group membership search failed"
+#~ msgstr "用户更新失败"
+
+#, fuzzy
 #~ msgid "Group module settings"
 #~ msgstr "主机描述"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s failed imaging %2$s: %3$s"
+#~ msgstr "打印机已经存在"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished capturing image %2$s."
+#~ msgstr "打印机已经存在"
+
+#, fuzzy, php-format
+#~ msgid "Host %1$s finished deploying image %2$s."
+#~ msgstr "打印机已经存在"
 
 #, fuzzy
 #~ msgid "Host Associated"
@@ -10222,6 +9960,17 @@ msgstr ""
 #~ msgid "Host Ext Variable"
 #~ msgstr "用户更新失败"
 
+#~ msgid "Host Location"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Host Location Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Host Location Updated!"
+#~ msgstr "更新位置"
+
 #, fuzzy
 #~ msgid "Host Site"
 #~ msgstr "主机列表"
@@ -10237,6 +9986,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Snapins"
 #~ msgstr "历史管理单元"
+
+#, fuzzy
+#~ msgid "Host Update Location Fail"
+#~ msgstr "主机更新失败"
 
 #, fuzzy
 #~ msgid "Host Update Site Fail"
@@ -10275,6 +10028,22 @@ msgstr ""
 #~ msgstr "用户更新"
 
 #, fuzzy
+#~ msgid "Image Windows Key"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Fail"
+#~ msgstr "用户管理"
+
+#, fuzzy
+#~ msgid "Image Windows Key Update Success"
+#~ msgstr "用户管理"
+
+#, fuzzy
+#~ msgid "Image Windows Key Updated!"
+#~ msgstr "用户管理"
+
+#, fuzzy
 #~ msgid "Import Host Exts"
 #~ msgstr "进口主机"
 
@@ -10283,6 +10052,10 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Import LDAP Settings"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Import Locations"
 #~ msgstr "主机位置"
 
 #~ msgid "Import Printers"
@@ -10311,12 +10084,43 @@ msgstr ""
 #~ msgid "Import Storage Nodes"
 #~ msgstr "所有存储节点"
 
+#, fuzzy
+#~ msgid "Import Subnet Groups"
+#~ msgstr "导入组"
+
+#, fuzzy
+#~ msgid "Import Task States"
+#~ msgstr "任务的国家"
+
+#, fuzzy
+#~ msgid "Import Task Types"
+#~ msgstr "任务类型"
+
 #~ msgid "Import Users"
 #~ msgstr "导入用户"
 
 #, fuzzy
+#~ msgid "Import Windows Keys"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
 #~ msgid "Invalid Type"
 #~ msgstr "无效类型"
+
+#, fuzzy, php-format
+#~ msgid "Invalid certificate verification level: %s"
+#~ msgstr "选择一个有效的图像"
+
+#~ msgid "Invalid method called"
+#~ msgstr "所谓的无效方法"
+
+#, fuzzy
+#~ msgid "Key Association"
+#~ msgstr "图像协会"
+
+#, fuzzy
+#~ msgid "LDAP Servers"
+#~ msgstr "LDAP服务器"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -10335,11 +10139,28 @@ msgstr ""
 #~ msgstr "列表中的所有%s"
 
 #, fuzzy
+#~ msgid "List All Task States"
+#~ msgstr "任务的国家"
+
+#, fuzzy
+#~ msgid "List All Task Types"
+#~ msgstr "任务类型"
+
+#, fuzzy
+#~ msgid "Location Association"
+#~ msgstr "图像协会"
+
+#, fuzzy
 #~ msgid "Module Associated"
 #~ msgstr "无关联的节点"
 
-#~ msgid "No FOGPage Class found for this node"
-#~ msgstr "没有FOGPage类中找到此节点"
+#, fuzzy
+#~ msgid "NOTE"
+#~ msgstr "不"
+
+#, fuzzy
+#~ msgid "Nested group search failed"
+#~ msgstr "用户更新失败"
 
 #, fuzzy
 #~ msgid "No directory group feeds this user group."
@@ -10371,8 +10192,15 @@ msgstr ""
 #~ msgid "Please Enter an admin or mobile lookup name"
 #~ msgstr "这个位置输入名称。"
 
+#, fuzzy
+#~ msgid "Port is not valid ldap/ldaps port"
+#~ msgstr "端口是无效的LDAP / LDAPS端口"
+
 #~ msgid "Printer Alias"
 #~ msgstr "打印机别名"
+
+#~ msgid "Pushbullet Accounts"
+#~ msgstr "Pushbullet账户"
 
 #~ msgid "Registered"
 #~ msgstr "注册"
@@ -10380,6 +10208,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Remove Selected"
 #~ msgstr "删除选定snapins"
+
+#, fuzzy
+#~ msgid "Result"
+#~ msgstr "结果"
 
 #~ msgid "Results"
 #~ msgstr "结果"
@@ -10440,8 +10272,19 @@ msgstr ""
 #~ msgstr "打印机更新失败！"
 
 #, fuzzy
+#~ msgid "Search DN"
+#~ msgstr "搜索"
+
+#, fuzzy
+#~ msgid "Search Method"
+#~ msgstr "搜索"
+
+#, fuzzy
 #~ msgid "Site Association"
 #~ msgstr "图像协会"
+
+#~ msgid "Slack Accounts"
+#~ msgstr "斯莱克账户"
 
 #, fuzzy
 #~ msgid "Snapin Created"
@@ -10455,8 +10298,18 @@ msgstr ""
 #~ msgid "Storage Node Associated"
 #~ msgstr "存储节点创建"
 
+#, fuzzy
+#~ msgid "Subnet Groups"
+#~ msgstr "出口组"
+
 #~ msgid "Successful"
 #~ msgstr "成功"
+
+#~ msgid "Task States"
+#~ msgstr "任务的国家"
+
+#~ msgid "Task Types"
+#~ msgstr "任务类型"
 
 #, fuzzy
 #~ msgid "Task run time"
@@ -10486,6 +10339,14 @@ msgstr ""
 #~ msgid "This server is not a master node"
 #~ msgstr "|这不是主节点"
 
+#, fuzzy
+#~ msgid "This setting defines sending the"
+#~ msgstr "此设置定义"
+
+#, fuzzy
+#~ msgid "Those images should be activated with the associated"
+#~ msgstr "没有与此主机关联snapins"
+
 #~ msgid "Total Rows"
 #~ msgstr "共行"
 
@@ -10508,6 +10369,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Update/Remove printers"
 #~ msgstr "删除选定的打印机"
+
+#, fuzzy
+#~ msgid "User DN"
+#~ msgstr "用户名"
 
 #, fuzzy
 #~ msgid "User Group Site"
@@ -10553,6 +10418,33 @@ msgstr ""
 #~ msgid "User Site Updated!"
 #~ msgstr "服务更新！"
 
+#~ msgid "User call is invalid"
+#~ msgstr "用户调用无效"
+
+#, fuzzy
+#~ msgid "User was not authorized by the LDAP server"
+#~ msgstr "这个LDAP服务器输入名称。"
+
+#, fuzzy
+#~ msgid "Username was blank"
+#~ msgstr "用户名"
+
+#, fuzzy
+#~ msgid "We cannot connect to LDAP server"
+#~ msgstr "无法连接到数据库"
+
+#, fuzzy
+#~ msgid "Windows Key"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Windows Keys"
+#~ msgstr "Windows 8的"
+
+#, fuzzy
+#~ msgid "Windows keys is a plugin that associates product keys"
+#~ msgstr "图像已经存在具有此名称！"
+
 #, fuzzy
 #~ msgid "You have version"
 #~ msgstr "最新版本"
@@ -10573,6 +10465,18 @@ msgstr ""
 #~ msgstr "完成"
 
 #, fuzzy
+#~ msgid "has completed on"
+#~ msgstr "已被破坏"
+
+#, fuzzy
+#~ msgid "has completed snapin tasking"
+#~ msgstr "无效的管理单元任务处理"
+
+#, fuzzy
+#~ msgid "key"
+#~ msgstr "DMI关键"
+
+#, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "活动组播任务"
 
@@ -10583,3 +10487,7 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "版"
+
+#, fuzzy
+#~ msgid "with the host"
+#~ msgstr "不在此"


### PR DESCRIPTION
Closes #1254.

`FOGFTP::connect()` opens the socket and then logs in, and reports the same failure for both stages — a bare `false` on this branch, a generic exception on `dev-branch`. So the replicator logged `Cannot connect to <node>` whether the network was down or the password was simply wrong.

That sends people at the network, and the network is almost never the cause. Every master keeps its own copy of every peer's FTP credential in `nfsGroupMembers` and nothing syncs them, so changing the `fogproject` account password on one server — or reinstalling it — silently invalidates every *other* master's copy. Replication then fails in one direction only, indefinitely, while the log insists the host is unreachable. On a lab pair that ran for three weeks and 4,121 log lines with ping and TCP 21 answering the whole time.

`connect()` now records which stage it reached and `lastFailure()` reports it:

```
 * FTP login rejected by 10.253.25.2 for user fogproject
 | Check the password stored for this node
```

An unreachable host still reads `Cannot connect to <node>`.

The stage is tracked rather than matched out of the exception text, because that text is PHP's own warning (`ftp_login(): Login incorrect`) and is not a stable contract across versions.

## Verification

Against the live vsftpd on a lab node:

| case | `connect()` | `lastFailure()` |
|---|---|---|
| good credentials | ok | `` |
| wrong password | false | `login` |
| unknown user | false | `login` |
| unreachable host | false | `connect` |

## Ports

`dev-branch` equivalent: #1256 — same change, shaped for that branch's throwing `connect()`.

## Downstream

None. No route, class list, or OpenAPI surface changes.