### PR TITLE
fix(replication): report a refused FTP login as a login failure (#1254)

### DIFF
--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -66,6 +66,17 @@ class FOGFTP extends FOGGetSet
      */
     private $_currentLoginHash;
     /**
+     * Which stage of connect() failed, if one did.
+     *
+     * Either 'connect' (the socket never came up) or 'login' (the server
+     * answered and refused the credentials). connect() throws the same generic
+     * exception for both, so without this the caller cannot tell a network
+     * problem from a wrong password -- and every caller guessed "network".
+     *
+     * @var string
+     */
+    private $_lastFailure = '';
+    /**
      * Destroy the ftp object
      *
      * @return void
@@ -168,6 +179,7 @@ class FOGFTP extends FOGGetSet
         $autologin = true,
         $connectmethod = 'ftp_connect'
     ) {
+        $this->_lastFailure = '';
         try {
             $this->_currentConnectionHash = password_hash(
                 print_r($this->data, 1),
@@ -214,20 +226,32 @@ class FOGFTP extends FOGGetSet
                     $timeout = $this->get('timeout');
                 }
             }
+            $this->_lastFailure = 'connect';
             $this->_link = $connectmethod($host, $port, $timeout);
             if ($this->_link === false) {
                 trigger_error(_('FTP connection failed'), E_USER_NOTICE);
                 $this->ftperror($this->data);
             }
             if ($autologin) {
+                $this->_lastFailure = 'login';
                 $this->login();
                 $this->pasv($this->get('passive'));
             }
+            $this->_lastFailure = '';
         } catch (Exception $e) {
             throw new Exception($e->getMessage());
         }
         $this->_lastConnectionHash = $this->_currentConnectionHash;
         return $this;
+    }
+    /**
+     * Which stage of the last connect() failed.
+     *
+     * @return string 'connect', 'login', or '' when the last attempt succeeded
+     */
+    public function lastFailure()
+    {
+        return $this->_lastFailure;
     }
     /**
      * Deletes the item passed

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -561,13 +561,36 @@ abstract class FOGService extends FOGBase
                 try {
                     self::$FOGFTP->connect();
                 } catch (Exception $e) {
-                    self::outall(
-                        sprintf(
-                            ' * Error: %s %s',
-                            _('Cannot connect to'),
-                            $StorageNode->name
-                        )
-                    );
+                    // A refused login used to be reported as "Cannot connect",
+                    // which points at the network when the cause is nearly
+                    // always a stale password for this node. Each master keeps
+                    // its own copy of every peer's credential and nothing syncs
+                    // them, so say which of the two actually failed.
+                    if (self::$FOGFTP->lastFailure() === 'login') {
+                        self::outall(
+                            sprintf(
+                                ' * Error: %s %s %s %s',
+                                _('FTP login rejected by'),
+                                $StorageNode->name,
+                                _('for user'),
+                                $StorageNode->user
+                            )
+                        );
+                        self::outall(
+                            sprintf(
+                                ' | %s',
+                                _('Check the password stored for this node')
+                            )
+                        );
+                    } else {
+                        self::outall(
+                            sprintf(
+                                ' * Error: %s %s',
+                                _('Cannot connect to'),
+                                $StorageNode->name
+                            )
+                        );
+                    }
                     continue;
                 }
                 $nodename = $StorageNode->name;

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -996,6 +996,10 @@ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -2012,6 +2016,9 @@ msgstr "FTP-Pfad"
 #, fuzzy
 msgid "FTP connection failed"
 msgstr "FTP-Verbindung fehlgeschlagen"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 #, fuzzy
 msgid "Fail to destroy"
@@ -7561,6 +7568,10 @@ msgstr "für die erweiterten Menüparameter"
 
 msgid "for the menu background"
 msgstr "für das Menü"
+
+#, fuzzy
+msgid "for user"
+msgstr "Benutzer erstellen?"
 
 #, fuzzy
 msgid "found"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1001,6 +1001,10 @@ msgstr "Check that database is running"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "No FOGPage Class found for this node"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -2016,6 +2020,9 @@ msgstr "FTP Path"
 #, fuzzy
 msgid "FTP connection failed"
 msgstr "FTP Connection failed"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 #, fuzzy
 msgid "Fail to destroy"
@@ -7558,6 +7565,10 @@ msgstr ""
 
 msgid "for the menu background"
 msgstr ""
+
+#, fuzzy
+msgid "for user"
+msgstr "Create User"
 
 #, fuzzy
 msgid "found"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -990,6 +990,9 @@ msgstr "Campo obligatorio está vacio"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+msgid "Check the password stored for this node"
+msgstr ""
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1997,6 +2000,9 @@ msgstr ""
 #, fuzzy
 msgid "FTP connection failed"
 msgstr "No disponible"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 #, fuzzy
 msgid "Fail to destroy"
@@ -7515,6 +7521,10 @@ msgstr "Menú %s"
 #, fuzzy
 msgid "for the menu background"
 msgstr "Menú principal"
+
+#, fuzzy
+msgid "for user"
+msgstr "Usuario"
 
 #, fuzzy
 msgid "found"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -874,6 +874,10 @@ msgstr "Vérifiez que la base de données est en cours d'exécution"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Aucune classe FOGPage n'a été trouvée pour ce nœud"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1777,6 +1781,9 @@ msgstr "Chemin FTP"
 
 msgid "FTP connection failed"
 msgstr "La connexion FTP a échoué"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Fail to destroy"
 msgstr "Impossible à détruire"
@@ -6684,6 +6691,10 @@ msgstr "pour les paramètres du menu avancé"
 
 msgid "for the menu background"
 msgstr "pour l'arrière-plan du menu"
+
+#, fuzzy
+msgid "for user"
+msgstr "Créer un utilisateur ?"
 
 msgid "found"
 msgstr "trouvé"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -902,6 +902,10 @@ msgstr "Controllare che database è in esecuzione"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Nessun FOGPage Classe trovato per questo nodo"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1824,6 +1828,9 @@ msgstr "Percorso FTP"
 #, fuzzy
 msgid "FTP connection failed"
 msgstr "La connessione FTP non è riuscita"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 #, fuzzy
 msgid "Fail to destroy"
@@ -6825,6 +6832,10 @@ msgstr "per i parametri di menu avanzati"
 
 msgid "for the menu background"
 msgstr "per il menu di sfondo"
+
+#, fuzzy
+msgid "for user"
+msgstr "Crea utente?"
 
 msgid "found"
 msgstr "trovato"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -863,6 +863,10 @@ msgstr "データベースが稼働していることを確認してください
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "このノードの FOGPage クラスが見つかりません"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1760,6 +1764,9 @@ msgstr "FTP パス"
 
 msgid "FTP connection failed"
 msgstr "FTP 接続に失敗しました"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Fail to destroy"
 msgstr "破棄に失敗しました"
@@ -6618,6 +6625,10 @@ msgstr "詳細メニューパラメーター用"
 
 msgid "for the menu background"
 msgstr "メニュー背景用"
+
+#, fuzzy
+msgid "for user"
+msgstr "ユーザーを作成しますか？"
 
 msgid "found"
 msgstr "見つかりました"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -849,6 +849,9 @@ msgstr ""
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+msgid "Check the password stored for this node"
+msgstr ""
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1742,6 +1745,9 @@ msgid "FTP Path"
 msgstr ""
 
 msgid "FTP connection failed"
+msgstr ""
+
+msgid "FTP login rejected by"
 msgstr ""
 
 msgid "Fail to destroy"
@@ -6584,6 +6590,9 @@ msgid "for the advanced menu parameters"
 msgstr ""
 
 msgid "for the menu background"
+msgstr ""
+
+msgid "for user"
 msgstr ""
 
 msgid "found"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -873,6 +873,10 @@ msgstr "Verifique se o banco de dados está em execução"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "Nenhuma Classe FOGPage encontrada para este nó"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1770,6 +1774,9 @@ msgstr "Caminho FTP"
 
 msgid "FTP connection failed"
 msgstr "Conexão FTP falhou"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Fail to destroy"
 msgstr "Falha ao destruir"
@@ -6646,6 +6653,10 @@ msgstr "para os parâmetros de menu avançado"
 
 msgid "for the menu background"
 msgstr "para o fundo do menu"
+
+#, fuzzy
+msgid "for user"
+msgstr "Criar usuário?"
 
 msgid "found"
 msgstr "encontrado"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -873,6 +873,10 @@ msgstr "检查数据库运行状态"
 msgid "Check the capture folder is owned by and writable to the storage node user"
 msgstr ""
 
+#, fuzzy
+msgid "Check the password stored for this node"
+msgstr "在FOGPage类中找不到此节点"
+
 msgid "Check this value matches what the enrolment script prints before confirming. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
@@ -1770,6 +1774,9 @@ msgstr "FTP路径"
 
 msgid "FTP connection failed"
 msgstr "FTP连接失败"
+
+msgid "FTP login rejected by"
+msgstr ""
 
 msgid "Fail to destroy"
 msgstr "未能摧毁"
@@ -6646,6 +6653,10 @@ msgstr "用于高级菜单参数"
 
 msgid "for the menu background"
 msgstr "用于菜单背景"
+
+#, fuzzy
+msgid "for user"
+msgstr "创建用户?"
 
 msgid "found"
 msgstr "找到"


### PR DESCRIPTION
Port of the `working-1.6` fix in #1255 to the 1.5 line. Same issue: #1254.

`FOGFTP::connect()` opens the socket and then logs in, and throws the same generic exception for both stages, so the replicator logged `Cannot connect to <node>` whether the network was down or the password was simply wrong.

That sends people at the network, and the network is almost never the cause. Every master keeps its own copy of every peer's FTP credential in `nfsGroupMembers` and nothing syncs them, so changing the `fogproject` account password on one server — or reinstalling it — silently invalidates every *other* master's copy. Replication then fails in one direction only, indefinitely, while the log insists the host is unreachable. On a lab pair that ran for three weeks and 4,121 log lines with ping and TCP 21 answering the whole time.

`connect()` now records which stage it reached and `lastFailure()` reports it:

```
 * Error: FTP login rejected by 10.253.25.2 for user fogproject
 | Check the password stored for this node
```

An unreachable host still reads `Cannot connect to <node>`.

The stage is tracked rather than matched out of the exception text, because that text is PHP's own warning (`ftp_login(): Login incorrect`) and is not a stable contract across versions.

## Verification

Run on a live 1.5 server against a real vsftpd, loading this class alongside the installed stack:

| case | `connect()` | `lastFailure()` |
|---|---|---|
| good credentials | ok | `` |
| wrong password | threw | `login` |
| unknown user | threw | `login` |
| unreachable host | threw | `connect` |

## Downstream

None. No route, class list, or OpenAPI surface changes.