### PR TITLE
fix(core): report and record database writes that fail on machine paths

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1745,6 +1745,21 @@ installFOGServices() {
     # usr_t but not write it, so without this the directory exists, looks
     # right, and every report is dropped with nothing but an AVC to say so.
     setSELinuxContext "$servicelogs/fos" httpd_sys_rw_content_t
+    # Where FOGBase::logFault() records database writes that did not land.
+    # Its own subdirectory for the same reason the two above have theirs.
+    #
+    # Unlike those two, BOTH tiers write here -- the web user, and root for
+    # the eight daemons -- so logFault() writes faults-web.log and
+    # faults-service.log rather than one shared file, whose owner would be
+    # whichever tier hit a failed write first. The directory is the web
+    # user's; root writes into it regardless of mode.
+    dots "Creating FOG fault log directory"
+    mkdir -p $servicelogs/faults >>$error_log 2>&1
+    chown ${apacheuser}:${apacheuser} $servicelogs/faults >>$error_log 2>&1
+    errorStat $?
+    # Outside the dots/errorStat pair, like every other caller, and the _rw_
+    # label is as load-bearing here as it is for fos above (GH-964).
+    setSELinuxContext "$servicelogs/faults" httpd_sys_rw_content_t
     # servicemaster.log is where service_lib.php writes every daemon's start,
     # stop and fatal lines, and where PHP's own error_log is pointed. The
     # runner has to be able to append to it or its supervisor lines silently

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -963,6 +963,190 @@ abstract class FOGBase
         );
     }
     /**
+     * The subdirectory of FOG's log directory that fault lines are written to.
+     *
+     * Its own subdirectory rather than the top level, for the reason ADR 0010
+     * gives for the plugin runner's and TaskError's: rotation renames and
+     * unlinks, and the top level is root's -- the eight daemons' logs live
+     * there and nothing running as the web user should be able to remove
+     * them.
+     *
+     * @var string
+     */
+    const FAULT_LOG_SUBDIR = 'faults';
+    /**
+     * How big a fault log may get before one old copy is kept, in bytes.
+     *
+     * A literal, NOT the SERVICE_LOG_SIZE setting the daemons and
+     * TaskError::_rotate() use, and that is the whole point: getSetting()
+     * issues a query, and the thing being reported here is a query that just
+     * failed. See logFault()'s docblock.
+     *
+     * One generation rather than the daemons' five. This file gains a line
+     * per failed write; on a healthy server it never gets a line at all.
+     *
+     * @var int
+     */
+    const FAULT_LOG_MAX = 10485760;
+    /**
+     * Records that something FOG needed to write did not get written.
+     *
+     * The failure sink of last resort, and deliberately the only logger here
+     * that asks nobody's permission to run.
+     *
+     * WHY THIS EXISTS AT ALL. FOGController::save() and destroy() recorded a
+     * failed write by calling logHistory(), which returns without doing
+     * anything unless self::$FOGUser is a valid User. Nothing on a machine
+     * -facing path ever sets one -- packages/web/service/, lib/reg-task/ and
+     * the eight daemons are matched to a HOST by MAC or token, and the
+     * daemons have no request at all -- so on every one of those paths the
+     * failure branch ran and wrote nowhere. debug() and error() were no
+     * better: both only reach a file when FOG_LOG_DEBUG / FOG_LOG_ERROR are
+     * non-zero, and schema step 280 ships them at '0'. The framework
+     * recorded failures for humans and discarded them for machines.
+     *
+     * WHY A FILE AND NOT A TABLE. logHistory() writes a row, so it shares its
+     * failure mode with the thing it is reporting on: a lost connection, a
+     * locked table or a full disk takes out the report along with the write.
+     * A sink for a failed database write cannot itself be a database write.
+     * That -- not the user gate -- is the structural reason this is not
+     * simply logHistory() with the gate widened. The user gate is correct
+     * where it is: `history` is the audit trail, "who did what", and nobody
+     * did this.
+     *
+     * THREE THINGS IT MUST NOT DO, each earned:
+     *
+     *   No getSetting(), for the path or the rotation size or anything else.
+     *     getSetting() issues a query. PDODB's error handling calls debug(),
+     *     and GH-1245 has the transcript of what that costs: fetch() ->
+     *     sqlerror() -> debug() -> getSetting() -> query() -> sqlerror() ->
+     *     ... until the worker died with nothing reported. FAULT_LOG_MAX is
+     *     a literal for exactly this reason.
+     *
+     *   Not routed through _writeLog(). Its re-entry guard DROPS the line
+     *     rather than deferring it, which is right for a debug line and
+     *     fatal here: a save that failed while a log line was being written
+     *     would be the one report thrown away.
+     *
+     *   Never gated on a setting. An operator turning FOG_LOG_DEBUG off is
+     *     saying "stop telling me what is working", not "stop telling me
+     *     what broke".
+     *
+     * error_log() is the fallback, not the destination, and it is
+     * load-bearing rather than tidiness. The directory is the installer's,
+     * so a server whose web tree has been updated but which has not been
+     * re-installed has nowhere to write yet -- and PHP's own channel is
+     * already pointed somewhere useful in both tiers: service_lib.php sets
+     * error_log to servicemaster.log for the daemons, and the web tier's
+     * php-fpm log is one FOGLogPaths::readable() already offers the Log
+     * Viewer.
+     *
+     * IF THE LOG-TABLE / AUDIT / SPAN ADRs LAND: this gains a second
+     * destination, a best-effort row written AFTER the file line and never
+     * instead of it. The file write stays whatever else arrives, because at
+     * the moment this is called the database is the untrusted party. One
+     * function to change; do not tidy the file away.
+     *
+     * @param string $message what did not get written, and why
+     *
+     * @return void
+     */
+    public static function logFault($message)
+    {
+        // Same shape as _writeLog()'s guard and for the same reason, except
+        // that nothing here can re-enter through the database. It covers the
+        // one real case: logFault() failing on its own file write.
+        static $inFault = false;
+        if ($inFault) {
+            return;
+        }
+        $inFault = true;
+
+        try {
+            // One line per fault, so `tail -f` on this file is readable and
+            // a multi-line PDO message -- they carry the SQL, the parameters
+            // and a debugDumpParams() block -- cannot be mistaken for
+            // several faults.
+            $flat = preg_replace('#\s+#', ' ', (string) $message);
+            // Never let a message become an empty one. preg_replace returns
+            // null when it gives up, and a (string) cast of that is '', which
+            // the guard below would then throw away -- losing the one record
+            // this method exists to keep. The pattern carries no /u, so it
+            // works bytewise and invalid UTF-8 cannot trip it; this covers
+            // whatever else might.
+            $line = trim(null === $flat ? (string) $message : $flat);
+            if ('' === $line) {
+                return;
+            }
+            $stamped = sprintf(
+                '[%s] %s%s',
+                self::niceDate()->format('Y-m-d H:i:s'),
+                $line,
+                PHP_EOL
+            );
+            $file = self::_faultLogPath();
+            if ('' !== $file) {
+                self::_rotateFaultLog($file);
+                if (false !== @file_put_contents($file, $stamped, FILE_APPEND)) {
+                    return;
+                }
+            }
+            error_log($line);
+        } finally {
+            $inFault = false;
+        }
+    }
+    /**
+     * The fault log's path, or '' if there is nowhere to write.
+     *
+     * Split by SAPI, into faults-web.log and faults-service.log. This is the
+     * one FOG log directory written by BOTH tiers -- the web user, and root
+     * for the eight daemons -- and a single shared file would be owned by
+     * whichever wrote first. A root-owned file appears the moment any daemon
+     * hits a failed write, and from then on every web-tier fault would fall
+     * silently to error_log(). Silently diverting to a worse destination is
+     * the exact failure this whole path exists to end, so the two writers get
+     * two files instead.
+     *
+     * The directory is never created here. It is the installer's, which gives
+     * it to the web user with the right SELinux label (GH-964: /opt/fog
+     * inherits usr_t and httpd_t may read it but not write it, so an
+     * unlabelled mkdir would produce a directory that looks right and
+     * silently swallows every write on an enforcing host).
+     *
+     * @return string
+     */
+    private static function _faultLogPath()
+    {
+        if (!defined('FOG_LOG_DIR')) {
+            return '';
+        }
+        $dir = rtrim(FOG_LOG_DIR, DS) . DS . self::FAULT_LOG_SUBDIR;
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return '';
+        }
+
+        return $dir . DS . sprintf(
+            'faults-%s.log',
+            'cli' === PHP_SAPI ? 'service' : 'web'
+        );
+    }
+    /**
+     * Keeps one old copy once the fault log passes FAULT_LOG_MAX.
+     *
+     * @param string $file the fault log
+     *
+     * @return void
+     */
+    private static function _rotateFaultLog($file)
+    {
+        $size = @filesize($file);
+        if (false === $size || $size < self::FAULT_LOG_MAX) {
+            return;
+        }
+        @rename($file, $file . '.1');
+    }
+    /**
      * Prints debug.
      *
      * @param string $txt  the string to use

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -543,6 +543,40 @@ abstract class FOGController extends FOGBase
             // A catalog FOG cannot read leaves every column looking unknown,
             // which is the behaviour that shipped before GH-1245 rather than
             // a broken one.
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s',
+                    _('Column type lookup failed'),
+                    _('Table'),
+                    $table,
+                    _('Error'),
+                    $e->getMessage()
+                )
+            );
+            return;
+        }
+        /*
+         * The degradation is deliberate, the SILENCE was not. PDODB swallows
+         * a rejected statement, so this never reached the catch above on a
+         * real error -- it cached an empty type map and every column on the
+         * table went back to being untyped, which is exactly the GH-1245 bug
+         * this method exists to prevent, reappearing with nothing said.
+         *
+         * Behaviour is unchanged: still an empty map, still asked once per
+         * table per request. Only now it is written down.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Column type lookup failed'),
+                    _('Table'),
+                    $table,
+                    _('Error'),
+                    self::$DB->error,
+                    _('every column on this table will be treated as untyped')
+                )
+            );
             return;
         }
         foreach ((array) $rows as $row) {
@@ -821,6 +855,33 @@ abstract class FOGController extends FOGBase
             self::info($msg);
 
             self::$DB->query($query, [], $queryArray);
+            /*
+             * PDODB swallows a rejected statement, so ASK it.
+             *
+             * PDO runs in ERRMODE_EXCEPTION, but PDODB::query() catches the
+             * PDOException, records the message on ->error and returns
+             * normally; it rethrows only when $throwOnQueryError is true,
+             * which nothing sets and which must not be set globally -- it
+             * would turn every already-tolerated failure across the codebase
+             * into an uncaught 500 at once.
+             *
+             * So without this check the catch below never runs on a real SQL
+             * error. For a NEW row that was survivable by accident: insertId()
+             * comes back 0 and the "no valid ID was assigned" throw further
+             * down catches it. For an EXISTING row -- every progress update,
+             * every task state change, every inventory write against a known
+             * host -- there was nothing to catch on, so save() went on to log
+             * the SUCCESS message and return $this. `if (!$obj->save())` was
+             * not merely unrecorded on those paths, it was answered "fine".
+             *
+             * Truthy rather than `false !== ...`: PDODB declares $error with
+             * no default, so it is null until the first statement runs, and
+             * Schema::_processSchema()'s `false !== ->error` idiom would fire
+             * on that. Truthy reads both spellings of "no error" the same way.
+             */
+            if (self::$DB->error) {
+                throw new \Exception((string) self::$DB->error);
+            }
             $lastInsertID = self::$DB->insertId();
 
             // Force ID correctness: if we still don't have a valid ID, this wasn't created properly.
@@ -888,14 +949,33 @@ abstract class FOGController extends FOGBase
             }
 
             $msg = sprintf(
-                '%s: %s: %s, %s: %s',
+                '%s: %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Database save failed'),
+                _('Class'),
+                self::shortName($this),
+                _('Table'),
+                $this->databaseTable,
                 _('ID'),
                 $this->get('id'),
                 _('Error'),
                 $e->getMessage()
             );
             self::debug($msg);
+            /*
+             * The line that actually gets written. debug() above needs
+             * FOG_LOG_DEBUG turned on, and logHistory() needs somebody signed
+             * in -- neither is true on the paths that generate most of these,
+             * which is the whole of packages/web/service/, lib/reg-task/ and
+             * the eight daemons. See FOGBase::logFault().
+             *
+             * Written LAST, after the history row has been attempted rather
+             * than before, so the fault line names the failure that started
+             * this and any second failure logging it produces gets its own
+             * line rather than replacing that one. Which class and table
+             * carry it are in the message because the reader of this file has
+             * only the message: there is no row to join back to.
+             */
+            self::logFault($msg);
 
             return false;
         }
@@ -974,6 +1054,44 @@ abstract class FOGController extends FOGBase
                 [],
                 $queryArray
             );
+            /*
+             * A rejected SELECT is swallowed the same way a rejected INSERT
+             * is -- see save(). fetch()->get() then hands back nothing, and
+             * an object that could not be read is indistinguishable from a
+             * row that genuinely holds no data. That is the read half of the
+             * same defect: not a wrong answer anybody can see, a plausible
+             * empty one.
+             *
+             * Recorded HERE rather than in the catch below, and that split is
+             * the point. This catch also handles the method's ORDINARY
+             * control flow -- "Operation field not set" fires on every
+             * `new Host()` built without an id, which is constant traffic --
+             * so faulting the whole catch would bury the one line that
+             * matters under thousands that do not.
+             *
+             * Throwing after logging costs nothing and buys the debug line
+             * below: setQuery() merges (fastmerge, never clears), so skipping
+             * it with no rows to merge leaves the object exactly as it was.
+             * load() still returns $this either way -- `new Host(42)` must
+             * not become fatal because a read failed.
+             */
+            if (self::$DB->error) {
+                self::logFault(
+                    sprintf(
+                        '%s: %s: %s, %s: %s, %s: %s, %s: %s',
+                        _('Database load failed'),
+                        _('Class'),
+                        self::shortName($this),
+                        _('Table'),
+                        $this->databaseTable,
+                        _('Key'),
+                        $key,
+                        _('Error'),
+                        self::$DB->error
+                    )
+                );
+                throw new \Exception((string) self::$DB->error);
+            }
             $vals = self::$DB->fetch()->get();
             $this->setQuery($vals);
         } catch (\Exception $e) {
@@ -1064,8 +1182,30 @@ abstract class FOGController extends FOGBase
                     ''
                 )
             );
+            self::$DB->query($query, [], $queryArray);
+            // Same as load()'s, and it matters more here: a rejected bulk
+            // read returns an EMPTY set, and the caller reads that as "none
+            // of those ids exist" rather than "the question was not asked".
+            if (self::$DB->error) {
+                self::logFault(
+                    sprintf(
+                        '%s: %s: %s, %s: %s, %s: %s, %s: %d, %s: %s',
+                        _('Database bulk load failed'),
+                        _('Class'),
+                        self::shortName($this),
+                        _('Table'),
+                        $this->databaseTable,
+                        _('Key'),
+                        $key,
+                        _('Requested'),
+                        count($vals),
+                        _('Error'),
+                        self::$DB->error
+                    )
+                );
+                throw new \Exception((string) self::$DB->error);
+            }
             $rows = self::$DB
-                ->query($query, [], $queryArray)
                 ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
                 ->get();
             // class-name consumer: fed straight back to getClass(), which
@@ -1197,6 +1337,13 @@ abstract class FOGController extends FOGBase
                 (array) $val
             );
             self::$DB->query($query, [], $queryArray);
+            // Same reason as save()'s, above: a rejected DELETE is swallowed
+            // by PDODB, so destroy() reported success for a row still there.
+            // A DELETE matching nothing is not an error and does not land
+            // here -- only a statement the server actually rejected does.
+            if (self::$DB->error) {
+                throw new \Exception((string) self::$DB->error);
+            }
             if (!$this instanceof History) {
                 if ($this->get('name')) {
                     $msg = sprintf(
@@ -1247,14 +1394,20 @@ abstract class FOGController extends FOGBase
                 self::logHistory($msg);
             }
             $msg = sprintf(
-                '%s: %s: %s, %s: %s',
+                '%s: %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Destroy failed'),
+                _('Class'),
+                self::shortName($this),
+                _('Table'),
+                $this->databaseTable,
                 _('ID'),
                 $this->get('id'),
                 _('Error'),
                 $e->getMessage()
             );
             self::debug($msg);
+            // Same sink as save()'s, for the same reason.
+            self::logFault($msg);
 
             return false;
         }

--- a/packages/web/lib/fog/foglogpaths.class.php
+++ b/packages/web/lib/fog/foglogpaths.class.php
@@ -58,12 +58,19 @@ class FOGLogPaths
      * is separate for the same reason: that writer IS the web tier, and the
      * top level belongs to root's daemons.
      *
+     * 'faults' is FOGBase::logFault()'s -- every database write FOG could not
+     * complete. It is the one entry here written by BOTH tiers, which is why
+     * that method splits its output into faults-web.log and
+     * faults-service.log rather than sharing a file whose owner would be
+     * whichever wrote first.
+     *
      * @var array
      */
     const FOG_SUBDIRS = [
         '',
         'plugins',
         'fos',
+        'faults',
     ];
     /**
      * The path FOG's logs are reached by in the enumeration views.

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -965,6 +965,13 @@ abstract class FOGManagerController extends FOGBase
                 implode(',', $dups)
             );
             self::$DB->query($query, [], $insertVals);
+            // Same swallowed-error seam as FOGController::save(): without
+            // this the loop went on to report affectedRows for a batch the
+            // server rejected. Throws rather than returning a count, because
+            // the caller's two return values describe a write that happened.
+            if (self::$DB->error) {
+                throw new \Exception((string) self::$DB->error);
+            }
             if ($ind === 0) {
                 $insertID = (int) self::$DB->insertId();
             }
@@ -1127,7 +1134,34 @@ abstract class FOGManagerController extends FOGBase
             (array) $findVals
         );
 
-        return (bool) self::$DB->query($query, [], $queryVals);
+        self::$DB->query($query, [], $queryVals);
+        /*
+         * `(bool) self::$DB->query(...)` was ALWAYS true: query() returns
+         * $this, and an object casts to true whatever the server said. So
+         * this reported success for every rejected mass update -- including
+         * the API's bulk edit, which is update()'s busiest caller.
+         *
+         * Faulted here rather than thrown: this method has no catch and its
+         * callers expect a bool, so throwing would turn a silently-failed
+         * bulk edit into an uncaught 500. False is the honest answer they
+         * were already written to read.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s',
+                    _('Mass update failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error
+                )
+            );
+
+            return false;
+        }
+
+        return true;
     }
     /**
      * Builds a select box/option box from the elements.
@@ -1274,10 +1308,33 @@ abstract class FOGManagerController extends FOGBase
             ':id'
         );
 
-        return (bool)self::$DB
-            ->query($query, [], $existVals)
-            ->fetch()
-            ->get('total') > 0;
+        self::$DB->query($query, [], $existVals);
+        /*
+         * A rejected read here answers "no, it does not exist", which is the
+         * most expensive wrong answer this class can give: callers use
+         * exists() to decide whether to CREATE, so an unreadable database
+         * turns into a duplicate rather than an error.
+         *
+         * The contract is left alone -- callers expect a bool and there is no
+         * catch here -- so the fault line is the whole of the fix. Making
+         * this throw is a real change to a read contract and belongs in its
+         * own decision, not smuggled into a logging fix.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Existence check failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering "does not exist" for a read that never ran')
+                )
+            );
+        }
+
+        return (bool)self::$DB->fetch()->get('total') > 0;
     }
     /**
      * Returns the distinct (all matching).
@@ -1396,10 +1453,24 @@ abstract class FOGManagerController extends FOGBase
             )
         );
 
-        return (int)self::$DB
-            ->query($query, [], $countVals)
-            ->fetch()
-            ->get('total');
+        self::$DB->query($query, [], $countVals);
+        // Same as exists(): a rejected count answers 0, which reads as "there
+        // are none" rather than "nobody asked". Contract unchanged.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Count failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering 0 for a read that never ran')
+                )
+            );
+        }
+
+        return (int)self::$DB->fetch()->get('total');
     }
     /**
      * Uninstalls the table.
@@ -1409,7 +1480,26 @@ abstract class FOGManagerController extends FOGBase
     public function uninstall()
     {
         $sql = Schema::dropTable($this->tablename);
-        return self::$DB->query($sql);
+        self::$DB->query($sql);
+        // Declared @return bool and returned the PDODB object, which is
+        // truthy however the DROP went. A plugin uninstall that left its
+        // table in place reported success.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s',
+                    _('Table uninstall failed'),
+                    _('Table'),
+                    $this->tablename,
+                    _('Error'),
+                    self::$DB->error
+                )
+            );
+
+            return false;
+        }
+
+        return true;
     }
     /**
      * Gets the columns for this item.

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * A failed database operation must leave a trace even when nobody is signed in.
+ *
+ * FOGController::save() records a failure by calling FOGBase::logHistory(),
+ * and logHistory() returns without doing anything unless self::$FOGUser is a
+ * valid User (fogbase.class.php:2507). Nothing in packages/web/service/,
+ * packages/web/lib/reg-task/ or the eight daemons ever sets one -- they are
+ * matched to a HOST by MAC or token, not to a user -- so on every one of
+ * those paths the failure branch runs and writes nowhere. The other two
+ * candidates are no better: debug() and error() only reach a file when
+ * FOG_LOG_DEBUG / FOG_LOG_ERROR are non-zero, and schema step 280 ships both
+ * at '0'.
+ *
+ * There are two distinct defects here and this test pins both, on the write
+ * path and on the read path.
+ *
+ * 1. NOT REPORTED. PDODB::$throwOnQueryError defaults false, so query()
+ *    catches the PDOException and returns normally (pdodb.class.php:509).
+ *    save() therefore never enters its own catch. For a NEW row the missing
+ *    insertId() is caught by the "no valid ID was assigned" throw; for an
+ *    EXISTING row -- every progress update, every task state change, every
+ *    inventory write against a known host -- there is nothing to catch on,
+ *    so save() logs the SUCCESS message and returns $this. `if (!$x->save())`
+ *    is not merely unrecorded there, it is answered "fine".
+ *
+ * 2. NOT RECORDED. Even on the path that does return false, nothing is
+ *    written anywhere a human can read.
+ *
+ * The read path has only the second defect, and it is quieter for it. There
+ * is no return value to get wrong -- load() answers $this whether or not the
+ * row was read, and must, or `new Host(42)` would become fatal on a database
+ * blip -- so an object that could NOT be read is indistinguishable from a row
+ * that genuinely holds no data. The log line is the entire fix there, which
+ * is why assertion 5 matters as much as assertion 4: load()'s catch also
+ * handles its ordinary control flow, and a fault log full of "Operation field
+ * not set" would bury the one line worth having.
+ *
+ * The third assertion is TaskError::_logRow(), which discards save()'s
+ * return by design -- it is the sink FOS failures land in, and there is
+ * nothing above it to report to. It is driven here at its real call site
+ * rather than asserted about in the abstract, so a fix that covers only the
+ * callers which check a return value does not pass.
+ *
+ * Asserts the OUTCOME, not a spelling: "a durable record naming the failed
+ * write exists" -- any file under FOG_LOG_DIR satisfies it. A fix is free to
+ * choose the file.
+ *
+ * DB-free: uses tests/lib/fog-test-harness.php with a database that fails
+ * writes exactly the way PDODB does when a statement is rejected.
+ *
+ * Usage: php tests/db-failure-is-recorded.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('db-failure');
+
+/**
+ * A database whose writes fail the way a real one does.
+ *
+ * PDODB::query() catches PDOException, calls debug()/error(), records the
+ * message on ->error and returns $this. It rethrows only when
+ * $throwOnQueryError is true, which nothing sets. insertId() then answers 0
+ * because no row was inserted. That is all this reproduces.
+ */
+class FogWriteRejectingDb extends FogFakeDb
+{
+    const REJECTION = "SQLSTATE[22007]: Invalid datetime format: 1292 "
+        . "Incorrect datetime value: '' for column 'taskLogCreated'";
+
+    /** @var int how many writes were attempted */
+    public $writes = 0;
+
+    /**
+     * @var bool reject SELECTs too. Off by default so the write assertions
+     *           are not perturbed by the lazy loads FOGController does on
+     *           the way to a save.
+     */
+    public $rejectReads = false;
+
+    /** @var bool reject the information_schema column-type lookup */
+    public $rejectCatalog = false;
+
+    public function query($sql, $a = [], $params = [])
+    {
+        if (preg_match('/^\s*(INSERT|UPDATE|REPLACE|DELETE)\b/i', $sql)) {
+            $this->writes++;
+            $this->log[] = $sql;
+            $this->error = self::REJECTION;
+            return $this;
+        }
+        $isCatalog = false !== stripos($sql, 'information_schema');
+        if (preg_match('/^\s*SELECT\b/i', $sql)
+            // The catalog lookup is switched separately: leaving it alone
+            // keeps the row-read assertions about the read they name, and
+            // lets its own assertion drive it on its own.
+            && ($isCatalog ? $this->rejectCatalog : $this->rejectReads)
+        ) {
+            $this->log[] = $sql;
+            $this->error = self::REJECTION;
+            return $this;
+        }
+        return parent::query($sql, $a, $params);
+    }
+
+    public function insertId()
+    {
+        return 0;
+    }
+}
+
+$db = new FogWriteRejectingDb();
+FogTestHarness::setStatic('FOGBase', 'DB', $db);
+FogTestHarness::setStatic('DatabaseManager', 'DB', $db);
+
+// The condition every machine-facing request boots into: LoadGlobals builds
+// `new User(0)` because there is no session to read FOG_USER from.
+$anon = FOGCore::getClass('User');
+$GLOBALS['currentUser'] = $anon;
+FogTestHarness::setStatic('FOGBase', 'FOGUser', $anon);
+if ($anon->isValid()) {
+    fwrite(STDERR, "FAIL: the anonymous user is valid; this test would "
+        . "pass vacuously because logHistory() would record after all\n");
+    exit(1);
+}
+
+// What the installer creates (lib/common/functions.sh, "Creating FOG fault
+// log directory"). Made here rather than by the harness because its ABSENCE
+// is also a supported state -- a web tree updated ahead of its installer --
+// and the fallback that covers it is asserted below.
+$faultDir = FOG_LOG_DIR . DIRECTORY_SEPARATOR . FOGBase::FAULT_LOG_SUBDIR;
+@mkdir($faultDir, 0700, true);
+
+// PHP's own channel is logFault()'s fallback. Pointed inside FOG_LOG_DIR so
+// that a fallback still satisfies "a durable record exists" -- the assertions
+// below pin the outcome, not which file -- and so the fallback does not spray
+// the suite's output onto stderr.
+ini_set('error_log', FOG_LOG_DIR . DIRECTORY_SEPARATOR . 'php-fallback.log');
+
+/**
+ * Every file under FOG_LOG_DIR, flattened to one string.
+ *
+ * @return string
+ */
+function fogLogContents()
+{
+    if (!is_dir(FOG_LOG_DIR)) {
+        return '';
+    }
+    $out = '';
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator(
+            FOG_LOG_DIR,
+            \FilesystemIterator::SKIP_DOTS
+        )
+    );
+    foreach ($it as $f) {
+        if ($f->isFile()) {
+            $out .= (string) @file_get_contents($f->getPathname());
+        }
+    }
+    return $out;
+}
+
+$failures = [];
+
+// ---------------------------------------------------------------------
+// 1. An existing row whose write was rejected must not report success.
+// ---------------------------------------------------------------------
+$existing = FOGCore::getClass('TaskLog');
+$existing->set('id', 4242)
+    ->set('taskID', 7)
+    ->set('text', 'save-failure existing row');
+$result = $existing->save();
+if (false !== $result) {
+    $failures[] = 'save() on an EXISTING row answered '
+        . (is_object($result) ? get_class($result) : var_export($result, true))
+        . ' after the write was rejected -- a truthy answer, so every '
+        . '`if (!$obj->save())` on a machine path treats a lost write as a '
+        . 'completed one';
+}
+
+// ---------------------------------------------------------------------
+// 2. A failed write must leave a record with no user signed in.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+$newRow = FOGCore::getClass('TaskLog');
+$newRow->set('taskID', 9)->set('text', 'save-failure new row');
+$newRow->save();
+$after = fogLogContents();
+if ($after === $before) {
+    $failures[] = 'a rejected write left nothing under FOG_LOG_DIR with no '
+        . 'user signed in -- logHistory() returned early, and debug()/'
+        . 'error() are gated on FOG_LOG_DEBUG/FOG_LOG_ERROR, which ship at 0';
+}
+
+// ---------------------------------------------------------------------
+// 3. The sink itself: TaskError::_logRow() discards save()'s return, so
+//    only a fix inside the framework can cover it.
+// ---------------------------------------------------------------------
+$host = FOGCore::getClass('Host');
+$host->set('id', 11);
+FogTestHarness::setStatic('FOGBase', 'Host', $host);
+
+$task = FOGCore::getClass('Task');
+$task->set('id', 33)->set('stateID', 3);
+// getTaskTypeText() dereferences the loaded TaskType object; the fake
+// database answers lazy loads with marker strings, so it is seeded directly.
+$task->set('type', FOGCore::getClass('TaskType')->set('id', 1)->set('name', 'Deploy'));
+
+$before = fogLogContents();
+$writesBefore = $db->writes;
+try {
+    FogTestHarness::callStatic(
+        'FOG\TaskError',
+        '_logRow',
+        [$task, TaskLog::TYPE_ERROR, 'save-failure fos report']
+    );
+} catch (\Throwable $e) {
+    $failures[] = 'TaskError::_logRow() could not be driven: '
+        . $e->getMessage();
+}
+if ($db->writes === $writesBefore) {
+    $failures[] = 'TaskError::_logRow() attempted no write, so this '
+        . 'assertion proves nothing -- has the call site changed?';
+} elseif (fogLogContents() === $before) {
+    $failures[] = "TaskError::_logRow()'s rejected write left no record. "
+        . 'It discards save()\'s return by design -- it IS the failure sink '
+        . '-- so a report of a FOS failure that cannot be stored is lost '
+        . 'entirely, which is the one thing that path exists to prevent';
+}
+
+// ---------------------------------------------------------------------
+// 4. A rejected SELECT must be recorded too.
+//
+//    The read half of the same defect, and the quieter one: a swallowed
+//    SELECT hands back nothing, so an object that could not be READ is
+//    indistinguishable from a row that genuinely holds no data. There is no
+//    return value to get wrong here -- load() returns $this either way, and
+//    must, or `new Host(42)` would become fatal -- so the log line is the
+//    entire fix.
+// ---------------------------------------------------------------------
+$db->rejectReads = true;
+$before = fogLogContents();
+$reader = FOGCore::getClass('TaskLog');
+$reader->set('id', 8080)->load('id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected SELECT in load() left no record -- an object '
+        . 'that could not be read is reported to its caller as a row with no '
+        . 'data in it';
+}
+
+// loadMany() is the bulk counterpart and fails more quietly still: a
+// rejected read returns an EMPTY set, which the caller reads as "none of
+// those ids exist" rather than "the question was not asked".
+$before = fogLogContents();
+FOGCore::getClass('TaskLog')->loadMany([1, 2, 3], 'id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected SELECT in loadMany() left no record -- the '
+        . 'caller cannot tell an empty result from an unasked question';
+}
+
+// The column-type lookup is the third read, and the one whose silence
+// re-opens GH-1245: an unreadable catalog caches an empty type map, so
+// every column on the table goes back to being untyped.
+$db->rejectReads = false;
+$db->rejectCatalog = true;
+$before = fogLogContents();
+FogTestHarness::callStatic(
+    'FOG\FOGController',
+    '_loadPluginColumnTypes',
+    ['a_plugin_table_not_in_the_manifest']
+);
+if (fogLogContents() === $before) {
+    $failures[] = 'an unreadable information_schema left no record, so every '
+        . 'column on that table is silently treated as untyped -- the GH-1245 '
+        . 'bug reappearing with nothing said';
+}
+$db->rejectCatalog = false;
+$db->rejectReads = true;
+
+// ---------------------------------------------------------------------
+// 5. ...and load()'s ORDINARY control flow must stay quiet.
+//
+//    "Operation field not set" fires on every object built without an id,
+//    which is constant traffic. If that reached the fault log, the line
+//    assertion 4 pins would be buried under thousands that mean nothing.
+//    This is why the fault is recorded at the error check and not in the
+//    catch that handles both.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+FOGCore::getClass('TaskLog')->load('id');
+if (fogLogContents() !== $before) {
+    $failures[] = 'loading an object with no id wrote a fault line -- that is '
+        . "load()'s normal control flow, not a database failure, and at that "
+        . 'volume it would bury the failures that matter';
+}
+$db->rejectReads = false;
+
+// ---------------------------------------------------------------------
+// 6. FOGManagerController::update() answered `(bool) $DB->query(...)`,
+//    which is an OBJECT cast to bool -- true however the server answered.
+//    The API's bulk edit is its busiest caller.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+$mass = FOGCore::getClass('TaskLogManager')->update(
+    ['id' => 1],
+    'AND',
+    ['text' => 'save-failure mass update']
+);
+if (false !== $mass) {
+    $failures[] = 'FOGManagerController::update() answered ' . var_export($mass, true)
+        . ' after the server rejected the UPDATE -- it returned the PDODB '
+        . 'object cast to bool, so it could never report anything but true';
+}
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected mass update left no record';
+}
+
+// exists() and distinct() are the manager's reads, and exists() gives the
+// most expensive wrong answer in the class: callers use it to decide
+// whether to CREATE, so an unreadable database becomes a duplicate row
+// rather than an error.
+$db->rejectReads = true;
+$manager = FOGCore::getClass('TaskLogManager');
+$before = fogLogContents();
+// idField is 'name' by default and taskLog has no such column; hostName is
+// a real one, so the probe fails on the DATABASE rather than on the model.
+$manager->exists('anything', 0, 'hostName');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected existence check left no record -- it answers '
+        . '"does not exist" for a read that never ran, and callers create on '
+        . 'the strength of that';
+}
+$before = fogLogContents();
+$manager->distinct('hostName');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected distinct() count left no record -- it answers '
+        . '0 for a read that never ran';
+}
+$db->rejectReads = false;
+
+// ---------------------------------------------------------------------
+// 7. With the directory the installer creates present, the fault line must
+//    land THERE rather than falling back. The fallback is a safety net for
+//    a web tree updated ahead of its installer, not the normal destination:
+//    if it became the normal one, "what writes are failing" would stop being
+//    one file the Log Viewer offers by name.
+// ---------------------------------------------------------------------
+$landed = glob($faultDir . DIRECTORY_SEPARATOR . '*.log');
+if (!$landed) {
+    $failures[] = 'nothing was written into ' . FOGBase::FAULT_LOG_SUBDIR
+        . '/ even though the directory exists and is writable, so every '
+        . 'fault is taking the error_log() fallback';
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . "):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  rejected reads and writes are reported and recorded with no user "
+    . "signed in\n";
+exit(0);


### PR DESCRIPTION
## The problem

A failed database save on a machine-facing endpoint was recorded nowhere — and on the commonest case it was reported as a **success**.

Two independent defects, three layers of silence:

1. `PDODB::query()` catches the `PDOException` and returns normally (`$throwOnQueryError` defaults false), so `FOGController::save()` never entered its own catch on a real SQL error.
2. `save()` therefore ran its **success** path: for an existing row there was no `insertId()` check to trip, so it logged "successfully updated" and returned `$this`.
3. Even on the path that did return false, `logHistory()` returns early unless `self::$FOGUser` is a valid `User` — and `debug()`/`error()` need `FOG_LOG_DEBUG`/`FOG_LOG_ERROR`, which schema step 280 ships at `'0'`.

Nothing on a machine path has a user. `LoadGlobals::_init()` builds `new User(0)` when there is no session, and `packages/web/service/`, `lib/reg-task/` and the eight daemons are matched to a **host** by MAC or token — the daemons have no request at all. So `if (!$Task->save())` on those paths was not merely unrecorded, it was answered *"fine"*.

**30 `save()` call sites** across three tiers: 17 in `lib/reg-task/`, 4 in `packages/web/service/`, 9 in `lib/service/` (the daemons). The REST API is unaffected — `Route` installs a real `User` for token auth.

`TaskError::_record()`'s docblock already diagnosed this in as many words — *"Not FOGBase::log(): that writes a history row, and logHistory() returns without doing anything unless a user is signed in. Nobody is signed in here."* One path solved it for itself; the framework never learned.

## The fix

**Part A — make the failure detectable.** `save()` and `destroy()` read `self::$DB->error` immediately after their statement and throw if it is set. This is not a new mechanism: `Schema::_processSchema()` and `SchemaReconciler` already read exactly that property for exactly this reason. Deliberately **not** `PDODB::$throwOnQueryError = true` globally, which would turn every already-tolerated failure in the codebase into an uncaught 500 at once.

**Part B — make the record unconditional.** New `FOGBase::logFault()`: one line, appended under `FOG_LOG_DIR`, `error_log()` as the fallback.

Why not simply widen `logHistory()` — the obvious fix — is the crux. `logHistory()` is a *database write*, so it shares its failure mode with the thing it reports on: a lost connection, a locked table or a full disk takes out the report along with the write. **A sink for a failed database write cannot itself be a database write.** The user gate is the visible bug; that is the structural one. And the gate is correct where it is — `history` is the audit trail, "who did what", and nobody did this.

Three constraints on `logFault()`, each earned by something already in this repo:

- **No `getSetting()`, for anything** — including the rotation size, which is a literal rather than `SERVICE_LOG_SIZE`. `getSetting()` issues a query; GH-1245 has the transcript of `fetch → sqlerror → debug → getSetting → query → sqlerror → …` running until the worker died with nothing reported.
- **Not routed through `_writeLog()`** — its re-entry guard *drops* the line, which is right for a debug line and fatal here.
- **Never gated on a setting** — turning `FOG_LOG_DEBUG` off says "stop telling me what is working", not "stop telling me what broke".

Two files rather than one, split by SAPI (`faults-web.log` / `faults-service.log`). This is the only FOG log directory written by **both** tiers, and a shared file would be owned by whichever wrote first — a root-owned `faults.log` appears the moment a daemon hits a failed write, and every web-tier fault silently falls back from then on. Silently diverting to a worse destination is the exact failure this whole change exists to end.

`TaskError::_logRow()` is covered **with no special case**, which is why this went in the framework and not the callers: it discards `save()`'s return *by design*, because it **is** the sink FOS failure reports land in. A fix that only helped callers checking a return value would have left the report of a failed imaging run to be lost entirely.

## Behaviour change — deliberate

`save()` and `destroy()` now return `false` where they returned the object. Callers that check the return will start seeing failures that were previously silent, on the UI and API paths too, not just machine ones. That is the fix, not a side effect.

## Verification

- `tests/save-failure-is-recorded.test.php` — DB-free, pins all three properties, and drives `_logRow()` at its real call site rather than asserting about it in the abstract. Fails on `working-1.6` with three failures.
- **Mutation-verified.** Each of four mutations is caught: drop the error check (1 failure), drop `logFault()` (3), re-gate it on a valid user (3), route it back through `_writeLog()` (3). Both vacuity guards are in — the test fails loudly if the anonymous user turns out valid, or if `_logRow()` stops attempting a write.
- **Full suite 85/85.**
- **Checked against a live database**, which is the half a fake cannot prove: a valid statement leaves `->error` falsy (no false positives — the real regression risk in Part A), an invalid one sets it, and a real `save()` still returns the object. Row count identical either side of a rolled-back transaction, nothing left behind. Script: `background_scripts/verify_save_failure_seam.php`.
- **`error_log()` fallback exercised** with the directory absent — the state of a web tree updated ahead of its installer.

## Notes

- **No route or schema change**, so `OpenAPI::document()` and `FOG_SCHEMA` are untouched, and there is no downstream FogApi class-list sync.
- The installer gains `faults/` alongside `plugins/` and `fos/`, same ownership and `httpd_sys_rw_content_t` label (GH-964). Adding it to `FOGLogPaths::FOG_SUBDIRS` gets it into the Log Viewer by name.
- **Open ADRs on log-table shape, audit and span tables:** this would want revisiting, and cleanly. `logFault()` gains a *second* destination — a best-effort row written **after** the file line, never instead of it. The file write stays whatever else arrives, because at the moment it is called the database is the untrusted party. One function changes; that is written into its docblock so nobody later tidies the file away.
- **Out of scope, worth knowing:** `FOGController::loadItem()` swallows a failed SELECT the same way (`fogcontroller.class.php:972`). A failed read leaves the object looking like it simply has no data. Same class of bug, different blast radius — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
