### PR TITLE
fix(core): report and record database operations that fail on machine paths (1.5 port of #1257)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -902,6 +902,21 @@ installFOGServices() {
     # without this the directory exists, looks right, and every report is
     # dropped with nothing but an AVC to say so.
     setSELinuxContext "$servicelogs/fos" httpd_sys_rw_content_t
+    # Where FOGBase::logFault() records database operations that did not
+    # happen. Its own subdirectory for the same reason the one above has its.
+    #
+    # Unlike that one, BOTH tiers write here -- the web user, and root for the
+    # daemons -- so logFault() writes faults-web.log and faults-service.log
+    # rather than one shared file, whose owner would be whichever tier hit a
+    # failure first. The directory is the web user's; root writes into it
+    # regardless of mode.
+    dots "Creating FOG fault log directory"
+    mkdir -p $servicelogs/faults >>$error_log 2>&1
+    chown ${apacheuser}:${apacheuser} $servicelogs/faults >>$error_log 2>&1
+    errorStat $?
+    # Outside the dots/errorStat pair, like every other caller, and the _rw_
+    # label is as load-bearing here as it is for fos above (GH-964).
+    setSELinuxContext "$servicelogs/faults" httpd_sys_rw_content_t
 }
 configureUDPCast() {
     dots "Setting up UDPCast"

--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -556,6 +556,28 @@ class PDODB extends DatabaseManager
                 $this->sqlerror()
             );
             self::$_result = false;
+            /*
+             * $msg used to be built here and dropped on the floor: a failed
+             * fetch set no ->error, logged nothing, and left $_result false
+             * -- so get() answered an empty set and the caller could not tell
+             * "the read failed" from "there are no rows". That is the same
+             * defect FOGController::save() and load() were carrying, one
+             * layer down, and it is why those checks alone were not enough.
+             *
+             * Only ever ADDS a failure, never overwrites one. query() owns
+             * clearing ->error -- it runs immediately before every fetch()
+             * and always sets it to false or to a message -- so when a fetch
+             * fails BECAUSE the query did ("No query result, use query()
+             * first"), the guard keeps the original cause rather than
+             * replacing it with the symptom.
+             *
+             * Not logged from here. The callers know which class and table
+             * they were reading, and this does not; a line naming neither is
+             * worse than the caller's, and two lines per failure is noise.
+             */
+            if (!$this->error) {
+                $this->error = $msg;
+            }
 
             if (self::$throwOnQueryError) {
                 throw $e;

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -768,6 +768,175 @@ abstract class FOGBase
         printf('<div class="debug debug-error">%s</div>', $string);
     }
     /**
+     * FOG's log directory.
+     *
+     * 1.5 has no FOG_LOG_DIR constant -- every service spells this path out
+     * -- so this one does too, matching TaskError::LOG_DIR and the
+     * installer's $servicelogs default. FOG_LOG_DIR is still preferred when
+     * something HAS defined it, which costs nothing, keeps this method the
+     * same shape as the 1.6 original it was ported from, and is what lets a
+     * test point it somewhere writable.
+     *
+     * @var string
+     */
+    const FAULT_LOG_DIR = '/opt/fog/log';
+    /**
+     * The subdirectory of that directory fault lines are written to.
+     *
+     * Its own subdirectory rather than the top level, for the reason
+     * TaskError gives for the FOS report log: rotation renames and unlinks,
+     * and the top level is root's -- the eight daemons' logs live there and
+     * nothing running as the web user should be able to remove them.
+     *
+     * @var string
+     */
+    const FAULT_LOG_SUBDIR = 'faults';
+    /**
+     * How big a fault log may get before one old copy is kept, in bytes.
+     *
+     * A literal, NOT the SERVICE_LOG_SIZE setting the daemons rotate on, and
+     * that is the whole point: getSetting() issues a query, and the thing
+     * being reported here is a query that just failed.
+     *
+     * @var int
+     */
+    const FAULT_LOG_MAX = 10485760;
+    /**
+     * Records that something FOG needed to write or read did not happen.
+     *
+     * The failure sink of last resort, and deliberately the only logger here
+     * that asks nobody's permission to run.
+     *
+     * WHY THIS EXISTS AT ALL. FOGController::save(), destroy() and load()
+     * recorded a failure by calling logHistory(), which returns without doing
+     * anything unless self::$FOGUser is a valid User. Nothing on a machine
+     * -facing path ever sets one -- packages/web/service/, lib/reg-task/ and
+     * the daemons are matched to a HOST by MAC or token, and the daemons have
+     * no request at all -- so on every one of those paths the failure branch
+     * ran and wrote nowhere.
+     *
+     * debug() was not a second chance. On this branch it writes to no file at
+     * ALL -- it printf()s into the page and returns immediately when
+     * self::$service or self::$ajax is set, which on a machine endpoint is
+     * always. So a failed write on a service path had literally no possible
+     * output. (1.6's debug() at least reaches a file, behind a globalSetting
+     * that ships off.)
+     *
+     * WHY A FILE AND NOT A TABLE. logHistory() writes a row, so it shares its
+     * failure mode with the thing it is reporting on: a lost connection, a
+     * locked table or a full disk takes out the report along with the write.
+     * A sink for a failed database operation cannot itself be a database
+     * write. That -- not the user gate -- is the structural reason this is
+     * not simply logHistory() with the gate widened. The user gate is correct
+     * where it is: `history` is the audit trail, "who did what", and nobody
+     * did this.
+     *
+     * IT MUST NOT call getSetting(), for the path or the rotation size or
+     * anything else: getSetting() issues a query, and a logger that queries
+     * in order to report a failed query is the recursion that has already
+     * cost this project a silently dying worker. FAULT_LOG_MAX is a literal
+     * for exactly that reason.
+     *
+     * error_log() is the fallback, not the destination, and it is
+     * load-bearing rather than tidiness. The directory is the installer's, so
+     * a server whose web tree has been updated but which has not been
+     * re-installed has nowhere to write yet -- and PHP's own channel is
+     * already pointed somewhere useful in both tiers.
+     *
+     * @param string $message what did not happen, and why
+     *
+     * @return void
+     */
+    public static function logFault($message)
+    {
+        // Nothing here can re-enter through the database; this covers the one
+        // real case, which is logFault() failing on its own file write.
+        static $inFault = false;
+        if ($inFault) {
+            return;
+        }
+        $inFault = true;
+
+        try {
+            // One line per fault, so `tail -f` stays readable and a
+            // multi-line PDO message -- they carry the SQL, the parameters
+            // and a debugDumpParams() block -- cannot be mistaken for
+            // several faults.
+            $flat = preg_replace('#\s+#', ' ', (string) $message);
+            // Never let a message become an empty one. preg_replace returns
+            // null when it gives up, and a (string) cast of that is '', which
+            // the guard below would then throw away -- losing the one record
+            // this method exists to keep.
+            $line = trim(null === $flat ? (string) $message : $flat);
+            if ('' === $line) {
+                return;
+            }
+            $stamped = sprintf(
+                '[%s] %s%s',
+                date('Y-m-d H:i:s'),
+                $line,
+                PHP_EOL
+            );
+            $file = self::_faultLogPath();
+            if ('' !== $file) {
+                self::_rotateFaultLog($file);
+                if (false !== @file_put_contents($file, $stamped, FILE_APPEND)) {
+                    return;
+                }
+            }
+            error_log($line);
+        } finally {
+            $inFault = false;
+        }
+    }
+    /**
+     * The fault log's path, or '' if there is nowhere to write.
+     *
+     * Split by SAPI, into faults-web.log and faults-service.log. This is the
+     * one FOG log directory written by BOTH tiers -- the web user, and root
+     * for the daemons -- and a single shared file would be owned by whichever
+     * wrote first. A root-owned file appears the moment any daemon hits a
+     * failed write, and from then on every web-tier fault would fall silently
+     * to error_log(). Silently diverting to a worse destination is the exact
+     * failure this whole path exists to end, so the two writers get two files.
+     *
+     * The directory is never created here. It is the installer's, which gives
+     * it to the web user with the right SELinux label (GH-964: /opt/fog
+     * inherits usr_t and httpd_t may read it but not write it, so an
+     * unlabelled mkdir would produce a directory that looks right and
+     * silently swallows every write on an enforcing host).
+     *
+     * @return string
+     */
+    private static function _faultLogPath()
+    {
+        $base = defined('FOG_LOG_DIR') ? FOG_LOG_DIR : self::FAULT_LOG_DIR;
+        $dir = rtrim($base, DS) . DS . self::FAULT_LOG_SUBDIR;
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return '';
+        }
+
+        return $dir . DS . sprintf(
+            'faults-%s.log',
+            'cli' === PHP_SAPI ? 'service' : 'web'
+        );
+    }
+    /**
+     * Keeps one old copy once the fault log passes FAULT_LOG_MAX.
+     *
+     * @param string $file the fault log
+     *
+     * @return void
+     */
+    private static function _rotateFaultLog($file)
+    {
+        $size = @filesize($file);
+        if (false === $size || $size < self::FAULT_LOG_MAX) {
+            return;
+        }
+        @rename($file, $file . '.1');
+    }
+    /**
      * Prints info.
      *
      * @param string $txt  the string to use

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -928,6 +928,7 @@ abstract class FOGController extends FOGBase
                 array(),
                 $queryArray
             );
+            $vals = self::$DB->fetch()->get();
             /*
              * A rejected SELECT is swallowed the same way a rejected INSERT
              * is -- see save(). fetch()->get() then hands back nothing, and
@@ -935,6 +936,13 @@ abstract class FOGController extends FOGBase
              * row that genuinely holds no data. That is the read half of the
              * same defect: not a wrong answer anybody can see, a plausible
              * empty one.
+             *
+             * AFTER the fetch, not between it and the query, so that ONE
+             * check covers both halves of the read. fetch() records its own
+             * failure on ->error and never clears one, and query() always
+             * sets ->error immediately before -- so a fetch that failed
+             * because the query did still reports the query's message here,
+             * not "No query result, use query() first".
              *
              * Recorded HERE rather than in the catch below, and that split is
              * the point. This catch also handles the method's ORDINARY
@@ -945,7 +953,7 @@ abstract class FOGController extends FOGBase
              *
              * Throwing after logging costs nothing and buys the debug line
              * below: setQuery() merges (fastmerge, never clears), so skipping
-             * it with no rows to merge leaves the object exactly as it was.
+             * it with nothing to merge leaves the object exactly as it was.
              * load() still returns $this either way -- `new Host(42)` must
              * not become fatal because a read failed.
              */
@@ -966,7 +974,6 @@ abstract class FOGController extends FOGBase
                 );
                 throw new Exception((string) self::$DB->error);
             }
-            $vals = self::$DB->fetch()->get();
             $this->setQuery($vals);
         } catch (Exception $e) {
             $str = sprintf(

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -437,6 +437,37 @@ abstract class FOGController extends FOGBase
             )->fetch(PDO::FETCH_ASSOC, 'fetch_all')->get();
         } catch (Exception $e) {
             $rows = array();
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s',
+                    _('Column type lookup failed'),
+                    _('Error'),
+                    $e->getMessage(),
+                    _('every column will be treated as untyped')
+                )
+            );
+        }
+        /*
+         * The degradation is deliberate, the SILENCE was not. PDODB swallows
+         * a rejected statement, so this never reached the catch above on a
+         * real error -- it cached an empty type map and every column went
+         * back to being untyped, which is exactly the bug this method exists
+         * to prevent, reappearing with nothing said.
+         *
+         * Behaviour is unchanged: still an empty map. Only now it is written
+         * down.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s',
+                    _('Column type lookup failed'),
+                    _('Error'),
+                    self::$DB->error,
+                    _('every column will be treated as untyped')
+                )
+            );
+            $rows = array();
         }
         foreach ((array)$rows as $row) {
             if (!isset($row['t'], $row['c'], $row['ty'])) {
@@ -707,6 +738,31 @@ abstract class FOGController extends FOGBase
             self::info($msg);
 
             self::$DB->query($query, [], $queryArray);
+            /*
+             * PDODB swallows a rejected statement, so ASK it.
+             *
+             * PDO runs in ERRMODE_EXCEPTION, but PDODB::query() catches the
+             * PDOException, records the message on ->error and returns
+             * normally; it rethrows only when $throwOnQueryError is true,
+             * which nothing sets and which must not be set globally -- it
+             * would turn every already-tolerated failure across the codebase
+             * into an uncaught 500 at once.
+             *
+             * So without this check the catch below never runs on a real SQL
+             * error. For a NEW row that was survivable by accident: insertId()
+             * comes back 0 and the "no valid ID was assigned" throw further
+             * down catches it. For an EXISTING row -- every progress update,
+             * every task state change, every inventory write against a known
+             * host -- there was nothing to catch on, so save() went on to log
+             * the SUCCESS message and return $this. `if (!$obj->save())` was
+             * not merely unrecorded on those paths, it was answered "fine".
+             *
+             * Truthy rather than `false !== ...`: PDODB declares $error with
+             * no default, so it is null until the first statement runs.
+             */
+            if (self::$DB->error) {
+                throw new Exception((string) self::$DB->error);
+            }
             $lastInsertID = self::$DB->insertId();
 
             // Force ID correctness: if we still don't have a valid ID, this wasn't created properly.
@@ -774,14 +830,26 @@ abstract class FOGController extends FOGBase
             }
 
             $msg = sprintf(
-                '%s: %s: %s, %s: %s',
+                '%s: %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Database save failed'),
+                _('Class'),
+                get_class($this),
+                _('Table'),
+                $this->databaseTable,
                 _('ID'),
                 $this->get('id'),
                 _('Error'),
                 $e->getMessage()
             );
             self::debug($msg);
+            /*
+             * The line that actually gets written. debug() on this branch
+             * writes to no file at all and returns immediately on a service
+             * or ajax request, and logHistory() needs somebody signed in --
+             * neither is true on the paths that generate most of these.
+             * See FOGBase::logFault().
+             */
+            self::logFault($msg);
 
             return false;
         }
@@ -860,6 +928,44 @@ abstract class FOGController extends FOGBase
                 array(),
                 $queryArray
             );
+            /*
+             * A rejected SELECT is swallowed the same way a rejected INSERT
+             * is -- see save(). fetch()->get() then hands back nothing, and
+             * an object that could not be read is indistinguishable from a
+             * row that genuinely holds no data. That is the read half of the
+             * same defect: not a wrong answer anybody can see, a plausible
+             * empty one.
+             *
+             * Recorded HERE rather than in the catch below, and that split is
+             * the point. This catch also handles the method's ORDINARY
+             * control flow -- "Operation field not set" fires on every
+             * `new Host()` built without an id, which is constant traffic --
+             * so faulting the whole catch would bury the one line that
+             * matters under thousands that do not.
+             *
+             * Throwing after logging costs nothing and buys the debug line
+             * below: setQuery() merges (fastmerge, never clears), so skipping
+             * it with no rows to merge leaves the object exactly as it was.
+             * load() still returns $this either way -- `new Host(42)` must
+             * not become fatal because a read failed.
+             */
+            if (self::$DB->error) {
+                self::logFault(
+                    sprintf(
+                        '%s: %s: %s, %s: %s, %s: %s, %s: %s',
+                        _('Database load failed'),
+                        _('Class'),
+                        get_class($this),
+                        _('Table'),
+                        $this->databaseTable,
+                        _('Key'),
+                        $key,
+                        _('Error'),
+                        self::$DB->error
+                    )
+                );
+                throw new Exception((string) self::$DB->error);
+            }
             $vals = self::$DB->fetch()->get();
             $this->setQuery($vals);
         } catch (Exception $e) {
@@ -958,6 +1064,13 @@ abstract class FOGController extends FOGBase
                 (array) $val
             );
             self::$DB->query($query, array(), $queryArray);
+            // Same reason as save()'s, above: a rejected DELETE is swallowed
+            // by PDODB, so destroy() reported success for a row still there.
+            // A DELETE matching nothing is not an error and does not land
+            // here -- only a statement the server actually rejected does.
+            if (self::$DB->error) {
+                throw new Exception((string) self::$DB->error);
+            }
             if (!$this instanceof History) {
                 if ($this->get('name')) {
                     $msg = sprintf(
@@ -1008,14 +1121,26 @@ abstract class FOGController extends FOGBase
                 self::logHistory($msg);
             }
             $msg = sprintf(
-                '%s: %s: %s, %s: %s',
+                '%s: %s: %s, %s: %s, %s: %s, %s: %s',
                 _('Destroy failed'),
+                _('Class'),
+                get_class($this),
+                _('Table'),
+                $this->databaseTable,
                 _('ID'),
                 $this->get('id'),
                 _('Error'),
                 $e->getMessage()
             );
             self::debug($msg);
+            /*
+             * The line that actually gets written. debug() on this branch
+             * writes to no file at all and returns immediately on a service
+             * or ajax request, and logHistory() needs somebody signed in --
+             * neither is true on the paths that generate most of these.
+             * See FOGBase::logFault().
+             */
+            self::logFault($msg);
 
             return false;
         }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -448,6 +448,23 @@ abstract class FOGManagerController extends FOGBase
             PDO::FETCH_ASSOC,
             'fetch_all'
         );
+        // A rejected read answers an EMPTY set, which every caller reads as
+        // "there are none" rather than "the question was not asked". The
+        // return contract is left alone -- there is no catch here and callers
+        // expect an array -- so the fault line is the whole of the fix.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Find failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering an empty set for a read that never ran')
+                )
+            );
+        }
         if ($idField) {
             $data = (array)self::$DB->get($idField);
             if ($filter) {
@@ -602,10 +619,24 @@ abstract class FOGManagerController extends FOGBase
             )
         );
 
-        return (int)self::$DB
-            ->query($query, array(), $countVals)
-            ->fetch()
-            ->get('total');
+        self::$DB->query($query, array(), $countVals);
+        // A rejected count answers 0, which reads as "there are none" rather
+        // than "nobody asked". Contract unchanged; the fault line is the fix.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Count failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering 0 for a read that never ran')
+                )
+            );
+        }
+
+        return (int)self::$DB->fetch()->get('total');
     }
     /**
      * Inserts data in mass to the database.
@@ -671,6 +702,12 @@ abstract class FOGManagerController extends FOGBase
                 implode(',', $dups)
             );
             self::$DB->query($query, array(), $insertVals);
+            // Same swallowed-error seam as FOGController::save(): without
+            // this the loop went on to report affectedRows for a batch the
+            // server rejected.
+            if (self::$DB->error) {
+                throw new Exception((string) self::$DB->error);
+            }
             if ($ind === 0) {
                 $insertID = (int) self::$DB->insertId();
             }
@@ -848,7 +885,33 @@ abstract class FOGManagerController extends FOGBase
             (array) $findVals
         );
 
-        return (bool) self::$DB->query($query, array(), $queryVals);
+        self::$DB->query($query, array(), $queryVals);
+        /*
+         * `(bool) self::$DB->query(...)` was ALWAYS true: query() returns
+         * $this, and an object casts to true whatever the server said. So
+         * this reported success for every rejected mass update.
+         *
+         * Faulted here rather than thrown: this method has no catch and its
+         * callers expect a bool, so throwing would turn a silently-failed
+         * bulk edit into an uncaught 500. False is the honest answer they
+         * were already written to read.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s',
+                    _('Mass update failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error
+                )
+            );
+
+            return false;
+        }
+
+        return true;
     }
     /**
      * Destroys items related to the main object.
@@ -917,6 +980,24 @@ abstract class FOGManagerController extends FOGBase
             );
             unset($destroyKeys);
             self::$DB->query($query, array(), $destroyVals);
+            // Returned true unconditionally, so a rejected DELETE reported
+            // every row removed. Faulted and answered false rather than
+            // thrown, for the same reason update() is: no catch here, and
+            // callers expect a bool.
+            if (self::$DB->error) {
+                self::logFault(
+                    sprintf(
+                        '%s: %s: %s, %s: %s',
+                        _('Mass destroy failed'),
+                        _('Table'),
+                        $this->databaseTable,
+                        _('Error'),
+                        self::$DB->error
+                    )
+                );
+
+                return false;
+            }
             unset($destroyVals, $destroyKeys);
         }
 
@@ -1067,10 +1148,33 @@ abstract class FOGManagerController extends FOGBase
             ':id'
         );
 
-        return (bool)self::$DB
-            ->query($query, array(), $existVals)
-            ->fetch()
-            ->get('total') > 0;
+        self::$DB->query($query, array(), $existVals);
+        /*
+         * A rejected read here answers "no, it does not exist", which is the
+         * most expensive wrong answer this class can give: callers use
+         * exists() to decide whether to CREATE, so an unreadable database
+         * turns into a duplicate rather than an error.
+         *
+         * The contract is left alone -- callers expect a bool and there is no
+         * catch here -- so the fault line is the whole of the fix. Making
+         * this throw is a real change to a read contract and belongs in its
+         * own decision, not smuggled into a logging fix.
+         */
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Existence check failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering "does not exist" for a read that never ran')
+                )
+            );
+        }
+
+        return (bool)self::$DB->fetch()->get('total') > 0;
     }
     /**
      * Search for items passed to keyword.
@@ -1550,10 +1654,23 @@ abstract class FOGManagerController extends FOGBase
             )
         );
 
-        return (int)self::$DB
-            ->query($query, array(), $countVals)
-            ->fetch()
-            ->get('total');
+        self::$DB->query($query, array(), $countVals);
+        // Same as exists(): a rejected distinct count answers 0.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s, %s',
+                    _('Count failed'),
+                    _('Table'),
+                    $this->databaseTable,
+                    _('Error'),
+                    self::$DB->error,
+                    _('answering 0 for a read that never ran')
+                )
+            );
+        }
+
+        return (int)self::$DB->fetch()->get('total');
     }
     /**
      * Uninstalls the table.
@@ -1563,6 +1680,25 @@ abstract class FOGManagerController extends FOGBase
     public function uninstall()
     {
         $sql = Schema::dropTable($this->tablename);
-        return self::$DB->query($sql);
+        self::$DB->query($sql);
+        // Declared @return bool and returned the PDODB object, which is
+        // truthy however the DROP went. A plugin uninstall that left its
+        // table in place reported success.
+        if (self::$DB->error) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s, %s: %s',
+                    _('Table uninstall failed'),
+                    _('Table'),
+                    $this->tablename,
+                    _('Error'),
+                    self::$DB->error
+                )
+            );
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -620,8 +620,10 @@ abstract class FOGManagerController extends FOGBase
         );
 
         self::$DB->query($query, array(), $countVals);
+        $total = self::$DB->fetch()->get('total');
         // A rejected count answers 0, which reads as "there are none" rather
-        // than "nobody asked". Contract unchanged; the fault line is the fix.
+        // than "nobody asked". After the fetch, so one check covers both
+        // halves. Contract unchanged; the fault line is the fix.
         if (self::$DB->error) {
             self::logFault(
                 sprintf(
@@ -636,7 +638,7 @@ abstract class FOGManagerController extends FOGBase
             );
         }
 
-        return (int)self::$DB->fetch()->get('total');
+        return (int)$total;
     }
     /**
      * Inserts data in mass to the database.
@@ -1149,7 +1151,11 @@ abstract class FOGManagerController extends FOGBase
         );
 
         self::$DB->query($query, array(), $existVals);
+        $total = self::$DB->fetch()->get('total');
         /*
+         * After the fetch, so one check covers both halves of the read --
+         * fetch() records its own failure on ->error and never clears one.
+         *
          * A rejected read here answers "no, it does not exist", which is the
          * most expensive wrong answer this class can give: callers use
          * exists() to decide whether to CREATE, so an unreadable database
@@ -1174,7 +1180,7 @@ abstract class FOGManagerController extends FOGBase
             );
         }
 
-        return (bool)self::$DB->fetch()->get('total') > 0;
+        return (bool)$total > 0;
     }
     /**
      * Search for items passed to keyword.
@@ -1655,7 +1661,9 @@ abstract class FOGManagerController extends FOGBase
         );
 
         self::$DB->query($query, array(), $countVals);
-        // Same as exists(): a rejected distinct count answers 0.
+        $total = self::$DB->fetch()->get('total');
+        // Same as exists(): a rejected distinct count answers 0. After the
+        // fetch, so one check covers both halves.
         if (self::$DB->error) {
             self::logFault(
                 sprintf(
@@ -1670,7 +1678,7 @@ abstract class FOGManagerController extends FOGBase
             );
         }
 
-        return (int)self::$DB->fetch()->get('total');
+        return (int)$total;
     }
     /**
      * Uninstalls the table.

--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -218,6 +218,7 @@ class StorageNode extends FOGController
             '/var/log/apache2',
             '/var/log/fog',
             '/var/log/fog/fos',
+            '/var/log/fog/faults',
             '/var/log/httpd',
             '/var/log/nginx',
             '/var/log/php*',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1087,6 +1087,9 @@ msgstr "Client-Version"
 msgid "Clients"
 msgstr "Clients"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 #, fuzzy
 msgid "Command"
 msgstr "Befehl"
@@ -1174,6 +1177,10 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 #, fuzzy
 msgid "Could not register"
 msgstr "Konnte nicht registriert werden."
+
+#, fuzzy
+msgid "Count failed"
+msgstr "Laden fehlgeschlagen: %s"
 
 msgid "Create"
 msgstr "Erstellen"
@@ -1355,6 +1362,10 @@ msgstr "Datenbankänderungen rückgängig gemacht"
 #, fuzzy
 msgid "Database imported and added successfully!"
 msgstr "Datenbank erfolgreich importiert und hinzugefügt"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "Datenbankspeicherung fehlgeschlagen"
 
 #, fuzzy
 msgid "Database not available"
@@ -1766,6 +1777,10 @@ msgstr "Ereignisname muss eine Zeichenfolge sein."
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "Privater Schlüssel ist fehlgeschlagen"
 
 msgid "Exists item must be boolean"
 msgstr "Bestehendes Objekt muss boolean sein"
@@ -2206,6 +2221,10 @@ msgstr "Dateigröße"
 #, fuzzy
 msgid "Filter"
 msgstr "Filter"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
 msgid "Finding any images associated"
@@ -3958,6 +3977,14 @@ msgstr "Management-Passwort"
 
 msgid "Management Username"
 msgstr "Management-Benutzernamen"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Zerstörung fehlgeschlagen: %s"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "Benutzer-Update fehlgeschlagen"
 
 msgid "Master Node"
 msgstr "Master-Knoten"
@@ -6298,8 +6325,16 @@ msgid "TX"
 msgstr "TX"
 
 #, fuzzy
+msgid "Table"
+msgstr "Aktiviert"
+
+#, fuzzy
 msgid "Table not defined for this class"
 msgstr "Keine Datenbank-Tabelle für diese Klasse definiert"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "Datenbankspeicherung fehlgeschlagen"
 
 #, fuzzy
 msgid "Tag Name"
@@ -7406,6 +7441,15 @@ msgstr "und das entsprechende Modul, das früher"
 msgid "and the location of the file on that"
 msgstr "und der Speicherort der Datei auf diesem"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "da der FOG versuchen wird, mit dem Internet zu verbinden, "
 
@@ -7535,6 +7579,9 @@ msgstr "ob bereits ausgewählt oder hochgeladen"
 
 msgid "either because you have updated"
 msgstr "entweder weil Sie aktualisiert haben"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 #, fuzzy
 msgid "failed to execute, image file: "

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1091,6 +1091,9 @@ msgstr "CPU Version"
 msgid "Clients"
 msgstr "Clients"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 #, fuzzy
 msgid "Command"
 msgstr "Snapin Command"
@@ -1178,6 +1181,10 @@ msgstr "Could not read tmp file."
 #, fuzzy
 msgid "Could not register"
 msgstr "Could not create printer"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "Load failed: %s"
 
 msgid "Create"
 msgstr "Create"
@@ -1359,6 +1366,10 @@ msgstr "Database changes reverted"
 #, fuzzy
 msgid "Database imported and added successfully!"
 msgstr "Database Imported and added successfully"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "Database update failed"
 
 #, fuzzy
 msgid "Database not available"
@@ -1770,6 +1781,10 @@ msgstr "Event must be a string"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "Private key failed"
 
 msgid "Exists item must be boolean"
 msgstr ""
@@ -2210,6 +2225,10 @@ msgstr "filesize"
 #, fuzzy
 msgid "Filter"
 msgstr "File"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "Load failed: %s"
 
 #, fuzzy
 msgid "Finding any images associated"
@@ -3958,6 +3977,14 @@ msgstr "Management Password"
 
 msgid "Management Username"
 msgstr "Management Username"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Destroy failed: %s"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "User update failed"
 
 msgid "Master Node"
 msgstr "Master Node"
@@ -6296,8 +6323,16 @@ msgid "TX"
 msgstr "TX"
 
 #, fuzzy
+msgid "Table"
+msgstr "Enabled"
+
+#, fuzzy
 msgid "Table not defined for this class"
 msgstr "No database table defined for this class"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "Database update failed"
 
 #, fuzzy
 msgid "Tag Name"
@@ -7403,6 +7438,15 @@ msgstr ""
 msgid "and the location of the file on that"
 msgstr ""
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr ""
 
@@ -7531,6 +7575,9 @@ msgid "either already selected or uploaded"
 msgstr ""
 
 msgid "either because you have updated"
+msgstr ""
+
+msgid "every column will be treated as untyped"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1079,6 +1079,9 @@ msgstr "Versión"
 msgid "Clients"
 msgstr "Nodo Almacenamiento Clientes Max"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr ""
 
@@ -1162,6 +1165,10 @@ msgstr ""
 #, fuzzy
 msgid "Could not register"
 msgstr "No se puede encontrar el nodo de almacenamiento:"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "Error al cargar"
 
 msgid "Create"
 msgstr "Crear"
@@ -1335,6 +1342,10 @@ msgstr "Guardar Cambios"
 
 msgid "Database imported and added successfully!"
 msgstr ""
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "Fallo al actualizar la base de datos"
 
 #, fuzzy
 msgid "Database not available"
@@ -1737,6 +1748,9 @@ msgid "Event must be a string"
 msgstr ""
 
 msgid "Every configured multicast port is already in use"
+msgstr ""
+
+msgid "Existence check failed"
 msgstr ""
 
 msgid "Exists item must be boolean"
@@ -2194,6 +2208,10 @@ msgstr ""
 
 msgid "Filter"
 msgstr ""
+
+#, fuzzy
+msgid "Find failed"
+msgstr "Error al cargar"
 
 msgid "Finding any images associated"
 msgstr ""
@@ -3961,6 +3979,14 @@ msgstr "Gestión"
 #, fuzzy
 msgid "Management Username"
 msgstr "Usuario"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Error al eliminar"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "Fallo al actualizar"
 
 #, fuzzy
 msgid "Master Node"
@@ -6294,8 +6320,16 @@ msgstr ""
 msgid "TX"
 msgstr ""
 
+#, fuzzy
+msgid "Table"
+msgstr "Habilitado"
+
 msgid "Table not defined for this class"
 msgstr ""
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "Fallo al actualizar la base de datos"
 
 #, fuzzy
 msgid "Tag Name"
@@ -7355,6 +7389,15 @@ msgstr ""
 msgid "and the location of the file on that"
 msgstr ""
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr ""
 
@@ -7486,6 +7529,9 @@ msgid "either already selected or uploaded"
 msgstr ""
 
 msgid "either because you have updated"
+msgstr ""
+
+msgid "every column will be treated as untyped"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -956,6 +956,9 @@ msgstr "Version Client"
 msgid "Clients"
 msgstr "Clients"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr "Commande"
 
@@ -1030,6 +1033,10 @@ msgstr "Impossible de lire le fichier tmp."
 
 msgid "Could not register"
 msgstr "Impossible d'enregistrer"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "La connexion a échoué"
 
 msgid "Create"
 msgstr "Créer"
@@ -1181,6 +1188,10 @@ msgstr "Les modifications de la base de données ont été rétablies !"
 
 msgid "Database imported and added successfully!"
 msgstr "Base de données importée et ajoutée avec succès !"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "La sauvegarde de la base de données a échoué"
 
 msgid "Database not available"
 msgstr "Base de données non disponible"
@@ -1556,6 +1567,10 @@ msgstr "Événement doit être une chaîne de caractères"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "La clé privée a échoué"
 
 msgid "Exists item must be boolean"
 msgstr "L'élément Exists doit être booléen"
@@ -1953,6 +1968,10 @@ msgstr "Taille du fichier"
 
 msgid "Filter"
 msgstr "Filtrer"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "La connexion a échoué"
 
 msgid "Finding any images associated"
 msgstr "Trouver les images associées"
@@ -3498,6 +3517,14 @@ msgstr "Gestion des mots de passe"
 
 msgid "Management Username"
 msgstr "Gestion des identifiants"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Échec de la destruction"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "La mise à jour de l'utilisateur a échoué !"
 
 msgid "Master Node"
 msgstr "Nœud maître"
@@ -5565,8 +5592,16 @@ msgstr "Imprimante Port TCP / IP"
 msgid "TX"
 msgstr "TX"
 
+#, fuzzy
+msgid "Table"
+msgstr "Activé"
+
 msgid "Table not defined for this class"
 msgstr "Tableau non défini pour cette classe"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "La sauvegarde de la base de données a échoué"
 
 #, fuzzy
 msgid "Tag Name"
@@ -6542,6 +6577,15 @@ msgstr "et le module équivalent à ce que faisait FOG"
 msgid "and the location of the file on that"
 msgstr "et l'emplacement du fichier sur ce"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "car FOG va essayer de sortir sur internet"
 
@@ -6661,6 +6705,9 @@ msgstr "soit déjà sélectionné ou téléchargé"
 
 msgid "either because you have updated"
 msgstr "soit parce que vous avez mis à jour"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 msgid "failed to execute, image file: "
 msgstr "n'a pas réussi à s'exécuter, fichier image : "

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -984,6 +984,9 @@ msgstr "Versione client"
 msgid "Clients"
 msgstr "clienti"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr "Comando"
 
@@ -1058,6 +1061,10 @@ msgstr "Impossibile leggere il file tmp."
 
 msgid "Could not register"
 msgstr "Non posso registrare"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "Caricamento non riuscito"
 
 msgid "Create"
 msgstr "Creare"
@@ -1212,6 +1219,10 @@ msgstr "Modifiche al database ripristinate"
 
 msgid "Database imported and added successfully!"
 msgstr "Database importati e aggiunti con successo"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "Salvataggio del database non riuscito"
 
 msgid "Database not available"
 msgstr "Database non disponibile"
@@ -1595,6 +1606,10 @@ msgstr "Evento deve essere una stringa"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "Chiave privata non è riuscita"
 
 msgid "Exists item must be boolean"
 msgstr "Exists deve essere boolean"
@@ -2004,6 +2019,10 @@ msgstr "Dimensione del file"
 
 msgid "Filter"
 msgstr "Filtro"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "Caricamento non riuscito"
 
 msgid "Finding any images associated"
 msgstr "Trovare tutte le immagini associate"
@@ -3567,6 +3586,14 @@ msgstr "Gestione delle password"
 
 msgid "Management Username"
 msgstr "Gestione utente"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Deistruzione fallita"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "Aggiornamento utente non riuscita"
 
 msgid "Master Node"
 msgstr "Maestro Node"
@@ -5685,8 +5712,16 @@ msgstr "Porta TCP / IP della stampante"
 msgid "TX"
 msgstr "TX"
 
+#, fuzzy
+msgid "Table"
+msgstr "Abilitato"
+
 msgid "Table not defined for this class"
 msgstr "Tabella del database non definita per questa classe"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "Salvataggio del database non riuscito"
 
 #, fuzzy
 msgid "Tag Name"
@@ -6677,6 +6712,15 @@ msgstr "E il modulo equivalente per quello Green"
 msgid "and the location of the file on that"
 msgstr "e la posizione del file su quel"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "come FOG proverà ad andare in internet"
 
@@ -6801,6 +6845,9 @@ msgstr "già selezionati o caricati"
 
 msgid "either because you have updated"
 msgstr "Sia perché hai aggiornato"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 #, fuzzy
 msgid "failed to execute, image file: "

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -945,6 +945,9 @@ msgstr "クライアントバージョン"
 msgid "Clients"
 msgstr "クライアント"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr "コマンド"
 
@@ -1019,6 +1022,10 @@ msgstr "一時ファイルを読み取れませんでした。"
 
 msgid "Could not register"
 msgstr "登録できませんでした"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "ログインに失敗しました"
 
 msgid "Create"
 msgstr "作成"
@@ -1170,6 +1177,10 @@ msgstr "データベースの変更を元に戻しました！"
 
 msgid "Database imported and added successfully!"
 msgstr "データベースを正常にインポートして追加しました！"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "データベースの保存に失敗しました"
 
 msgid "Database not available"
 msgstr "データベースを利用できません"
@@ -1539,6 +1550,10 @@ msgstr "イベントは文字列で指定してください"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "秘密鍵の処理に失敗しました"
 
 msgid "Exists item must be boolean"
 msgstr "Exists 項目はブール値である必要があります"
@@ -1932,6 +1947,10 @@ msgstr "ファイルサイズ"
 
 msgid "Filter"
 msgstr "フィルター"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "ログインに失敗しました"
 
 msgid "Finding any images associated"
 msgstr "関連付けられたイメージを検索しています"
@@ -3460,6 +3479,14 @@ msgstr "管理パスワード"
 
 msgid "Management Username"
 msgstr "管理ユーザー名"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "解除に失敗しました"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "ユーザーの更新に失敗しました！"
 
 msgid "Master Node"
 msgstr "マスターノード"
@@ -5511,8 +5538,16 @@ msgstr "TCP/IP ポートプリンター"
 msgid "TX"
 msgstr "TX"
 
+#, fuzzy
+msgid "Table"
+msgstr "有効"
+
 msgid "Table not defined for this class"
 msgstr "このクラスにテーブルが定義されていません"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "データベースの保存に失敗しました"
 
 #, fuzzy
 msgid "Tag Name"
@@ -6479,6 +6514,15 @@ msgstr "および Green FOG の同等機能を持つモジュール"
 msgid "and the location of the file on that"
 msgstr "および、その上のファイルの保存場所"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "FOG がインターネットへ接続を試みるため"
 
@@ -6595,6 +6639,9 @@ msgstr "既に選択済み、またはアップロード済み"
 
 msgid "either because you have updated"
 msgstr "更新したため、または"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 msgid "failed to execute, image file: "
 msgstr "実行に失敗しました。イメージファイル: "

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -930,6 +930,9 @@ msgstr ""
 msgid "Clients"
 msgstr ""
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr ""
 
@@ -1003,6 +1006,9 @@ msgid "Could not read tmp file."
 msgstr ""
 
 msgid "Could not register"
+msgstr ""
+
+msgid "Count failed"
 msgstr ""
 
 msgid "Create"
@@ -1154,6 +1160,9 @@ msgid "Database changes reverted!"
 msgstr ""
 
 msgid "Database imported and added successfully!"
+msgstr ""
+
+msgid "Database load failed"
 msgstr ""
 
 msgid "Database not available"
@@ -1520,6 +1529,9 @@ msgid "Event must be a string"
 msgstr ""
 
 msgid "Every configured multicast port is already in use"
+msgstr ""
+
+msgid "Existence check failed"
 msgstr ""
 
 msgid "Exists item must be boolean"
@@ -1913,6 +1925,9 @@ msgid "Filesize"
 msgstr ""
 
 msgid "Filter"
+msgstr ""
+
+msgid "Find failed"
 msgstr ""
 
 msgid "Finding any images associated"
@@ -3433,6 +3448,12 @@ msgid "Management Password"
 msgstr ""
 
 msgid "Management Username"
+msgstr ""
+
+msgid "Mass destroy failed"
+msgstr ""
+
+msgid "Mass update failed"
 msgstr ""
 
 msgid "Master Node"
@@ -5482,7 +5503,13 @@ msgstr ""
 msgid "TX"
 msgstr ""
 
+msgid "Table"
+msgstr ""
+
 msgid "Table not defined for this class"
+msgstr ""
+
+msgid "Table uninstall failed"
 msgstr ""
 
 msgid "Tag Name"
@@ -6445,6 +6472,15 @@ msgstr ""
 msgid "and the location of the file on that"
 msgstr ""
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr ""
 
@@ -6560,6 +6596,9 @@ msgid "either already selected or uploaded"
 msgstr ""
 
 msgid "either because you have updated"
+msgstr ""
+
+msgid "every column will be treated as untyped"
 msgstr ""
 
 msgid "failed to execute, image file: "

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -955,6 +955,9 @@ msgstr "Versão do Cliente"
 msgid "Clients"
 msgstr "Clientes"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr "Comando"
 
@@ -1029,6 +1032,10 @@ msgstr "Não foi possível ler o arquivo tmp."
 
 msgid "Could not register"
 msgstr "Não foi possível registrar"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "Login falhou"
 
 msgid "Create"
 msgstr "Criar"
@@ -1180,6 +1187,10 @@ msgstr "Alterações no banco de dados revertidas!"
 
 msgid "Database imported and added successfully!"
 msgstr "Banco de dados importado e adicionado com sucesso!"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "Falha ao salvar banco de dados"
 
 msgid "Database not available"
 msgstr "Banco de dados não disponível"
@@ -1549,6 +1560,10 @@ msgstr "Evento deve ser uma string"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "Chave privada falhou"
 
 msgid "Exists item must be boolean"
 msgstr "Item 'Exists' deve ser booleano"
@@ -1945,6 +1960,10 @@ msgstr "Tamanho do arquivo"
 
 msgid "Filter"
 msgstr "Filtro"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "Login falhou"
 
 msgid "Finding any images associated"
 msgstr "Procurando imagens associadas"
@@ -3480,6 +3499,14 @@ msgstr "Senha de Gerenciamento"
 
 msgid "Management Username"
 msgstr "Usuário de Gerenciamento"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "Falha ao Destruir"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "Atualização de usuário falhou!"
 
 msgid "Master Node"
 msgstr "Nó Mestre"
@@ -5538,8 +5565,16 @@ msgstr "Impressora de Porta TCP/IP"
 msgid "TX"
 msgstr "TX"
 
+#, fuzzy
+msgid "Table"
+msgstr "Ativado"
+
 msgid "Table not defined for this class"
 msgstr "Tabela não definida para esta classe"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "Falha ao salvar banco de dados"
 
 #, fuzzy
 msgid "Tag Name"
@@ -6507,6 +6542,15 @@ msgstr "e o módulo equivalente para o que o Green"
 msgid "and the location of the file on that"
 msgstr "e a localização do arquivo naquele"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "pois o FOG tentará sair para a internet"
 
@@ -6623,6 +6667,9 @@ msgstr "já selecionado ou enviado"
 
 msgid "either because you have updated"
 msgstr "seja porque você atualizou"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 msgid "failed to execute, image file: "
 msgstr "falha ao executar, arquivo de imagem: "

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -955,6 +955,9 @@ msgstr "CPU版本"
 msgid "Clients"
 msgstr "客户端"
 
+msgid "Column type lookup failed"
+msgstr ""
+
 msgid "Command"
 msgstr "命令"
 
@@ -1029,6 +1032,10 @@ msgstr "无法读取临时文件"
 
 msgid "Could not register"
 msgstr "无法注册"
+
+#, fuzzy
+msgid "Count failed"
+msgstr "加载失败"
 
 msgid "Create"
 msgstr "创建"
@@ -1180,6 +1187,10 @@ msgstr "数据库更改已还原!"
 
 msgid "Database imported and added successfully!"
 msgstr "数据库已导入成功!"
+
+#, fuzzy
+msgid "Database load failed"
+msgstr "数据库保存失败"
 
 msgid "Database not available"
 msgstr "数据库不可达"
@@ -1549,6 +1560,10 @@ msgstr "事件必须是字符串"
 
 msgid "Every configured multicast port is already in use"
 msgstr ""
+
+#, fuzzy
+msgid "Existence check failed"
+msgstr "私钥失效"
 
 msgid "Exists item must be boolean"
 msgstr "现存物品必须是布尔值"
@@ -1945,6 +1960,10 @@ msgstr "文件大小"
 
 msgid "Filter"
 msgstr "文件"
+
+#, fuzzy
+msgid "Find failed"
+msgstr "加载失败"
 
 msgid "Finding any images associated"
 msgstr "找到关联镜像"
@@ -3480,6 +3499,14 @@ msgstr "管理密码"
 
 msgid "Management Username"
 msgstr "管理用户名"
+
+#, fuzzy
+msgid "Mass destroy failed"
+msgstr "销毁失败"
+
+#, fuzzy
+msgid "Mass update failed"
+msgstr "用户更新失败!"
 
 msgid "Master Node"
 msgstr "主节点"
@@ -5538,8 +5565,16 @@ msgstr "TCP / IP端口打印机"
 msgid "TX"
 msgstr "TX"
 
+#, fuzzy
+msgid "Table"
+msgstr "启用"
+
 msgid "Table not defined for this class"
 msgstr "该类定义没有数据库表"
+
+#, fuzzy
+msgid "Table uninstall failed"
+msgstr "数据库保存失败"
 
 #, fuzzy
 msgid "Tag Name"
@@ -6507,6 +6542,15 @@ msgstr "以及 Green 的相应模块"
 msgid "and the location of the file on that"
 msgstr "以及该文件在那里的位置"
 
+msgid "answering \"does not exist\" for a read that never ran"
+msgstr ""
+
+msgid "answering 0 for a read that never ran"
+msgstr ""
+
+msgid "answering an empty set for a read that never ran"
+msgstr ""
+
 msgid "as FOG will attempt to go out to the internet"
 msgstr "因为 FOG 将尝试连接到互联网"
 
@@ -6623,6 +6667,9 @@ msgstr "已经选中或上传"
 
 msgid "either because you have updated"
 msgstr "要么是因为你已经更新了"
+
+msgid "every column will be treated as untyped"
+msgstr ""
 
 msgid "failed to execute, image file: "
 msgstr "执行失败，镜像文件："

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -45,6 +45,11 @@ $validPaths = [
     '/var/log/apache2',
     '/var/log/fog',
     '/var/log/fog/fos',
+    // FOGBase::logFault()'s. 1.6 keeps this list in one place
+    // (FOGLogPaths); on this branch it is spelled out in three, so a new
+    // log directory has to be added to all three or it is enumerated but
+    // not readable, or neither.
+    '/var/log/fog/faults',
     '/var/log/httpd',
     '/var/log/nginx',
     '/var/log/php*'

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -74,8 +74,13 @@ function vals($reverse, $HookManager, $lines, $file)
     $folders = array(
         '/var/log/fog/',
         '/var/log/fog/fos/',
+        // FOGBase::logFault()'s, both spellings. This list is matched
+        // ANCHORED and EXACT against a requested file's dirname, so the
+        // trailing separator is not decoration.
+        '/var/log/fog/faults/',
         '/opt/fog/log/',
         '/opt/fog/log/fos/',
+        '/opt/fog/log/faults/',
         '/var/log/httpd/',
         '/var/log/apache2/',
         '/var/log/nginx/',

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -100,6 +100,25 @@ class FogRejectingDb extends ScopeFakeDB
         return parent::query($sql, $a, $p);
     }
 
+    /**
+     * @var bool let SELECTs through but fail the FETCH, the way PDODB does
+     *           when the statement ran and reading the rows did not.
+     */
+    public $rejectFetch = false;
+
+    public function fetch($m = null, $t = '', $p = array())
+    {
+        if ($this->rejectFetch) {
+            // What PDODB::fetch() does: result false, message onto ->error
+            // if nothing is there already, no exception.
+            if (!$this->error) {
+                $this->error = self::REJECTION;
+            }
+            return $this;
+        }
+        return parent::fetch($m, $t, $p);
+    }
+
     public function insertId()
     {
         return 0;
@@ -254,6 +273,54 @@ if (fogLogContents() === $before) {
     $failures[] = 'a rejected existence check left no record -- it answers '
         . '"does not exist" for a read that never ran, and callers create on '
         . 'the strength of that';
+}
+
+// A fetch that fails after the QUERY succeeded is the case that was
+// invisible even to the check above: PDODB::fetch() built an error message
+// and dropped it on the floor, so the read came back empty with ->error
+// still false. The check sits after the fetch precisely so this lands.
+$db->rejectReads = false;
+$db->rejectFetch = true;
+$before = fogLogContents();
+$fetchReader = new TaskLog(0);
+$fetchReader->set('id', 9090)->load('id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a SELECT that ran but could not be FETCHED left no record '
+        . '-- the caller sees an empty result and cannot tell it from "no '
+        . 'rows", which is the same defect one layer down';
+}
+$db->rejectFetch = false;
+$db->rejectReads = true;
+
+// ...and the REAL PDODB::fetch(), driven directly.
+//
+// The fake above models a fetch() that behaves; it cannot prove the real one
+// does. Pinning a symbol's USE rather than its DEFINITION is how a gate
+// passes the mutation that guts the definition, so this drives the actual
+// method: with no query result to read, fetch() raises internally, catches,
+// and must leave the message on ->error rather than dropping it.
+$realDb = (new ReflectionClass('PDODB'))->newInstanceWithoutConstructor();
+$qr = new ReflectionProperty('PDODB', '_queryResult');
+$qr->setAccessible(true);
+$qr->setValue(null, null);
+$realDb->error = false;
+$realDb->fetch();
+if (!$realDb->error) {
+    $failures[] = 'PDODB::fetch() failed and left ->error false -- it builds '
+        . 'the message and drops it, so every caller sees an empty result set '
+        . 'with nothing to distinguish it from "no rows"';
+}
+// ...and it must not overwrite a cause already recorded. query() runs
+// immediately before every fetch(), so when a fetch fails BECAUSE the query
+// did, the query's message is the one worth keeping -- not "No query result,
+// use query() first", which is the symptom.
+$qr->setValue(null, null);
+$realDb->error = 'the original cause';
+$realDb->fetch();
+if ('the original cause' !== $realDb->error) {
+    $failures[] = 'PDODB::fetch() overwrote an error already on ->error with '
+        . 'its own, so a read that failed because the QUERY failed reports '
+        . 'the symptom instead of the cause';
 }
 
 // ---------------------------------------------------------------------

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * A failed database operation must leave a trace even when nobody is signed in.
+ *
+ * PORT of the working-1.6 test of the same name. Same defects, same fix; the
+ * differences are noted where they matter.
+ *
+ * FOGController::save(), destroy() and load() record a failure by calling
+ * FOGBase::logHistory(), and logHistory() returns without doing anything
+ * unless self::$FOGUser is a valid User. Nothing in packages/web/service/,
+ * packages/web/lib/reg-task/ or the daemons ever sets one -- they are matched
+ * to a HOST by MAC or token, not to a user -- so on every one of those paths
+ * the failure branch runs and writes nowhere.
+ *
+ * debug() is not a second chance on THIS branch, and this is where 1.5 is
+ * worse than 1.6: it writes to no file at all. It printf()s into the page and
+ * returns immediately when self::$service or self::$ajax is set, which on a
+ * machine endpoint is always. So a failed write on a service path had
+ * literally no possible output. (1.6's at least reaches a file, behind a
+ * globalSetting that ships off.)
+ *
+ * There are two distinct defects here and this test pins both, on the write
+ * path and on the read path.
+ *
+ * 1. NOT REPORTED. PDODB::$throwOnQueryError defaults false, so query()
+ *    catches the PDOException and returns normally. save() therefore never
+ *    enters its own catch. For a NEW row the missing insertId() is caught by
+ *    the "no valid ID was assigned" throw; for an EXISTING row -- every
+ *    progress update, every task state change, every inventory write against
+ *    a known host -- there is nothing to catch on, so save() logs the SUCCESS
+ *    message and returns $this. `if (!$x->save())` is not merely unrecorded
+ *    there, it is answered "fine".
+ *
+ * 2. NOT RECORDED. Even on the path that does return false, nothing is
+ *    written anywhere a human can read.
+ *
+ * The read path has only the second defect, and is quieter for it. There is
+ * no return value to get wrong -- load() answers $this whether or not the row
+ * was read, and must, or `new Host(42)` would become fatal on a database blip
+ * -- so an object that could NOT be read is indistinguishable from a row that
+ * genuinely holds no data. The log line is the entire fix there, which is why
+ * assertion 5 matters as much as assertion 4: load()'s catch also handles its
+ * ordinary control flow, and a fault log full of "Operation field not set"
+ * would bury the one line worth having.
+ *
+ * TaskError::_logRow() is driven at its real call site rather than asserted
+ * about in the abstract. It discards save()'s return BY DESIGN -- it is the
+ * sink FOS failure reports land in, so there is nothing above it to report to
+ * -- which is why the fix had to go in the framework and not in the callers.
+ *
+ * Asserts the OUTCOME, not a spelling: "a durable record naming the failure
+ * exists". A fix is free to choose the file.
+ *
+ * DB-free: reuses tests/lib/scope-harness.php, which boots FOG against a fake
+ * database and points FOG_LOG_DIR at a temp directory.
+ *
+ * Usage: php tests/db-failure-is-recorded.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+require __DIR__ . '/lib/scope-harness.php';
+scopeHarnessBoot($web, 'none');
+
+/**
+ * A database whose statements fail the way a real one does.
+ *
+ * PDODB::query() catches PDOException, calls debug()/error(), records the
+ * message on ->error and returns $this. It rethrows only when
+ * $throwOnQueryError is true, which nothing sets. insertId() then answers 0
+ * because no row was inserted. That is all this reproduces.
+ */
+class FogRejectingDb extends ScopeFakeDB
+{
+    const REJECTION = "SQLSTATE[22007]: Invalid datetime format: 1292 "
+        . "Incorrect datetime value: '' for column 'taskLogCreated'";
+
+    /** @var int how many writes were attempted */
+    public $writes = 0;
+
+    /**
+     * @var bool reject SELECTs too. Off by default so the write assertions
+     *           are not perturbed by the lazy loads FOGController does on
+     *           the way to a save.
+     */
+    public $rejectReads = false;
+
+    public function query($sql, $a = array(), $p = array())
+    {
+        if (preg_match('/^\s*(INSERT|UPDATE|REPLACE|DELETE)\b/i', $sql)) {
+            $this->writes++;
+            $this->error = self::REJECTION;
+            return $this;
+        }
+        if ($this->rejectReads && preg_match('/^\s*SELECT\b/i', $sql)) {
+            $this->error = self::REJECTION;
+            return $this;
+        }
+        $this->error = false;
+        return parent::query($sql, $a, $p);
+    }
+
+    public function insertId()
+    {
+        return 0;
+    }
+}
+
+$set = function ($class, $prop, $value) {
+    $p = new ReflectionProperty($class, $prop);
+    $p->setAccessible(true);
+    $p->setValue(null, $value);
+};
+
+$db = new FogRejectingDb();
+$set('FOGBase', 'DB', $db);
+
+// The condition every machine-facing request boots into: LoadGlobals builds
+// `new User(0)` because there is no session to read FOG_USER from.
+$anon = new User(0);
+$GLOBALS['currentUser'] = $anon;
+$set('FOGBase', 'FOGUser', $anon);
+if ($anon->isValid()) {
+    fwrite(STDERR, "FAIL: the anonymous user is valid; this test would "
+        . "pass vacuously because logHistory() would record after all\n");
+    exit(1);
+}
+
+// What the installer creates (lib/common/functions.sh, "Creating FOG fault
+// log directory"). Made here rather than by the harness because its ABSENCE
+// is also a supported state -- a web tree updated ahead of its installer --
+// and the fallback that covers it is asserted below.
+$faultDir = FOG_LOG_DIR . DIRECTORY_SEPARATOR . 'faults';
+@mkdir($faultDir, 0700, true);
+
+// PHP's own channel is logFault()'s fallback. Pointed inside FOG_LOG_DIR so
+// that a fallback still satisfies "a durable record exists" -- the assertions
+// pin the outcome, not which file -- and so the fallback does not spray the
+// suite's output onto stderr.
+ini_set('error_log', FOG_LOG_DIR . DIRECTORY_SEPARATOR . 'php-fallback.log');
+
+/**
+ * Every file under FOG_LOG_DIR, flattened to one string.
+ *
+ * @return string
+ */
+function fogLogContents()
+{
+    if (!is_dir(FOG_LOG_DIR)) {
+        return '';
+    }
+    $out = '';
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(
+            FOG_LOG_DIR,
+            FilesystemIterator::SKIP_DOTS
+        )
+    );
+    foreach ($it as $f) {
+        if ($f->isFile()) {
+            $out .= (string) @file_get_contents($f->getPathname());
+        }
+    }
+    return $out;
+}
+
+$failures = array();
+
+// ---------------------------------------------------------------------
+// 1. An existing row whose write was rejected must not report success.
+// ---------------------------------------------------------------------
+$existing = new TaskLog(0);
+$existing->set('id', 4242)
+    ->set('taskID', 7)
+    ->set('text', 'db-failure existing row');
+$result = $existing->save();
+if (false !== $result) {
+    $failures[] = 'save() on an EXISTING row answered '
+        . (is_object($result) ? get_class($result) : var_export($result, true))
+        . ' after the write was rejected -- a truthy answer, so every '
+        . '`if (!$obj->save())` on a machine path treats a lost write as a '
+        . 'completed one';
+}
+
+// ---------------------------------------------------------------------
+// 2. A failed write must leave a record with no user signed in.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+$newRow = new TaskLog(0);
+$newRow->set('taskID', 9)->set('text', 'db-failure new row');
+$newRow->save();
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected write left nothing under FOG_LOG_DIR with no '
+        . 'user signed in -- logHistory() returned early, and debug() on this '
+        . 'branch writes to no file at all';
+}
+
+// ---------------------------------------------------------------------
+// 3. The sink itself: TaskError::_logRow() discards save()'s return, so
+//    only a fix inside the framework can cover it.
+// ---------------------------------------------------------------------
+$host = new Host(0);
+$host->set('id', 11);
+$set('FOGBase', 'Host', $host);
+
+$task = new Task(0);
+$task->set('id', 33)->set('stateID', 3);
+// getTaskTypeText() dereferences the loaded TaskType object; the fake
+// database answers lazy loads with nothing, so it is seeded directly.
+$task->set('type', (new TaskType(0))->set('id', 1)->set('name', 'Deploy'));
+
+$before = fogLogContents();
+$writesBefore = $db->writes;
+try {
+    $m = new ReflectionMethod('TaskError', '_logRow');
+    $m->setAccessible(true);
+    $m->invokeArgs(null, array($task, TaskLog::TYPE_ERROR, 'db-failure report'));
+} catch (Throwable $e) {
+    $failures[] = 'TaskError::_logRow() could not be driven: '
+        . $e->getMessage();
+}
+if ($db->writes === $writesBefore) {
+    $failures[] = 'TaskError::_logRow() attempted no write, so this '
+        . 'assertion proves nothing -- has the call site changed?';
+} elseif (fogLogContents() === $before) {
+    $failures[] = "TaskError::_logRow()'s rejected write left no record. "
+        . 'It discards save()\'s return by design -- it IS the failure sink '
+        . '-- so a report of a FOS failure that cannot be stored is lost '
+        . 'entirely, which is the one thing that path exists to prevent';
+}
+
+// ---------------------------------------------------------------------
+// 4. A rejected SELECT must be recorded too.
+// ---------------------------------------------------------------------
+$db->rejectReads = true;
+$before = fogLogContents();
+$reader = new TaskLog(0);
+$reader->set('id', 8080)->load('id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected SELECT in load() left no record -- an object '
+        . 'that could not be read is reported to its caller as a row with no '
+        . 'data in it';
+}
+
+// The manager's reads. exists() gives the most expensive wrong answer in the
+// class: callers use it to decide whether to CREATE, so an unreadable
+// database becomes a duplicate row rather than an error.
+$manager = new TaskLogManager();
+$before = fogLogContents();
+// idField is 'name' by default and taskLog has no such column; hostName is a
+// real one, so the probe fails on the DATABASE rather than on the model.
+$manager->exists('anything', 0, 'hostName');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected existence check left no record -- it answers '
+        . '"does not exist" for a read that never ran, and callers create on '
+        . 'the strength of that';
+}
+
+// ---------------------------------------------------------------------
+// 5. ...and load()'s ORDINARY control flow must stay quiet.
+//
+//    "Operation field not set" fires on every object built without an id,
+//    which is constant traffic. If that reached the fault log, the line
+//    assertion 4 pins would be buried under thousands that mean nothing.
+//    This is why the fault is recorded at the error check and not in the
+//    catch that handles both.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+(new TaskLog(0))->load('id');
+if (fogLogContents() !== $before) {
+    $failures[] = 'loading an object with no id wrote a fault line -- that is '
+        . "load()'s normal control flow, not a database failure, and at that "
+        . 'volume it would bury the failures that matter';
+}
+$db->rejectReads = false;
+
+// ---------------------------------------------------------------------
+// 6. FOGManagerController::update() answered `(bool) $DB->query(...)`,
+//    which is an OBJECT cast to bool -- true however the server answered.
+// ---------------------------------------------------------------------
+$before = fogLogContents();
+$mass = $manager->update(array('id' => 1), 'AND', array('text' => 'x'));
+if (false !== $mass) {
+    $failures[] = 'FOGManagerController::update() answered '
+        . var_export($mass, true) . ' after the server rejected the UPDATE -- '
+        . 'it returned the PDODB object cast to bool, so it could never '
+        . 'report anything but true';
+}
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected mass update left no record';
+}
+
+// ---------------------------------------------------------------------
+// 7. With the directory the installer creates present, the fault line must
+//    land THERE rather than falling back. The fallback is a safety net for
+//    a web tree updated ahead of its installer, not the normal destination.
+// ---------------------------------------------------------------------
+if (!glob($faultDir . DIRECTORY_SEPARATOR . '*.log')) {
+    $failures[] = 'nothing was written into faults/ even though the directory '
+        . 'exists and is writable, so every fault is taking the error_log() '
+        . 'fallback';
+}
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . "):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  rejected reads and writes are reported and recorded with no user "
+    . "signed in\n";
+exit(0);


### PR DESCRIPTION
Port of #1257 (working-1.6). Same two defects, same fix. **Merge #1257 first** — this is the backport, not the other way round.

## The problem

A failed database operation on a machine-facing endpoint was recorded nowhere, and on the commonest cases it was reported as a **success**.

1. `PDODB::query()` catches the `PDOException` and returns normally (`$throwOnQueryError` defaults false), so `save()` never entered its own catch on a real SQL error.
2. For an existing row there was no `insertId()` check to trip, so `save()` logged "successfully updated" and returned `$this`.
3. `logHistory()` returns early unless `self::$FOGUser` is a valid `User`, and nothing on a machine path has one — `service/`, `lib/reg-task/` and the daemons are matched to a **host** by MAC or token.

**This branch is worse than 1.6 at step 3, which is why the port is not optional.** 1.6's `debug()` at least reaches a file, behind a globalSetting that ships off. This one writes to no file **at all** — it `printf()`s into the page and returns immediately when `self::$service` or `self::$ajax` is set, which on a machine endpoint is always. A failed write on a service path had *literally no possible output*.

## The fix

**Part A** — `save()`, `destroy()` and `load()` read `self::$DB->error` immediately after their statement. Not `PDODB::$throwOnQueryError = true` globally, which would turn every already-tolerated failure in the codebase into an uncaught 500 at once.

**Part B** — new `FOGBase::logFault()`: one line under FOG's log directory, `error_log()` as the fallback. Deliberately **not** `logHistory()` with the gate widened: `logHistory()` is a database write, so it shares its failure mode with the thing it reports on. **A sink for a failed database operation cannot itself be a database write.** It reads no setting and issues no query — a logger that queries in order to report a failed query is a recursion this project has already paid for.

Two files rather than one, split by SAPI. This is the only FOG log directory written by **both** tiers, and a shared file would be owned by whichever wrote first — a root-owned `faults.log` appears the moment a daemon hits a failed write, and every web-tier fault silently falls back from then on.

**The read path** has only the second defect and is quieter for it. A swallowed SELECT hands back nothing, so an object that could not be **read** is indistinguishable from a row that genuinely holds no data. There is no return value to get wrong — `load()` answers `$this` either way, and must, or `new Host(42)` becomes fatal on a database blip — so the log line is the entire fix. It is recorded at the error check rather than in `load()`'s catch, because that catch also handles the method's *ordinary control flow*: "Operation field not set" fires on every object built without an id, and at that volume it would bury the one line worth having.

`FOGManagerController` had it in **seven** places — `update()` (`(bool)` of an object, always true), `destroy()` (returned `true` unconditionally), `uninstall()` (returned the PDODB object while documented `@return bool`), `insertBatch()`, and the reads `find()`, `exists()`, `count()`/`distinct()`. `exists()` gives the most expensive wrong answer in the class: callers use it to decide whether to **create**, so an unreadable database becomes a duplicate row rather than an error. Read return contracts are left alone — making a read throw is a real change that belongs in its own decision.

`TaskError::_logRow()` is covered **with no special case**, which is why this went in the framework: it discards `save()`'s return *by design*, because it **is** the sink FOS reports land in.

## Differences from #1257, all forced by this branch

| | |
|---|---|
| No `FOG_LOG_DIR` constant exists here | `FAULT_LOG_DIR` spells `/opt/fog/log` out the way `TaskError::LOG_DIR` already does, for the reason its docblock gives. `FOG_LOG_DIR` is still preferred when defined — costs nothing, keeps both branches the same shape. |
| No `FOGLogPaths` here | `faults/` added to all **three** hardcoded lists (`getfiles.php`, `logtoview.php`, `StorageNode`) — the duplication `FOGLogPaths` was created to end. |
| No `loadMany()`, no per-plugin-table column lookup | `_loadColumnTypes()` is the whole-catalog equivalent and gets the same treatment. |
| `FOGManagerController::destroy()` and `find()` exist only here | Both covered. |

## Behaviour change — deliberate

`save()` and `destroy()` now return `false` where they returned the object, and the manager's `update()`, `destroy()` and `uninstall()` return a real bool. Callers that check the return start seeing failures that were previously silent. That is the fix. The read paths' return contracts are unchanged.

## Verification

- `tests/db-failure-is-recorded.test.php` is **behavioural, not source-reading** — it reuses `tests/lib/scope-harness.php`, which boots FOG against a fake database. That was better than expected for this branch.
- **Six mutations caught**, including the one that moves `load()`'s fault into the catch, which proves the control-flow separation is real rather than decorative.
- **Suite 21/21.**
- **The seam checked against a real server using this branch's own PDODB:** a valid statement leaves `->error` falsy, an invalid one sets it, and a valid one after a failure clears it again — so one bad query cannot fault every statement after it.

**What was not done here, stated plainly:** the full end-to-end live run (a real `save()` rolled back, a real `load()`, `exists()`, `distinct()`) was performed on working-1.6, not on 1.5. The only 1.5 servers in the lab are remote with no sudo, so their database is not reachable from here, and running this branch's ORM against the local 1.6 database would be asserting against a schema it was not written for. `PDODB::query()` is materially identical on both branches — both set `$this->error = false` at the end of the try — which is what makes the 1.6 run transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
