### PR TITLE
fix(db): record a failed FETCH, and check for it after the fetch not before

### DIFF
--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -562,6 +562,30 @@ class PDODB extends DatabaseManager
                 $this->sqlerror()
             );
             self::$_result = false;
+            /*
+             * $msg used to be built here and dropped on the floor: a failed
+             * fetch set no ->error, logged nothing, and left $_result false
+             * -- so get() answered an empty set and the caller could not tell
+             * "the read failed" from "there are no rows". That is the same
+             * defect GH-1257 fixed in FOGController::save() and load(), one
+             * layer down, and it is why those checks alone were not enough:
+             * they sat between query() and fetch(), covering a rejected
+             * STATEMENT and missing a rejected READ of its rows.
+             *
+             * Only ever ADDS a failure, never overwrites one. query() owns
+             * clearing ->error -- it runs immediately before every fetch()
+             * and always sets it to false or to a message -- so when a fetch
+             * fails BECAUSE the query did ("No query result, use query()
+             * first"), the guard keeps the original cause rather than
+             * replacing it with the symptom.
+             *
+             * Not logged from here. The callers know which class and table
+             * they were reading, and this does not; a line naming neither is
+             * worse than the caller's, and two lines per failure is noise.
+             */
+            if (!$this->error) {
+                $this->error = $msg;
+            }
 
             if (self::$throwOnQueryError) {
                 throw $e;

--- a/packages/web/lib/fog/fogcontroller.class.php
+++ b/packages/web/lib/fog/fogcontroller.class.php
@@ -1054,6 +1054,7 @@ abstract class FOGController extends FOGBase
                 [],
                 $queryArray
             );
+            $vals = self::$DB->fetch()->get();
             /*
              * A rejected SELECT is swallowed the same way a rejected INSERT
              * is -- see save(). fetch()->get() then hands back nothing, and
@@ -1061,6 +1062,13 @@ abstract class FOGController extends FOGBase
              * row that genuinely holds no data. That is the read half of the
              * same defect: not a wrong answer anybody can see, a plausible
              * empty one.
+             *
+             * AFTER the fetch, not between it and the query, so that ONE
+             * check covers both halves of the read. fetch() records its own
+             * failure on ->error and never clears one, and query() always
+             * sets ->error immediately before -- so a fetch that failed
+             * because the query did still reports the query's message here,
+             * not "No query result, use query() first".
              *
              * Recorded HERE rather than in the catch below, and that split is
              * the point. This catch also handles the method's ORDINARY
@@ -1092,7 +1100,6 @@ abstract class FOGController extends FOGBase
                 );
                 throw new \Exception((string) self::$DB->error);
             }
-            $vals = self::$DB->fetch()->get();
             $this->setQuery($vals);
         } catch (\Exception $e) {
             $str = sprintf(
@@ -1183,9 +1190,13 @@ abstract class FOGController extends FOGBase
                 )
             );
             self::$DB->query($query, [], $queryArray);
-            // Same as load()'s, and it matters more here: a rejected bulk
-            // read returns an EMPTY set, and the caller reads that as "none
-            // of those ids exist" rather than "the question was not asked".
+            $rows = self::$DB
+                ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
+                ->get();
+            // Same as load()'s, after the fetch for the same reason: a
+            // rejected bulk read returns an EMPTY set, and the caller reads
+            // that as "none of those ids exist" rather than "the question
+            // was not asked".
             if (self::$DB->error) {
                 self::logFault(
                     sprintf(
@@ -1205,9 +1216,6 @@ abstract class FOGController extends FOGBase
                 );
                 throw new \Exception((string) self::$DB->error);
             }
-            $rows = self::$DB
-                ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
-                ->get();
             // class-name consumer: fed straight back to getClass(), which
             // resolves a namespaced name and a global one alike.
             $classname = get_class($this);

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1309,7 +1309,11 @@ abstract class FOGManagerController extends FOGBase
         );
 
         self::$DB->query($query, [], $existVals);
+        $total = self::$DB->fetch()->get('total');
         /*
+         * After the fetch, so one check covers both halves of the read --
+         * fetch() records its own failure on ->error and never clears one.
+         *
          * A rejected read here answers "no, it does not exist", which is the
          * most expensive wrong answer this class can give: callers use
          * exists() to decide whether to CREATE, so an unreadable database
@@ -1334,7 +1338,7 @@ abstract class FOGManagerController extends FOGBase
             );
         }
 
-        return (bool)self::$DB->fetch()->get('total') > 0;
+        return (bool)$total > 0;
     }
     /**
      * Returns the distinct (all matching).
@@ -1454,8 +1458,10 @@ abstract class FOGManagerController extends FOGBase
         );
 
         self::$DB->query($query, [], $countVals);
+        $total = self::$DB->fetch()->get('total');
         // Same as exists(): a rejected count answers 0, which reads as "there
-        // are none" rather than "nobody asked". Contract unchanged.
+        // are none" rather than "nobody asked". After the fetch, so one check
+        // covers both halves. Contract unchanged.
         if (self::$DB->error) {
             self::logFault(
                 sprintf(
@@ -1470,7 +1476,7 @@ abstract class FOGManagerController extends FOGBase
             );
         }
 
-        return (int)self::$DB->fetch()->get('total');
+        return (int)$total;
     }
     /**
      * Uninstalls the table.

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -91,6 +91,13 @@ class FogWriteRejectingDb extends FogFakeDb
             $this->error = self::REJECTION;
             return $this;
         }
+        // Reset FIRST, the way the real PDODB::query() does: it sets
+        // ->error to false at the end of every successful statement. Without
+        // this the fake leaves an error set from a previous rejected query,
+        // and every later assertion passes on that stale value rather than on
+        // what it meant to test -- which is precisely how the check-position
+        // mutations survived the first time round.
+        $this->error = false;
         $isCatalog = false !== stripos($sql, 'information_schema');
         if (preg_match('/^\s*SELECT\b/i', $sql)
             // The catalog lookup is switched separately: leaving it alone
@@ -103,6 +110,25 @@ class FogWriteRejectingDb extends FogFakeDb
             return $this;
         }
         return parent::query($sql, $a, $params);
+    }
+
+    /**
+     * @var bool let SELECTs through but fail the FETCH, the way PDODB does
+     *           when the statement ran and reading the rows did not.
+     */
+    public $rejectFetch = false;
+
+    public function fetch($mode = null, $type = '')
+    {
+        if ($this->rejectFetch) {
+            // What PDODB::fetch() does: result false, message onto ->error
+            // if nothing is there already, no exception.
+            if (!$this->error) {
+                $this->error = self::REJECTION;
+            }
+            return $this;
+        }
+        return parent::fetch($mode, $type);
     }
 
     public function insertId()
@@ -280,6 +306,64 @@ if (fogLogContents() === $before) {
 }
 $db->rejectCatalog = false;
 $db->rejectReads = true;
+
+// A fetch that fails after the QUERY succeeded is the case the first cut of
+// this fix missed entirely: PDODB::fetch() built an error message and
+// dropped it on the floor, so the read came back empty with ->error still
+// false. The checks sit after the fetch precisely so this lands.
+$db->rejectReads = false;
+$db->rejectFetch = true;
+$before = fogLogContents();
+$fetchReader = FOGCore::getClass('TaskLog');
+$fetchReader->set('id', 9090)->load('id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a SELECT that ran but could not be FETCHED left no record '
+        . '-- the caller sees an empty result and cannot tell it from "no '
+        . 'rows", which is the same defect one layer down';
+}
+// loadMany() has its own fetch, with its own arguments, so it needs its own
+// assertion -- driving load() alone leaves the bulk read's check position
+// unpinned.
+$before = fogLogContents();
+FOGCore::getClass('TaskLog')->loadMany([4, 5, 6], 'id');
+if (fogLogContents() === $before) {
+    $failures[] = 'a bulk SELECT that ran but could not be FETCHED left no '
+        . 'record -- the caller reads the empty set as "none of those ids '
+        . 'exist"';
+}
+$db->rejectFetch = false;
+$db->rejectReads = true;
+
+// ...and the REAL PDODB::fetch(), driven directly.
+//
+// The fake above models a fetch() that behaves; it cannot prove the real one
+// does. Pinning a symbol's USE rather than its DEFINITION is how a gate
+// passes the mutation that guts the definition, so this drives the actual
+// method: with no query result to read, fetch() raises internally, catches,
+// and must leave the message on ->error rather than dropping it.
+$realDb = (new \ReflectionClass('FOG\PDODB'))->newInstanceWithoutConstructor();
+$qr = new \ReflectionProperty('FOG\PDODB', '_queryResult');
+$qr->setAccessible(true);
+$qr->setValue(null, null);
+$realDb->error = false;
+$realDb->fetch();
+if (!$realDb->error) {
+    $failures[] = 'PDODB::fetch() failed and left ->error false -- it builds '
+        . 'the message and drops it, so every caller sees an empty result set '
+        . 'with nothing to distinguish it from "no rows"';
+}
+// ...and it must not overwrite a cause already recorded. query() runs
+// immediately before every fetch(), so when a fetch fails BECAUSE the query
+// did, the query's message is the one worth keeping -- not "No query result,
+// use query() first", which is the symptom.
+$qr->setValue(null, null);
+$realDb->error = 'the original cause';
+$realDb->fetch();
+if ('the original cause' !== $realDb->error) {
+    $failures[] = 'PDODB::fetch() overwrote an error already on ->error with '
+        . 'its own, so a read that failed because the QUERY failed reports '
+        . 'the symptom instead of the cause';
+}
 
 // ---------------------------------------------------------------------
 // 5. ...and load()'s ORDINARY control flow must stay quiet.


### PR DESCRIPTION
Follow-up to #1257, found while reviewing its dev-branch port (#1258). Fixed there in the same PR; #1257 was already merged, so working-1.6 gets it here.

## The defect

#1257's checks sit **between** `query()` and `fetch()` — which covers a rejected *statement* and misses a rejected *read of that statement's rows*.

`PDODB::fetch()` built its error message in the catch and **dropped it on the floor** — `$msg` assigned, never used. A fetch failure set no `->error`, logged nothing, and left `$_result` false, so `get()` answered an empty set with nothing to distinguish it from "there are no rows". Same defect #1257 fixed in `save()` and `load()`, one layer down.

## The fix

`fetch()` records the message on `->error`, and **only when nothing is there already**. `query()` owns clearing `->error` — it runs immediately before every `fetch()` and always sets it — so when a fetch fails *because* the query did (`No query result, use query() first`), the guard keeps the original cause rather than replacing it with the symptom.

Not logged from inside PDODB: the callers know which class and table they were reading and it does not, so a line naming neither is worse than theirs, and two lines per failure is noise.

With `fetch()` recording and never clearing, **one** check after the fetch covers both halves of a read. `load()`, `loadMany()`, `exists()` and `distinct()` now check there rather than before — fewer checks than checking twice, and it reads the right message either way.

## #1257's test was partly vacuous, and that is fixed here too

Worth stating plainly, because it is the more useful half of this PR.

**The fake database never reset `->error` on a successful statement**, which the real `PDODB::query()` does at the end of every one. So an error set by an earlier rejected query stayed set, and later assertions passed on that *stale* value rather than on what they meant to test. Moving `load()`'s and `loadMany()`'s checks to the wrong side of the fetch did **not** fail the suite. The fake now resets the way the real one does, and both repositionings are caught.

**Same gap in the other direction:** the first version of the fetch gate asserted through a *fake* `fetch()` that modelled the fixed behaviour — so gutting the real `PDODB::fetch()` still passed. That is pinning a symbol's **use** rather than its **definition**, which is exactly how a gate survives the mutation it exists to catch. The assertion now drives the real method through reflection: with no query result to read it must leave a message on `->error`, and it must not overwrite one already there.

## Verification

Seven mutations re-run against the corrected test, **all caught**: both check repositionings, both halves of the fetch fix, `save()`'s error check, `logFault` re-gated on a user, and `update()` back to `(bool) query()`.

Suite **85/85**. Re-checked against the live database: a valid statement leaves `->error` falsy, an invalid one sets it, a valid one after a failure clears it again, and a real `save()`, `load()`, `exists()` and `distinct()` all answer correctly without writing a fault line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
