### PR TITLE
test: pin FOGManagerController::find()'s failure check

### DIFF
--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -323,6 +323,29 @@ if ('the original cause' !== $realDb->error) {
         . 'the symptom instead of the cause';
 }
 
+// find() is the manager's bulk read and the busiest one in the class. Driven
+// on its own because its check sits after its own fetch chain, and a
+// position that is never exercised is a position that is not pinned.
+$db->rejectFetch = false;
+$db->rejectReads = true;
+$before = fogLogContents();
+$manager->find(array('id' => 1), 'AND', 'hostName');
+if (fogLogContents() === $before) {
+    $failures[] = 'a rejected find() left no record -- it answers an empty '
+        . 'set, which every caller reads as "there are none" rather than '
+        . '"the question was never asked"';
+}
+// ...and the same read failing at the FETCH rather than the query.
+$db->rejectReads = false;
+$db->rejectFetch = true;
+$before = fogLogContents();
+$manager->find(array('id' => 1), 'AND', 'hostName');
+if (fogLogContents() === $before) {
+    $failures[] = 'a find() that ran but could not be FETCHED left no record';
+}
+$db->rejectFetch = false;
+$db->rejectReads = true;
+
 // ---------------------------------------------------------------------
 // 5. ...and load()'s ORDINARY control flow must stay quiet.
 //


### PR DESCRIPTION
Coverage gap left by #1258.

`find()` is the manager's bulk read and its busiest method, and nothing drove it — so the check added there was **unverified**. Deleting it entirely still passed the suite. A position that is never exercised is a position that is not pinned, which is the same class of gap that let two check-repositionings survive on working-1.6 (#1259).

Two assertions, because the check sits after `find()`'s own fetch chain and has to cover both halves: the query rejected, and the query running but the fetch failing. Removing the check now fails both.

No production change. Suite 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)