### PR TITLE
fix(security): keep the failed statement's bound values out of the fault log (1.5 port of #1261)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -802,6 +802,17 @@ abstract class FOGBase
      */
     const FAULT_LOG_MAX = 10485760;
     /**
+     * How long a single fault line may get, in bytes, before it is cut.
+     *
+     * A backstop, not the main defence: logFault() drops PDODB's debug tail
+     * outright (see there). This catches what has no tail to drop -- a
+     * driver message that is itself enormous, or a caller that built its
+     * own. One fault stays one readable line either way.
+     *
+     * @var int
+     */
+    const FAULT_LINE_MAX = 2048;
+    /**
      * Records that something FOG needed to write or read did not happen.
      *
      * The failure sink of last resort, and deliberately the only logger here
@@ -858,18 +869,44 @@ abstract class FOGBase
         $inFault = true;
 
         try {
+            /*
+             * Drop PDODB's debug tail BEFORE anything else looks at the
+             * message. Its error text always appends
+             * "\nSQL: ...\nParams: ...\nErrorInfo: ...\nDebug: ..."
+             * (pdodb.class.php, both sqlerror() formats), and the Params and
+             * Debug sections print every BOUND VALUE of the statement that
+             * failed. On `users` that is the password hash, on `hosts` the
+             * client security token, on `nfsGroupMembers` the storage node's
+             * FTP password -- the credential GHSA-2hqx turns into root.
+             *
+             * That was survivable while this text only ever reached
+             * logHistory(), which is user-gated and so dropped it on exactly
+             * the machine paths that fail most, and debug(), which ships
+             * off. It is NOT survivable in a file written unconditionally on
+             * every failed write, and readable by any local account. What an
+             * operator actually needs is the part before the tail: the
+             * driver, the SQLSTATE and the message.
+             */
+            $raw = (string) $message;
+            foreach (array("\nSQL: ", "\nParams: ", "\nErrorInfo: ", "\nDebug: ") as $marker) {
+                $tail = strpos($raw, $marker);
+                if (false !== $tail) {
+                    $raw = substr($raw, 0, $tail);
+                }
+            }
             // One line per fault, so `tail -f` stays readable and a
-            // multi-line PDO message -- they carry the SQL, the parameters
-            // and a debugDumpParams() block -- cannot be mistaken for
-            // several faults.
-            $flat = preg_replace('#\s+#', ' ', (string) $message);
+            // multi-line message cannot be mistaken for several faults.
+            $flat = preg_replace('#\s+#', ' ', $raw);
             // Never let a message become an empty one. preg_replace returns
             // null when it gives up, and a (string) cast of that is '', which
             // the guard below would then throw away -- losing the one record
             // this method exists to keep.
-            $line = trim(null === $flat ? (string) $message : $flat);
+            $line = trim(null === $flat ? $raw : $flat);
             if ('' === $line) {
                 return;
+            }
+            if (strlen($line) > self::FAULT_LINE_MAX) {
+                $line = substr($line, 0, self::FAULT_LINE_MAX) . ' [truncated]';
             }
             $stamped = sprintf(
                 '[%s] %s%s',

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -391,6 +391,60 @@ if (!glob($faultDir . DIRECTORY_SEPARATOR . '*.log')) {
         . 'fallback';
 }
 
+// ---------------------------------------------------------------------
+// A fault line must not carry the failed statement's BOUND VALUES.
+// PDODB's error text appends "\nSQL: ...\nParams: ...\nDebug: ...", and
+// Params/Debug print every bound value -- on `users` the password hash, on
+// `hosts` the client token, on `nfsGroupMembers` the storage node's FTP
+// password. Harmless while it only reached the user-gated logHistory() and
+// the off-by-default debug(); writing it to a file on every failure turned a
+// debugging aid into a credential leak.
+//
+// Driven through the REAL FOGBase::logFault() so this pins that method's
+// DEFINITION -- gutting the redaction has to fail here.
+// ---------------------------------------------------------------------
+$secret = 'sup3rs3cr3t-ftp-p4ssw0rd';
+$before = strlen(fogLogContents());
+FOGBase::logFault(
+    'Database save failed: Class: StorageNode, Table: nfsGroupMembers, '
+    . "ID: 1, Error: Failed to query: SQLSTATE[23000]: Integrity "
+    . "constraint violation\nSQL: INSERT INTO `nfsGroupMembers` "
+    . "(`ngmPass`) VALUES (:ngmPass_insert)\nParams: Array ( "
+    . "[:ngmPass_insert] => $secret )\nErrorInfo: Array ( )\nDebug: SQL: "
+    . "[1] INSERT INTO `nfsGroupMembers` Params: 1 Key: Name: [13] "
+    . ":ngmPass_insert $secret"
+);
+$after = fogLogContents();
+
+if (strlen($after) <= $before) {
+    $failures[] = 'logFault() recorded nothing for a PDODB-shaped message';
+}
+if (false !== strpos($after, $secret)) {
+    $failures[] = 'the fault log contains the failed statement\'s bound '
+        . 'value -- a storage node password reached a file on disk';
+}
+$needles = array('StorageNode', 'nfsGroupMembers', 'Integrity constraint violation');
+foreach ($needles as $needle) {
+    if (false === strpos($after, $needle)) {
+        $failures[] = "redaction removed the cause too: '$needle' is not in "
+            . 'the fault line, leaving an operator nothing to act on';
+    }
+}
+
+// ---------------------------------------------------------------------
+// The length backstop, for a message carrying no tail to cut.
+// ---------------------------------------------------------------------
+$before = strlen(fogLogContents());
+FOGBase::logFault('LONGFAULT ' . str_repeat('x', 10000));
+$added = substr(fogLogContents(), $before);
+if (strlen($added) > FOGBase::FAULT_LINE_MAX + 128) {
+    $failures[] = 'a fault line of ' . strlen($added) . ' bytes was written; '
+        . 'FAULT_LINE_MAX is ' . FOGBase::FAULT_LINE_MAX;
+}
+if (false === strpos($added, '[truncated]')) {
+    $failures[] = 'an over-long fault line was cut without saying so';
+}
+
 if (count($failures)) {
     fwrite(STDERR, 'FAIL (' . count($failures) . "):\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
The 1.5 port of #1261. Same defect and same code, because #1258 ported `logFault()` verbatim.

## The problem

Forcing a genuine constraint violation on a **real 1.5.10 lab server** produced a **4,782-character** fault line containing every bound value of the statement that failed.

`PDODB` builds its error text as `"Failed to …\nSQL: …\nParams: …\nErrorInfo: …\nDebug: …"` (`packages/web/lib/db/pdodb.class.php`, both `sqlerror()` formats). `Params` is a `print_r()` of the bound parameter array:

| Table | What lands in the log |
|---|---|
| `users` | `uPass` — the password hash |
| `hosts` | `hostSecToken` — the client security token |
| `nfsGroupMembers` | `ngmPass` — the storage node FTP password (the credential GHSA-2hqx escalates to root) |

**That text is not new — where it lands is.** It previously reached only `logHistory()`, which is user-gated and so discarded it on exactly the machine-facing paths that fail most, and `debug()`, which ships off. `logFault()` writes unconditionally, to `/opt/fog/log/faults/` (0755, readable by any local account).

## The fix

Identical to #1261: cut the message at the earliest of the four markers before flattening, keep class/table/driver/SQLSTATE/message, drop the dump. `FAULT_LINE_MAX` (2048 bytes, marked `[truncated]`) backstops a message with no marker.

## Verification

Run on a real 1.5.10 server against its live database, inside a rolled-back InnoDB transaction. GH-1245's removal of `SET SESSION sql_mode=''` landed on this branch too (`pdodb.class.php:295`), so `STRICT_TRANS_TABLES` is in force and MySQL rejects the over-length write rather than truncating it:

| | before | after |
|---|---|---|
| fault line | 4,782 chars, bound values present | **994 chars, none** |
| valid `save()` | succeeds, writes nothing | unchanged |

Two new assertions drive the **real** `FOGBase::logFault()` rather than a fake, so they pin its definition. Both mutation-verified. Full suite: 19/19.

## Downstream

None. No route, class list or schema change.