### PR TITLE
Scope the db-alone enrolment claim to firmware and hypervisor routes

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -10809,7 +10809,7 @@ _espFileNote() {
         refind/*.efi)
             echo "rEFInd, signed by this server. A boot manager that finds and boots whatever OS is installed locally. Not needed by the default exit type (sanboot hands straight back to firmware), but it is what the refind_efi exit type chainloads, and it is here so an ESP assembled from this archive carries every route off FOG rather than only the configured one." ;;
         */MOK.der)
-            echo "This server's certificate in DER form, and it does TWO jobs. MokManager enrols it, which makes the shim routes work. It is also the certificate to put in db -- adding it to db alone, with no PK and no KEK, is enough to boot FOG's binaries directly with no shim at all (confirmed). It is the intermediate that FOG's signatures carry via sbsign --addcert, so this one certificate covers every FOG binary and the signing leaf can rotate without re-enrolling." ;;
+            echo "This server's certificate in DER form, and it does TWO jobs. MokManager enrols it, which makes the shim routes work. It is also the certificate to put in db, which is what lets FOG's binaries boot directly with no shim -- and when you enrol through the FIRMWARE's own tool, or a hypervisor setting, db on its own is enough because that write is unauthenticated. Enrolling from a running OS instead (FOG's task, a Linux tool, PowerShell) is a User Mode write that must be authenticated by a KEK-signed update, so that route needs the full PK/KEK/db set. It is the intermediate that FOG's signatures carry via sbsign --addcert, so this one certificate covers every FOG binary and the signing leaf can rotate without re-enrolling." ;;
         */PK.auth|*/KEK.auth|*/db.auth)
             echo "Signed EFI variable update, for FOG's unattended enrolment task, which writes all of them from a client in Setup/Custom Mode. NOT what a firmware menu or a hypervisor wants -- those take a plain DER certificate, so use MOK.der there. Replacing db with this keeps Microsoft's CAs and so still boots Windows, but appending MOK.der to the existing db is the lower-risk operation." ;;
         */fog-enroll-mok.sh|*/fog-enroll-mok.desktop)
@@ -11161,10 +11161,24 @@ ESPNOMOK
 fi)
 
   As the db certificate, for booting with no shim at all:
-      Put MOK.der in db. DB ALONE IS ENOUGH -- you do not need PK or KEK. db is
-      what firmware checks to verify a boot image; PK and KEK only control who
-      may change db. Confirmed working: MOK.der added to db, then FOG's signed
-      binary booted directly with no shim.
+      Put MOK.der in db. db is what firmware checks to verify a boot image; PK
+      and KEK only control who may CHANGE db.
+
+      HOW MANY VARIABLES YOU NEED DEPENDS ON WHO DOES THE WRITE:
+
+        Firmware's own tool, or a hypervisor setting, with the platform in
+        Setup/Custom Mode -- db ALONE is enough. That write is unauthenticated,
+        so nothing has to vouch for it. Confirmed: MOK.der added to db by itself,
+        then FOG's signed binary booted directly with no shim.
+
+        From a running OS -- FOG's enrolment task, a Linux tool, PowerShell's
+        Secure Boot cmdlets -- expect to need PK, KEK and db together. In User
+        Mode a db write must be authenticated by a KEK-signed update, and the
+        machine only trusts FOG's KEK if FOG's PK is enrolled too. That is what
+        the .auth files are for.
+
+      Not every firmware has been tested either way. If yours behaves
+      differently, please say so on the FOG forums or in the issue tracker.
 
       MOK.der is the intermediate, and FOG's signatures carry it inside them, so
       this one certificate covers every binary here and the signing key can be


### PR DESCRIPTION
Follow-up to [#1265](https://github.com/FOGProject/fogproject/pull/1265). This commit was pushed to that branch after GitHub had stopped re-associating pushes with the PR, so the merge took the commit before it and the correction was left behind. Nothing wrong with the merge — it landed exactly what GitHub was showing.

## What is wrong on `working-1.6` right now

`_espKitReadme()` and `_espFileNote()` both tell an admin:

> **DB ALONE IS ENOUGH — you do not need PK or KEK.**

That was asserted flat, from **one** measurement: `MOK.der` added to `db` on a VMware guest through the firmware's own tool, then a FOG-signed binary booted directly with no shim. The result is real. Stating it unqualified is not.

## The actual rule

How many variables you need is not a property of `db`. It is a property of **who performs the write**:

| Enrolling via | Needs | Why |
|---|---|---|
| The firmware's own tool, or a hypervisor setting, platform in Setup/Custom Mode | **`db` alone** | The write is unauthenticated — nothing has to vouch for it. **This is the row that was tested.** |
| A running OS: FOG's enrolment task, a Linux tool, PowerShell's Secure Boot cmdlets | **PK, KEK and `db`** | A User Mode `db` write must be authenticated by a KEK-signed update, and the machine only trusts FOG's KEK if FOG's PK is enrolled too |

The second row is mechanism, not measurement, and is labelled as such rather than presented as settled. Both point at [#1267](https://github.com/FOGProject/fogproject/issues/1267), which is collecting community results across firmwares and enrolment tools.

## Why this matters beyond accuracy

Unqualified, the claim made FOG's own `.auth` files look redundant — they are precisely what the OS-side route needs, and they are what FOG's *Enroll Secure Boot Key* task writes. An admin who read the old text and concluded "I only ever need `db`" would have had no idea why that task writes three variables, or why it might be the only route that works on their hardware.

## Scope

Text inside two `echo` strings and one heredoc in `lib/common/functions.sh`. **No control flow changed** — verified by filtering the diff for `if`/`for`/`while`/`[[`/braces/heredoc openers, which matches nothing. `bash -n` clean.

`tests/localboot-publish.test.sh` asserts on the archive's shape rather than on note prose, so it is unaffected; it passed 105/105 on the pre-merge branch and this commit touches nothing it inspects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KitrjXwpVEsH4PnKDi83L
