### PR TITLE
Give the installer one absolute scratch directory, and stop hiding why it failed

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1162,8 +1162,17 @@ updateDB() {
             fi
         fi
     fi
-    [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
-    cat >../tmp/fog-db-grant-fogstorage-access.sql <<EOF
+    # Same scratch directory as everything else. This one does not cd, so the
+    # old code failed differently -- the heredoc write failed, then mysql was
+    # handed a missing file -- but from the same cause, and with the mkdir error
+    # discarded just the same.
+    local sqltmp=""
+    if ! sqltmp="$(_installerTmpDir)"; then
+        echo "Failed"
+        echo " * Could not prepare the installer's scratch directory."
+        return 1
+    fi
+    cat >"${sqltmp}/fog-db-grant-fogstorage-access.sql" <<EOF
 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ANSI' ;
 GRANT SELECT ON $mysqldbname.* TO 'fogstorage'@'%' ;
 GRANT INSERT,UPDATE ON $mysqldbname.hosts TO 'fogstorage'@'%' ;
@@ -1180,7 +1189,7 @@ GRANT INSERT,UPDATE ON $mysqldbname.imagingLog TO 'fogstorage'@'%' ;
 FLUSH PRIVILEGES ;
 SET SQL_MODE=@OLD_SQL_MODE ;
 EOF
-    mysql $sqloptionsroot --password="${snmysqlrootpass}" <../tmp/fog-db-grant-fogstorage-access.sql >>$error_log 2>&1
+    mysql $sqloptionsroot --password="${snmysqlrootpass}" <"${sqltmp}/fog-db-grant-fogstorage-access.sql" >>$error_log 2>&1
     errorStat $?
 }
 validip() {
@@ -1877,12 +1886,27 @@ installFOGServices() {
 }
 configureUDPCast() {
     dots "Setting up UDPCast"
-    cur=$(pwd)
-    [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
-    cd ../tmp
-    rm -rf $udpcastout
-    tar xzf $udpcastsrc >>$error_log 2>&1
-    cd $udpcastout
+    local cur="$(pwd)" udptmp=""
+    # Same scratch directory, same reasons -- see _installerTmpDir(). This one
+    # would fail in exactly the way downloadfiles() did, just further down the
+    # install, and its mkdir error was going to /dev/null too.
+    if ! udptmp="$(_installerTmpDir)"; then
+        echo "Failed"
+        echo " * Could not prepare the installer's scratch directory."
+        return 1
+    fi
+    cd "$udptmp" || { echo "Failed"; return 1; }
+    rm -rf "$udpcastout"
+    tar xzf "$udpcastsrc" >>$error_log 2>&1
+    # Guarded because everything after it -- configure, make, make install --
+    # would otherwise run in the scratch directory instead of the unpacked
+    # source, each failing separately and none of them saying why.
+    if ! cd "$udpcastout"; then
+        echo "Failed"
+        echo " * ${udpcastsrc} did not unpack to ${udpcastout}. See ${error_log}."
+        cd "$cur"
+        return 1
+    fi
     grep -q 'BCM[0-9][0-9][0-9][0-9]' /proc/cpuinfo >>$error_log 2>&1
     if [[ $? -eq 0 ]]; then
         # Bounded, and the retry count cut right down. wget defaults to
@@ -1915,7 +1939,7 @@ configureUDPCast() {
             ln -sf "/usr/sbin/udp-sender" "/usr/local/sbin/udp-sender"
         fi
     fi
-    cd $cur
+    cd "$cur"
 }
 configureFTP() {
     dots "Setting up and starting VSFTP Server"
@@ -2075,9 +2099,13 @@ fetchipxeasset() {
     local tarball="$1"
     local dest="$2"
     local url="${ipxeurl}/${ipxeVer}/${tarball}"
-    [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >>$error_log 2>&1
-    local cwd=$(pwd)
-    cd ../tmp/
+    # This one already logged its mkdir error, so it was the least broken of the
+    # three -- but it was still resolving ../tmp/ against the ambient cwd. Routed
+    # through the same helper so there is one definition of where scratch space is.
+    local tmpdir=""
+    tmpdir="$(_installerTmpDir)" || return 1
+    local cwd="$(pwd)"
+    cd "$tmpdir" || return 1
     local checksum=1
     local cnt=0
     # Ten rounds of two timeout-less curls is the most expensive stall in the
@@ -4220,8 +4248,15 @@ configureMySql() {
             read
         fi
     fi
-    [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
-    cat >../tmp/fog-db-and-user-setup.sql <<EOF
+    # As above: no cd here, so the old failure was a heredoc write into a missing
+    # directory followed by mysql being handed a file that was never created.
+    local sqltmp=""
+    if ! sqltmp="$(_installerTmpDir)"; then
+        echo "Failed"
+        echo " * Could not prepare the installer's scratch directory."
+        return 1
+    fi
+    cat >"${sqltmp}/fog-db-and-user-setup.sql" <<EOF
 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ANSI' ;
 DELETE FROM mysql.user WHERE User='' ;
 DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1') ;
@@ -4257,7 +4292,7 @@ DROP PROCEDURE IF EXISTS $mysqldbname.create_user_if_not_exists ;
 FLUSH PRIVILEGES ;
 SET SQL_MODE=@OLD_SQL_MODE ;
 EOF
-    mysql $sqloptionsroot --password="${snmysqlrootpass}" <../tmp/fog-db-and-user-setup.sql >>$error_log 2>&1
+    mysql $sqloptionsroot --password="${snmysqlrootpass}" <"${sqltmp}/fog-db-and-user-setup.sql" >>$error_log 2>&1
     errorStat $?
 }
 configureFOGService() {
@@ -9039,8 +9074,49 @@ die();
     chown -R ${apacheuser}:${apacheuser} "$webdirdest"
     chown -R ${username}:${apacheuser} "$webdirdest/service/ipxe"
 }
+# The installer's scratch directory, as an ABSOLUTE path, or non-zero with a
+# reason on stderr.
+#
+# Callers used to write this inline as
+#
+#     [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
+#     cd ../tmp/
+#
+# which has three faults that compound into a bad failure. "../tmp/" resolves
+# against whatever the ambient cwd happens to be; the mkdir error goes to
+# /dev/null, so the one message explaining a failure is destroyed at the moment
+# it occurs; and the cd is unguarded, so execution CONTINUES in the wrong
+# directory. Because the copy step that follows was also relative, a failed cd
+# downloaded 60-80MB of kernels into bin/ and then copied them from there -- the
+# install "succeeded", left untracked binaries in the source tree, and reported
+# only a bare "cd: ../tmp/: No such file or directory" that nothing could act on.
+#
+# Anchored on $workingdir, which installfog.sh captures with pwd before anything
+# has a chance to move, so this is correct regardless of who cd'd where.
+#
+# The not-a-directory case is called out separately because it is the one that
+# does NOT clear on a re-run: mkdir -p refuses when the path exists as a file or
+# a dangling symlink, so every subsequent attempt fails the same way, and the
+# generic message sends people looking for a permissions problem they do not have.
+_installerTmpDir() {
+    local d="${workingdir%/}/../tmp"
+    if [[ -e $d && ! -d $d ]]; then
+        echo "ERROR: ${d} exists but is not a directory." >&2
+        echo "       Remove or rename it -- the installer needs it as scratch space." >&2
+        return 1
+    fi
+    if ! mkdir -p "$d" 2>>$error_log; then
+        echo "ERROR: could not create ${d}" >&2
+        echo "       See ${error_log} for the reason." >&2
+        return 1
+    fi
+    ( cd "$d" 2>/dev/null && pwd ) || {
+        echo "ERROR: ${d} exists but could not be entered." >&2
+        return 1
+    }
+}
 downloadfiles() {
-    local copypath=""
+    local copypath="" tmpdir=""
     dots "Downloading kernel, init and fog-client binaries"
     clientVer="$(awk -F\' /"define\('FOG_CLIENT_VERSION'[,](.*)"/'{print $4}' ../packages/web/lib/fog/system.class.php | tr -d '[[:space:]]')"
     fosURL="https://github.com/FOGProject/fos/releases/download"
@@ -9054,9 +9130,23 @@ downloadfiles() {
     build_version=$(echo -e $fileversion | sed -n 's/.*Buildroot \([0-9.]*\).*/\1/p')
     fosLatestURL="https://github.com/FOGProject/fos/releases/latest/download"
     fogclientURL="https://github.com/FOGProject/fog-client/releases/download"
-    [[ ! -d ../tmp/  ]] && mkdir -p ../tmp/ >/dev/null 2>&1
-    cwd=$(pwd)
-    cd ../tmp/
+    # Fail here, loudly, rather than downloading into the source tree. The old
+    # code carried on after a failed cd and the install appeared to succeed.
+    if ! tmpdir="$(_installerTmpDir)"; then
+        echo "Failed"
+        echo " * Could not prepare the installer's scratch directory."
+        exit 1
+    fi
+    # Every cp below goes through $copypath, so the copy step no longer depends
+    # on the cwd either -- belt as well as braces. copypath was already the hook
+    # for this and had only ever been the empty string.
+    copypath="${tmpdir}/"
+    local cwd="$(pwd)"
+    if ! cd "$tmpdir"; then
+        echo "Failed"
+        echo " * Could not enter ${tmpdir}."
+        exit 1
+    fi
     if [[ $version =~ ^[0-9]\.[0-9]\.[0-9]+$ ]]; then
         urls=( "${fosURL}/${version}/init.xz" "${fosURL}/${version}/init_32.xz" "${fosURL}/${version}/bzImage" "${fosURL}/${version}/bzImage32" "${fogclientURL}/${clientVer}/FOGService.msi" "${fogclientURL}/${clientVer}/SmartInstaller.exe" )
         urls+=( "${fosURL}/${version}/arm_init.cpio.gz" "${fosURL}/${version}/arm_Image" )
@@ -9135,7 +9225,7 @@ downloadfiles() {
     _stampFogSum ${webdirdest}/service/ipxe/arm_init.cpio.gz
     cp -vf ${copypath}FOGService.msi ${copypath}SmartInstaller.exe ${webdirdest}/client/ >>$error_log 2>&1
     errorStat $?
-    cd $cwd
+    cd "$cwd"
     _ensureSecureBootKeys
     _ensureSecureBootPlatformKeys
     _resignKernels

--- a/tests/installer-tmpdir.test.sh
+++ b/tests/installer-tmpdir.test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Guards the installer's scratch-directory helper.
+#
+#   tests/installer-tmpdir.test.sh
+#
+# Five call sites used to write this inline as
+#
+#     [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
+#     cd ../tmp/
+#
+# Three faults, which compound. "../tmp/" resolves against whatever the ambient
+# cwd happens to be. The mkdir error goes to /dev/null, destroying the one
+# message that would explain a failure. And the cd is unguarded, so execution
+# CONTINUES in the wrong directory -- and because the copy step that followed was
+# also relative, a failed cd downloaded 60-80MB of kernels into bin/ and then
+# copied them from there. The install "succeeded", left untracked binaries in the
+# source tree, and printed only
+#
+#     lib/common/functions.sh: line 9059: cd: ../tmp/: No such file or directory
+#
+# which is not enough to act on. Reported twice; the second time it did not clear
+# on a re-run, which is the signature of the path existing as a non-directory --
+# mkdir -p refuses that forever, so every retry fails identically.
+#
+# What this pins:
+#
+#   1. the returned path is ABSOLUTE, so no caller depends on cwd
+#   2. it is created when missing, and a second call is a no-op
+#   3. a path that exists as a FILE fails with a message naming that specific
+#      cause, rather than the generic one that sends people hunting permissions
+#   4. failure is reported by exit status, so callers can stop instead of
+#      carrying on into the wrong directory
+#   5. no call site still resolves ../tmp relative to the cwd
+#
+# Needs bash only. Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# Only the helper, not the whole installer: sourcing functions.sh runs nothing,
+# but it does pull in every other definition, and this test has no business
+# depending on those.
+eval "$(awk '/^_installerTmpDir\(\) \{/,/^\}/' "$FUNCS")"
+if ! declare -F _installerTmpDir >/dev/null; then
+    echo "ERROR: could not extract _installerTmpDir from $FUNCS" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+error_log="$WORK/error.log"
+: > "$error_log"
+
+echo "installer scratch directory:"
+
+# installfog.sh captures workingdir with pwd from bin/ before anything can move,
+# so the helper anchors on it rather than on the cwd of whoever calls it.
+workingdir="$WORK/bin"
+mkdir -p "$workingdir"
+
+# --- created when missing, and absolute -------------------------------------
+out="$(_installerTmpDir)"
+rc=$?
+is "$rc" "0" "succeeds when the directory does not exist yet"
+if [[ $out == /* ]]; then
+    ok "returns an ABSOLUTE path, so no caller depends on its cwd"
+else
+    bad "returned a relative path: $out"
+fi
+[[ -d $out ]] && ok "the directory it names actually exists" \
+    || bad "returned $out but it is not a directory"
+
+# THE point of anchoring on workingdir: the answer must not move when the caller
+# does. The old code returned a different directory per cwd, silently.
+elsewhere="$WORK/elsewhere/deeper"
+mkdir -p "$elsewhere"
+out2="$(cd "$elsewhere" && _installerTmpDir)"
+is "$out2" "$out" "the same path from a completely different cwd"
+
+# --- idempotent -------------------------------------------------------------
+out3="$(_installerTmpDir)"
+is "$?" "0" "a second call succeeds"
+is "$out3" "$out" "and returns the same path"
+
+# --- the case that does NOT clear on a re-run -------------------------------
+#
+# mkdir -p refuses a path that exists as a file, every time, so a re-run cannot
+# help. The message has to name this cause specifically: the generic "could not
+# create" sends an admin looking for a permissions problem they do not have.
+rm -rf "$out"
+: > "$WORK/tmp"
+err="$(_installerTmpDir 2>&1 >/dev/null)"
+rc=$?
+is "$rc" "1" "fails when the path exists as a file"
+if [[ $err == *"not a directory"* ]]; then
+    ok "and says so, rather than reporting a generic create failure"
+else
+    bad "message does not identify the cause: $err"
+fi
+if [[ $err == *"Remove or rename"* ]]; then
+    ok "and says what to do about it"
+else
+    bad "message gives no remedy: $err"
+fi
+rm -f "$WORK/tmp"
+
+# --- failure is detectable by callers ---------------------------------------
+#
+# This is what the old code lacked. The cd was unguarded, so a failure became a
+# successful-looking install that had written to the wrong place.
+: > "$WORK/tmp"
+if _installerTmpDir >/dev/null 2>&1; then
+    bad "returned success while the scratch path was unusable"
+else
+    ok "non-zero exit lets callers stop instead of continuing"
+fi
+rm -f "$WORK/tmp"
+
+# --- no call site resolves ../tmp against the cwd any more ------------------
+#
+# Grep rather than behaviour, because the failure being guarded is a call site
+# quietly reintroducing the relative form. Comments are excluded, and the
+# helper's own definition is the one legitimate use.
+stray="$(grep -nE '(^|[^#])\.\./tmp' "$FUNCS" \
+    | grep -vE '^\s*[0-9]+:\s*#' \
+    | grep -v 'local d="\${workingdir%/}/\.\./tmp"' \
+    | grep -vE ':\s*#')"
+if [[ -z $stray ]]; then
+    ok "no call site resolves ../tmp relative to the cwd"
+else
+    bad "a relative ../tmp came back:"
+    printf '          %s\n' "$stray"
+fi
+
+echo
+if [[ $FAIL -eq 0 ]]; then
+    echo "$PASS passed, 0 failed"
+    exit 0
+fi
+echo "$PASS passed, $FAIL failed"
+exit 1


### PR DESCRIPTION
Give the installer one absolute scratch directory, and stop hiding why it failed

Reported twice from the field:

    Downloading kernel, init and fog-client binaries..............
    lib/common/functions.sh: line 9059: cd: ../tmp/: No such file or directory

Five call sites wrote the same three lines:

    [[ ! -d ../tmp/ ]] && mkdir -p ../tmp/ >/dev/null 2>&1
    cd ../tmp/

Three faults, and they compound into something worse than the message suggests.

  * ../tmp/ resolves against whatever the ambient cwd happens to be, so the
    answer moves depending on who called and whether anything cd'd earlier.
  * The mkdir error goes to /dev/null. The one message that would say WHY is
    destroyed at the instant it is produced, which is why two reports of this
    contain no diagnosis between them.
  * The cd is unguarded, so execution CONTINUES in the wrong directory.

That last one is the expensive part. copypath was the empty string, so every
copy after the download loop was relative too -- meaning a failed cd downloaded
60-80MB of kernels, inits and installers into bin/, and then copied them out of
bin/ successfully. The install appeared to work. It left untracked binaries in
the source tree (.gitignore covers tmp/* and *.exe, not bzImage, init.xz or
*.msi) and the retry loop found them again on the next run, which is what made
this look transient the first time it was reported.

It is not transient. The second report did not clear on a re-run, and that is
the signature of the path existing as a non-directory: mkdir -p refuses a file
or a dangling symlink every time, so every retry fails identically. The generic
wording sent the reporter looking for a permissions problem they did not have.

_installerTmpDir() now owns the answer. It anchors on $workingdir, which
installfog.sh captures with pwd before anything can move, so it is correct
regardless of the caller's cwd; it returns an absolute path; it reports the
not-a-directory case by name and says to remove or rename the path; and it fails
non-zero so callers can stop.

All five call sites converted:

  downloadfiles()          fails the install rather than downloading into bin/.
                           copypath is set to the scratch directory as well, so
                           the copy step no longer depends on cwd either -- that
                           variable was already the hook for it and had only ever
                           held "".
  configureUDPCast()       same, plus a guard on `cd $udpcastout`. Without it a
                           tarball that did not unpack ran configure, make and
                           make install in the scratch directory instead, each
                           failing separately and none of them saying why.
  fetchipxeasset()         was the least broken -- it logged its mkdir error --
                           but still resolved ../tmp/ against the cwd.
  the two SQL setup paths  no cd, so these failed differently: the heredoc wrote
                           into a missing directory and mysql was then handed a
                           file that had never been created. Same cause, same
                           discarded error.

cwd/cur are now local and quoted at those sites; cwd in downloadfiles had been a
global.

tests/installer-tmpdir.test.sh pins it: the path is absolute, it does not move
with the caller's cwd, creation is idempotent, a path that exists as a file fails
with a message naming THAT cause and offering a remedy, failure is visible in the
exit status, and no call site has quietly gone back to the relative form.
Mutation-verified -- returning a relative path fails 7 assertions, and removing
the not-a-directory guard fails the two that check the message is specific rather
than generic. 11 passed, 0 failed. Picked up automatically by run-all.sh's glob.

What this does NOT do is explain the original failure. The reason was thrown away
by the code being fixed here. If it recurs, the message will now name the cause.

Co-Authored-By: Claude <noreply@anthropic.com>
