### PR TITLE
Schema step 286: give FOG's optional columns a real default

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4288,3 +4288,288 @@ $this->schema[] = array(
     "UPDATE `taskTypes` SET `ttIsAccess` = 'both' WHERE `ttIsAccess` = ''",
     "UPDATE `users` SET `uAllowAPI` = '0' WHERE `uAllowAPI` = ''",
 );
+
+// 286
+$this->schema[] = array(
+    // GH-1245, the third instalment: make the schema SAY which columns are
+    // optional, instead of leaving it to be inferred.
+    //
+    // A column declared NOT NULL with no DEFAULT is only mandatory if
+    // something enforces it. Under a non-strict sql_mode the server does not
+    // -- it downgrades the error to a warning and substitutes an implicit
+    // zero value -- so for the nine years PDODB cleared sql_mode, the
+    // declaration was a comment rather than a constraint. Removing the clear
+    // turned every one of those columns into a real constraint at once, which
+    // is how saving FOG settings started failing with error 1364.
+    //
+    // For the TEXT columns it was never even a decision: MySQL could not
+    // attach a DEFAULT to a TEXT or BLOB column until 8.0.13, MariaDB until
+    // 10.2.1. `longtext NOT NULL` was the only phrasing the schema language
+    // offered, so those columns are mandatory by accident of syntax.
+    //
+    // WHICH COLUMNS. Not a judgement call: FOG already states its intent in
+    // each model's $databaseFieldsRequired, and this is that statement made
+    // true in the database. Of the 312 core columns that are NOT NULL, carry
+    // no DEFAULT and are not AUTO_INCREMENT, 97 stay exactly as they are --
+    // the ones the models declare required, plus every column whose name ends
+    // in ID, because an INSERT that forgets the row it hangs off should fail
+    // rather than make a silent orphan. The 215 below are the rest.
+    //
+    // WHY THIS CANNOT BREAK A WORKING WRITE. An INSERT that names the column
+    // is unaffected; a default applies only to an omitted column. An INSERT
+    // that omits it currently FAILS outright on a strict server, so there is
+    // no working behaviour to change. On a non-strict server it currently
+    // gets the server's implicit coercion -- and the defaults chosen here are
+    // exactly that coercion ('' for text, 0 for integers, the first member
+    // for an enum), which is the same rule save() applies for an empty value.
+    // So both kinds of server end up where they already were, with the
+    // difference that the schema now says so.
+    //
+    // users.uCreateDate is the one column given a live default rather than a
+    // zero: a user record created without a date wants now, and writing a
+    // zero date is the GH-1245 bug in a different costume. Existing rows are
+    // untouched either way -- a DEFAULT never rewrites stored data.
+    //
+    // PLUGIN TABLES ARE DELIBERATELY ABSENT. A plugin's table is not built
+    // here: it is built by Schema::createTable() when the plugin installs,
+    // with every column NOT NULL and no defaults at all, and install() calls
+    // uninstall() first -- which DROPS the table. An ALTER applied here would
+    // therefore be erased by the next plugin install, so it would be false
+    // comfort rather than a fix. The runtime paths still cover those tables:
+    // save() writes an empty value explicitly and insertBatch() backfills the
+    // columns the caller omitted.
+    function () {
+        $optional = array(
+            'clientUpdates' => array(
+                'cuMD5', 'cuType'
+            ),
+            'globalSettings' => array(
+                'settingCategory', 'settingDesc', 'settingValue'
+            ),
+            'greenFog' => array(
+                'gfAction', 'gfDays', 'gfHour', 'gfMin'
+            ),
+            'groups' => array(
+                'groupBuilding', 'groupCreateBy', 'groupDesc',
+                'groupKernel', 'groupKernelArgs', 'groupPrimaryDisk'
+            ),
+            'history' => array(
+                'hIP', 'hText', 'hUser'
+            ),
+            'hostMAC' => array(
+                'hmDesc', 'hmIgnoreClient', 'hmIgnoreImaging',
+                'hmPending', 'hmPrimary'
+            ),
+            'hosts' => array(
+                'hostADDomain', 'hostADOU', 'hostADPass',
+                'hostADPassLegacy', 'hostADUser', 'hostBuilding',
+                'hostCreateBy', 'hostDesc', 'hostDevice', 'hostImage',
+                'hostIP', 'hostKernel', 'hostKernelArgs',
+                'hostPending', 'hostPrinterLevel', 'hostPubKey',
+                'hostSecToken', 'hostSecTokenPrev', 'hostUseAD'
+            ),
+            'hostScreenSettings' => array(
+                'hssHeight', 'hssOrientation', 'hssOther1',
+                'hssOther2', 'hssRefresh', 'hssWidth'
+            ),
+            'imageGroupAssoc' => array(
+                'igaPrimary'
+            ),
+            'images' => array(
+                'imageBuilding', 'imageCreateBy', 'imageDesc',
+                'imageMagnetUri', 'imageProtect', 'imageSize'
+            ),
+            'imagingLog' => array(
+                'ilCreatedBy', 'ilType'
+            ),
+            'inventory' => array(
+                'iBiosdate', 'iBiosvendor', 'iBiosversion',
+                'iCaseasset', 'iCaseman', 'iCaseserial', 'iCasever',
+                'iCpucurrent', 'iCpuman', 'iCpumax', 'iCpuversion',
+                'iGpuproducts', 'iGpuvendors', 'iHdfirmware',
+                'iHdmodel', 'iHdserial', 'iMbasset', 'iMbman',
+                'iMbproductname', 'iMbserial', 'iMbversion', 'iMem',
+                'iOtherTag', 'iOtherTag1', 'iPrimaryUser', 'iSysman',
+                'iSysproduct', 'iSysserial', 'iSystype', 'iSysversion'
+            ),
+            'ipxeTable' => array(
+                'ipxeFailure', 'ipxeFilename', 'ipxeMAC',
+                'ipxeManufacturer', 'ipxeProduct', 'ipxeSuccess',
+                'ipxeVersion'
+            ),
+            'modules' => array(
+                'description'
+            ),
+            'moduleStatusByHost' => array(
+                'msState'
+            ),
+            'multicastSessions' => array(
+                'msAnon3', 'msAnon4', 'msAnon5', 'msBasePort',
+                'msClients', 'msImage', 'msInterface', 'msIsDD',
+                'msLogPath', 'msName', 'msPercent', 'msSessClients',
+                'msState'
+            ),
+            'nfsGroupMembers' => array(
+                'ngmBandwidthLimit', 'ngmIsEnabled', 'ngmIsMasterNode',
+                'ngmKey', 'ngmMaxClients', 'ngmMemberDescription',
+                'ngmMemberName', 'ngmSnapinPath', 'ngmSSLPath',
+                'ngmWebroot'
+            ),
+            'nfsGroups' => array(
+                'ngDesc'
+            ),
+            'os' => array(
+                'osDescription'
+            ),
+            'plugins' => array(
+                'pAnon1', 'pAnon2', 'pAnon3', 'pAnon4', 'pAnon5',
+                'pInstalled', 'pState', 'pVersion'
+            ),
+            'powerManagement' => array(
+                'pmDom', 'pmDow', 'pmHour', 'pmMin', 'pmMonth',
+                'pmOndemand'
+            ),
+            'printerAssoc' => array(
+                'paAnon1', 'paAnon2', 'paAnon3', 'paAnon4', 'paAnon5',
+                'paIsDefault'
+            ),
+            'printers' => array(
+                'pAnon2', 'pAnon3', 'pAnon4', 'pAnon5', 'pConfig',
+                'pConfigFile', 'pDefFile', 'pIP', 'pModel', 'pPort'
+            ),
+            'pxeMenu' => array(
+                'pxeDesc', 'pxeHotKeyEnable', 'pxeKeySequence',
+                'pxeParams'
+            ),
+            'scheduledTasks' => array(
+                'stDesc', 'stDOM', 'stDOW', 'stHour', 'stMinute',
+                'stMonth', 'stName', 'stOther1', 'stOther2',
+                'stOther3', 'stOther4', 'stOther5', 'stShutDown'
+            ),
+            'schemaVersion' => array(
+                'vValue'
+            ),
+            'snapinGroupAssoc' => array(
+                'sgaPrimary'
+            ),
+            'snapins' => array(
+                'sAnon3', 'sArgs', 'sCreator', 'sDesc',
+                'snapinProtect', 'sReboot', 'sRunWith', 'sRunWithArgs'
+            ),
+            'snapinTasks' => array(
+                'stReturnCode', 'stReturnDetails', 'stState'
+            ),
+            'supportedOS' => array(
+                'osName', 'osValue'
+            ),
+            'taskLog' => array(
+                'createdBy', 'ip'
+            ),
+            'tasks' => array(
+                'taskBPM', 'taskCreateBy', 'taskDataCopied',
+                'taskDataTotal', 'taskForce', 'taskIsDebug',
+                'taskNFSFailures', 'taskPassreset', 'taskPCT',
+                'taskPercentText', 'taskShutdown', 'taskTimeElapsed',
+                'taskTimeRemaining', 'taskWOL'
+            ),
+            'taskStates' => array(
+                'tsDescription', 'tsIcon'
+            ),
+            'taskTypes' => array(
+                'ttDescription', 'ttInitrd', 'ttKernel', 'ttKernelArgs'
+            ),
+            'users' => array(
+                'uAPIToken', 'uCreateBy', 'uCreateDate', 'uDisplay',
+                'uType'
+            ),
+            'userTracking' => array(
+                'utAction', 'utAnon3', 'utDesc'
+            ),
+            'virus' => array(
+                'vAnon2', 'vMode'
+            ),
+        );
+
+        // MySQL and MariaDB spell a TEXT/BLOB default differently: MariaDB
+        // takes the literal, MySQL requires it parenthesised as an
+        // expression and rejects it outright below 8.0.13.
+        $version = (string)self::$DB->query('SELECT VERSION() AS `v`')
+            ->fetch()->get('v');
+        $maria = false !== stripos($version, 'mariadb');
+        $lobDefaults = $maria;
+        if (!$maria) {
+            preg_match('/^(\d+)\.(\d+)\.(\d+)/', $version, $m);
+            $lobDefaults = count($m) === 4
+                && (int)$m[1] * 10000 + (int)$m[2] * 100 + (int)$m[3]
+                    >= 80013;
+        }
+
+        foreach ($optional as $table => $columns) {
+            // Only columns that are actually still missing a default, so a
+            // re-run is a read and nothing else. A table that does not exist
+            // on this install returns nothing and is skipped rather than
+            // erroring.
+            $rows = self::$DB->query(
+                "SELECT `COLUMN_NAME` AS `c`, `COLUMN_TYPE` AS `ty` "
+                . "FROM `information_schema`.`COLUMNS` "
+                . "WHERE `TABLE_SCHEMA` = DATABASE() "
+                . "AND LOWER(`TABLE_NAME`) = :table "
+                . "AND `IS_NULLABLE` = 'NO' "
+                . "AND `COLUMN_DEFAULT` IS NULL "
+                . "AND `EXTRA` NOT LIKE '%auto_increment%'",
+                array(),
+                array(':table' => strtolower($table))
+            )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+
+            $want = array_map('strtolower', $columns);
+            foreach ((array)$rows as $row) {
+                if (!isset($row['c'], $row['ty'])
+                    || !in_array(strtolower($row['c']), $want, true)
+                ) {
+                    continue;
+                }
+                $type = trim($row['ty']);
+                $lob = (bool)preg_match(
+                    '/^(tiny|medium|long)?(text|blob)\b/i',
+                    $type
+                );
+                if ($lob && !$lobDefaults) {
+                    // Nothing sensible to do on MySQL below 8.0.13, and
+                    // nothing broken by skipping: insertBatch() backfills
+                    // the column and save() writes it explicitly.
+                    continue;
+                }
+                if (preg_match('/^datetime\b/i', $type)) {
+                    $default = 'current_timestamp()';
+                } elseif (preg_match(
+                    '/^(tiny|small|medium|big)?int\b/i',
+                    $type
+                )) {
+                    $default = '0';
+                } elseif (preg_match(
+                    "/^(enum|set)\\s*\\(\\s*'((?:[^']|'')*)'/i",
+                    $type,
+                    $member
+                )) {
+                    $default = "'" . $member[2] . "'";
+                } elseif ($lob) {
+                    $default = $maria ? "''" : "('')";
+                } else {
+                    $default = "''";
+                }
+                self::$DB->query(
+                    sprintf(
+                        'ALTER TABLE `%s` MODIFY COLUMN `%s` %s NOT NULL '
+                        . 'DEFAULT %s',
+                        $table,
+                        $row['c'],
+                        $type,
+                        $default
+                    )
+                );
+            }
+        }
+
+        return true;
+    },
+);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -54,7 +54,7 @@ class System
     {
         self::_versionCompare();
         define('FOG_VERSION', '1.5.10.2331');
-        define('FOG_SCHEMA', 285);
+        define('FOG_SCHEMA', 286);
         define('FOG_BCACHE_VER', 143);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/tests/optional-columns-match-the-models.test.php
+++ b/tests/optional-columns-match-the-models.test.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Schema step 286 must give a default to exactly the columns FOG calls
+ * optional -- no more, no less.
+ *
+ * GH-1245, third instalment. A column declared NOT NULL with no DEFAULT is
+ * only mandatory if something enforces it, and for nine years nothing did:
+ * PDODB cleared sql_mode on every connection, so the server downgraded the
+ * error to a warning and substituted an implicit zero. Removing the clear
+ * turned 329 such declarations into real constraints at once, which is how
+ * saving FOG settings started failing with error 1364.
+ *
+ * Step 286 resolves that by giving the OPTIONAL ones a default. Which ones
+ * are optional is not a judgement call -- FOG already states it, in each
+ * model's $databaseFieldsRequired -- so the risk is not that the step is
+ * wrong today but that the two statements drift apart later, silently and in
+ * either direction:
+ *
+ *   - a column added to $databaseFieldsRequired while it still carries a
+ *     default from the map. The model refuses the save, the database does
+ *     not, and every write path that bypasses isValid() -- insertBatch(),
+ *     the API, a service -- can still make the row the model forbids.
+ *   - a foreign key finding its way into the map. An INSERT that forgets the
+ *     row it hangs off then succeeds and makes a silent orphan pointing at
+ *     id 0 or ''. taskLog.taskID is the near miss: it is a mediumtext on
+ *     this branch, so a type-based rule does not see it as a key at all.
+ *
+ * This branch has no commons/schema-expected.php and no SchemaReconciler, so
+ * 1.6's manifest-driven equivalent cannot port. The rule is checked against
+ * the models directly instead, which needs no database.
+ *
+ * Plugin tables are absent from the map on purpose and that is asserted too:
+ * a plugin's table is built by Schema::createTable() at install time with no
+ * defaults at all, and install() calls uninstall() -- which DROPS it. An
+ * ALTER here would be erased by the next plugin install.
+ *
+ * The live half was proven separately, against a real 1.5 server:
+ * scripts/background_scripts/prove_schema_286.php runs the step through
+ * FOG's own boot and checks what the server then accepts.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = array();
+$checks = 0;
+
+/**
+ * Records a check.
+ *
+ * @param bool   $ok      whether it passed
+ * @param string $message what failed, stated as the defect
+ *
+ * @return void
+ */
+function ocCheck($ok, $message)
+{
+    global $checks, $failures;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $message;
+    }
+}
+
+// ---------------------------------------------------------------
+// 1. The step is present and the schema version reaches it.
+// ---------------------------------------------------------------
+$schemaSrc = file_get_contents($web . '/commons/schema.php');
+$systemSrc = file_get_contents($web . '/lib/fog/system.class.php');
+
+ocCheck(
+    false !== strpos($schemaSrc, "\n// 286\n"),
+    'schema step 286 is gone. Optional columns lose their defaults again and '
+    . 'error 1364 comes back on any INSERT that omits one.'
+);
+
+preg_match("/define\('FOG_SCHEMA',\s*(\d+)\)/", $systemSrc, $ver);
+ocCheck(
+    isset($ver[1]) && (int) $ver[1] >= 286,
+    'FOG_SCHEMA is below 286, so the schema updater never runs the step. '
+    . 'A step nothing reaches is not a migration.'
+);
+
+// ---------------------------------------------------------------
+// 2. Read the map out of the step.
+// ---------------------------------------------------------------
+$optional = array();
+$block = substr($schemaSrc, (int) strpos($schemaSrc, "\n// 286\n"));
+if (preg_match('/\$optional = array\((.*?)\n        \);/s', $block, $m)) {
+    $table = '';
+    foreach (explode("\n", $m[1]) as $line) {
+        if (preg_match("/^\s*'([^']+)' => array\(/", $line, $t)) {
+            $table = $t[1];
+            $optional[$table] = array();
+            continue;
+        }
+        if ('' === $table) {
+            continue;
+        }
+        preg_match_all("/'([^']+)'/", $line, $c);
+        foreach ($c[1] as $col) {
+            $optional[$table][] = $col;
+        }
+    }
+}
+$total = 0;
+foreach ($optional as $cols) {
+    $total += count($cols);
+}
+ocCheck(
+    count($optional) > 20 && $total > 150,
+    'the $optional map could not be read out of step 286, so every check '
+    . 'below passes vacuously.'
+);
+
+// ---------------------------------------------------------------
+// 3. Read every model's table, fields and required fields.
+// ---------------------------------------------------------------
+$classes = array();
+$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($web));
+foreach ($it as $file) {
+    if (!preg_match('/\.class\.php$/', $file->getFilename())) {
+        continue;
+    }
+    $src = file_get_contents($file->getPathname());
+    if (!preg_match('/^\s*class\s+(\w+)\s+extends\s+(\w+)/mi', $src, $m)) {
+        continue;
+    }
+    $fields = array();
+    if (preg_match(
+        '/\$databaseFields\s*=\s*(?:array\s*\(|\[)(.*?)(?:\)|\])\s*;/s',
+        $src,
+        $b
+    )) {
+        preg_match_all(
+            '/[\'"]([^\'"]+)[\'"]\s*=>\s*[\'"]([^\'"]+)[\'"]/',
+            $b[1],
+            $p,
+            PREG_SET_ORDER
+        );
+        foreach ($p as $pair) {
+            $fields[$pair[1]] = $pair[2];
+        }
+    }
+    $req = array();
+    if (preg_match(
+        '/\$databaseFieldsRequired\s*=\s*(?:array\s*\(|\[)(.*?)(?:\)|\])\s*;/s',
+        $src,
+        $b
+    )) {
+        preg_match_all('/[\'"]([^\'"]+)[\'"]/', $b[1], $p);
+        $req = $p[1];
+    }
+    $tbl = '';
+    if (preg_match('/\$databaseTable\s*=\s*[\'"]([^\'"]+)/', $src, $t)) {
+        $tbl = $t[1];
+    }
+    $classes[$m[1]] = array(
+        'parent' => $m[2],
+        'table' => $tbl,
+        'fields' => $fields,
+        'req' => $req,
+        'plugin' => false !== strpos($file->getPathname(), '/lib/plugins/'),
+    );
+}
+
+/**
+ * Collects a property up the inheritance chain, parent first.
+ *
+ * A model states only what it adds; Host does not restate FOGController's.
+ *
+ * @param string $name    class to start from
+ * @param string $key     'fields' or 'req'
+ * @param array  $classes every class read above
+ * @param array  $seen    guards a cycle
+ *
+ * @return array
+ */
+function ocResolve($name, $key, $classes, $seen = array())
+{
+    if (!isset($classes[$name]) || isset($seen[$name])) {
+        return array();
+    }
+    $seen[$name] = true;
+
+    return array_merge(
+        ocResolve($classes[$name]['parent'], $key, $classes, $seen),
+        $classes[$name][$key]
+    );
+}
+
+$required = array();
+$pluginOwned = array();
+foreach ($classes as $name => $class) {
+    $table = $class['table'];
+    if (!$table) {
+        $walk = $name;
+        while (isset($classes[$walk]) && !$classes[$walk]['table']) {
+            $walk = $classes[$walk]['parent'];
+        }
+        $table = isset($classes[$walk]) ? $classes[$walk]['table'] : '';
+    }
+    if (!$table) {
+        continue;
+    }
+    $key = strtolower($table);
+    // Plugin-owned only if NO core class claims the same table: the
+    // taskstateedit and tasktypeedit plugins declare models on the CORE
+    // taskStates and taskTypes tables, and those are schema.php's.
+    if ($class['plugin']) {
+        if (!isset($pluginOwned[$key])) {
+            $pluginOwned[$key] = true;
+        }
+    } else {
+        $pluginOwned[$key] = false;
+    }
+    $fields = ocResolve($name, 'fields', $classes);
+    foreach (ocResolve($name, 'req', $classes) as $friendly) {
+        if (isset($fields[$friendly])) {
+            $required[$key][strtolower($fields[$friendly])] = true;
+        }
+    }
+}
+
+ocCheck(
+    count($classes) > 50 && count($required) > 20,
+    'the model scan found almost nothing, so the two checks below pass '
+    . 'vacuously.'
+);
+
+// ---------------------------------------------------------------
+// 4. Nothing in the map is a column a model calls required.
+// ---------------------------------------------------------------
+foreach ($optional as $table => $cols) {
+    $key = strtolower($table);
+    foreach ($cols as $col) {
+        ocCheck(
+            !isset($required[$key][strtolower($col)]),
+            sprintf(
+                '%s.%s carries a DEFAULT from step 286 while a model lists '
+                . 'it in $databaseFieldsRequired. The model refuses the '
+                . 'save and the database accepts it, so every write path '
+                . 'that skips isValid() can still create the row the model '
+                . 'forbids. Drop it from the map, or from the model.',
+                $table,
+                $col
+            )
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// 5. No foreign key is in the map, and no plugin table.
+// ---------------------------------------------------------------
+foreach ($optional as $table => $cols) {
+    ocCheck(
+        empty($pluginOwned[strtolower($table)]),
+        sprintf(
+            '%s is a plugin-owned table and step 286 alters it. The next '
+            . 'plugin install DROPS and rebuilds that table without '
+            . 'defaults, so the alter is erased and the entry is false '
+            . 'comfort. Fix Schema::createTable()\'s callers instead.',
+            $table
+        )
+    );
+    foreach ($cols as $col) {
+        ocCheck(
+            !preg_match('/ID$/', $col),
+            sprintf(
+                '%s.%s ends in ID and step 286 gives it a default, so an '
+                . 'INSERT that forgets the row it hangs off now succeeds '
+                . 'and makes a silent orphan. Not gated on an integer '
+                . 'type on purpose: taskLog.taskID is a mediumtext.',
+                $table,
+                $col
+            )
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// 6. The columns that must never be defaulted, named outright.
+// ---------------------------------------------------------------
+$canaries = array(
+    'users' => array('uName', 'uPass'),
+    'hosts' => array('hostName'),
+    'nfsGroupMembers' => array('ngmPass', 'ngmRootPath', 'ngmUser'),
+    'taskLog' => array('taskID', 'taskStateID'),
+    'tasks' => array('taskHostID', 'taskTypeID'),
+);
+foreach ($canaries as $table => $cols) {
+    foreach ($cols as $col) {
+        ocCheck(
+            !isset($optional[$table])
+            || !in_array($col, $optional[$table], true),
+            sprintf(
+                '%s.%s appears in step 286. A default here makes a row that '
+                . 'is meaningless -- a nameless user, a storage node with '
+                . 'no root path, a log line belonging to no task -- '
+                . 'insertable without complaint.',
+                $table,
+                $col
+            )
+        );
+    }
+}
+
+if (count($failures) > 0) {
+    echo 'FAIL optional-columns-match-the-models ('
+        . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS optional-columns-match-the-models ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
Port of working-1.6's step 348 (#1271) to the 1.5 line. Third instalment of GH-1245, following #1270 (the `insertBatch()` backfill) on this branch.

## The problem

A column declared `NOT NULL` with no `DEFAULT` is only mandatory if something enforces it. Under a non-strict `sql_mode` the server does not — it downgrades the error to a warning and substitutes an implicit zero. For the nine years `PDODB` cleared `sql_mode`, the declaration was a comment rather than a constraint. Removing the clear turned **329** of them into real constraints at once, which is how saving FOG settings started failing with `error 1364 Field 'settingDesc' doesn't have a default value`.

For the TEXT columns it was never even a decision: MySQL could not attach a `DEFAULT` to a `TEXT`/`BLOB` column until 8.0.13, MariaDB until 10.2.1. `longtext NOT NULL` was the only phrasing the schema language offered.

## Which columns

Not a judgement call. FOG already states its intent in each model's `$databaseFieldsRequired`, and this makes that statement true in the database.

Of the **312 core** columns that are `NOT NULL`, carry no `DEFAULT` and are not `AUTO_INCREMENT`:

| | count |
|---|---|
| stay bare — the models declare them required, plus every column whose name ends in `ID` | 97 |
| get a default | 215 |

The foreign-key rule is deliberately **not** gated on an integer type: `taskLog.taskID` is a `mediumtext` on this branch and is no less a foreign key for it. An INSERT that forgets the row it hangs off should fail rather than make a silent orphan.

## Why it cannot break a working write

An INSERT that names the column is unaffected — a default applies only to an omitted column. An INSERT that omits it currently **fails outright** on a strict server, so there is no working behaviour to change. On a non-strict server it currently gets the server's implicit coercion, and the defaults chosen here are exactly that coercion (`''` for text, `0` for integers, the first member for an enum) — the same rule `save()` already applies for an empty value. Both kinds of server end up where they already were, with the difference that the schema now says so.

`users.uCreateDate` is the one column given a live default rather than a zero: a user record created without a date wants *now*, and writing a zero date is the GH-1245 bug in a different costume. Existing rows are untouched either way — a `DEFAULT` never rewrites stored data.

## Plugin tables are absent on purpose

A plugin's table is not built here. `Schema::createTable()` builds it at install time with every column `NOT NULL` and no defaults at all, and `install()` calls `uninstall()` — which **drops** the table. An `ALTER` applied here would therefore be erased by the next plugin install, so it would be false comfort rather than a fix. The runtime paths still cover those tables: `save()` writes an empty value explicitly and `insertBatch()` backfills the columns the caller omitted.

## Verification

Run through FOG's own boot against a live 1.5.10 server (`scripts/background_scripts/prove_schema_286.php` executes the closure straight out of `schema.php`, so it cannot drift from what ships):

- **329 bare columns → 114**, which is exactly the 97 predicted required plus the 17 belonging to the installed LDAP plugin. Set comparison in both directions: nothing unexpectedly kept its bareness, nothing predicted-required lost it.
- **Idempotent** — a second run reports `true` with no error and the count is unchanged.
- **Behaviour**, under the server's own `STRICT_TRANS_TABLES` (temporary tables cloned with `LIKE`, so nothing is written to a table anyone reads):
  - INSERT naming only `globalSettings.settingKey` → **accepted** (this is the reported bug)
  - INSERT naming only `hosts.hostName` → accepted
  - INSERT naming only `hosts.hostDesc` → **still refused** (`hostName` remains mandatory)
  - INSERT naming only `taskLog.taskStateID` → **still refused** (`taskID` stayed bare)

## The test

`tests/optional-columns-match-the-models.test.php` pins the *rule*, not today's map, because the risk is drift later rather than a wrong entry now — in either direction:

- a column added to `$databaseFieldsRequired` while it still carries a default from the map: the model refuses the save, the database does not, and every write path that skips `isValid()` can still create the row the model forbids;
- a foreign key or a plugin table finding its way in.

481 checks. **Eight mutations, eight caught** — required column into the map, foreign key into the map, plugin table into the map, step removed, `FOG_SCHEMA` left at 285, the canary arm alone (with the model edited so nothing else could catch it), and both vacuous-pass guards.

1.6's manifest-driven equivalent cannot port — this branch has no `commons/schema-expected.php` and no `SchemaReconciler` — so the models are read directly, which needs no database.

## Downstream

None. No route classes added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)