### PR TITLE
Give plugin tables real column defaults, and stop createTable dropping them

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1725,6 +1725,119 @@ abstract class FOGManagerController extends FOGBase
         return (int)$total;
     }
     /**
+     * Builds the CREATE TABLE for this manager's table, with a default on
+     * every column that is optional.
+     *
+     * GH-1245. Schema::createTable() emits `NOT NULL` with no DEFAULT for
+     * almost everything a caller does not spell out, which is the same defect
+     * schema step 286 repairs on an existing install -- except that install()
+     * calls uninstall() first, and uninstall() DROPS the table. So a plugin
+     * being installed, or reinstalled, put the bare columns straight back and
+     * the step could not help: 72 of the 99 columns across the plugin tables
+     * came back mandatory, and under the server's own sql_mode any INSERT
+     * omitting one fails with error 1364.
+     *
+     * WHICH COLUMNS KEEP THEIR TEETH. Not a judgement call, and not a list
+     * kept by hand -- FOG already states it, and this class already holds the
+     * statement: $databaseFieldsRequired, resolved up the model's inheritance
+     * chain by the constructor. Three kinds of column are left bare:
+     *
+     *   - the primary key and the auto-increment column;
+     *   - anything the model declares required;
+     *   - anything whose name ends in ID, because an INSERT that forgets the
+     *     row it hangs off should fail rather than make a silent orphan.
+     *     Deliberately not gated on an integer type: taskLog.taskID is a
+     *     mediumtext and is no less a foreign key for it.
+     *
+     * That is deliberately the SAME rule schema step 286 applies, so a table
+     * created by a plugin install and a table migrated by the step say the
+     * same thing. Two installs of the same FOG should not have two different
+     * schemas.
+     *
+     * A default the caller passed explicitly always wins; this only fills in
+     * where there was nothing.
+     *
+     * The signature mirrors Schema::createTable() exactly so a call site
+     * changes by one token.
+     *
+     * @param string $name    What are we calling the table?
+     * @param bool   $exists  If not exists?
+     * @param array  $fields  The fields and names.
+     * @param array  $types   The types for the fields.
+     * @param array  $nulls   Which fields to have null or not.
+     * @param array  $default Default values for field(s).
+     * @param array  $unique  The unique fields.
+     * @param string $engine  The db engine for the table.
+     * @param string $charset The charset to use for the table.
+     * @param string $prime   The primary field, if one.
+     * @param string $autoin  The auto increment field.
+     *
+     * @return string
+     */
+    public function createTableSql(
+        $name,
+        $exists,
+        $fields,
+        $types,
+        $nulls,
+        $default,
+        $unique,
+        $engine = 'InnoDB',
+        $charset = 'utf8',
+        $prime = '',
+        $autoin = ''
+    ) {
+        $keep = array();
+        foreach ((array)$this->databaseFieldsRequired as $friendly) {
+            if (isset($this->databaseFields[$friendly])) {
+                $keep[strtolower($this->databaseFields[$friendly])] = true;
+            }
+        }
+        if ($prime) {
+            $keep[strtolower($prime)] = true;
+        }
+        if ($autoin) {
+            $keep[strtolower($autoin)] = true;
+        }
+        foreach ((array)$fields as $i => $field) {
+            $notNull = isset($nulls[$i]) && $nulls[$i] === false;
+            $hasDefault = isset($default[$i])
+                && false !== $default[$i]
+                && null !== $default[$i]
+                && '' !== $default[$i];
+            if (!$notNull
+                || $hasDefault
+                || isset($keep[strtolower($field)])
+                || preg_match('/ID$/', $field)
+            ) {
+                continue;
+            }
+            $fill = Schema::emptyDefaultFor($types[$i]);
+            if (null === $fill) {
+                // A TEXT or BLOB column on a server too old to carry a
+                // default for one. Nothing to do and nothing broken by
+                // leaving it: save() writes the column explicitly and
+                // insertBatch() backfills it.
+                continue;
+            }
+            $default[$i] = $fill;
+        }
+
+        return Schema::createTable(
+            $name,
+            $exists,
+            $fields,
+            $types,
+            $nulls,
+            $default,
+            $unique,
+            $engine,
+            $charset,
+            $prime,
+            $autoin
+        );
+    }
+    /**
      * Uninstalls the table.
      *
      * @return bool

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -285,6 +285,124 @@ class Schema extends FOGController
         return $string;
     }
     /**
+     * Renders a caller's default as an SQL literal.
+     *
+     * GH-1245. What callers pass is a VALUE, not SQL -- every one of the
+     * thirty defaults in the tree is a literal like '0' or
+     * '0000-00-00 00:00:00'. The one exception is CURRENT_TIMESTAMP, which is
+     * an expression and must go in bare. Emitting them all raw put an
+     * unquoted 0 against an ENUM -- where 0 is an INDEX, and index 0 is the
+     * error value -- and an unquoted zero date against a TIMESTAMP. The
+     * server refuses both, so a plugin install would have died on its own
+     * CREATE TABLE.
+     *
+     * It never showed because the truthiness test in createTable() dropped
+     * every '0' before it could reach the server. Fixing that test is what
+     * made these visible; they were wrong the whole time.
+     *
+     * Quoting is skipped for a value that is already quoted, for a
+     * parenthesised expression -- which is how MySQL 8.0.13+ requires a
+     * TEXT/BLOB default to be written -- and for the small set of bare SQL
+     * expressions FOG actually uses.
+     *
+     * @param string $value the default as the caller wrote it
+     *
+     * @return string
+     */
+    public static function defaultLiteral($value)
+    {
+        $value = (string)$value;
+        $trim = trim($value);
+        if (preg_match("/^'.*'$/s", $trim)
+            || preg_match('/^\(.*\)$/s', $trim)
+            || preg_match(
+                '/^(CURRENT_TIMESTAMP(\(\))?|NOW\(\)|NULL)$/i',
+                $trim
+            )
+        ) {
+            return $value;
+        }
+
+        return sprintf("'%s'", str_replace("'", "''", $value));
+    }
+    /**
+     * The DEFAULT an optional NOT NULL column of this type should carry.
+     *
+     * GH-1245. A column declared NOT NULL with no DEFAULT is only mandatory
+     * if something enforces it, and for nine years nothing did: PDODB cleared
+     * sql_mode on every connection, so the server downgraded the error to a
+     * warning and substituted an implicit zero. What is returned here IS that
+     * implicit zero, written down -- the same rule schema step 286 applies to
+     * an existing install and FOGBase::emptyValueFor() applies to a write. So
+     * a table created here and a table migrated by the step end up saying the
+     * same thing, which is the point: two installs of the same FOG should not
+     * have two different schemas.
+     *
+     * @param string $type the column type, as handed to createTable()
+     *
+     * @return string|null the SQL literal, or null if this server cannot
+     *                     carry a default for this type at all
+     */
+    public static function emptyDefaultFor($type)
+    {
+        $type = trim((string)$type);
+        $lob = (bool)preg_match(
+            '/^(tiny|medium|long)?(text|blob)\b/i',
+            $type
+        );
+        if ($lob) {
+            // MySQL could not attach a DEFAULT to a TEXT or BLOB column
+            // until 8.0.13 and still requires it parenthesised as an
+            // expression; MariaDB has taken the plain literal since 10.2.1.
+            // Below that there is nothing to do and nothing broken by
+            // skipping: save() writes the column explicitly and
+            // insertBatch() backfills it.
+            static $lobStyle = null;
+            if (null === $lobStyle) {
+                $version = (string)self::$DB
+                    ->query('SELECT VERSION() AS `v`')
+                    ->fetch()
+                    ->get('v');
+                if (false !== stripos($version, 'mariadb')) {
+                    $lobStyle = 'literal';
+                } else {
+                    preg_match('/^(\d+)\.(\d+)\.(\d+)/', $version, $m);
+                    $lobStyle = count($m) === 4
+                        && (int)$m[1] * 10000
+                            + (int)$m[2] * 100
+                            + (int)$m[3] >= 80013
+                        ? 'expression'
+                        : 'none';
+                }
+            }
+            if ($lobStyle === 'none') {
+                return null;
+            }
+
+            return $lobStyle === 'expression' ? "('')" : "''";
+        }
+        // These match the type as a CALLER WROTE IT, which is not the same
+        // vocabulary information_schema reports. Schema step 286 does the
+        // same job reading COLUMN_TYPE, where an integer is always 'int(11)'
+        // or 'bigint(20)'; here the tree says 'INTEGER' 120 times, plus
+        // BOOLEAN and TIMESTAMP. A rule copied across without widening it
+        // silently gives every integer column a default of '' -- so the two
+        // are deliberately not identical.
+        if (preg_match('/^(datetime|timestamp)\b/i', $type)) {
+            return 'current_timestamp()';
+        }
+        if (preg_match('/^(tiny|small|medium|big)?int(eger)?\b/i', $type)
+            || preg_match('/^bool(ean)?\b/i', $type)
+        ) {
+            return '0';
+        }
+        if (preg_match("/^(enum|set)\\s*\\(\\s*'((?:[^']|'')*)'/i", $type, $member)) {
+            return "'" . $member[2] . "'";
+        }
+
+        return "''";
+    }
+    /**
      * SQL create table syntax
      *
      * @param string $name    What are we calling the table?
@@ -349,10 +467,21 @@ class Schema extends FOGController
                     ''
                 ),
                 (
-                    $default[$i] ?
+                    // Truthiness dropped a DEFAULT of '0' on the floor: '0'
+                    // is falsey in PHP, so a caller asking for DEFAULT '0'
+                    // -- an enum's first member, a boolean-ish flag -- got a
+                    // bare NOT NULL column instead. That is GH-1245's defect
+                    // inflicted by the builder itself, and it was live: the
+                    // LDAP plugin lost three defaults this way and FOG's own
+                    // host, snapin, MAC and scheduled-task tables lost ten
+                    // more between them.
+                    isset($default[$i])
+                    && false !== $default[$i]
+                    && null !== $default[$i]
+                    && '' !== $default[$i] ?
                     sprintf(
                         ' DEFAULT %s',
-                        $default[$i]
+                        self::defaultLiteral($default[$i])
                     ) :
                     ''
                 ),

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolassociationmanager.class.php
@@ -35,7 +35,7 @@ class AccessControlAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolmanager.class.php
@@ -40,7 +40,7 @@ class AccessControlManager extends FOGManagerController
          * create anything.
          */
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolruleassociationmanager.class.php
@@ -35,7 +35,7 @@ class AccessControlRuleAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
+++ b/packages/web/lib/plugins/accesscontrol/class/accesscontrolrulemanager.class.php
@@ -40,7 +40,7 @@ class AccessControlRuleManager extends FOGManagerController
          * create anything.
          */
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/capone/class/caponemanager.class.php
+++ b/packages/web/lib/plugins/capone/class/caponemanager.class.php
@@ -35,7 +35,7 @@ class CaponeManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/example/class/examplemanager.class.php
+++ b/packages/web/lib/plugins/example/class/examplemanager.class.php
@@ -35,7 +35,7 @@ class ExampleManager extends FOGManagerController
          * This is commented out so we don't actually
          * create anything.
          *
-         * $sql = Schema::createTable(
+         * $sql = $this->createTableSql(
          *     'example',
          *     true,
          *     array(

--- a/packages/web/lib/plugins/fileintegrity/class/fileintegritymanager.class.php
+++ b/packages/web/lib/plugins/fileintegrity/class/fileintegritymanager.class.php
@@ -35,7 +35,7 @@ class FileIntegrityManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/hoststatus/class/hoststatusmanager.class.php
+++ b/packages/web/lib/plugins/hoststatus/class/hoststatusmanager.class.php
@@ -24,7 +24,7 @@ class HostStatusManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
+++ b/packages/web/lib/plugins/ldap/class/ldapmanager.class.php
@@ -39,7 +39,7 @@ class LDAPManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationassociationmanager.class.php
@@ -37,7 +37,7 @@ class LocationAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/location/class/locationmanager.class.php
+++ b/packages/web/lib/plugins/location/class/locationmanager.class.php
@@ -35,7 +35,7 @@ class LocationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
+++ b/packages/web/lib/plugins/pushbullet/class/pushbulletmanager.class.php
@@ -65,7 +65,7 @@ class PushbulletManager extends FOGManagerController
             'pID',
             'pToken'
         );
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             $fields,

--- a/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitehostassociationmanager.class.php
@@ -35,7 +35,7 @@ class SiteHostAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/site/class/sitemanager.class.php
+++ b/packages/web/lib/plugins/site/class/sitemanager.class.php
@@ -35,7 +35,7 @@ class SiteManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserassociationmanager.class.php
@@ -35,7 +35,7 @@ class SiteUserAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
+++ b/packages/web/lib/plugins/site/class/siteuserrestrictionmanager.class.php
@@ -35,7 +35,7 @@ class SiteUserRestrictionManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/slack/class/slackmanager.class.php
+++ b/packages/web/lib/plugins/slack/class/slackmanager.class.php
@@ -35,7 +35,7 @@ class SlackManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
+++ b/packages/web/lib/plugins/subnetgroup/class/subnetgroupmanager.class.php
@@ -37,7 +37,7 @@ class SubnetgroupManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeyassociationmanager.class.php
@@ -37,7 +37,7 @@ class WindowsKeyAssociationManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
+++ b/packages/web/lib/plugins/windowskey/class/windowskeymanager.class.php
@@ -35,7 +35,7 @@ class WindowsKeyManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/packages/web/lib/plugins/wolbroadcast/class/wolbroadcastmanager.class.php
+++ b/packages/web/lib/plugins/wolbroadcast/class/wolbroadcastmanager.class.php
@@ -35,7 +35,7 @@ class WolbroadcastManager extends FOGManagerController
     public function install()
     {
         $this->uninstall();
-        $sql = Schema::createTable(
+        $sql = $this->createTableSql(
             $this->tablename,
             true,
             array(

--- a/tests/plugin-tables-carry-column-defaults.test.php
+++ b/tests/plugin-tables-carry-column-defaults.test.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * A plugin install must build its table with a DEFAULT on every optional
+ * column -- and without one on the columns that must keep their teeth.
+ *
+ * GH-1245, the plugin half. Schema step 286 gives the optional columns of an
+ * existing install a default, but it cannot help a plugin table: install()
+ * calls uninstall(), uninstall() DROPS the table, and createTable() then
+ * rebuilt it with `NOT NULL` and no default on almost everything. 72 of the
+ * 99 columns across the plugin tables came back mandatory, and under the
+ * server's own sql_mode any INSERT omitting one fails with error 1364.
+ *
+ * Two defects, and the second was hiding the first:
+ *
+ *   - createTable() tested the caller's default for TRUTHINESS, so a default
+ *     of '0' -- an enum's first member, a boolean-ish flag -- was dropped on
+ *     the floor. Thirteen columns across the tree lost their default that
+ *     way, three of them in the LDAP plugin.
+ *   - what callers pass is a VALUE, not SQL. Emitting them raw put an
+ *     unquoted 0 against an ENUM, where 0 is an INDEX and index 0 is the
+ *     error value, and an unquoted zero date against a TIMESTAMP. The server
+ *     refuses both -- so fixing the truthiness test ALONE would have made
+ *     five CREATE TABLE statements fail outright. That is why
+ *     defaultLiteral() exists and why it is checked here.
+ *
+ * WHICH COLUMNS KEEP THEIR TEETH is not a judgement call and not a list kept
+ * by hand: FOGManagerController already holds the model's
+ * $databaseFieldsRequired, resolved up the inheritance chain by its
+ * constructor. Three kinds of column stay bare -- the primary key and
+ * auto-increment column, anything the model declares required, and anything
+ * whose name ends in ID. That is deliberately the SAME rule schema step 286
+ * applies, so a table built by a plugin install and a table migrated by the
+ * step say the same thing.
+ *
+ * The core managers are deliberately NOT converted: nothing calls a core
+ * manager's install() -- their tables come from commons/schema.php -- so
+ * changing 46 unreachable methods would be churn. They still get the
+ * defaultLiteral() fix, because createTable() is shared and without it four
+ * of them would now emit invalid DDL.
+ *
+ * The live half was proven separately, against a real 1.5 server:
+ * scripts/background_scripts/prove_plugin_table_defaults.php builds every
+ * plugin's CREATE TABLE through FOG's own boot, creates it under a scratch
+ * name, and reads the result back out of information_schema.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = array();
+$checks = 0;
+
+/**
+ * Records a check.
+ *
+ * @param bool   $ok      whether it passed
+ * @param string $message what failed, stated as the defect
+ *
+ * @return void
+ */
+function ptCheck($ok, $message)
+{
+    global $checks, $failures;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $message;
+    }
+}
+
+/**
+ * Lifts one method's source out of a class file by matching braces.
+ *
+ * The two methods under test are pure enough to run on their own, and running
+ * the SHIPPED source beats restating its rules in the test -- a restatement
+ * passes happily while the real thing is broken.
+ *
+ * @param string $src  the file contents
+ * @param string $name the method name
+ *
+ * @return string|false
+ */
+function ptGrabMethod($src, $name)
+{
+    $at = strpos($src, 'public static function ' . $name . '(');
+    if (false === $at) {
+        return false;
+    }
+    $open = strpos($src, '{', $at);
+    if (false === $open) {
+        return false;
+    }
+    $depth = 0;
+    for ($i = $open, $n = strlen($src); $i < $n; $i++) {
+        if ($src[$i] === '{') {
+            $depth++;
+        }
+        if ($src[$i] === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($src, $at, $i - $at + 1);
+            }
+        }
+    }
+
+    return false;
+}
+
+$schemaSrc = file_get_contents($web . '/lib/fog/schema.class.php');
+$managerSrc = file_get_contents($web . '/lib/fog/fogmanagercontroller.class.php');
+
+// ---------------------------------------------------------------
+// 1. defaultLiteral() renders a value as SQL, and knows an expression.
+// ---------------------------------------------------------------
+$literal = ptGrabMethod($schemaSrc, 'defaultLiteral');
+ptCheck(
+    false !== $literal,
+    'Schema::defaultLiteral() is gone. Caller defaults go back to being '
+    . 'emitted raw, which puts an unquoted 0 against an ENUM -- where 0 is '
+    . 'an index and index 0 is the error value -- and the server refuses the '
+    . 'CREATE TABLE outright.'
+);
+if (false !== $literal) {
+    eval('class PtLiteral { ' . $literal . ' }');
+    $cases = array(
+        // input, expected, why it matters
+        array('0', "'0'", "an enum's first member must be quoted; unquoted 0 "
+            . 'is an index and index 0 is the error value'),
+        array('1', "'1'", 'same, for the second member'),
+        array('0000-00-00 00:00:00', "'0000-00-00 00:00:00'",
+            'an unquoted zero date is a syntax error'),
+        array('https', "'https'", 'a bare word is not an SQL expression'),
+        array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP',
+            'quoting this turns a live default into the literal string'),
+        array('current_timestamp()', 'current_timestamp()',
+            'the parenthesised spelling is the same expression'),
+        array('NOW()', 'NOW()', 'likewise'),
+        array("'already'", "'already'",
+            'a caller that already quoted must not be double-quoted'),
+        array("('')", "('')",
+            "MySQL 8.0.13+ needs a TEXT default written as an expression"),
+        array("it's", "'it''s'", 'an embedded quote must be escaped'),
+    );
+    foreach ($cases as $case) {
+        list($in, $want, $why) = $case;
+        $got = PtLiteral::defaultLiteral($in);
+        ptCheck(
+            $got === $want,
+            sprintf(
+                'defaultLiteral(%s) returned %s, wanted %s -- %s',
+                var_export($in, true),
+                var_export($got, true),
+                var_export($want, true),
+                $why
+            )
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// 2. emptyDefaultFor() writes down the server's own implicit zero.
+// ---------------------------------------------------------------
+$empty = ptGrabMethod($schemaSrc, 'emptyDefaultFor');
+ptCheck(
+    false !== $empty,
+    'Schema::emptyDefaultFor() is gone, so createTableSql() has nothing to '
+    . 'fill an optional column with and every plugin table goes back to '
+    . 'being mandatory throughout.'
+);
+if (false !== $empty) {
+    // The LOB arm asks the server its version; everything else returns
+    // before touching it. A fake with just enough shape to answer that.
+    eval('
+        class PtFakeRow {
+            public $v;
+            public function __construct($v) { $this->v = $v; }
+            public function get($k) { return $this->v; }
+        }
+        class PtFakeDB {
+            public $v;
+            public function __construct($v) { $this->v = $v; }
+            public function query($sql) { return $this; }
+            public function fetch() { return new PtFakeRow($this->v); }
+        }
+    ');
+    $server = function ($version) use ($empty) {
+        // A fresh class each time: emptyDefaultFor() caches the version in a
+        // static, which is right in production and would hide a bug here.
+        static $n = 0;
+        $cls = 'PtEmpty' . (++$n);
+        eval(
+            'class ' . $cls . ' { public static $DB; ' . $empty . ' }'
+        );
+        $cls::$DB = new PtFakeDB($version);
+
+        return $cls;
+    };
+
+    $maria = $server('11.8.8-MariaDB');
+    // Every type the tree's createTable() callers actually write, because
+    // these are hand-written type strings, not information_schema's
+    // vocabulary: 'INTEGER' appears 120 times and does not match a rule
+    // written for 'int(11)'.
+    $simple = array(
+        'INTEGER' => '0',
+        'int(11)' => '0',
+        'BIGINT(20)' => '0',
+        'MEDIUMINT' => '0',
+        'TINYINT(1)' => '0',
+        'BOOLEAN' => '0',
+        'DATETIME' => 'current_timestamp()',
+        'TIMESTAMP' => 'current_timestamp()',
+        'VARCHAR(255)' => "''",
+        "ENUM('0', '1')" => "'0'",
+        "ENUM('shutdown','reboot','wol')" => "'shutdown'",
+        'LONGTEXT' => "''",
+        'TEXT' => "''",
+        'LONGBLOB' => "''",
+    );
+    foreach ($simple as $type => $want) {
+        $got = $maria::emptyDefaultFor($type);
+        ptCheck(
+            $got === $want,
+            sprintf(
+                'emptyDefaultFor(%s) returned %s on MariaDB, wanted %s. This '
+                . 'is the value the server used to substitute silently while '
+                . 'sql_mode was cleared; writing down a different one changes '
+                . 'behaviour rather than recording it.',
+                var_export($type, true),
+                var_export($got, true),
+                var_export($want, true)
+            )
+        );
+    }
+
+    $my8 = $server('8.0.36');
+    ptCheck(
+        $my8::emptyDefaultFor('longtext') === "('')",
+        'MySQL 8.0.13+ requires a TEXT/BLOB default written as a '
+        . 'parenthesised expression and rejects the bare literal, so the '
+        . 'CREATE TABLE fails on MySQL while passing on MariaDB.'
+    );
+    ptCheck(
+        $my8::emptyDefaultFor('INTEGER') === '0',
+        'the MySQL branch changed a non-LOB default'
+    );
+
+    $my57 = $server('5.7.44');
+    ptCheck(
+        null === $my57::emptyDefaultFor('longtext'),
+        'MySQL below 8.0.13 cannot carry a default on a TEXT or BLOB column '
+        . 'at all. Returning anything but null there makes the CREATE TABLE '
+        . 'fail on an older server; null means "leave it bare", which costs '
+        . 'nothing because save() writes the column and insertBatch() '
+        . 'backfills it.'
+    );
+}
+
+// ---------------------------------------------------------------
+// 3. createTable() no longer tests the default for truthiness.
+// ---------------------------------------------------------------
+ptCheck(
+    (bool) preg_match(
+        '/self::defaultLiteral\(\s*\$default\[\$i\]\s*\)/',
+        $schemaSrc
+    ),
+    'createTable() emits the caller default without defaultLiteral(). An '
+    . "unquoted 0 against an ENUM and an unquoted zero date against a "
+    . 'TIMESTAMP are both refused, so five CREATE TABLE statements in the '
+    . 'tree stop working.'
+);
+ptCheck(
+    !preg_match('/\n\s*\$default\[\$i\] \?\n/', $schemaSrc),
+    "createTable() tests the caller's default for truthiness again. '0' is "
+    . 'falsey in PHP, so a DEFAULT of \'0\' is silently dropped and the '
+    . 'column ships bare -- which is GH-1245 inflicted by the builder itself.'
+);
+
+// ---------------------------------------------------------------
+// 4. createTableSql() exists and keeps all three exemptions.
+// ---------------------------------------------------------------
+ptCheck(
+    false !== strpos($managerSrc, 'public function createTableSql('),
+    'FOGManagerController::createTableSql() is gone, so a plugin install '
+    . 'builds its table straight through createTable() again and every '
+    . 'optional column comes back mandatory.'
+);
+$wrapper = '';
+$at = strpos($managerSrc, 'public function createTableSql(');
+if (false !== $at) {
+    $wrapper = substr($managerSrc, $at, 4000);
+}
+$exemptions = array(
+    'databaseFieldsRequired' =>
+        'a column the model declares required would be given a default, so '
+        . 'the model refuses the save and the database accepts it -- every '
+        . 'write path that skips isValid() can still create the forbidden row',
+    '$prime' =>
+        'the primary key would be given a default',
+    '$autoin' =>
+        'the auto-increment column would be given a default, which MySQL '
+        . 'refuses outright',
+    "preg_match('/ID\$/', \$field)" =>
+        'a foreign key would be given a default, so an INSERT that forgets '
+        . 'the row it hangs off succeeds and makes a silent orphan',
+);
+foreach ($exemptions as $needle => $why) {
+    ptCheck(
+        false !== strpos($wrapper, $needle),
+        sprintf('createTableSql() no longer exempts %s: %s.', $needle, $why)
+    );
+}
+ptCheck(
+    false !== strpos($wrapper, '|| $hasDefault'),
+    'createTableSql() overwrites a default the caller passed explicitly. An '
+    . 'explicit default is a decision; this should only fill in where there '
+    . 'was nothing.'
+);
+
+// ---------------------------------------------------------------
+// 5. Every plugin install() goes through the wrapper.
+// ---------------------------------------------------------------
+$plugins = $web . '/lib/plugins';
+$seen = 0;
+$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($plugins));
+foreach ($it as $file) {
+    if (!preg_match('/manager\.class\.php$/', $file->getFilename())) {
+        continue;
+    }
+    $src = file_get_contents($file->getPathname());
+    if (false === strpos($src, 'createTableSql(')
+        && false === strpos($src, 'Schema::createTable(')
+    ) {
+        continue;
+    }
+    $seen++;
+    $short = str_replace($web . '/', '', $file->getPathname());
+    ptCheck(
+        false === strpos($src, 'Schema::createTable('),
+        sprintf(
+            '%s calls Schema::createTable() directly, so its table is built '
+            . 'with every optional column NOT NULL and no default -- and '
+            . 'schema step 286 cannot repair it, because install() drops the '
+            . 'table and builds it again.',
+            $short
+        )
+    );
+}
+ptCheck(
+    $seen >= 20,
+    sprintf(
+        'only %d plugin managers were scanned, so the check above passes '
+        . 'vacuously',
+        $seen
+    )
+);
+
+// The gate is only meaningful if the scan reached the tree at all.
+ptCheck(
+    strlen($schemaSrc) > 10000 && strlen($managerSrc) > 10000,
+    'the scan did not reach the sources and would pass vacuously'
+);
+
+if (count($failures) > 0) {
+    echo 'FAIL plugin-tables-carry-column-defaults ('
+        . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS plugin-tables-carry-column-defaults ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
The plugin half of GH-1245, following #1273 (schema step 286) and #1270 (the `insertBatch()` backfill).

## Why step 286 could not reach these

A plugin's table is not built by `commons/schema.php`. `install()` calls `uninstall()`, `uninstall()` **drops** the table, and `Schema::createTable()` rebuilds it — with `NOT NULL` and no default on almost everything. **72 of the 99 columns** across the plugin tables came back mandatory, and under the server's own `sql_mode` any INSERT omitting one fails with `error 1364`. So the step's repair was undone by the next plugin install.

## Two defects in `Schema::createTable()`, and the second was hiding the first

**1. It tested the caller's default for truthiness.** `'0'` is falsey in PHP, so a default of `'0'` — an enum's first member, a boolean-ish flag — was silently dropped and the column shipped bare. Thirteen columns lost their default that way: three in the LDAP plugin, ten across FOG's own `hosts`, `hostMAC`, `snapins` and `scheduledTasks` definitions. GH-1245 inflicted by the builder itself.

**2. What callers pass is a value, not SQL.** All thirty defaults in the tree are literals like `'0'` or `'0000-00-00 00:00:00'`; the sole exception is `CURRENT_TIMESTAMP`. Emitting them raw puts an unquoted `0` against an `ENUM` — where `0` is an *index*, and index 0 is the error value — and an unquoted zero date against a `TIMESTAMP`. The server refuses both.

Those two interact, and that's the part worth pausing on: **fixing the truthiness test alone would have made five `CREATE TABLE` statements fail outright.** The falsey bug had been masking the malformed literals for years. `Schema::defaultLiteral()` is what makes the first fix safe — it quotes a value, and leaves alone an expression, an already-quoted literal, and a parenthesised expression.

## The seam

`FOGManagerController::createTableSql()` — same signature as `Schema::createTable()`, so a call site changes by one token. It fills in a default for every `NOT NULL` column that has none, and leaves three kinds bare:

| Left bare | Why |
|---|---|
| primary key / auto-increment | MySQL refuses a default on `AUTO_INCREMENT` |
| anything the model declares required | the model refuses the save; the database should too |
| anything whose name ends in `ID` | an INSERT that forgets the row it hangs off should fail, not make a silent orphan |

That is **deliberately the same rule step 286 applies**, so a table built by a plugin install and a table migrated by the step say the same thing. Which columns are required is not a hand-kept list — `FOGManagerController::__construct()` already resolves the model's `$databaseFieldsRequired` up the inheritance chain, so the two statements cannot drift. A default the caller passed explicitly always wins.

## One trap worth naming

`Schema::emptyDefaultFor()`'s type vocabulary is **deliberately not identical** to step 286's, even though the rules look the same. The step reads `COLUMN_TYPE`, where an integer is always `int(11)`. Here the types are hand-written by the caller and the tree says `INTEGER` **120 times**, plus `BOOLEAN` and `TIMESTAMP`. Copying the step's regex across unwidened gives every integer column a default of `''` — which is exactly how I first wrote it, and what the new test caught. There is a comment on the branch saying so, because "align these two" is the obvious wrong refactor.

## Core managers are deliberately not converted

The 46 core managers still call `Schema::createTable()` directly. Their `install()` is **unreachable** — nothing calls it, their tables come from `commons/schema.php`, and step 286 has already defaulted them — so converting 46 dead methods would be churn. They still get the `defaultLiteral()` fix, because `createTable()` is shared and without it four of them would now emit invalid DDL.

The example plugin's commented template is updated too: it is what a plugin author copies, and left as it was it would keep teaching the pattern this fixes.

## Verification

Against a live 1.5.10 server through FOG's own boot. `scripts/background_scripts/prove_plugin_table_defaults.php` lifts each `install()` body out of the source, truncates it at the point it has built the SQL and evaluates it — so it runs the *same* call with the *same* arguments, without letting `uninstall()` drop a real table. It then creates the table under a `zzclaude_` scratch name, reads the result back out of `information_schema` and drops it.

- **20/20 plugin tables accepted.** 43 columns carrying a default, 40 left bare — every one of the 40 for a stated reason (model-required, foreign key, or primary key).
- **48/48 core tables accepted**, confirming the shared `defaultLiteral()` fix does not break them.
- No scratch tables left behind.

Two negative controls:

- wrapper filling nothing → 35 plugin columns flagged optional-and-still-mandatory;
- `defaultLiteral()` removed → five `CREATE TABLE` statements refused (1 plugin, 4 core).

## The test

`tests/plugin-tables-carry-column-defaults.test.php`, 60 checks, needs no database. It lifts the two shipped methods out of the class file and *runs* them rather than restating their rules — a restatement passes happily while the real thing is broken. Covers every type the tree's callers actually write, all three LOB outcomes (MariaDB, MySQL 8.0.13+, MySQL below that), and the structural half: the truthiness test does not come back, every plugin `install()` goes through the wrapper, and all three exemptions survive.

**Nine mutations, nine caught.**

## Downstream

None. No route classes added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)