### PR TITLE
Add a createTable seam that gives optional columns a default

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -1522,6 +1522,118 @@ abstract class FOGManagerController extends FOGBase
         return (int)$total;
     }
     /**
+     * Builds the CREATE TABLE for this manager's table, with a default on
+     * every column that is optional.
+     *
+     * GH-1245. Schema::createTable() emits `NOT NULL` with no DEFAULT for
+     * almost everything a caller does not spell out, which is the same defect
+     * schema step 348 repairs on an existing install -- except that the step
+     * can only repair a table that is already there. A plugin's createSql()
+     * runs as step 0 of its own schema(), so a plugin installed AFTER the
+     * migration gets a table built the old way: every optional column
+     * mandatory, and under the server's own sql_mode any INSERT omitting one
+     * fails with error 1364.
+     *
+     * WHICH COLUMNS KEEP THEIR TEETH. Not a judgement call, and not a list
+     * kept by hand -- FOG already states it, and this class already holds the
+     * statement: $databaseFieldsRequired, resolved up the model's inheritance
+     * chain by the constructor. Three kinds of column are left bare:
+     *
+     *   - the primary key and the auto-increment column;
+     *   - anything the model declares required;
+     *   - anything whose name ends in ID, because an INSERT that forgets the
+     *     row it hangs off should fail rather than make a silent orphan.
+     *     Deliberately not gated on an integer type: a foreign key stored as
+     *     text is no less a foreign key.
+     *
+     * That is deliberately the SAME rule schema step 348 applies, so a table
+     * a plugin creates and a table the step migrated say the same thing. Two
+     * installs of the same FOG should not have two different schemas.
+     *
+     * A default the caller passed explicitly always wins; this only fills in
+     * where there was nothing.
+     *
+     * The signature mirrors Schema::createTable() exactly so a call site
+     * changes by one token.
+     *
+     * @param string $name    What are we calling the table?
+     * @param bool   $exists  If not exists?
+     * @param array  $fields  The fields and names.
+     * @param array  $types   The types for the fields.
+     * @param array  $nulls   Which fields to have null or not.
+     * @param array  $default Default values for field(s).
+     * @param array  $unique  The unique fields.
+     * @param string $engine  The db engine for the table.
+     * @param string $charset The charset to use for the table.
+     * @param string $prime   The primary field, if one.
+     * @param string $autoin  The auto increment field.
+     *
+     * @return string
+     */
+    public function createTableSql(
+        $name,
+        $exists,
+        $fields,
+        $types,
+        $nulls,
+        $default,
+        $unique,
+        $engine = 'InnoDB',
+        $charset = 'utf8',
+        $prime = '',
+        $autoin = ''
+    ) {
+        $keep = [];
+        foreach ((array)$this->databaseFieldsRequired as $friendly) {
+            if (isset($this->databaseFields[$friendly])) {
+                $keep[strtolower($this->databaseFields[$friendly])] = true;
+            }
+        }
+        if ($prime) {
+            $keep[strtolower($prime)] = true;
+        }
+        if ($autoin) {
+            $keep[strtolower($autoin)] = true;
+        }
+        foreach ((array)$fields as $i => $field) {
+            $notNull = isset($nulls[$i]) && $nulls[$i] === false;
+            $hasDefault = isset($default[$i])
+                && false !== $default[$i]
+                && null !== $default[$i]
+                && '' !== $default[$i];
+            if (!$notNull
+                || $hasDefault
+                || isset($keep[strtolower($field)])
+                || preg_match('/ID$/', $field)
+            ) {
+                continue;
+            }
+            $fill = Schema::emptyDefaultFor($types[$i]);
+            if (null === $fill) {
+                // A TEXT or BLOB column on a server too old to carry a
+                // default for one. Nothing to do and nothing broken by
+                // leaving it: save() writes the column explicitly and
+                // insertBatch() backfills it.
+                continue;
+            }
+            $default[$i] = $fill;
+        }
+
+        return Schema::createTable(
+            $name,
+            $exists,
+            $fields,
+            $types,
+            $nulls,
+            $default,
+            $unique,
+            $engine,
+            $charset,
+            $prime,
+            $autoin
+        );
+    }
+    /**
      * Uninstalls the table.
      *
      * @return bool

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -476,6 +476,123 @@ class Schema extends FOGController
         return $string;
     }
     /**
+     * Renders a caller's default as an SQL literal.
+     *
+     * GH-1245. What callers pass is a VALUE, not SQL -- a literal like '0' or
+     * '0000-00-00 00:00:00'. The one exception is CURRENT_TIMESTAMP, which is
+     * an expression and must go in bare. Emitting them all raw puts an
+     * unquoted 0 against an ENUM -- where 0 is an INDEX, and index 0 is the
+     * error value -- and an unquoted zero date against a TIMESTAMP. The
+     * server refuses both, so a plugin's CREATE TABLE would die on itself.
+     *
+     * It never showed because the truthiness test in createTable() dropped
+     * every '0' before it could reach the server. Fixing that test is what
+     * makes these visible; they were wrong the whole time.
+     *
+     * Quoting is skipped for a value that is already quoted, for a
+     * parenthesised expression -- which is how MySQL 8.0.13+ requires a
+     * TEXT/BLOB default to be written -- and for the small set of bare SQL
+     * expressions FOG actually uses.
+     *
+     * @param string $value the default as the caller wrote it
+     *
+     * @return string
+     */
+    public static function defaultLiteral($value)
+    {
+        $value = (string)$value;
+        $trim = trim($value);
+        if (preg_match("/^'.*'$/s", $trim)
+            || preg_match('/^\(.*\)$/s', $trim)
+            || preg_match(
+                '/^(CURRENT_TIMESTAMP(\(\))?|NOW\(\)|NULL)$/i',
+                $trim
+            )
+        ) {
+            return $value;
+        }
+
+        return sprintf("'%s'", str_replace("'", "''", $value));
+    }
+    /**
+     * The DEFAULT an optional NOT NULL column of this type should carry.
+     *
+     * GH-1245. A column declared NOT NULL with no DEFAULT is only mandatory
+     * if something enforces it, and for nine years nothing did: PDODB cleared
+     * sql_mode on every connection, so the server downgraded the error to a
+     * warning and substituted an implicit zero. What is returned here IS that
+     * implicit zero, written down -- the same rule schema step 348 applies to
+     * an existing install and FOGBase::emptyValueFor() applies to a write. So
+     * a table a plugin creates and a table the step migrated end up saying
+     * the same thing, which is the point: two installs of the same FOG should
+     * not have two different schemas.
+     *
+     * The type vocabulary here is deliberately NOT step 348's. The step reads
+     * COLUMN_TYPE, where an integer is always 'int(11)' or 'bigint(20)';
+     * these types are hand-written by the caller, and the plugins say
+     * 'INTEGER' far more often than anything else, plus BOOLEAN and
+     * TIMESTAMP. A rule copied across without widening it silently gives
+     * every integer column a default of '' -- so the two are not identical on
+     * purpose.
+     *
+     * @param string $type the column type, as handed to createTable()
+     *
+     * @return string|null the SQL literal, or null if this server cannot
+     *                     carry a default for this type at all
+     */
+    public static function emptyDefaultFor($type)
+    {
+        $type = trim((string)$type);
+        $lob = (bool)preg_match(
+            '/^(tiny|medium|long)?(text|blob)\b/i',
+            $type
+        );
+        if ($lob) {
+            // MySQL could not attach a DEFAULT to a TEXT or BLOB column
+            // until 8.0.13 and still requires it parenthesised as an
+            // expression; MariaDB has taken the plain literal since 10.2.1.
+            // Below that there is nothing to do and nothing broken by
+            // skipping: save() writes the column explicitly and
+            // insertBatch() backfills it.
+            static $lobStyle = null;
+            if (null === $lobStyle) {
+                $version = (string)self::$DB
+                    ->query('SELECT VERSION() AS `v`')
+                    ->fetch()
+                    ->get('v');
+                if (false !== stripos($version, 'mariadb')) {
+                    $lobStyle = 'literal';
+                } else {
+                    preg_match('/^(\d+)\.(\d+)\.(\d+)/', $version, $m);
+                    $lobStyle = count($m) === 4
+                        && (int)$m[1] * 10000
+                            + (int)$m[2] * 100
+                            + (int)$m[3] >= 80013
+                        ? 'expression'
+                        : 'none';
+                }
+            }
+            if ($lobStyle === 'none') {
+                return null;
+            }
+
+            return $lobStyle === 'expression' ? "('')" : "''";
+        }
+        if (preg_match('/^(datetime|timestamp)\b/i', $type)) {
+            return 'current_timestamp()';
+        }
+        if (preg_match('/^(tiny|small|medium|big)?int(eger)?\b/i', $type)
+            || preg_match('/^bool(ean)?\b/i', $type)
+        ) {
+            return '0';
+        }
+        if (preg_match("/^(enum|set)\\s*\\(\\s*'((?:[^']|'')*)'/i", $type, $member)) {
+            return "'" . $member[2] . "'";
+        }
+
+        return "''";
+    }
+    /**
      * SQL create table syntax
      *
      * @param string $name    What are we calling the table?
@@ -540,10 +657,18 @@ class Schema extends FOGController
                     ''
                 ),
                 (
-                    $default[$i] ?
+                    // Truthiness dropped a DEFAULT of '0' on the floor: '0'
+                    // is falsey in PHP, so a caller asking for DEFAULT '0'
+                    // -- an enum's first member, a boolean-ish flag -- got a
+                    // bare NOT NULL column instead. That is GH-1245's defect
+                    // inflicted by the builder itself.
+                    isset($default[$i])
+                    && false !== $default[$i]
+                    && null !== $default[$i]
+                    && '' !== $default[$i] ?
                     sprintf(
                         ' DEFAULT %s',
-                        $default[$i]
+                        self::defaultLiteral($default[$i])
                     ) :
                     ''
                 ),

--- a/tests/createtable-column-defaults.test.php
+++ b/tests/createtable-column-defaults.test.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * A plugin must build its table with a DEFAULT on every optional column --
+ * and without one on the columns that must keep their teeth.
+ *
+ * GH-1245, the createTable() half. Schema step 348 gives the optional columns
+ * of an existing install a default, but it can only repair a table that is
+ * already there. On this branch a plugin's createSql() runs as step 0 of its
+ * own schema(), applied by Schema::applyUpdates() -- so a plugin installed
+ * AFTER the migration gets a table built the old way: `NOT NULL` and no
+ * default on almost everything, and under the server's own sql_mode any
+ * INSERT omitting one fails with error 1364.
+ *
+ * Two defects in Schema::createTable(), and the second was hiding the first:
+ *
+ *   - it tested the caller's default for TRUTHINESS, so a default of '0' --
+ *     an enum's first member, a boolean-ish flag -- was dropped on the floor;
+ *   - what callers pass is a VALUE, not SQL. Emitting them raw puts an
+ *     unquoted 0 against an ENUM, where 0 is an INDEX and index 0 is the
+ *     error value, and an unquoted zero date against a TIMESTAMP. The server
+ *     refuses both. That is why defaultLiteral() exists, and it is not
+ *     hypothetical: on dev-branch, where the same two fixes went in first,
+ *     repairing the truthiness test ALONE made five CREATE TABLE statements
+ *     fail outright.
+ *
+ * WHICH COLUMNS KEEP THEIR TEETH is not a judgement call and not a list kept
+ * by hand: FOGManagerController already holds the model's
+ * $databaseFieldsRequired, resolved up the inheritance chain by its
+ * constructor. Three kinds of column stay bare -- the primary key and
+ * auto-increment column, anything the model declares required, and anything
+ * whose name ends in ID. That is deliberately the SAME rule schema step 348
+ * applies, so a table a plugin creates and a table the step migrated say the
+ * same thing.
+ *
+ * WHAT IS NOT CHECKED HERE, and where it is. That every plugin actually
+ * routes through the wrapper cannot be asserted from this repository: since
+ * ADR 0009 the bundled plugins live in FOGProject/fog-plugins and arrive as a
+ * pinned release asset, so packages/web/lib/plugins is gitignored staging and
+ * is empty in a fresh clone. That check lives in fog-plugins' own suite. What
+ * this file pins is the half that ships here -- the seam itself, and the
+ * values it fills in.
+ *
+ * The live half was proven separately against the local 1.6 install:
+ * scripts/background_scripts/prove_plugin_table_defaults_16.php calls every
+ * plugin manager's createSql(), creates the table under a scratch name, and
+ * reads the result back out of information_schema.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = array();
+$checks = 0;
+
+/**
+ * Records a check.
+ *
+ * @param bool   $ok      whether it passed
+ * @param string $message what failed, stated as the defect
+ *
+ * @return void
+ */
+function ptCheck($ok, $message)
+{
+    global $checks, $failures;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $message;
+    }
+}
+
+/**
+ * Lifts one method's source out of a class file by matching braces.
+ *
+ * The two methods under test are pure enough to run on their own, and running
+ * the SHIPPED source beats restating its rules in the test -- a restatement
+ * passes happily while the real thing is broken.
+ *
+ * @param string $src  the file contents
+ * @param string $name the method name
+ *
+ * @return string|false
+ */
+function ptGrabMethod($src, $name)
+{
+    $at = strpos($src, 'public static function ' . $name . '(');
+    if (false === $at) {
+        return false;
+    }
+    $open = strpos($src, '{', $at);
+    if (false === $open) {
+        return false;
+    }
+    $depth = 0;
+    for ($i = $open, $n = strlen($src); $i < $n; $i++) {
+        if ($src[$i] === '{') {
+            $depth++;
+        }
+        if ($src[$i] === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($src, $at, $i - $at + 1);
+            }
+        }
+    }
+
+    return false;
+}
+
+$schemaSrc = file_get_contents($web . '/lib/fog/schema.class.php');
+$managerSrc = file_get_contents($web . '/lib/fog/fogmanagercontroller.class.php');
+
+// ---------------------------------------------------------------
+// 1. defaultLiteral() renders a value as SQL, and knows an expression.
+// ---------------------------------------------------------------
+$literal = ptGrabMethod($schemaSrc, 'defaultLiteral');
+ptCheck(
+    false !== $literal,
+    'Schema::defaultLiteral() is gone. Caller defaults go back to being '
+    . 'emitted raw, which puts an unquoted 0 against an ENUM -- where 0 is '
+    . 'an index and index 0 is the error value -- and the server refuses the '
+    . 'CREATE TABLE outright.'
+);
+if (false !== $literal) {
+    eval('class PtLiteral { ' . $literal . ' }');
+    $cases = array(
+        // input, expected, why it matters
+        array('0', "'0'", "an enum's first member must be quoted; unquoted 0 "
+            . 'is an index and index 0 is the error value'),
+        array('1', "'1'", 'same, for the second member'),
+        array('0000-00-00 00:00:00', "'0000-00-00 00:00:00'",
+            'an unquoted zero date is a syntax error'),
+        array('https', "'https'", 'a bare word is not an SQL expression'),
+        array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP',
+            'quoting this turns a live default into the literal string'),
+        array('current_timestamp()', 'current_timestamp()',
+            'the parenthesised spelling is the same expression'),
+        array('NOW()', 'NOW()', 'likewise'),
+        array("'already'", "'already'",
+            'a caller that already quoted must not be double-quoted'),
+        array("('')", "('')",
+            "MySQL 8.0.13+ needs a TEXT default written as an expression"),
+        array("it's", "'it''s'", 'an embedded quote must be escaped'),
+    );
+    foreach ($cases as $case) {
+        list($in, $want, $why) = $case;
+        $got = PtLiteral::defaultLiteral($in);
+        ptCheck(
+            $got === $want,
+            sprintf(
+                'defaultLiteral(%s) returned %s, wanted %s -- %s',
+                var_export($in, true),
+                var_export($got, true),
+                var_export($want, true),
+                $why
+            )
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// 2. emptyDefaultFor() writes down the server's own implicit zero.
+// ---------------------------------------------------------------
+$empty = ptGrabMethod($schemaSrc, 'emptyDefaultFor');
+ptCheck(
+    false !== $empty,
+    'Schema::emptyDefaultFor() is gone, so createTableSql() has nothing to '
+    . 'fill an optional column with and every plugin table goes back to '
+    . 'being mandatory throughout.'
+);
+if (false !== $empty) {
+    // The LOB arm asks the server its version; everything else returns
+    // before touching it. A fake with just enough shape to answer that.
+    eval('
+        class PtFakeRow {
+            public $v;
+            public function __construct($v) { $this->v = $v; }
+            public function get($k) { return $this->v; }
+        }
+        class PtFakeDB {
+            public $v;
+            public function __construct($v) { $this->v = $v; }
+            public function query($sql) { return $this; }
+            public function fetch() { return new PtFakeRow($this->v); }
+        }
+    ');
+    $server = function ($version) use ($empty) {
+        // A fresh class each time: emptyDefaultFor() caches the version in a
+        // static, which is right in production and would hide a bug here.
+        static $n = 0;
+        $cls = 'PtEmpty' . (++$n);
+        eval(
+            'class ' . $cls . ' { public static $DB; ' . $empty . ' }'
+        );
+        $cls::$DB = new PtFakeDB($version);
+
+        return $cls;
+    };
+
+    $maria = $server('11.8.8-MariaDB');
+    // Every type the tree's createTable() callers actually write, because
+    // these are hand-written type strings, not information_schema's
+    // vocabulary: 'INTEGER' appears 120 times and does not match a rule
+    // written for 'int(11)'.
+    $simple = array(
+        'INTEGER' => '0',
+        'int(11)' => '0',
+        'BIGINT(20)' => '0',
+        'MEDIUMINT' => '0',
+        'TINYINT(1)' => '0',
+        'BOOLEAN' => '0',
+        'DATETIME' => 'current_timestamp()',
+        'TIMESTAMP' => 'current_timestamp()',
+        'VARCHAR(255)' => "''",
+        "ENUM('0', '1')" => "'0'",
+        "ENUM('shutdown','reboot','wol')" => "'shutdown'",
+        'LONGTEXT' => "''",
+        'TEXT' => "''",
+        'LONGBLOB' => "''",
+    );
+    foreach ($simple as $type => $want) {
+        $got = $maria::emptyDefaultFor($type);
+        ptCheck(
+            $got === $want,
+            sprintf(
+                'emptyDefaultFor(%s) returned %s on MariaDB, wanted %s. This '
+                . 'is the value the server used to substitute silently while '
+                . 'sql_mode was cleared; writing down a different one changes '
+                . 'behaviour rather than recording it.',
+                var_export($type, true),
+                var_export($got, true),
+                var_export($want, true)
+            )
+        );
+    }
+
+    $my8 = $server('8.0.36');
+    ptCheck(
+        $my8::emptyDefaultFor('longtext') === "('')",
+        'MySQL 8.0.13+ requires a TEXT/BLOB default written as a '
+        . 'parenthesised expression and rejects the bare literal, so the '
+        . 'CREATE TABLE fails on MySQL while passing on MariaDB.'
+    );
+    ptCheck(
+        $my8::emptyDefaultFor('INTEGER') === '0',
+        'the MySQL branch changed a non-LOB default'
+    );
+
+    $my57 = $server('5.7.44');
+    ptCheck(
+        null === $my57::emptyDefaultFor('longtext'),
+        'MySQL below 8.0.13 cannot carry a default on a TEXT or BLOB column '
+        . 'at all. Returning anything but null there makes the CREATE TABLE '
+        . 'fail on an older server; null means "leave it bare", which costs '
+        . 'nothing because save() writes the column and insertBatch() '
+        . 'backfills it.'
+    );
+}
+
+// ---------------------------------------------------------------
+// 3. createTable() no longer tests the default for truthiness.
+// ---------------------------------------------------------------
+ptCheck(
+    (bool) preg_match(
+        '/self::defaultLiteral\(\s*\$default\[\$i\]\s*\)/',
+        $schemaSrc
+    ),
+    'createTable() emits the caller default without defaultLiteral(). An '
+    . "unquoted 0 against an ENUM and an unquoted zero date against a "
+    . 'TIMESTAMP are both refused, so five CREATE TABLE statements in the '
+    . 'tree stop working.'
+);
+ptCheck(
+    !preg_match('/\n\s*\$default\[\$i\] \?\n/', $schemaSrc),
+    "createTable() tests the caller's default for truthiness again. '0' is "
+    . 'falsey in PHP, so a DEFAULT of \'0\' is silently dropped and the '
+    . 'column ships bare -- which is GH-1245 inflicted by the builder itself.'
+);
+
+// ---------------------------------------------------------------
+// 4. createTableSql() exists and keeps all three exemptions.
+// ---------------------------------------------------------------
+ptCheck(
+    false !== strpos($managerSrc, 'public function createTableSql('),
+    'FOGManagerController::createTableSql() is gone, so a plugin install '
+    . 'builds its table straight through createTable() again and every '
+    . 'optional column comes back mandatory.'
+);
+$wrapper = '';
+$at = strpos($managerSrc, 'public function createTableSql(');
+if (false !== $at) {
+    $wrapper = substr($managerSrc, $at, 4000);
+}
+$exemptions = array(
+    'databaseFieldsRequired' =>
+        'a column the model declares required would be given a default, so '
+        . 'the model refuses the save and the database accepts it -- every '
+        . 'write path that skips isValid() can still create the forbidden row',
+    '$prime' =>
+        'the primary key would be given a default',
+    '$autoin' =>
+        'the auto-increment column would be given a default, which MySQL '
+        . 'refuses outright',
+    "preg_match('/ID\$/', \$field)" =>
+        'a foreign key would be given a default, so an INSERT that forgets '
+        . 'the row it hangs off succeeds and makes a silent orphan',
+);
+foreach ($exemptions as $needle => $why) {
+    ptCheck(
+        false !== strpos($wrapper, $needle),
+        sprintf('createTableSql() no longer exempts %s: %s.', $needle, $why)
+    );
+}
+ptCheck(
+    false !== strpos($wrapper, '|| $hasDefault'),
+    'createTableSql() overwrites a default the caller passed explicitly. An '
+    . 'explicit default is a decision; this should only fill in where there '
+    . 'was nothing.'
+);
+
+// The gate is only meaningful if the scan reached the tree at all.
+ptCheck(
+    strlen($schemaSrc) > 10000 && strlen($managerSrc) > 10000,
+    'the scan did not reach the sources and would pass vacuously'
+);
+
+if (count($failures) > 0) {
+    echo 'FAIL createtable-column-defaults ('
+        . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS createtable-column-defaults ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
Port of #1274 (dev-branch) to the 1.6 line. GH-1245.

## Why step 348 could not reach these

Schema step 348 gives the optional columns of an existing install a default, but it can only repair a table that is **already there**. A plugin's `createSql()` runs as step 0 of its own `schema()`, applied by `Schema::applyUpdates()` — so a plugin installed *after* the migration gets a table built the old way: `NOT NULL` and no default on almost everything. Under the server's own `sql_mode`, any INSERT omitting one fails with `error 1364`.

Measured against the live 1.6 install: **31 columns** across the bundled plugins are mandatory purely by accident.

## Two defects in `Schema::createTable()`, and the second was hiding the first

**1. It tested the caller's default for truthiness.** `'0'` is falsey in PHP, so a default of `'0'` — an enum's first member, a boolean-ish flag — was dropped on the floor and the column shipped bare. GH-1245 inflicted by the builder itself.

**2. What callers pass is a value, not SQL.** Emitting them raw puts an unquoted `0` against an `ENUM` — where `0` is an *index*, and index 0 is the error value — and an unquoted zero date against a `TIMESTAMP`. The server refuses both.

On dev-branch that interaction was not hypothetical: **repairing the truthiness test alone made five `CREATE TABLE` statements fail outright.** `Schema::defaultLiteral()` is what makes the first fix safe — it quotes a value and leaves alone an expression, an already-quoted literal, and a parenthesised expression.

## The seam

`FOGManagerController::createTableSql()` — same signature as `Schema::createTable()`, so a call site changes by one token. It fills a default into every `NOT NULL` column that has none, and leaves three kinds bare:

| Left bare | Why |
|---|---|
| primary key / auto-increment | MySQL refuses a default on `AUTO_INCREMENT` |
| anything the model declares required | the model refuses the save; the database should too |
| anything whose name ends in `ID` | an INSERT that forgets the row it hangs off should fail, not make a silent orphan |

Deliberately the same rule step 348 applies, so a table a plugin creates and a table the step migrated say the same thing. Which columns are required is not a hand-kept list — the constructor already resolves the model's `$databaseFieldsRequired` up the inheritance chain. A default the caller passed explicitly always wins.

## One trap worth naming

`Schema::emptyDefaultFor()`'s type vocabulary is **deliberately not** step 348's, even though the rules look identical. The step reads `COLUMN_TYPE`, where an integer is always `int(11)`. These types are hand-written by the caller and the plugins say `INTEGER` far more often than anything else, plus `BOOLEAN` and `TIMESTAMP`. Copying the step's regex across unwidened gives every integer column a default of `''` — which is how it was first written on dev-branch, and what the test caught. There's a comment saying so, because "align these two" is the obvious wrong refactor.

## This is safe to merge on its own

Verified against the live 1.6 database with the **currently pinned plugins unmodified**: all 23 tables still build and the server accepts every one. So nothing breaks between this landing and the plugins release that uses the seam. (On dev-branch the equivalent check was the reason the two halves had to be reasoned about separately — there, five DDLs *would* have broken.)

## Verification

`scripts/background_scripts/prove_plugin_table_defaults_16.php` calls every plugin manager's `createSql()`, creates the table under a `zzclaude_` scratch name, reads the result back out of `information_schema`, and drops it.

- **core only, plugins untouched:** 23/23 accepted, 29 columns defaulted, 83 bare.
- **with the plugin side applied:** 23/23 accepted, **60** defaulted, 52 bare — every one of the 52 for a stated reason.
- **negative control** (wrapper filling nothing): 31 columns back to optional-and-still-mandatory.
- No scratch tables left behind.

## The test

`tests/createtable-column-defaults.test.php`, 38 checks, no database. It lifts the two shipped methods out of the class file and *runs* them rather than restating their rules. **Nine mutations, nine caught.**

That every plugin routes through the wrapper cannot be asserted from this repo: since ADR 0009 the bundled plugins live in `FOGProject/fog-plugins` and arrive as a pinned release asset, so `packages/web/lib/plugins` is gitignored staging and empty in a fresh clone. That check lives in fog-plugins' own suite.

## Downstream

`FOGProject/fog-plugins` — a companion PR switches its 25 call sites to the wrapper. It needs this merged first, then a plugins release and a `FOG_PLUGINS_VERSION` bump here.

No route classes added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)