### PR TITLE
Bump FOG_PLUGINS_VERSION to v1.6.13

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.12');
+        define('FOG_PLUGINS_VERSION', 'v1.6.13');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Picks up FOGProject/fog-plugins#23 (released as [v1.6.13](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.13)), which routes all 25 plugin table builds through `FOGManagerController::createTableSql()` so their optional columns carry a `DEFAULT`. GH-1245.

Schema step 348 repairs the tables an install already has. It cannot repair a plugin's: `createSql()` runs as step 0 of the plugin's own `schema()`, so a plugin installed *after* the migration rebuilt its table the old way — every optional column mandatory, and any INSERT omitting one failing with `error 1364`.

Measured against a live 1.6 install, across the 23 tables the probe can build:

| | v1.6.12 | v1.6.13 |
|---|---|---|
| DDL accepted by the server | 23/23 | 23/23 |
| columns carrying a default | 29 | **60** |
| columns left bare | 83 | 52 |

The seam those plugins call landed in #1275, which is already on this branch — so the pin can move. Without it a plugin install would die on `Call to undefined method`, which is why the release notes say the two have to move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)