### PR TITLE
Bump FOG_PLUGINS_VERSION to v1.6.14

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.13');
+        define('FOG_PLUGINS_VERSION', 'v1.6.14');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Picks up FOGProject/fog-plugins#24 (released as [v1.6.14](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.14)): wolbroadcast adopts the non-destructive `schema()` contract.

It was the last plugin still building its table from `install()` directly, and `install()` called `uninstall()` first — which is a **DROP**. `Plugin::installdb()` falls back to calling `install()` when a manager has no `schema()`, and wolbroadcast had none, so that drop ran on **every install** and took the user's broadcast addresses with it.

Step 0 is now a `CREATE TABLE IF NOT EXISTS`, so on an existing install the change is a no-op that records `pSchema = 1`. Nothing is dropped and no data moves.

It also closes the last verification gap in the GH-1245 plugin work: with `createSql()` public the probe can call it, so the live check covers **24 tables rather than 23** — all accepted, 61 columns carrying a default.

No core change needed — the seam these plugins call landed in #1275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)