### PR TITLE
ADR 0020 phase 2: the event-frame columns, inert

### DIFF
--- a/bin/verify-plugin-install-nondestructive.php
+++ b/bin/verify-plugin-install-nondestructive.php
@@ -72,28 +72,6 @@ if ('' === $webroot || !file_exists($webroot . '/commons/base.inc.php')) {
 require_once $webroot . '/commons/base.inc.php';
 
 /**
- * FOGBase::$DB is protected, so reach it from inside a subclass.
- *
- * @category VerifyPluginInstall
- * @package  FOGProject
- * @author   Tom Elliott <tommygunsster@gmail.com>
- * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
- * @link     https://fogproject.org
- */
-class VerifyPluginInstallDb extends \FOG\FOGBase
-{
-    /**
-     * The shared PDODB.
-     *
-     * @return object
-     */
-    public static function db()
-    {
-        return self::$DB;
-    }
-}
-
-/**
  * Reports one check.
  *
  * Output goes to STDERR because commons/base.inc.php starts an output buffer
@@ -194,23 +172,32 @@ if ($ddl === $sql) {
 }
 
 $fail = 0;
-$db   = VerifyPluginInstallDb::db();
+
+// A plain PDO rather than FOGBase::$DB, which is protected and would need a
+// subclass declared here -- and a class declared in bin/ breaks the tree-wide
+// checks in tests/all-classes-load.test.php and its two siblings, which
+// require every declared class to sit in a file named after it. Booting the
+// tree above is what defines these constants.
+$db = new \PDO(
+    sprintf('mysql:host=%s;dbname=%s', DATABASE_HOST, DATABASE_NAME),
+    DATABASE_USERNAME,
+    DATABASE_PASSWORD
+);
+$db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 try {
-    $db->query(sprintf('DROP TABLE IF EXISTS `%s`', $scratch));
-    $db->query($ddl);
+    $db->exec(sprintf('DROP TABLE IF EXISTS `%s`', $scratch));
+    $db->exec($ddl);
     vpiSay(sprintf('run 1: `%s` created', $scratch));
 
-    $db->query(vpiInsertFor($sql, $scratch));
-    $before = (int)$db->query(sprintf('SELECT COUNT(*) AS c FROM `%s`', $scratch))
-        ->fetch()
-        ->get('c');
+    $db->exec(vpiInsertFor($sql, $scratch));
+    $before = (int)$db->query(sprintf('SELECT COUNT(*) FROM `%s`', $scratch))
+        ->fetchColumn();
     vpiSay(sprintf('row inserted, count = %d', $before));
 
     // Exactly what a second plugin install now runs.
-    $db->query($ddl);
-    $after = (int)$db->query(sprintf('SELECT COUNT(*) AS c FROM `%s`', $scratch))
-        ->fetch()
-        ->get('c');
+    $db->exec($ddl);
+    $after = (int)$db->query(sprintf('SELECT COUNT(*) FROM `%s`', $scratch))
+        ->fetchColumn();
     vpiSay(sprintf('run 2 (re-install): count = %d', $after));
 
     if (1 === $before && 1 === $after) {
@@ -219,10 +206,10 @@ try {
         vpiSay(sprintf('FAIL: row count went %d -> %d', $before, $after));
         $fail = 1;
     }
-} catch (Exception $e) {
+} catch (\Exception $e) {
     vpiSay('FAIL: ' . $e->getMessage());
     $fail = 1;
 }
-$db->query(sprintf('DROP TABLE IF EXISTS `%s`', $scratch));
+$db->exec(sprintf('DROP TABLE IF EXISTS `%s`', $scratch));
 vpiSay('scratch table dropped');
 exit($fail);

--- a/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
+++ b/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-proposed -- phases 0 and 1 of the Migration section are implemented on
+accepted -- phases 0, 1 and 2 of the Migration section are implemented on
 `working-1.6`
 
-Those two are the ones the ADR marks as worth doing whatever happens to the
-rest, and neither touches the database or changes behaviour: phase 0 was two
+Phases 0 and 1 are the ones the ADR marks as worth doing whatever happens to
+the rest, and neither touches the database or changes behaviour: phase 0 was two
 live defects found while writing this (`UserTrack::json()` setting a key no
 model declares, and the list formatter falling out of its switch into a blank
 cell), and phase 1 writes the convention down -- the six frame keys are
@@ -14,8 +14,25 @@ documented on `FOGController` beside `createdBy`/`createdTime`, and
 `userTracking`'s three `utAction` codes are class constants that its two
 readers now share instead of each spelling the same literals.
 
-Phases 2 to 5 add columns and are **not** started. They need this ADR
-accepted first, and they are what gates ADR 0023's item 5.
+Phase 2 is schema steps 349 (`userTracking`: `utCreatedBy`, `utIP`,
+`utHostName`) and 350 (`history`: `hType`, `hSubjectType`, `hSubjectID`,
+`hSubjectLabel`), one step per table, each a guarded closure in the style of
+steps 336/338/341. The columns exist and nothing writes to them: no model maps
+them, so a row saved through the ORM leaves every one at its default. That was
+tested rather than assumed, against a copy of a real database -- 2,256
+`history` rows and the full `userTracking` table survived the ALTER, a re-run
+of both steps was a no-op, and a write through each model left all seven
+columns untouched.
+
+Phases 3 to 5 -- writers, then readers, then the backfill and the index drop
+-- are **not** started. Phase 4 is what gates ADR 0023's item 5.
+
+One coverage note worth keeping visible: `tests/schema-executes.test.php`
+deliberately skips closure steps, so CI's schema replay does **not** exercise
+349 or 350. Real installs do run them; only the harness does not. The
+end-state guarantee for those two steps therefore rests on
+`commons/schema-expected.php` -- amended by hand here, and confirmed column by
+column against a database that had actually run them.
 
 ## Context
 

--- a/docs/adr/0023-activity-is-a-view-and-retention-is-a-registry.md
+++ b/docs/adr/0023-activity-is-a-view-and-retention-is-a-registry.md
@@ -309,7 +309,8 @@ either companion ADR. 6 and 7 are gated, deliberately.
   per table.
 - The dashboard gains a card and no new timer.
 - A `report.view` holder stops getting a movement log for named employees as a
-  side effect — pending Decision 1's signoff.
+  side effect. Signed off and shipped as item 1; a role holding `report.view`
+  loses user tracking on deploy and is re-granted deliberately.
 - Retention is one mechanism for four tables rather than four mechanisms.
 - Upgraded servers keep every existing `userTracking` row until an
   administrator decides otherwise, and are told that they hold them.

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -176,13 +176,17 @@ return [
             ],
         ],
         'history' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `history` ( `hID` int(11) NOT NULL AUTO_INCREMENT, `hText` varchar(255) NOT NULL DEFAULT \'\', `hUser` varchar(200) NOT NULL DEFAULT \'\', `hTime` timestamp NOT NULL DEFAULT current_timestamp(), `hIP` varchar(50) NOT NULL DEFAULT \'\', PRIMARY KEY (`hID`), UNIQUE KEY `updateTime` (`hText`,`hTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `history` ( `hID` int(11) NOT NULL AUTO_INCREMENT, `hText` varchar(255) NOT NULL DEFAULT \'\', `hUser` varchar(200) NOT NULL DEFAULT \'\', `hTime` timestamp NOT NULL DEFAULT current_timestamp(), `hIP` varchar(50) NOT NULL DEFAULT \'\', `hType` varchar(16) NOT NULL DEFAULT \'\', `hSubjectType` varchar(64) NOT NULL DEFAULT \'\', `hSubjectID` int(11) DEFAULT NULL, `hSubjectLabel` varchar(200) NOT NULL DEFAULT \'\', PRIMARY KEY (`hID`), UNIQUE KEY `updateTime` (`hText`,`hTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'hID' => 'int(11) NOT NULL',
                 'hText' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'hUser' => 'varchar(200) NOT NULL DEFAULT \'\'',
                 'hTime' => 'timestamp NOT NULL DEFAULT current_timestamp()',
                 'hIP' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'hType' => 'varchar(16) NOT NULL DEFAULT \'\'',
+                'hSubjectType' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'hSubjectID' => 'int(11) DEFAULT NULL',
+                'hSubjectLabel' => 'varchar(200) NOT NULL DEFAULT \'\'',
             ],
         ],
         'hookEvents' => [
@@ -917,7 +921,7 @@ return [
             ],
         ],
         'userTracking' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `userTracking` ( `utID` int(11) NOT NULL AUTO_INCREMENT, `utHostID` int(11) NOT NULL, `utUserName` varchar(50) NOT NULL, `utAction` varchar(2) NOT NULL DEFAULT \'\', `utDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `utDesc` varchar(250) NOT NULL DEFAULT \'\', `utDate` date DEFAULT NULL, `utAnon3` varchar(2) NOT NULL DEFAULT \'\', PRIMARY KEY (`utID`), KEY `new_index` (`utHostID`), KEY `new_index1` (`utUserName`), KEY `new_index2` (`utAction`), KEY `new_index3` (`utDateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `userTracking` ( `utID` int(11) NOT NULL AUTO_INCREMENT, `utHostID` int(11) NOT NULL, `utUserName` varchar(50) NOT NULL, `utAction` varchar(2) NOT NULL DEFAULT \'\', `utDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `utDesc` varchar(250) NOT NULL DEFAULT \'\', `utDate` date DEFAULT NULL, `utAnon3` varchar(2) NOT NULL DEFAULT \'\', `utCreatedBy` varchar(30) NOT NULL DEFAULT \'\', `utIP` varchar(50) NOT NULL DEFAULT \'\', `utHostName` varchar(16) NOT NULL DEFAULT \'\', PRIMARY KEY (`utID`), KEY `new_index` (`utHostID`), KEY `new_index1` (`utUserName`), KEY `new_index2` (`utAction`), KEY `new_index3` (`utDateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'utID' => 'int(11) NOT NULL',
                 'utHostID' => 'int(11) NOT NULL',
@@ -927,6 +931,9 @@ return [
                 'utDesc' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'utDate' => 'date DEFAULT NULL',
                 'utAnon3' => 'varchar(2) NOT NULL DEFAULT \'\'',
+                'utCreatedBy' => 'varchar(30) NOT NULL DEFAULT \'\'',
+                'utIP' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'utHostName' => 'varchar(16) NOT NULL DEFAULT \'\'',
             ],
         ],
         'virus' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -6778,3 +6778,152 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 349
+$this->schema[] = [
+    // ADR 0020 phase 2, userTracking half: add the frame columns, write
+    // nothing to them.
+    //
+    // `userTracking` records a login or logout on a host. Three of the six
+    // frame keys have no column at all today, so a row cannot say who in FOG
+    // is responsible, where it arrived from, or which host it was about once
+    // that host is deleted.
+    //
+    // utCreatedBy -- the FOG identity, matching taskLog.createdBy's width.
+    // This is NOT utUserName. utUserName is the endpoint's OS account, which
+    // is the subject of the event, not its actor; ADR 0020 decision 3 calls
+    // that the load-bearing correction and the reason to add a column rather
+    // than reinterpret the one that is there. save() auto-fills createdBy
+    // once the model maps it, which is phase 3, not this step.
+    //
+    // utIP -- the origin address. The estate has two widths for this frame
+    // key, taskLog.ip varchar(15) and history.hIP varchar(50). Taking the
+    // wider one deliberately: 15 characters cannot hold an IPv6 address, and
+    // a new column has no reason to inherit that.
+    //
+    // utHostName -- the denormalized subject label. varchar(16) matches
+    // hosts.hostName, which is capped at the NetBIOS limit and cannot
+    // outgrow this copy. Same shape and same reason as logHostName in step
+    // 341: Route::deletemass('host') removes the host, and a login history
+    // that survives with a dangling id and no name is not a history.
+    //
+    // Every column is nullable or DEFAULT '', nothing writes to them, and no
+    // reader knows they exist. An install that stops here behaves exactly as
+    // it did before -- this is the reversible half of the ADR's DDL.
+    //
+    // A closure rather than a bare ALTER for the same reason steps 336, 338
+    // and 341 are: ADD COLUMN has no IF NOT EXISTS below MariaDB 10.0.2 /
+    // MySQL 8.0.29, so a re-run has to converge on its own rather than
+    // error. Every column is named in the probe, because steps 336 and 338
+    // broke the installer's grant check by not naming them (GH-336, GH-338).
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() "
+            . "AND `TABLE_NAME` = 'userTracking' "
+            . "AND `COLUMN_NAME` IN ('utCreatedBy','utIP','utHostName')"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        $adds = [];
+        if (!in_array('utCreatedBy', $cols)) {
+            $adds[] = "ADD `utCreatedBy` VARCHAR(30) NOT NULL DEFAULT ''";
+        }
+        if (!in_array('utIP', $cols)) {
+            $adds[] = "ADD `utIP` VARCHAR(50) NOT NULL DEFAULT ''";
+        }
+        if (!in_array('utHostName', $cols)) {
+            $adds[] = "ADD `utHostName` VARCHAR(16) NOT NULL DEFAULT ''";
+        }
+        if (count($adds) > 0) {
+            self::$DB->query(
+                "ALTER TABLE `userTracking` " . implode(', ', $adds)
+            );
+        }
+
+        return true;
+    },
+];
+
+// 350
+$this->schema[] = [
+    // ADR 0020 phase 2, history half: give `history` a subject and a type,
+    // write nothing to them.
+    //
+    // `history` is the outlier of the three event tables, and its defect is
+    // structural rather than cosmetic: it has no subject at all. The entity a
+    // row is about exists only inside hText, which is assembled from gettext
+    // calls at write time -- so the record of what happened is stored in
+    // whatever language the server was set to when it happened, and nothing
+    // can query it.
+    //
+    // hType -- what kind of event, as a stable machine code, matching
+    // taskLog.logType's width. DEFAULT '' is deliberate and is the whole
+    // rollout: an empty hType marks a row written before this ADR, and that
+    // is exactly what phase 4's readers key their prose fallback on. Step 338
+    // gave logType a DEFAULT of 'state', which reads as though a real value
+    // was recorded when none was, and step 340 had to repair it. Do not give
+    // this column a plausible-looking default.
+    //
+    // hSubjectType -- the subject's class name. `history` needs this and
+    // taskLog/userTracking do not: they are always about a Host and can say
+    // so as a constant, while `history` is about anything (ADR 0020
+    // decision 2).
+    //
+    // hSubjectID -- the subject's id, nullable. FOGController::save() omits
+    // an unset OPTIONAL column whose friendly key ends in "id", so it takes
+    // the DEFAULT; for every other key an unset value is written as '',
+    // never NULL. Declaring this one NULL DEFAULT NULL and the rest NOT NULL
+    // DEFAULT '' says what the ORM will really store, rather than describing
+    // a value the writer cannot produce. Same split, same reason, as step
+    // 341.
+    //
+    // hSubjectLabel -- the denormalized label, so the row still names its
+    // subject after the subject is deleted. varchar(200) because unlike
+    // taskLog and userTracking this table's subject is not always a host:
+    // it is sized to the widest name column a subject can have
+    // (snapins.sName varchar(200)), not to hosts.hostName varchar(16).
+    //
+    // Additive and inert, exactly as step 349. Dropping history's
+    // UNIQUE (hText, hTime) and widening hText belong to phase 5, a full
+    // release cycle after the readers switch, and are deliberately not here.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() "
+            . "AND `TABLE_NAME` = 'history' "
+            . "AND `COLUMN_NAME` IN "
+            . "('hType','hSubjectType','hSubjectID','hSubjectLabel')"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        $adds = [];
+        if (!in_array('hType', $cols)) {
+            $adds[] = "ADD `hType` VARCHAR(16) NOT NULL DEFAULT ''";
+        }
+        if (!in_array('hSubjectType', $cols)) {
+            $adds[] = "ADD `hSubjectType` VARCHAR(64) NOT NULL DEFAULT ''";
+        }
+        if (!in_array('hSubjectID', $cols)) {
+            $adds[] = "ADD `hSubjectID` INT(11) NULL DEFAULT NULL";
+        }
+        if (!in_array('hSubjectLabel', $cols)) {
+            $adds[] = "ADD `hSubjectLabel` VARCHAR(200) NOT NULL DEFAULT ''";
+        }
+        if (count($adds) > 0) {
+            self::$DB->query(
+                "ALTER TABLE `history` " . implode(', ', $adds)
+            );
+        }
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 348);
+        define('FOG_SCHEMA', 350);
         define('FOG_BCACHE_VER', 294);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as


### PR DESCRIPTION
Schema steps **349** and **350**, one per table, adding the frame columns `userTracking` and `history` have never had. Nothing writes to them and no reader knows they exist — an install that stops here behaves exactly as it did before. This is the reversible half of ADR 0020's DDL, and phases 3 and 4 (writers, then readers) need it in place first.

| table | column | type | why |
|---|---|---|---|
| `userTracking` | `utCreatedBy` | `varchar(30)` | the FOG identity responsible |
| | `utIP` | `varchar(50)` | the address it arrived from |
| | `utHostName` | `varchar(16)` | subject label, denormalized |
| `history` | `hType` | `varchar(16)` | event kind, as a machine code |
| | `hSubjectType` | `varchar(64)` | the subject's class |
| | `hSubjectID` | `int(11) NULL` | the subject's id |
| | `hSubjectLabel` | `varchar(200)` | subject label, denormalized |

`history` is the outlier of the three event tables and its defect is structural: it has **no subject at all**. The entity a row is about exists only inside `hText`, which is assembled from gettext calls at write time — so the record of what happened is stored in whatever language the server was set to, and nothing can query it.

### Three shapes chosen rather than copied

- **`utCreatedBy` is not `utUserName`.** `utUserName` is the endpoint's OS account — the *subject* of the event, not its actor. ADR 0020 decision 3 calls that the load-bearing correction, and it is why this is a new column rather than a reinterpretation of the one already there.
- **`utIP` takes `history.hIP`'s `varchar(50)`, not `taskLog.ip`'s `varchar(15)`.** The estate has both widths for the same frame key; 15 characters cannot hold an IPv6 address and a new column has no reason to inherit that.
- **`hType` defaults to `''` deliberately.** An empty `hType` marks a row written before this ADR and is exactly what phase 4's readers key their prose fallback on. Step 338 gave `logType` a plausible-looking `DEFAULT 'state'` and step 340 had to repair it; this does not repeat that.

Both steps are guarded closures in the style of 336/338/341 — `ADD COLUMN` has no `IF NOT EXISTS` below MariaDB 10.0.2 / MySQL 8.0.29, so a re-run has to converge rather than error — and both **name every column** in their `information_schema` probe, which is what 336 and 338 failed to do and broke the installer's grant check by.

### The manifest is hand-edited on purpose

`bin/schema-manifest.php generate` snapshots a live database and is not idempotent: the server version rewrites all 67 `create` strings, and the replay it can be pointed at skips closure steps. So both the `create` and `columns` blocks were edited by hand and `tests/schema-manifest-consistent.test.php` confirms they agree — 683 checks.

### Verification

Against a copy of a real database (MariaDB 11.8, 2,256 `history` rows, schema 348):

- both steps applied; all seven columns landed with exactly the declared types and defaults
- every row survived the ALTER
- a **second run of both steps was a no-op** — column counts and row counts unchanged
- a row written through each model left **all seven columns at their defaults**, which is the inertness claim tested rather than asserted
- the manifest was then compared column by column against that database: **20 of 20 match**, no extras, no omissions

**Coverage note worth keeping visible:** `tests/schema-executes.test.php` deliberately skips closure steps, so CI's schema replay does **not** exercise 349 or 350. Real installs run them; only the harness does not. The manifest check is what stands in for that, which is why it was proven against a database rather than read.

### Also in here

- Fixes three test failures introduced by 3efd27f8: the verify probe declared a class in `bin/`, which `all-classes-load`, `global-class-prefix` and `namespaced-tree` all reject tree-wide. It now uses a plain `\PDO` built from the booted tree's `DATABASE_*` constants. Suite is **98/98**.
- ADR 0023's Consequences said the `report.view` narrowing was "pending Decision 1's signoff", which its own Status contradicts — item 1 shipped as 3775e05d. Text only.

ADR 0020 moves from `proposed` to **`accepted`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)