### PR TITLE
fix(installer): report "Skipped" when no web backup was written (1.5 port)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4818,11 +4818,17 @@ configureHttpd() {
     fi
     errorStat $?
     dots "Backing up old data"
+    # Whether either branch below actually copied anything. Both can be false:
+    # $webdirdest may not exist at all, and $priorwebdir is only set when
+    # ${docroot}fog was a symlink this run removed. See the report at the end
+    # of this step for why that has to be said out loud.
+    webbackedup=""
     if [[ -d $backupPath/fog_web_${version}.BACKUP ]]; then
         rm -rf $backupPath/fog_web_${version}.BACKUP >>$error_log 2>&1
     fi
     if [[ -d $webdirdest ]]; then
         cp -RT "$webdirdest" "${backupPath}/fog_web_${version}.BACKUP" >>$error_log 2>&1
+        webbackedup=1
         rm -rf ${backupPath}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol
         rm -rf "$webdirdest" >>$error_log 2>&1
     elif [[ -n $priorwebdir && -d $priorwebdir ]]; then
@@ -4832,6 +4838,7 @@ configureHttpd() {
         # being left behind before this fix -- backing it up is the gain here,
         # and deleting it would be a new behaviour nobody asked for.
         cp -RT "$priorwebdir" "${backupPath}/fog_web_${version}.BACKUP" >>$error_log 2>&1
+        webbackedup=1
         rm -rf ${backupPath}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol
     fi
     if [[ $osid -eq 2 ]]; then
@@ -4855,7 +4862,21 @@ configureHttpd() {
     if [[ ${docroot%/}/${webrootbare} != ${webdirdest%/} && -n $webrootbare ]]; then
         linkIfAbsent "${webdirdest%/}" "${docroot%/}/${webrootbare}"
     fi
-    errorStat $?
+    # This step printed "OK" whether or not a fog_web_<ver>.BACKUP was written.
+    # errorStat is reached forty lines after the copy and reports the status of
+    # the link work above it, so an install that found nothing to preserve
+    # still told the admin their web root had been backed up. It is reachable
+    # on any server whose webroot is moved aside between installs -- the tree
+    # is neither at $webdirdest nor behind a symlink this run removed, so both
+    # branches are skipped -- and the only trace was the absence of a directory
+    # nobody looks for until they need it.
+    webbackupstat=$?
+    errorStat $webbackupstat skip
+    if [[ -n $webbackedup ]]; then
+        echo "OK"
+    else
+        echo "Skipped"
+    fi
     if [[ $copybackold -gt 0 ]]; then
         if [[ -d ${backupPath}/fog_web_${version}.BACKUP ]]; then
             dots "Copying back old web folder as is";


### PR DESCRIPTION
1.5 port of #1281. The `configureHttpd()` block is identical on this branch — verified before porting.

## Problem

The **Backing up old data** step prints `OK` whether or not a `fog_web_<ver>.BACKUP` was actually created.

Its `errorStat` sits forty lines below the copy, after the `mkdir`/`ln`/`linkIfAbsent` work, so it reports the status of the *link* work — not the backup. Both backup branches being skipped is indistinguishable from a successful backup:

```bash
if [[ -d $webdirdest ]]; then          # no tree there
elif [[ -n $priorwebdir && -d $priorwebdir ]]; then   # no symlink was removed
fi
```

Both are skipped whenever the tree is neither at `$webdirdest` nor behind a symlink this run removed — every install on a server whose webroot is renamed aside between runs. Found on a 1.6 lab box where the post-install step is `mv /var/www/html/fog{,-1.6}`: three consecutive installs reported a successful backup and wrote none.

## Fix

Track whether either branch copied anything, and print `Skipped` when neither did — the same idiom the database backup uses a few hundred lines above.

Pass/fail behaviour is unchanged: `errorStat` still receives the same status and still aborts on a non-zero one. It is called with the `skipOk` argument so it no longer supplies the `OK`, and the branch below decides between `OK` and `Skipped`.

## Verification

Control flow simulated across all three cases:

| Case | Reports |
|---|---|
| tree at `$webdirdest` | `OK` |
| only `$priorwebdir` set | `OK` |
| neither | `Skipped` |

`bash -n lib/common/functions.sh` clean.

## Downstream

None — installer-only, no route or class-list change.