### PR TITLE
fix(auth): give plugins back the list half of the object-scope seam

### DIFF
--- a/docs/adr/0006-site-object-scope-boundary.md
+++ b/docs/adr/0006-site-object-scope-boundary.md
@@ -148,3 +148,78 @@ answers unable to disagree.
 - Nothing changes on upgrade day. Both tables start empty, three of the four
   arms return nothing, and `userSiteIDs()` answers exactly what it answered
   before until an administrator creates a grant.
+
+## Amendment — the seam has a LIST half, and it kept its 1.5 names
+
+Sites moving into core (ADR 0019) rebuilt the list boundary as SQL owned by
+`Authorization`. The plugin seam did not come with it. What was left on 1.6
+was a seam with one half:
+
+| | 1.5 / `dev-branch` | 1.6 before this amendment |
+|---|---|---|
+| Deny one object | `OBJECT_SCOPE_CHECK` | `OBJECT_SCOPE_CHECK` |
+| Bound a list | `API_SCOPE_WHERE`, `API_SCOPE_IDS` | **nothing** |
+
+`OBJECT_SCOPE_CHECK` is only ever consulted about a single id, so a plugin on
+1.6 could veto `GET /host/5` and had no way at all to narrow `GET /host/list`.
+A plugin that scoped lists on 1.5 therefore stopped scoping them on upgrade —
+no error, nothing logged, and it fails **open**, which is the direction that
+matters.
+
+### Decision
+
+`Authorization` fires both events and composes their answers with its own.
+
+- **The names keep their `API_` prefix even though they now fire for page
+  routes too.** They are a compatibility contract: a 1.5 plugin registers those
+  exact strings, and a tidier name would leave every one of them inert, which
+  is the whole failure being fixed. Same for the payload keys — `classname`,
+  `idExpr`, `where`, `ids`.
+- **In `Authorization`, not in `Route`.** `scopedObjectWhere()` and
+  `scopedObjectIDs()` are the single funnel every list path already goes
+  through — `listem()`, `names()`, `ids()`, `unisearch()`, and the management
+  page list. One seam covers all of them, where `dev-branch` needed the call
+  repeated in five handlers.
+- **Composition is narrowing-only, in both dialects.** Fragments are ANDed with
+  each side parenthesised; id lists are intersected. Either side may narrow,
+  neither may widen — the same deny-wins rule `OBJECT_SCOPE_CHECK` already
+  has, and for the same reason: otherwise a plugin hands out another site's
+  hosts by answering an event.
+- **The `*` exemption is shared; core's other short circuits are not.** A
+  global `*` holder bypasses a plugin boundary exactly as they bypass core's,
+  because the single-object and list paths have to agree about who is scoped.
+  "The node is not site-scoped", "no sites exist" and "the user is in the
+  catch-all" are statements about *sites*, say nothing about whatever
+  dimension a plugin scopes on, and so do not suppress it.
+- **An id-list answer becomes SQL rather than a post-filter.** ADR 0019's whole
+  argument applies to a plugin's boundary as much as to core's: a boundary
+  applied to rows the database has already `LIMIT`ed empties pages while later
+  pages still hold rows the caller may see. `dev-branch` filters rows because
+  its `listem()` has no `LIMIT`; 1.6's does.
+- **`objectInScope()` answers the same boundary the lists do**, evaluating the
+  fragment as a bounded existence check. Otherwise a plugin hides an object
+  from every list and core still serves it through `GET /<class>/<id>` — two
+  statements of who may see what, and the one nobody looks at stays wrong.
+
+### Consequences
+
+- **Stock installs are untouched.** With no listener registered both events are
+  inert and every fragment and id list is byte-identical to before.
+- **Dispatch is guarded against re-entry**, and that is not theoretical.
+  `HookManager::processEvent()` primes its known-event cache with
+  `Route::getIds('hookevent')` — a scoped read, which arrives straight back at
+  the event — and assigns the cache only *after* that call returns, so the
+  recursion has no floor. It exhausts memory rather than erroring, so it
+  presents as a hung request. A listener that computes its own boundary by
+  reading through `getIds()`/`getNames()`, which is the obvious way to write
+  one, does the same thing one level further out. A nested read is answered
+  with core's boundary alone; the outer call still applies the plugin's, and
+  a boundary only ever narrows, so the inner answer is never wider than core
+  allows.
+- **A null `HookManager` is a real state on this path.** `objectInScope()` has
+  always dereferenced it unguarded, but the list helpers are reached from
+  `listem()` and from ~90 `getIds()`/`getNames()` call sites, including boots
+  that never build one. They check.
+- `tests/plugin-list-scope-events.test.php` pins it, and every assertion in it
+  was verified by mutation — eight single-line edits to the composition, each
+  of which turns the file red.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -796,6 +796,83 @@ just-provisioned account has no id before then.
 
 ---
 
+## 8a. Object scope — narrowing *which* objects a user reaches
+
+Permissions (§4.5) say what a user may **do**. Object scope says which objects
+they may do it **to**. Core owns the seam; sites are core's own answer to it,
+and your plugin can add its own boundary on any dimension you like — a
+department, a customer, a tenant.
+
+**Two halves, and you almost always want both.** A single-object check that
+holds while the list is unfiltered is not a boundary: the user is refused the
+host edit page and shown every host on the way to it, names, MACs and all.
+
+| Event | Asked | Answer by setting |
+|---|---|---|
+| `OBJECT_SCOPE_CHECK` | may this user reach object `id` of `node`? | `$arguments['allowed'] = false` |
+| `API_SCOPE_WHERE` | bound a list, as SQL | `$arguments['where'] = '<fragment>'` |
+| `API_SCOPE_IDS` | bound a list, as ids | `$arguments['ids'] = [1, 2, …]` |
+
+```php
+public function scopeWhere($arguments)
+{
+    if (!in_array($this->node, (array)self::$pluginsinstalled)) {
+        return;
+    }
+    // No acting user means no boundary. The service daemons and the boot
+    // endpoints reach the read routes with nobody logged in, and narrowing
+    // those to a department would break imaging rather than protect anything.
+    if (!self::$FOGUser || !self::$FOGUser->isValid()) {
+        return;
+    }
+    if ('host' !== $arguments['classname']) {
+        return;
+    }
+    // $idExpr is the caller's own id column, already quoted and qualified,
+    // so you need not know the table name or worry about ambiguity in a join.
+    $arguments['where'] = sprintf(
+        'EXISTS (SELECT 1 FROM `deptHosts` WHERE `dhHostID` = %s '
+        . 'AND `dhDeptID` IN (%s))',
+        $arguments['idExpr'],
+        implode(',', array_map('intval', $this->deptIDsFor(self::$FOGUser)))
+    );
+}
+```
+
+**Prefer `API_SCOPE_WHERE`.** It costs one expression whatever the fleet size.
+`API_SCOPE_IDS` reads every object the user may see into PHP on every request,
+and is only consulted when nothing answered the fragment event. Register both
+if you like — the fragment wins and the id list is not even asked for.
+
+**Mind the tri-states. They are not the same tri-state.**
+
+| | means "no boundary" | means "you may see nothing" |
+|---|---|---|
+| `API_SCOPE_WHERE` | leave `where` as `null` — **`''` is read as silence** | the literal fragment `'1=0'` |
+| `API_SCOPE_IDS` | leave `ids` as `null` | `[]` |
+
+The trap both ways round is that "unbounded" and "entitled to nothing" are both
+falsy. `if (!$ids)` is true for `null` *and* `[]`, so a listener or a caller
+written that way shows every object on the server to the one user entitled to
+none. Say `'1=0'`, never `''`.
+
+**What you cannot do.** Composition is deny-wins: core ANDs your fragment onto
+its own and intersects your id list with its own, so you can only ever
+**narrow**. You cannot grant a user an object core denies them — otherwise any
+plugin could hand out another site's hosts by answering an event. A global `*`
+holder is exempt from your boundary exactly as they are from core's.
+
+**Don't read through `getIds()`/`getNames()` inside a listener** to compute your
+boundary. Those are scoped reads, so they arrive back at your own listener; core
+guards the re-entry and answers the nested read with its own boundary alone, but
+you will get an answer you did not expect. Query your tables directly, as the
+example above does.
+
+Full reasoning, including why the events kept their `API_` prefix now that they
+fire for page routes too: `docs/adr/0006-site-object-scope-boundary.md`.
+
+---
+
 ## 9. Common hook events
 
 | Event | Purpose |
@@ -808,6 +885,8 @@ just-provisioned account has no id before then.
 | `PERMISSION_REGISTRY_DATA` | register the node and its actions — **required**, see §4.5 |
 | `API_VALID_CLASSES` | expose the node over the REST API (name classes after your permission node — see §4.5) |
 | `API_SENSITIVE_FIELDS` | keep credential columns out of API and boot-endpoint output — see §8 |
+| `OBJECT_SCOPE_CHECK` | deny **one** object the acting user would otherwise reach — see §8a |
+| `API_SCOPE_WHERE` / `API_SCOPE_IDS` | bound a **list** to the objects the acting user may see — see §8a |
 | `API_SERVER_OWNED_FIELDS` | refuse API writes to columns your own code maintains — see §8 |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |

--- a/docs/route-listem-access-control-map.md
+++ b/docs/route-listem-access-control-map.md
@@ -1,8 +1,30 @@
 # The access-control map of `Route::listem()` and the API read path
 
-**Status:** reference. Written to outlive the decomposition it was written for.
+**Status:** reference, and **partly superseded — read this box first.**
 **Baseline:** `working-1.6` at `47ddae8b8`. Every line number is from
 `packages/web/lib/router/route.class.php` unless stated otherwise.
+
+> **Superseded as of 2026-08-22.** Three things this document describes as
+> open have since been built, so the line numbers below have drifted and two
+> of the defects it names no longer exist. Do not "fix" them.
+>
+> - **SCOPE-1 — `names`, `ids`, `count` and `unisearch` are unscoped.**
+>   Fixed. All four now carry `Route::_requestScopeWhere()`, which gates on
+>   `'cli' === PHP_SAPI` so the daemons keep finding their work. ADR 0019.
+> - **SCOPE-2 — the boundary runs after the SQL `LIMIT`.** Fixed. It is a
+>   subquery ANDed into the row query and both counts, passed into
+>   `FOGManagerController::complex()`. `_applySiteScope()` survives as a
+>   backstop over `listem()` and `search()`, which is what §3 below still
+>   correctly describes. ADR 0019.
+> - **"`requireApiObjectScope` is inert on every list route" (§0).** Still
+>   true of that call, and no longer the whole story: `objectInScope()` now
+>   also answers the same plugin boundary the lists are narrowed with, so a
+>   single-object route and a list route cannot disagree. ADR 0006's
+>   list-half amendment.
+>
+> What this document still gets right, and is worth reading for, is §6: the
+> catalogue of single-line deletions that remove a control without failing a
+> test, and why `tests/route-read-path-guards.test.php` exists.
 
 This document answers one question: **which lines in the read path remove or
 mask a row or a column, and what happens if one of them stops running.**

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -260,6 +260,20 @@ class Authorization extends FOGBase
      */
     private static $_permCache = [];
     /**
+     * Per-node [table, idColumn] cache for the plugin object-scope check.
+     * node => [table, idCol], or node => null when the node has no model.
+     *
+     * @var array
+     */
+    private static $_scopeClassVars = [];
+    /**
+     * Reentrancy guard for the plugin object-scope events. True while one
+     * is being dispatched; see _pluginScopeApplies().
+     *
+     * @var bool
+     */
+    private static $_inPluginScope = false;
+    /**
      * Memoized permission registry.
      *
      * @var array|null
@@ -1193,6 +1207,16 @@ class Authorization extends FOGBase
         if ($allowed && !SiteScope::inScope($node, $id, (int)$userID)) {
             $allowed = false;
         }
+        // The boundary the LIST routes carry, asked about this one object.
+        // A plugin that narrows lists through API_SCOPE_WHERE/API_SCOPE_IDS
+        // would otherwise hide an object from every list and still serve it
+        // through GET /<class>/<id> -- two statements of who may see what,
+        // and the one nobody looks at is the one that stays wrong.
+        if ($allowed
+            && !self::_objectPassesPluginScope($node, $id, (int)$userID)
+        ) {
+            $allowed = false;
+        }
         return (bool)$allowed;
     }
     /**
@@ -1211,6 +1235,9 @@ class Authorization extends FOGBase
      * catch-all site -- the same short circuits objectInScope() applies,
      * so single objects and lists cannot disagree about who is scoped.
      *
+     * A plugin's own boundary is composed in afterwards, by INTERSECTION:
+     * either side may narrow, neither may widen. See _pluginScopeIDs().
+     *
      * @param string   $node   the node being listed
      * @param int|null $userID acting user (defaults to current user)
      *
@@ -1218,11 +1245,22 @@ class Authorization extends FOGBase
      */
     public static function scopedObjectIDs($node, $userID = null)
     {
-        $userID = self::_boundedUserID($node, $userID);
-        if (null === $userID) {
-            return null;
-        }
-        return SiteScope::allInScopeIDs($node, $userID);
+        // Core's own answer. _boundedUserID() returns null for every reason
+        // CORE has not to narrow -- '*' holder, unscoped node, no sites,
+        // catch-all member -- and all but the first of those are statements
+        // about SITES, so none of them may suppress a plugin's boundary on
+        // some other dimension. The '*' exemption is shared, and lives in
+        // _pluginScopeApplies() so both sides state it once.
+        $bounded = self::_boundedUserID($node, $userID);
+        $coreIDs = (
+            null === $bounded ?
+            null :
+            SiteScope::allInScopeIDs($node, $bounded)
+        );
+        return self::_composeScopeIDs(
+            $coreIDs,
+            self::_pluginScopeIDs($node, $userID)
+        );
     }
     /**
      * The same boundary as scopedObjectIDs(), as a SQL WHERE fragment.
@@ -1243,6 +1281,9 @@ class Authorization extends FOGBase
      * scopedObjectIDs() rather than restated here, and the membership rule
      * itself is shared inside SiteScope. Neither can drift from the other.
      *
+     * A plugin's own boundary is composed in afterwards with AND: either
+     * side may narrow, neither may widen. See _pluginScopeWhere().
+     *
      * @param string   $node   the node being listed
      * @param string   $idExpr the object-id column, quoted and qualified
      * @param int|null $userID the acting user (defaults to current)
@@ -1251,11 +1292,43 @@ class Authorization extends FOGBase
      */
     public static function scopedObjectWhere($node, $idExpr, $userID = null)
     {
-        $userID = self::_boundedUserID($node, $userID);
-        if (null === $userID) {
-            return null;
+        // See scopedObjectIDs() for why core's short circuits are not the
+        // plugin's.
+        $bounded = self::_boundedUserID($node, $userID);
+        $coreWhere = (
+            null === $bounded ?
+            null :
+            SiteScope::inScopeWhere($node, $idExpr, $bounded)
+        );
+        $pluginWhere = self::_pluginScopeWhere($node, $idExpr, $userID);
+        if (null === $pluginWhere) {
+            // A listener that knows only API_SCOPE_IDS still bounds this
+            // QUERY. The ids are turned into an IN () here rather than
+            // handed back for the caller to filter rows with, because a
+            // boundary applied to rows the database has already LIMITed
+            // empties pages while later pages still hold rows the caller
+            // may see, and leaves the counts describing objects they may
+            // not -- ADR 0019, and the defect that ADR was written for.
+            //
+            // Safe to interpolate: _pluginScopeIDs() has already put every
+            // element through intval.
+            $pluginIDs = self::_pluginScopeIDs($node, $userID);
+            if (null !== $pluginIDs) {
+                $pluginWhere = (
+                    count($pluginIDs) ?
+                    sprintf(
+                        '%s IN (%s)',
+                        $idExpr,
+                        implode(',', $pluginIDs)
+                    ) :
+                    // Deny-all as SQL, never ''. An empty fragment reads as
+                    // silence one level up and would show every row on the
+                    // server -- the tri-state trap SiteScope documents.
+                    '1=0'
+                );
+            }
         }
-        return SiteScope::inScopeWhere($node, $idExpr, $userID);
+        return self::_andScopeFragment($coreWhere, $pluginWhere);
     }
     /**
      * Does a site boundary apply, and to whom?
@@ -1296,6 +1369,348 @@ class Authorization extends FOGBase
             return null;
         }
         return $userID;
+    }
+    /**
+     * Does a PLUGIN-supplied object boundary apply to this caller at all?
+     *
+     * One rule, and it is the one objectInScope() already makes structural
+     * for core's own boundary: a global '*' holder is never narrowed.
+     * Stated here rather than left to each listener because the
+     * single-object and list paths have to agree -- an administrator who
+     * reached an object through GET /host/5 but could not see it in the
+     * list would be looking at two different statements of who may see
+     * what.
+     *
+     * Every OTHER reason core declines to narrow -- the node is not
+     * site-scoped, no sites exist, the user is in a catch-all site -- is a
+     * fact about SITES and says nothing about whatever dimension a plugin
+     * scopes on, so none of them appears here.
+     *
+     * @param int|null $userID the acting user (defaults to current)
+     *
+     * @return bool
+     */
+    private static function _pluginScopeApplies($userID = null)
+    {
+        // No hook manager, no listeners, and nothing to ask. LoadGlobals
+        // builds it, so this is null on the paths that run before or
+        // without a full boot -- the schema updater and the CLI harnesses.
+        // objectInScope() has always dereferenced it unguarded; these two
+        // are reached from listem() and from ~90 getIds()/getNames() call
+        // sites, so they cannot.
+        if (!self::$HookManager) {
+            return false;
+        }
+        // Asking a plugin for a boundary must not recurse into asking a
+        // plugin for a boundary. Two ways in, and neither is theoretical:
+        //
+        //   - HookManager::processEvent() primes its known-event cache with
+        //     Route::getIds('hookevent'), which is a scoped read, which
+        //     arrives back here. The cache is assigned AFTER that call
+        //     returns, so on re-entry the guard is still null and the
+        //     recursion has no floor -- it exhausts memory rather than
+        //     erroring, which is why it looks like a hung request.
+        //   - A listener that computes its own boundary by reading through
+        //     getIds()/getNames() -- the obvious way to write one -- does
+        //     the same thing one level further out.
+        //
+        // The nested read is answered with CORE's boundary alone. That is
+        // the safe direction: the outer call still applies the plugin's,
+        // and a boundary is only ever a narrowing, so the inner read is
+        // wider than the caller's answer and never wider than core allows.
+        if (self::$_inPluginScope) {
+            return false;
+        }
+        return !self::_isUnrestricted($userID);
+    }
+    /**
+     * A plugin's object boundary for a list, as a SQL fragment, or null.
+     *
+     * The list-side counterpart of OBJECT_SCOPE_CHECK, and the reason it
+     * exists: OBJECT_SCOPE_CHECK is only ever consulted about ONE object,
+     * so a plugin can veto `GET /host/5` and has no way at all to bound
+     * `GET /host/list`. On 1.5 the same plugin could, through this event
+     * and API_SCOPE_IDS. Firing them here means a plugin written against
+     * 1.5 keeps bounding lists after the upgrade instead of silently
+     * ceasing to -- and silently ceasing to would fail OPEN, which is the
+     * direction that matters.
+     *
+     * The name keeps its API_ prefix even though this now fires for page
+     * routes as well. It is a compatibility contract: a 1.5 plugin
+     * registers THIS string, and a tidier name would leave every one of
+     * them inert, which is the whole failure being fixed.
+     *
+     * THE RETURN IS A TRI-STATE, and it is not the id list's:
+     *
+     *   null      nobody answered -- fall through to API_SCOPE_IDS
+     *   '<sql>'   narrow with this expression
+     *   '1=0'     a real answer meaning "you may see nothing"
+     *
+     * There is deliberately no empty-string state. An empty fragment is
+     * indistinguishable from silence, so it is READ as silence: a listener
+     * meaning "nothing" must say so in SQL. Treating '' as deny-all would
+     * make an accidental '' deny; treating it as a boundary would emit
+     * `WHERE ()`, a syntax error. Reading it as no-answer is the only
+     * option that fails towards the id-list path rather than towards
+     * either a broken query or a silent policy change.
+     *
+     * $idExpr is the caller's own id column, already quoted and qualified,
+     * so a listener can write `EXISTS (... WHERE assoc.hostID = <idExpr>)`
+     * without knowing the table name or guessing at ambiguity in a join.
+     *
+     * Inert with no listener registered, which is every stock install.
+     *
+     * @param string   $node   the node being listed
+     * @param string   $idExpr the object-id column, quoted and qualified
+     * @param int|null $userID the acting user (defaults to current)
+     *
+     * @return string|null the fragment, or null for no answer
+     */
+    private static function _pluginScopeWhere($node, $idExpr, $userID = null)
+    {
+        if (!self::_pluginScopeApplies($userID)) {
+            return null;
+        }
+        // 'classname' and not 'node': the payload key is part of the
+        // contract a 1.5 plugin was written against.
+        $classname = strtolower(trim((string)$node));
+        $where = null;
+        self::$_inPluginScope = true;
+        try {
+            self::$HookManager->processEvent(
+                'API_SCOPE_WHERE',
+                [
+                    'classname' => &$classname,
+                    'idExpr' => &$idExpr,
+                    'where' => &$where
+                ]
+            );
+        } finally {
+            // finally, not a trailing assignment: a listener that throws
+            // would otherwise leave the guard set for the rest of the
+            // request and silently disable every plugin boundary after it.
+            self::$_inPluginScope = false;
+        }
+        if (!is_string($where)) {
+            return null;
+        }
+        $where = trim($where);
+        return '' === $where ? null : $where;
+    }
+    /**
+     * A plugin's object boundary for a list, as ids, or null.
+     *
+     * Consulted only when nothing answered API_SCOPE_WHERE. A fragment
+     * costs one expression whatever the fleet size; an id list costs a
+     * lookup of every object the caller may see, materialised into PHP, on
+     * every request. Both are supported because a plugin written before
+     * the fragment event existed knows only this one.
+     *
+     * THE RETURN IS A TRI-STATE and it is NOT the fragment's:
+     *
+     *   null        no boundary -- leave the list alone
+     *   array(...)  narrow to exactly these ids
+     *   array()     a real answer meaning "nothing"
+     *
+     * null is the ONLY value meaning unbounded. `if (!$ids)` is true for
+     * both null and array(), so a caller written that way shows every
+     * object to the one caller entitled to none. Test `null ===`.
+     *
+     * Every element is put through intval here, once, so the callers may
+     * interpolate the result into SQL.
+     *
+     * @param string   $node   the node being listed
+     * @param int|null $userID the acting user (defaults to current)
+     *
+     * @return array|null ids to narrow to, or null for no boundary
+     */
+    private static function _pluginScopeIDs($node, $userID = null)
+    {
+        if (!self::_pluginScopeApplies($userID)) {
+            return null;
+        }
+        $classname = strtolower(trim((string)$node));
+        $ids = null;
+        self::$_inPluginScope = true;
+        try {
+            self::$HookManager->processEvent(
+                'API_SCOPE_IDS',
+                [
+                    'classname' => &$classname,
+                    'ids' => &$ids
+                ]
+            );
+        } finally {
+            self::$_inPluginScope = false;
+        }
+        return (
+            is_array($ids) ?
+            array_values(array_map('intval', $ids)) :
+            null
+        );
+    }
+    /**
+     * ANDs core's boundary fragment together with a plugin's.
+     *
+     * Deny-wins by construction: each side can only ever remove rows the
+     * other allowed. Both are parenthesised because a fragment is written
+     * by someone else and may contain OR -- `a OR b AND c` would bind the
+     * boundary to one arm and leave the rest matching server-wide, which is
+     * the same mistake unisearch() carries a comment about.
+     *
+     * @param string|null $core   core's fragment, or null
+     * @param string|null $plugin the plugin's fragment, or null
+     *
+     * @return string|null the combined fragment, or null when neither
+     *                     side answered
+     */
+    private static function _andScopeFragment($core, $plugin)
+    {
+        if (null === $core) {
+            return $plugin;
+        }
+        if (null === $plugin) {
+            return $core;
+        }
+        return sprintf('(%s) AND (%s)', $core, $plugin);
+    }
+    /**
+     * Intersects core's id boundary with a plugin's.
+     *
+     * The id-list twin of _andScopeFragment(), with the same property: an
+     * intersection can only shrink. An empty result is passed on as an
+     * empty ARRAY and not as null -- that is a real deny-all, and the two
+     * are the trap this file documents in three other places.
+     *
+     * @param array|null $core   core's ids, or null for no boundary
+     * @param array|null $plugin the plugin's ids, or null
+     *
+     * @return array|null the combined ids, or null when neither answered
+     */
+    private static function _composeScopeIDs($core, $plugin)
+    {
+        if (null === $core) {
+            return $plugin;
+        }
+        if (null === $plugin) {
+            return $core;
+        }
+        return array_values(
+            array_intersect(array_map('intval', $core), $plugin)
+        );
+    }
+    /**
+     * Does ONE object satisfy the plugin boundary the lists are narrowed
+     * with?
+     *
+     * Keeps `GET /<class>/<id>` and `GET /<class>/list` telling the same
+     * story. The fragment is preferred and evaluated as a bounded existence
+     * check -- one row at most, the id bound as a parameter, and the
+     * plugin's id list never materialised.
+     *
+     * Allows when there is nothing to evaluate. A node with no model class,
+     * or a model with no table, is not something a query can be built
+     * against; a plugin that wants to deny such an object still has
+     * OBJECT_SCOPE_CHECK, which is the event written for exactly that
+     * decision and is fired first.
+     *
+     * @param string   $node   the node being checked
+     * @param int      $id     the target object id
+     * @param int|null $userID the acting user (defaults to current)
+     *
+     * @return bool
+     */
+    private static function _objectPassesPluginScope($node, $id, $userID = null)
+    {
+        if (!self::_pluginScopeApplies($userID)) {
+            return true;
+        }
+        $vars = self::_scopeClassVars($node);
+        if (null === $vars) {
+            return true;
+        }
+        list($table, $idCol) = $vars;
+        $frag = self::_pluginScopeWhere(
+            $node,
+            sprintf('`%s`.`%s`', $table, $idCol),
+            $userID
+        );
+        if (null !== $frag) {
+            return self::_objectSatisfies($table, $idCol, $id, $frag);
+        }
+        $ids = self::_pluginScopeIDs($node, $userID);
+        if (null === $ids) {
+            return true;
+        }
+        return in_array((int)$id, $ids, true);
+    }
+    /**
+     * The table and id column behind a node, or null when there is none.
+     *
+     * Memoised per node. objectInScope() is called once per id on a mass
+     * operation, and reflecting a class' default properties for each of
+     * several hundred ids is the shape the grid query-storm bugs had.
+     *
+     * @param string $node the node
+     *
+     * @return array|null [table, idColumn], or null
+     */
+    private static function _scopeClassVars($node)
+    {
+        $node = strtolower(trim((string)$node));
+        if (array_key_exists($node, self::$_scopeClassVars)) {
+            return self::$_scopeClassVars[$node];
+        }
+        $vars = null;
+        if (class_exists(__NAMESPACE__ . '\\' . $node, true)) {
+            $props = self::getClass($node, '', true);
+            if (!empty($props['databaseTable'])
+                && !empty($props['databaseFields']['id'])
+            ) {
+                $vars = [
+                    $props['databaseTable'],
+                    $props['databaseFields']['id']
+                ];
+            }
+        }
+        self::$_scopeClassVars[$node] = $vars;
+        return $vars;
+    }
+    /**
+     * Is there a row with this id that also satisfies the fragment?
+     *
+     * A query that cannot run answers NO, and that is the safe direction
+     * here: this decides whether to serve a single object, so refusing one
+     * the caller was entitled to is a visible, reportable failure, where
+     * serving one they were not is silent.
+     *
+     * @param string $table the model's table
+     * @param string $idCol the model's id column
+     * @param int    $id    the target object id
+     * @param string $frag  the boundary fragment
+     *
+     * @return bool
+     */
+    private static function _objectSatisfies($table, $idCol, $id, $frag)
+    {
+        $sql = sprintf(
+            'SELECT COUNT(*) AS `cnt` FROM `%s` '
+            . 'WHERE `%s`.`%s` = :oid AND (%s)',
+            $table,
+            $table,
+            $idCol,
+            $frag
+        );
+        try {
+            $res = self::$DB->query($sql, [], ['oid' => (int)$id]);
+            if (false !== $res->error) {
+                return false;
+            }
+            $row = $res->fetch(\PDO::FETCH_ASSOC)->get();
+        } catch (\Exception $e) {
+            return false;
+        }
+        return is_array($row) && isset($row['cnt']) && (int)$row['cnt'] > 0;
     }
     /**
      * Enforce object scope for a management page request. Allowed →

--- a/tests/plugin-list-scope-events.test.php
+++ b/tests/plugin-list-scope-events.test.php
@@ -1,0 +1,617 @@
+<?php
+/**
+ * A plugin can bound a LIST again, not only veto a single object.
+ *
+ * OBJECT_SCOPE_CHECK is asked about exactly one object, so on its own a
+ * plugin could deny `GET /host/5` and had no way at all to narrow
+ * `GET /host/list`. On 1.5 the same plugin could, through API_SCOPE_WHERE
+ * and API_SCOPE_IDS -- the site plugin's own two handlers. Sites moved into
+ * core and the two events did not come with them, so a plugin written
+ * against 1.5 lost its list boundary on upgrade: no error, nothing logged,
+ * and it fails OPEN, which is the direction that matters.
+ *
+ * This pins the composition, which is the part that is silent when wrong:
+ *
+ *   - core's short circuits are about SITES and must not suppress a
+ *     plugin's boundary on some other dimension;
+ *   - the '*' exemption IS shared, because the single-object and list paths
+ *     have to agree about who is scoped;
+ *   - either side may narrow, neither may widen -- fragments are ANDed and
+ *     id lists intersected;
+ *   - the fragment tri-state (null / sql / '1=0') is not the id list's
+ *     (null / array / []), and '' is silence in one and impossible in the
+ *     other;
+ *   - `GET /<class>/<id>` answers the same boundary the list does;
+ *   - dispatching a scope event must not recurse into dispatching a scope
+ *     event.
+ *
+ * DB-free by the same means as site-scope.test.php: FOGBase::$DB takes a
+ * recording fake, the hook manager is replaced with one the test drives,
+ * and the permission cache is primed so no roles query is needed.
+ *
+ * Usage: php tests/plugin-list-scope-events.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-plugin-scope-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+foreach (['Authorization', 'SiteScope', 'Host'] as $needed) {
+    if (!class_exists($needed, true)) {
+        fwrite(STDERR, "FAIL: $needed does not resolve\n");
+        exit(1);
+    }
+}
+
+/** Minimal stand-in for PDODB; see site-scope.test.php for the rationale. */
+class FakeDB
+{
+    public $error = false;
+    public $log = [];
+    private $_responder;
+    private $_result;
+
+    public function __construct(callable $responder)
+    {
+        $this->_responder = $responder;
+    }
+
+    public function query($sql, $a = [], $params = [])
+    {
+        $this->log[] = $sql;
+        $this->_result = call_user_func($this->_responder, $sql, $params);
+        return $this;
+    }
+
+    public function fetch($mode = null, $type = '')
+    {
+        return $this;
+    }
+
+    public function get($field = '')
+    {
+        return $this->_result;
+    }
+}
+
+/**
+ * A hook manager that dispatches to whatever the test registered, on the
+ * real event names. Registering the real strings is the point: the whole
+ * defect being fixed is that a plugin registers 'API_SCOPE_WHERE' and
+ * nothing fires it, so a test that used a tidier name would pass while
+ * the bug was still there.
+ */
+class FakeHookManager
+{
+    public $listeners = [];
+    public $fired = [];
+
+    public function processEvent($event, $arguments = [])
+    {
+        $this->fired[$event] = ($this->fired[$event] ?? 0) + 1;
+        if (isset($this->listeners[$event])) {
+            call_user_func($this->listeners[$event], $arguments);
+        }
+    }
+}
+
+$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp->setAccessible(true);
+$hookProp = new \ReflectionProperty('FOGBase', 'HookManager');
+$hookProp->setAccessible(true);
+$permProp = new \ReflectionProperty('Authorization', '_permCache');
+$permProp->setAccessible(true);
+
+/**
+ * The plugin fragments below all carry this token so the fake database can
+ * tell the object-existence check apart from SiteScope's own queries
+ * without having to parse SQL.
+ */
+$TOKEN = '/*pluginfrag*/';
+
+$scenario = function (
+    array $tables,
+    array $perms,
+    array $listeners = []
+) use ($dbProp, $hookProp, $permProp, $TOKEN) {
+    $db = new FakeDB(
+        function ($sql, $params) use ($tables, $TOKEN) {
+            // The single-object existence check the plugin fragment is
+            // evaluated through. Answered from the declared allow list.
+            if (false !== strpos($sql, $TOKEN)) {
+                $oid = (int)$params['oid'];
+                $ok = in_array(
+                    $oid,
+                    (array)($tables['pluginObjects'] ?? []),
+                    true
+                );
+                return ['cnt' => $ok ? 1 : 0];
+            }
+            if (false !== strpos($sql, 'IS NOT NULL AND `s`.`siteID` IN (')) {
+                $uid = (int)$params['uid'];
+                $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
+                return ['cnt' => $hit ? 1 : 0];
+            }
+            if (false !== strpos($sql, 'FROM `sites`')) {
+                return ['cnt' => (int)($tables['siteCount'] ?? 0)];
+            }
+            if (false !== strpos($sql, 'FROM `siteUserMembers` WHERE')) {
+                $uid = (int)$params['uid'];
+                $out = [];
+                foreach ((array)($tables['userSites'][$uid] ?? []) as $s) {
+                    $out[] = ['siteID' => $s];
+                }
+                return $out;
+            }
+            // allInScopeIDs, and inScope's membership count.
+            if (isset($params['oid'])) {
+                $oid = (int)$params['oid'];
+                $hit = in_array($oid, (array)($tables['members'] ?? []), true);
+                return ['cnt' => $hit ? 1 : 0];
+            }
+            $out = [];
+            foreach ((array)($tables['members'] ?? []) as $oid) {
+                $out[] = ['oid' => $oid];
+            }
+            return $out;
+        }
+    );
+    $db->error = (bool)($tables['dbError'] ?? false);
+    $dbProp->setValue(null, $db);
+    $permProp->setValue(null, $perms);
+    $hm = new FakeHookManager();
+    $hm->listeners = $listeners;
+    $hookProp->setValue(null, $hm);
+    SiteScope::forgetCaches();
+    return [$db, $hm];
+};
+
+/** A site-scoped fixture: user 3 is in site 7, which holds hosts 1 and 2. */
+$scoped = [
+    'siteCount' => 2,
+    'catchAll' => [],
+    'userSites' => [3 => [7]],
+    'members' => [1, 2],
+];
+
+/** Listener factories, in the shape a real hook handler has. */
+$whereListener = function ($frag) {
+    return function ($arguments) use ($frag) {
+        $arguments['where'] = $frag;
+    };
+};
+$idsListener = function ($ids) {
+    return function ($arguments) use ($ids) {
+        $arguments['ids'] = $ids;
+    };
+};
+
+$HOSTID = '`hosts`.`hostID`';
+$IMAGEID = '`images`.`imageID`';
+
+/*
+ * 1. Inert with nothing registered. This is every stock install, and it is
+ *    the regression that would be noticed last.
+ */
+$scenario($scoped, [3 => ['image.view']]);
+check(
+    'no listener, unscoped node: still null',
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3) === null,
+    $failures,
+    $checks
+);
+
+$scenario($scoped, [3 => ['host.view']]);
+$coreOnly = Authorization::scopedObjectWhere('host', $HOSTID, 3);
+check(
+    "no listener, scoped user: core's fragment, unwrapped",
+    is_string($coreOnly)
+    && false !== strpos($coreOnly, 'IN (SELECT')
+    && '(' !== substr($coreOnly, 0, 1),
+    $failures,
+    $checks
+);
+
+$scenario($scoped, [3 => ['host.view']]);
+check(
+    'no listener: scopedObjectIDs unchanged',
+    Authorization::scopedObjectIDs('host', 3) === [1, 2],
+    $failures,
+    $checks
+);
+
+/*
+ * 2. The defect itself. A listener bounds a list on a node core does NOT
+ *    site-scope -- which is precisely what OBJECT_SCOPE_CHECK can never do,
+ *    because it is only ever asked about one object.
+ */
+list($db, $hm) = $scenario(
+    $scoped,
+    [3 => ['image.view']],
+    ['API_SCOPE_WHERE' => $whereListener('`images`.`imageID` IN (4,5)')]
+);
+check(
+    'a listener bounds a list on a node core does not scope',
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3)
+    === '`images`.`imageID` IN (4,5)',
+    $failures,
+    $checks
+);
+check(
+    'API_SCOPE_WHERE is actually fired',
+    ($hm->fired['API_SCOPE_WHERE'] ?? 0) === 1,
+    $failures,
+    $checks
+);
+
+/*
+ * 3. Both sides answering. ANDed, and BOTH parenthesised -- a fragment is
+ *    written by someone else and may contain OR, and `a OR b AND c` binds
+ *    the boundary to one arm while the rest keeps matching server-wide.
+ *    unisearch() carries a comment about the same mistake.
+ */
+$scenario(
+    $scoped,
+    [3 => ['host.view']],
+    ['API_SCOPE_WHERE' => $whereListener('`hosts`.`hostID` = 1 OR 1=1')]
+);
+$both = Authorization::scopedObjectWhere('host', $HOSTID, 3);
+check(
+    'core AND plugin, both parenthesised',
+    is_string($both)
+    && 1 === preg_match(
+        '#^\(.*IN \(SELECT.*\) AND \(`hosts`\.`hostID` = 1 OR 1=1\)$#s',
+        $both
+    ),
+    $failures,
+    $checks
+);
+
+/*
+ * 4. The id-list fallback, for a plugin that predates the fragment event.
+ *    Turned into SQL rather than handed back for a post-filter: a boundary
+ *    applied to rows the database has already LIMITed empties pages while
+ *    later pages still hold rows the caller may see (ADR 0019).
+ */
+$scenario(
+    $scoped,
+    [3 => ['image.view']],
+    ['API_SCOPE_IDS' => $idsListener([4, 5])]
+);
+check(
+    'an ids-only listener still bounds the QUERY',
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3)
+    === '`images`.`imageID` IN (4,5)',
+    $failures,
+    $checks
+);
+
+// Every element goes through intval once, in _pluginScopeIDs, which is what
+// lets the fragment interpolate them. If that ever moves, this is the only
+// thing standing between a listener and the query.
+$scenario(
+    $scoped,
+    [3 => ['image.view']],
+    ['API_SCOPE_IDS' => $idsListener(['4; DROP TABLE `images`', '5abc'])]
+);
+check(
+    'ids are intval-ed before they reach the fragment',
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3)
+    === '`images`.`imageID` IN (4,5)',
+    $failures,
+    $checks
+);
+
+// Deny-all is SQL and is TRUTHY. '' would read as silence one level up and
+// show every row on the server.
+$scenario(
+    $scoped,
+    [3 => ['image.view']],
+    ['API_SCOPE_IDS' => $idsListener([])]
+);
+$denyAll = Authorization::scopedObjectWhere('image', $IMAGEID, 3);
+check(
+    'an empty id list becomes 1=0, and it is truthy',
+    $denyAll === '1=0' && (bool)$denyAll,
+    $failures,
+    $checks
+);
+
+// A listener answering both: the fragment wins and the id list is not even
+// asked for. One boundary, never two half-applied ones.
+list($db, $hm) = $scenario(
+    $scoped,
+    [3 => ['image.view']],
+    [
+        'API_SCOPE_WHERE' => $whereListener('`images`.`imageID` IN (9)'),
+        'API_SCOPE_IDS' => $idsListener([4, 5])
+    ]
+);
+check(
+    'the fragment wins over the id list',
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3)
+    === '`images`.`imageID` IN (9)',
+    $failures,
+    $checks
+);
+check(
+    'the id list is not consulted when a fragment answered',
+    !isset($hm->fired['API_SCOPE_IDS']),
+    $failures,
+    $checks
+);
+
+/*
+ * 5. Tri-states. '' is silence in the fragment event -- treating it as
+ *    deny-all would make an accidental '' deny, and treating it as a
+ *    boundary would emit `WHERE ()`.
+ */
+$scenario(
+    $scoped,
+    [3 => ['image.view']],
+    [
+        'API_SCOPE_WHERE' => $whereListener('   '),
+        'API_SCOPE_IDS' => $idsListener([4])
+    ]
+);
+check(
+    "an empty fragment is read as silence, not as a boundary",
+    Authorization::scopedObjectWhere('image', $IMAGEID, 3)
+    === '`images`.`imageID` IN (4)',
+    $failures,
+    $checks
+);
+
+/*
+ * 6. scopedObjectIDs composes by INTERSECTION, with the same null-vs-[]
+ *    distinction the core path already carries.
+ */
+$scenario(
+    $scoped,
+    [3 => ['host.view']],
+    ['API_SCOPE_IDS' => $idsListener([2, 3])]
+);
+check(
+    'core ids intersected with plugin ids',
+    Authorization::scopedObjectIDs('host', 3) === [2],
+    $failures,
+    $checks
+);
+
+$scenario(
+    $scoped,
+    [3 => ['host.view']],
+    ['API_SCOPE_IDS' => $idsListener([9])]
+);
+check(
+    'an empty intersection is [], not null',
+    Authorization::scopedObjectIDs('host', 3) === [],
+    $failures,
+    $checks
+);
+
+$scenario(
+    $scoped,
+    [3 => ['image.view']],
+    ['API_SCOPE_IDS' => $idsListener([4, 5])]
+);
+check(
+    'plugin ids alone bound an otherwise unbounded node',
+    Authorization::scopedObjectIDs('image', 3) === [4, 5],
+    $failures,
+    $checks
+);
+
+/*
+ * 7. Neither side may WIDEN. A plugin naming ids outside the user's sites
+ *    gains it nothing -- if this ever inverts, any plugin can hand out
+ *    every other site's hosts.
+ */
+$scenario(
+    $scoped,
+    [3 => ['host.view']],
+    ['API_SCOPE_IDS' => $idsListener([1, 2, 50, 51])]
+);
+check(
+    'a plugin cannot widen past core (ids)',
+    Authorization::scopedObjectIDs('host', 3) === [1, 2],
+    $failures,
+    $checks
+);
+
+/*
+ * 8. The '*' exemption IS shared, and it is structural: an administrator
+ *    who reached an object through GET /host/5 but could not see it in the
+ *    list would be looking at two different statements of who may see what.
+ */
+list($db, $hm) = $scenario(
+    $scoped,
+    [3 => ['*']],
+    ['API_SCOPE_WHERE' => $whereListener('1=0')]
+);
+check(
+    'a global * holder is not narrowed by a plugin either',
+    Authorization::scopedObjectWhere('host', $HOSTID, 3) === null,
+    $failures,
+    $checks
+);
+check(
+    'a global * holder does not even fire the scope events',
+    empty($hm->fired),
+    $failures,
+    $checks
+);
+
+/*
+ * 9. The single object answers the same boundary the list does. Without
+ *    this a plugin hides an object from every list and still serves it
+ *    through GET /<class>/<id>.
+ */
+$objFixture = $scoped + ['pluginObjects' => [1]];
+
+$scenario(
+    $objFixture,
+    [3 => ['host.edit']],
+    ['API_SCOPE_WHERE' => $whereListener($TOKEN . ' 1=1')]
+);
+check(
+    'an object the plugin fragment matches is allowed',
+    Authorization::objectInScope('host', 1, 3) === true,
+    $failures,
+    $checks
+);
+
+$scenario(
+    $objFixture,
+    [3 => ['host.edit']],
+    ['API_SCOPE_WHERE' => $whereListener($TOKEN . ' 1=1')]
+);
+check(
+    'an object the plugin fragment excludes is denied',
+    Authorization::objectInScope('host', 2, 3) === false,
+    $failures,
+    $checks
+);
+
+$scenario(
+    $objFixture,
+    [3 => ['host.edit']],
+    ['API_SCOPE_IDS' => $idsListener([1])]
+);
+check(
+    'the id-list fallback denies a single object too',
+    Authorization::objectInScope('host', 2, 3) === false,
+    $failures,
+    $checks
+);
+
+// A query that cannot run answers NO. Refusing an object the caller was
+// entitled to is visible and gets reported; serving one they were not is
+// silent.
+$scenario(
+    $objFixture + ['dbError' => true],
+    [3 => ['host.edit']],
+    ['API_SCOPE_WHERE' => $whereListener($TOKEN . ' 1=1')]
+);
+check(
+    'a failed existence check denies',
+    Authorization::objectInScope('host', 1, 3) === false,
+    $failures,
+    $checks
+);
+
+// A node with no model class has nothing to build a query against and is
+// allowed through -- a plugin that wants to deny it still has
+// OBJECT_SCOPE_CHECK, which is fired first.
+$scenario(
+    $objFixture,
+    [3 => ['settings.edit']],
+    ['API_SCOPE_WHERE' => $whereListener($TOKEN . ' 1=1')]
+);
+check(
+    'a node with no model is allowed rather than denied',
+    Authorization::objectInScope('nosuchnodeatall', 1, 3) === true,
+    $failures,
+    $checks
+);
+
+/*
+ * 10. Dispatching a scope event must not recurse into dispatching one.
+ *     Two ways in, both real: HookManager primes its known-event cache with
+ *     a scoped read, and a listener computing its boundary through
+ *     getIds()/getNames() does the same one level further out. Unbounded
+ *     recursion here exhausts memory rather than erroring, so it presents
+ *     as a hung request.
+ *
+ *     The nested read gets CORE's boundary alone, which is the safe
+ *     direction: the outer call still applies the plugin's.
+ */
+$nested = null;
+$reentrant = function ($arguments) use (&$nested, $HOSTID) {
+    $nested = Authorization::scopedObjectWhere('host', $HOSTID, 3);
+    $arguments['where'] = '`hosts`.`hostID` IN (1)';
+};
+list($db, $hm) = $scenario(
+    $scoped,
+    [3 => ['host.view']],
+    ['API_SCOPE_WHERE' => $reentrant]
+);
+$outer = Authorization::scopedObjectWhere('host', $HOSTID, 3);
+check(
+    'a re-entrant listener terminates, and the outer answer is composed',
+    is_string($outer)
+    && false !== strpos($outer, 'IN (SELECT')
+    && false !== strpos($outer, '`hosts`.`hostID` IN (1)'),
+    $failures,
+    $checks
+);
+check(
+    'the nested read gets core-only, and the event fires exactly once',
+    is_string($nested)
+    && false === strpos($nested, '`hosts`.`hostID` IN (1)')
+    && ($hm->fired['API_SCOPE_WHERE'] ?? 0) === 1,
+    $failures,
+    $checks
+);
+
+$dbProp->setValue(null, null);
+$hookProp->setValue(null, null);
+$permProp->setValue(null, []);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
## Problem

Sites moved from a plugin into core and the list boundary was rebuilt as SQL that `Authorization` owns (ADR 0019). The **plugin** seam did not come with it, so 1.6 shipped a seam with one half:

| | 1.5 / `dev-branch` | `working-1.6` before this |
|---|---|---|
| Deny one object | `OBJECT_SCOPE_CHECK` | `OBJECT_SCOPE_CHECK` |
| Bound a list | `API_SCOPE_WHERE`, `API_SCOPE_IDS` | **nothing** |

`OBJECT_SCOPE_CHECK` is only ever consulted about a single id, so a plugin on 1.6 could veto `GET /host/5` and had no way at all to narrow `GET /host/list`.

A plugin that scoped lists on 1.5 therefore **stops scoping them on upgrade** — no error, nothing logged, and it fails **open**, which is the direction that matters.

## Fix

`Authorization` fires both events and composes their answers with its own.

- **In `Authorization`, not in `Route`.** `scopedObjectWhere()` and `scopedObjectIDs()` are the single funnel `listem()`, `names()`, `ids()`, `unisearch()` and the management page list already go through. One seam covers all of them; `dev-branch` repeats the call in five handlers.
- **The `API_` prefix and the payload keys are kept deliberately**, even though these now fire for page routes too. They are a compatibility contract: a 1.5 plugin registers those exact strings, and a tidier name would leave every one of them inert — which is the whole failure being fixed.
- **Composition narrows only.** Fragments are ANDed with each side parenthesised (a fragment is written by someone else and may contain `OR`; `a OR b AND c` binds the boundary to one arm). Id lists are intersected. Same deny-wins rule `OBJECT_SCOPE_CHECK` already has.
- **The `*` exemption is shared; core's other short circuits are not.** A global `*` holder bypasses a plugin boundary exactly as they bypass core's, so the single-object and list paths agree about who is scoped. "Not site-scoped", "no sites exist", "catch-all member" are statements about *sites* and say nothing about a plugin's own dimension, so they do not suppress it.
- **An id-list answer becomes SQL**, not a post-filter — ADR 0019's argument applies to a plugin's boundary too: a boundary applied after the `LIMIT` empties pages while later pages still hold rows the caller may see.
- **`objectInScope()` answers the same boundary** as a bounded existence check, so a plugin cannot hide an object from every list while core still serves it through `GET /<class>/<id>`.

## Two bugs found while building it, both reproduced rather than predicted

- **Unbounded recursion.** `HookManager::processEvent()` primes its known-event cache with `Route::getIds('hookevent')` — a scoped read, which arrives straight back at the event — and assigns the cache only *after* that call returns, so the guard is still `null` on re-entry. It exhausts memory rather than erroring, so it presents as a hung request. A listener computing its own boundary through `getIds()`/`getNames()` — the obvious way to write one — does the same thing one level further out. Guarded; a nested read is answered with core's boundary alone, which is safe because the outer call still applies the plugin's and a boundary only ever narrows.
- **Null `HookManager` is a real state here.** `objectInScope()` has always dereferenced it unguarded, but the list helpers are reached from `listem()` and from ~90 `getIds()`/`getNames()` call sites, including boots that never build one. They check.

## Verification

- `tests/plugin-list-scope-events.test.php` — 25 checks, DB-free.
- **Mutation-verified.** Eight single-line edits to the composition each turn the file red: never fire `API_SCOPE_WHERE`; drop the single-object agreement; AND without parentheses; let plugin ids replace core's instead of intersecting; remove the re-entrancy guard; emit `''` instead of `1=0` for deny-all; drop the `intval` on plugin ids; allow instead of deny when the existence check fails.
- Full PHP suite **81/81**.
- **Inert with no listener registered** — every stock install. Both events are skipped and every fragment and id list is byte-identical to before.

## Not needed

No schema change, no `FOG_SCHEMA` bump, no JS/CSS so no `FOG_BCACHE_VER` bump, no route change so no `OpenAPI::document()` change.

## Docs

- ADR 0006 amended with the list half and the reasoning above.
- `docs/plugin-development.md` §8a — a worked listener, both tri-state tables (`''` is silence in one and impossible in the other), and what a plugin *cannot* do.
- `docs/route-listem-access-control-map.md` refreshed: it still described SCOPE-1 and SCOPE-2 as open defects, both fixed in ADR 0019. A reader would have gone and re-fixed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FuR7nCyBFCCLoQh86MyX5