### PR TITLE
fix(ping): a refused connection proves the host is up

### DIFF
--- a/packages/web/lib/fog/ping.class.php
+++ b/packages/web/lib/fog/ping.class.php
@@ -123,6 +123,54 @@ class Ping
         );
     }
     /**
+     * Does this result prove the host was ALIVE, whatever the port did?
+     *
+     * The distinction the whole ping rests on, and it is not "did the
+     * connection succeed". This is a TCP connect to ONE port, so a
+     * successful connection proves the host is up AND running a service
+     * there -- two facts, of which only the first is being asked about.
+     *
+     * ECONNREFUSED is the second way to learn the first fact. The host's own
+     * kernel answered with a TCP RST, which it can only do if it is powered
+     * on, on the network, and routable from here. Nothing was listening on
+     * the port; the MACHINE is up. Recording that as "unreachable" is
+     * exactly the report that made a Linux host on port 445, or a Windows
+     * host on port 22, permanently look switched off.
+     *
+     * Everything else stays not-alive, and each for a reason:
+     *
+     *   ETIMEDOUT      nothing came back. Off, or a firewall DROPping rather
+     *                  than rejecting. Genuinely unknown, so not alive.
+     *   EHOSTUNREACH   a ROUTER said so, not the host.
+     *   ENETUNREACH    no route at all.
+     *   ENXIO          the name did not resolve, so nothing was contacted.
+     *
+     * The one false positive to know about: a middlebox configured to REJECT
+     * on a host's behalf sends the same RST, so "alive" would mean "the
+     * firewall in front of it is alive". A firewall that DROPs -- the common
+     * default -- still times out and is still reported correctly. That is a
+     * better trade than the alternative, which mislabels every correctly
+     * functioning host that happens not to run the chosen service.
+     *
+     * Single-sourced deliberately. The service decides whether to stamp
+     * hostLastPing with this, and the host grid decides how to draw the
+     * badge with it; two copies of "is this alive" would drift, and the
+     * failure when they do is silent -- a grid that says up next to a
+     * timestamp that never advances.
+     *
+     * @param int|string|null $code the stored hostPingCode
+     *
+     * @return bool
+     */
+    public static function isAlive($code)
+    {
+        if ($code === null || $code === '') {
+            return false;
+        }
+
+        return 0 === (int)$code || SOCKET_ECONNREFUSED === (int)$code;
+    }
+    /**
      * Test many hosts at once and return each one's errno.
      *
      * execute() above tests exactly one host and blocks for up to $timeout

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2113,12 +2113,28 @@ class Route extends FOGBase
                         'db' => $real,
                         'dt' => $common,
                         'formatter' => function ($d, $row) {
-                            // hostPingCode: NULL/'' = never pinged,
-                            // 0 = online, any non-zero errno = unreachable.
-                            // Only "online" is worth an attention color;
-                            // an unreachable host is the normal resting
-                            // state for a managed host, so keep it neutral
-                            // and surface the specific reason as the text.
+                            // hostPingCode is FOUR states, not two, and the
+                            // third is the one this column used to get
+                            // wrong:
+                            //
+                            //   NULL/''       never pinged
+                            //   0             up, and the port answered
+                            //   ECONNREFUSED  UP -- the host's own kernel
+                            //                 sent a RST; nothing is
+                            //                 listening on the port
+                            //   anything else not reachable
+                            //
+                            // Ping::isAlive() owns which errnos mean the
+                            // host answered, shared with the service that
+                            // stamps hostLastPing, so the badge and the
+                            // timestamp cannot disagree.
+                            //
+                            // Refused gets its own colour rather than
+                            // borrowing success: the machine is up, which
+                            // is what was asked, but "the port is shut" is
+                            // the fact behind every "why is my Linux host
+                            // green now" question and is worth reading off
+                            // the grid.
                             if ($d === null || $d === '') {
                                 return '<span class="badge bg-secondary">'
                                     . _('Not pinged')
@@ -2127,6 +2143,11 @@ class Route extends FOGBase
                             if ((int)$d === 0) {
                                 return '<span class="badge bg-success">'
                                     . _('Online')
+                                    . '</span>';
+                            }
+                            if (Ping::isAlive($d)) {
+                                return '<span class="badge bg-info">'
+                                    . _('Up, port closed')
                                     . '</span>';
                             }
                             return '<span class="badge bg-secondary">'

--- a/packages/web/lib/service/pinghosts.class.php
+++ b/packages/web/lib/service/pinghosts.class.php
@@ -267,7 +267,18 @@ class PingHosts extends FOGService
                         (
                             $code === 0 ?
                             _('online') :
-                            socket_strerror($code)
+                            // Say both halves for a refused connection: the
+                            // errno alone reads as a failure in the log, and
+                            // it is the one failure that is really a success.
+                            (
+                                Ping::isAlive($code) ?
+                                sprintf(
+                                    '%s (%s)',
+                                    _('up, port closed'),
+                                    socket_strerror($code)
+                                ) :
+                                socket_strerror($code)
+                            )
                         )
                     )
                 );
@@ -275,13 +286,20 @@ class PingHosts extends FOGService
             $seen = self::niceDate()->format('Y-m-d H:i:s');
             foreach ($byCode as $code => $ids) {
                 $update = ['pingstatus' => $code];
-                // lastping records "this host answered", so only a
-                // successful connect writes it. A failure must leave the
-                // previous value alone -- overwriting it with the time of
-                // the failed attempt would make a host that has been off for
-                // a month indistinguishable from one that answered a minute
-                // ago, which is the whole reason the column exists.
-                if ($code === 0) {
+                // lastping records "this host answered", so only a result
+                // that PROVES the host answered writes it -- which is not
+                // the same as a successful connection. A refused connection
+                // is a TCP RST from the host's own kernel, so the machine is
+                // demonstrably up and merely has nothing listening on the
+                // port. Ping::isAlive() owns that judgement for both this
+                // and the host grid; see its docblock for the full list.
+                //
+                // A failure must leave the previous value alone --
+                // overwriting it with the time of the failed attempt would
+                // make a host that has been off for a month indistinguishable
+                // from one that answered a minute ago, which is the whole
+                // reason the column exists.
+                if (Ping::isAlive($code)) {
                     $update['lastping'] = $seen;
                 }
                 // Chunked so a large fleet cannot build an IN () list past
@@ -299,14 +317,21 @@ class PingHosts extends FOGService
                         );
                 }
             }
-            $online = count($byCode[0] ?? []);
+            // Counted by "was the host alive", not by "was the port open",
+            // so the summary agrees with what got a lastping stamp above.
+            $alive = 0;
+            foreach ($byCode as $code => $ids) {
+                if (Ping::isAlive($code)) {
+                    $alive += count($ids);
+                }
+            }
             self::outall(
                 sprintf(
                     ' * %s: %d %s, %d %s, %d %s (%.2fs)',
                     _('Ping cycle complete'),
-                    $online,
-                    _('online'),
-                    count($results) - $online,
+                    $alive,
+                    _('up'),
+                    count($results) - $alive,
                     _('not reachable'),
                     $skipped,
                     _('skipped'),

--- a/tests/ping-alive-codes.test.php
+++ b/tests/ping-alive-codes.test.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * A refused connection proves the host is UP.
+ *
+ * FOGPingHosts opens a TCP connection to one port -- 445 by default -- so a
+ * successful connection proves two things at once: the host is up, AND it
+ * runs a service on that port. Only the first was ever being asked about,
+ * and treating the pair as inseparable is what made a Linux host on 445, or
+ * a Windows host on 22, look permanently switched off.
+ *
+ * ECONNREFUSED is the second way to learn the first fact. The host's own
+ * kernel sent a TCP RST, which it can only do if it is powered on, on the
+ * network, and routable from here. Nothing was listening; the MACHINE is up.
+ *
+ * Three things are pinned here, and they fail in three different ways:
+ *
+ *   1. Ping::isAlive() itself -- which errnos mean "the host answered". A
+ *      mutation that widens it (say, ETIMEDOUT) silently marks every
+ *      switched-off host as alive and advances its hostLastPing, which is
+ *      the failure that destroys the field's whole value.
+ *   2. The host grid's badge, driven for real through the column table
+ *      plugins receive on CUSTOMIZE_DT_COLUMNS -- not read from the source.
+ *      A grid that says "Connection refused" next to a timestamp that just
+ *      advanced is the visible half of the two decisions drifting apart.
+ *   3. That the service and the grid both route through isAlive() rather
+ *      than each testing `=== 0` again. This third one is a source lint and
+ *      is honest about being one: checks 1 and 2 cannot see a consumer that
+ *      stops calling the shared helper and reimplements it correctly-for-now.
+ *
+ * Usage: php tests/ping-alive-codes.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('ping-alive');
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+if (!extension_loaded('sockets')) {
+    fwrite(STDERR, "FAIL: ext-sockets is required by the code under test\n");
+    exit(1);
+}
+
+/*
+ * 1. The definition.
+ */
+check(
+    'a completed connection is alive',
+    Ping::isAlive(0) === true,
+    $failures,
+    $checks
+);
+check(
+    'a REFUSED connection is alive -- the host sent the RST',
+    Ping::isAlive(SOCKET_ECONNREFUSED) === true,
+    $failures,
+    $checks
+);
+
+// hostPingCode is varchar(20), so every value read back out of the database
+// arrives as a STRING. An identity comparison against an int would answer
+// false for every host on a live server while passing any test that only
+// ever hands it an int.
+check(
+    'the code is compared numerically, not by identity',
+    Ping::isAlive((string)SOCKET_ECONNREFUSED) === true
+    && Ping::isAlive('0') === true,
+    $failures,
+    $checks
+);
+
+// Everything below is NOT alive, each for its own reason. ETIMEDOUT is the
+// important one: nothing answered at all, so the host may be off or may be
+// silently dropping, and "unknown" must not be recorded as "up".
+$notAlive = [
+    'ETIMEDOUT (nothing answered)' => SOCKET_ETIMEDOUT,
+    'EHOSTUNREACH (a router said so, not the host)' => SOCKET_EHOSTUNREACH,
+    'ENETUNREACH (no route)' => SOCKET_ENETUNREACH,
+    'ENXIO (the name did not resolve)' => SOCKET_ENXIO,
+];
+foreach ($notAlive as $label => $errno) {
+    check(
+        "not alive: $label",
+        Ping::isAlive($errno) === false,
+        $failures,
+        $checks
+    );
+}
+
+// Never pinged is not alive. Both spellings, because the column is nullable
+// AND FOGController::save() has historically written '' into columns of
+// every type -- so both are on disk on real servers.
+check(
+    'never pinged (null) is not alive',
+    Ping::isAlive(null) === false,
+    $failures,
+    $checks
+);
+check(
+    "never pinged ('') is not alive",
+    Ping::isAlive('') === false,
+    $failures,
+    $checks
+);
+
+/*
+ * 2. The badge the host grid actually renders.
+ *
+ * Captured from the column table at the point plugins receive it, then
+ * called, so this drives the real closure rather than reading the source.
+ */
+$db = FogTestHarness::fakeDb();
+$db->pdo->rowCount = 1;
+$db->pdo->countValue = 1;
+
+$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
+    FogTestHarness::setStatic($cls, 'FOGUser', $admin);
+}
+FogTestHarness::setStatic('Authorization', '_permCache', [1 => ['*']]);
+
+/** Grabs the host column table on its way to plugins. */
+class PingBadgeHook extends Hook
+{
+    /** @var array|null */
+    public static $captured = null;
+
+    public $name = 'PingBadgeHook';
+    public $description = 'Captures the host DataTables column table';
+    public $active = true;
+
+    public function __construct()
+    {
+        parent::__construct();
+        self::$HookManager->register('CUSTOMIZE_DT_COLUMNS', [$this, 'grab']);
+    }
+
+    public function grab($arguments)
+    {
+        if (null !== self::$captured || 'host' !== $arguments['classname']) {
+            return;
+        }
+        self::$captured = $arguments['columns'];
+    }
+}
+new PingBadgeHook();
+
+// Rendering a synthetic row is noise -- see route-column-contract.test.php
+// for why. The table is captured before the first row is formatted, so the
+// render itself is discarded.
+Route::$data = [];
+ob_start();
+$prevLevel = error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+$prevLog = ini_set('error_log', FOG_LOG_DIR . '/render-noise.log');
+try {
+    Route::asValue(
+        function () {
+            Route::listem('host', false, true);
+        }
+    );
+} catch (\Throwable $e) {
+    // Intentionally ignored; see above.
+}
+if (false !== $prevLog) {
+    ini_set('error_log', $prevLog);
+}
+error_reporting($prevLevel);
+ob_end_clean();
+Route::$data = [];
+
+$badge = null;
+foreach ((array)PingBadgeHook::$captured as $col) {
+    if (isset($col['dt'], $col['formatter']) && 'pingstatus' === $col['dt']) {
+        $badge = $col['formatter'];
+        break;
+    }
+}
+
+check(
+    'the host grid still has a pingstatus formatter',
+    is_callable($badge),
+    $failures,
+    $checks
+);
+
+if (is_callable($badge)) {
+    $render = function ($code) use ($badge) {
+        return (string)$badge($code, []);
+    };
+
+    check(
+        'code 0 renders as Online, in the success colour',
+        false !== strpos($render(0), 'Online')
+        && false !== strpos($render(0), 'bg-success'),
+        $failures,
+        $checks
+    );
+
+    // The fix. This used to render "Connection refused" in the same neutral
+    // badge as a host that is genuinely off.
+    $refused = $render((string)SOCKET_ECONNREFUSED);
+    check(
+        'a refused connection renders as UP, not as a failure',
+        false !== stripos($refused, 'Up')
+        && false === stripos($refused, 'refused'),
+        $failures,
+        $checks
+    );
+    check(
+        'a refused connection is visually distinct from a plain Online',
+        false === strpos($refused, 'bg-success')
+        && false === strpos($refused, 'bg-secondary'),
+        $failures,
+        $checks
+    );
+    check(
+        'a refused connection still says the port is shut',
+        false !== stripos($refused, 'port'),
+        $failures,
+        $checks
+    );
+
+    $timedOut = $render((string)SOCKET_ETIMEDOUT);
+    check(
+        'a timed-out host is still reported as not reachable',
+        false === stripos($timedOut, 'Up')
+        && false === strpos($timedOut, 'bg-success')
+        && false === strpos($timedOut, 'bg-info'),
+        $failures,
+        $checks
+    );
+
+    check(
+        'a host that was never pinged still says so',
+        false !== strpos($render(null), 'Not pinged')
+        && false !== strpos($render(''), 'Not pinged'),
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 3. Both consumers route through the shared helper.
+ *
+ * A source lint, deliberately. Checks 1 and 2 both pass if a consumer stops
+ * calling isAlive() and reimplements the same rule inline -- and that is
+ * exactly the state the two decisions drift apart from, silently, the next
+ * time one of them is edited.
+ */
+$service = file_get_contents(
+    dirname(__DIR__) . '/packages/web/lib/service/pinghosts.class.php'
+);
+check(
+    'the service decides lastping through Ping::isAlive()',
+    false !== strpos($service, "Ping::isAlive(\$code)"),
+    $failures,
+    $checks
+);
+check(
+    'the service no longer stamps lastping on a bare === 0',
+    0 === preg_match(
+        "#if \(\\\$code === 0\) \{\s*\\\$update\['lastping'\]#",
+        $service
+    ),
+    $failures,
+    $checks
+);
+
+$route = file_get_contents(
+    dirname(__DIR__) . '/packages/web/lib/router/route.class.php'
+);
+check(
+    'the grid formatter decides through Ping::isAlive()',
+    false !== strpos($route, 'Ping::isAlive($d)'),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
## Problem

`FOGPingHosts` opens a TCP connection to **one** port — 445 by default — so a successful connection proves two things at once: the host is up, **and** it runs a service on that port. Only the first was ever being asked about.

Treating the pair as inseparable is what makes a Linux host on 445, or a Windows host on 22, look permanently switched off. Changing `PINGHOSTPORT` just moves the blind spot; there is no TCP port every machine answers.

## Fix

`ECONNREFUSED` is the second way to learn the first fact. The host's own kernel sent a TCP RST, which it can only do if it is powered on, on the network and routable from here. Nothing was listening on the port — **the machine is up**.

Verified on the LAN before writing the fix:

```
closed port, host alive     10.255.20.1     errno=111  Connection refused
host that is not there      10.255.20.99    errno=110  timed out
```

`Ping::isAlive()` owns which errnos mean the host answered, and both consumers route through it. Two copies of that judgement would drift, and the failure when they do is silent — a grid saying "up" beside a timestamp that never advances.

Everything else stays not-alive on its own merits:

| errno | Verdict | Why |
|---|---|---|
| `0` | alive | connection completed |
| `ECONNREFUSED` | **alive** | RST from the host's own kernel |
| `ETIMEDOUT` | not alive | nothing came back — off, or silently DROPping. Genuinely unknown, and unknown must not be recorded as up |
| `EHOSTUNREACH` | not alive | a *router* said so, not the host |
| `ENETUNREACH` | not alive | no route at all |
| `ENXIO` | not alive | the name did not resolve, so nothing was contacted |

**The known false positive**, stated rather than left to be discovered: a middlebox configured to REJECT on a host's behalf sends the same RST, so "alive" would mean "the firewall in front of it is alive". A firewall that DROPs — the common default — still times out and is still reported correctly. That is the better trade against mislabelling every correctly functioning host that happens not to run the chosen service.

## Three consequences

- **`hostLastPing` is stamped for a refused connection**, so the field now means "the last time the host answered" rather than "the last time the port was open". That is the fact it was always meant to record.
- **The host grid gains a fourth state.** Refused renders `Up, port closed` in its own colour instead of sharing the neutral badge with a host that is genuinely off. The machine is up, which is what was asked — but the shut port is the fact behind every "why is my Linux host green now" question and belongs on the grid.
- **The cycle summary counts hosts that were alive**, not hosts whose port answered, so the log agrees with what got a timestamp.

## Verification

`tests/ping-alive-codes.test.php`, 19 checks. The grid badge is driven **for real** through the column table plugins receive on `CUSTOMIZE_DT_COLUMNS`, not read from source.

Verified by mutation — six edits, each turning the file red: drop `ECONNREFUSED`; widen to `ETIMEDOUT`; compare by identity; report never-pinged as alive; drop the grid branch; revert the service to `=== 0`.

The identity-comparison mutation is worth calling out. `hostPingCode` is `varchar(20)`, so every value read back is a **string** — an `===` against an int would answer false for every host on a live server while passing any test that only ever hands it an int.

Full suite 87/87. No schema change, no settings change, no JS/CSS.

## Follow-up

Real ICMP echo is next, as a first-choice probe with this TCP check as the fallback. Proven feasible from PHP via ext-sockets (both the unprivileged `SOCK_DGRAM` ping socket and `SOCK_RAW`, which `FOGPingHosts` can use today because it runs as root) — that is its own change and its own decision about distros that ship `net.ipv4.ping_group_range` closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FuR7nCyBFCCLoQh86MyX5