### PR TITLE
Close two blind gates in the API object-scope tests

### DIFF
--- a/tests/site-api-scope-behaviour.test.php
+++ b/tests/site-api-scope-behaviour.test.php
@@ -380,6 +380,46 @@ if (null !== $dbSkip) {
     );
 
     /*
+     * A fragment containing a top-level OR is still bound by the caller's
+     * filter.
+     *
+     * _andScopeWhere() parenthesises BOTH sides, and until this case existed
+     * nothing proved the fragment's own pair: every fragment the site plugin
+     * emits is a single `EXISTS (...)` term, which binds the same with or
+     * without them, so dropping them was invisible.
+     *
+     * It is not invisible in general, and the direction it fails is
+     * disclosure. `(caller) AND a OR b` parses as `((caller) AND a) OR b`, so
+     * the OR's second arm escapes the caller's filter entirely and returns
+     * rows nobody asked for. Here the caller asks for ONE group and the
+     * fragment permits two: parenthesised that is one row, unparenthesised it
+     * is two -- and the extra one was never in the caller's filter at all.
+     *
+     * A third-party listener is free to emit OR at the top level; nothing in
+     * the contract says a fragment must be a single term.
+     */
+    ScopeProbe::$whereAnswer = function ($idExpr) use ($ids) {
+        return $idExpr . ' = ' . $ids[0] . ' OR ' . $idExpr . ' = ' . $ids[1];
+    };
+    Route::$data = null;
+    Route::names('group', ['id' => [$ids[0]]]);
+    check(
+        'fragment: a top-level OR cannot escape the caller\'s own filter',
+        $mine(array_column((array)Route::$data, 'id')) === [$ids[0]],
+        $failures,
+        $checks
+    );
+    Route::$data = null;
+    Route::listem('group', 'name', false, ['id' => [$ids[0]]]);
+    check(
+        'fragment: listem() binds a top-level OR to the caller\'s filter too',
+        $mine(array_column((array)(Route::$data['groups'] ?? []), 'id'))
+        === [$ids[0]],
+        $failures,
+        $checks
+    );
+
+    /*
      * Exactly ONE boundary is applied, never both.
      *
      * Two narrowings ANDed together is not a safer boundary, it is a

--- a/tests/site-api-scope.test.php
+++ b/tests/site-api-scope.test.php
@@ -436,12 +436,31 @@ check(
     $failures,
     $checks
 );
-check(
-    'the API hook applies no boundary when nobody is logged in (daemons)',
-    false !== strpos($apiHook, 'self::$FOGUser->isValid()'),
-    $failures,
-    $checks
-);
+// Per handler, not once for the file. Both scopeIDs() and scopeWhere() carry
+// this guard and BOTH have to: scopeWhere() is consulted first, so a boundary
+// it emitted would apply before scopeIDs() was ever asked, and the daemons and
+// status endpoints reach Route::ids()/names() logged out. A file-wide strpos()
+// is satisfied by either copy, so deleting the one on the fragment path -- the
+// likelier regression, being the newer code -- passed this check unchanged.
+// Mutation-verified: removing either guard alone must fail, not just removing
+// both.
+foreach (array('scopeIDs', 'scopeWhere') as $handler) {
+    $body = '';
+    if (preg_match(
+        '/public function ' . $handler . '\(.*?\n    \}/s',
+        $apiHook,
+        $m
+    )) {
+        $body = $m[0];
+    }
+    check(
+        'the API hook\'s ' . $handler . '() applies no boundary when nobody'
+        . ' is logged in (daemons)',
+        false !== strpos($body, 'self::$FOGUser->isValid()'),
+        $failures,
+        $checks
+    );
+}
 // SiteHostAssociation is read twice in the management hook and only one
 // of those is the boundary. The grid shows each row's site name, which is
 // a per-host lookup by hostID and stays. What must not come back is a


### PR DESCRIPTION
Follow-up to #1233. **No product code changes** — both tests passed against mutations that would have opened the object boundary.

## How they were found

The behaviour test's **database arm had been skipping on every developer box**: it needs a 1.5 schema matching this tree, and a working install is normally a few steps behind (`the 1.5 install is at schema 278 and this tree needs 286`). Every row-level assertion — all three characterization states — sits inside that arm, so the suite reported green while proving only the source lints.

Armed it against a replayed scratch schema, then mutated the code it covers rather than trusting the green run.

## 1. The no-acting-user guard was a file-wide `strpos()`

```php
false !== strpos($apiHook, 'self::$FOGUser->isValid()')
```

`scopeIDs()` and `scopeWhere()` each carry that guard and **both have to**: the daemons and status endpoints reach `Route::ids()`/`names()` logged out, and `scopeWhere()` is consulted *first*, so a boundary it emitted would apply before `scopeIDs()` was ever asked.

A substring test on the whole file is satisfied by either copy — so deleting one passed. The likelier regression is deleting the one on the fragment path, being the newer code, and that was exactly the invisible case.

Now checked **per handler**. Removing either alone fails, and the failure names which one.

> Failure direction is not a 403. A boundary applied to a logged-out daemon narrows imaging to a site nobody selected, and imaging breaks.

## 2. Nothing proved the composition parenthesizes the fragment

`_andScopeWhere()` wraps both sides, and so does the manager's own compose at `fogmanagercontroller.class.php:424`. But every fragment the site plugin emits is a single `EXISTS (...)` term, which binds identically with or without them — so **dropping the parentheses at either site was invisible**.

It is not invisible in general, and it fails towards **disclosure**:

```sql
(caller) AND a OR b    -- parses as ((caller) AND a) OR b
```

The OR's second arm escapes the caller's filter entirely and returns rows nobody asked for. Nothing in the contract says a fragment must be a single term, so a third-party listener is free to emit a top-level `OR`.

Added a case **per composition site** — `names()` for `_andScopeWhere()`, `listem()` for the manager — where the caller asks for one group and the fragment permits two. Parenthesized that is one row; unparenthesized it is two, and the extra was never in the caller's filter. Each check kills only its own site's mutation, so they are not redundant.

## Mutation results

Six mutations, all now killed, each naming the right check:

| Mutation | Killed by |
|---|---|
| guard removed from `scopeWhere()` alone | `scopeWhere() applies no boundary when nobody is logged in` |
| guard removed from `scopeIDs()` alone | `scopeIDs() applies no boundary when nobody is logged in` |
| empty intersection read as "no constraint" | the four deny-all row checks |
| `scopedObjectWhere()` returns `null` not `'1=0'` for deny-all | `says deny-all in SQL rather than returning empty` |
| `_andScopeWhere()` ignores the fragment | the scoped + deny-all row checks |
| either compose site unparenthesized | the two new top-level-`OR` checks |

All three characterization states now have live row-level proof:

| State | Behaviour |
|---|---|
| no plugin / no acting user | read unrestricted |
| scoped user with objects | subquery narrows |
| scoped user with nothing | compiles to `WHERE 1=0` |

## Running the database arm

```
bash scripts/background_scripts/replay_15_schema_1245.sh <worktree>
FOG_TEST_DSN='mysql:host=127.0.0.1;port=13313;dbname=fog15' \
FOG_TEST_USER=root FOG_TEST_PASS= php tests/<name>.test.php
```

Two things the replay does **not** do for you, both of which silently skip every arm:

1. It leaves `schemaVersion` at the value `schema.php` itself seeds (32) rather than the step count — the updater *page* is what normally stamps it. `MAX(vValue)` has to be set to `FOG_SCHEMA` by hand.
2. The site plugin's tables are not created by core `schema.php`, so the macless-site arm needs `site` and `siteHostAssoc` adding before it will run.

Both are recorded in the commit message.

## Verification

- full dev-branch suite: **23/23 pass**, zero skips, against the armed database
- the two scope tests: 67 + 57 checks (was 28 + 56 with the arm skipping)