### PR TITLE
Say why _scopeWhere() carries no reentrancy guard

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -592,6 +592,32 @@ class Route extends FOGBase
      *
      * Inert in core: nothing here knows what a site is.
      *
+     * NO REENTRANCY GUARD HERE, AND THAT IS NOT AN OVERSIGHT.
+     *
+     * 1.6 fires this same event from Authorization and has to guard against
+     * asking a plugin for a boundary while already asking a plugin for a
+     * boundary, because there its HookManager primes its known-event cache
+     * with Route::getIds('hookevent') -- a scoped read, which arrives straight
+     * back here, with the cache assigned only AFTER that call returns, so the
+     * recursion has no floor. It exhausts memory rather than erroring, which
+     * is why it presents as a hung request rather than a stack trace.
+     *
+     * Neither half of that exists on this branch. HookManager primes from
+     * getSubObjectIDs('HookEvent', ...), a direct model read that never enters
+     * Route; and the site plugin's listener reads through getSubObjectIDs too,
+     * not getIds()/getNames(). So there is nothing to guard against today.
+     *
+     * What WOULD reintroduce it: a listener that computes its boundary by
+     * reading through Route::getIds()/getNames(), which is the obvious way to
+     * write one. If that ever lands, this needs the same in-progress flag
+     * Authorization carries on 1.6 -- set in a try/finally, so a listener that
+     * throws cannot leave the guard set and silently disable every plugin
+     * boundary for the rest of the request -- and the nested read is answered
+     * with core's boundary alone. That is the safe direction: the outer call
+     * still applies the plugin's, and a boundary only ever narrows, so the
+     * inner read is wider than the caller's answer and never wider than core
+     * allows.
+     *
      * @param string $classname The class being read.
      * @param string $idExpr    The object-id column, quoted and qualified.
      *


### PR DESCRIPTION
**Comment only.** No behavior change.

Follow-up to #1233 and #1291.

## The confusion this prevents

1.6 fires `API_SCOPE_WHERE` from `Authorization` and carries an in-progress flag (`$_inPluginScope`) to stop it asking a plugin for a boundary while already asking a plugin for a boundary. dev-branch fires the same event from `Route::_scopeWhere()` and carries no such flag.

Read side by side, that looks like an omission on this branch. It isn't — but the reason lives in a difference nobody has written down, and the failure it would cause is the kind you cannot diagnose cold.

## Why 1.6 needs it

1.6's `HookManager::processEvent()` primes its known-event cache with `Route::getIds('hookevent')` — a **scoped read**, which arrives straight back at the boundary. The cache is assigned only *after* that call returns, so on re-entry the guard is still unset and the recursion has no floor.

It exhausts memory rather than erroring, so it presents as a **hung request**, not a stack trace.

## Why this branch does not

Neither half of that mechanism exists here:

| | 1.6 | dev-branch |
|---|---|---|
| HookManager primes from | `Route::getIds('hookevent')` — re-enters the boundary | `getSubObjectIDs('HookEvent', …)` — direct model read, never enters `Route` |
| Site listener reads via | — | `getSubObjectIDs`, not `getIds()`/`getNames()` |

So there is nothing to guard against today.

## What would reintroduce it

A listener that computes its boundary by reading through `Route::getIds()`/`getNames()` — which is the obvious way to write one. The comment records that, and what the fix would have to look like:

- the same in-progress flag `Authorization` carries on 1.6
- set in a **try/finally**, so a listener that throws cannot leave the guard set and silently disable every plugin boundary for the rest of the request
- the nested read answered with **core's boundary alone**, which is the safe direction: the outer call still applies the plugin's, and a boundary only ever narrows, so the inner read is wider than the caller's answer and never wider than core allows

## Verification

Full dev-branch suite: 23/23 pass.