### PR TITLE
PKI follow-up to the .fogsettings rename: make the reconciled scenarios hold

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -309,7 +309,7 @@ while :; do
             shift 2
             ;;
         -o | --oldcopy)
-            sFOG_copy_back_old=1
+            sFOG_copy_back_old="yes"
             shift
 			;;
         -d | --no-defaults)
@@ -503,8 +503,7 @@ while :; do
                 exit 5
             fi
             sDHCP_range_start=$2
-            sDHCP_enabled="Y"
-            sDHCP_enabled=1
+            sDHCP_enabled="yes"
             shift 2
             ;;
         -e | --endrange)
@@ -514,12 +513,11 @@ while :; do
                 exit 6
             fi
             sDHCP_range_end=$2
-            sDHCP_enabled="Y"
-            sDHCP_enabled=1
+            sDHCP_enabled="yes"
             shift 2
             ;;
         -E | --no-exportbuild)
-            sSTORAGE_rebuild_nfs_exports=0
+            sSTORAGE_rebuild_nfs_exports="no"
             shift
             ;;
         -X | --exitFail)
@@ -527,7 +525,7 @@ while :; do
             shift
             ;;
         -T | --no-tftpbuild)
-            sBOOT_external_tftp_server="true"
+            sBOOT_external_tftp_server="yes"
             shift
             ;;
         -F | --no-vhost)
@@ -559,7 +557,7 @@ while :; do
             shift 2
             ;;
         --no-secure-boot)
-            sPKI_sb_enabled=0
+            sPKI_sb_enabled="no"
             shift
             ;;
         --netboot-proto)
@@ -751,15 +749,13 @@ resolvedfoggitpath="${FOG_git_path}"
 [[ -z ${FOG_os_id} ]] && FOG_os_id=""
 [[ -z ${FOG_os_name} ]] && FOG_os_name=""
 [[ -z ${DHCP_enabled} ]] && DHCP_enabled=""
-[[ -z ${DHCP_enabled} ]] && DHCP_enabled=""
 [[ -z ${FOG_install_type} ]] && FOG_install_type=""
 [[ -z ${NET_interface} ]] && NET_interface=""
 [[ -z ${NET_fog_server_ip} ]] && NET_fog_server_ip=""
 [[ -z ${NET_hostname} ]] && NET_hostname=""
 [[ -z ${DHCP_router} ]] && DHCP_router=""
-[[ -z ${DHCP_router} ]] && DHCP_router=""
-[[ -z ${STORAGE_rebuild_nfs_exports} ]] && STORAGE_rebuild_nfs_exports=1
-[[ -z ${FOG_install_lang} ]] && FOG_install_lang=0
+[[ -z ${STORAGE_rebuild_nfs_exports} ]] && STORAGE_rebuild_nfs_exports="yes"
+[[ -z ${FOG_install_lang} ]] && FOG_install_lang="no"
 [[ -z $bluseralreadyexists ]] && bluseralreadyexists=0
 [[ -z $guessdefaults ]] && guessdefaults=1
 [[ -z $doupdate ]] && doupdate=1
@@ -911,8 +907,10 @@ esac
 #
 # DHCP_enabled: dodhcp was Y/N and bldhcp was 1/0, both written from the same
 # prompt. Seeded from bldhcp because every DECISION read that one; dodhcp was
-# read only by the prompt loop that wrote it. So the 1/0 encoding survives and
-# no value has to be translated.
+# read only by the prompt loop that wrote it. Either encoding is fine to copy
+# here -- _normalizeBooleanSettings below converts whatever arrives to yes/no,
+# so the seed stays a copy and does not have to know which literal it is
+# carrying.
 [[ -z ${DHCP_enabled} ]] && DHCP_enabled="$bldhcp"
 #
 # DHCP_router: routeraddress doubled as a config-file comment -- declining a
@@ -1002,7 +1000,6 @@ _applyInstallMode
 # an upgrade the .fogsettings sourced above overwrote them (both are managed
 # keys) and the ranges were accepted while DHCP configuration stayed off.
 [[ -n ${sDHCP_enabled} ]] && DHCP_enabled=${sDHCP_enabled}
-[[ -n ${sDHCP_enabled} ]] && DHCP_enabled=${sDHCP_enabled}
 [[ -n ${sPKI_client_cert_dir} ]] && PKI_client_cert_dir=${sPKI_client_cert_dir}
 [[ -n $srecreateCA ]] && recreateCA=$srecreateCA
 [[ -n $srecreateKeys ]] && recreateKeys=$srecreateKeys
@@ -1040,6 +1037,17 @@ _applyInstallMode
 # without hand-editing .fogsettings.
 [[ -n ${sPKI_allowed_domain_names} ]] && PKI_allowed_domain_names=${sPKI_allowed_domain_names}
 [[ -n ${sPKI_internal_subnets} ]] && PKI_internal_subnets=${sPKI_internal_subnets}
+# --- one boolean encoding ----------------------------------------------------
+#
+# Deliberately AFTER the flag shadows above, not before them: every source of a
+# boolean feeds in by this point -- the value .fogsettings persisted, the value
+# the rename seed block copied off a pre-1.6 key, and the value a flag set this
+# run -- and the flag layer was itself the worst offender for mixed encodings.
+# Normalizing earlier would leave whatever the flags assigned unconverted.
+#
+# input.sh/newinput.sh are sourced later still and write yes/no directly, since
+# they run after this point.
+_normalizeBooleanSettings
 # Supplying any web-zone CA file implies --external-ca, the same way supplying
 # --ca-cert always has. Saves an admin from the "I gave you the files and
 # nothing happened" failure, which produces a working install with the wrong
@@ -1169,7 +1177,7 @@ case ${FOG_install_type} in
         echo " * Installation Type: Normal Server"
         echo -n " * Internationalization: "
         case ${FOG_install_lang} in
-            1)
+            yes)
                 echo "Yes"
                 ;;
             *)
@@ -1178,7 +1186,7 @@ case ${FOG_install_type} in
         esac
         echo " * Image Storage Location: ${STORAGE_image_share_path}"
         case ${DHCP_enabled} in
-            1)
+            yes)
                 echo " * Using FOG DHCP: Yes"
                 echo " * DHCP router Address: ${DHCP_router}"
                 ;;
@@ -1205,7 +1213,7 @@ case ${FOG_install_type} in
 esac
 echo -n " * Send OS Name, OS Version, and FOG Version: "
 case ${FOG_send_reports} in
-    Y)
+    yes)
         echo "Yes"
         ;;
     *)
@@ -1241,7 +1249,7 @@ while [[ -z $blGo ]]; do
                 done
                 FOG_packages="$(echo $newpackagelist)"
             fi
-            if [[ ${DHCP_enabled} == 0 ]]; then
+            if [[ ${DHCP_enabled} != yes ]]; then
                 [[ -z $newpackagelist ]] && newpackagelist=""
                 for z in ${FOG_packages}; do
                     [[ $z != $dhcpname ]] && newpackagelist="$newpackagelist $z"

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -170,6 +170,11 @@ usage() {
     echo -e "\t                 \t\t\tof all RFC1918 ranges"
     echo -e "\t      --web-ca-cert/-key/-root\tBring your own CA for the WEB zone only"
     echo -e "\t                 \t\t\t(equivalent to --external-ca --ca-*)"
+    echo -e "\t      --client-cert/--client-key\tYour own CLIENT COMMUNICATION keypair,"
+    echo -e "\t                 \t\t\tthe one every registered fog-client pins. Both"
+    echo -e "\t                 \t\t\tor neither. Swapping it warns and proceeds --"
+    echo -e "\t                 \t\t\tevery client must then be reinstalled or"
+    echo -e "\t                 \t\t\tre-pinned"
     echo -e "\t      --secureboot-ca-cert\tYour own SECURE BOOT intermediate: the"
     echo -e "\t                 \t\t\tcertificate enrolled in firmware. Pair it with"
     echo -e "\t                 \t\t\t--secure-boot-key/--secure-boot-cert, which name"
@@ -602,7 +607,8 @@ while :; do
             sPKI_internal_subnets="${sPKI_internal_subnets:+${sPKI_internal_subnets} }${2}"
             shift 2
             ;;
-        --web-ca-cert | --web-ca-key | --web-ca-root | --secureboot-ca-cert)
+        --web-ca-cert | --web-ca-key | --web-ca-root | --secureboot-ca-cert \
+            | --client-cert | --client-key)
             if [[ ! -f $2 ]]; then
                 echo "$1 requires a readable file after"
                 usage
@@ -612,6 +618,16 @@ while :; do
                 --web-ca-cert)    sImportWebCACert="$2" ;;
                 --web-ca-key)     sImportWebCAKey="$2" ;;
                 --web-ca-root)    sImportWebCARoot="$2" ;;
+                # The client-communication keypair, which every registered
+                # fog-client pins. Named so it can be supplied rather than only
+                # dropped at the canonical paths by hand -- the client zone was
+                # the last one an admin could not point at their own files.
+                #
+                # These name the leaf itself, not a CA: there is no intermediate
+                # in this zone, because fog-client pins the root and the leaf is
+                # signed by it directly.
+                --client-cert)    sPKI_client_encrypt_cert="$2" ;;
+                --client-key)     sPKI_client_encrypt_key="$2" ;;
                 # The Secure Boot zone's anchor: what gets ENROLLED in
                 # firmware. Pairs with --secure-boot-key/--secure-boot-cert,
                 # which name the leaf that actually signs. Supplying only the
@@ -1001,6 +1017,8 @@ _applyInstallMode
 # keys) and the ranges were accepted while DHCP configuration stayed off.
 [[ -n ${sDHCP_enabled} ]] && DHCP_enabled=${sDHCP_enabled}
 [[ -n ${sPKI_client_cert_dir} ]] && PKI_client_cert_dir=${sPKI_client_cert_dir}
+[[ -n ${sPKI_client_encrypt_cert} ]] && PKI_client_encrypt_cert=${sPKI_client_encrypt_cert}
+[[ -n ${sPKI_client_encrypt_key} ]] && PKI_client_encrypt_key=${sPKI_client_encrypt_key}
 [[ -n $srecreateCA ]] && recreateCA=$srecreateCA
 [[ -n $srecreateKeys ]] && recreateKeys=$srecreateKeys
 [[ -n $sexternalca ]] && externalca=$sexternalca
@@ -1097,6 +1115,49 @@ if [[ -n ${PKI_sb_codesign_key} || -n ${PKI_sb_codesign_cert} ]]; then
         fi
     done
     unset sbfile
+fi
+# --client-cert / --client-key: only meaningful as a pair, and gated on the
+# SHADOWS rather than on the resolved values.
+#
+# That differs from the Secure Boot pair above and has to. These two are managed
+# keys -- canonical-path RECORDS that writeUpdateFile persists on every run --
+# so on any upgrade they are non-empty from .fogsettings alone. Testing the
+# resolved values would refuse every ordinary upgrade. The shadows are set only
+# when a flag was actually passed on this run.
+if [[ -n ${sPKI_client_encrypt_cert} || -n ${sPKI_client_encrypt_key} ]]; then
+    if [[ -z ${sPKI_client_encrypt_cert} || -z ${sPKI_client_encrypt_key} ]]; then
+        echo " * --client-cert and --client-key must be set together"
+        echo "   Half a pair cannot be used: fog-client encrypts to the public"
+        echo "   half and the server decrypts with the private half, so a"
+        echo "   certificate without its key locks out every registered host."
+        exit 9
+    fi
+    # A supplied pair that does not actually pair is a typo, not history, and
+    # every registered client stops authenticating the moment it is installed.
+    # The admin has just named both files, so say so now rather than letting
+    # _createCommLeaf's mismatch warning report it after the fact.
+    # The raw modulus, NOT piped through `openssl md5`. That idiom appears
+    # elsewhere in this codebase and it defeats the emptiness test below: an
+    # unreadable file makes the x509/rsa call print nothing, and `openssl md5`
+    # of nothing is the perfectly non-empty MD5 of the empty string. So two
+    # unreadable files produce identical non-empty values and "pair".
+    ccmod=$(openssl x509 -noout -modulus -in "${sPKI_client_encrypt_cert}" 2>/dev/null)
+    ckmod=$(openssl rsa -noout -modulus -in "${sPKI_client_encrypt_key}" 2>/dev/null)
+    if [[ -z $ccmod || -z $ckmod ]]; then
+        echo " * Could not read --client-cert/--client-key as a certificate and key"
+        echo "   cert: ${sPKI_client_encrypt_cert}"
+        echo "   key:  ${sPKI_client_encrypt_key}"
+        exit 9
+    fi
+    if [[ $ccmod != "$ckmod" ]]; then
+        echo " * --client-cert and --client-key do not pair"
+        echo "   cert: ${sPKI_client_encrypt_cert}"
+        echo "   key:  ${sPKI_client_encrypt_key}"
+        echo "   Installing these would stop every registered fog-client"
+        echo "   authenticating, and no re-pin would fix it."
+        exit 9
+    fi
+    unset ccmod ckmod
 fi
 # Immediately after validation and long before configureHttpd() rebuilds the
 # web tree, so a pair the admin parked somewhere that gets deleted is copied

--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -97,10 +97,27 @@ source (permalinks below, pinned to
 [`ipxe/ipxe@bfc442a`](https://github.com/ipxe/ipxe/commit/bfc442ad18577c876292e10bbed0d40d421456dc)):
 
 1. **`TRUST=` is additive, not exclusive.** FOG's own build
-   (`buildipxe.sh`) passes `TRUST=${cert}` (FOG's CA) into iPXE's `make`. That
-   compiles FOG's CA in as a pinned root
+   (`buildipxe.sh`) passes `TRUST=${cert}` into iPXE's `make`, where `${cert}`
+   is **`PKI_web_ca_cert`** — the Web CA intermediate itself, resolved by
+   `_resolveIpxeTrust()`. That compiles it in as a pinned root
    ([`src/Makefile.housekeeping#L620-L649`](https://github.com/ipxe/ipxe/blob/bfc442ad18577c876292e10bbed0d40d421456dc/src/Makefile.housekeeping#L620-L649)) —
    but it does not remove iPXE's other, unconditional default described next.
+
+   **The Web CA, not `PKI_web_trust_chain`.** The chain bundle is the web zone's
+   trust *path* — intermediate plus the root anchoring it — and embedding the
+   whole bundle would make iPXE trust the FOG root, and so anything the root ever
+   signs, when all it has to validate is `boot.php`'s leaf. The intermediate on
+   its own is name-constrained and `serverAuth`-only, which is enforceable
+   precisely because iPXE is a verifier FOG can patch (ADR 0016) — so pinning
+   that one certificate is both narrower and sufficient. It is also what makes
+   bring-your-own-CA work here: an admin whose Web CA is their own intermediate
+   has no FOG root above it, so there was never anything sensible for the chain
+   to contain.
+
+   Expect **one** forced rebuild per server on the upgrade that changed this.
+   `_ipxeBuildStampValue()` hashes this file into the stamp's `ca=` field, so the
+   stamp stops matching and exactly one rebuild is scheduled — correct, because
+   the binary on disk really does embed different bytes than are now asked for.
 2. **iPXE ships a public-CA fallback by default, regardless of `TRUST=`.**
    [`src/config/crypto.h`](https://github.com/ipxe/ipxe/blob/bfc442ad18577c876292e10bbed0d40d421456dc/src/config/crypto.h)
    unconditionally defines

--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -204,6 +204,30 @@ also given.
 If the source files are no longer readable on a later run, the installer reuses
 the already-imported CA in `/opt/fog/pki/root/ca/`.
 
+### Storage nodes are issued from it too
+
+An imported Web CA issues certificates to storage nodes, exactly as FOG's own
+would. Each node generates its own keypair and its own CSR locally and sends
+only the CSR to the master, which signs it with whatever `PKI_web_ca_cert` names
+— your intermediate included. The node's private key never leaves the node.
+
+This was broken until recently, and the failure was worth naming: the signing
+helper verified each freshly issued node certificate against `PKI_root_ca_cert`,
+which is FOG's own root and is *not* replaced by an external **web** CA (it is
+what fog-client pins). Your intermediate was never signed by it, so no chain
+could be built and every node request was refused — with a message blaming the
+CA's name constraints, which sent people looking in the wrong place entirely.
+
+The helper now anchors on `pki/web/ca/.trustAnchor.pem`, which carries FOG's root
+*and* your root where you supplied one, and hands the node
+`PKI_web_trust_chain` — your intermediate plus your root — rather than appending
+FOG's root to a chain it does not anchor. See
+[PKI_ZONES.md](PKI_ZONES.md#storage-node-certificates).
+
+>[!note]
+>If you supplied a root FOG already trusts, `PKI_web_external_root_cert` stays
+>empty and the anchor holds one certificate. Nothing else changes.
+
 ---
 
 ## Recommended: internal ACME CA (step-ca)

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -251,11 +251,69 @@ Then, unconditionally:
 - **`settingLine()` must stay single-quote-safe.** Values reach it from admin
   input and package lists.
 - **`FOG_installed` is unquoted and numeric** to match the historical format.
+  It is also the one boolean-looking key the normalizer below leaves alone —
+  see "Boolean values".
 - **A typo in `managedKeys` is silent, not fatal.** `settingLine()` resolves
   `${!key}`, so a key naming no live variable emits an empty line.
 - Adding a key to `managedKeys` **turns a hand-set key into a managed one**, so
   the admin's value starts being overwritten. That is a behavior change even
   though it looks like documentation.
+
+---
+
+## Boolean values
+
+Every boolean key holds `yes` or `no`. There were three encodings before this,
+and the flag layer mixed them inside a single variable — `sDHCP_enabled` was
+assigned `"Y"` and then `1` on the very next line, and
+`sBOOT_external_tftp_server` was assigned the string `"true"`, which nothing
+tested for.
+
+| Old encoding | Keys |
+|---|---|
+| `yes`/`no` | `WEB_https_redirect`, `BOOT_rebuild_ipxe_with_my_ca`, `PKI_web_cert_publicly_trusted`, `BOOT_url_proto_forced` |
+| `1`/`0` | `FOG_copy_back_old`, `DHCP_enabled`, `DB_external`, `BOOT_external_tftp_server`, `STORAGE_rebuild_nfs_exports`, `PKI_sb_enabled`, `FOG_install_lang` |
+| `Y`/`N` | `FOG_send_reports` |
+
+Which literal a test had to use was a per-key fact nobody could carry, and
+getting it wrong fails silently in both directions:
+
+```sh
+[[ "N" == 0 ]]    # simply false
+[[ "N" -eq 1 ]]   # "N" is evaluated as an ARITHMETIC expression -- an unset
+                  # variable named N, so 0 -- rather than erroring
+```
+
+That pair is how `DHCP_enabled="N"` satisfied neither the enabled test nor the
+disabled one.
+
+`_normalizeBool()` maps `yes|y|1|true|on|enabled` and the negatives, in any
+case, onto `yes`/`no`. Two things it deliberately does not do:
+
+- **An unrecognised value is left alone**, not guessed at. Turning a typo into
+  `no` is how a deliberate setting disappears with nothing to show why.
+- **Empty stays empty.** The prompt loops are `while [[ -z ${KEY} ]]`, so
+  collapsing unset into `no` would stop every prompt firing.
+
+`_normalizeBooleanSettings()` applies it to the twelve keys and runs on **every**
+install, not once behind a version marker — `.fogsettings` is a file admins edit,
+so an old encoding can arrive at any time. That makes it idempotent and
+self-repairing, and it is what keeps the GH-1120 key migration a *copy* rather
+than a translation. It runs after the flag shadows, because every source of a
+value has fed in by that point and the flag layer was itself the worst offender.
+`writeUpdateFile()` therefore only ever sees `yes`/`no`.
+
+**Polarity is untouched.** `BOOT_external_tftp_server` keeps the sense it
+inherited from `noTftpBuild`, so values carry across unchanged and only the
+encoding moves.
+
+Three keys are outside this:
+
+| Key | Why |
+|---|---|
+| `FOG_installed` | unquoted numeric via `settingLine()`'s own branch to preserve the historical format, read by `bin/updatefog.sh`, and install *state* rather than a preference |
+| `SVC_firewall_control` | tri-state — `configure`/`disable`/`skip`. Folding it to `yes`/`no` destroys an answer |
+| `FOG_install_type` | an `N`/`S` enum |
 
 ---
 

--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -245,7 +245,10 @@ refused). FOG keeps them from then on and never re-issues.
 
 Dropping the files at the canonical names still works and is equivalent: those
 are `$PKI_client_cert_dir/.srvpublic.crt` and `.srvprivate.key`, now symlinks
-into `pki/client/leaf/`. Either way FOG checks the modulus first.
+into `pki/client/leaf/`. Either way FOG checks the modulus first — comparing the
+raw modulus, not `openssl md5` of it, because md5 of the empty output an
+unreadable file produces is a perfectly non-empty hash, so two unreadable files
+used to "pair".
 
 >[!danger]
 >The two must pair. Every registered fog-client encrypts to the public half of

--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -240,8 +240,12 @@ The FOG root and everything fog-client depends on are untouched.
 
 ### The client-communication leaf (external issuer)
 
-Drop the certificate at `$PKI_client_cert_dir/.srvpublic.crt` with its key at
-`$PKI_client_cert_dir/.srvprivate.key`. FOG keeps both from then on and never re-issues.
+Pass `--client-cert` and `--client-key` (both, or neither — half a pair is
+refused). FOG keeps them from then on and never re-issues.
+
+Dropping the files at the canonical names still works and is equivalent: those
+are `$PKI_client_cert_dir/.srvpublic.crt` and `.srvprivate.key`, now symlinks
+into `pki/client/leaf/`. Either way FOG checks the modulus first.
 
 >[!danger]
 >The two must pair. Every registered fog-client encrypts to the public half of

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -76,6 +76,11 @@ issues day to day) — everything is a dotfile (`ls -a`):
 root/ca/.fogCA.{key,pem}          the anchor. Key never regenerated, 0400 root:root.
                                    .fogCA.pem is a symlink to wherever the
                                    certificate already lived before this split.
+conf/req.cnf                      the CSR subject and SANs, and the v3 extensions
+conf/ca.cnf                        written into a signed certificate. SHARED --
+                                   both issuing zones read them, so the two can
+                                   never disagree about the names this server
+                                   answers to. Also read by renewal-helper.
 client/leaf/.srvprivate.key       the client communication keypair, which every
 client/leaf/.srvpublic.crt         registered fog-client pins. The REAL files.
                                    0640 root:$apacheuser, in a 0710 directory --
@@ -84,9 +89,16 @@ client/leaf/.srvpublic.crt         registered fog-client pins. The REAL files.
                                    not 0700 root:root.
                                    $PKI_client_cert_dir/.srvprivate.key and
                                    .srvpublic.crt are symlinks to these.
+client/leaf/fog.csr               the comm leaf's own CSR, kept with the leaf it
+                                   requested.
 web/ca/.fogWebCA.{key,pem}        signs the vhost's certificate and node certificates
 web/ca/.fogWebCAchain.pem         CA + web intermediate
 web/leaf/.webLeaf.{key,pem}       what the web server actually serves
+web/ca/.trustAnchor.pem           what this server anchors the web zone on: the
+                                  FOG root, plus an imported root where there is
+                                  one, deduped by fingerprint
+web/dhparam.pem                   Diffie-Hellman parameters the nginx vhost
+                                  names directly
 secureboot/ca/.fogSBCA.{key,pem,der}  signs the code-signing leaf; .der is
                                   the same certificate MOK.der publishes, kept
                                   here so it can be verified without reaching
@@ -127,12 +139,66 @@ the keypair. The names have to keep resolving because `FOGBase::_decryptCheck()`
 builds `<sslpath>/.srvprivate.key` with the filename hardcoded, taking the
 directory from the storage-node database record rather than from `.fogsettings`.
 
-Only the keypair moved. `req.cnf` and `ca.cnf` are read by the web leaf's own
-issuance and by `packages/pki/renewal-helper`; `fog.csr` is replicated to storage
-nodes by `SnapinReplicator`; `dhparam.pem` is named in the emitted nginx config;
-and the legacy `CA/` tree is read by the web UI to report offline-key state. Each
-is a contract with something outside the installer, so relocating them is its own
-change.
+The rest of that directory moved too, and not all to the same place — where a
+file went says what it is:
+
+| File | New home | Why there |
+|---|---|---|
+| `fog.csr` | `pki/client/leaf/` | the comm leaf's own request, so it belongs with the leaf |
+| `req.cnf`, `ca.cnf` | `pki/conf/` | **shared** — the client leaf *and* the web leaf read both, so neither zone owns them, and putting them under one would make that zone's directory a dependency of the other's issuance |
+| `dhparam.pem` | `pki/web/` | web-server TLS parameters, named directly by the nginx vhost |
+
+None of these gets a compatibility symlink, and that is the difference from the
+keypair rather than an inconsistency: the keypair's canonical names are baked
+into `FOGBase`, so they had to keep resolving. These are named only by the
+installer, by `packages/pki/renewal-helper` (updated with them), and by the vhost
+the installer writes — a symlink would be a second name for a file with one
+reader.
+
+`ca.cnf`'s **bytes** are unchanged by the move, which matters more than it looks:
+`_createWebLeaf` hashes that file into `.webLeaf.sans` to decide whether the web
+leaf's name set changed. Moving it without touching its contents leaves the stamp
+valid, so no server re-issues its web certificate over this. Verified on a live
+upgrade: identical stamp, identical web-leaf and comm-leaf fingerprints.
+
+Only the legacy `CA/` tree stays behind. The root certificate genuinely lives
+there — `pki/root/ca/.fogCA.pem` is a symlink to it — and the web UI reads it to
+report offline-key state.
+
+`SnapinReplicator` no longer replicates `ssl/fog.csr` to storage nodes. It is the
+*master's* client-communication CSR, a request fulfilled long ago, and a node has
+no use for it: a node generates its own keypair and its own CSR and is issued a
+certificate by the master's Web CA (below). `ssl/CA` still replicates — that is
+the CA certificate, public trust material a node legitimately holds.
+
+## Storage node certificates
+
+A node never sends a private key anywhere. `_requestNodeCert()` generates a
+keypair and a CSR **on the node**, POSTs the CSR to the master's
+`service/nodecert.php`, and installs what comes back as its web vhost
+certificate. The master signs through `fog-sign-node-cert`, a root-only helper
+the web user may invoke but cannot hand paths to — every path comes from a
+root-owned config, which is what stops a compromised web tier naming its own CA
+key.
+
+**This works when the Web CA is an imported one, and did not before.** The helper
+used to append `PKI_ROOT_CERT` to the chain it returned and verify the freshly
+signed leaf against `PKI_ROOT_CERT` — the FOG root, which on a bring-your-own-CA
+server never signed that intermediate. `openssl verify` therefore could not build
+a chain and *every* node request was refused, with a message blaming name
+constraints for something that was never a name problem.
+
+Two config values fix it, and both are per-zone because the zones are not
+anchored by the same thing:
+
+| Value | Is | Why not `PKI_ROOT_CERT` |
+|---|---|---|
+| `PKI_WEB_ANCHOR` | `pki/web/ca/.trustAnchor.pem` | carries the FOG root **and** an imported root where there is one, so one path verifies on either kind of install |
+| `PKI_WEB_CHAIN` | `PKI_web_trust_chain` | already *is* issuer-plus-its-root, so it is the right thing for a node to serve beneath its leaf; building it from the FOG root appended an unrelated certificate |
+
+The Secure Boot zone keeps `PKI_ROOT_CERT` as its anchor, and that is not an
+oversight: there is no "bring your own Secure Boot root", because firmware trusts
+the enrolled certificate directly and nothing above it is ever consulted.
 
 `pki/root/leaf/` held discoverability symlinks to the keypair while it lived in
 the snapin directory. It is retired — a second set of links pointing at the first
@@ -233,6 +299,22 @@ nothing renews them automatically. To rotate either one sooner:
 /opt/fog/pki/renewal-helper --zone web
 /opt/fog/pki/renewal-helper --zone secureboot
 ```
+
+>[!warning]
+>This helper was **missed entirely by the GH-1120 key rename** and was broken on
+>every 1.6 server until it was fixed alongside the moves above. It read eleven
+>retired key names — `sslpath`, `sslprivkey`, `sslpubcert`, `sslcakey`,
+>`sslcapem`, `sslcachain`, `rootCAPem`, `hostname`, `osid` and `acmeLeaf` — all
+>of which `deprecatedKeys` *strips* from `.fogsettings`. Each read therefore
+>produced an empty string and fell through to a default: correct only on a server
+>that had customised nothing. `$fogprogramdir` is the one old spelling still
+>right, because `/etc/fog/fog.conf` is deliberately exempt from the rename.
+>
+>It also refused on `acmeLeaf=yes`, a key that no longer exists. It now asks the
+>filesystem the same question `_externallyManagedLeaf()` does — does the
+>canonical path resolve outside the web zone — and it verifies the reissued leaf
+>against `.trustAnchor.pem` rather than the FOG root, so it works on an
+>external-CA install too.
 
 The web leaf re-issues from the online Web CA (or the root directly, on a
 server whose root can't anchor an intermediate) and reloads Apache so it

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -76,10 +76,14 @@ issues day to day) — everything is a dotfile (`ls -a`):
 root/ca/.fogCA.{key,pem}          the anchor. Key never regenerated, 0400 root:root.
                                    .fogCA.pem is a symlink to wherever the
                                    certificate already lived before this split.
-root/leaf/.srvprivate.key         symlink -> $PKI_client_cert_dir/.srvprivate.key
-root/leaf/.srvpublic.crt          symlink -> $PKI_client_cert_dir/.srvpublic.crt
-                                   (the comm leaf's real files stay at
-                                   $PKI_client_cert_dir -- see "Why they were separated")
+client/leaf/.srvprivate.key       the client communication keypair, which every
+client/leaf/.srvpublic.crt         registered fog-client pins. The REAL files.
+                                   0640 root:$apacheuser, in a 0710 directory --
+                                   the web tier has to read the key on every
+                                   handshake, so this is the one leaf/ that is
+                                   not 0700 root:root.
+                                   $PKI_client_cert_dir/.srvprivate.key and
+                                   .srvpublic.crt are symlinks to these.
 web/ca/.fogWebCA.{key,pem}        signs the vhost's certificate and node certificates
 web/ca/.fogWebCAchain.pem         CA + web intermediate
 web/leaf/.webLeaf.{key,pem}       what the web server actually serves
@@ -109,10 +113,31 @@ done (safe to remove by hand). `$fogprogramdir/secureboot-staging` is a
 separate, web-user-writable directory for in-flight kernel-signing requests --
 unrelated key material, and deliberately not part of this tree.
 
-`.srvprivate.key`/`.srvpublic.crt` themselves stay exactly where they have
-always been, at `$PKI_client_cert_dir` — `root/leaf/` only adds discoverability symlinks
-to them, so nothing under `pki/` is flat while the comm keypair's real files
-never move.
+`.srvprivate.key`/`.srvpublic.crt` used to live directly at
+`$PKI_client_cert_dir` — i.e. `$snapindir/ssl`, the same directory an admin edits
+to change snapin SSL and the directory the snapin replicator walks. So "change
+the snapin certificates" and "replace the one keypair every registered client
+pins" were the same operation on the same directory, and the second is invisible
+until hosts stop checking in.
+
+They now live in their own zone at `pki/client/leaf/`, with a **symlink per file**
+left at the historic names. Per file rather than a directory symlink on purpose:
+symlinking `$snapindir/ssl` itself would put snapin uploads straight back beside
+the keypair. The names have to keep resolving because `FOGBase::_decryptCheck()`
+builds `<sslpath>/.srvprivate.key` with the filename hardcoded, taking the
+directory from the storage-node database record rather than from `.fogsettings`.
+
+Only the keypair moved. `req.cnf` and `ca.cnf` are read by the web leaf's own
+issuance and by `packages/pki/renewal-helper`; `fog.csr` is replicated to storage
+nodes by `SnapinReplicator`; `dhparam.pem` is named in the emitted nginx config;
+and the legacy `CA/` tree is read by the web UI to report offline-key state. Each
+is a contract with something outside the installer, so relocating them is its own
+change.
+
+`pki/root/leaf/` held discoverability symlinks to the keypair while it lived in
+the snapin directory. It is retired — a second set of links pointing at the first
+had nothing reading either — and removed on upgrade if it holds nothing but those
+links.
 
 An install that already ran an earlier layout (flat `CA/.fogCA.*` directly
 under `$PKI_client_cert_dir`, or the intermediate one-level-down `CA/web/.fogWebCA.*`
@@ -126,7 +151,7 @@ anything might still reference them directly.
 |---|---|
 | `pki/root/ca/.fogCA.pem` | **unchanged**, byte for byte |
 | `ca.cert.der` | **unchanged** — no client re-pins |
-| `.srvprivate.key` | **unchanged** — client authentication is unaffected |
+| `.srvprivate.key` | **same bytes** — moved into `pki/client/leaf/`, with a symlink left at the old path. Client authentication is unaffected |
 | `srvpublic.crt` | the same certificate, adopted rather than re-issued |
 | the web certificate | **new**, issued by the Web CA, on its own keypair |
 | the Secure Boot MOK | **new** — see below, this one needs action |

--- a/docs/adr/0016-ipxe-enforces-x509-name-constraints.md
+++ b/docs/adr/0016-ipxe-enforces-x509-name-constraints.md
@@ -19,8 +19,21 @@ extension to be marked critical, and it is.
 
 FOG also builds its own iPXE. When the netboot protocol is HTTPS --
 `_resolveNetbootProto()` selects that automatically whenever
-`BOOT_rebuild_ipxe_with_my_ca` is set -- `buildipxe.sh` bakes `.fogCA.pem` into the
-binary as `CERT=`/`TRUST=` so iPXE can validate the FOG server over TLS.
+`BOOT_rebuild_ipxe_with_my_ca` is set -- `buildipxe.sh` bakes a certificate into
+the binary as `CERT=`/`TRUST=` so iPXE can validate the FOG server over TLS.
+
+Which certificate is `_resolveIpxeTrust()`'s answer, and it is
+`PKI_web_ca_cert` — the name-constrained, `serverAuth`-only Web CA intermediate
+itself, not `PKI_web_trust_chain`. That makes this ADR's subject the certificate
+iPXE actually parses: embedding the chain bundle instead would hand iPXE the FOG
+root as well, and so trust in anything the root ever signs, to validate one
+leaf. Narrowing it to the intermediate is only *safe* because of the patch below
+— an unpatched iPXE cannot parse a critical `nameConstraints` at all, which is
+exactly the incompatibility this ADR exists to resolve.
+
+The distinction that makes this decision possible, and that the Secure Boot zone
+cannot borrow (see ADR 0024 and `_sbNameConstraints`' removal): iPXE is a
+verifier FOG can patch, and UEFI firmware is not.
 
 **These two features are mutually incompatible.** iPXE's `x509_extensions[]`
 table knows five extensions: `basicConstraints`, `keyUsage`, `extKeyUsage`,

--- a/docs/adr/0024-fogsettings-unified-key-model.md
+++ b/docs/adr/0024-fogsettings-unified-key-model.md
@@ -185,11 +185,16 @@ because something preserves what it does not manage.
 
 ## Deliberately not done
 
-- **Boolean encoding and polarity normalisation.** Five encodings remain. Fixing
-  them changes *values*, not names, and would have made the migration a
-  translation rather than a copy — including for `BOOT_external_tftp_server`,
-  which keeps `noTftpBuild`'s polarity precisely so the value carries across
-  untouched and still reads correctly against the firewall behaviour.
+- **Boolean encoding and polarity normalisation.** Deferred here, and the
+  encoding half has since been done — see
+  [ADR 0025](0025-one-boolean-encoding-normalised-on-load.md). The reasoning
+  below is what it had to answer: fixing encodings changes *values*, not names,
+  and would have made this migration a translation rather than a copy.
+  0025 resolves that by normalising on **load** every run rather than rewriting
+  once, which leaves the migration a copy. **Polarity is still not done** —
+  `BOOT_external_tftp_server` keeps `noTftpBuild`'s polarity precisely so the
+  value carries across untouched and still reads correctly against the firewall
+  behaviour.
 - **`FOG_update_channel`'s values.** `branchToChannel()` produces
   `stable`/`staging`/`dev` while `FOG_CHANNEL` is stamped
   `Patches`/`Beta`/`Release Candidate`/`Feature`. Reconciling them touches

--- a/docs/adr/0025-one-boolean-encoding-normalised-on-load.md
+++ b/docs/adr/0025-one-boolean-encoding-normalised-on-load.md
@@ -1,0 +1,115 @@
+# One boolean encoding in `.fogsettings`, normalised on load
+
+## Status
+
+accepted
+
+Follows [ADR 0024](0024-fogsettings-unified-key-model.md), which named this and
+deliberately deferred it.
+
+## Context
+
+`.fogsettings` is sourced as shell, so a key's value is whatever literal the file
+contains. Twelve boolean keys carried three encodings between them:
+
+| Encoding | Keys |
+|---|---|
+| `yes`/`no` | `WEB_https_redirect`, `BOOT_rebuild_ipxe_with_my_ca`, `PKI_web_cert_publicly_trusted`, `BOOT_url_proto_forced` |
+| `1`/`0` | `FOG_copy_back_old`, `DHCP_enabled`, `DB_external`, `BOOT_external_tftp_server`, `STORAGE_rebuild_nfs_exports`, `PKI_sb_enabled`, `FOG_install_lang` |
+| `Y`/`N` | `FOG_send_reports` |
+
+The flag layer mixed them *within a single variable*: `sDHCP_enabled` was
+assigned `"Y"` and then `1` on the very next line, and
+`sBOOT_external_tftp_server` was assigned the string `"true"`, which nothing
+anywhere tested for.
+
+So which literal a test had to use was a per-key fact, carried by nobody. That
+would be a tidiness problem if getting it wrong were loud. It is silent, in two
+different ways:
+
+```sh
+[[ "N" == 0 ]]     # simply false
+[[ "N" -eq 1 ]]    # "N" is evaluated as an ARITHMETIC expression -- an unset
+                   # variable named N, hence 0 -- rather than erroring
+```
+
+Both directions were live. `DHCP_enabled` was written `"N"` by the interactive
+prompt and read with `== 0` in one place and `-eq 1` in others, so it satisfied
+**neither** the enabled test nor the disabled one: FOG neither configured DHCP
+nor took the "DHCP is disabled" branch.
+
+ADR 0024 deferred this because changing values would have made the key-rename
+migration a translation rather than a copy — and a translation that runs once,
+against 79 old keys, is a much riskier thing to get wrong than a rename.
+
+## Decision
+
+**Every boolean key holds `yes` or `no`, and the value is normalised on load,
+every run.**
+
+`_normalizeBool()` maps `yes|y|1|true|on|enabled` and the corresponding
+negatives, in any case, onto `yes`/`no`. `_normalizeBooleanSettings()` applies it
+to the twelve keys.
+
+Two things it deliberately does not do:
+
+- **An unrecognised value is left alone**, not coerced. Silently turning a typo
+  into `no` is how a deliberate setting disappears with nothing to show why.
+- **Empty stays empty.** The interactive prompts are `while [[ -z ${KEY} ]]`
+  loops; collapsing unset into `no` would stop every prompt firing and answer for
+  the admin.
+
+Normalisation runs **after** the flag shadows in `bin/installfog.sh`. Every
+source of a value has fed in by that point — the value `.fogsettings` persisted,
+the value the rename seed block copied off a pre-1.6 key, and the value a flag
+set this run — and the flag layer was itself the worst offender for mixed
+encodings. Normalising earlier would leave whatever the flags assigned
+unconverted. `lib/common/input.sh` and `newinput.sh` are sourced later still and
+write `yes`/`no` directly.
+
+### Why on load, and not as a one-time rewrite
+
+A version-marked migration would have been the obvious shape, and it is the
+wrong one. `.fogsettings` is a file administrators edit by hand, and every
+FOG document that says "set `X=1`" is still out there. An old encoding can
+therefore arrive at any time — not only on the upgrade that renamed things.
+
+Normalising on load is idempotent by construction, so it is also
+self-repairing, and it answers ADR 0024's objection directly: `writeUpdateFile()`
+only ever sees `yes`/`no`, so the key migration stays a copy. Nothing has to
+know whether it is running for the first time.
+
+### Excluded
+
+| Key | Why |
+|---|---|
+| `FOG_installed` | `settingLine()` writes it unquoted and numeric to preserve the historical file format, `bin/updatefog.sh` reads it, and it records install **state** rather than a preference |
+| `SVC_firewall_control` | tri-state: `configure`/`disable`/`skip`. Not a boolean; folding it to `yes`/`no` destroys an answer |
+| `FOG_install_type` | an `N`/`S` enum |
+
+The latter two are not booleans at all, so they are outside this decision rather
+than exceptions to it. `tests/boolean-encoding.test.sh` asserts all three stay
+off the list, so a later sweep cannot quietly fold them.
+
+### Polarity is not in scope
+
+`BOOT_external_tftp_server` keeps the sense it inherited from `noTftpBuild`. Only
+the encoding moves, so values carry across untouched — which is what lets this be
+a normalisation rather than a migration.
+
+## Consequences
+
+- A test against a boolean key is `== yes` or `!= yes`. Arithmetic comparisons
+  (`-eq`, `-lt`) are gone, and must stay gone: they are the ones that fail
+  silently rather than merely returning false.
+- `tests/boolean-encoding.test.sh` greps `lib/`, `bin/` and `utils/` and fails if
+  any arithmetic comparison, any `0`/`1`/`Y`/`N`/`true`/`false` comparison, or any
+  such assignment reappears — including on the `s`-prefixed flag shadows.
+- `tests/fogsettings-migration.test.sh` asserts end to end that a pre-rename
+  file supplying all three encodings is written back uniformly `yes`/`no`.
+- Nothing outside the installer reads these keys — no PHP, no `utils/` — so the
+  change did not have to be negotiated with the web tier. That was checked
+  rather than assumed; it is why this could be done as one commit.
+- A hand-edited `.fogsettings` using any documented-anywhere spelling now works,
+  which it did not before: `DHCP_enabled=1` and `DHCP_enabled=yes` are the same
+  setting.

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -71,7 +71,7 @@ fog_udpversion="20250223"
 # a fingerprint and an enrolment kit to hand out. --no-secure-boot sets this to
 # 0, and because .fogsettings is sourced before this file, that choice survives
 # an upgrade rather than being silently re-enabled.
-[[ -z ${PKI_sb_enabled} ]] && PKI_sb_enabled=1
+[[ -z ${PKI_sb_enabled} ]] && PKI_sb_enabled="yes"
 # Anchoring this server's own CA in this server's own trust store is on by
 # default: without it every HTTPS call made ON the FOG server TO the FOG server
 # fails to verify, including the ones inside FOG that have no way to be handed

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1194,7 +1194,6 @@ GRANT INSERT,UPDATE ON ${DB_name}.taskStates TO 'fogstorage'@'%' ;
 GRANT INSERT,UPDATE ON ${DB_name}.taskLog TO 'fogstorage'@'%' ;
 GRANT INSERT,UPDATE ON ${DB_name}.snapinTasks TO 'fogstorage'@'%' ;
 GRANT INSERT,UPDATE ON ${DB_name}.snapinJobs TO 'fogstorage'@'%' ;
-GRANT INSERT,UPDATE ON ${DB_name}.imagingLog TO 'fogstorage'@'%' ;
 FLUSH PRIVILEGES ;
 SET SQL_MODE=@OLD_SQL_MODE ;
 EOF

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2157,11 +2157,31 @@ fetchipxeasset() {
     cd $cwd
     return $stat
 }
-# The CA that gets compiled into a locally built iPXE. ${PKI_web_trust_chain} when there
-# is one, so an external CA's chain is embedded rather than FOG's own root --
-# buildipxe.sh takes it as CERT=/TRUST=, its only per-site input.
+# The CA that gets compiled into a locally built iPXE: ${PKI_web_ca_cert}, the
+# Web intermediate itself. buildipxe.sh takes it as CERT=/TRUST=, its only
+# per-site input.
+#
+# The Web CA and NOT ${PKI_web_trust_chain}, which is what this used to prefer.
+# The chain is the web zone's trust PATH -- intermediate plus the root anchoring
+# it -- and embedding the whole bundle gives iPXE strictly more trust than the
+# job needs: it makes iPXE trust the FOG root, and therefore anything the root
+# ever signs, when all it has to validate is boot.php's leaf. The intermediate
+# is name-constrained and serverAuth-only (ADR 0016, which is enforceable
+# precisely because iPXE is a verifier FOG can patch), so pinning that one
+# certificate is both narrower and sufficient.
+#
+# It is also what makes bring-your-own-CA work here. An admin whose Web CA is
+# their own intermediate has no FOG root above it, so there was nothing sensible
+# for the chain to contain -- the old preference either embedded a bundle whose
+# root FOG does not own, or fell through to this same value anyway.
+#
+# Expect ONE forced rebuild per server on upgrade: _ipxeBuildStampValue() hashes
+# this file into the stamp's ca= field, so the stamp no longer matches and
+# _needsLocalIpxeBuild() schedules exactly one rebuild. That is correct rather
+# than unfortunate -- the binary on disk really does embed different bytes than
+# the ones this now asks for.
 _resolveIpxeTrust() {
-    [[ -n ${PKI_web_trust_chain} && -f ${PKI_web_trust_chain} ]] && ipxetrust="${PKI_web_trust_chain}" || ipxetrust="${PKI_web_ca_cert}"
+    ipxetrust="${PKI_web_ca_cert}"
 }
 # What a built tree is built FROM: the iPXE release tag, and the exact bytes of
 # the CA that got compiled into it.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5219,9 +5219,13 @@ _hardenPkiPermissions() {
     # stricter mode here does not harden anything -- it stops every client on
     # the server from authenticating, with "Private key not readable" as the
     # only clue.
-    if [[ -f ${PKI_client_cert_dir}/.srvprivate.key ]]; then
-        chown root:${apacheuser} "${PKI_client_cert_dir}/.srvprivate.key" >>$error_log 2>&1
-        chmod 0640 "${PKI_client_cert_dir}/.srvprivate.key" >>$error_log 2>&1
+    # The REAL file, not the canonical name. chown/chmod follow symlinks, so
+    # going through the compat link would work by accident -- but it silently
+    # does nothing at all on the run before the link exists, and names the wrong
+    # thing in the error log when it fails.
+    if [[ -f ${PKI_client_encrypt_key} ]]; then
+        chown root:${apacheuser} "${PKI_client_encrypt_key}" >>$error_log 2>&1
+        chmod 0640 "${PKI_client_encrypt_key}" >>$error_log 2>&1
     fi
     errorStat $?
     # configureSnapins now prunes ${PKI_client_cert_dir}, so its recursive relabel no longer
@@ -5607,14 +5611,15 @@ writeUpdateFile() {
     # under its own name here or the emitted line would be empty.
     FOG_program_dir="$fogprogramdir"
 
-    # Same shape, for the same reason: canonical-path RECORDS whose value is a
-    # pure function of ${PKI_client_cert_dir}. Derived here as well as in
-    # _createCommLeaf() so they are still recorded on an install that never
-    # reached it -- settingLine() resolves values by ${!key}, so an unset key
-    # emits an empty line, which #1121 would read as "no client cert configured".
-    if [[ -n ${PKI_client_cert_dir} ]]; then
-        PKI_client_encrypt_key="${PKI_client_cert_dir}/.srvprivate.key"
-        PKI_client_encrypt_cert="${PKI_client_cert_dir}/.srvpublic.crt"
+    # Same shape, for the same reason: canonical-path RECORDS, now a pure
+    # function of the client PKI zone rather than of ${PKI_client_cert_dir}.
+    # Derived here as well as in _createCommLeaf() so they are still recorded on
+    # an install that never reached it -- settingLine() resolves values by
+    # ${!key}, so an unset key emits an empty line, which #1121 would read as
+    # "no client cert configured".
+    if [[ -n $fogprogramdir ]]; then
+        PKI_client_encrypt_key="$(_pkiZoneDir client)/leaf/.srvprivate.key"
+        PKI_client_encrypt_cert="$(_pkiZoneDir client)/leaf/.srvpublic.crt"
     fi
 
     # Managed keys, in the canonical order a freshly written file uses. This one
@@ -6308,9 +6313,12 @@ emitNginxPhpBody() {
 #   |                                storage nodes. Online.
 #   +-- FOG Secure Boot CA           enrolled as MOK.der / written to db;
 #   |                                issues the code-signing leaves.
-#   \-- .srvprivate.key + srvpublic.crt
-#                                    the client communication keypair, left
-#                                    exactly where it has always been.
+#   \-- FOG Client Comm leaf         .srvprivate.key + .srvpublic.crt, in
+#                                    pki/client/leaf. Signed by the root
+#                                    directly -- fog-client pins the root, so
+#                                    there is no intermediate to chain through.
+#                                    Reachable at the historic $snapindir/ssl
+#                                    names through a symlink each.
 #
 # Why the intermediates hang off the EXISTING root rather than a new one above
 # it: an existing server then gets the separation on an ordinary update. A new
@@ -6348,8 +6356,85 @@ _pkiZoneDir() {
     case "$1" in
         root) echo "${fogprogramdir}/pki/root" ;;
         web) echo "${fogprogramdir}/pki/web" ;;
+        client) echo "${fogprogramdir}/pki/client" ;;
         secureboot) echo "${fogprogramdir}/pki/secureboot" ;;
     esac
+}
+# The client zone's leaf directory, and the compatibility links that keep the
+# canonical names working.
+#
+# The comm keypair used to live directly in ${PKI_client_cert_dir}, i.e.
+# $snapindir/ssl -- the same directory an admin edits to change snapin SSL, and
+# the directory the snapin replicator walks. So "change the snapin certificates"
+# and "replace the one keypair every registered client pins" were the same
+# operation on the same directory, and the second one is invisible until hosts
+# stop checking in.
+#
+# The real files move into the client zone. What stays behind at the canonical
+# names is a SYMLINK per file, because the names are not free: FOGBase's
+# _decryptCheck() builds `<sslpath>/.srvprivate.key` with the filename
+# hardcoded, taking the directory from the storage-node record rather than from
+# .fogsettings, so the path has to keep resolving. Per file and not a directory
+# symlink on purpose -- symlinking the whole directory would put snapin uploads
+# straight back beside the keypair, which is the thing being fixed.
+#
+# Everything else in that directory stays put, and this is not laziness: req.cnf
+# and ca.cnf are read by the WEB leaf's issuance too and by packages/pki/
+# renewal-helper, fog.csr is replicated to storage nodes by
+# SnapinReplicator, dhparam.pem is named in the emitted nginx config, and the
+# legacy CA/ tree is read by the web UI to report offline-key state. Each is its
+# own contract with something outside the installer.
+_resolveClientLeafPaths() {
+    local leafdir f
+    leafdir="$(_pkiZoneDir client)/leaf"
+    mkdir -p "$leafdir" >>$error_log 2>&1
+    # 0710 root:${apacheuser}, NOT the 0700 root:root the other zones' leaf dirs
+    # get. The web tier must be able to TRAVERSE this to read the private key --
+    # certDecrypt() opens it on every fog-client handshake -- and 0700 here
+    # fails that as `Private key not readable`, per client, with nothing naming
+    # this directory. Traverse only: 0710 grants no listing.
+    chown root:${apacheuser} "$leafdir" >>$error_log 2>&1
+    chmod 0710 "$leafdir" >>$error_log 2>&1
+    # Migrate a REAL file only. A symlink here is either FOG's own compat link
+    # from a previous run (already migrated, nothing to do) or an admin pointing
+    # at their own file, which _separateCommKey settles first and which must not
+    # be dragged into the zone as a link.
+    for f in .srvprivate.key .srvpublic.crt; do
+        [[ -f "${PKI_client_cert_dir}/${f}" && ! -L "${PKI_client_cert_dir}/${f}" \
+            && ! -e "${leafdir}/${f}" ]] \
+            && mv "${PKI_client_cert_dir}/${f}" "${leafdir}/${f}" >>$error_log 2>&1
+    done
+    PKI_client_encrypt_key="${leafdir}/.srvprivate.key"
+    PKI_client_encrypt_cert="${leafdir}/.srvpublic.crt"
+}
+# The compat links themselves, made once the files they point at exist. Split
+# from _resolveClientLeafPaths because on a fresh install the keypair does not
+# exist yet when the paths have to be settled -- _linkCanonical is a no-op for a
+# target that is not there, so linking early would silently link nothing.
+_linkClientLeafCompat() {
+    mkdir -p "${PKI_client_cert_dir}" >>$error_log 2>&1
+    _linkCanonical "${PKI_client_encrypt_key}" "${PKI_client_cert_dir}/.srvprivate.key"
+    _linkCanonical "${PKI_client_encrypt_cert}" "${PKI_client_cert_dir}/.srvpublic.crt"
+}
+# pki/root/leaf/ held discoverability symlinks to the comm keypair, from when
+# its real files lived in $snapindir/ssl and the root zone was the only zone
+# without a leaf/. The keypair has its own zone now, so that directory would be
+# a second set of links pointing at the first -- two indirections to the same
+# file and nothing reading either.
+#
+# Only ever unlinks a SYMLINK, so a real file somebody else put there survives
+# and the rmdir then fails harmlessly rather than taking it. Finding nothing
+# there is the normal case, on a fresh install and on any server installed after
+# this landed.
+_retireRootLeafLinks() {
+    local rootLeafDir f
+    rootLeafDir="$(_pkiZoneDir root)/leaf"
+    [[ -d $rootLeafDir ]] || return 0
+    for f in .srvprivate.key .srvpublic.crt; do
+        [[ -L "${rootLeafDir}/${f}" ]] && rm -f "${rootLeafDir}/${f}" >>$error_log 2>&1
+    done
+    rmdir "$rootLeafDir" >/dev/null 2>&1
+    return 0
 }
 # Whether the certificate this server serves is managed OUTSIDE FOG.
 #
@@ -7058,11 +7143,11 @@ $(_nameConstraints)" "FOG Web UI"
 # The client communication certificate: the public half of the keypair
 # fog-client encrypts to, and whose private half FOGBase::certDecrypt() opens.
 #
-# Nothing about the keypair changes here. .srvprivate.key stays exactly where
-# it has always been and keeps exactly the contents it has always had -- that
-# is the point of hanging the new zones off the existing root instead of
-# restructuring beneath it. What changes is only that the vhost stops pointing
-# at this certificate and serves a Web CA leaf instead.
+# The keypair's CONTENTS never change: every registered client is already
+# encrypting to its public half, so re-keying locks all of them out at once.
+# Its LOCATION did move, into the client zone -- see _resolveClientLeafPaths for
+# why $snapindir/ssl was the wrong home and what stays behind there. The vhost
+# also stopped pointing at this certificate and serves a Web CA leaf instead.
 #
 # Two properties this has to hold that the historic code did not:
 #
@@ -7081,18 +7166,15 @@ _createCommLeaf() {
     # premise is "say where the cert is" cannot have.
     #
     # They are RECORDS of a canonical path, re-derived every run, not controls.
-    # The filename is not free: FOGBase builds `<dir>/.srvprivate.key` with the
-    # name hardcoded, taking the directory from the storage-node record rather
-    # than from .fogsettings. So the canonical NAME must not move even though
-    # its target may -- point it at your own file with a symlink, exactly as
-    # the web vhost pair works.
-    PKI_client_encrypt_key="${PKI_client_cert_dir}/.srvprivate.key"
-    PKI_client_encrypt_cert="${PKI_client_cert_dir}/.srvpublic.crt"
+    # Settled by _resolveClientLeafPaths, which createSSLCA calls before this --
+    # re-derived here too so the function is safe to reach on its own, and
+    # idempotent either way.
+    _resolveClientLeafPaths
 
     # Already present: keep it, whoever issued it. This is also the supported
-    # way to run a comm leaf issued OUTSIDE FOG -- drop the certificate at
-    # ${PKI_client_cert_dir}/.srvpublic.crt with its key at ${PKI_client_cert_dir}/.srvprivate.key and FOG
-    # leaves both alone from then on.
+    # way to run a comm leaf issued OUTSIDE FOG -- drop the pair at
+    # ${PKI_client_encrypt_cert} / ${PKI_client_encrypt_key} (or pass
+    # --client-cert/--client-key) and FOG leaves both alone from then on.
     #
     # Checked with the same modulus test the adopt branch below uses, and for
     # the same reason it gives: a certificate that does not pair with this key
@@ -7193,7 +7275,7 @@ _createCommLeaf() {
 # where to restore the key. A stale certificate is recoverable -- put the old
 # key back -- where no certificate at all is not.
 _discardOrphanedCommLeaf() {
-    local cert="${PKI_client_cert_dir}/.srvpublic.crt" key="${PKI_client_cert_dir}/.srvprivate.key"
+    local cert="${PKI_client_encrypt_cert}" key="${PKI_client_encrypt_key}"
     [[ -f $cert && -f $key && ${rootCAKeyOffline:-0} -ne 1 ]] || return 0
     local certmod keymod
     certmod=$(openssl x509 -noout -modulus -in "$cert" 2>/dev/null | openssl md5 2>/dev/null)
@@ -7227,7 +7309,7 @@ _discardOrphanedCommLeaf() {
 # the byte-identical file, has to stay silent or the warning stops meaning
 # anything.
 _warnClientRepin() {
-    local newcert="${PKI_client_encrypt_cert:-${PKI_client_cert_dir}/.srvpublic.crt}"
+    local newcert="${PKI_client_encrypt_cert:-$(_pkiZoneDir client)/leaf/.srvpublic.crt}"
     [[ -f $newcert ]] || return 0
     # configureHttpd rm -rf's $webdirdest before createSSLCA runs, so the live
     # copy is usually already gone -- but it backs the tree up first. Same two
@@ -7270,7 +7352,8 @@ _warnClientRepin() {
 }
 # Make .srvprivate.key a file FOG owns outright.
 #
-# An admin who relocated ${PKI_web_vhost_key} has ${PKI_client_cert_dir}/.srvprivate.key as a symlink
+# An admin who relocated ${PKI_web_vhost_key} has the canonical
+# ${PKI_client_cert_dir}/.srvprivate.key as a symlink
 # to their own key -- which under the historic layout was the web key AND the
 # comm key. Separating the zones means the comm key has to stop following that
 # link, or an ACME renewal writing their file would still change what
@@ -7280,10 +7363,26 @@ _warnClientRepin() {
 # already encrypting to its public half, and a new key would lock all of them
 # out at once.
 _separateCommKey() {
-    local canon="${PKI_client_cert_dir}/.srvprivate.key" target
+    local canon="${PKI_client_cert_dir}/.srvprivate.key" target zonedir
     [[ ! -L $canon ]] && return 0
     target=$(readlink -f "$canon" 2>/dev/null)
     [[ -z $target || ! -f $target ]] && return 0
+    # FOG's OWN compat link into the client zone is not something to separate --
+    # it is the layout. Without this test the link is dereferenced and the key
+    # copied back over it on every run: a real duplicate of the client private
+    # key reappears in $snapindir/ssl, and this function announces that it
+    # separated a key from the web key, which it did not.
+    #
+    # _linkClientLeafCompat does put the link back later in the same run, so the
+    # duplicate is transient -- but only if the run gets that far, and errorStat
+    # exits between here and there. A private key left lying in the directory
+    # the snapin replicator walks is not a state to reach and then rely on being
+    # tidied.
+    #
+    # Same question, and the same readlink -f on both sides, as
+    # _externallyManagedLeaf asks of the web leaf.
+    zonedir=$(readlink -f "$(_pkiZoneDir client)" 2>/dev/null)
+    [[ -n $zonedir && $target == "$zonedir"/* ]] && return 0
     dots "Separating the client communication key from the web key"
     rm -f "$canon" >>$error_log 2>&1
     cp -f "$target" "$canon" >>$error_log 2>&1
@@ -8093,8 +8192,14 @@ EOF
     # one path, and was re-derived to it on every run anyway. Every reader now
     # names the canonical location directly, so there is no ordering dependency
     # between this function and _createCommLeaf() below.
+    # Order matters. _separateCommKey first, while the canonical name may still
+    # be an admin's symlink to their web key: it copies the material out from
+    # under that link. _resolveClientLeafPaths second, which then has a real
+    # file to move into the client zone and sets the two canonical-path records
+    # every line below reads.
     _separateCommKey
-    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_cert_dir}/.srvprivate.key || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
+    _resolveClientLeafPaths
+    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
         dots "Creating SSL Private Key"
         if [[ $(validip $certip) -ne 0 ]]; then
             echo -e "\n"
@@ -8109,8 +8214,8 @@ EOF
         # 4096 to match what certDecrypt() expects: it chunks the ciphertext by
         # modulus size (openssl_pkey_get_details -> bits/8), so the key size is
         # part of the wire framing, not a tunable.
-        if [[ ! -e ${PKI_client_cert_dir}/.srvprivate.key || $recreateKeys == yes || $recreateCA == yes ]]; then
-            openssl genrsa -out ${PKI_client_cert_dir}/.srvprivate.key 4096 >>$error_log 2>&1
+        if [[ ! -e ${PKI_client_encrypt_key} || $recreateKeys == yes || $recreateCA == yes ]]; then
+            openssl genrsa -out ${PKI_client_encrypt_key} 4096 >>$error_log 2>&1
             # Only under the flags that ASKED for a new key. This branch also
             # fires when .srvprivate.key is merely ABSENT -- a bad restore, a
             # lost disk -- and that is damage, not intent. There, the surviving
@@ -8127,7 +8232,7 @@ EOF
         # config and openssl reads nothing from stdin. Feeding it a line here
         # would be dead input, and it was the mismatch between that one line and
         # the number of prompted fields that broke fresh installs.
-        openssl req -new -sha512 -key ${PKI_client_cert_dir}/.srvprivate.key -out ${PKI_client_cert_dir}/fog.csr -config ${PKI_client_cert_dir}/req.cnf >>$error_log 2>&1
+        openssl req -new -sha512 -key ${PKI_client_encrypt_key} -out ${PKI_client_cert_dir}/fog.csr -config ${PKI_client_cert_dir}/req.cnf >>$error_log 2>&1
         errorStat $?
     fi
     _createCommLeaf
@@ -8137,17 +8242,14 @@ EOF
     # re-issued, adopted, or left exactly as it was.
     _warnClientRepin
 
-    # Discoverability symlinks only -- the comm leaf's real files stay at
-    # ${PKI_client_cert_dir} (see _createCommLeaf's own comment for why). This just gives
-    # the root zone the same ca/+leaf/ shape as the other two zones, so
-    # nothing under pki/ is flat. ${PKI_client_encrypt_key}/${PKI_client_encrypt_cert} are set
-    # unconditionally at the top of _createCommLeaf, so they're valid here
-    # even if that call returned early without issuing anything yet.
-    local rootLeafDir="$(_pkiZoneDir root)/leaf"
-    mkdir -p "$rootLeafDir" >>$error_log 2>&1
-    chmod 0700 "$rootLeafDir" >>$error_log 2>&1
-    [[ -f ${PKI_client_encrypt_key} ]] && ln -sf "${PKI_client_encrypt_key}" "${rootLeafDir}/.srvprivate.key" >>$error_log 2>&1
-    [[ -f ${PKI_client_encrypt_cert} ]] && ln -sf "${PKI_client_encrypt_cert}" "${rootLeafDir}/.srvpublic.crt" >>$error_log 2>&1
+    # The compat links at the canonical $snapindir/ssl names, now that the
+    # keypair definitely exists. FOGBase's _decryptCheck() builds
+    # `<sslpath>/.srvprivate.key` from the storage-node record with the filename
+    # hardcoded, so those two names have to keep resolving whatever the layout
+    # underneath them is.
+    _linkClientLeafCompat
+
+    _retireRootLeafLinks
 
     # --- Web zone ----------------------------------------------------------
     #

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6180,9 +6180,11 @@ validateExternalCA() {
     dots "Validating external CA files (${zone})"
     # The supplied private key must match the supplied intermediate certificate
     local certmod keymod
-    certmod=$(openssl x509 -noout -modulus -in "$certsrc" 2>>$error_log | openssl md5 2>>$error_log)
-    keymod=$(openssl rsa -noout -modulus -in "$keysrc" 2>>$error_log | openssl md5 2>>$error_log)
-    if [[ -z $certmod || $certmod != $keymod ]]; then
+    # Raw modulus, no `openssl md5`: md5 of the empty output an unreadable file
+    # produces is a non-empty hash, so with it two unreadable files "pair".
+    certmod=$(openssl x509 -noout -modulus -in "$certsrc" 2>>$error_log)
+    keymod=$(openssl rsa -noout -modulus -in "$keysrc" 2>>$error_log)
+    if [[ -z $certmod || -z $keymod || $certmod != "$keymod" ]]; then
         echo "Failed"
         echo "  The supplied CA private key ($keysrc) does not match the"
         echo "  supplied CA certificate ($certsrc)."
@@ -6404,8 +6406,37 @@ _resolveClientLeafPaths() {
             && ! -e "${leafdir}/${f}" ]] \
             && mv "${PKI_client_cert_dir}/${f}" "${leafdir}/${f}" >>$error_log 2>&1
     done
-    PKI_client_encrypt_key="${leafdir}/.srvprivate.key"
-    PKI_client_encrypt_cert="${leafdir}/.srvpublic.crt"
+    PKI_client_encrypt_key="$(_clientLeafTarget "${PKI_client_encrypt_key}" \
+        "${leafdir}/.srvprivate.key" "${PKI_client_cert_dir}/.srvprivate.key")"
+    PKI_client_encrypt_cert="$(_clientLeafTarget "${PKI_client_encrypt_cert}" \
+        "${leafdir}/.srvpublic.crt" "${PKI_client_cert_dir}/.srvpublic.crt")"
+}
+# Where one half of the comm keypair actually lives: FOG's own zone path, or a
+# file the admin named with --client-cert/--client-key.
+#
+# $1 the current record, $2 the zone path, $3 the historic canonical name.
+#
+# The awkward case is that an UPGRADED server's record holds $3 -- the previous
+# version recorded the snapin-dir path -- and $3 is outside the zone, so a plain
+# "outside the zone means the admin's" test would declare every upgraded server
+# externally managed and never migrate anything. $3 is one of FOG's own names,
+# so it is answered with the zone path, exactly as _resolveWebLeafPaths answers
+# its own pre-separation and old-flat-layout paths.
+#
+# Anything else that exists is the admin's file and is returned untouched; the
+# canonical name is then symlinked at it, which is what "point FOG at your own
+# file" means in this zone. A recorded path that no longer exists falls back to
+# the zone rather than being trusted -- the file was removed, and FOG issuing
+# into its own zone is recoverable where a dangling record is not.
+_clientLeafTarget() {
+    local record="$1" zonepath="$2" canon="$3" rr
+    [[ -z $record ]] && { echo "$zonepath"; return 0; }
+    rr="$(readlink -f "$record" 2>/dev/null)"
+    [[ $record == "$zonepath" || $record == "$canon" ]] && { echo "$zonepath"; return 0; }
+    [[ -n $rr && ( $rr == "$(readlink -f "$zonepath" 2>/dev/null)" \
+        || $rr == "$(readlink -f "$canon" 2>/dev/null)" ) ]] && { echo "$zonepath"; return 0; }
+    [[ -f $record ]] && { echo "$record"; return 0; }
+    echo "$zonepath"
 }
 # The compat links themselves, made once the files they point at exist. Split
 # from _resolveClientLeafPaths because on a fresh install the keypair does not
@@ -7186,8 +7217,9 @@ _createCommLeaf() {
     # there was the one path into this state.
     if [[ -f ${PKI_client_encrypt_cert} ]]; then
         local haveMod wantMod
-        haveMod=$(openssl x509 -noout -modulus -in "${PKI_client_encrypt_cert}" 2>/dev/null | openssl md5 2>/dev/null)
-        wantMod=$(openssl rsa -noout -modulus -in "${PKI_client_encrypt_key}" 2>/dev/null | openssl md5 2>/dev/null)
+        # Raw modulus, no `openssl md5` -- see _discardOrphanedCommLeaf.
+        haveMod=$(openssl x509 -noout -modulus -in "${PKI_client_encrypt_cert}" 2>/dev/null)
+        wantMod=$(openssl rsa -noout -modulus -in "${PKI_client_encrypt_key}" 2>/dev/null)
         # No key yet is not a mismatch. An install that has the certificate but
         # not the key is mid-migration, not broken -- _separateCommKey runs
         # after this and is what settles that case.
@@ -7227,13 +7259,16 @@ _createCommLeaf() {
         "${DB_backup_path}/fog_web_${version}.BACKUP/management/other/ssl/srvpublic.crt"; do
         [[ -f $oldcert && -f ${PKI_client_encrypt_key} ]] || continue
         local certmod keymod
-        certmod=$(openssl x509 -noout -modulus -in "$oldcert" 2>/dev/null | openssl md5 2>/dev/null)
-        keymod=$(openssl rsa -noout -modulus -in "${PKI_client_encrypt_key}" 2>/dev/null | openssl md5 2>/dev/null)
+        # Raw modulus, no `openssl md5`. With it, an unreadable $oldcert and an
+        # unreadable key both hashed to md5("") and compared EQUAL, so this
+        # branch adopted a certificate it had never actually parsed.
+        certmod=$(openssl x509 -noout -modulus -in "$oldcert" 2>/dev/null)
+        keymod=$(openssl rsa -noout -modulus -in "${PKI_client_encrypt_key}" 2>/dev/null)
         # The modulus test is what makes this safe. A certificate that does NOT
         # pair with this key is the web certificate of a server whose zones
         # were already separated some other way; copying it here would publish
         # a public key nothing on this server can decrypt against.
-        if [[ -n $certmod && $certmod == $keymod ]]; then
+        if [[ -n $certmod && -n $keymod && $certmod == "$keymod" ]]; then
             dots "Adopting existing client communication certificate"
             cp -f "$oldcert" "${PKI_client_encrypt_cert}" >>$error_log 2>&1
             errorStat $?
@@ -7278,8 +7313,14 @@ _discardOrphanedCommLeaf() {
     local cert="${PKI_client_encrypt_cert}" key="${PKI_client_encrypt_key}"
     [[ -f $cert && -f $key && ${rootCAKeyOffline:-0} -ne 1 ]] || return 0
     local certmod keymod
-    certmod=$(openssl x509 -noout -modulus -in "$cert" 2>/dev/null | openssl md5 2>/dev/null)
-    keymod=$(openssl rsa -noout -modulus -in "$key" 2>/dev/null | openssl md5 2>/dev/null)
+    # The raw modulus, NOT piped through `openssl md5`. With the md5 the
+    # emptiness guard below does not work: an unreadable file makes the x509/rsa
+    # call print nothing, and md5 of nothing is a perfectly non-empty hash of
+    # the empty string. So an unreadable CERT beside a readable key produced a
+    # "mismatch" and this function deleted the certificate -- exactly the
+    # destroyed-certificate outcome the comment below says it must not cause.
+    certmod=$(openssl x509 -noout -modulus -in "$cert" 2>/dev/null)
+    keymod=$(openssl rsa -noout -modulus -in "$key" 2>/dev/null)
     # Unreadable either way is not a mismatch. _createCommLeaf() reports that
     # case rather than acting on it, and deleting on a failed read would turn a
     # bad openssl invocation into a destroyed certificate.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -645,7 +645,7 @@ backupDB() {
     # External Unprivileged Database Implementation
     # Skip database backup for external databases
     # ---------------------------------------------------------
-    if [[ "${DB_external}" == "1" ]]; then
+    if [[ ${DB_external} == yes ]]; then
         echo " * Skipping database backup (External Database Mode)"
         return 0
     fi
@@ -908,7 +908,7 @@ checkWebTier() {
 # hold, table not created yet). Callers must treat empty as "unknown" and never
 # as zero.
 schemaVersionInDB() {
-    [[ "${DB_external}" == "1" ]] && return 0
+    [[ ${DB_external} == yes ]] && return 0
     [[ -z $sqloptionsuser ]] && return 0
     mysql $sqloptionsuser --password="${DB_password}" -N -B --execute="SELECT vValue FROM \`${DB_name}\`.\`schemaVersion\` WHERE vID=1" 2>/dev/null | tail -1
 }
@@ -918,7 +918,7 @@ schemaVersionInDB() {
 # an established install, and guessing "established" would leave a genuinely
 # fresh install with no way to bootstrap. Callers show both instructions.
 fogUserCount() {
-    if [[ "${DB_external}" == "1" ]]; then
+    if [[ ${DB_external} == yes ]]; then
         [[ -z ${DB_host} || -z ${DB_user} ]] && return 0
         mysql --host="${DB_host}" --user="${DB_user}" --password="${DB_password}" $mysqlsslopt -N -B --execute="SELECT COUNT(*) FROM \`${DB_name}\`.\`users\`" 2>/dev/null | tail -1
         return 0
@@ -1101,7 +1101,7 @@ updateDB() {
     # External Unprivileged Database Implementation
     # Bypass DB user management (fogstorage) requiring root GRANT
     # ---------------------------------------------------------
-    if [[ "${DB_external}" == "1" ]]; then
+    if [[ ${DB_external} == yes ]]; then
         echo " * Skipping fogstorage DB user management (External Database Mode)"
         # Return cleanly, skipping the GRANT/ALTER commands below
         return 0
@@ -1536,7 +1536,7 @@ listPackages() {
         done
         FOG_packages=$(echo $newpackagelist)
     fi
-    if [[ ${DHCP_enabled} == 0 ]]; then
+    if [[ ${DHCP_enabled} != yes ]]; then
         [[ -z $newpackagelist ]] && newpackagelist=""
         for z in ${FOG_packages}; do
             [[ -$z != $dhcpname ]] && newpackagelist="$newpackagelist $z"
@@ -1556,7 +1556,7 @@ listPackages() {
     case ${FOG_os_id} in
         1)
             FOG_packages="${FOG_packages} php-bcmath bc"
-            if [[ ${FOG_install_lang} -eq 1 ]]; then
+            if [[ ${FOG_install_lang} == yes ]]; then
                 FOG_packages="${FOG_packages} php-intl"
                 for i in fr de eu es pt zh en ja; do
                     FOG_packages="${FOG_packages} glibc-langpack-${i}"
@@ -1581,9 +1581,9 @@ listPackages() {
             FOG_packages="${FOG_packages// xinetd/}"
             FOG_packages="${FOG_packages// php-gettext/}"
             FOG_packages="${FOG_packages// php-php-gettext/}"
-            if [[ ${FOG_install_lang} -eq 1 ]]; then
+            if [[ ${FOG_install_lang} == yes ]]; then
                 FOG_packages="${FOG_packages} php-intl"
-                if [[ ${FOG_install_lang} -eq 1 ]]; then
+                if [[ ${FOG_install_lang} == yes ]]; then
                     for i in fr de eu es pt zh-hans en ja; do
                         FOG_packages="${FOG_packages} language-pack-${i}"
                     done
@@ -2884,7 +2884,7 @@ resolveDHCPEngine() {
     # doOSSpecificIncludes before we ever get here). Must run after repo setup
     # so the Kea availability probe sees enabled repos (e.g. EPEL on RHEL).
     [[ -z $keaconfig ]] && keaconfig="/etc/kea/kea-dhcp4.conf"
-    [[ ${DHCP_enabled} -eq 1 ]] || return 0
+    [[ ${DHCP_enabled} == yes ]] || return 0
     local iscpkg="$dhcpname"
     [[ -n $iscpkg && ${FOG_packages} == *"$iscpkg"* ]] || return 0
     # Honor an explicit/persisted choice; an existing install is never switched.
@@ -2995,7 +2995,7 @@ pkgFirstInstalled() {
     return 1
 }
 installPackages() {
-    [[ ${FOG_install_lang} -eq 1 ]] && FOG_packages="${FOG_packages} gettext"
+    [[ ${FOG_install_lang} == yes ]] && FOG_packages="${FOG_packages} gettext"
     FOG_packages="${FOG_packages} jq"
     FOG_packages="${FOG_packages} unzip"
     FOG_packages="${FOG_packages} attr"
@@ -3034,7 +3034,7 @@ installPackages() {
     case ${FOG_os_id} in
         1)
             FOG_packages="${FOG_packages} php-bcmath bc"
-            if [[ ${FOG_install_lang} -eq 1 ]]; then
+            if [[ ${FOG_install_lang} == yes ]]; then
                 FOG_packages="${FOG_packages} php-intl"
                 for i in fr de eu es pt zh en ja; do
                     FOG_packages="${FOG_packages} glibc-langpack-${i}";
@@ -3088,12 +3088,12 @@ installPackages() {
             FOG_packages="${FOG_packages// php-php-gettext/}"
             FOG_packages="${FOG_packages} php-bcmath bc"
             FOG_packages="${FOG_packages} php-ssh2"
-            if [[ ${FOG_install_lang} -eq 1 ]]; then
+            if [[ ${FOG_install_lang} == yes ]]; then
                 FOG_packages="${FOG_packages} php-intl"
             fi
             case $linuxReleaseName_lower in
                 *ubuntu*|*mint*)
-                    if [[ ${FOG_install_lang} -eq 1 ]]; then
+                    if [[ ${FOG_install_lang} == yes ]]; then
                         for i in fr de eu es pt zh-hans en ja; do
                             FOG_packages="${FOG_packages} language-pack-${i}";
                         done
@@ -3623,7 +3623,7 @@ _firewallPortList() {
     # 443 is listening on every install whatever httpproto says. Gating this on
     # httpproto told admins to leave closed a port their server was serving on.
     echo "443/tcp HTTPS (web UI, client check-in)"
-    [[ ${BOOT_external_tftp_server} != 1 ]] && echo "69/udp TFTP (PXE boot)"
+    [[ ${BOOT_external_tftp_server} != yes ]] && echo "69/udp TFTP (PXE boot)"
     echo "21/tcp FTP (image/snapin replication, node operations)"
     # Passive data. vsftpd is pinned to this range by configureFTP() for
     # exactly this reason -- see the comment there.
@@ -3640,7 +3640,7 @@ _firewallPortList() {
     # random per boot and could not be firewalled at all.
     echo "20048/tcp NFS mountd"
     echo "20048/udp NFS mountd"
-    [[ ${DHCP_enabled} -eq 1 ]] && echo "67/udp DHCP (FOG is your DHCP server)"
+    [[ ${DHCP_enabled} == yes ]] && echo "67/udp DHCP (FOG is your DHCP server)"
     # udpcast multicast. UDPCAST_STARTINGPORT is the base and each concurrent
     # session consumes two ports, so the window is base .. base + 2*sessions.
     echo "${mcastportmin}-${mcastportmax}/udp Multicast (udpcast)"
@@ -3656,8 +3656,8 @@ _configureFirewalld() {
     local svc
     for svc in http tftp ftp nfs mountd rpc-bind dhcp; do
         case $svc in
-            tftp)     [[ ${BOOT_external_tftp_server} == 1 ]] && continue ;;
-            dhcp)     [[ ${DHCP_enabled} -ne 1 ]] && continue ;;
+            tftp)     [[ ${BOOT_external_tftp_server} == yes ]] && continue ;;
+            dhcp)     [[ ${DHCP_enabled} != yes ]] && continue ;;
         esac
         firewall-cmd --permanent --add-service=$svc >>$error_log 2>&1 || failed=1
     done
@@ -3683,7 +3683,7 @@ _configureUfw() {
     # loaded -- ufw's stock before.rules already accepts RELATED,ESTABLISHED,
     # so the helper is the only missing piece. Persisted, because a reboot
     # without it breaks PXE and nothing says why.
-    if [[ ${BOOT_external_tftp_server} != 1 ]]; then
+    if [[ ${BOOT_external_tftp_server} != yes ]]; then
         echo "nf_conntrack_tftp" > /etc/modules-load.d/fog-conntrack.conf 2>>$error_log
         modprobe nf_conntrack_tftp >>$error_log 2>&1 || true
     fi
@@ -3717,7 +3717,7 @@ _reportIptables() {
         port="${p%/*}"
         echo " *   iptables -I INPUT -p $proto --dport ${port/-/:} -j ACCEPT"
     done < <(_firewallPortList)
-    if [[ ${BOOT_external_tftp_server} != 1 ]]; then
+    if [[ ${BOOT_external_tftp_server} != yes ]]; then
         echo " * TFTP also needs the conntrack helper, or PXE transfers stall:"
         echo " *   modprobe nf_conntrack_tftp"
     fi
@@ -4011,7 +4011,7 @@ configureMySql() {
     # ---------------------------------------------------------
     # External Unprivileged Database Implementation
     # ---------------------------------------------------------
-    if [[ "${DB_external}" == "1" ]]; then
+    if [[ ${DB_external} == yes ]]; then
         dots "Verifying external database connection"
 
         # Test connection and ensure the database exists and is accessible.
@@ -4335,7 +4335,7 @@ EOF
     fi
     errorStat $?
     dots "Setting up exports file"
-    if [[ ${STORAGE_rebuild_nfs_exports} != 1 ]]; then
+    if [[ ${STORAGE_rebuild_nfs_exports} != yes ]]; then
         echo "Skipped"
         if [[ -f "$nfsconfig" ]] && grep -q "no_root_squash" "$nfsconfig"; then
             echo
@@ -5511,10 +5511,65 @@ configureStorage() {
 clearScreen() {
     clear
 }
+# One boolean encoding for .fogsettings: yes / no.
+#
+# Before this there were three, and the flag layer mixed them inside a single
+# variable -- sDHCP_enabled was assigned "Y" and then 1 on the very next line,
+# and sBOOT_external_tftp_server was assigned the string "true", which nothing
+# tested for. The keys divided up as yes/no (three keys), 1/0 (seven) and Y/N
+# (one), so which literal a test had to use was a per-key fact nobody could
+# carry, and getting it wrong is silent: `[[ $x == 0 ]]` against "N" is simply
+# false, and `[[ "N" -eq 1 ]]` evaluates "N" as an arithmetic expression --
+# an unset variable named N, so zero -- rather than erroring. That pair is
+# exactly how DHCP_enabled="N" satisfied neither the enabled test nor the
+# disabled one (GH-1120 follow-up).
+#
+# Anything a human might reasonably have typed maps in, so hand-edited files
+# keep working; anything else is left ALONE rather than guessed at, because
+# silently turning a typo into "no" is how a deliberate setting disappears.
+# Empty stays empty -- callers distinguish "unset" from "no" (see the
+# `[[ -z ${DHCP_enabled} ]]` prompt loops), and collapsing that here would make
+# every prompt stop firing.
+_normalizeBool() {
+    case "${1,,}" in
+        yes|y|1|true|on|enabled)   echo "yes" ;;
+        no|n|0|false|off|disabled) echo "no" ;;
+        *)                         echo "$1" ;;
+    esac
+}
+# The keys _normalizeBool applies to, and the only ones it may.
+#
+# FOG_installed is deliberately absent: settingLine() writes it unquoted and
+# numeric to preserve the historical file format, bin/updatefog.sh reads it, and
+# it records install STATE rather than a preference. SVC_firewall_control
+# (configure/disable/skip) and FOG_install_type (N/S) are absent because they
+# are not booleans at all -- folding either to yes/no would destroy an answer.
+_booleanSettingKeys() {
+    echo BOOT_external_tftp_server BOOT_rebuild_ipxe_with_my_ca \
+         BOOT_url_proto_forced DB_external DHCP_enabled FOG_copy_back_old \
+         FOG_install_lang FOG_send_reports PKI_sb_enabled \
+         PKI_web_cert_publicly_trusted STORAGE_rebuild_nfs_exports \
+         WEB_https_redirect
+}
+# Normalize in place, every run.
+#
+# NOT a one-shot migration keyed on a version marker: .fogsettings is a file
+# admins edit, so an old encoding can arrive at any time, not just on the
+# upgrade that renamed things. Running every time makes this idempotent and
+# self-repairing, and means writeUpdateFile() only ever sees yes/no -- so the
+# migration stays a copy rather than becoming a translation.
+_normalizeBooleanSettings() {
+    local key
+    for key in $(_booleanSettingKeys); do
+        [[ -n ${!key} ]] || continue
+        printf -v "$key" '%s' "$(_normalizeBool "${!key}")"
+    done
+}
 writeUpdateFile() {
     PKI_client_cert_dir="${PKI_client_cert_dir//\/$}"
     tmpDte=$(date +%c)
-    [[ -z ${FOG_copy_back_old} || ${FOG_copy_back_old} -lt 1 ]] && FOG_copy_back_old=0
+    _normalizeBooleanSettings
+    [[ -z ${FOG_copy_back_old} ]] && FOG_copy_back_old="no"
 
     # GH-632: this assumed $fogprogramdir already existed. On a pristine system
     # it does not -- nothing creates it until `mkdir -p $fogprogramdir/cache`
@@ -5976,7 +6031,7 @@ writeUpdateFile() {
         # No file, or a file with no recognizable header: write from scratch.
         # Fresh files default an empty DB_external to 0 (historical behavior;
         # the in-place upgrade path leaves it as-is).
-        DB_external="${DB_external:-0}"
+        DB_external="${DB_external:-no}"
         emitFogSettings "" > "$fogprogramdir/.fogsettings"
     fi
     # This file holds two cleartext passwords -- ${SVC_password} (the ${SVC_user}
@@ -9214,7 +9269,7 @@ configureHttpd() {
     else
         echo "Skipped"
     fi
-    if [[ ${FOG_copy_back_old} -gt 0 ]]; then
+    if [[ ${FOG_copy_back_old} == yes ]]; then
         if [[ -d ${DB_backup_path}/fog_web_${version}.BACKUP ]]; then
             dots "Copying back old web folder as is";
             cp -Rf ${DB_backup_path}/fog_web_${version}.BACKUP/* $webdirdest/
@@ -9280,7 +9335,7 @@ configureHttpd() {
     for i in $(find ${DB_backup_path}/fog_web_${version}.BACKUP/management/other/ -maxdepth 1 -type f -not -name gpl-3.0.txt -a -not -name index.php -a -not -name 'ca.*' 2>>$error_log); do
         cp -Rf $i ${webdirdest}/management/other/ >>$error_log 2>&1
     done
-    if [[ ${FOG_install_lang} -eq 1 ]]; then
+    if [[ ${FOG_install_lang} == yes ]]; then
         dots "Creating the language binaries"
         langpath="${webdirdest}/management/languages"
         languagesfound=$(find $langpath -maxdepth 1 -type d -exec basename {} \; | awk -F. '/\./ {print $1}' 2>>$error_log)
@@ -10021,7 +10076,7 @@ _ensureSecureBootKeys() {
         # absent and the notice would only send an admin looking for a 404. The
         # keys are still minted and the binaries still signed -- see the top of
         # this function -- there is simply nothing to enrol them with yet.
-        if [[ -f $key && -f $cert && ${PKI_sb_enabled:-1} != 0 ]]; then
+        if [[ -f $key && -f $cert && ${PKI_sb_enabled:-yes} == yes ]]; then
             echo
             echo "  ###################################################################"
             echo "  # NOTICE: this server's Secure Boot trust has moved from a self-  #"
@@ -10145,7 +10200,7 @@ _ensureSecureBootPlatformKeys() {
     # (see _ensureSecureBootKeys); enrolment material is not. Blanked rather
     # than merely skipped so _publishSecureBootAuthVars takes its "no platform
     # keys" branch and clears any blobs a previous, non-opted-out run left.
-    [[ ${PKI_sb_enabled:-1} == 0 ]] && return 0
+    [[ ${PKI_sb_enabled:-yes} != yes ]] && return 0
     # No signing key means the whole feature is opted out; there is nothing for
     # a platform key to authorise.
     [[ -z ${PKI_sb_codesign_key} || -z ${PKI_sb_codesign_cert} ]] && return 0
@@ -10228,7 +10283,7 @@ _publishSecureBootKit() {
     # this file existing (bootmenu.class.php:2089). The binaries are still
     # signed -- see _ensureSecureBootKeys for why signing is not part of what
     # the flag turns off.
-    if [[ -z ${PKI_sb_ca_cert} || ${PKI_sb_enabled:-1} == 0 ]]; then
+    if [[ -z ${PKI_sb_ca_cert} || ${PKI_sb_enabled:-yes} != yes ]]; then
         rm -rf "$kitdir" >>$error_log 2>&1
         return 0
     fi
@@ -12501,12 +12556,12 @@ $(_keaSecureBootClassCommented)"
     fi
 }
 configureDHCP() {
-    if [[ ${DHCP_enabled} -eq 1 && ${DHCP_engine} == kea ]]; then
+    if [[ ${DHCP_enabled} == yes && ${DHCP_engine} == kea ]]; then
         dots "Setting up and starting DHCP Server (Kea)"
     else
         case $linuxReleaseName_lower in
             *debian*)
-                if [[ ${DHCP_enabled} -eq 1 ]]; then
+                if [[ ${DHCP_enabled} == yes ]]; then
                     dots "Setting up and starting DHCP Server (incl. debian 9 fix)"
                     sed -i.fog "s/INTERFACESv4=\"\"/INTERFACESv4=\"${NET_interface}\"/g" /etc/default/isc-dhcp-server
                 else
@@ -12519,7 +12574,7 @@ configureDHCP() {
         esac
     fi
     case ${DHCP_enabled} in
-        1)
+        yes)
             # GH-954: one line per address, so a second address on the NIC
             # made this multi-line and every consumer below it wrong.
             serverip=$(ip -4 -o addr show ${NET_interface} | awk -F'([ /])+' '/global/ {print $4}' | head -1)
@@ -12775,7 +12830,7 @@ diffconfig() {
     fi
 }
 setupFogReporting() {
-    [[ ${FOG_send_reports} == "N" ]] && return
+    [[ ${FOG_send_reports} != yes ]] && return
     local reportingdir="$fogprogramdir/reporting"
     local rreports="$reportingdir/report.sh"
     dots "Setting up FOG External Reporting"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -496,7 +496,7 @@ registerStorageNode() {
     # over ${DB_password}, which is the real control on the node<->master trust
     # bootstrap. Closing this properly needs the master to hand a node its
     # anchor out of band, which is a design change, not a flag change.
-    storageNodeExists=$(curl -s -X POST -d "ip=${NET_fog_server_ip}" -d "fogverified" -kL ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/check_node_exists.php -o -)
+    storageNodeExists=$(curl -s --noproxy '*' -X POST -d "ip=${NET_fog_server_ip}" -d "fogverified" -kL ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/check_node_exists.php -o -)
     echo "Done"
     if [[ $storageNodeExists != exists ]]; then
         [[ -z $maxClients ]] && maxClients=10
@@ -531,7 +531,7 @@ registerStorageNode() {
         # the VALUES now come from ${PKI_client_cert_dir}, ${NET_interface} and
         # ${WEB_root}. Renaming the field names to match the settings would make
         # the master silently drop them.
-        regstatus=$(curl -s -k -L -o /dev/null -w '%{http_code}' -X POST -d "newNode" -d "name=$(echo -n $nodeRegName|base64)" -d "path=$(echo -n ${STORAGE_image_share_path}|base64)" -d "ftppath=$(echo -n ${STORAGE_image_share_path}|base64)" -d "snapinpath=$(echo -n $snapindir|base64)" -d "sslpath=$(echo -n ${PKI_client_cert_dir}|base64)" -d "ip=$(echo -n ${NET_fog_server_ip}|base64)" -d "maxClients=$(echo -n $maxClients|base64)" -d "user=$(echo -n ${SVC_user}|base64)" --data-urlencode "pass=$(echo -n ${SVC_password}|base64)" -d "interface=$(echo -n ${NET_interface}|base64)" -d "bandwidth=1" -d "webroot=$(echo -n ${WEB_root}|base64)" -d "fogverified" ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/create_update_node.php)
+        regstatus=$(curl -s --noproxy '*' -k -L -o /dev/null -w '%{http_code}' -X POST -d "newNode" -d "name=$(echo -n $nodeRegName|base64)" -d "path=$(echo -n ${STORAGE_image_share_path}|base64)" -d "ftppath=$(echo -n ${STORAGE_image_share_path}|base64)" -d "snapinpath=$(echo -n $snapindir|base64)" -d "sslpath=$(echo -n ${PKI_client_cert_dir}|base64)" -d "ip=$(echo -n ${NET_fog_server_ip}|base64)" -d "maxClients=$(echo -n $maxClients|base64)" -d "user=$(echo -n ${SVC_user}|base64)" --data-urlencode "pass=$(echo -n ${SVC_password}|base64)" -d "interface=$(echo -n ${NET_interface}|base64)" -d "bandwidth=1" -d "webroot=$(echo -n ${WEB_root}|base64)" -d "fogverified" ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/create_update_node.php)
         case $regstatus in
             2*)
                 echo "Done"
@@ -558,7 +558,7 @@ updateStorageNodeCredentials() {
     # -k on purpose -- see registerStorageNode. This is called from the node
     # path before any anchor exists, and from the master path after one does;
     # the shared function has to work in the earlier of the two.
-    curl -s -k -X POST -d "nodePass" -d "ip=$(echo -n ${NET_fog_server_ip}|base64)" -d "user=$(echo -n ${SVC_user}|base64)" --data-urlencode "pass=$(echo -n ${SVC_password}|base64)" -d "fogverified" ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/create_update_node.php
+    curl -s --noproxy '*' -k -X POST -d "nodePass" -d "ip=$(echo -n ${NET_fog_server_ip}|base64)" -d "user=$(echo -n ${SVC_user}|base64)" --data-urlencode "pass=$(echo -n ${SVC_password}|base64)" -d "fogverified" ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}/maintenance/create_update_node.php
     echo "Done"
 }
 # Mirrors fog_git_path/fog_update_channel/extraServerNames/servicelogs into
@@ -714,10 +714,33 @@ backupDB() {
         # Verified, not -k: this is an HTTPS call to this server, and
         # _resolveSelfCacert names the anchor for the chain it is serving.
         _resolveSelfCacert
-        dbhttpcode=$(curl -s "${selfCacertOpts[@]}" --max-redirs 0 -w '%{http_code}' -o "$dbraw" "$url" 2>"$dbcurlerr")
+        # --noproxy '*' because this is a call to THIS server. With http_proxy
+        # or https_proxy set in the installer's environment -- ordinary on a
+        # server behind corporate egress filtering -- curl sends even a
+        # self-addressed request to the proxy, which either cannot route back to
+        # the FOG server or refuses to CONNECT to it. Observed as
+        # `curl: (56) CONNECT tunnel failed, response 502`, i.e. the backup step
+        # failing for a reason that has nothing to do with the database. The two
+        # other self-calls in this file (the serves-FOG probe and the schema
+        # POST) already pass it; this one was missed.
+        #
+        # -sS, not -s. Plain -s suppresses curl's error message as well as the
+        # progress meter, so $dbcurlerr came back EMPTY and the "curl exited N"
+        # branch below reported a bare exit code with no reason -- defeating the
+        # diagnostics the rest of this block exists to produce.
+        dbhttpcode=$(curl -sS --noproxy '*' "${selfCacertOpts[@]}" --max-redirs 0 -w '%{http_code}' -o "$dbraw" "$url" 2>"$dbcurlerr")
         dbcurlstat=$?
-        jq -r '. | ._content' < "$dbraw" > "$dbbackupfile" 2>>"$dbcurlerr"
-        dbjqstat=$?
+        # Only when curl actually produced a body. Running jq unconditionally
+        # meant that on any curl failure the redirection `< "$dbraw"` failed
+        # too, and bash printed "No such file or directory" to the installer's
+        # stderr -- landing in the middle of the progress line, before the
+        # guards below had a chance to say what really happened.
+        if [[ -f $dbraw ]]; then
+            jq -r '. | ._content' < "$dbraw" > "$dbbackupfile" 2>>"$dbcurlerr"
+            dbjqstat=$?
+        else
+            dbjqstat=1
+        fi
         # Ordered most specific first, so the message names the earliest
         # thing that went wrong rather than its downstream effect. A redirect
         # is called out on its own: -f fails only on 4xx and 5xx, so a 3xx
@@ -4623,7 +4646,7 @@ _requestNodeCert() {
     # on ${DB_password} -- a secret only a genuine node of this master holds -- and
     # what comes back is a certificate chain the caller validates on its own
     # terms. See registerStorageNode for the full reasoning.
-    resp=$(curl -sS -k -X POST \
+    resp=$(curl -sS --noproxy '*' -k -X POST \
         -d "type=${type}" \
         -d "hmac=${mac}" \
         --data-urlencode "csr=${b64}" \

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4551,6 +4551,14 @@ _installNodeCertSigner() {
         echo "PKI_WEB_CA_CERT=${PKI_web_ca_cert}"
         echo "PKI_WEB_CA_KEY=${PKI_web_ca_key}"
         echo "PKI_ROOT_CERT=${PKI_root_ca_cert}"
+        # What the web zone is actually anchored by, and the chain a node should
+        # serve beneath its leaf. Both differ from PKI_ROOT_CERT as soon as the
+        # admin supplies their own Web CA: the FOG root never signed that
+        # intermediate, so it can neither verify what this helper issues nor
+        # belong in what the node serves. .trustAnchor.pem carries the FOG root
+        # AND an imported root where there is one, so it is correct either way.
+        echo "PKI_WEB_ANCHOR=$(_pkiZoneDir web)/ca/.trustAnchor.pem"
+        echo "PKI_WEB_CHAIN=${PKI_web_trust_chain}"
         if [[ -f $sbca ]]; then
             echo "PKI_SB_CA_CERT=${sbca}"
             echo "PKI_SB_CA_KEY=$(_pkiZoneDir secureboot)/ca/.fogSBCA.key"
@@ -6384,6 +6392,22 @@ _pkiZoneDir() {
         secureboot) echo "${fogprogramdir}/pki/secureboot" ;;
     esac
 }
+# The shared openssl configuration both issuing zones read.
+#
+# req.cnf (the CSR's subject and SANs) and ca.cnf (the v3 extensions written
+# into a signed certificate) are NOT client-zone material, even though they
+# lived in $snapindir/ssl next to the comm keypair. Each is read by the client
+# comm leaf AND the web leaf, and by packages/pki/renewal-helper -- one name set,
+# so the two zones can never disagree about which names this server answers to.
+# Putting them under a zone would make one zone's directory a dependency of
+# another's issuance.
+#
+# Deliberately not a zone token in _pkiZoneDir: conf/ holds no keys and no
+# certificates, so giving it the ca/+leaf/ shape the zones have would say
+# something false about it.
+_pkiConfDir() {
+    echo "${fogprogramdir}/pki/conf"
+}
 # The client zone's leaf directory, and the compatibility links that keep the
 # canonical names working.
 #
@@ -6402,12 +6426,10 @@ _pkiZoneDir() {
 # symlink on purpose -- symlinking the whole directory would put snapin uploads
 # straight back beside the keypair, which is the thing being fixed.
 #
-# Everything else in that directory stays put, and this is not laziness: req.cnf
-# and ca.cnf are read by the WEB leaf's issuance too and by packages/pki/
-# renewal-helper, fog.csr is replicated to storage nodes by
-# SnapinReplicator, dhparam.pem is named in the emitted nginx config, and the
-# legacy CA/ tree is read by the web UI to report offline-key state. Each is its
-# own contract with something outside the installer.
+# The rest of what used to sit in that directory moves too, but not all into
+# this zone -- see _relocatePkiConf. Only the legacy CA/ tree stays behind: the
+# root certificate genuinely lives there (pki/root/ca/.fogCA.pem is a symlink to
+# it) and the web UI reads it to report offline-key state.
 _resolveClientLeafPaths() {
     local leafdir f
     leafdir="$(_pkiZoneDir client)/leaf"
@@ -6432,6 +6454,44 @@ _resolveClientLeafPaths() {
         "${leafdir}/.srvprivate.key" "${PKI_client_cert_dir}/.srvprivate.key")"
     PKI_client_encrypt_cert="$(_clientLeafTarget "${PKI_client_encrypt_cert}" \
         "${leafdir}/.srvpublic.crt" "${PKI_client_cert_dir}/.srvpublic.crt")"
+    # The comm leaf's own CSR belongs with the leaf it requested.
+    [[ -f "${PKI_client_cert_dir}/fog.csr" && ! -e "${leafdir}/fog.csr" ]] \
+        && mv "${PKI_client_cert_dir}/fog.csr" "${leafdir}/fog.csr" >>$error_log 2>&1
+    return 0
+}
+# Move the shared openssl config, and the web server's DH parameters, out of
+# $snapindir/ssl.
+#
+# No compatibility symlinks for these, unlike the keypair, and the difference is
+# the point: nothing outside FOG's own code reads them. The keypair's canonical
+# names are baked into FOGBase, so they had to keep resolving; these three are
+# named only by this installer, by packages/pki/renewal-helper (updated with
+# them) and by the vhost this installer writes. A symlink would be a second name
+# for a file with one reader.
+#
+# The CONTENTS of ca.cnf are unchanged by moving it, which matters more than it
+# looks: _createWebLeaf stamps .webLeaf.sans with a hash of this file to decide
+# whether the web leaf's name set changed. Moving the file without touching its
+# bytes leaves that stamp valid, so no server re-issues its web certificate over
+# this.
+_relocatePkiConf() {
+    local confdir webdir f
+    confdir="$(_pkiConfDir)"
+    webdir="$(_pkiZoneDir web)"
+    mkdir -p "$confdir" "$webdir" >>$error_log 2>&1
+    # Readable: openssl reads these as root, but the renewal helper and an admin
+    # inspecting the name set do too, and they hold no secrets.
+    chmod 0755 "$confdir" >>$error_log 2>&1
+    for f in req.cnf ca.cnf; do
+        [[ -f "${PKI_client_cert_dir}/${f}" && ! -e "${confdir}/${f}" ]] \
+            && mv "${PKI_client_cert_dir}/${f}" "${confdir}/${f}" >>$error_log 2>&1
+        [[ -f "${confdir}/${f}" ]] && chmod 0644 "${confdir}/${f}" >>$error_log 2>&1
+    done
+    # dhparam.pem is web-server TLS parameters -- the nginx vhost names it
+    # directly -- so it belongs in the web zone rather than beside the snapins.
+    [[ -f "${PKI_client_cert_dir}/dhparam.pem" && ! -e "${webdir}/dhparam.pem" ]] \
+        && mv "${PKI_client_cert_dir}/dhparam.pem" "${webdir}/dhparam.pem" >>$error_log 2>&1
+    return 0
 }
 # Where one half of the comm keypair actually lives: FOG's own zone path, or a
 # file the admin named with --client-cert/--client-key.
@@ -7309,9 +7369,9 @@ _createCommLeaf() {
     # Signed by the ROOT, not by an intermediate. fog-client pins the root and
     # fetches this certificate directly; giving it its own intermediate would
     # add a chain the client has no reason to walk.
-    openssl x509 -req -in "${PKI_client_cert_dir}/fog.csr" -CA "${PKI_root_ca_cert}" -CAkey "${PKI_root_ca_key}" \
+    openssl x509 -req -in "$(_pkiZoneDir client)/leaf/fog.csr" -CA "${PKI_root_ca_cert}" -CAkey "${PKI_root_ca_key}" \
         -CAcreateserial -sha512 -days 3650 -extensions v3_ca \
-        -extfile "${PKI_client_cert_dir}/ca.cnf" -out "${PKI_client_encrypt_cert}" >>$error_log 2>&1 || st=1
+        -extfile "$(_pkiConfDir)/ca.cnf" -out "${PKI_client_encrypt_cert}" >>$error_log 2>&1 || st=1
     chmod 0644 "${PKI_client_encrypt_cert}" >>$error_log 2>&1
     errorStat $st
 }
@@ -7656,7 +7716,7 @@ _createWebLeaf() {
     # NAMES had not changed. The install reported success and the vhost went on
     # serving a certificate signed by the CA that had just been replaced, with
     # nothing anywhere saying so.
-    want=$( { cat "${PKI_client_cert_dir}/ca.cnf" 2>/dev/null
+    want=$( { cat "$(_pkiConfDir)/ca.cnf" 2>/dev/null
               openssl x509 -in "${PKI_web_ca_cert}" -noout -fingerprint -sha256 2>/dev/null
             } | openssl md5 2>/dev/null)
     if [[ -e ${PKI_web_vhost_cert} && -e $stamp && "$(cat "$stamp" 2>/dev/null)" == "$want" ]]; then
@@ -7671,14 +7731,14 @@ _createWebLeaf() {
     # the same file req.cnf's comm-leaf CSR (below) also reads, so the two
     # never diverge on names, only on subject.
     openssl req -new -sha512 -key "${PKI_web_vhost_key}" -out "${leafdir}/.webLeaf.csr" \
-        -config "${PKI_client_cert_dir}/req.cnf" \
+        -config "$(_pkiConfDir)/req.cnf" \
         -subj "/CN=${NET_hostname}/O=FOG Project/OU=FOG Web UI" >>$error_log 2>&1 || st=1
     # 5 years: short enough that a compromised leaf key ages out on its own,
     # long enough not to need automatic renewal. renewal-helper (packages/pki)
     # exists for an admin who wants to rotate it sooner.
     openssl x509 -req -in "${leafdir}/.webLeaf.csr" -CA "${PKI_web_ca_cert}" -CAkey "${PKI_web_ca_key}" \
         -CAcreateserial -out "${PKI_web_vhost_cert}" -days 1825 -extensions v3_ca \
-        -extfile "${PKI_client_cert_dir}/ca.cnf" >>$error_log 2>&1 || st=1
+        -extfile "$(_pkiConfDir)/ca.cnf" >>$error_log 2>&1 || st=1
     [[ $st -eq 0 ]] && echo "$want" > "$stamp"
     chmod 0600 "${PKI_web_vhost_key}" >>$error_log 2>&1
     chmod 0644 "${PKI_web_vhost_cert}" >>$error_log 2>&1
@@ -8138,6 +8198,10 @@ createSSLCA() {
     PKI_client_cert_dir=${PKI_client_cert_dir//\/$}
     [[ ! -d ${PKI_client_cert_dir} ]] && mkdir -p ${PKI_client_cert_dir} >>$error_log 2>&1
     [[ ! -d ${PKI_client_cert_dir}/CA ]] && mkdir -p ${PKI_client_cert_dir}/CA >>$error_log 2>&1
+    # Before anything reads or writes req.cnf/ca.cnf -- which is both zones'
+    # issuance below -- so an upgrade finds them where this run expects them and
+    # a fresh install has the directory to write into.
+    _relocatePkiConf
     _collectPkiNames
     _resolveRootCA
     # Detect-then-LINK, before anything below decides whether to issue a
@@ -8209,7 +8273,7 @@ createSSLCA() {
     # where a certificate has no DNS SAN at all OpenSSL falls back to matching
     # the subject CN against them -- and this CN is an IP literal. A leaf with
     # only IP SANs would be rejected by its own CA.
-    cat > ${PKI_client_cert_dir}/ca.cnf << EOF
+    cat > $(_pkiConfDir)/ca.cnf << EOF
 [v3_ca]
 subjectAltName = @alt_names
 [alt_names]
@@ -8229,7 +8293,7 @@ EOF
     # .srvprivate.key not already existing, which is why upgrades never hit it.
     # With prompt = no the values below are taken literally, which is what they
     # were always meant to be.
-    cat > ${PKI_client_cert_dir}/req.cnf << EOF
+    cat > $(_pkiConfDir)/req.cnf << EOF
 [req]
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
@@ -8262,7 +8326,7 @@ EOF
     # every line below reads.
     _separateCommKey
     _resolveClientLeafPaths
-    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
+    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e $(_pkiZoneDir client)/leaf/fog.csr ]]; then
         dots "Creating SSL Private Key"
         if [[ $(validip $certip) -ne 0 ]]; then
             echo -e "\n"
@@ -8295,7 +8359,7 @@ EOF
         # config and openssl reads nothing from stdin. Feeding it a line here
         # would be dead input, and it was the mismatch between that one line and
         # the number of prompted fields that broke fresh installs.
-        openssl req -new -sha512 -key ${PKI_client_encrypt_key} -out ${PKI_client_cert_dir}/fog.csr -config ${PKI_client_cert_dir}/req.cnf >>$error_log 2>&1
+        openssl req -new -sha512 -key ${PKI_client_encrypt_key} -out $(_pkiZoneDir client)/leaf/fog.csr -config $(_pkiConfDir)/req.cnf >>$error_log 2>&1
         errorStat $?
     fi
     _createCommLeaf
@@ -8497,8 +8561,12 @@ EOF
                         echo "    proxy_cookie_domain ~(?P<secure_domain>([-0-9a-z]+\.)?[-0-9a-z]+\.[a-z]+)$ \"$secure_domain; secure\";" >> "$etcconf"
                         echo "}" >> "$etcconf"
                         # Creates the diffie helman param file.
-                        if [[ ! -f ${PKI_client_cert_dir}/dhparam.pem ]]; then
-                            openssl dhparam -dsaparam -out ${PKI_client_cert_dir}/dhparam.pem 4096 >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                        if [[ ! -f $(_pkiZoneDir web)/dhparam.pem ]]; then
+                            # The web zone dir normally exists by here, but a
+                            # storage node reaches this vhost writer without
+                            # having minted a Web CA, so nothing has created it.
+                            mkdir -p "$(_pkiZoneDir web)" >>$error_log 2>&1
+                            openssl dhparam -dsaparam -out $(_pkiZoneDir web)/dhparam.pem 4096 >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                         fi
                         echo "server {" >> "$etcconf"
                         echo "    listen ${NET_fog_server_ip}:443 ssl${nginxhttp2listen};" >> "$etcconf"
@@ -8508,7 +8576,7 @@ EOF
                         echo "    client_max_body_size 3000m;" >> "$etcconf"
                         echo "    ssl_protocols TLSv1.2 TLSv1.3;" >> "$etcconf"
                         echo "    ssl_prefer_server_ciphers off;" >> "$etcconf"
-                        echo "    ssl_dhparam ${PKI_client_cert_dir}/dhparam.pem;" >> "$etcconf"
+                        echo "    ssl_dhparam $(_pkiZoneDir web)/dhparam.pem;" >> "$etcconf"
                         echo "    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;" >> "$etcconf"
                         # nginx has no separate chain directive -- ssl_certificate must BE the
                         # concatenation. Falls back to the bare leaf when nothing sits between
@@ -8646,9 +8714,13 @@ EOF
                         echo "}" >> "$etcconf"
                         echo "Continued (See Below)"
                         # Creates the diffie helman param file.
-                        if [[ ! -f ${PKI_client_cert_dir}/dhparam.pem ]]; then
+                        if [[ ! -f $(_pkiZoneDir web)/dhparam.pem ]]; then
                             dots "Creating DHParam file"
-                            openssl dhparam -dsaparam -out ${PKI_client_cert_dir}/dhparam.pem 4096 >>$workingdir/error_logs/fog_error_${version}.log 2>&1
+                            # See the other dhparam site: a storage node reaches
+                            # this without having minted a Web CA, so nothing has
+                            # created the zone directory.
+                            mkdir -p "$(_pkiZoneDir web)" >>$error_log 2>&1
+                            openssl dhparam -dsaparam -out $(_pkiZoneDir web)/dhparam.pem 4096 >>$workingdir/error_logs/fog_error_${version}.log 2>&1
                             echo "Done"
                         fi
                         dots "Setting up Nginx virtualhost${sslenabled}"
@@ -8671,7 +8743,7 @@ EOF
                         echo "    client_max_body_size 3000m;" >> "$etcconf"
                         echo "    ssl_protocols TLSv1.2 TLSv1.3;" >> "$etcconf"
                         echo "    ssl_prefer_server_ciphers off;" >> "$etcconf"
-                        echo "    ssl_dhparam ${PKI_client_cert_dir}/dhparam.pem;" >> "$etcconf"
+                        echo "    ssl_dhparam $(_pkiZoneDir web)/dhparam.pem;" >> "$etcconf"
                         echo "    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;" >> "$etcconf"
                         # nginx has no separate chain directive -- ssl_certificate must BE the
                         # concatenation. Falls back to the bare leaf when nothing sits between

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -73,7 +73,7 @@ while [[ -z ${FOG_install_type} ]]; do
         echo "     http://www.fogproject.org/wiki/index.php?title=InstallationModes"
         echo
         echo -n "  What type of installation would you like to do? [N/s (Normal/Storage)] "
-        read installtype
+        read FOG_install_type
     fi
     case ${FOG_install_type} in
         [Nn]|[Nn][Oo][Rr][Mm][Aa][Ll]|"")
@@ -108,7 +108,7 @@ testInterface() {
                 ;;
             [Yy]|[Yy][Ee][Ss])
                 echo -n "  What network interface would you like to use? "
-                read interface
+                read NET_interface
                 ;;
             *)
                 echo "  Invalid input, please try again."
@@ -158,17 +158,21 @@ case ${FOG_install_type} in
             if [[ -z $autoaccept ]]; then
                 echo
                 echo -n "  Would you like to use the FOG server for DHCP service? [y/N] "
-                read dodhcp
+                read DHCP_enabled
             fi
             case ${DHCP_enabled} in
                 [Nn]|[Nn][Oo]|"")
                     DHCP_enabled=0
-                    DHCP_enabled="N"
                     ;;
                 [Yy]|[Yy][Ee][Ss])
                     DHCP_enabled=1
                     ;;
                 *)
+                    # Cleared so the loop re-prompts. Before the read targeted
+                    # this key it was always empty here and always matched ""
+                    # above, so an unrecognised answer could not survive; now it
+                    # can, and a non-empty one would end the loop.
+                    DHCP_enabled=""
                     echo "  Invalid input, please try again."
                     ;;
             esac
@@ -185,7 +189,7 @@ case ${FOG_install_type} in
                         if [[ $count -ge 1 ]] || [[ -z $autoaccept ]]; then
                             echo "  What is the IP address to be used for the router on"
                             echo -n "      the DHCP server? [$strSuggestedRoute]"
-                            read routeraddress
+                            read DHCP_router
                         fi
                         case ${DHCP_router} in
                             "")
@@ -221,7 +225,7 @@ case ${FOG_install_type} in
                     [Yy]|[Yy][Ee][Ss]|"")
                         if [[ $count -ge 1 ]] || [[ -z $autoaccept ]]; then
                             echo -n "  What DNS address should DHCP allow? [$strSuggestedDNS] "
-                            read dnsaddress
+                            read DHCP_dns_server_ip
                         fi
                         case ${DHCP_dns_server_ip} in
                             "")
@@ -253,7 +257,7 @@ case ${FOG_install_type} in
                 echo
                 echo "  This version of FOG has internationalization support, would  "
                 echo -n "  you like to install the additional language packs? [y/N] "
-                read installlang
+                read FOG_install_lang
             fi
             case ${FOG_install_lang} in
                 [Nn]|[Nn][Oo]|"")
@@ -263,6 +267,9 @@ case ${FOG_install_type} in
                     FOG_install_lang=1
                     ;;
                 *)
+                    # See the DHCP_enabled loop above: cleared so an
+                    # unrecognised answer re-prompts instead of ending the loop.
+                    FOG_install_lang=""
                     echo "  Invalid input, please try again."
                     ;;
             esac
@@ -276,7 +283,7 @@ case ${FOG_install_type} in
             echo "  What is the IP address or hostname of the FOG server running "
             echo "  the fog database?  This is typically the server that also "
             echo -n "  runs the web server, dhcp, and tftp.  IP or Hostname: "
-            read snmysqlhost
+            read DB_host
         done
         DB_user='fogstorage'
         while [[ -z ${DB_password} ]]; do
@@ -287,7 +294,7 @@ case ${FOG_install_type} in
             echo "  'FOG Settings' -> "
             echo "  'FOG Storage Nodes' -> "
             echo  -n "  'FOG_STORAGENODE_MYSQLPASS'.  Password: "
-            read -r snmysqlpass
+            read -r DB_password
             [[ -z ${DB_password} ]] && echo "Invalid input, please try again."
         done
         ;;

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -162,10 +162,10 @@ case ${FOG_install_type} in
             fi
             case ${DHCP_enabled} in
                 [Nn]|[Nn][Oo]|"")
-                    DHCP_enabled=0
+                    DHCP_enabled="no"
                     ;;
                 [Yy]|[Yy][Ee][Ss])
-                    DHCP_enabled=1
+                    DHCP_enabled="yes"
                     ;;
                 *)
                     # Cleared so the loop re-prompts. Before the read targeted
@@ -177,7 +177,7 @@ case ${FOG_install_type} in
                     ;;
             esac
         done
-        if [[ ${DHCP_enabled} -eq 1 ]]; then
+        if [[ ${DHCP_enabled} == yes ]]; then
             while [[ -z ${DHCP_router} ]]; do
                 if [[ -z $autoaccept ]]; then
                     echo
@@ -261,10 +261,10 @@ case ${FOG_install_type} in
             fi
             case ${FOG_install_lang} in
                 [Nn]|[Nn][Oo]|"")
-                    FOG_install_lang=0
+                    FOG_install_lang="no"
                     ;;
                 [Yy]|[Yy][Ee][Ss])
-                    FOG_install_lang=1
+                    FOG_install_lang="yes"
                     ;;
                 *)
                     # See the DHCP_enabled loop above: cleared so an

--- a/lib/common/newinput.sh
+++ b/lib/common/newinput.sh
@@ -32,7 +32,7 @@ while [[ -z ${NET_hostname} ]]; do
             ;;
         [Yy]|[Yy][Ee][Ss])
             echo -n "  Which hostname would you like to use? "
-            read hostname
+            read NET_hostname
             ;;
         *)
             echo "  Invalid input, please try again."

--- a/lib/common/newinput.sh
+++ b/lib/common/newinput.sh
@@ -112,10 +112,10 @@ while [[ -z ${FOG_send_reports} ]]; do
     fi
     case $blReports in
         [Yy]|[Yy][Ee][Ss]|"")
-            FOG_send_reports="Y"
+            FOG_send_reports="yes"
             ;;
         [Nn]|[Nn][Oo])
-            FOG_send_reports="N"
+            FOG_send_reports="no"
             ;;
         *)
             FOG_send_reports=""

--- a/packages/pki/fog-sign-node-cert
+++ b/packages/pki/fog-sign-node-cert
@@ -70,16 +70,39 @@ chainout="${PKI_STAGING}/${reqid}.chain"
 [[ -f $csr ]] || die "no request at ${csr}"
 [[ -f $san ]] || die "no name list at ${san}"
 
+# anchor: what the issued certificate must verify against, and what the node is
+# handed so it can serve a usable chain. Per zone, because the two zones are not
+# anchored by the same thing.
+#
+# The web zone's anchor is NOT necessarily PKI_ROOT_CERT. When the admin brought
+# their own Web CA, PKI_WEB_CA_CERT is their intermediate and the FOG root never
+# signed it -- so verifying against the FOG root cannot build a chain, and
+# appending the FOG root to what the node serves adds an unrelated certificate.
+# PKI_WEB_ANCHOR is the web zone's own trust anchor
+# (pki/web/ca/.trustAnchor.pem), which _resolveTrustAnchor builds with the FOG
+# root AND an external root where there is one, deduped by fingerprint. That
+# covers both installs with no branch here.
 case "$type" in
     web)
         cacert="${PKI_WEB_CA_CERT:-}"
         cakey="${PKI_WEB_CA_KEY:-}"
+        anchor="${PKI_WEB_ANCHOR:-${PKI_ROOT_CERT:-}}"
+        # What the node serves beneath its leaf. PKI_WEB_CHAIN is the web zone's
+        # trust path -- the issuing intermediate plus the root that anchors it --
+        # so it is right for a FOG-issued and an imported CA alike. Falling back
+        # to building it here keeps an older config working.
+        chainsrc="${PKI_WEB_CHAIN:-}"
         eku="serverAuth"
         days=825
         ;;
     signing)
         cacert="${PKI_SB_CA_CERT:-}"
         cakey="${PKI_SB_CA_KEY:-}"
+        # The Secure Boot intermediate is always minted under the FOG root --
+        # there is no "bring your own Secure Boot root", because firmware trusts
+        # the enrolled certificate directly and nothing above it is consulted.
+        anchor="${PKI_ROOT_CERT:-}"
+        chainsrc=""
         eku="codeSigning"
         days=730
         ;;
@@ -166,15 +189,38 @@ fi
 
 # The node needs the issuer to serve a usable chain, and the anchor to know
 # what it is trusting. Both are public.
-cat "$cacert" > "$chainout"
-[[ -n ${PKI_ROOT_CERT:-} && -f ${PKI_ROOT_CERT} ]] && cat "$PKI_ROOT_CERT" >> "$chainout"
+#
+# Prefer the zone's own maintained chain: it already IS issuer-plus-its-root,
+# which is what an imported CA needs and what building it from PKI_ROOT_CERT got
+# wrong. Without a chain configured, fall back to the issuer plus the anchor.
+if [[ -n $chainsrc && -s $chainsrc ]]; then
+    cat "$chainsrc" > "$chainout"
+else
+    cat "$cacert" > "$chainout"
+    [[ -n $anchor && -f $anchor ]] && cat "$anchor" >> "$chainout"
+fi
 
 # Verify before handing it back. A certificate that does not chain is the
 # failure mode name constraints produce, and catching it here means the node
 # is told rather than silently installing something no client accepts.
-if ! openssl verify -CAfile "${PKI_ROOT_CERT:-$cacert}" -untrusted "$cacert" "$out" >/dev/null 2>&1; then
+#
+# Against $anchor, not PKI_ROOT_CERT. On an external-CA install the FOG root did
+# not sign this issuer, so anchoring there failed for every node -- and failed
+# with the message below, which sent the admin looking at name constraints for
+# something that was never a name problem.
+# Narrowing fallbacks, most correct first. A missing .trustAnchor.pem means an
+# install that has not run _resolveTrustAnchor yet; the FOG root is still right
+# on an ordinary install, and the issuer itself is the last resort that at least
+# proves this helper signed what it thinks it signed.
+if [[ -z $anchor || ! -f $anchor ]]; then
+    anchor="${PKI_ROOT_CERT:-}"
+fi
+if [[ -z $anchor || ! -f $anchor ]]; then
+    anchor="$cacert"
+fi
+if ! openssl verify -CAfile "$anchor" -untrusted "$cacert" "$out" >/dev/null 2>&1; then
     rm -f "$out" "$chainout"
-    die "the issued certificate does not verify -- a requested name is probably outside the CA's name constraints"
+    die "the issued certificate does not verify against ${anchor} -- a requested name is probably outside the CA's name constraints"
 fi
 
 chmod 0644 "$out" "$chainout"

--- a/packages/pki/renewal-helper
+++ b/packages/pki/renewal-helper
@@ -42,8 +42,9 @@ running install already expects them.
 
   --zone web          the certificate the web server (Apache) serves.
                       Reloads Apache afterward so it picks up the new cert.
-                      Refuses if the leaf is ACME-managed (acmeLeaf=yes) --
-                      renew that one through your ACME client instead.
+                      Refuses if the leaf is managed outside FOG -- i.e. the
+                      canonical path resolves outside the web PKI zone. Renew
+                      that one through whatever issues it.
 
   --zone secureboot   the code-signing leaf fog-sign-kernel signs with.
                       No reload needed and no firmware re-enrollment --
@@ -74,10 +75,19 @@ done
 # .fogsettings is the source of truth for where this install keeps things and
 # what it's already using for each zone's leaf -- the same file installfog.sh
 # itself reads and writes. Sourcing it (rather than re-deriving paths) is what
-# keeps this in sync with a server that customized sslprivkey/sslpubcert, and
-# with whichever CA installfog.sh already resolved for the web leaf (its own
-# Web intermediate, or the root directly, on a server whose root can't anchor
-# one).
+# keeps this in sync with a server that pointed PKI_web_vhost_key/_cert
+# somewhere of its own, and with whichever CA installfog.sh already resolved for
+# the web leaf (its own Web intermediate, or the root directly, on a server
+# whose root can't anchor one).
+#
+# The key names below are the GH-1120 ones. This script was missed by that
+# rename and went on reading sslpath, sslprivkey, sslpubcert, sslcakey,
+# sslcapem, sslcachain, rootCAPem, hostname, osid and acmeLeaf -- every one of
+# which deprecatedKeys now STRIPS from .fogsettings. So each read produced an
+# empty string and fell through to a default: correct only on a server that had
+# customised nothing, and silently wrong on any other. $fogprogramdir is the one
+# old spelling that is still right, because /etc/fog/fog.conf is deliberately
+# exempt from the rename.
 if [[ -r $CONF ]]; then
     # shellcheck disable=SC1090
     . "$CONF"
@@ -86,17 +96,30 @@ elif [[ -r /etc/fog/fog.conf ]]; then
     [[ -r "${fogprogramdir}/.fogsettings" ]] && . "${fogprogramdir}/.fogsettings"
 fi
 : "${fogprogramdir:=/opt/fog}"
-: "${sslpath:=${fogprogramdir}/snapins/ssl}"
+# The shared openssl config both issuing zones read. Moved out of
+# $snapindir/ssl with the client keypair; installfog.sh's _pkiConfDir is the
+# authority on this path.
+: "${pkiconfdir:=${fogprogramdir}/pki/conf}"
 
 _reissueWeb() {
-    if [[ ${acmeLeaf:-} == yes ]]; then
-        echo "Refusing: this web certificate is externally managed (acmeLeaf=yes)." >&2
-        echo "Renew it through your ACME client instead." >&2
+    local key="${PKI_web_vhost_key:-${fogprogramdir}/pki/web/leaf/.webLeaf.key}"
+    local cert="${PKI_web_vhost_cert:-${fogprogramdir}/pki/web/leaf/.webLeaf.pem}"
+    local cakey="${PKI_web_ca_key:-}" capem="${PKI_web_ca_cert:-}"
+    # "Is this leaf mine?" is a question for the filesystem, not a stored key.
+    # GH-1120 retired acmeLeaf for exactly the reason it mattered here: it had to
+    # be typed in by hand and nothing re-checked it. The canonical path
+    # resolving outside the web zone IS the signal -- the same test
+    # _externallyManagedLeaf() makes in the installer.
+    local zonedir target
+    zonedir="$(readlink -f "${fogprogramdir}/pki/web" 2>/dev/null)"
+    target="$(readlink -f "$cert" 2>/dev/null)"
+    if [[ -n $zonedir && -n $target && $target != "$zonedir"/* ]]; then
+        echo "Refusing: this web certificate is managed outside FOG." >&2
+        echo "  ${cert}" >&2
+        echo "  resolves to ${target}, which is outside ${zonedir}." >&2
+        echo "Renew it through whatever issues it (an ACME client, your CA)." >&2
         return 1
     fi
-    local key="${sslprivkey:-${fogprogramdir}/pki/web/leaf/.webLeaf.key}"
-    local cert="${sslpubcert:-${fogprogramdir}/pki/web/leaf/.webLeaf.pem}"
-    local cakey="${sslcakey:-}" capem="${sslcapem:-}"
     if [[ -z $cakey || -z $capem ]]; then
         echo "Cannot renew: this install hasn't resolved a web signing CA yet." >&2
         echo "Run installfog.sh at least once before using this script." >&2
@@ -108,8 +131,8 @@ _reissueWeb() {
         echo "Restore it there, then re-run this script." >&2
         return 1
     fi
-    if [[ ! -f "$sslpath/req.cnf" || ! -f "$sslpath/ca.cnf" ]]; then
-        echo "Cannot renew: ${sslpath}/req.cnf or ca.cnf is missing." >&2
+    if [[ ! -f "$pkiconfdir/req.cnf" || ! -f "$pkiconfdir/ca.cnf" ]]; then
+        echo "Cannot renew: ${pkiconfdir}/req.cnf or ca.cnf is missing." >&2
         echo "Run installfog.sh once to generate them, then re-run this script." >&2
         return 1
     fi
@@ -121,11 +144,11 @@ _reissueWeb() {
     openssl genrsa -out "$key" 4096 >/dev/null 2>&1 || st=1
     echo "Issuing a new web certificate, signed by ${capem}..."
     openssl req -new -sha512 -key "$key" -out "${leafdir}/.webLeaf.csr" \
-        -config "$sslpath/req.cnf" \
-        -subj "/CN=${hostname:-}/O=FOG Project/OU=FOG Web UI" >/dev/null 2>&1 || st=1
+        -config "$pkiconfdir/req.cnf" \
+        -subj "/CN=${NET_hostname:-}/O=FOG Project/OU=FOG Web UI" >/dev/null 2>&1 || st=1
     openssl x509 -req -in "${leafdir}/.webLeaf.csr" -CA "$capem" -CAkey "$cakey" \
         -CAcreateserial -out "$cert" -days 1825 -extensions v3_ca \
-        -extfile "$sslpath/ca.cnf" >/dev/null 2>&1 || st=1
+        -extfile "$pkiconfdir/ca.cnf" >/dev/null 2>&1 || st=1
     if [[ $st -ne 0 ]]; then
         echo "Failed -- see openssl's output above." >&2
         return 1
@@ -136,9 +159,15 @@ _reissueWeb() {
     # Same stamp _createWebLeaf writes, so the next installfog.sh run doesn't
     # mistake this fresh cert for one that needs re-issuing over a name-set
     # mismatch that was never there.
-    openssl md5 < "$sslpath/ca.cnf" 2>/dev/null > "${leafdir}/.webLeaf.sans"
-    if [[ -n ${sslcachain:-} && -f $sslcachain ]] && \
-        ! openssl verify -CAfile "${rootCAPem:-}" -untrusted "$sslcachain" "$cert" >/dev/null 2>&1; then
+    openssl md5 < "$pkiconfdir/ca.cnf" 2>/dev/null > "${leafdir}/.webLeaf.sans"
+    # Anchored on the web zone's own trust anchor, which _resolveTrustAnchor
+    # writes with BOTH the FOG root and an external root where there is one --
+    # so this verifies on an external-CA install too, where PKI_root_ca_cert
+    # alone cannot complete the chain.
+    local anchor="${fogprogramdir}/pki/web/ca/.trustAnchor.pem"
+    [[ -f $anchor ]] || anchor="${PKI_root_ca_cert:-}"
+    if [[ -n ${PKI_web_trust_chain:-} && -f ${PKI_web_trust_chain} && -n $anchor ]] && \
+        ! openssl verify -CAfile "$anchor" -untrusted "${PKI_web_trust_chain}" "$cert" >/dev/null 2>&1; then
         echo "WARNING: the new certificate does not verify against its chain." >&2
         echo "Its name set may no longer be permitted by the Web CA's nameConstraints" >&2
         echo "-- re-run installfog.sh with the current --hostname/--extra-server-name" >&2
@@ -147,7 +176,7 @@ _reissueWeb() {
     echo "New web certificate issued, valid 5 years: ${cert}"
     if command -v systemctl >/dev/null 2>&1; then
         local svc="httpd"
-        [[ ${osid:-} -eq 2 ]] && svc="apache2"
+        [[ ${FOG_os_id:-} -eq 2 ]] && svc="apache2"
         echo "Reloading ${svc} so it picks up the new certificate..."
         systemctl reload "$svc" >/dev/null 2>&1 || systemctl restart "$svc" >/dev/null 2>&1 || \
             echo "WARNING: could not reload/restart ${svc} -- reload it yourself." >&2

--- a/packages/web/lib/service/snapinreplicator.class.php
+++ b/packages/web/lib/service/snapinreplicator.class.php
@@ -221,9 +221,20 @@ class SnapinReplicator extends FOGService
                 );
                 /**
                  * Handles replicating of our ssl folder and contents.
+                 *
+                 * 'ssl/fog.csr' was dropped here. It is the MASTER's
+                 * client-communication CSR -- a request that was fulfilled years
+                 * of installs ago -- and a storage node has no use for it: since
+                 * the zoned PKI landed, a node generates its own keypair and its
+                 * own CSR in _requestNodeCert() and is issued a certificate by
+                 * the master's Web CA. The installer also moved that file into
+                 * pki/client/leaf/ with the rest of the client leaf's material,
+                 * so this entry named a path that no longer exists.
+                 *
+                 * 'ssl/CA' stays: that is the CA certificate itself, and it is
+                 * public trust material a node legitimately holds.
                  */
                 $ssls = [
-                    'ssl/fog.csr',
                     'ssl/CA'
                 ];
                 self::outall(

--- a/tests/boolean-encoding.test.sh
+++ b/tests/boolean-encoding.test.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Guards the single boolean encoding for .fogsettings: yes / no.
+#
+#   tests/boolean-encoding.test.sh
+#
+# Before GH-1120's follow-up there were three encodings, and the flag layer
+# mixed them inside one variable: sDHCP_enabled was assigned "Y" and then 1 on
+# the very next line, and sBOOT_external_tftp_server was assigned the string
+# "true", which nothing ever tested for. Twelve boolean keys split three ways --
+# yes/no, 1/0, Y/N -- so which literal a test had to use was a per-key fact, and
+# getting it wrong fails silently in both directions:
+#
+#   [[ "N" == 0 ]]   is simply false
+#   [[ "N" -eq 1 ]]  evaluates "N" as an ARITHMETIC expression -- an unset
+#                    variable named N, hence 0 -- rather than erroring
+#
+# That pair is how DHCP_enabled="N" satisfied neither the enabled test nor the
+# disabled one, which is what this whole change exists to make impossible.
+#
+# Runs the real _normalizeBool/_normalizeBooleanSettings out of functions.sh and
+# greps the real source for stragglers. No install, no network, no root.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+declare -F _normalizeBool >/dev/null \
+    || { echo "ERROR: _normalizeBool is not defined" >&2; exit 1; }
+declare -F _booleanSettingKeys >/dev/null \
+    || { echo "ERROR: _booleanSettingKeys is not defined" >&2; exit 1; }
+declare -F _normalizeBooleanSettings >/dev/null \
+    || { echo "ERROR: _normalizeBooleanSettings is not defined" >&2; exit 1; }
+
+boolKeys="$(_booleanSettingKeys)"
+
+# --- A. every spelling a human or an old installer might have left behind ----
+for v in yes y 1 true on enabled YES Y True ON Enabled; do
+    is "$(_normalizeBool "$v")" "yes" "_normalizeBool '$v' -> yes"
+done
+for v in no n 0 false off disabled NO N False OFF Disabled; do
+    is "$(_normalizeBool "$v")" "no" "_normalizeBool '$v' -> no"
+done
+
+# --- B. what it must NOT do --------------------------------------------------
+# Empty stays empty: the prompt loops are `while [[ -z ${KEY} ]]`, so collapsing
+# unset into "no" would stop every prompt firing and silently answer for the
+# admin.
+is "$(_normalizeBool "")" "" "empty stays empty (prompt loops depend on it)"
+# An unrecognised value is left alone rather than guessed at. Turning a typo
+# into "no" is how a deliberate setting disappears with nothing to show why.
+is "$(_normalizeBool "maybe")" "maybe" "an unrecognised value is left untouched"
+is "$(_normalizeBool "2")" "2" "an out-of-range number is left untouched"
+
+# --- C. idempotence ----------------------------------------------------------
+# This runs on EVERY install, not once behind a version marker, because
+# .fogsettings is a file admins edit -- an old encoding can arrive at any time.
+# So a second pass must be a no-op.
+is "$(_normalizeBool "$(_normalizeBool 1)")" "yes" "normalizing twice is stable (yes)"
+is "$(_normalizeBool "$(_normalizeBool N)")" "no" "normalizing twice is stable (no)"
+
+# --- D. the whole-set sweep, on the real key list ----------------------------
+# Seed every boolean key with a legacy encoding and check they all convert.
+DHCP_enabled=1
+FOG_install_lang=0
+FOG_send_reports=Y
+FOG_copy_back_old=1
+DB_external=1
+BOOT_external_tftp_server=true
+BOOT_rebuild_ipxe_with_my_ca=yes
+BOOT_url_proto_forced=1
+PKI_sb_enabled=0
+PKI_web_cert_publicly_trusted=no
+STORAGE_rebuild_nfs_exports=1
+WEB_https_redirect=yes
+_normalizeBooleanSettings
+stragglers=""
+for k in $boolKeys; do
+    case "${!k}" in
+        yes|no) ;;
+        *) stragglers="$stragglers $k=${!k}" ;;
+    esac
+done
+is "$stragglers" "" "every boolean key normalizes to yes/no from a legacy value"
+is "$DHCP_enabled" "yes" "DHCP_enabled 1 -> yes"
+is "$FOG_install_lang" "no" "FOG_install_lang 0 -> no"
+is "$FOG_send_reports" "yes" "FOG_send_reports Y -> yes"
+is "$BOOT_external_tftp_server" "yes" "BOOT_external_tftp_server true -> yes"
+is "$PKI_sb_enabled" "no" "PKI_sb_enabled 0 -> no"
+
+# An unset key must stay unset through the sweep, for the same reason as B.
+unset DHCP_enabled
+_normalizeBooleanSettings
+is "${DHCP_enabled-UNSET}" "UNSET" "the sweep leaves an unset key unset"
+
+# --- E. the list itself ------------------------------------------------------
+# FOG_installed is excluded on purpose: settingLine() writes it unquoted and
+# numeric to keep the historical file format, bin/updatefog.sh reads it, and it
+# records install state rather than a preference.
+printf '%s\n' $boolKeys | grep -qxF FOG_installed \
+    && bad "FOG_installed is in the boolean list -- it is a numeric state marker" \
+    || ok "FOG_installed is excluded from the boolean list"
+# These two are not booleans at all. Folding either to yes/no destroys an
+# answer, so the guard is that they never join the list.
+for k in SVC_firewall_control FOG_install_type; do
+    printf '%s\n' $boolKeys | grep -qxF "$k" \
+        && bad "$k is in the boolean list -- it is not a boolean" \
+        || ok "$k is excluded from the boolean list"
+done
+# Every key in the list must actually be a managed .fogsettings key, or
+# normalizing it accomplishes nothing.
+arrayKeys() {
+    sed -n "/local -a $1=(/,/^    )/p" "$FUNCS" \
+        | sed -e 's/#.*$//' -e "s/local -a $1=(//" -e 's/)//' \
+        | tr -s ' \n' '\n\n' | grep -vE '^$'
+}
+managed="$(arrayKeys managedKeys)"
+unmanaged=""
+for k in $boolKeys; do
+    printf '%s\n' "$managed" | grep -qxF "$k" || unmanaged="$unmanaged $k"
+done
+is "$unmanaged" "" "every boolean key is a managed key"
+
+# --- F. no old-encoding test survives in the shell sources -------------------
+# The point of one encoding is that there is nowhere left for the other two to
+# hide. Arithmetic comparisons are called out separately because they are the
+# ones that fail silently rather than merely being false.
+alt="$(printf '%s|' $boolKeys | sed 's/|$//')"
+arith="$(grep -rnE "\\\$\{?($alt)\}?[[:space:]]*(-eq|-ne|-lt|-gt|-ge|-le)" \
+    "$REPO/lib" "$REPO/bin" "$REPO/utils" 2>/dev/null)"
+is "$arith" "" "no boolean key is tested with an arithmetic operator"
+# The literal has to be a COMPLETE token: without the trailing boundary,
+# [YyNn] happily matches the "y" of "yes" and every correct line is a hit.
+lits="$(grep -rnE "\\\$\{?($alt)\}?[[:space:]]*(==|!=)[[:space:]]*[\"']?(0|1|[YyNn]|true|false)[\"']?[[:space:]]*(\]|&|\||;|\$)" \
+    "$REPO/lib" "$REPO/bin" "$REPO/utils" 2>/dev/null)"
+is "$lits" "" "no boolean key is compared against 0/1/Y/N/true/false"
+assigns="$(grep -rnE "($alt)=[\"']?([01]|[YyNn]|true|false)[\"']?[[:space:]]*(;|\$)" \
+    "$REPO/lib" "$REPO/bin" "$REPO/utils" 2>/dev/null)"
+is "$assigns" "" "no boolean key is assigned 0/1/Y/N/true/false"
+# Including the s-prefixed flag shadows, which were the worst offenders --
+# sDHCP_enabled held "Y" and 1 on consecutive lines.
+shadows="$(grep -rnE "s($alt)=[\"']?([01]|[YyNn]|true|false)[\"']?[[:space:]]*(;|\$)" \
+    "$REPO/lib" "$REPO/bin" 2>/dev/null)"
+is "$shadows" "" "no flag shadow is assigned 0/1/Y/N/true/false"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/client-cert-flags.test.sh
+++ b/tests/client-cert-flags.test.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+#
+# Guards --client-cert / --client-key.
+#
+#   tests/client-cert-flags.test.sh
+#
+# The client-communication keypair is the one certificate every registered
+# fog-client pins, and until now it was the only zone an admin could not point
+# at their own files -- the exception a model whose premise is "say where the
+# cert is" cannot have.
+#
+# Three behaviours, and the difference between them is the whole point:
+#
+#   half a pair          REFUSED. A certificate without its key locks out every
+#                        registered host, and the failure surfaces per host as a
+#                        failed authorize with nothing naming the file.
+#   a pair that does     REFUSED. Same outcome, and since the admin just named
+#   not pair             both files it is a typo rather than history.
+#   a valid DIFFERENT    WARNED, and PROCEEDED. Re-pinning a fleet is a
+#   pair                 legitimate thing to ask for; refusing it would make the
+#                        flags useless for the case they exist for.
+#
+# The refusals are gated on the flag SHADOWS, not on the resolved values, and
+# that is load-bearing: both are managed keys that writeUpdateFile persists every
+# run, so on any upgrade they are non-empty from .fogsettings alone and a check
+# against the resolved values would refuse every ordinary upgrade. Pinned below.
+#
+# Needs openssl. No network, no root, no install -- the refusal block is
+# extracted from bin/installfog.sh and evaluated, so it cannot drift from the
+# installer.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+INSTALLER="$REPO/bin/installfog.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+[[ -f $INSTALLER ]] || { echo "ERROR: $INSTALLER not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+echo "client cert flags:"
+
+# --- the flag is actually parsed --------------------------------------------
+# Both spellings must reach the shadow variables, and via the same readable-file
+# guard the other file-taking flags use.
+for f in --client-cert --client-key; do
+    grep -qF -- "$f" "$INSTALLER" \
+        && ok "$f appears in bin/installfog.sh" \
+        || bad "$f is not in bin/installfog.sh"
+    grep -qF -- "$f" <(sed -n '/^usage()/,/^}/p' "$INSTALLER") \
+        && ok "$f is documented in usage()" \
+        || bad "$f is missing from usage()"
+done
+sed -n '/--web-ca-cert | --web-ca-key/,/^            ;;/p' "$INSTALLER" \
+    | grep -q 'sPKI_client_encrypt_cert="\$2"' \
+    && ok "--client-cert stages sPKI_client_encrypt_cert" \
+    || bad "--client-cert does not stage its shadow"
+sed -n '/--web-ca-cert | --web-ca-key/,/^            ;;/p' "$INSTALLER" \
+    | grep -q 'sPKI_client_encrypt_key="\$2"' \
+    && ok "--client-key stages sPKI_client_encrypt_key" \
+    || bad "--client-key does not stage its shadow"
+grep -q '^\[\[ -n \${sPKI_client_encrypt_cert} \]\] && PKI_client_encrypt_cert=' "$INSTALLER" \
+    && ok "the cert shadow is applied to the managed key" \
+    || bad "the cert shadow is never applied"
+grep -q '^\[\[ -n \${sPKI_client_encrypt_key} \]\] && PKI_client_encrypt_key=' "$INSTALLER" \
+    && ok "the key shadow is applied to the managed key" \
+    || bad "the key shadow is never applied"
+
+# --- fixtures: two genuine pairs, plus a mismatched one ---------------------
+mkpair() {
+    openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 3 \
+        -subj "/CN=comm-$1" -keyout "$WORK/$1.key" -out "$WORK/$1.crt" \
+        >>$error_log 2>&1
+}
+mkpair a || { echo "ERROR: fixture pair a failed" >&2; exit 1; }
+mkpair b || { echo "ERROR: fixture pair b failed" >&2; exit 1; }
+
+# --- the refusal block, extracted from the installer ------------------------
+# Evaluated rather than restated, so a change to the real guard is reflected
+# here instead of being shadowed by a copy.
+block=$(sed -n '/^# --client-cert \/ --client-key: only meaningful as a pair/,/^    unset ccmod ckmod$/p' "$INSTALLER")
+block="$block"$'\nfi'
+if [[ -z $block || $block != *"exit 9"* ]]; then
+    bad "could not extract the --client-cert/--client-key refusal block"
+    printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+    exit 1
+fi
+ok "the refusal block is present in bin/installfog.sh"
+
+# Runs the block in a subshell with `exit` captured, and reports status+output.
+tryflags() {
+    local out st
+    out=$(
+        sPKI_client_encrypt_cert="$1"
+        sPKI_client_encrypt_key="$2"
+        PKI_client_encrypt_cert="$3"
+        PKI_client_encrypt_key="$4"
+        eval "$block"
+        echo "__REACHED_END__"
+    )
+    st=$?
+    printf '%s\n' "$out"
+    return $st
+}
+
+# 1. cert without key
+out=$(tryflags "$WORK/a.crt" "" "" ""); st=$?
+is "$st" "9" "--client-cert alone exits 9"
+[[ $out == *"must be set together"* ]] \
+    && ok "...and says both are required" || bad "...but did not say why (got: $out)"
+
+# 2. key without cert
+out=$(tryflags "" "$WORK/a.key" "" ""); st=$?
+is "$st" "9" "--client-key alone exits 9"
+
+# 3. a mismatched pair
+out=$(tryflags "$WORK/a.crt" "$WORK/b.key" "" ""); st=$?
+is "$st" "9" "a cert and key that do not pair exits 9"
+[[ $out == *"do not pair"* ]] \
+    && ok "...and says they do not pair" || bad "...but did not say why (got: $out)"
+
+# 4. unreadable as a certificate/key
+echo "not a certificate" > "$WORK/junk.pem"
+echo "not a key" > "$WORK/junk2.pem"
+out=$(tryflags "$WORK/junk.pem" "$WORK/a.key" "" ""); st=$?
+is "$st" "9" "a file that is not a certificate exits 9"
+
+# 4b. BOTH unreadable. This is the case that makes the raw-modulus comparison
+#     necessary: `openssl x509 -modulus` on a bad file prints nothing, and
+#     nothing piped through `openssl md5` is the perfectly non-empty MD5 of the
+#     empty string -- so with the md5 idiom two garbage files produce identical
+#     non-empty values, satisfy the emptiness guard, and "pair".
+out=$(tryflags "$WORK/junk.pem" "$WORK/junk2.pem" "" ""); st=$?
+is "$st" "9" "TWO unreadable files exit 9 rather than 'pairing'"
+[[ $out == *"Could not read"* ]] \
+    && ok "...and are reported as unreadable, not as a mismatch" \
+    || bad "...but the message did not say they were unreadable (got: $out)"
+
+# 5. THE POINT: a valid pair is accepted and does NOT exit
+out=$(tryflags "$WORK/a.crt" "$WORK/a.key" "" ""); st=$?
+is "$st" "0" "a valid pair is accepted"
+[[ $out == *"__REACHED_END__"* ]] \
+    && ok "...and the install proceeds rather than refusing" \
+    || bad "a valid pair did not reach the end of the block"
+
+# 6. And a valid but DIFFERENT pair is equally accepted -- that is a re-pin,
+#    which is warned about later by _warnClientRepin, never refused here.
+out=$(tryflags "$WORK/b.crt" "$WORK/b.key" "$WORK/a.crt" "$WORK/a.key"); st=$?
+is "$st" "0" "swapping to a different valid pair is accepted, not refused"
+
+# 7. The shadow gating. An ordinary upgrade has both managed keys populated from
+#    .fogsettings and no flags on the command line. Checking the resolved values
+#    instead of the shadows would refuse this -- every upgrade, for everyone.
+out=$(tryflags "" "" "$WORK/a.crt" "$WORK/a.key"); st=$?
+is "$st" "0" "an upgrade with both keys persisted and no flags is not refused"
+#    Including the pathological version of it: a persisted pair that no longer
+#    pairs is history to be reported by _createCommLeaf, not grounds to refuse
+#    an install that might be the thing that fixes it.
+out=$(tryflags "" "" "$WORK/a.crt" "$WORK/b.key"); st=$?
+is "$st" "0" "a persisted pair that no longer pairs does not block an upgrade"
+
+# --- _clientLeafTarget: where a supplied pair actually points ---------------
+# The flags are only useful if the resolver keeps the admin's path instead of
+# overwriting it with the zone path.
+fogprogramdir="$WORK/opt/fog"
+snapindir="$fogprogramdir/snapins"
+PKI_client_cert_dir="$snapindir/ssl"
+mkdir -p "${PKI_client_cert_dir}"
+zonekey="$(_pkiZoneDir client)/leaf/.srvprivate.key"
+canonkey="${PKI_client_cert_dir}/.srvprivate.key"
+
+is "$(_clientLeafTarget "" "$zonekey" "$canonkey")" "$zonekey" \
+   "unset resolves to the zone path"
+is "$(_clientLeafTarget "$zonekey" "$zonekey" "$canonkey")" "$zonekey" \
+   "the zone path resolves to itself"
+# The upgrade case, and the one most easily got wrong: an upgraded server's
+# record holds the old snapin-dir path, which IS outside the zone. Treating that
+# as "the admin's own file" would mean no server ever migrates.
+is "$(_clientLeafTarget "$canonkey" "$zonekey" "$canonkey")" "$zonekey" \
+   "an upgraded server's recorded snapin-dir path still resolves to the zone"
+is "$(_clientLeafTarget "$WORK/a.key" "$zonekey" "$canonkey")" "$WORK/a.key" \
+   "a file the admin named is kept, not overwritten by the zone path"
+# A record naming something that is gone falls back rather than being trusted.
+is "$(_clientLeafTarget "$WORK/removed.key" "$zonekey" "$canonkey")" "$zonekey" \
+   "a recorded path that no longer exists falls back to the zone"
+
+# --- the same flaw in _discardOrphanedCommLeaf, which DELETES ---------------
+# Its own comment says "deleting on a failed read would turn a bad openssl
+# invocation into a destroyed certificate", and the md5 idiom defeated the guard
+# meant to prevent exactly that: an unreadable CERT beside a readable key gave
+# md5("") != real-modulus, i.e. a "mismatch", and the certificate was removed.
+# The certificate is the admin's way back from a lost key, so destroying it
+# converts a recoverable accident into a mandatory re-pin of every client.
+rootCAKeyOffline=0
+PKI_client_encrypt_cert="$WORK/orphan.crt"
+PKI_client_encrypt_key="$WORK/orphan.key"
+
+# a. a genuinely mismatched, READABLE pair: the certificate should go.
+cp "$WORK/a.crt" "${PKI_client_encrypt_cert}"
+cp "$WORK/b.key" "${PKI_client_encrypt_key}"
+_discardOrphanedCommLeaf
+[[ ! -f "${PKI_client_encrypt_cert}" ]] \
+    && ok "_discardOrphanedCommLeaf removes a genuinely orphaned certificate" \
+    || bad "_discardOrphanedCommLeaf kept a certificate that does not pair"
+
+# b. an UNREADABLE certificate beside a readable key: it must survive.
+echo "truncated or unreadable" > "${PKI_client_encrypt_cert}"
+cp "$WORK/a.key" "${PKI_client_encrypt_key}"
+_discardOrphanedCommLeaf
+[[ -f "${PKI_client_encrypt_cert}" ]] \
+    && ok "an unreadable certificate is NOT destroyed on a failed read" \
+    || bad "an unreadable certificate was deleted -- a bad read destroyed it"
+
+# c. a matching readable pair is obviously left alone.
+cp "$WORK/a.crt" "${PKI_client_encrypt_cert}"
+cp "$WORK/a.key" "${PKI_client_encrypt_key}"
+_discardOrphanedCommLeaf
+[[ -f "${PKI_client_encrypt_cert}" ]] \
+    && ok "a matching pair is left alone" \
+    || bad "a matching pair was deleted"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/client-repin-warning.test.sh
+++ b/tests/client-repin-warning.test.sh
@@ -84,14 +84,15 @@ comm_pass() {
     _resolveRootCA >/dev/null 2>&1
 
     local sanentries="IP.1 = ${NET_fog_server_ip}"
-    cat > "${PKI_client_cert_dir}/ca.cnf" << CNF
+    _relocatePkiConf
+    cat > "$(_pkiConfDir)/ca.cnf" << CNF
 [v3_ca]
 subjectAltName = @alt_names
 [alt_names]
 $sanentries
 DNS.1 = ${NET_hostname}
 CNF
-    cat > "${PKI_client_cert_dir}/req.cnf" << CNF
+    cat > "$(_pkiConfDir)/req.cnf" << CNF
 [req]
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
@@ -109,15 +110,15 @@ CNF
 
     _separateCommKey
     _resolveClientLeafPaths
-    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
+    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e $(_pkiZoneDir client)/leaf/fog.csr ]]; then
         if [[ ! -e ${PKI_client_encrypt_key} || $recreateKeys == yes || $recreateCA == yes ]]; then
             openssl genrsa -out "${PKI_client_encrypt_key}" 4096 >>$error_log 2>&1
             if [[ $recreateKeys == yes || $recreateCA == yes ]]; then
                 _discardOrphanedCommLeaf
             fi
         fi
-        openssl req -new -sha512 -key "${PKI_client_encrypt_key}" -out "${PKI_client_cert_dir}/fog.csr" \
-            -config "${PKI_client_cert_dir}/req.cnf" >>$error_log 2>&1
+        openssl req -new -sha512 -key "${PKI_client_encrypt_key}" -out "$(_pkiZoneDir client)/leaf/fog.csr" \
+            -config "$(_pkiConfDir)/req.cnf" >>$error_log 2>&1
     fi
     _createCommLeaf >/dev/null 2>&1
     _warnClientRepin

--- a/tests/client-repin-warning.test.sh
+++ b/tests/client-repin-warning.test.sh
@@ -108,18 +108,20 @@ DNS.1 = ${NET_hostname}
 CNF
 
     _separateCommKey
-    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_cert_dir}/.srvprivate.key || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
-        if [[ ! -e ${PKI_client_cert_dir}/.srvprivate.key || $recreateKeys == yes || $recreateCA == yes ]]; then
-            openssl genrsa -out "${PKI_client_cert_dir}/.srvprivate.key" 4096 >>$error_log 2>&1
+    _resolveClientLeafPaths
+    if [[ $recreateKeys == yes || $recreateCA == yes || ! -e ${PKI_client_encrypt_key} || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
+        if [[ ! -e ${PKI_client_encrypt_key} || $recreateKeys == yes || $recreateCA == yes ]]; then
+            openssl genrsa -out "${PKI_client_encrypt_key}" 4096 >>$error_log 2>&1
             if [[ $recreateKeys == yes || $recreateCA == yes ]]; then
                 _discardOrphanedCommLeaf
             fi
         fi
-        openssl req -new -sha512 -key "${PKI_client_cert_dir}/.srvprivate.key" -out "${PKI_client_cert_dir}/fog.csr" \
+        openssl req -new -sha512 -key "${PKI_client_encrypt_key}" -out "${PKI_client_cert_dir}/fog.csr" \
             -config "${PKI_client_cert_dir}/req.cnf" >>$error_log 2>&1
     fi
     _createCommLeaf >/dev/null 2>&1
     _warnClientRepin
+    _linkClientLeafCompat
     # The publish at the end of createSSLCA(), which is what makes the file this
     # run compared against the "deployed copy" for the next one.
     mkdir -p "$webdirdest/management/other/ssl" >>$error_log 2>&1

--- a/tests/client-zone-migration.test.sh
+++ b/tests/client-zone-migration.test.sh
@@ -82,9 +82,14 @@ seedNeighbours() {
     echo "legacy-ca"           > "${PKI_client_cert_dir}/CA/.fogCA.pem"
     echo "an-admins-snapin-cert" > "${PKI_client_cert_dir}/snapin-upload.crt"
 }
+# What must STAY in $snapindir/ssl. req.cnf, ca.cnf, fog.csr and dhparam.pem all
+# move now -- see _relocatePkiConf and the fog.csr line in
+# _resolveClientLeafPaths -- so the only thing left to protect here is the
+# legacy CA/ tree (the root certificate genuinely lives there) and whatever
+# snapin material the admin put beside it, which is the whole point of the move.
 neighboursIntact() {
     local f bad=""
-    for f in req.cnf ca.cnf fog.csr dhparam.pem CA/.fogCA.pem snapin-upload.crt; do
+    for f in CA/.fogCA.pem snapin-upload.crt; do
         [[ -f "${PKI_client_cert_dir}/${f}" && ! -L "${PKI_client_cert_dir}/${f}" ]] \
             || bad="$bad $f"
     done
@@ -154,6 +159,45 @@ is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" \
    "$(readlink -f "$ZONE/.srvprivate.key")" \
    "upgrade: the canonical name still resolves to the key"
 is "$(neighboursIntact)" "" "upgrade: every neighbouring file is untouched"
+
+# --- C2. and the rest of the material lands in its own new home -------------
+# Asserting where each file WENT, not merely that it left $snapindir/ssl. The
+# destinations differ on purpose: fog.csr is the client leaf's own request,
+# req.cnf/ca.cnf are the shared name set BOTH issuing zones read, and
+# dhparam.pem is web-server TLS parameters the vhost names directly.
+_relocatePkiConf
+CONFDIR="$fogprogramdir/pki/conf"
+is "$(cat "$ZONE/fog.csr" 2>/dev/null)" "client-csr" \
+   "upgrade: fog.csr moved into the client leaf dir"
+is "$(cat "$CONFDIR/req.cnf" 2>/dev/null)" "shared-req-config" \
+   "upgrade: req.cnf moved into pki/conf (shared, not client-owned)"
+is "$(cat "$CONFDIR/ca.cnf" 2>/dev/null)" "shared-ca-config" \
+   "upgrade: ca.cnf moved into pki/conf"
+is "$(cat "$fogprogramdir/pki/web/dhparam.pem" 2>/dev/null)" "dhparams" \
+   "upgrade: dhparam.pem moved into the web zone"
+# Gone from the old location, so nothing can go on reading a stale copy.
+moved=""
+for f in fog.csr req.cnf ca.cnf dhparam.pem; do
+    [[ -e "${PKI_client_cert_dir}/${f}" ]] && moved="$moved $f"
+done
+is "$moved" "" "upgrade: none of them is left behind in \$snapindir/ssl"
+# No compat symlinks for these, unlike the keypair: every reader is FOG's own
+# code, updated with the move. A link would be a second name with one reader.
+links=""
+for f in fog.csr req.cnf ca.cnf dhparam.pem; do
+    [[ -L "${PKI_client_cert_dir}/${f}" ]] && links="$links $f"
+done
+is "$links" "" "upgrade: and no compatibility symlinks were left for them"
+# ca.cnf's BYTES must survive the move: _createWebLeaf hashes this file into
+# .webLeaf.sans to decide whether the web leaf's name set changed, so altering
+# it here would re-issue every server's web certificate for no reason.
+is "$(sha256sum < "$CONFDIR/ca.cnf")" "$(printf 'shared-ca-config\n' | sha256sum)" \
+   "upgrade: ca.cnf's bytes are unchanged, so the SAN stamp stays valid"
+# Idempotent: a second pass has nothing to move and must not disturb what it
+# finds.
+_relocatePkiConf
+is "$(cat "$CONFDIR/ca.cnf" 2>/dev/null)" "shared-ca-config" \
+   "a second relocation pass changes nothing"
 
 # --- D. THE TRAP: _separateCommKey must not eat its own compat link ---------
 # _separateCommKey dereferences a symlink at the canonical name and copies the

--- a/tests/client-zone-migration.test.sh
+++ b/tests/client-zone-migration.test.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+# Guards the client-communication keypair's move into its own PKI zone.
+#
+#   tests/client-zone-migration.test.sh
+#
+# The keypair used to live directly in ${PKI_client_cert_dir}, i.e.
+# $snapindir/ssl. So "change the snapin SSL certificates" and "replace the one
+# keypair every registered fog-client pins" were the same operation on the same
+# directory -- and the second is invisible until hosts stop checking in, per
+# host, with nothing naming the file. The real files now live in
+# pki/client/leaf and a symlink per file stays behind at the canonical names,
+# because FOGBase::_decryptCheck() builds `<sslpath>/.srvprivate.key` with the
+# filename hardcoded, taking the directory from the storage-node DB record
+# rather than from .fogsettings.
+#
+# Four things have to hold, and three of them fail silently:
+#
+#   1. The key's CONTENTS never change. Every registered client encrypts to its
+#      public half, so a migration that regenerates rather than moves locks out
+#      the entire fleet at once.
+#   2. _separateCommKey must not treat FOG's own compat link as an admin's
+#      symlink to their web key. It dereferences and copies such links, so
+#      without a zone test it copies the keypair back into $snapindir/ssl on
+#      every single run -- silently undoing the move.
+#   3. pki/client/leaf must be TRAVERSABLE by the web user. Every other zone's
+#      leaf/ is 0700 root:root; copying that here makes certDecrypt() fail as
+#      `Private key not readable`, per client.
+#   4. The snapin material next to it must be untouched, or the move
+#      accomplished nothing.
+#
+# Drives the helpers directly rather than calling createSSLCA(), as
+# tests/pki-idempotence.test.sh and tests/client-repin-warning.test.sh do, and
+# in the same order createSSLCA calls them.
+#
+# Needs openssl. No network, no root, no install.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+apacheuser="$(id -un)"
+
+# A fresh tree per scenario, so one case cannot leak into the next.
+newtree() {
+    fogprogramdir="$WORK/$1/opt/fog"
+    snapindir="$fogprogramdir/snapins"
+    PKI_client_cert_dir="$snapindir/ssl"
+    PKI_client_encrypt_key=""
+    PKI_client_encrypt_cert=""
+    mkdir -p "${PKI_client_cert_dir}/CA"
+    ZONE="$fogprogramdir/pki/client/leaf"
+}
+# Stand-ins for the snapin SSL material and shared config that must NOT move.
+seedNeighbours() {
+    echo "shared-req-config"   > "${PKI_client_cert_dir}/req.cnf"
+    echo "shared-ca-config"    > "${PKI_client_cert_dir}/ca.cnf"
+    echo "client-csr"          > "${PKI_client_cert_dir}/fog.csr"
+    echo "dhparams"            > "${PKI_client_cert_dir}/dhparam.pem"
+    echo "legacy-ca"           > "${PKI_client_cert_dir}/CA/.fogCA.pem"
+    echo "an-admins-snapin-cert" > "${PKI_client_cert_dir}/snapin-upload.crt"
+}
+neighboursIntact() {
+    local f bad=""
+    for f in req.cnf ca.cnf fog.csr dhparam.pem CA/.fogCA.pem snapin-upload.crt; do
+        [[ -f "${PKI_client_cert_dir}/${f}" && ! -L "${PKI_client_cert_dir}/${f}" ]] \
+            || bad="$bad $f"
+    done
+    echo "$bad"
+}
+genkey() { openssl genrsa -out "$1" 2048 >>$error_log 2>&1; }
+
+echo "client zone migration:"
+
+# --- A. a fresh install ------------------------------------------------------
+newtree fresh
+seedNeighbours
+_resolveClientLeafPaths
+is "${PKI_client_encrypt_key}"  "$ZONE/.srvprivate.key" "fresh: the key record names the client zone"
+is "${PKI_client_encrypt_cert}" "$ZONE/.srvpublic.crt"  "fresh: the cert record names the client zone"
+genkey "${PKI_client_encrypt_key}"
+echo "cert-bytes" > "${PKI_client_encrypt_cert}"
+_linkClientLeafCompat
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "fresh: the canonical key name is a symlink" \
+    || bad "fresh: the canonical key name is not a symlink"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" \
+   "$(readlink -f "$ZONE/.srvprivate.key")" \
+   "fresh: the canonical key name resolves into the zone"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvpublic.crt")" \
+   "$(readlink -f "$ZONE/.srvpublic.crt")" \
+   "fresh: the canonical cert name resolves into the zone"
+# $snapindir/ssl itself stays a real directory. A directory symlink would put
+# snapin uploads straight back beside the keypair.
+[[ -d ${PKI_client_cert_dir} && ! -L ${PKI_client_cert_dir} ]] \
+    && ok "fresh: \$snapindir/ssl is still a real directory, not a symlink" \
+    || bad "fresh: \$snapindir/ssl became a symlink"
+
+# --- B. permissions: the trap that fails per-client, silently ----------------
+mode=$(stat -c '%a' "$ZONE")
+is "$mode" "710" "the leaf dir is 0710 (traversable by the web user)"
+[[ $mode != 700 ]] \
+    && ok "...and NOT 0700, which is what would break certDecrypt()" \
+    || bad "the leaf dir is 0700 -- the web user cannot traverse it"
+is "$(stat -c '%U:%G' "$ZONE")" "root:${apacheuser}" "the leaf dir is root:\${apacheuser}"
+# 0710 over 0750 on purpose: the group digit is 1, so the web user can traverse
+# INTO the directory but cannot list what is in it.
+is "$(stat -c '%a' "$ZONE" | cut -c2)" "1" "group bit is execute-only: traverse, no listing"
+
+# --- C. an upgrade from the old layout --------------------------------------
+# The keypair sitting as REAL files in $snapindir/ssl, which is every existing
+# server. The bytes must survive: a regenerated key locks out the whole fleet.
+newtree upgrade
+seedNeighbours
+genkey "${PKI_client_cert_dir}/.srvprivate.key"
+echo "the-deployed-cert" > "${PKI_client_cert_dir}/.srvpublic.crt"
+keysum=$(sha256sum < "${PKI_client_cert_dir}/.srvprivate.key")
+_separateCommKey
+_resolveClientLeafPaths
+_linkClientLeafCompat
+[[ -f "$ZONE/.srvprivate.key" && ! -L "$ZONE/.srvprivate.key" ]] \
+    && ok "upgrade: the real key is now in the zone" \
+    || bad "upgrade: the real key did not move into the zone"
+is "$(sha256sum < "$ZONE/.srvprivate.key")" "$keysum" \
+   "upgrade: the key bytes are IDENTICAL (a re-key would orphan every client)"
+is "$(cat "$ZONE/.srvpublic.crt")" "the-deployed-cert" \
+   "upgrade: the deployed certificate moved with it"
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "upgrade: a compat symlink was left at the canonical name" \
+    || bad "upgrade: no compat symlink at the canonical name"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" \
+   "$(readlink -f "$ZONE/.srvprivate.key")" \
+   "upgrade: the canonical name still resolves to the key"
+is "$(neighboursIntact)" "" "upgrade: every neighbouring file is untouched"
+
+# --- D. THE TRAP: _separateCommKey must not eat its own compat link ---------
+# _separateCommKey dereferences a symlink at the canonical name and copies the
+# target over it. FOG's own compat link IS such a symlink, so without a zone
+# test it writes a real duplicate of the client PRIVATE KEY back into
+# $snapindir/ssl -- the directory the snapin replicator walks -- and announces a
+# separation that did not happen.
+#
+# Asserted immediately after _separateCommKey and BEFORE the relink. That
+# ordering is the whole point: _linkClientLeafCompat puts the symlink back later
+# in the same run, so a check at the end of a pass sees nothing wrong and passes
+# with the guard removed -- which is exactly what an earlier version of this
+# test did. The duplicate is transient only if the run reaches the relink, and
+# errorStat exits in between.
+_separateCommKey
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "_separateCommKey leaves FOG's own compat link alone" \
+    || bad "_separateCommKey dereferenced its own link -- a real private key is back in the snapin dir"
+[[ ! -f "${PKI_client_cert_dir}/.srvprivate.key" || -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "...so no duplicate private key sits beside the snapin material" \
+    || bad "a real duplicate of the client private key is in the snapin dir"
+_resolveClientLeafPaths
+_linkClientLeafCompat
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "second pass: the canonical name is still a symlink" \
+    || bad "second pass: the canonical name is not a symlink"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" \
+   "$(readlink -f "$ZONE/.srvprivate.key")" \
+   "second pass: it still resolves into the zone"
+is "$(sha256sum < "$ZONE/.srvprivate.key")" "$keysum" \
+   "second pass: the key bytes are unchanged"
+# A third, for the same reason: the loop this guards against is per-run.
+_separateCommKey; _resolveClientLeafPaths; _linkClientLeafCompat
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "third pass: still stable" || bad "third pass: the layout drifted"
+
+# --- E. the case _separateCommKey actually exists for ------------------------
+# An admin who relocated the web key has the canonical name pointing at THEIR
+# file, which under the historic layout was the web key and the comm key at
+# once. That must still be separated -- an ACME renewal writing their file must
+# not change what certDecrypt() reads -- and then migrated like any real file.
+newtree adminlink
+seedNeighbours
+mkdir -p "$WORK/adminlink/etc/letsencrypt"
+genkey "$WORK/adminlink/etc/letsencrypt/privkey.pem"
+acmesum=$(sha256sum < "$WORK/adminlink/etc/letsencrypt/privkey.pem")
+ln -s "$WORK/adminlink/etc/letsencrypt/privkey.pem" "${PKI_client_cert_dir}/.srvprivate.key"
+_separateCommKey
+[[ -f "${PKI_client_cert_dir}/.srvprivate.key" && ! -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "admin link: the comm key was separated into a real file" \
+    || bad "admin link: the symlink to the admin's web key was not separated"
+_resolveClientLeafPaths
+_linkClientLeafCompat
+is "$(sha256sum < "$ZONE/.srvprivate.key")" "$acmesum" \
+   "admin link: the separated material kept the admin's key bytes"
+# And the admin's own file is left where it is -- FOG copies, never moves it.
+[[ -f "$WORK/adminlink/etc/letsencrypt/privkey.pem" ]] \
+    && ok "admin link: the admin's own key file is untouched" \
+    || bad "admin link: FOG moved or removed the admin's key"
+
+# --- F. the retired pki/root/leaf links -------------------------------------
+# They pointed at the keypair while it lived in $snapindir/ssl. With the keypair
+# in its own zone they would be a second set of links to the first.
+newtree rootleaf
+seedNeighbours
+genkey "${PKI_client_cert_dir}/.srvprivate.key"
+echo c > "${PKI_client_cert_dir}/.srvpublic.crt"
+mkdir -p "$fogprogramdir/pki/root/leaf"
+ln -s "${PKI_client_cert_dir}/.srvprivate.key" "$fogprogramdir/pki/root/leaf/.srvprivate.key"
+ln -s "${PKI_client_cert_dir}/.srvpublic.crt" "$fogprogramdir/pki/root/leaf/.srvpublic.crt"
+_separateCommKey; _resolveClientLeafPaths
+_retireRootLeafLinks
+[[ ! -e "$fogprogramdir/pki/root/leaf" ]] \
+    && ok "root zone: the stale discoverability links and dir are gone" \
+    || bad "root zone: pki/root/leaf survived"
+# A real file there is somebody else's, and must survive.
+newtree rootleafreal
+mkdir -p "$fogprogramdir/pki/root/leaf"
+echo "not-a-link" > "$fogprogramdir/pki/root/leaf/.srvprivate.key"
+_retireRootLeafLinks
+is "$(cat "$fogprogramdir/pki/root/leaf/.srvprivate.key" 2>/dev/null)" "not-a-link" \
+   "root zone: a REAL file there is never unlinked"
+
+# --- G. the zone token exists at all ----------------------------------------
+is "$(_pkiZoneDir client)" "$fogprogramdir/pki/client" "_pkiZoneDir knows the client zone"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -99,11 +99,83 @@ out=$(_detectExternalCertManagement) && ok "D: fires on a leaf that does not cha
 #    admin who already aimed the canonical path at their own certificate is
 #    never second-guessed. GH-1120 replaced the $acmeLeaf key with this derived
 #    test, so the guard is the predicate rather than a persisted value.
+#
+#    This one assertion is necessarily structural: it is about the ORDER
+#    createSSLCA consults things in, and the only way to observe that
+#    behaviourally is to run createSSLCA, which mints the vhost, writes under
+#    /etc and restarts services. The predicate itself is exercised for real
+#    below -- which is the part that used to be missing entirely.
 if awk '/Detect-then-LINK/,/_warnExternalCertTooling/' "$FUNCS" | grep -q '! _externallyManagedLeaf'; then
     ok "E: detection is skipped when the leaf is already externally managed"
 else
     bad "E: detection does not check _externallyManagedLeaf first"
 fi
+
+echo "== _externallyManagedLeaf: the symlink test that replaced \$acmeLeaf =="
+
+# The whole point of retiring $acmeLeaf was to stop asking a persisted key and
+# ask the filesystem instead: a canonical vhost path resolving OUTSIDE the web
+# zone dir IS the signal that somebody else manages the leaf. Getting it wrong
+# is expensive in both directions -- a false negative regenerates the leaf from
+# the original CSR against an ACME key and the web server will not start, a
+# false positive silently ends FOG's own renewals -- and until now nothing
+# executed the predicate at all.
+#
+# Needs a real $fogprogramdir, which is why the fixture above could not do this:
+# _pkiZoneDir derives from it, and unset it resolves to /pki/web.
+eml_env() {
+    fogprogramdir="$WORK/eml/opt/fog"
+    EMLZONE="$fogprogramdir/pki/web"
+    EMLLEAF="$EMLZONE/leaf"
+    mkdir -p "$EMLLEAF" "$WORK/eml/etc/letsencrypt/live/fog"
+    : > "$EMLLEAF/.webLeaf.pem"
+    : > "$EMLZONE/sibling.pem"
+    : > "$WORK/eml/etc/letsencrypt/live/fog/fullchain.pem"
+}
+eml() { _externallyManagedLeaf && echo external || echo fog; }
+eml_env
+
+# FOG's own leaf, the ordinary install. A false positive here is what ends a
+# server's renewals with nothing to show why.
+PKI_web_vhost_cert="$EMLLEAF/.webLeaf.pem"
+check "$(eml)" "fog" "a real file inside the web zone is FOG-managed"
+
+# THE case this exists for: the canonical path is a symlink into an ACME tree.
+ln -sf "$WORK/eml/etc/letsencrypt/live/fog/fullchain.pem" "$EMLLEAF/acme.pem"
+PKI_web_vhost_cert="$EMLLEAF/acme.pem"
+check "$(eml)" "external" "a symlink out of the zone is externally managed"
+
+# A symlink that stays inside the zone is still FOG's -- the test is on where it
+# LANDS, not on the fact that it is a link. FOG makes such links itself
+# (_linkCanonical), so reading them as external would make FOG disown its own
+# certificates.
+ln -sf "$EMLZONE/sibling.pem" "$EMLLEAF/inzone.pem"
+PKI_web_vhost_cert="$EMLLEAF/inzone.pem"
+check "$(eml)" "fog" "a symlink landing inside the zone is still FOG-managed"
+
+# No symlink needed: the key may simply name a path elsewhere.
+PKI_web_vhost_cert="$WORK/eml/etc/letsencrypt/live/fog/fullchain.pem"
+check "$(eml)" "external" "a path outside the zone needs no symlink to count"
+
+# Unset and unresolvable both mean FOG-managed, which is the SAFE direction: a
+# fresh install has no leaf yet and must go on managing its own.
+PKI_web_vhost_cert=""
+check "$(eml)" "fog" "unset is FOG-managed (a fresh install must still issue)"
+PKI_web_vhost_cert="$EMLLEAF/never-created.pem"
+check "$(eml)" "fog" "a path that does not exist yet is FOG-managed"
+ln -sf "$WORK/eml/no-such-dir/gone.pem" "$EMLLEAF/dangling.pem"
+PKI_web_vhost_cert="$EMLLEAF/dangling.pem"
+check "$(eml)" "fog" "a dangling symlink is FOG-managed, not external"
+
+# readlink -f on BOTH sides, so an install reached through a symlinked
+# $fogprogramdir is not mistaken for somebody else's certificate. Without the
+# resolution on the zone side this compares a real path against a symlinked one
+# and every such server is declared externally managed.
+mkdir -p "$WORK/eml/real"
+mv "$WORK/eml/opt/fog" "$WORK/eml/real/fog"
+ln -sf "$WORK/eml/real/fog" "$WORK/eml/opt/fog"
+PKI_web_vhost_cert="$fogprogramdir/pki/web/leaf/.webLeaf.pem"
+check "$(eml)" "fog" "a symlinked \$fogprogramdir is still FOG-managed"
 
 echo "== the paths are captured, and captured from the vhost =="
 

--- a/tests/fogsettings-migration.test.sh
+++ b/tests/fogsettings-migration.test.sh
@@ -184,7 +184,10 @@ is "${PKI_sb_codesign_key}"           "/opt/fog/pki/secureboot/.fogSB.key" "PKI_
 is "${FOG_program_dir}"               "$fogprogramdir"   "FOG_program_dir records the LIVE path, not the stale line"
 
 # The merges: two old keys, one answer.
-is "${DHCP_enabled}"  "1"        "DHCP_enabled takes bldhcp's encoding, not dodhcp's"
+# Whichever of the two the seed reads, it copies the value verbatim -- the seed
+# block is a copy, never a translation. Normalizing the ENCODING to yes/no is a
+# separate step (_normalizeBooleanSettings), asserted on the written file below.
+is "${DHCP_enabled}"  "1"        "DHCP_enabled takes bldhcp's value, not dodhcp's"
 is "${DHCP_router}"   "10.0.0.1" "DHCP_router takes the clean value"
 is "${PKI_web_ca_cert}"   "/opt/fog/pki/web/ca/.fogWebCA.pem"  "PKI_web_ca_cert comes from FOG's own canonical path"
 is "${PKI_web_vhost_cert}" "/opt/fog/pki/web/leaf/.webLeaf.pem" "PKI_web_vhost_cert comes from sslpubcert when no external leaf was recorded"
@@ -245,6 +248,39 @@ grep -qx "NET_hostname='fog.example.org'" "$NEW" \
 grep -qx "FOG_installed=1" "$NEW" \
     && ok "FOG_installed stays unquoted and numeric, as the format has always been" \
     || bad "FOG_installed was quoted"
+
+# Booleans land in ONE encoding, whatever the old file used. The fixture above
+# deliberately supplies all three: installlang='1', sendreports='Y',
+# httpsRedirect='yes'. Asserted on the written file rather than on the seed
+# block, because the seed only copies -- normalization is what converts.
+for pair in "FOG_install_lang=yes:installlang='1'" \
+            "FOG_send_reports=yes:sendreports='Y'" \
+            "DB_external=no:snmysqlexternal='0'" \
+            "PKI_sb_enabled=yes:secureboot='1'" \
+            "DHCP_enabled=yes:bldhcp='1'" \
+            "WEB_https_redirect=yes:httpsRedirect='yes'" \
+            "PKI_web_cert_publicly_trusted=no:publicWebCert='no'" \
+            "BOOT_url_proto_forced=no:netbootProtoForced='no'"; do
+    want="${pair%%:*}"; from="${pair#*:}"
+    grep -qx "${want%%=*}='${want#*=}'" "$NEW" \
+        && ok "${want} (from ${from})" \
+        || bad "${want} not written (from ${from}); got: $(grep -E "^${want%%=*}=" "$NEW" || echo MISSING)"
+done
+
+# And nothing else slipped through in an old encoding. Reads the real key list
+# out of functions.sh so a key added to it later is covered without editing this.
+badbool=""
+while read -r k; do
+    [[ -z $k ]] && continue
+    line=$(grep -E "^${k}=" "$NEW") || continue
+    case "$line" in
+        "$k='yes'"|"$k='no'"|"$k=''") ;;
+        *) badbool="$badbool [$line]" ;;
+    esac
+done < <(sed -n '/^_booleanSettingKeys()/,/^}/p' "$FUNCS" \
+    | sed -e 's/^ *echo //' -e 's/\\$//' -e '/^_booleanSettingKeys/d' -e '/^}/d' \
+    | tr -s ' \n' '\n\n' | grep -vE '^$')
+is "$badbool" "" "every boolean key was written as yes/no (or empty)"
 
 # What an upgrade must not eat. Hand-set keys work ONLY because the merge keeps
 # lines it does not manage; a plain fresh write would silently drop all of this.

--- a/tests/fogstorage-grants-exist.test.sh
+++ b/tests/fogstorage-grants-exist.test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Guards the fogstorage GRANT list against naming a table that does not exist.
+#
+#   tests/fogstorage-grants-exist.test.sh
+#
+# grantFogStorageAccess() writes a .sql file of per-table GRANTs and feeds it to
+# mysql in ONE batch. MySQL refuses a grant on a missing table
+# (ERROR 1146 ... Table 'fog.x' doesn't exist) and the client stops at that
+# statement, so a single stale name aborts the whole batch: the grants after it
+# never apply, errorStat sees a non-zero status, and the install stops with
+# "Granting access to fogstorage database user ... Failed!".
+#
+# That shipped. ADR 0022 decision 3 retired `imagingLog` -- taskLog carries the
+# image name now, so the two logs no longer recorded different things -- and
+# Schema::dropTable('imagingLog') drops it, but the grant list still named it.
+# Every FRESH install of working-1.6 failed at that step, which is late enough
+# to look like a database problem rather than a stale list.
+#
+# The two halves live in different languages and different directories, so
+# nothing connected them. This does: every table named in the grant block must
+# be created by the schema and must not be dropped by it.
+#
+# Pure source analysis: no database, no install, no root.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+SCHEMA="$REPO/packages/web/commons/schema.php"
+
+[[ -f $FUNCS ]]  || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+[[ -f $SCHEMA ]] || { echo "ERROR: $SCHEMA not found" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+echo "fogstorage grants:"
+
+# The per-table grants, read out of the real heredoc. `${DB_name}.*` is the
+# database-wide SELECT and names no table, so it is excluded.
+granted="$(grep -oE "GRANT [A-Z,]+ ON \\\$\{DB_name\}\.[A-Za-z_][A-Za-z0-9_]*" "$FUNCS" \
+    | sed -E 's/.*\}\.//' | sort -u)"
+count=$(printf '%s\n' "$granted" | grep -cvE '^$')
+
+# A floor, so a change to the heredoc that stops the extraction matching cannot
+# turn this into a test that passes by finding nothing.
+[[ $count -ge 8 ]] && ok "found $count per-table grants to check" \
+    || bad "only found $count per-table grants; extraction is probably broken"
+
+# Tables the schema creates. Both spellings appear in this file: the CREATE TABLE
+# strings and Schema::createTable() calls.
+# Both `CREATE TABLE  \`x\`` (with the stray double space this file has) and
+# `CREATE TABLE IF NOT EXISTS \`x\`` occur, alongside Schema::createTable().
+# Missing a spelling here makes a live table look absent, which is a false
+# failure rather than a missed regression -- but it is still wrong, and it did
+# happen while writing this.
+created="$( { grep -oE 'CREATE TABLE +(IF +NOT +EXISTS +)?`[A-Za-z0-9_]+`' "$SCHEMA" \
+                 | sed -E 's/.*`(.*)`/\1/'
+             grep -oE "Schema::createTable\('[A-Za-z0-9_]+'" "$SCHEMA" | sed -E "s/.*'(.*)'/\1/"
+           } | sort -u)"
+dropped="$(grep -oE "Schema::dropTable\('[A-Za-z0-9_]+'" "$SCHEMA" | sed -E "s/.*'(.*)'/\1/" | sort -u)"
+
+[[ -n $created ]] || { bad "no CREATE TABLE names found in schema.php"; }
+
+missing=""
+retired=""
+while read -r t; do
+    [[ -z $t ]] && continue
+    printf '%s\n' "$dropped" | grep -qxF "$t" && { retired="$retired $t"; continue; }
+    printf '%s\n' "$created" | grep -qxF "$t" || missing="$missing $t"
+done <<< "$granted"
+
+is "$retired" "" "no grant names a table the schema DROPS"
+is "$missing" "" "every granted table is created by the schema"
+
+# And the specific regression, by name, so a failure says what happened rather
+# than only that a set was non-empty.
+printf '%s\n' "$granted" | grep -qxF imagingLog \
+    && bad "imagingLog is still granted -- ADR 0022 dropped that table" \
+    || ok "imagingLog is no longer granted (ADR 0022 dropped it)"
+printf '%s\n' "$dropped" | grep -qxF imagingLog \
+    && ok "...and the schema does still drop it, so this test is testing something" \
+    || bad "schema.php no longer drops imagingLog -- re-check this test's premise"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/interactive-prompt-wiring.test.sh
+++ b/tests/interactive-prompt-wiring.test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+#
+# Guards the interactive installer's prompts against reading into a dead
+# variable.
+#
+#   tests/interactive-prompt-wiring.test.sh
+#
+# `.fogsettings` is SOURCED, so a key name IS a shell variable name. That is
+# what made the GH-1120 rename a ~2500-site variable sweep, and it is why the
+# prompts in lib/common/input.sh are written as
+#
+#     while [[ -z ${SOME_KEY} ]]; do
+#         read SOME_KEY          # <-- the prompt fills the key directly
+#         case ${SOME_KEY} in ...
+#     done
+#
+# The rename moved every `while`/`case`/test onto the new spelling and left nine
+# `read` statements on the OLD one. The answer went to a variable nothing reads,
+# the loop re-tested the still-empty new key, and the `""` branch of the case
+# supplied a default -- so the prompt appeared, accepted input, and silently
+# discarded it:
+#
+#   read installtype   / case ${FOG_install_type}      storage node unselectable
+#   read interface     / while [[ -z ${NET_interface} ]]   re-prompts forever
+#   read dodhcp        / case ${DHCP_enabled}          DHCP always off
+#   read routeraddress / case ${DHCP_router}           router IP ignored
+#   read dnsaddress    / case ${DHCP_dns_server_ip}    DNS ignored
+#   read installlang   / case ${FOG_install_lang}      language packs never install
+#   read snmysqlhost   / while [[ -z ${DB_host} ]]     INFINITE LOOP
+#   read snmysqlpass   / while [[ -z ${DB_password} ]] INFINITE LOOP
+#   read hostname      / case $blHost (newinput.sh)    hostname change ignored
+#
+# Every prompt sits behind `[[ -z $autoaccept ]]`, so `-y` runs were unaffected
+# and the whole existing suite stayed green -- nothing covered interactive
+# wiring at all. The two storage-node loops have no autoaccept guard, so a
+# storage-node install hung with no way out.
+#
+# The invariant: a `read` target is either a key the installer manages, or a
+# local scratch variable. It is NEVER a retired spelling -- all nine bugs above
+# read into a key that is in deprecatedKeys, so that one test catches the whole
+# class, including a recurrence under some future rename.
+#
+# Pure source analysis: no install, no network, no root, no openssl.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+INPUTS=("$REPO/lib/common/input.sh" "$REPO/lib/common/newinput.sh")
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+for f in "${INPUTS[@]}"; do
+    [[ -f $f ]] || { echo "ERROR: $f not found" >&2; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# Both key arrays come out of the real source with COMMENTS STRIPPED. The arrays
+# carry a lot of prose that names keys, so a grep over the raw block matches a
+# key that is merely mentioned -- the same trap install-settings-resolution
+# documents, and the same helper.
+arrayKeys() {
+    sed -n "/local -a $1=(/,/^    )/p" "$FUNCS" \
+        | sed -e 's/#.*$//' -e "s/local -a $1=(//" -e 's/)//' \
+        | tr -s ' \n' '\n\n' | grep -vE '^$'
+}
+managed="$(arrayKeys managedKeys)"
+deprecated="$(arrayKeys deprecatedKeys)"
+inlist() { printf '%s\n' "$2" | grep -qxF "$1"; }
+
+[[ -n $managed ]]    || { echo "ERROR: managedKeys came back empty" >&2; exit 1; }
+[[ -n $deprecated ]] || { echo "ERROR: deprecatedKeys came back empty" >&2; exit 1; }
+
+# Local scratch variables the prompts legitimately read into: a yes/no answer
+# that is then translated into a key by the case below it. Deliberately a short
+# explicit allowlist rather than a pattern -- "it looks local" is how
+# `read interface` passed review.
+scratch="
+blInt
+blRouter
+blDNS
+blHost
+blReports
+blConstrain
+blExtCA
+answer
+inextcacert
+inextcakey
+inextcaroot
+"
+
+# Every `read` in both files, one record per statement: "file:line target".
+readTargets() {
+    for f in "$@"; do
+        grep -nE '^[[:space:]]*read[[:space:]]+(-r[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*$' "$f" \
+            | while IFS= read -r hit; do
+                ln="${hit%%:*}"
+                var="$(printf '%s' "${hit#*:}" | sed -E 's/^[[:space:]]*read[[:space:]]+(-r[[:space:]]+)?//' | tr -d '[:space:]')"
+                printf '%s:%s %s\n' "$(basename "$f")" "$ln" "$var"
+            done
+    done
+}
+
+allReads="$(readTargets "${INPUTS[@]}")"
+count=$(printf '%s\n' "$allReads" | grep -cvE '^$')
+
+# A sanity floor. If the extraction silently stops matching -- a reformat, a
+# `read -p`, a here-string -- every assertion below passes vacuously and this
+# test becomes decoration.
+[[ $count -ge 15 ]] && ok "found $count read statements to check" \
+    || bad "only found $count read statements; extraction is probably broken"
+
+# --- A. the actual bug: never read into a retired key ------------------------
+retired=""
+while read -r where var; do
+    [[ -n $var ]] || continue
+    inlist "$var" "$deprecated" && retired="$retired $where($var)"
+done <<< "$allReads"
+is "$retired" "" "no prompt reads into a deprecatedKeys spelling"
+
+# --- B. and every target is accounted for ------------------------------------
+# Catches a NEW old-style name that was never a .fogsettings key at all, which
+# test A cannot see.
+unknown=""
+while read -r where var; do
+    [[ -n $var ]] || continue
+    inlist "$var" "$managed" && continue
+    inlist "$var" "$scratch" && continue
+    unknown="$unknown $where($var)"
+done <<< "$allReads"
+is "$unknown" "" "every read target is a managed key or an allowlisted scratch var"
+
+# --- C. the nine specific sites, by key --------------------------------------
+# Named individually so a regression names the prompt that broke rather than
+# just a count. Each is the canonical key its own loop tests.
+for key in FOG_install_type NET_interface DHCP_enabled DHCP_router \
+           DHCP_dns_server_ip FOG_install_lang DB_host DB_password; do
+    printf '%s\n' "$allReads" | grep -qE "[[:space:]]${key}\$" \
+        && ok "input.sh reads into ${key}" \
+        || bad "nothing reads into ${key} -- its prompt cannot fill it"
+done
+printf '%s\n' "$allReads" | grep -qE "^newinput\.sh:[0-9]+ NET_hostname\$" \
+    && ok "newinput.sh reads into NET_hostname" \
+    || bad "newinput.sh does not read into NET_hostname"
+
+# --- D. no `while [[ -z ${KEY} ]]` loop can spin without a way to fill KEY ---
+# The two storage-node loops hung precisely because the only read inside them
+# targeted a dead name and the loop condition could never become false. A loop
+# over a managed key must contain either a read into it or an assignment to it.
+spinners=""
+for f in "${INPUTS[@]}"; do
+    base="$(basename "$f")"
+    while IFS= read -r hit; do
+        ln="${hit%%:*}"
+        key="$(printf '%s' "${hit#*:}" | sed -E 's/.*-z[[:space:]]+\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?.*/\1/')"
+        inlist "$key" "$managed" || continue
+        # Body runs to the matching `done` at the same indentation.
+        indent="$(printf '%s' "${hit#*:}" | sed -E 's/[^[:space:]].*//')"
+        end=$(awk -v s="$ln" -v ind="^${indent}done" 'NR>s && $0 ~ ind {print NR; exit}' "$f")
+        [[ -n $end ]] || { spinners="$spinners $base:$ln($key:no-done)"; continue; }
+        body="$(sed -n "$((ln+1)),$((end-1))p" "$f")"
+        printf '%s\n' "$body" | grep -qE "^[[:space:]]*read[[:space:]]+(-r[[:space:]]+)?${key}[[:space:]]*\$" && continue
+        printf '%s\n' "$body" | grep -qE "^[[:space:]]*${key}=" && continue
+        spinners="$spinners $base:$ln($key)"
+    done < <(grep -nE '^[[:space:]]*while[[:space:]]+\[\[[[:space:]]+-z[[:space:]]+\$\{?[A-Za-z_][A-Za-z0-9_]*\}?[[:space:]]+\]\]' "$f")
+done
+is "$spinners" "" "every 'while [[ -z KEY ]]' loop can actually fill KEY"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/ipxe-build-stamp.test.sh
+++ b/tests/ipxe-build-stamp.test.sh
@@ -81,6 +81,46 @@ needs() { _needsLocalIpxeBuild && echo yes || echo no; }
 
 echo "ipxe build stamp:"
 
+# --- what gets embedded: the Web CA, never the chain ------------------------
+# TRUST=/CERT= is iPXE's whole per-site trust configuration, so this selection
+# decides what a netbooting client will accept. The chain bundle is the web
+# zone's trust PATH -- intermediate PLUS the root anchoring it -- and embedding
+# it makes iPXE trust the FOG root and so anything the root ever signs, when all
+# it has to validate is boot.php's leaf. The intermediate alone is
+# name-constrained and serverAuth-only, hence narrower and sufficient (ADR 0016).
+#
+# Pinned in the presence of a perfectly valid chain file, because that is the
+# state every existing HTTPS server is in and the old code preferred it.
+PKI_web_trust_chain="$WORK/chain.pem"
+cat "${PKI_web_ca_cert}" > "${PKI_web_trust_chain}"
+echo "-----BEGIN CERTIFICATE----- fixture-root -----END CERTIFICATE-----" >> "${PKI_web_trust_chain}"
+ipxetrust=""
+_resolveIpxeTrust
+is "$ipxetrust" "${PKI_web_ca_cert}" "the Web CA is embedded even when a chain file exists"
+[[ $ipxetrust != "${PKI_web_trust_chain}" ]] \
+    && ok "the trust chain bundle is not embedded" \
+    || bad "the chain bundle was embedded -- iPXE would trust the FOG root"
+
+# Bring-your-own-CA: an admin's own intermediate with no FOG root above it. The
+# answer must still be their CA, not an empty or absent chain.
+( PKI_web_trust_chain=""; ipxetrust=""; _resolveIpxeTrust
+  [[ $ipxetrust == "${PKI_web_ca_cert}" ]] ) \
+    && ok "with no chain at all it is still the Web CA" \
+    || bad "no chain left ipxetrust wrong"
+
+# --- the one forced rebuild this change costs on upgrade --------------------
+# A server built before this landed has a stamp whose ca= is the sha256 of the
+# CHAIN. The binary on disk really does embed different bytes than are now
+# asked for, so exactly one rebuild is correct -- and it must then settle, or
+# every subsequent update pays 10-25 minutes again.
+BOOT_rebuild_ipxe_with_my_ca="yes"
+locallybuilt
+( ipxetrust="${PKI_web_trust_chain}"; _ipxeBuildStampValue > "$stamp" )   # the old stamp
+is "$(needs)" "yes" "one rebuild is scheduled for a server stamped against the chain"
+writestamp                                                                # the new one
+is "$(needs)" "no"  "...and it settles: the next update does not rebuild again"
+PKI_web_trust_chain=""
+
 # --- the build only ever happens when it was asked for ----------------------
 BOOT_rebuild_ipxe_with_my_ca="no"
 published

--- a/tests/node-cert-external-ca.test.sh
+++ b/tests/node-cert-external-ca.test.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+#
+# Guards storage-node certificate issuance, including from an imported Web CA.
+#
+#   tests/node-cert-external-ca.test.sh
+#
+# A storage node generates its OWN keypair and its OWN CSR (_requestNodeCert),
+# POSTs it to the master's service/nodecert.php, and the master signs it with
+# the Web CA through fog-sign-node-cert -- a root-only helper the web user can
+# invoke but cannot hand paths to.
+#
+# That worked only while the Web CA was FOG's own. The helper appended
+# PKI_ROOT_CERT to the chain it returned and verified the freshly-signed leaf
+# against PKI_ROOT_CERT, and PKI_ROOT_CERT is the FOG root -- which, on a server
+# whose admin supplied their own Web CA, never signed that intermediate. So:
+#
+#   * `openssl verify -CAfile <FOG root> -untrusted <imported intermediate>`
+#     cannot build a chain, so EVERY node request was refused, and
+#   * the refusal said "a requested name is probably outside the CA's name
+#     constraints", sending the admin to look at name constraints for something
+#     that was never a name problem.
+#
+# The fix is one idea: the web zone's anchor is not necessarily the FOG root.
+# PKI_WEB_ANCHOR names pki/web/ca/.trustAnchor.pem, which _resolveTrustAnchor
+# builds with the FOG root AND an imported root where there is one, deduped by
+# fingerprint -- so one path covers both installs. PKI_WEB_CHAIN names the
+# zone's own trust path (issuer + the root anchoring it), which is what a node
+# should serve beneath its leaf.
+#
+# Runs fog-sign-node-cert directly against generated CAs. Needs openssl. No
+# install, no network, no root, no sudo.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+HELPER="$REPO/packages/pki/fog-sign-node-cert"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $HELPER ]] || { echo "ERROR: $HELPER not found" >&2; exit 1; }
+[[ -f $FUNCS ]]  || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# --- fixtures ---------------------------------------------------------------
+# Two independent worlds, each a root that signs an intermediate:
+#   fog/  what FOG mints itself
+#   ext/  an intermediate an enterprise PKI handed the admin, under ITS own
+#         root, which FOG has never seen
+mkca() {
+    local d="$WORK/$1"
+    mkdir -p "$d"
+    openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 5 \
+        -subj "/CN=$1 Root" -keyout "$d/root.key" -out "$d/root.pem" \
+        -addext "basicConstraints=critical,CA:TRUE" >/dev/null 2>&1 || return 1
+    openssl req -new -nodes -newkey rsa:2048 -sha256 -subj "/CN=$1 Web CA" \
+        -keyout "$d/int.key" -out "$d/int.csr" >/dev/null 2>&1 || return 1
+    printf '[v3_int]\nbasicConstraints=critical,CA:TRUE,pathlen:0\nkeyUsage=critical,keyCertSign,cRLSign\n' > "$d/int.cnf"
+    openssl x509 -req -in "$d/int.csr" -CA "$d/root.pem" -CAkey "$d/root.key" \
+        -CAcreateserial -sha256 -days 5 -extensions v3_int -extfile "$d/int.cnf" \
+        -out "$d/int.pem" >/dev/null 2>&1 || return 1
+    # The zone's trust path, exactly as _writeWebChainFiles builds it.
+    cat "$d/int.pem" "$d/root.pem" > "$d/chain.pem"
+    return 0
+}
+mkca fog || { echo "ERROR: fog CA fixture failed" >&2; exit 1; }
+mkca ext || { echo "ERROR: ext CA fixture failed" >&2; exit 1; }
+
+# A node's request: its own key, its own CSR. This is the node side of
+# _requestNodeCert, and the point of the whole design -- the node's private key
+# never leaves the node.
+mkdir -p "$WORK/node"
+openssl genrsa -out "$WORK/node/node.key" 2048 >/dev/null 2>&1
+openssl req -new -sha256 -key "$WORK/node/node.key" -out "$WORK/node/node.csr" \
+    -subj "/CN=node1.test.local" >/dev/null 2>&1
+
+# The staging dir and the root-only conf the helper reads.
+STAGE="$WORK/staging"
+mkdir -p "$STAGE"
+run_helper() {
+    # The helper requires a 32-char lowercase hex id -- it is validated before
+    # it ever reaches the filesystem, which is what stops a request id being a
+    # path. Use a real one rather than working around the check.
+    local zone="$1" conf="$WORK/fog-pki.conf"
+    local reqid="deadbeefcafe4000900000000000000f"
+    cp "$WORK/node/node.csr" "$STAGE/${reqid}.csr"
+    # One entry per line, 'DNS:name' or 'IP:addr' -- the helper re-validates
+    # each and refuses anything else, since a line with '[' or '=' would open a
+    # new section in the extension file it builds.
+    printf 'DNS:node1.test.local\n' > "$STAGE/${reqid}.san"
+    rm -f "$STAGE/${reqid}.pem" "$STAGE/${reqid}.chain"
+    sed "s|^CONF=.*|CONF=\"${conf}\"|" "$HELPER" > "$WORK/helper.sh"
+    chmod +x "$WORK/helper.sh"
+    HELPER_OUT="$("$WORK/helper.sh" "$zone" "$reqid" 2>&1)"
+    HELPER_ST=$?
+    LEAF="$STAGE/${reqid}.pem"
+    CHAIN="$STAGE/${reqid}.chain"
+    return $HELPER_ST
+}
+writeconf() { printf '%s\n' "$@" > "$WORK/fog-pki.conf"; }
+
+echo "node cert issuance:"
+
+# --- A. FOG's own Web CA: the case that already worked -----------------------
+writeconf \
+    "PKI_WEB_CA_CERT=$WORK/fog/int.pem" \
+    "PKI_WEB_CA_KEY=$WORK/fog/int.key" \
+    "PKI_ROOT_CERT=$WORK/fog/root.pem" \
+    "PKI_WEB_ANCHOR=$WORK/fog/root.pem" \
+    "PKI_WEB_CHAIN=$WORK/fog/chain.pem" \
+    "PKI_STAGING=$STAGE"
+run_helper web
+is "$HELPER_ST" "0" "A: FOG's own Web CA issues to a node"
+[[ -s $LEAF ]] && ok "A: a leaf was written" || bad "A: no leaf (out: $HELPER_OUT)"
+openssl verify -CAfile "$WORK/fog/root.pem" -untrusted "$WORK/fog/int.pem" "$LEAF" >/dev/null 2>&1 \
+    && ok "A: the leaf verifies under the FOG root" \
+    || bad "A: the leaf does not verify"
+# The leaf must belong to the key the NODE holds, which is what proves the
+# master signed the node's own CSR rather than issuing a keypair for it.
+lm=$(openssl x509 -noout -modulus -in "$LEAF" 2>/dev/null)
+km=$(openssl rsa -noout -modulus -in "$WORK/node/node.key" 2>/dev/null)
+is "$lm" "$km" "A: the leaf pairs with the node's own private key"
+
+# --- B. THE REGRESSION: an imported Web CA ----------------------------------
+# Everything is the admin's except PKI_ROOT_CERT, which stays FOG's root because
+# that is what fog-client pins and an external WEB CA does not replace it. This
+# is precisely the shape that used to fail.
+writeconf \
+    "PKI_WEB_CA_CERT=$WORK/ext/int.pem" \
+    "PKI_WEB_CA_KEY=$WORK/ext/int.key" \
+    "PKI_ROOT_CERT=$WORK/fog/root.pem" \
+    "PKI_WEB_ANCHOR=$WORK/ext/root.pem" \
+    "PKI_WEB_CHAIN=$WORK/ext/chain.pem" \
+    "PKI_STAGING=$STAGE"
+run_helper web
+is "$HELPER_ST" "0" "B: an IMPORTED Web CA issues to a node"
+[[ $HELPER_OUT != *"name constraints"* ]] \
+    && ok "B: no bogus name-constraints refusal" \
+    || bad "B: refused with the name-constraints message (out: $HELPER_OUT)"
+[[ -s $LEAF ]] && ok "B: a leaf was written" || bad "B: no leaf (out: $HELPER_OUT)"
+openssl verify -CAfile "$WORK/ext/root.pem" -untrusted "$WORK/ext/int.pem" "$LEAF" >/dev/null 2>&1 \
+    && ok "B: the leaf verifies under the ADMIN's root" \
+    || bad "B: the leaf does not verify under the admin's root"
+
+# The chain handed to the node must be the admin's trust path, and must NOT
+# carry the FOG root -- a node serving an unrelated root is what the old code
+# produced.
+is "$(grep -c 'BEGIN CERTIFICATE' "$CHAIN")" "2" "B: the chain is issuer + its own root"
+extrootfp=$(openssl x509 -in "$WORK/ext/root.pem" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//')
+fogrootfp=$(openssl x509 -in "$WORK/fog/root.pem" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//')
+chainfps=$(awk 'BEGIN{n=0} /BEGIN CERT/{n++} {print > "'"$WORK"'/c" n ".pem"}' "$CHAIN"; \
+           for f in "$WORK"/c*.pem; do openssl x509 -in "$f" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//'; done)
+[[ $chainfps == *"$extrootfp"* ]] \
+    && ok "B: the admin's root IS in the chain" \
+    || bad "B: the admin's root is missing from the chain"
+[[ $chainfps != *"$fogrootfp"* ]] \
+    && ok "B: the FOG root is NOT in the chain" \
+    || bad "B: the FOG root was appended to a chain it does not anchor"
+rm -f "$WORK"/c*.pem
+
+# --- C. the fallback, for a conf written before these keys existed ----------
+# An upgraded master whose .fog-pki predates PKI_WEB_ANCHOR/PKI_WEB_CHAIN must
+# still issue on an ordinary FOG-CA install rather than failing closed.
+writeconf \
+    "PKI_WEB_CA_CERT=$WORK/fog/int.pem" \
+    "PKI_WEB_CA_KEY=$WORK/fog/int.key" \
+    "PKI_ROOT_CERT=$WORK/fog/root.pem" \
+    "PKI_STAGING=$STAGE"
+run_helper web
+is "$HELPER_ST" "0" "C: an old conf with neither new key still issues"
+is "$(grep -c 'BEGIN CERTIFICATE' "$CHAIN")" "2" "C: and still builds issuer + root"
+
+# --- D. a genuinely absent CA is still refused -------------------------------
+# The fallbacks must not turn "no CA here" into a silent success.
+writeconf \
+    "PKI_WEB_CA_CERT=$WORK/nope/int.pem" \
+    "PKI_WEB_CA_KEY=$WORK/nope/int.key" \
+    "PKI_ROOT_CERT=$WORK/fog/root.pem" \
+    "PKI_STAGING=$STAGE"
+run_helper web
+[[ $HELPER_ST -ne 0 ]] && ok "D: a missing Web CA is refused" \
+    || bad "D: a missing Web CA was accepted"
+
+# --- E. the master's conf actually carries the new keys ----------------------
+# The helper cannot use what _installNodeCertSigner does not write.
+signer=$(awk '/^_installNodeCertSigner\(\) \{/,/^\}/' "$FUNCS")
+for k in PKI_WEB_ANCHOR PKI_WEB_CHAIN; do
+    printf '%s\n' "$signer" | grep -q "echo \"${k}=" \
+        && ok "E: _installNodeCertSigner writes ${k}" \
+        || bad "E: _installNodeCertSigner does not write ${k}"
+done
+# And the anchor it names is the trust-anchor bundle, not the FOG root -- naming
+# PKI_root_ca_cert there would reintroduce the whole bug.
+printf '%s\n' "$signer" | grep -q 'PKI_WEB_ANCHOR=.*trustAnchor' \
+    && ok "E: PKI_WEB_ANCHOR names the web zone's trust anchor bundle" \
+    || bad "E: PKI_WEB_ANCHOR does not name .trustAnchor.pem"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/pki-idempotence.test.sh
+++ b/tests/pki-idempotence.test.sh
@@ -99,14 +99,15 @@ pki_pass() {
     _resolveRootCA
 
     local sanentries="IP.1 = ${NET_fog_server_ip}"
-    cat > "${PKI_client_cert_dir}/ca.cnf" << EOF
+    _relocatePkiConf
+    cat > "$(_pkiConfDir)/ca.cnf" << EOF
 [v3_ca]
 subjectAltName = @alt_names
 [alt_names]
 $sanentries
 DNS.1 = ${NET_hostname}
 EOF
-    cat > "${PKI_client_cert_dir}/req.cnf" << EOF
+    cat > "$(_pkiConfDir)/req.cnf" << EOF
 [req]
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
@@ -123,10 +124,11 @@ DNS.1 = ${NET_hostname}
 EOF
 
     _separateCommKey
-    if [[ ! -e ${PKI_client_cert_dir}/.srvprivate.key || ! -e ${PKI_client_cert_dir}/fog.csr ]]; then
-        openssl genrsa -out "${PKI_client_cert_dir}/.srvprivate.key" 4096 >>$error_log 2>&1
-        openssl req -new -sha512 -key "${PKI_client_cert_dir}/.srvprivate.key" -out "${PKI_client_cert_dir}/fog.csr" \
-            -config "${PKI_client_cert_dir}/req.cnf" >>$error_log 2>&1
+    _resolveClientLeafPaths
+    if [[ ! -e ${PKI_client_encrypt_key} || ! -e $(_pkiZoneDir client)/leaf/fog.csr ]]; then
+        openssl genrsa -out "${PKI_client_encrypt_key}" 4096 >>$error_log 2>&1
+        openssl req -new -sha512 -key "${PKI_client_encrypt_key}" -out "$(_pkiZoneDir client)/leaf/fog.csr" \
+            -config "$(_pkiConfDir)/req.cnf" >>$error_log 2>&1
     fi
     _createCommLeaf >/dev/null 2>&1
 

--- a/tests/selfcall-verification.test.sh
+++ b/tests/selfcall-verification.test.sh
@@ -184,6 +184,54 @@ else
     bad "M: checkWebTier still dials \${NET_fog_server_ip}"
 fi
 
+# N. No self-addressed call may be sent to a proxy.
+#
+# A FOG server behind corporate egress filtering has http_proxy/https_proxy in
+# root's environment, and curl honours them for every host that is not in
+# no_proxy -- including the server's own name and its own LAN address. The
+# request then goes to the proxy, which either cannot route back or refuses to
+# CONNECT. Observed on backupDB() as
+# `curl: (56) CONNECT tunnel failed, response 502`, i.e. the backup step failing
+# for a reason with nothing to do with the database, and reported with a blank
+# explanation because plain -s also suppresses curl's error text.
+#
+# Matched on the URL each call dials rather than on a list of function names, so
+# a self-call added later is covered without editing this.
+# Any curl invocation naming one of the addresses this server dials itself (or
+# its master) by. The URL can sit a long way down the line, after a dozen -d
+# flags, so this matches the whole line rather than a URL-shaped prefix.
+selfcalls=$(grep -nE '\bcurl\b' "$FUNCS" \
+    | grep -E '\$\{NET_fog_server_ip\}|\$\{DB_host\}|\$\{selfName\}|selfCacertOpts')
+n=$(printf '%s\n' "$selfcalls" | grep -cvE '^$')
+[[ $n -ge 5 ]] && ok "N: found $n self-addressed curl calls to check" \
+    || bad "N: only found $n self-addressed curl calls; the match is probably broken"
+proxied=""
+while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    [[ $line == *"--noproxy"* ]] || proxied="$proxied ${line%%:*}"
+done <<< "$selfcalls"
+check "$proxied" "" "N: every self-addressed curl passes --noproxy"
+
+# O. And the dump fetch reports WHY it failed.
+#    The block builds a $dbwhy string for five distinct failure modes; plain -s
+#    silences curl's message, so the "curl exited N" branch had nothing to put
+#    after the colon.
+if awk '/dbhttpcode=\$\(curl/,/dbcurlstat=\$\?/' "$FUNCS" | grep -q 'curl -sS'; then
+    ok "O: the dump fetch uses -sS, so its failure reason is not blank"
+else
+    bad "O: the dump fetch still uses plain -s -- \$dbcurlerr will be empty"
+fi
+
+# P. jq only runs when curl actually produced a body.
+#    Unconditional, the redirection `< \$dbraw` failed on any curl error and bash
+#    printed "No such file or directory" into the middle of the progress line,
+#    ahead of the guards that would have explained the real fault.
+if awk '/dbcurlstat=\$\?/,/dbjqstat=1/' "$FUNCS" | grep -q 'if \[\[ -f \$dbraw \]\]'; then
+    ok "P: jq is guarded on curl having written the response body"
+else
+    bad "P: jq runs unconditionally, so a curl failure leaks a bash error"
+fi
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1
 exit 0


### PR DESCRIPTION
Follow-up pass to the `.fogsettings` key rename (#1293), making the scenarios
settled in [#1120's final model comment](https://github.com/FOGProject/fogproject/issues/1120#issuecomment-5382375472)
actually hold. Every item below was verified against source rather than against
the tables in that thread — and three of the six were already done by the rename
itself, so the real work turned out to be elsewhere.

Suite: **114 → 120**, all passing. Every new test is negative-controlled
(deliberately broken, observed to fail, restored). A real FOG 1.6 server was
installed and exercised end to end; the live checks are called out per item.

## Already landed with #1293 — verified, not re-opened

| Item | Evidence |
|---|---|
| retire `acmeLeaf`, replace its signal | `_externallyManagedLeaf()` at `functions.sh:6296`; `acmeLeaf` in `deprecatedKeys` |
| delete `_sbNameConstraints()` | gone; the SB CA call site passes `extendedKeyUsage = codeSigning` alone; the `[[ ! -f ]]` gate is intact |
| retire `caCreated`/`catrust`/`externalca`/`sslcsr` | all four deprecated; `externalca` is run-scoped; the `$caCreated`-gated warning was already re-keyed to a file test |

Item 1 needed **test coverage only** — see below.

## Shipped bugs found while doing this

None of these was on the list. All break installs today.

**The interactive installer discarded every answer.** Nine `read` statements in
`lib/common/input.sh` / `newinput.sh` still wrote the *old* key names while the
loops tested the new ones, so the answer landed in a dead variable and the
case's `""` branch supplied a default. Driving the real code with piped input:

```
PRE-FIX  answer=s|S|storage  ->  FOG_install_type=N    # storage node unselectable
PRE-FIX  answer=y|n          ->  DHCP_enabled=N        # matches neither == 0 nor -eq 1
```

Two storage-node prompts were hard infinite loops with no `autoaccept` guard.
All prompts sit behind `[[ -z $autoaccept ]]`, which is why `-y` runs were fine
and the whole suite stayed green — nothing covered interactive wiring at all.

**A fresh install could not complete.** The `fogstorage` GRANT list still named
`imagingLog`, which ADR 0022 dropped. MySQL refuses a grant on a missing table
and the client stops there, so one stale name aborted the whole batch and the
install failed at *"Granting access to fogstorage database user"* — late enough
to read as a database problem.

**The DB backup failed on every upgrade behind a proxy.** Three faults in one
block, each hiding the next: the self-call was missing `--noproxy '*'` (the two
other `selfCacertOpts` calls already had it), `-s` instead of `-sS` blanked the
very reason the five-way `$dbwhy` diagnostic exists to report, and `jq` ran
unconditionally so a curl failure leaked a raw bash `No such file or directory`
into the middle of the progress line. Live: `Backing up database ... Done`, a
128 KB dump with all 68 tables.

**`packages/pki/renewal-helper` was missed entirely by the rename** and has been
broken on every 1.6 server. It read eleven retired keys — `sslpath`,
`sslprivkey`, `sslpubcert`, `sslcakey`, `sslcapem`, `sslcachain`, `rootCAPem`,
`hostname`, `osid`, `acmeLeaf` — all of which `deprecatedKeys` now *strips*, so
each read produced an empty string and fell through to a default: correct only
on a server that had customised nothing. Its `acmeLeaf=yes` refusal was dead
code against a key that no longer exists.

## The items themselves

**One boolean encoding: `yes`/`no`.** Deferred as "R6" out of #1293 because
changing values would have made that migration a translation rather than a copy.
Resolved by normalising on **load**, every run, instead of rewriting once — which
keeps the migration a copy and is self-repairing for a hand-edited file. Three
encodings were live and the flag layer mixed them *inside one variable*
(`sDHCP_enabled` was assigned `"Y"` and then `1` on the next line;
`sBOOT_external_tftp_server` got the string `"true"`, which nothing tested for).
Both failure directions are silent:

```sh
[[ "N" == 0 ]]    # simply false
[[ "N" -eq 1 ]]   # "N" evaluated as ARITHMETIC -- an unset variable, so 0
```

`FOG_installed` is excluded (numeric file-format contract, read by
`updatefog.sh`, install *state* not a preference). `SVC_firewall_control`
(tri-state) and `FOG_install_type` (`N`/`S` enum) are not booleans, so they fall
outside rather than being exempted — and the test asserts they never join the
list. Polarity is untouched. ADR **0025** records the decision; ADR 0024's
"deliberately not done" entry now points at it. Live: injecting `1`/`N`/`0`/`TRUE`
into `.fogsettings` and re-running normalised all of them, case-insensitively,
with hand-set keys and comments surviving the merge.

**iPXE embeds the Web CA, not the trust chain.** `TRUST=`/`CERT=` is iPXE's
entire per-site trust configuration. The chain bundle is the zone's trust *path* —
intermediate plus root — so embedding it made iPXE trust the FOG root, and
therefore anything the root ever signs, to validate one leaf. The intermediate
alone is name-constrained and `serverAuth`-only (enforceable precisely because
iPXE is a verifier FOG can patch, per ADR 0016). It is also what makes
bring-your-own-CA work: an admin whose Web CA is their own intermediate has no
FOG root above it. **Expect one forced iPXE rebuild per server on upgrade** —
correct, since the stamp hashes this file and the binary really does embed
different bytes. Live: the 2-cert chain exists and is *not* chosen; the 1-cert
Web CA is.

**The client-communication keypair moved into its own zone.** It lived in
`$snapindir/ssl` — the directory an admin edits for snapin SSL and the one the
snapin replicator walks — so "change the snapin certs" and "replace the keypair
every registered client pins" were the same operation, and the second is
invisible until hosts stop checking in. Real files now in `pki/client/leaf/`,
with a **symlink per file** at the canonical names because `FOGBase::_decryptCheck()`
builds `<sslpath>/.srvprivate.key` with the filename hardcoded. Per file, not a
directory symlink: symlinking the directory would put snapin uploads straight
back beside the keypair.

Three load-bearing details:

- **Traversal.** `pki/client/leaf` is `0710 root:$apacheuser`, not the `0700
  root:root` every other zone's `leaf/` gets. `certDecrypt()` opens the key on
  every handshake; `0700` fails that as `Private key not readable`, per client,
  with nothing naming the directory.
- **`_separateCommKey` had to become zone-aware.** It dereferences a symlink at
  the canonical name and copies the target over it — right for an admin's link to
  their own web key, wrong for FOG's own compat link, where it writes a real
  duplicate of the private key back into the replicated directory and reports a
  separation that did not happen.
- Linking is split from path resolution, because on a fresh install the keypair
  does not exist when the paths must be settled.

**`--client-cert` / `--client-key`.** The client zone was the last one an admin
could not point at their own files. Half a pair is refused; a pair that does not
pair is refused; a valid *different* pair **warns via `_warnClientRepin()` and
proceeds**, because re-pinning a fleet is a legitimate request. The refusals gate
on the flag *shadows*, not the resolved values — both are managed keys that
`writeUpdateFile()` persists every run, so gating on those would refuse every
ordinary upgrade.

**The rest of the client PKI material moved too**, and where each file went says
what it is:

| File | New home | Why |
|---|---|---|
| `fog.csr` | `pki/client/leaf/` | the comm leaf's own request |
| `req.cnf`, `ca.cnf` | `pki/conf/` | **shared** — client leaf *and* web leaf read both, so neither zone owns them |
| `dhparam.pem` | `pki/web/` | web-server TLS params, named by the vhost |

No compat symlinks for these — unlike the keypair, every reader is FOG's own
code. `ca.cnf`'s **bytes** are unchanged, which matters because `_createWebLeaf`
hashes it into `.webLeaf.sans`; live upgrade confirmed identical stamp and
identical web-leaf and comm-leaf fingerprints, so nothing re-issued. Only the
legacy `CA/` tree stays behind — the root certificate genuinely lives there.

`SnapinReplicator` no longer ships `ssl/fog.csr`: that is the *master's*
fulfilled request, a node has no use for it, and the entry named a path that no
longer exists. `ssl/CA` still replicates.

**Storage nodes are issued from an imported Web CA.** Nodes already generated
their own keypair and CSR locally — that part was right. What was broken is the
master signing it: `fog-sign-node-cert` verified each new leaf against
`PKI_ROOT_CERT`, which is FOG's root and is *not* replaced by an external **web**
CA (it is what fog-client pins). So with an imported intermediate

```
openssl verify -CAfile <FOG root> -untrusted <imported intermediate> <leaf>
```

could not build a chain and **every node request was refused** — with *"a
requested name is probably outside the CA's name constraints"*, sending the admin
to audit name constraints for something that was never a name problem.

The fix turns on one idea: the web zone's anchor is not necessarily the FOG root.
`PKI_WEB_ANCHOR` is `.trustAnchor.pem` (FOG's root **and** an imported root,
deduped by fingerprint — one path, both install kinds) and `PKI_WEB_CHAIN` is the
zone's trust path, which already *is* issuer-plus-its-root. Secure Boot keeps
`PKI_ROOT_CERT` deliberately: there is no bring-your-own-SB-root, because
firmware trusts the enrolled certificate directly. Live-verified both ways
against the *installed* helper — an "Acme Corp" intermediate issued a node leaf
signed by itself, chain carrying Acme's root and **not** FOG's, verifying under
Acme's anchor; and FOG's own Web CA still issuing afterward. The leaf pairs with
the node's key in both cases.

**Behavioural coverage for `_externallyManagedLeaf()`** (item 1). Case E asserted
only that the string `! _externallyManagedLeaf` appears near the call site. Eight
real cases now, including the one that justifies resolving *both* sides with
`readlink -f`: a symlinked `$fogprogramdir` would otherwise be declared
externally managed on every such install.

## A bug class the negative controls found

This idiom appears five times in the PKI code:

```sh
openssl x509 -noout -modulus -in bad.pem | openssl md5
```

`x509` prints nothing on an unreadable file, and md5 of nothing is the perfectly
non-empty MD5 of the empty string — so **two unreadable files satisfy every `-n`
guard and compare equal**. Consequences found: `_discardOrphanedCommLeaf`
*deleted* a certificate on a failed read, which is exactly the outcome its own
comment says it avoids and takes away the admin's way back from a lost key; and
`_createCommLeaf`'s adopt branch took a certificate it had never parsed as the
client comm cert, a fleet-wide lockout. All five compare the raw modulus now.
Four were pre-existing; fixing one and leaving four identical copies beside it
would have been worse than the wider diff.

## Upgrade impact

- **One** forced iPXE rebuild per server that builds its own (10–25 min), then
  it settles. Asserted in `ipxe-build-stamp.test.sh`.
- The client keypair and the shared PKI config relocate in place, contents
  byte-identical. No client re-pins. No web certificate re-issue.
- Boolean values in `.fogsettings` are rewritten to `yes`/`no` on the next run.
  Hand-set keys and admin comments survive.
- `renewal-helper` starts working again on servers that had customised any path.

## Deliberately out of scope

- **Boolean polarity.** `BOOT_external_tftp_server` keeps `noTftpBuild`'s sense
  so values carry across untouched.
- The legacy `snapins/ssl/CA/` tree — the root certificate lives there and the
  web UI reads it for offline-key state.
- `FOG_update_channel`'s values (#1279), retiring `FOG_os_id`, and
  client-encryption cert issuance, all still deferred per ADR 0024.

## Generated files

`core.hooksPath` was unset in the clone these commits were made in, so
`.githooks/pre-commit` did not run: there is **no version bump** (still
`1.6.0-beta.3869`), no `messages.pot`/`.po` regeneration and no PSR-2 pass. That
is the drift `fog-workflows`' `update-lang-fix-psr-and-sync-version.yml`
corrects, and it fires on merge into `working-1.6`. Flagging it rather than
hand-forcing a bump on a `claude/*` branch, which that sweep does not watch.

## Verification

```
sh tests/run-all.sh          # 120 passed, 0 failed  (was 114)
```

New: `interactive-prompt-wiring`, `boolean-encoding`, `client-zone-migration`,
`client-cert-flags`, `node-cert-external-ca`, `fogstorage-grants-exist`.
Extended: `external-cert-detection`, `ipxe-build-stamp`, `selfcall-verification`,
`fogsettings-migration`, `client-repin-warning`, `pki-idempotence`.

Live, on a real install driven to `EXIT=0` with the web UI serving
`Login | FOG Project`:

- `sudo -u www-data` can read the moved key through the compat symlink; an
  unrelated user cannot
- a second run re-issued nothing, kept the symlinks and kept `www-data` access
- legacy boolean encodings normalised; hand-set keys and comments survived
- `_resolveIpxeTrust` picked the 1-cert Web CA with a valid 2-cert chain present
- the installed `fog-sign-node-cert` issued to a node from FOG's own CA **and**
  from an imported CA

---
_Generated by [Claude Code](https://claude.ai/code/session_01US86oTKth7uXXwvWXMZjRN)_