### PR TITLE
Fix upgrades aborting with "Please change installation directory"

### DIFF
--- a/tests/client-zone-migration.test.sh
+++ b/tests/client-zone-migration.test.sh
@@ -129,7 +129,16 @@ is "$mode" "710" "the leaf dir is 0710 (traversable by the web user)"
 [[ $mode != 700 ]] \
     && ok "...and NOT 0700, which is what would break certDecrypt()" \
     || bad "the leaf dir is 0700 -- the web user cannot traverse it"
-is "$(stat -c '%U:%G' "$ZONE")" "root:${apacheuser}" "the leaf dir is root:\${apacheuser}"
+# Ownership needs root to assert: chown(2) cannot hand a file to another owner
+# unprivileged, so an unprivileged run leaves the directory owned by whoever ran
+# the test and asserting root:${apacheuser} would fail on a correct tree. The
+# mode assertions above and below are the ones that carry the traversal bug, and
+# they hold either way -- chmod on your own directory always works.
+if [[ $EUID -eq 0 ]]; then
+    is "$(stat -c '%U:%G' "$ZONE")" "root:${apacheuser}" "the leaf dir is root:\${apacheuser}"
+else
+    printf '  --    ownership assertion needs root; skipped (running as %s)\n' "$(id -un)"
+fi
 # 0710 over 0750 on purpose: the group digit is 1, so the web user can traverse
 # INTO the directory but cannot list what is in it.
 is "$(stat -c '%a' "$ZONE" | cut -c2)" "1" "group bit is execute-only: traverse, no listing"

--- a/tests/node-cert-external-ca.test.sh
+++ b/tests/node-cert-external-ca.test.sh
@@ -27,7 +27,9 @@
 # zone's own trust path (issuer + the root anchoring it), which is what a node
 # should serve beneath its leaf.
 #
-# Runs fog-sign-node-cert directly against generated CAs. Needs openssl. No
+# Runs fog-sign-node-cert directly against generated CAs, from a working copy
+# with its CONF path and its root guard rewritten -- see run_helper(), and case F
+# which asserts the shipped file still carries that guard. Needs openssl. No
 # install, no network, no root, no sudo.
 #
 # Exit status 0 = pass or skip, 1 = fail.
@@ -97,7 +99,15 @@ run_helper() {
     # new section in the extension file it builds.
     printf 'DNS:node1.test.local\n' > "$STAGE/${reqid}.san"
     rm -f "$STAGE/${reqid}.pem" "$STAGE/${reqid}.chain"
-    sed "s|^CONF=.*|CONF=\"${conf}\"|" "$HELPER" > "$WORK/helper.sh"
+    # Two rewrites, both so the real signing logic can run in a test:
+    #   - CONF, because the helper deliberately takes no path from its caller;
+    #     its locations come from a root-only config file.
+    #   - the root guard, because the helper legitimately refuses to run as
+    #     anyone else and CI runs unprivileged. Stripping it here does not weaken
+    #     the check -- case F below asserts the guard is still in the shipped
+    #     file, and everything the guard protects (the CA key) is a fixture.
+    sed -e "s|^CONF=.*|CONF=\"${conf}\"|" \
+        -e '/^\[\[ \$EUID -eq 0 \]\]/d' "$HELPER" > "$WORK/helper.sh"
     chmod +x "$WORK/helper.sh"
     HELPER_OUT="$("$WORK/helper.sh" "$zone" "$reqid" 2>&1)"
     HELPER_ST=$?
@@ -202,6 +212,15 @@ done
 printf '%s\n' "$signer" | grep -q 'PKI_WEB_ANCHOR=.*trustAnchor' \
     && ok "E: PKI_WEB_ANCHOR names the web zone's trust anchor bundle" \
     || bad "E: PKI_WEB_ANCHOR does not name .trustAnchor.pem"
+
+# --- F. the shipped helper still refuses to run unprivileged -----------------
+# run_helper() strips this line from its working copy so the signing logic is
+# reachable in CI. That is only safe while the real file still has it: without
+# the guard the web user could invoke the helper directly and openssl would read
+# a CA key it must never be able to read.
+grep -q '^\[\[ \$EUID -eq 0 \]\]' "$HELPER" \
+    && ok "F: the shipped helper refuses to run as non-root" \
+    || bad "F: the shipped helper lost its root guard"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Two commits. **The first is the urgent one** — it fixes a regression that stops
every upgrade from a pre-rename `.fogsettings`, reported from a real run. The
second is the CI fix that this PR originally carried, kept here because both land
on the same branch; say the word and I'll split them.

## The install regression

Reported output:

```
 * Found FOG Settings from previous install at: /opt/fog/.fogsettings
 * Performing upgrade using these settings
  Sorry, answer not recognized

Please change installation directory.
Running from here will fail.
You are in /home/telliott/fogproject/bin which is a folder that will
be moved during installation.
```

The directory was fine. Both messages come from `doOSSpecificIncludes()`, and
the cause is an ordering inversion introduced with the key rename (#1293).

`.fogsettings` is **sourced**, so on an upgrade the pre-1.6 key names are still
live shell variables, and the GH-1120 seed block is the only thing that moves
their values onto the new names. That block sat ~40 lines *below* the call to
`doOSSpecificIncludes()`, which cases on `${FOG_os_id}`. On any upgrade from a
`.fogsettings` written before the rename, `FOG_os_id` was empty at that point, so
the case fell through to its catch-all and **no per-distro config was sourced at
all**.

The guard immediately underneath is:

```sh
case $currentdir in
    *$webdirdest*|*$tftpdirdst*)
```

Both variables come from that config, so both were empty — making the pattern
`*|*`, which matches **every possible path**. Hence the directory complaint from
a directory that was fine.

### The half nobody reported is worse

Seven more renamed keys are read by that per-distro config, each as
`[[ -z $key ]] && key=<stock default>`:

`FOG_packages`, `WEB_docroot`, `WEB_server_engine`, `WEB_php_version`,
`DHCP_engine`, `DHCP_service_name`, `STORAGE_image_share_path`.

Seeding *after* that call means the stock default lands first, and then every
`[[ -z NEW ]] && NEW="$old"` guard sees a non-empty value and declines to
migrate. So an admin's own docroot, web server, image share, package list, PHP
version and DHCP engine were **silently replaced with FOG's defaults** on the
first upgrade — no message, exit 0.

### The fix

The block becomes `_migrateRenamedSettingKeys()` in `functions.sh`, called the
moment `.fogsettings` has been sourced and before `doOSSpecificIncludes()`. It is
guarded per key on the **new** name, so it is idempotent, and the call left at the
original site still covers any path that did not go through the upgrade branch.

## Three more faults found while tracing it

**The HTTPS redirect was switched off by upgrading.** `WEB_url_proto` was
defaulted to `http` *before* `.fogsettings` was sourced, which made the seed
`[[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"` unreachable. A server
that had been running `httpproto=https` therefore reached the redirect migration
with `http` and came out with `WEB_https_redirect=no`. The line's own comment
already said this value must not be defaulted before the source; nothing reads it
between there and the seed, and it is assigned unconditionally afterwards, so the
default is simply removed.

**The OS-choice prompt ignored your answer.** It did `read osid` while the `case`
below it tested `${FOG_os_id}`. `FOG_os_id` is already set to the suggested value
at the top of that loop, so the case matched the suggestion and broke — the
prompt accepted a choice and then always installed for the suggested distro.
Same class as the nine prompts fixed in `input.sh`; this one lives in
`functions.sh`, which that pass did not cover.

**The cwd guard now refuses to use empty paths as globs** and says the per-distro
configuration did not load, instead of blaming the directory. A wrong diagnosis
of a real fault cost this bug report.

## The CI fix (originally this PR)

Both tests added in #1295 passed locally and failed in CI: they were written
where everything runs as root, and CI runs unprivileged.

- **`node-cert-external-ca.test.sh`** drove `fog-sign-node-cert`, which refuses
  to run as non-root — correctly, since it opens a CA private key. The test
  already rewrites the helper into a working copy to repoint `CONF`; the root
  guard is now stripped in the same `sed`, and a new **case F** asserts the
  shipped file still carries the guard, so the property that makes stripping safe
  is itself covered.
- **`client-zone-migration.test.sh`** asserted `root:${apacheuser}` ownership.
  `chown(2)` cannot give a file away unprivileged, so that fails on a correct
  tree; gated on `$EUID` with a visible skip line. The **mode** assertions stay
  unconditional — they carry the `0710`-vs-`0700` traversal bug, and `chmod` on
  your own directory always works.

## Verification

```
sh tests/run-all.sh                     # 122 passed, 0 failed  (as root)
su ciuser -c 'sh tests/run-all.sh'      # 122 passed, 0 failed  (unprivileged)
```

New: `tests/upgrade-key-migration-order.test.sh` — 19 assertions driving the real
functions against a real pre-1.6 `.fogsettings`. It checks the call order at
source level (the consequence is 130 lines from the cause, so a later edit that
moves either one puts the bug straight back) *and* the behaviour: the per-distro
config is sourced, both install paths are non-empty, neither message appears, and
a custom docroot, web server, PHP version, DHCP engine, DHCP service name, image
share and package list all survive. Plus `httpproto=https` →
`WEB_https_redirect=yes`.

`fogsettings-migration.test.sh` now calls `_migrateRenamedSettingKeys` instead of
extracting and `eval`-ing the inline block by its header comment, so it can no
longer drift from the installer.

Every assertion negative-controlled against the pre-fix code. With the old order
restored the new test reports the abort and quotes what the installer printed:

```
  FAIL  D: the run aborted (status 1) before reporting; doOSSpecificIncludes said:
          |   Sorry, answer not recognized
          |   The OS-specific configuration did not load.
          |   Cannot determine the install paths, so refusing to continue.
```

## Downstream

Nothing. `route.class.php` and `openapi.class.php` are untouched, and no route
class changed, so there is no FogApi sync to make.
