### PR TITLE
fix(installer): migrate renamed .fogsettings keys before anything reads one

### DIFF
--- a/bin/fog-plugin-uploads.sh
+++ b/bin/fog-plugin-uploads.sh
@@ -31,9 +31,17 @@
 
 set -u
 
-progdir="${fogprogramdir:-/opt/fog}"
+# GH-1120 renamed fogprogramdir to FOG_program_dir. Both spellings are read,
+# newest first, because this script has to work either side of the upgrade
+# that rewrites .fogsettings: a server that has not upgraded yet still has the
+# old line, one that has only has the new. Reading just the old name meant
+# silently falling back to /opt/fog on any server with a custom program dir --
+# and it runs `set -u`, so it cannot call migrateDeprecatedKeys the way the
+# other entry points do (that function tests dozens of deliberately-unset
+# variables). Defaulted expansions are unbound-safe; a bare read is not.
+progdir="${FOG_program_dir:-${fogprogramdir:-/opt/fog}}"
 [[ -r $progdir/.fogsettings ]] && . "$progdir/.fogsettings"
-progdir="${fogprogramdir:-/opt/fog}"
+progdir="${FOG_program_dir:-${fogprogramdir:-/opt/fog}}"
 plugindir="$progdir/plugins"
 
 usage() {

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -812,6 +812,24 @@ case $doupdate in
             # which derives snapindir from it.
             fogprogramdir="$resolvedfogprogramdir"
             FOG_git_path="$resolvedfoggitpath"
+            # GH-1120 (this bug): doOSSpecificIncludes cases on FOG_os_id, so
+            # it is the FIRST consumer of a renamed key -- earlier than the
+            # migration block, which used to run only after this whole case
+            # statement. Upgrading a server whose .fogsettings predates the
+            # rename therefore reached here with FOG_os_id unset, fell to the
+            # `*)` arm, and printed "Sorry, answer not recognized".
+            #
+            # It did not exit: that arm blanks FOG_os_id and returns, so the
+            # distro config was never sourced and $webdirdest/$tftpdirdst
+            # stayed empty -- which made the `*$webdirdest*` guard below match
+            # EVERY directory, so the install then also refused to run from a
+            # path that was perfectly fine. One empty variable, two misleading
+            # messages, neither naming the real cause.
+            #
+            # Migrating before the first consumer rather than after the case is
+            # what fixes it. Idempotent: every line is guarded on the NEW key
+            # being empty, so the call at the end of the case is a no-op here.
+            migrateDeprecatedKeys
             doOSSpecificIncludes
             # This was `STORAGE_rebuild_nfs_exports=${STORAGE_rebuild_nfs_exports}` -- a self-assignment that did
             # nothing, so -E was silently discarded on upgrades: the handler
@@ -832,141 +850,7 @@ case $doupdate in
         echo -e "\n * FOG Installer will NOT attempt to upgrade from\n    previous version of FOG."
         ;;
 esac
-# --- GH-1120 key rename: carry every pre-1.6 value onto its new key ----------
-#
-# Runs after .fogsettings is sourced and BEFORE the flag shadows below, so the
-# order stays: explicit flag > persisted value > migrated value. It must also
-# run before the WEB_https_redirect migration further down, which reads
-# ${WEB_url_proto} -- on an upgrade that value only exists once this block has
-# copied $httpproto onto it.
-#
-# GH-1120 renamed all 79 managed keys to CATEGORY_lower_snake_case. .fogsettings
-# is SOURCED, so the old names are still live shell variables at this point,
-# holding everything the previous install recorded. This is the only thing that
-# moves them: deprecatedKeys in writeUpdateFile() strips the old lines and
-# carries NO value, so removing this block does not degrade the migration -- it
-# wipes every setting on the next upgrade, silently, and under -y.
-#
-# Each pair is guarded on the NEW key, so the block fires exactly once: after
-# this run the new name is persisted and the old line is gone, and a flag that
-# already set the new key on this run correctly wins over the persisted value.
-#
-# Modelled on the httpproto/httpsRedirect seeding immediately below, which is
-# the same shape for a single key.
-# FOG
-[[ -z ${FOG_install_type} ]] && FOG_install_type="$installtype"
-[[ -z ${FOG_os_id} ]] && FOG_os_id="$osid"
-[[ -z ${FOG_os_name} ]] && FOG_os_name="$osname"
-[[ -z ${FOG_packages} ]] && FOG_packages="$packages"
-[[ -z ${FOG_install_lang} ]] && FOG_install_lang="$installlang"
-[[ -z ${FOG_send_reports} ]] && FOG_send_reports="$sendreports"
-[[ -z ${FOG_installed} ]] && FOG_installed="$fogupdateloaded"
-[[ -z ${FOG_copy_back_old} ]] && FOG_copy_back_old="$copybackold"
-[[ -z ${FOG_update_channel} ]] && FOG_update_channel="$fog_update_channel"
-[[ -z ${FOG_git_path} ]] && FOG_git_path="$fog_git_path"
-[[ -z ${FOG_program_dir} ]] && FOG_program_dir="$fogprogramdir"
-# NET
-[[ -z ${NET_interface} ]] && NET_interface="$interface"
-[[ -z ${NET_fog_server_ip} ]] && NET_fog_server_ip="$ipaddress"
-[[ -z ${NET_subnet_mask} ]] && NET_subnet_mask="$submask"
-[[ -z ${NET_hostname} ]] && NET_hostname="$hostname"
-# DHCP
-[[ -z ${DHCP_engine} ]] && DHCP_engine="$dhcpengine"
-[[ -z ${DHCP_service_name} ]] && DHCP_service_name="$dhcpd"
-[[ -z ${DHCP_dns_server_ip} ]] && DHCP_dns_server_ip="$dnsaddress"
-[[ -z ${DHCP_range_start} ]] && DHCP_range_start="$startrange"
-[[ -z ${DHCP_range_end} ]] && DHCP_range_end="$endrange"
-# DB
-[[ -z ${DB_name} ]] && DB_name="$mysqldbname"
-[[ -z ${DB_host} ]] && DB_host="$snmysqlhost"
-[[ -z ${DB_user} ]] && DB_user="$snmysqluser"
-[[ -z ${DB_password} ]] && DB_password="$snmysqlpass"
-[[ -z ${DB_external} ]] && DB_external="$snmysqlexternal"
-[[ -z ${DB_backup_path} ]] && DB_backup_path="$backupPath"
-# WEB
-[[ -z ${WEB_server_engine} ]] && WEB_server_engine="$webserver"
-[[ -z ${WEB_docroot} ]] && WEB_docroot="$docroot"
-[[ -z ${WEB_root} ]] && WEB_root="$webroot"
-[[ -z ${WEB_php_version} ]] && WEB_php_version="$php_ver"
-[[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"
-[[ -z ${WEB_https_redirect} ]] && WEB_https_redirect="$httpsRedirect"
-# BOOT
-[[ -z ${BOOT_url_proto} ]] && BOOT_url_proto="$netbootproto"
-[[ -z ${BOOT_url_proto_forced} ]] && BOOT_url_proto_forced="$netbootProtoForced"
-[[ -z ${BOOT_rebuild_ipxe_with_my_ca} ]] && BOOT_rebuild_ipxe_with_my_ca="$rebuildIpxeWithMyCA"
-[[ -z ${BOOT_dhcp_delay_seconds} ]] && BOOT_dhcp_delay_seconds="$bootdelay"
-[[ -z ${BOOT_external_tftp_server} ]] && BOOT_external_tftp_server="$noTftpBuild"
-[[ -z ${BOOT_tftp_options} ]] && BOOT_tftp_options="$tftpAdvOpts"
-[[ -z ${BOOT_kernel_backups_kept} ]] && BOOT_kernel_backups_kept="$kernelBackupGenerations"
-# STORAGE
-[[ -z ${STORAGE_image_share_path} ]] && STORAGE_image_share_path="$storageLocation"
-[[ -z ${STORAGE_rebuild_nfs_exports} ]] && STORAGE_rebuild_nfs_exports="$blexports"
-# SVC
-[[ -z ${SVC_user} ]] && SVC_user="$username"
-[[ -z ${SVC_password} ]] && SVC_password="$password"
-[[ -z ${SVC_firewall_control} ]] && SVC_firewall_control="$fwconfigure"
-# PKI
-[[ -z ${PKI_root_ca_cert} ]] && PKI_root_ca_cert="$rootCAPem"
-[[ -z ${PKI_root_ca_key} ]] && PKI_root_ca_key="$rootCAKey"
-[[ -z ${PKI_web_trust_chain} ]] && PKI_web_trust_chain="$sslcachain"
-[[ -z ${PKI_client_cert_dir} ]] && PKI_client_cert_dir="$sslpath"
-[[ -z ${PKI_sb_ca_cert} ]] && PKI_sb_ca_cert="$secureBootMokCert"
-[[ -z ${PKI_sb_codesign_cert} ]] && PKI_sb_codesign_cert="$secureBootCert"
-[[ -z ${PKI_sb_codesign_key} ]] && PKI_sb_codesign_key="$secureBootKey"
-[[ -z ${PKI_sb_enabled} ]] && PKI_sb_enabled="$secureboot"
-[[ -z ${PKI_web_cert_publicly_trusted} ]] && PKI_web_cert_publicly_trusted="$publicWebCert"
-[[ -z ${PKI_allowed_domain_names} ]] && PKI_allowed_domain_names="$internalDomains"
-[[ -z ${PKI_internal_subnets} ]] && PKI_internal_subnets="$internalSubnets"
-[[ -z ${PKI_san_ip_addresses} ]] && PKI_san_ip_addresses="$ipaddresses"
-[[ -z ${PKI_san_dns_names} ]] && PKI_san_dns_names="$extraServerNames"
-# --- and the seven merges, where two old keys held one answer ----------------
-#
-# DHCP_enabled: dodhcp was Y/N and bldhcp was 1/0, both written from the same
-# prompt. Seeded from bldhcp because every DECISION read that one; dodhcp was
-# read only by the prompt loop that wrote it. Either encoding is fine to copy
-# here -- _normalizeBooleanSettings below converts whatever arrives to yes/no,
-# so the seed stays a copy and does not have to know which literal it is
-# carrying.
-[[ -z ${DHCP_enabled} ]] && DHCP_enabled="$bldhcp"
-#
-# DHCP_router: routeraddress doubled as a config-file comment -- declining a
-# router stored the literal "#   No router address added" -- which is why
-# plainrouter existed at all, to hold the clean value for display. One key holds
-# the clean value or nothing; the config writers emit the comment. Prefer
-# plainrouter, and fall back to routeraddress only when it is a real address.
-if [[ -z ${DHCP_router} ]]; then
-    if [[ -n $plainrouter ]]; then
-        DHCP_router="$plainrouter"
-    elif [[ -n $routeraddress && $routeraddress != \#* ]]; then
-        DHCP_router="$routeraddress"
-    fi
-fi
-# DHCP_dns_server_ip had the identical wart with no clean twin, so it is
-# cleaned here rather than merged.
-[[ ${DHCP_dns_server_ip} == \#* ]] && DHCP_dns_server_ip=""
-#
-# The Web CA pair is seeded from FOG's OWN canonical paths, not from the import
-# paths. validateExternalCA() already copies an imported CA into the canonical
-# location, so $sslcapem/$sslcakey are the right values on an external-CA
-# install too -- and --ca-cert/--ca-key/--web-ca-cert/--web-ca-key keep working
-# as run-scoped INPUTS. That is the whole point of the merge: six persisted keys
-# holding three values is what silently discarded anything typed at the prompt
-# whenever the flags were also given.
-[[ -z ${PKI_web_ca_cert} ]] && PKI_web_ca_cert="$sslcapem"
-[[ -z ${PKI_web_ca_key} ]]  && PKI_web_ca_key="$sslcakey"
-#
-# The imported root IS value-carrying, and stays separate from PKI_root_ca_cert:
-# validateExternalCA() feeds it to the chain file only, and conflating it with
-# the root fog-client pins is exactly what the three-zone split exists to
-# prevent. Flag spelling wins over prompt spelling, as it always did.
-[[ -z ${PKI_web_external_root_cert} ]] && PKI_web_external_root_cert="${webExtCARoot:-$extcaroot}"
-#
-# The vhost pair absorbs webCertFile/webKeyFile, which recorded where an
-# externally-managed leaf actually lived. Those win when set: on such a server
-# createSSLCA() had already reassigned $sslpubcert/$sslprivkey to them, but the
-# recorded pair is the one the admin's tooling renews.
-[[ -z ${PKI_web_vhost_cert} ]] && PKI_web_vhost_cert="${webCertFile:-$sslpubcert}"
-[[ -z ${PKI_web_vhost_key} ]]  && PKI_web_vhost_key="${webKeyFile:-$sslprivkey}"
+migrateDeprecatedKeys
 # --- WEB_url_proto / WEB_https_redirect migration ---------------------------
 #
 # Runs after .fogsettings is sourced and BEFORE the flags below, so the order

--- a/bin/restorekernel.sh
+++ b/bin/restorekernel.sh
@@ -105,6 +105,13 @@ if [[ ! -r "$fogprogramdir/.fogsettings" ]]; then
     exit 1
 fi
 . "$fogprogramdir/.fogsettings"
+# Before the first read of a renamed key. A .fogsettings written by a
+# pre-GH-1120 installer has osid/osname, not FOG_os_id/FOG_os_name, and the
+# doOSSpecificIncludes below is -n guarded -- so without this the distro config
+# is silently SKIPPED, $webdirdest stays empty, and $ipxedir below becomes the
+# relative string "service/ipxe". That is the exact bug the comment further
+# down says ca02e0b9e already fixed once.
+migrateDeprecatedKeys
 # .fogsettings records docroot and webroot but NOT webdirdest -- config.sh
 # derives that ("${WEB_docroot}fog/"). Sourcing .fogsettings alone therefore left
 # $webdirdest empty and $ipxedir as the relative string "service/ipxe", so

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -207,6 +207,11 @@ fi
 # rather than re-detected, since only doOSSpecificIncludes' per-distro
 # config.sh actually needs it here.
 . "$fogprogramdir/.fogsettings"
+# Before the first read of a renamed key. On a .fogsettings written by a
+# pre-GH-1120 installer FOG_os_name and FOG_os_id do not exist yet, and the
+# doOSSpecificIncludes below is -n guarded, so without this the distro config
+# is silently SKIPPED rather than failing loudly.
+migrateDeprecatedKeys
 linuxReleaseName_lower="${FOG_os_name,,}"
 . ../lib/common/config.sh
 [[ -n ${FOG_os_id} ]] && doOSSpecificIncludes >/dev/null

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3835,6 +3835,152 @@ displayOSChoices() {
     done
     doOSSpecificIncludes
 }
+# --- GH-1120 key migration --------------------------------------------------
+#
+# Lives here, next to its first consumer, because THREE entry points source
+# .fogsettings and then read a renamed key: installfog.sh, updatefog.sh and
+# restorekernel.sh. All three source this file first, so all three can call
+# this the moment .fogsettings has been read -- which is the ordering the whole
+# thing turns on. It was inline in installfog.sh and ran after that script's
+# `case $doupdate` statement, i.e. after doOSSpecificIncludes had already read
+# FOG_os_id, and the other two scripts had no migration at all.
+migrateDeprecatedKeys() {
+    # --- GH-1120 key rename: carry every pre-1.6 value onto its new key ----------
+    #
+    # Runs after .fogsettings is sourced and BEFORE the flag shadows below, so the
+    # order stays: explicit flag > persisted value > migrated value. It must also
+    # run before the WEB_https_redirect migration further down, which reads
+    # ${WEB_url_proto} -- on an upgrade that value only exists once this block has
+    # copied $httpproto onto it.
+    #
+    # GH-1120 renamed all 79 managed keys to CATEGORY_lower_snake_case. .fogsettings
+    # is SOURCED, so the old names are still live shell variables at this point,
+    # holding everything the previous install recorded. This is the only thing that
+    # moves them: deprecatedKeys in writeUpdateFile() strips the old lines and
+    # carries NO value, so removing this block does not degrade the migration -- it
+    # wipes every setting on the next upgrade, silently, and under -y.
+    #
+    # Each pair is guarded on the NEW key, so the block fires exactly once: after
+    # this run the new name is persisted and the old line is gone, and a flag that
+    # already set the new key on this run correctly wins over the persisted value.
+    #
+    # Modelled on the httpproto/httpsRedirect seeding immediately below, which is
+    # the same shape for a single key.
+    # FOG
+    [[ -z ${FOG_install_type} ]] && FOG_install_type="$installtype"
+    [[ -z ${FOG_os_id} ]] && FOG_os_id="$osid"
+    [[ -z ${FOG_os_name} ]] && FOG_os_name="$osname"
+    [[ -z ${FOG_packages} ]] && FOG_packages="$packages"
+    [[ -z ${FOG_install_lang} ]] && FOG_install_lang="$installlang"
+    [[ -z ${FOG_send_reports} ]] && FOG_send_reports="$sendreports"
+    [[ -z ${FOG_installed} ]] && FOG_installed="$fogupdateloaded"
+    [[ -z ${FOG_copy_back_old} ]] && FOG_copy_back_old="$copybackold"
+    [[ -z ${FOG_update_channel} ]] && FOG_update_channel="$fog_update_channel"
+    [[ -z ${FOG_git_path} ]] && FOG_git_path="$fog_git_path"
+    [[ -z ${FOG_program_dir} ]] && FOG_program_dir="$fogprogramdir"
+    # NET
+    [[ -z ${NET_interface} ]] && NET_interface="$interface"
+    [[ -z ${NET_fog_server_ip} ]] && NET_fog_server_ip="$ipaddress"
+    [[ -z ${NET_subnet_mask} ]] && NET_subnet_mask="$submask"
+    [[ -z ${NET_hostname} ]] && NET_hostname="$hostname"
+    # DHCP
+    [[ -z ${DHCP_engine} ]] && DHCP_engine="$dhcpengine"
+    [[ -z ${DHCP_service_name} ]] && DHCP_service_name="$dhcpd"
+    [[ -z ${DHCP_dns_server_ip} ]] && DHCP_dns_server_ip="$dnsaddress"
+    [[ -z ${DHCP_range_start} ]] && DHCP_range_start="$startrange"
+    [[ -z ${DHCP_range_end} ]] && DHCP_range_end="$endrange"
+    # DB
+    [[ -z ${DB_name} ]] && DB_name="$mysqldbname"
+    [[ -z ${DB_host} ]] && DB_host="$snmysqlhost"
+    [[ -z ${DB_user} ]] && DB_user="$snmysqluser"
+    [[ -z ${DB_password} ]] && DB_password="$snmysqlpass"
+    [[ -z ${DB_external} ]] && DB_external="$snmysqlexternal"
+    [[ -z ${DB_backup_path} ]] && DB_backup_path="$backupPath"
+    # WEB
+    [[ -z ${WEB_server_engine} ]] && WEB_server_engine="$webserver"
+    [[ -z ${WEB_docroot} ]] && WEB_docroot="$docroot"
+    [[ -z ${WEB_root} ]] && WEB_root="$webroot"
+    [[ -z ${WEB_php_version} ]] && WEB_php_version="$php_ver"
+    [[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"
+    [[ -z ${WEB_https_redirect} ]] && WEB_https_redirect="$httpsRedirect"
+    # BOOT
+    [[ -z ${BOOT_url_proto} ]] && BOOT_url_proto="$netbootproto"
+    [[ -z ${BOOT_url_proto_forced} ]] && BOOT_url_proto_forced="$netbootProtoForced"
+    [[ -z ${BOOT_rebuild_ipxe_with_my_ca} ]] && BOOT_rebuild_ipxe_with_my_ca="$rebuildIpxeWithMyCA"
+    [[ -z ${BOOT_dhcp_delay_seconds} ]] && BOOT_dhcp_delay_seconds="$bootdelay"
+    [[ -z ${BOOT_external_tftp_server} ]] && BOOT_external_tftp_server="$noTftpBuild"
+    [[ -z ${BOOT_tftp_options} ]] && BOOT_tftp_options="$tftpAdvOpts"
+    [[ -z ${BOOT_kernel_backups_kept} ]] && BOOT_kernel_backups_kept="$kernelBackupGenerations"
+    # STORAGE
+    [[ -z ${STORAGE_image_share_path} ]] && STORAGE_image_share_path="$storageLocation"
+    [[ -z ${STORAGE_rebuild_nfs_exports} ]] && STORAGE_rebuild_nfs_exports="$blexports"
+    # SVC
+    [[ -z ${SVC_user} ]] && SVC_user="$username"
+    [[ -z ${SVC_password} ]] && SVC_password="$password"
+    [[ -z ${SVC_firewall_control} ]] && SVC_firewall_control="$fwconfigure"
+    # PKI
+    [[ -z ${PKI_root_ca_cert} ]] && PKI_root_ca_cert="$rootCAPem"
+    [[ -z ${PKI_root_ca_key} ]] && PKI_root_ca_key="$rootCAKey"
+    [[ -z ${PKI_web_trust_chain} ]] && PKI_web_trust_chain="$sslcachain"
+    [[ -z ${PKI_client_cert_dir} ]] && PKI_client_cert_dir="$sslpath"
+    [[ -z ${PKI_sb_ca_cert} ]] && PKI_sb_ca_cert="$secureBootMokCert"
+    [[ -z ${PKI_sb_codesign_cert} ]] && PKI_sb_codesign_cert="$secureBootCert"
+    [[ -z ${PKI_sb_codesign_key} ]] && PKI_sb_codesign_key="$secureBootKey"
+    [[ -z ${PKI_sb_enabled} ]] && PKI_sb_enabled="$secureboot"
+    [[ -z ${PKI_web_cert_publicly_trusted} ]] && PKI_web_cert_publicly_trusted="$publicWebCert"
+    [[ -z ${PKI_allowed_domain_names} ]] && PKI_allowed_domain_names="$internalDomains"
+    [[ -z ${PKI_internal_subnets} ]] && PKI_internal_subnets="$internalSubnets"
+    [[ -z ${PKI_san_ip_addresses} ]] && PKI_san_ip_addresses="$ipaddresses"
+    [[ -z ${PKI_san_dns_names} ]] && PKI_san_dns_names="$extraServerNames"
+    # --- and the seven merges, where two old keys held one answer ----------------
+    #
+    # DHCP_enabled: dodhcp was Y/N and bldhcp was 1/0, both written from the same
+    # prompt. Seeded from bldhcp because every DECISION read that one; dodhcp was
+    # read only by the prompt loop that wrote it. Either encoding is fine to copy
+    # here -- _normalizeBooleanSettings below converts whatever arrives to yes/no,
+    # so the seed stays a copy and does not have to know which literal it is
+    # carrying.
+    [[ -z ${DHCP_enabled} ]] && DHCP_enabled="$bldhcp"
+    #
+    # DHCP_router: routeraddress doubled as a config-file comment -- declining a
+    # router stored the literal "#   No router address added" -- which is why
+    # plainrouter existed at all, to hold the clean value for display. One key holds
+    # the clean value or nothing; the config writers emit the comment. Prefer
+    # plainrouter, and fall back to routeraddress only when it is a real address.
+    if [[ -z ${DHCP_router} ]]; then
+        if [[ -n $plainrouter ]]; then
+            DHCP_router="$plainrouter"
+        elif [[ -n $routeraddress && $routeraddress != \#* ]]; then
+            DHCP_router="$routeraddress"
+        fi
+    fi
+    # DHCP_dns_server_ip had the identical wart with no clean twin, so it is
+    # cleaned here rather than merged.
+    [[ ${DHCP_dns_server_ip} == \#* ]] && DHCP_dns_server_ip=""
+    #
+    # The Web CA pair is seeded from FOG's OWN canonical paths, not from the import
+    # paths. validateExternalCA() already copies an imported CA into the canonical
+    # location, so $sslcapem/$sslcakey are the right values on an external-CA
+    # install too -- and --ca-cert/--ca-key/--web-ca-cert/--web-ca-key keep working
+    # as run-scoped INPUTS. That is the whole point of the merge: six persisted keys
+    # holding three values is what silently discarded anything typed at the prompt
+    # whenever the flags were also given.
+    [[ -z ${PKI_web_ca_cert} ]] && PKI_web_ca_cert="$sslcapem"
+    [[ -z ${PKI_web_ca_key} ]]  && PKI_web_ca_key="$sslcakey"
+    #
+    # The imported root IS value-carrying, and stays separate from PKI_root_ca_cert:
+    # validateExternalCA() feeds it to the chain file only, and conflating it with
+    # the root fog-client pins is exactly what the three-zone split exists to
+    # prevent. Flag spelling wins over prompt spelling, as it always did.
+    [[ -z ${PKI_web_external_root_cert} ]] && PKI_web_external_root_cert="${webExtCARoot:-$extcaroot}"
+    #
+    # The vhost pair absorbs webCertFile/webKeyFile, which recorded where an
+    # externally-managed leaf actually lived. Those win when set: on such a server
+    # createSSLCA() had already reassigned $sslpubcert/$sslprivkey to them, but the
+    # recorded pair is the one the admin's tooling renews.
+    [[ -z ${PKI_web_vhost_cert} ]] && PKI_web_vhost_cert="${webCertFile:-$sslpubcert}"
+    [[ -z ${PKI_web_vhost_key} ]]  && PKI_web_vhost_key="${webKeyFile:-$sslprivkey}"
+}
 doOSSpecificIncludes() {
     echo
     case ${FOG_os_id} in

--- a/tests/fogsettings-key-migration.test.sh
+++ b/tests/fogsettings-key-migration.test.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+#
+# .fogsettings is SOURCED, so a key rename is a data migration.
+#
+# GH-1120 renamed all 79 managed keys to CATEGORY_lower_snake_case. Every
+# server upgrading from an older FOG has a .fogsettings full of the OLD names,
+# and the only thing that carries those values forward is
+# migrateDeprecatedKeys(). Two properties have to hold, and neither is visible
+# by reading a diff:
+#
+#   1. The migration runs BEFORE the first read of a renamed key. Three entry
+#      points source .fogsettings and then immediately read one --
+#      installfog.sh, updatefog.sh, restorekernel.sh -- so "before" has to be
+#      true in three places, not one.
+#
+#   2. Every deprecated key has somewhere to go. writeUpdateFile() strips the
+#      old lines and carries NO value, so a key that is retired without a
+#      migration pair is not a rename, it is a deletion -- silently, on the
+#      next upgrade, under -y.
+#
+# THE BUG THIS PINS. The migration was inline in installfog.sh, positioned
+# after that script's `case $doupdate` statement. doOSSpecificIncludes is
+# called INSIDE that case and cases on ${FOG_os_id}, so it read the key ~40
+# lines before anything set it:
+#
+#     * Performing upgrade using these settings
+#       Sorry, answer not recognized
+#
+# The `*)` arm does not exit -- it blanks FOG_os_id and returns -- so the
+# distro config was never sourced and $webdirdest/$tftpdirdst stayed empty.
+# The very next guard is
+#
+#     case $currentdir in *$webdirdest*|*$tftpdirdst*)
+#
+# and with both empty that is `*`, which matches EVERY directory. So the
+# install ALSO refused to run from a path that was perfectly fine. One empty
+# variable, two misleading messages, neither naming the cause.
+#
+# updatefog.sh and restorekernel.sh had it worse: they guard the call as
+# `[[ -n ${FOG_os_id} ]] && doOSSpecificIncludes`, so an empty key SKIPPED the
+# distro config with no message at all.
+#
+# HOW THIS TESTS IT. The installer is not run -- not even partially. Nothing
+# is installed, no root is needed and no path outside a temp dir is touched.
+# What runs is a *resemblance harness*: the same four steps the real scripts
+# perform, in the same order, against fixture .fogsettings files written here.
+# The two `case` statements are copied in shape from the real ones, so the
+# failure mode is reproduced rather than described -- and the test proves it
+# is testing the right thing by asserting that skipping the migration brings
+# both symptoms back.
+#
+# Usage: bash tests/fogsettings-key-migration.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+repodir=$(cd "$(dirname "$0")/.." && pwd)
+functions="$repodir/lib/common/functions.sh"
+
+failures=0
+checks=0
+
+check() {
+    checks=$((checks + 1))
+    if [ "$2" != "yes" ]; then
+        failures=$((failures + 1))
+        echo "  - $1"
+    fi
+}
+
+is() {
+    checks=$((checks + 1))
+    if [ "$2" != "$3" ]; then
+        failures=$((failures + 1))
+        echo "  - $1 (got '$2', wanted '$3')"
+    fi
+}
+
+if [ ! -f "$functions" ]; then
+    echo "SKIP: no lib/common/functions.sh in $repodir"
+    exit 0
+fi
+
+tmp=$(mktemp -d) || exit 1
+trap 'rm -rf "$tmp"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+#
+# Written here rather than copied from a real install: a real .fogsettings
+# carries a database password and a storage account password, and a test
+# fixture must never be a thing anyone hesitates to paste into a bug report.
+# The values below are obviously synthetic for that reason.
+# ---------------------------------------------------------------------------
+
+cat > "$tmp/old.fogsettings" <<'EOF'
+## Fake pre-GH-1120 .fogsettings. Old key names only.
+installtype="N"
+osid="1"
+osname="Redhat"
+interface="eno1"
+ipaddress="192.0.2.10"
+submask="255.255.255.0"
+hostname="fog.example.invalid"
+dhcpengine="isc"
+dhcpd="dhcpd"
+docroot="/var/www/html/"
+webroot="/fog/"
+webserver="httpd"
+httpproto="https"
+mysqldbname="fog"
+snmysqlhost="localhost"
+snmysqluser="fogmaster"
+snmysqlpass="not-a-real-password"
+storageLocation="/images"
+username="fogproject"
+password="not-a-real-password-either"
+fogprogramdir="/opt/fog"
+EOF
+
+cat > "$tmp/new.fogsettings" <<'EOF'
+## Fake post-GH-1120 .fogsettings. New key names only.
+FOG_install_type="N"
+FOG_os_id="1"
+FOG_os_name="Redhat"
+NET_interface="eno1"
+NET_fog_server_ip="192.0.2.10"
+NET_subnet_mask="255.255.255.0"
+NET_hostname="fog.example.invalid"
+DHCP_engine="isc"
+DHCP_service_name="dhcpd"
+WEB_docroot="/var/www/html/"
+WEB_root="/fog/"
+WEB_server_service="httpd"
+WEB_url_proto="https"
+DB_name="fog"
+DB_host="localhost"
+DB_user="fogmaster"
+DB_pass="not-a-real-password"
+STORAGE_location="/images"
+SVC_user="fogproject"
+SVC_pass="not-a-real-password-either"
+FOG_program_dir="/opt/fog"
+EOF
+
+# ---------------------------------------------------------------------------
+# The resemblance harness.
+#
+# Four steps, the same order the real scripts use:
+#   1. source functions.sh          (all three do this first)
+#   2. source .fogsettings
+#   3. migrateDeprecatedKeys        <- the thing under test
+#   4. read a renamed key
+#
+# Step 3 is skipped when $2 is "skip", which is how the regression is pinned.
+#
+# Runs in a subshell so each case starts from a clean variable space -- these
+# scripts are all global state, and a leaked FOG_os_id would make a broken
+# migration look like a working one.
+# ---------------------------------------------------------------------------
+harness() {
+    (
+        settings=$1
+        mode=${2:-migrate}
+
+        # Only the function is taken from functions.sh. Sourcing the whole file
+        # would run its top-level code, which expects a real install.
+        eval "$(
+            sed -n '/^migrateDeprecatedKeys() {/,/^}$/p' "$functions"
+        )"
+        if ! declare -f migrateDeprecatedKeys >/dev/null 2>&1; then
+            echo "NOFUNC"
+            exit 0
+        fi
+
+        . "$settings"
+        [ "$mode" = "skip" ] || migrateDeprecatedKeys
+
+        # Step 4a: what doOSSpecificIncludes does with FOG_os_id. Same shape as
+        # the real case statement -- a recognised id picks a distro, anything
+        # else is the "Sorry, answer not recognized" arm.
+        case ${FOG_os_id} in
+            1) distro="Redhat"; webdirdest="${WEB_docroot}fog/"; tftpdirdst="/tftpboot" ;;
+            2) distro="Debian"; webdirdest="${WEB_docroot}fog/"; tftpdirdst="/tftpboot" ;;
+            3) distro="Alpine"; webdirdest="${WEB_docroot}fog/"; tftpdirdst="/tftpboot" ;;
+            4) distro="Arch";   webdirdest="${WEB_docroot}fog/"; tftpdirdst="/tftpboot" ;;
+            *) distro="UNRECOGNIZED"; webdirdest=""; tftpdirdst="" ;;
+        esac
+
+        # Step 4b: the directory guard that runs immediately after it. An empty
+        # $webdirdest turns `*$webdirdest*` into `*`, so this reports whether a
+        # perfectly ordinary path is wrongly rejected.
+        currentdir="/home/someone/fogproject/bin"
+        case $currentdir in
+            *$webdirdest*|*$tftpdirdst*) guard="REJECTED" ;;
+            *)                           guard="allowed"  ;;
+        esac
+
+        echo "${distro}|${guard}|${FOG_os_id}|${FOG_os_name}|${NET_interface}|${DB_user}|${WEB_docroot}"
+    )
+}
+
+# ---------------------------------------------------------------------------
+# 1. An old-format .fogsettings upgrades cleanly.
+# ---------------------------------------------------------------------------
+
+out=$(harness "$tmp/old.fogsettings")
+if [ "$out" = "NOFUNC" ]; then
+    echo "FAIL: migrateDeprecatedKeys() is not defined in lib/common/functions.sh"
+    exit 1
+fi
+IFS='|' read -r distro guard osid osname iface dbuser docroot <<EOF
+$out
+EOF
+
+is  'old format: the distro is recognised'          "$distro" "Redhat"
+is  'old format: FOG_os_id migrates from $osid'     "$osid"   "1"
+is  'old format: FOG_os_name migrates from $osname' "$osname" "Redhat"
+is  'old format: NET_interface migrates'            "$iface"  "eno1"
+is  'old format: DB_user migrates from $snmysqluser' "$dbuser" "fogmaster"
+is  'old format: WEB_docroot migrates from $docroot' "$docroot" "/var/www/html/"
+# The second symptom, and the one nobody would connect to a key rename.
+is  'old format: an unrelated directory is not rejected' "$guard" "allowed"
+
+# ---------------------------------------------------------------------------
+# 2. A new-format .fogsettings is untouched.
+#
+# The migration only ever fills an EMPTY new key, so a server that has already
+# upgraded once must come out identical -- and in particular must not have a
+# value replaced by an empty old variable.
+# ---------------------------------------------------------------------------
+
+IFS='|' read -r distro guard osid osname iface dbuser docroot <<EOF
+$(harness "$tmp/new.fogsettings")
+EOF
+
+is  'new format: the distro is recognised'  "$distro" "Redhat"
+is  'new format: FOG_os_id is untouched'    "$osid"   "1"
+is  'new format: DB_user is untouched'      "$dbuser" "fogmaster"
+is  'new format: WEB_docroot is untouched'  "$docroot" "/var/www/html/"
+is  'new format: an unrelated directory is not rejected' "$guard" "allowed"
+
+# ---------------------------------------------------------------------------
+# 3. The regression, reproduced.
+#
+# Without the migration an old-format file must produce BOTH symptoms. If this
+# ever passes, the harness has stopped exercising the thing it claims to.
+# ---------------------------------------------------------------------------
+
+IFS='|' read -r distro guard osid _ _ _ _ <<EOF
+$(harness "$tmp/old.fogsettings" skip)
+EOF
+
+is  'without the migration: FOG_os_id is empty'                "$osid"   ""
+is  'without the migration: the distro falls to the *) arm'    "$distro" "UNRECOGNIZED"
+is  'without the migration: every directory is wrongly rejected' "$guard" "REJECTED"
+
+# ---------------------------------------------------------------------------
+# 4. The migration runs before the first read, in every entry point.
+#
+# The property that actually prevents a recurrence. A source lint, and honest
+# about being one -- the harness above can only prove the function works, not
+# that a given script calls it early enough.
+#
+# The consumer is doOSSpecificIncludes, which cases on ${FOG_os_id} -- not
+# merely the first line that MENTIONS the key. installfog.sh defaults
+# FOG_os_id to "" near its top, long before .fogsettings is read, and that is
+# an initialisation rather than a read of a migrated value. Anchoring on the
+# real consumer keeps this lint precise instead of merely strict.
+# ---------------------------------------------------------------------------
+
+for script in installfog.sh updatefog.sh restorekernel.sh; do
+    path="$repodir/bin/$script"
+    [ -f "$path" ] || continue
+
+    # installfog.sh sources it via $fogpriorconfig; the other two name the path.
+    srcline=$(grep -nE '^[[:space:]]*\.[[:space:]]+"?\$\{?(fogpriorconfig|fogprogramdir)' "$path" \
+        | head -1 | cut -d: -f1)
+    callline=$(grep -n '^[[:space:]]*migrateDeprecatedKeys[[:space:]]*$' "$path" \
+        | head -1 | cut -d: -f1)
+    useline=$(grep -nE '^[[:space:]]*[^#]*\bdoOSSpecificIncludes\b' "$path" \
+        | head -1 | cut -d: -f1)
+
+    check "$script sources .fogsettings"          "$([ -n "$srcline" ] && echo yes)"
+    check "$script calls migrateDeprecatedKeys"   "$([ -n "$callline" ] && echo yes)"
+
+    if [ -n "$srcline" ] && [ -n "$callline" ]; then
+        check "$script migrates after sourcing .fogsettings" \
+            "$([ "$callline" -gt "$srcline" ] && echo yes)"
+    fi
+    if [ -n "$callline" ] && [ -n "$useline" ]; then
+        check "$script migrates BEFORE doOSSpecificIncludes reads FOG_os_id" \
+            "$([ "$callline" -lt "$useline" ] && echo yes)"
+    fi
+done
+
+# The function has to be defined somewhere every caller has already sourced.
+# It used to live inline in installfog.sh, which is precisely why the other two
+# scripts had no migration at all.
+check 'the migration lives in functions.sh, which all three source first' \
+    "$(grep -q '^migrateDeprecatedKeys() {' "$functions" && echo yes)"
+
+# ---------------------------------------------------------------------------
+# 5. Every deprecated key has a migration pair.
+#
+# writeUpdateFile() strips the old lines and carries no value, so a key on that
+# list with nowhere to go is a silent deletion rather than a rename. Retired
+# keys are exempt -- they are listed under the "Retired outright" comment
+# because the information is now derived -- so the exemption is read from the
+# list itself rather than restated here, and a key moved between the two
+# sections needs no edit to this test.
+# ---------------------------------------------------------------------------
+
+migbody=$(sed -n '/^migrateDeprecatedKeys() {/,/^}$/p' "$functions")
+deplist=$(sed -n '/local -a deprecatedKeys=(/,/^[[:space:]]*)/p' "$functions")
+
+# The list is grouped by comment, and two of those groups are deliberately
+# unmigrated: keys retired BEFORE GH-1120, and keys GH-1120 retired outright
+# because the information is now derived. Only the "-> PREFIX_*" groups have
+# to have a pair. Reading the grouping from the list itself means a key moved
+# between sections needs no edit here.
+active=$(printf '%s\n' "$deplist" | awk '
+    /retired earlier/  { want = 0; next }
+    /Retired outright/ { want = 0; next }
+    /-> [A-Z]/         { want = 1; next }
+    /^[[:space:]]*#/   { next }
+    want { print }
+' | grep -oE '\b[a-z][A-Za-z0-9_]{2,}\b' | sort -u)
+
+# Keys deliberately dropped rather than migrated, because a twin already
+# carries the value. Listed here rather than inferred from the prose in
+# functions.sh, and that is the point: dropping a key is then something
+# somebody has to come here and write down, instead of something that happens
+# by omission. A future rename that loses a value fails this check.
+#
+#   dodhcp        Y/N twin of bldhcp, both written from the same prompt.
+#                 DHCP_enabled seeds from bldhcp because every DECISION read
+#                 that one; dodhcp was only ever echoed back.
+#   extcacert     \
+#   extcakey       > extc*/webExtCA* were six keys holding three values.
+#   webExtCACert   / PKI_web_ca_cert/_key take $sslcapem/$sslcakey, which held
+#   webExtCAKey   /  the same content; only the imported ROOT is separately
+#                    value-carrying, and that one IS migrated
+#                    (PKI_web_external_root_cert).
+merged="dodhcp extcacert extcakey webExtCACert webExtCAKey"
+
+# Keys can be referenced as $key or ${key:-default} -- webCertFile is folded
+# into the vhost pair as ${webCertFile:-$sslpubcert}, so a bare "\$key\b"
+# pattern misses it and reports a false gap.
+missing=""
+for key in $active; do
+    case " $merged " in *" $key "*) continue ;; esac
+    printf '%s\n' "$migbody" | grep -qE "\\\$\{?${key}\b" || missing="$missing $key"
+done
+
+# The exemptions must still BE deprecated keys. A merged key that gets deleted
+# from deprecatedKeys stops being stripped from .fogsettings, so the old line
+# survives every upgrade and quietly shadows nothing -- harmless, but it means
+# this list has drifted from reality and the next reader cannot trust it.
+stale=""
+for key in $merged; do
+    printf '%s\n' "$deplist" | grep -qE "\b${key}\b" || stale="$stale $key"
+done
+check "every merged-key exemption is still a deprecated key (stale:${stale:- none})" \
+    "$([ -z "$stale" ] && echo yes)"
+
+check "every non-retired deprecated key is migrated (missing:${missing:- none})" \
+    "$([ -z "$missing" ] && echo yes)"
+
+# ---------------------------------------------------------------------------
+
+if [ "$failures" -gt 0 ]; then
+    echo "FAIL ($failures of $checks)"
+    exit 1
+fi
+
+echo "ok  $checks checks passed"
+exit 0

--- a/tests/fogsettings-migration.test.sh
+++ b/tests/fogsettings-migration.test.sh
@@ -15,12 +15,11 @@
 #
 # Keep 2 and drop 1 and every setting on every server is wiped, silently, on the
 # next upgrade -- and under -y there is nobody to notice. Nothing else in the
-# suite exercises the pair together, and no unit test can: the seed block is
-# inline in the installer and writeUpdateFile() only runs at the very end of an
-# install.
+# suite exercises the pair together, and no unit test can: writeUpdateFile()
+# only runs at the very end of an install.
 #
-# The seed block is EXTRACTED FROM THE INSTALLER AND EVALUATED here rather than
-# copied. A hand-copied replay is how a test passes while the behaviour is
+# The migration is EXTRACTED FROM lib/common/functions.sh AND EVALUATED here
+# rather than copied. A hand-copied replay is how a test passes while the behaviour is
 # wrong, which is the failure mode install-settings-resolution.test.sh already
 # documents for the httpsRedirect migration.
 #
@@ -29,9 +28,7 @@
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/.." && pwd)"
 FUNCS="$REPO/lib/common/functions.sh"
-INSTALLER="$REPO/bin/installfog.sh"
 [[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
-[[ -f $INSTALLER ]] || { echo "ERROR: $INSTALLER not found" >&2; exit 1; }
 
 PASS=0
 FAIL=0
@@ -147,14 +144,29 @@ OLDEOF
 
 echo "== the seed block carries every value =="
 
-# Extract the real block and run it, so this cannot drift from the installer.
-seedblock=$(sed -n '/^# --- GH-1120 key rename:/,/^# --- WEB_url_proto/p' "$INSTALLER" | sed '$d')
+# Extract the real migration and run it, so this cannot drift from the code.
+#
+# It used to be an inline block in bin/installfog.sh and is now
+# migrateDeprecatedKeys() in lib/common/functions.sh. It had to move: three
+# entry points source .fogsettings and then read a renamed key -- installfog.sh,
+# updatefog.sh and restorekernel.sh -- and a block living inside one of them
+# could not be called by the other two, which is why those two had no migration
+# at all. All three source functions.sh first.
+#
+# Evaluating the DEFINITION and then calling it keeps every eval site below
+# unchanged: the string still both defines and runs the migration.
+#
+# The ordering property this move exists for is pinned separately, in
+# tests/fogsettings-key-migration.test.sh. This file is about the VALUES.
+seedblock=$(sed -n '/^migrateDeprecatedKeys() {/,/^}$/p' "$FUNCS")
 if [[ -z $seedblock ]]; then
-    bad "could not extract the rename-seed block from bin/installfog.sh"
+    bad "could not extract migrateDeprecatedKeys() from lib/common/functions.sh"
     printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
     exit 1
 fi
-ok "the rename-seed block is present in bin/installfog.sh"
+seedblock="${seedblock}
+migrateDeprecatedKeys"
+ok "migrateDeprecatedKeys() is present in lib/common/functions.sh"
 
 # Sourcing the old file is what an upgrade does: .fogsettings is SHELL.
 resolvedfogprogramdir="$fogprogramdir"


### PR DESCRIPTION
Upgrading **any** server whose `.fogsettings` predates GH-1120 (#1293) fails:

```
 * Found FOG Settings from previous install at: /opt/fog/.fogsettings
 * Performing upgrade using these settings
  Sorry, answer not recognized

Please change installation directory.
Running from here will fail.
```

## Cause

`.fogsettings` is **sourced**, so a key rename is a data migration. The only thing carrying old values forward was a block inline in `installfog.sh`, positioned *after* its `case $doupdate` statement.

`doOSSpecificIncludes` is called **inside** that case and cases on `${FOG_os_id}` — so it read the key ~40 lines before anything set it, and fell to the `*)` arm.

That arm **does not exit**. It blanks `FOG_os_id` and returns, so the distro config was never sourced and `$webdirdest`/`$tftpdirdst` stayed empty. The very next guard is:

```bash
case $currentdir in *$webdirdest*|*$tftpdirdst*)
```

With both empty that is `*`, which matches **every** directory — hence the second message, about a path that was perfectly fine. One empty variable, two misleading messages, neither naming the cause.

### The other two entry points were worse, and silent

`updatefog.sh` and `restorekernel.sh` source `.fogsettings` and then run `[[ -n ${FOG_os_id} ]] && doOSSpecificIncludes` — with **no migration at all**. An empty key *skips* the distro config with no message. In `restorekernel.sh` that leaves `$webdirdest` empty and `$ipxedir` as the relative string `service/ipxe` — the exact bug its own comment says `ca02e0b9e` already fixed once.

## Fix

The block is now `migrateDeprecatedKeys()` in `lib/common/functions.sh`, called immediately after `.fogsettings` is sourced in all three entry points.

It **had** to move: a block living inside one entry point cannot be called by the other two, which is why the other two never had one. All three source `functions.sh` first, so all three can call it at the only moment that works.

Every line is guarded on the **new** key being empty, so the call left where the inline block used to sit is a no-op on an upgrade, and the documented ordering — flag > persisted > migrated — is unchanged.

`fog-plugin-uploads.sh` read only the old `fogprogramdir`, so once an upgrade rewrote `.fogsettings` it silently fell back to `/opt/fog` on any server with a custom program dir. It runs `set -u` and does not source `functions.sh`, so it reads both spellings through defaulted expansions instead.

## Tests

**`tests/fogsettings-key-migration.test.sh`** (new) does **not run the installer** — not even partially. No root, no install, nothing outside a temp dir. It is a *resemblance harness*: the same four steps the real scripts perform, in the same order, with the two `case` statements copied in shape.

| Case | Asserts |
|---|---|
| old-format `.fogsettings` | every key migrates, distro dispatches, directory guard stays quiet |
| new-format `.fogsettings` | nothing clobbered |
| **migration skipped** | **both symptoms come back** |
| all three entry points | migrate *before* `doOSSpecificIncludes` |
| deprecated-key list | every non-retired key has a migration pair |

The third row is the one that matters: it proves the harness is exercising the real failure rather than describing it. The five deliberately-merged keys (`dodhcp`, `extcacert`, `extcakey`, `webExtCACert`, `webExtCAKey`) are listed explicitly with reasons, so dropping a key is something somebody has to come and write down rather than something that happens by omission.

Fixtures are synthetic. A real `.fogsettings` carries the database and storage passwords, and a test fixture must never be a thing anyone hesitates to paste into a bug report.

**`tests/fogsettings-migration.test.sh`** already covered the values and the `writeUpdateFile` round-trip, and **passed throughout** — it never looked at ordering, which is why this shipped. It extracted the block from `installfog.sh`, so it follows the function to `functions.sh` here, evaluating the definition and calling it so its three eval sites are unchanged.

## Verification

Against a **real** pre-rename `.fogsettings`:

```
BEFORE migration: FOG_os_id='' FOG_os_name='' WEB_docroot=''
AFTER  migration: FOG_os_id='1' FOG_os_name='Redhat' WEB_docroot='/var/www/html/'
distro dispatch: OK (Redhat)
directory guard: allowed
```

`DB_password` carried across intact (length compared, never printed).

**Mutation-verified — six mutations, all killed:**

| Mutation | Killed by |
|---|---|
| early call removed from `installfog.sh` (the original bug) | `migrates BEFORE doOSSpecificIncludes` |
| call removed from `updatefog.sh` | `updatefog.sh calls migrateDeprecatedKeys` |
| call removed from `restorekernel.sh` | `restorekernel.sh calls migrateDeprecatedKeys` |
| `FOG_os_id` pair dropped | old-format dispatch + key checks |
| `DB_user` pair made unconditional | `new format: DB_user is untouched` |
| function moved out of `functions.sh` | the shared-location check |

Suite: **122 passed, 0 failed.**