### PR TITLE
fix(installer): don't reject every directory when the distro config is missing

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4014,15 +4014,27 @@ doOSSpecificIncludes() {
             ;;
     esac
     currentdir=$(pwd)
-    case $currentdir in
-        *$webdirdest*|*$tftpdirdst*)
-            echo "Please change installation directory."
-            echo "Running from here will fail."
-            echo "You are in $currentdir which is a folder that will"
-            echo "be moved during installation."
-            exit 1
-            ;;
-    esac
+    # Both variables are tested for non-emptiness FIRST, and that is the whole
+    # point rather than defensive noise: in a glob, `*$webdirdest*` with an
+    # empty $webdirdest is `**`, which matches EVERY path. So whenever this
+    # function reaches here without having sourced a distro config -- the `*)`
+    # arm above blanks the id and returns rather than exiting -- the old form
+    # refused to run from any directory at all, and said so in a message about
+    # the install layout that had nothing to do with the real problem.
+    #
+    # That is exactly what GH-1120 produced: a pre-rename .fogsettings left
+    # FOG_os_id unset, the `*)` arm fired, and the admin got "Sorry, answer not
+    # recognized" followed by "Please change installation directory" about a
+    # path that was perfectly fine. The key migration fixed the trigger; this
+    # fixes the amplifier, which was never specific to that bug.
+    if { [[ -n $webdirdest ]] && [[ $currentdir == *"$webdirdest"* ]]; } \
+        || { [[ -n $tftpdirdst ]] && [[ $currentdir == *"$tftpdirdst"* ]]; }; then
+        echo "Please change installation directory."
+        echo "Running from here will fail."
+        echo "You are in $currentdir which is a folder that will"
+        echo "be moved during installation."
+        exit 1
+    fi
 }
 errorStat() {
     local status=$1

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4801,7 +4801,7 @@ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 msgid "Master Node"
 msgstr "Master-Knoten"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6866,6 +6866,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Kernel-Versionen"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Service"
 
@@ -8785,10 +8788,10 @@ msgstr "Ausgewählten MAcs freigeben"
 msgid "Unmark selected pending"
 msgstr "Ausgewählten MAcs freigeben"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4799,7 +4799,7 @@ msgstr "User update failed"
 msgid "Master Node"
 msgstr "Master Node"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6864,6 +6864,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Kernel Versions"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Service"
 
@@ -8781,10 +8784,10 @@ msgstr "Approve selected Hosts"
 msgid "Unmark selected pending"
 msgstr "Approve selected Hosts"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 #, fuzzy
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4914,7 +4914,7 @@ msgstr "actualización Valoración falló"
 msgid "Master Node"
 msgstr "nodo de almacenamiento"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 #, fuzzy
@@ -7015,6 +7015,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Las versiones del kernel"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 #, fuzzy
 msgid "Service"
 msgstr "Maestro servicio"
@@ -8961,10 +8964,10 @@ msgstr "retirar"
 msgid "Unmark selected pending"
 msgstr "retirar"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4802,7 +4802,7 @@ msgstr "Aktualisierung der Rolle fehlgeschlagen"
 msgid "Master Node"
 msgstr "Master-Knoten"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6867,6 +6867,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Kernel-Versionen"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Service"
 
@@ -8786,10 +8789,10 @@ msgstr "Ausgewählten MAcs freigeben"
 msgid "Unmark selected pending"
 msgstr "Ausgewählten MAcs freigeben"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -465,7 +465,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4801,7 +4801,7 @@ msgstr "mise à jour de l'utilisateur a échoué"
 msgid "Master Node"
 msgstr "Node Master"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6866,6 +6866,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Kernel versions"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Un service"
 
@@ -8783,10 +8786,10 @@ msgstr "Approuver hôtes sélectionnés"
 msgid "Unmark selected pending"
 msgstr "Approuver hôtes sélectionnés"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -451,7 +451,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4632,7 +4632,7 @@ msgstr "Aggiornamento ruolo non riuscito"
 msgid "Master Node"
 msgstr "Maestro Node"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6639,6 +6639,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "versioni del kernel"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Servizio"
 
@@ -8481,10 +8484,10 @@ msgstr "Approvare MAC selezionati"
 msgid "Unmark selected pending"
 msgstr "Approvare MAC selezionati"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -436,7 +436,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4588,7 +4588,7 @@ msgstr "ホストの更新に失敗しました"
 msgid "Master Node"
 msgstr "マスターノード"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6591,6 +6591,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "カーネルバージョン"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "サービス"
 
@@ -8415,10 +8418,10 @@ msgstr "選択したイメージを削除"
 msgid "Unmark selected pending"
 msgstr "選択したスナップインを削除"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, fuzzy, php-format

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4063,7 +4063,7 @@ msgstr ""
 msgid "Master Node"
 msgstr ""
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -5838,6 +5838,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr ""
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr ""
 
@@ -7474,10 +7477,10 @@ msgstr ""
 msgid "Unmark selected pending"
 msgstr ""
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4800,7 +4800,7 @@ msgstr "atualização do utilizador falhou"
 msgid "Master Node"
 msgstr "Nó mestre"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6865,6 +6865,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "Versões do kernel"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "Serviço"
 
@@ -8782,10 +8785,10 @@ msgstr "Aprovar Hosts selecionados"
 msgid "Unmark selected pending"
 msgstr "Aprovar Hosts selecionados"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Aborted due to failure of \"%s\" with exit code %s"
 msgstr ""
 
-msgid "Accepts the same optional trailing filter segment as a list. Reports the true filtered total and ignores paging."
+msgid "Accepts the same optional filter as a list. Reports the true filtered total and ignores paging."
 msgstr ""
 
 msgid "Access"
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Also reachable as /delete and /remove."
 msgstr ""
 
-msgid "Also reachable as /list and /all. A trailing filter segment accepts field:value pairs."
+msgid "Also reachable as /list and /all. Filter with ?filter= or the equivalent trailing path segment; both take field=value pairs joined with &."
 msgstr ""
 
 msgid "Also reachable as /update and /edit. Send only the fields being changed."
@@ -4800,7 +4800,7 @@ msgstr "用户更新失败"
 msgid "Master Node"
 msgstr "主节点"
 
-msgid "Matches the term against the class name field. Returns the same envelope as a list."
+msgid "Matches the term against the class name field. Returns the same envelope as a list. Takes no filter -- the match is the whole query."
 msgstr ""
 
 msgid "Max Clients"
@@ -6865,6 +6865,9 @@ msgstr ""
 msgid "Server version and paging bounds"
 msgstr "内核版本"
 
+msgid "Server-side column filter, written as a URL encoded query string: field=value, joined with & for more than one, ANDed together. A comma separated value matches any of its parts. Only fields the class declares are accepted -- anything else answers 400 and names the offending key -- and credential fields are refused outright. Also accepted as a trailing path segment (/{class}/list/field=value), which wins when both are sent."
+msgstr ""
+
 msgid "Service"
 msgstr "服务"
 
@@ -8782,10 +8785,10 @@ msgstr "批准选定主机"
 msgid "Unmark selected pending"
 msgstr "批准选定主机"
 
-msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional trailing filter segment."
+msgid "Unpaged and uncapped -- the cheap way to enumerate a large table. Accepts an optional filter."
 msgstr ""
 
-msgid "Unpaged and uncapped. Accepts an optional trailing filter segment and an optional field name to return instead of the id."
+msgid "Unpaged and uncapped. Accepts an optional filter and an optional trailing field name to return instead of the id."
 msgstr ""
 
 #, php-format

--- a/tests/fogsettings-key-migration.test.sh
+++ b/tests/fogsettings-key-migration.test.sh
@@ -36,6 +36,13 @@
 # install ALSO refused to run from a path that was perfectly fine. One empty
 # variable, two misleading messages, neither naming the cause.
 #
+# Both halves are fixed. The migration is ordered before its first consumer,
+# and that guard now tests each variable for non-emptiness before matching on
+# it -- so a failed dispatch produces one accurate complaint instead of two,
+# only one of which was ever true. The amplifier was never specific to the key
+# rename: ANY path reaching that guard without a sourced distro config hit it,
+# which is why it is fixed separately rather than left to the migration.
+#
 # updatefog.sh and restorekernel.sh had it worse: they guard the call as
 # `[[ -n ${FOG_os_id} ]] && doOSSpecificIncludes`, so an empty key SKIPPED the
 # distro config with no message at all.
@@ -44,10 +51,11 @@
 # is installed, no root is needed and no path outside a temp dir is touched.
 # What runs is a *resemblance harness*: the same four steps the real scripts
 # perform, in the same order, against fixture .fogsettings files written here.
-# The two `case` statements are copied in shape from the real ones, so the
-# failure mode is reproduced rather than described -- and the test proves it
-# is testing the right thing by asserting that skipping the migration brings
-# both symptoms back.
+# The `case` statements are copied in shape from the real ones, so the failure
+# mode is reproduced rather than described -- and the test proves it is testing
+# the right thing by asserting that skipping the migration brings the dispatch
+# failure back. The directory guard is evaluated in BOTH shapes, old and new,
+# so the amplifier stays documented as well as fixed.
 #
 # Usage: bash tests/fogsettings-key-migration.test.sh
 # Exit status 0 = pass, 1 = fail.
@@ -185,16 +193,30 @@ harness() {
             *) distro="UNRECOGNIZED"; webdirdest=""; tftpdirdst="" ;;
         esac
 
-        # Step 4b: the directory guard that runs immediately after it. An empty
-        # $webdirdest turns `*$webdirdest*` into `*`, so this reports whether a
-        # perfectly ordinary path is wrongly rejected.
+        # Step 4b: the directory guard that runs immediately after it, in BOTH
+        # shapes, because the difference between them is the second half of
+        # this bug.
+        #
+        #   guard_glob  the original `case $currentdir in *$webdirdest*`. An
+        #               empty $webdirdest makes that `**`, which matches every
+        #               path -- so a failed dispatch was AMPLIFIED into a
+        #               second, unrelated-sounding complaint about the install
+        #               directory.
+        #   guard_safe  the current form, which tests each variable for
+        #               non-emptiness before using it in a match.
         currentdir="/home/someone/fogproject/bin"
         case $currentdir in
-            *$webdirdest*|*$tftpdirdst*) guard="REJECTED" ;;
-            *)                           guard="allowed"  ;;
+            *$webdirdest*|*$tftpdirdst*) guard_glob="REJECTED" ;;
+            *)                           guard_glob="allowed"  ;;
         esac
+        if { [ -n "$webdirdest" ] && case $currentdir in *"$webdirdest"*) true ;; *) false ;; esac; } \
+            || { [ -n "$tftpdirdst" ] && case $currentdir in *"$tftpdirdst"*) true ;; *) false ;; esac; }; then
+            guard_safe="REJECTED"
+        else
+            guard_safe="allowed"
+        fi
 
-        echo "${distro}|${guard}|${FOG_os_id}|${FOG_os_name}|${NET_interface}|${DB_user}|${WEB_docroot}"
+        echo "${distro}|${guard_safe}|${FOG_os_id}|${FOG_os_name}|${NET_interface}|${DB_user}|${WEB_docroot}|${guard_glob}"
     )
 }
 
@@ -207,7 +229,7 @@ if [ "$out" = "NOFUNC" ]; then
     echo "FAIL: migrateDeprecatedKeys() is not defined in lib/common/functions.sh"
     exit 1
 fi
-IFS='|' read -r distro guard osid osname iface dbuser docroot <<EOF
+IFS='|' read -r distro guard osid osname iface dbuser docroot guard_glob <<EOF
 $out
 EOF
 
@@ -228,7 +250,7 @@ is  'old format: an unrelated directory is not rejected' "$guard" "allowed"
 # value replaced by an empty old variable.
 # ---------------------------------------------------------------------------
 
-IFS='|' read -r distro guard osid osname iface dbuser docroot <<EOF
+IFS='|' read -r distro guard osid osname iface dbuser docroot guard_glob <<EOF
 $(harness "$tmp/new.fogsettings")
 EOF
 
@@ -245,13 +267,19 @@ is  'new format: an unrelated directory is not rejected' "$guard" "allowed"
 # ever passes, the harness has stopped exercising the thing it claims to.
 # ---------------------------------------------------------------------------
 
-IFS='|' read -r distro guard osid _ _ _ _ <<EOF
+IFS='|' read -r distro guard osid _ _ _ _ guard_glob <<EOF
 $(harness "$tmp/old.fogsettings" skip)
 EOF
 
-is  'without the migration: FOG_os_id is empty'                "$osid"   ""
-is  'without the migration: the distro falls to the *) arm'    "$distro" "UNRECOGNIZED"
-is  'without the migration: every directory is wrongly rejected' "$guard" "REJECTED"
+is  'without the migration: FOG_os_id is empty'             "$osid"   ""
+is  'without the migration: the distro falls to the *) arm' "$distro" "UNRECOGNIZED"
+# The amplifier, and why it is worth a fix of its own. With the dispatch
+# failed, $webdirdest is empty -- and the ORIGINAL glob then rejected every
+# directory on earth, which is the second message nobody could connect to a
+# key rename. The guarded form does not, so a failed dispatch now produces one
+# accurate complaint instead of two, only one of which was true.
+is  'the old glob rejects every directory once webdirdest is empty' "$guard_glob" "REJECTED"
+is  'the guarded form does not'                                     "$guard"      "allowed"
 
 # ---------------------------------------------------------------------------
 # 4. The migration runs before the first read, in every entry point.
@@ -297,6 +325,21 @@ done
 # scripts had no migration at all.
 check 'the migration lives in functions.sh, which all three source first' \
     "$(grep -q '^migrateDeprecatedKeys() {' "$functions" && echo yes)"
+
+# And the REAL guard, not the harness' copy of it.
+#
+# Without this the two guard_glob/guard_safe cases above are decorative: they
+# prove the two SHAPES differ, which is arithmetic, not that the shipped code
+# uses the safe one. Reverting functions.sh to the unguarded glob passed every
+# other check in this file.
+# Comments are stripped first -- the fix carries an explanation that QUOTES the
+# broken form, and grepping the whole function found that instead of code.
+guardcode=$(sed -n '/^doOSSpecificIncludes() {/,/^}$/p' "$functions" \
+    | grep -vE '^[[:space:]]*#')
+check 'the real directory guard does not glob on a possibly-empty $webdirdest' \
+    "$(printf '%s\n' "$guardcode" | grep -q '\*\$webdirdest\*' || echo yes)"
+check 'the real directory guard tests $webdirdest for non-emptiness first' \
+    "$(printf '%s\n' "$guardcode" | grep -q -- '-n \$webdirdest' && echo yes)"
 
 # ---------------------------------------------------------------------------
 # 5. Every deprecated key has a migration pair.


### PR DESCRIPTION
Second half of the GH-1120 fix (#1297 was the first). Standalone — it fixes a hazard that was never specific to that bug.

## The defect

```bash
case $currentdir in *$webdirdest*|*$tftpdirdst*)
```

In a glob, `*$webdirdest*` with an **empty** `$webdirdest` is `**` — which matches every path there is. So the installer refused to run from anywhere, and explained itself with a message about the install layout that had nothing to do with the real problem:

```
Please change installation directory.
Running from here will fail.
```

## Empty is reachable, and by design

`doOSSpecificIncludes`' `*)` arm blanks the id and **returns** rather than exiting, so any route that reaches this guard without having sourced a distro config finds both variables unset — and the guard is the very next thing in the same function.

That is the second message in GH-1120: a pre-rename `.fogsettings` left `FOG_os_id` unset, the `*)` arm fired, and the admin got `Sorry, answer not recognized` followed by a complaint about a directory that was perfectly fine. **Two messages, one cause, and the false one is the one that tells you where to look.**

#1297 fixed the trigger by ordering the key migration before its first consumer. This fixes the amplifier.

Each variable is now tested for non-emptiness before being used in a match, so a failed dispatch produces one accurate complaint instead of two.

## Tests

`tests/fogsettings-key-migration.test.sh` gains the guard in **both** shapes, so the amplifier stays documented as well as fixed — and, the part that matters, a lint on the **real** function.

Without that lint the shape cases are decorative: they prove the two shapes differ, which is arithmetic, not that the shipped code uses the safe one. Reverting `functions.sh` to the unguarded glob **passed every other check in the file** — a genuinely blind gate until the lint was added.

Comments are stripped before that lint runs: the fix carries an explanation quoting the broken form, and grepping the whole function found that instead of code.

Mutation-verified — reverting the guard now fails two checks by name.

Suite: **123 passed, 0 failed.**

## Companion

The dev-branch port is #1299. Only this half ports — dev-branch has no key rename, so there is nothing to order there.