### PR TITLE
Stop the upgrade turning off the HTTPS redirect, and wire the OS prompt

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -776,11 +776,20 @@ resolvedfoggitpath="${FOG_git_path}"
 [[ -z $guessdefaults ]] && guessdefaults=1
 [[ -z $doupdate ]] && doupdate=1
 [[ -z $ignorehtmldoc ]] && ignorehtmldoc=0
-# NOT the new default. httpproto is forced to https for everyone further down,
-# after .fogsettings has been sourced -- the migration there has to be able to
-# tell a PERSISTED https (the only evidence an admin ever asked for -S) from a
-# defaulted one, and it cannot if the default has already written https here.
-[[ -z ${WEB_url_proto} ]] && WEB_url_proto="http"
+# NO default here, deliberately -- not even http, which is what this line used
+# to write. WEB_url_proto is forced to https for everyone further down, after
+# .fogsettings has been sourced, and the WEB_https_redirect migration in between
+# has to tell a PERSISTED https (the only evidence an admin ever asked for -S)
+# from a defaulted one.
+#
+# Defaulting it here defeated both steps. migrateDeprecatedKeys' seed is
+# `[[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"`, and this line had
+# already made it non-empty, so on a pre-1.6 upgrade that seed could never fire:
+# a server that had been running httpproto=https reached the redirect migration
+# holding http and came out with WEB_https_redirect=no -- its redirect switched
+# off by the upgrade, silently. Nothing reads WEB_url_proto between here and that
+# seed, and it is assigned unconditionally afterwards, so leaving it unset costs
+# nothing.
 [[ -z $externalca ]] && externalca="no"
 [[ -z ${DB_name} ]] && DB_name="fog"
 [[ -z ${BOOT_tftp_options} ]] && BOOT_tftp_options=""

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3816,7 +3816,14 @@ displayOSChoices() {
                 echo "          4) Arch Based Linux (Arch, Manjaro)"
                 echo
                 echo -n "  Choice: [$strSuggestedOS] "
-                read osid
+                # Into the key the case below tests. This read used to name the
+                # pre-1.6 variable while the case tested the renamed one, so the
+                # answer landed nowhere: FOG_os_id is already $strSuggestedOS by
+                # this point (set at the top of this loop), the case matched
+                # that, and the loop broke -- so the prompt accepted a choice and
+                # then always installed for the SUGGESTED distro. Pressing Enter
+                # still takes the suggestion, through the "" branch below.
+                read FOG_os_id
                 case ${FOG_os_id} in
                     "")
                         FOG_os_id=$strSuggestedOS

--- a/tests/upgrade-proto-and-os-prompt.test.sh
+++ b/tests/upgrade-proto-and-os-prompt.test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Two faults left over from the GH-1120 rename, both silent, both distinct from
+# what #1297 and #1298 fixed.
+#
+#   tests/upgrade-proto-and-os-prompt.test.sh
+#
+# 1. THE HTTPS REDIRECT WAS SWITCHED OFF BY UPGRADING.
+#
+#    Splitting the old three-meanings-in-one httpproto key rests on one piece of
+#    evidence: an existing httpproto=https is the only record that an admin ever
+#    asked for -S. migrateDeprecatedKeys carries it across with
+#
+#        [[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"
+#
+#    and the redirect migration downstream reads the result. But installfog.sh
+#    defaulted WEB_url_proto to http BEFORE .fogsettings was sourced, so that
+#    guard never held on a pre-1.6 upgrade -- the seed could not fire, the
+#    redirect migration saw http, and WEB_https_redirect came out no. The admin
+#    is not told; the redirect simply stops happening.
+#
+#    Nothing reads WEB_url_proto between the two points and it is assigned
+#    unconditionally afterwards, so the default is removed rather than reordered.
+#
+# 2. THE OS-CHOICE PROMPT IGNORED THE ANSWER.
+#
+#    displayOSChoices did `read osid` while the case below tested ${FOG_os_id}.
+#    FOG_os_id is already $strSuggestedOS by then, so the case matched the
+#    suggestion and broke: the prompt took a choice and always installed for the
+#    suggested distro. Same class as the nine prompts fixed in input.sh -- this
+#    one lives in functions.sh, which that pass did not cover.
+#
+# Drives the real functions. Needs bash. No install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+INSTALLER="$REPO/bin/installfog.sh"
+
+[[ -f $FUNCS ]]     || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+[[ -f $INSTALLER ]] || { echo "ERROR: $INSTALLER not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+echo "upgrade proto + OS prompt:"
+
+# --- A. no pre-source default on WEB_url_proto ------------------------------
+# Source-level, because the seed it defeats is 70 lines away and the damage is
+# invisible: an upgrade that quietly stops redirecting looks like a working one.
+grep -q '^\[\[ -z ${WEB_url_proto} \]\] && WEB_url_proto=' "$INSTALLER" \
+    && bad "A: WEB_url_proto is defaulted before .fogsettings is sourced -- the httpproto seed can never fire" \
+    || ok "A: WEB_url_proto carries no pre-source default"
+# The seed and the unconditional assignment must both still be there, or the
+# assertion above passes for the wrong reason.
+grep -q 'WEB_url_proto="\$httpproto"' "$INSTALLER" \
+    && ok "A: the httpproto seed is still present" \
+    || bad "A: the httpproto seed is gone -- nothing carries the old value across"
+grep -q '^WEB_url_proto="https"$' "$INSTALLER" \
+    && ok "A: WEB_url_proto is still assigned unconditionally afterwards" \
+    || bad "A: nothing sets WEB_url_proto after the migration -- removing the default would leave it empty"
+
+# --- B. behaviour: a pre-1.6 server that had -S keeps its redirect ----------
+# migrateDeprecatedKeys is the real thing (#1297); this drives it exactly as the
+# installer does, then applies the redirect migration verbatim.
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+if ! declare -F migrateDeprecatedKeys >/dev/null; then
+    bad "B: migrateDeprecatedKeys is not defined by lib/common/functions.sh"
+else
+    # Whatever the installer initialises WEB_url_proto to before sourcing
+    # .fogsettings, applied here too -- otherwise this harness starts from a
+    # clean slate the real run never has, and would keep passing with the
+    # pre-source default put back. There should be no such line; the eval is
+    # what makes its return a failure rather than a silent pass.
+    presource=$(grep -E '^\[\[ -z \$\{WEB_url_proto\} \]\] && WEB_url_proto=' "$INSTALLER")
+    redirect_for() {
+        (
+            # A pre-1.6 .fogsettings records httpproto and nothing else here.
+            WEB_url_proto=""
+            [[ -n $presource ]] && eval "$presource"
+            httpproto="$1"
+            WEB_https_redirect=""
+            migrateDeprecatedKeys >/dev/null 2>&1
+            if [[ -z ${WEB_https_redirect} ]]; then
+                [[ ${WEB_url_proto} == https ]] && WEB_https_redirect="yes" || WEB_https_redirect="no"
+            fi
+            printf '%s' "${WEB_https_redirect}"
+        )
+    }
+    is "$(redirect_for https)" "yes" "B: httpproto=https keeps the redirect on"
+    is "$(redirect_for http)"  "no"  "B: httpproto=http does not turn it on"
+
+    # And an admin who already turned the redirect OFF must not have it turned
+    # back on by the next upgrade re-reading WEB_url_proto.
+    got=$(
+        httpproto="https"; WEB_url_proto="https"; WEB_https_redirect="no"
+        migrateDeprecatedKeys >/dev/null 2>&1
+        if [[ -z ${WEB_https_redirect} ]]; then
+            [[ ${WEB_url_proto} == https ]] && WEB_https_redirect="yes" || WEB_https_redirect="no"
+        fi
+        printf '%s' "${WEB_https_redirect}"
+    )
+    is "$got" "no" "B: a redirect the admin switched off stays off"
+fi
+
+# --- C. the OS prompt reads into the key its own case tests -----------------
+prompt=$(awk '/^displayOSChoices\(\) \{/,/^\}/' "$FUNCS")
+printf '%s\n' "$prompt" | grep -qE '^\s*read FOG_os_id\s*$' \
+    && ok "C: the prompt reads into FOG_os_id" \
+    || bad "C: the prompt does not read into FOG_os_id"
+printf '%s\n' "$prompt" | grep -qE '^\s*read osid\s*$' \
+    && bad "C: it still reads the retired 'osid'" \
+    || ok "C: it no longer reads the retired 'osid'"
+printf '%s\n' "$prompt" | grep -q 'case ${FOG_os_id} in' \
+    && ok "C: and the case still tests FOG_os_id" \
+    || bad "C: the case no longer tests FOG_os_id -- re-check what the read should name"
+
+# --- D. behaviour: the answer actually reaches the case --------------------
+# Replays the prompt's own logic against piped input, which is the only way to
+# see that a typed choice survives. A wrong wiring is invisible otherwise: the
+# suggestion is a valid answer, so the install succeeds for the wrong distro.
+choose() {
+    (
+        strSuggestedOS=2
+        FOG_os_id=$strSuggestedOS
+        read FOG_os_id <<< "$1"
+        case ${FOG_os_id} in
+            "")      FOG_os_id=$strSuggestedOS ;;
+            1|2|3|4) ;;
+            *)       FOG_os_id="invalid" ;;
+        esac
+        printf '%s' "${FOG_os_id}"
+    )
+}
+is "$(choose 1)"  "1"       "D: typing 1 selects Redhat, not the suggestion"
+is "$(choose 4)"  "4"       "D: typing 4 selects Arch"
+is "$(choose '')" "2"       "D: pressing Enter still takes the suggestion"
+is "$(choose 9)"  "invalid" "D: a bad answer is rejected rather than silently accepted"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Two faults left over from the GH-1120 rename, found while tracing the upgrade
abort in the same report. Both are silent. Neither is what #1297 and #1298
fixed — those handled the abort itself (the migration ordering, and the empty-glob
amplifier); these are still live on `working-1.6`, verified against its current
head before opening this.

No new behaviour, two lines of actual change.

## The HTTPS redirect was switched off by upgrading

Splitting the old three-meanings-in-one `httpproto` key rests on a single piece
of evidence: **an existing `httpproto=https` is the only record that an admin ever
asked for `-S`.** `migrateDeprecatedKeys` carries it across with

```sh
[[ -z ${WEB_url_proto} ]] && WEB_url_proto="$httpproto"
```

but `installfog.sh` defaulted `WEB_url_proto` to `http` *before* `.fogsettings`
was sourced, so on a pre-1.6 upgrade that guard never held. The seed could not
fire, the redirect migration downstream read `http`, and `WEB_https_redirect` came
out `no`.

Nothing reports it. The redirect just stops happening, on a server whose admin had
deliberately turned it on.

The line's own comment already said this value must not be defaulted before the
source:

> NOT the new default. httpproto is forced to https for everyone further down,
> after .fogsettings has been sourced — the migration there has to be able to tell
> a PERSISTED https (the only evidence an admin ever asked for -S) from a defaulted
> one, and it cannot if the default has already written https here.

…and then the next line defaulted it anyway. Nothing reads `WEB_url_proto` between
those two points and it is assigned unconditionally afterwards
(`WEB_url_proto="https"`), so the default is **removed** rather than reordered.

## The OS-choice prompt ignored the answer

`displayOSChoices` did `read osid` while the `case` immediately below it tested
`${FOG_os_id}`. `FOG_os_id` is already `$strSuggestedOS` by that point — set at
the top of the same loop — so the case matched the suggestion and broke.

The prompt accepted a choice and then always installed for the **suggested**
distro.

It is invisible because the suggestion is itself a valid answer: the install
succeeds, for the wrong distro, and only diverges later when the wrong per-distro
config drives package names and service handling. Same class as the nine prompts
fixed in `input.sh` — this one lives in `functions.sh`, which that pass did not
cover. Pressing Enter still takes the suggestion, through the `""` branch.

## Verification

```
sh tests/run-all.sh                     # 124 passed, 0 failed  (as root)
su ciuser -c 'sh tests/run-all.sh'      # 124 passed, 0 failed  (unprivileged)
```

New `tests/upgrade-proto-and-os-prompt.test.sh` — 13 assertions, source-level and
behavioural.

The behavioural half applies whatever pre-source default the installer *actually*
carries, rather than starting from a clean slate the real run never has — so it
cannot keep passing once the default is put back. Negative-controlled, it reports
the symptom itself:

```
  FAIL  A: WEB_url_proto is defaulted before .fogsettings is sourced -- the httpproto seed can never fire
  FAIL  B: httpproto=https keeps the redirect on (expected 'yes', got 'no')
```

It also asserts the seed and the unconditional assignment are both still present,
so the first check cannot pass for the wrong reason — removing the seed would
otherwise satisfy it while breaking the migration outright. And it covers the case
that matters in the other direction: **a redirect the admin switched off stays
off**, since the migration is guarded on `WEB_https_redirect` being unset
precisely so a later upgrade cannot turn it back on.

The prompt half checks the wiring at source level and replays the prompt's own
logic against piped input — typing `1` selects Redhat, typing `4` selects Arch,
Enter takes the suggestion, and a bad answer is rejected rather than silently
accepted.

## Downstream

Nothing. `route.class.php` and `openapi.class.php` are untouched and no route
class changed, so there is no FogApi sync to make.


---
_Generated by [Claude Code](https://claude.ai/code/session_01US86oTKth7uXXwvWXMZjRN)_