### PR TITLE
fix(multicast): make a kill answer whether the sender is actually gone

### DIFF
--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -1016,13 +1016,138 @@ abstract class FOGService extends FOGBase
         posix_kill($pid, $sig);
     }
     /**
-     * Kills the tasking
+     * Is a pid still present, and still running what we started?
+     *
+     * /proc is read rather than posix_kill($pid, 0) because a pid can be
+     * recycled between the kill and the check. Matching the cmdline means a
+     * reused pid running something else answers "gone", which is the honest
+     * answer -- and a zombie, whose cmdline is empty, answers "gone" too,
+     * correctly: it holds no port and no file.
+     *
+     * @param int    $pid   The pid to test.
+     * @param string $match Substring the cmdline must contain, if any.
+     *
+     * @return bool
+     */
+    public function isPidAlive($pid, $match = '')
+    {
+        $pid = (int)$pid;
+        if ($pid < 1) {
+            return false;
+        }
+        $cmdline = @file_get_contents(
+            sprintf('/proc/%d/cmdline', $pid)
+        );
+        if (empty($cmdline)) {
+            return false;
+        }
+        if ('' === $match) {
+            return true;
+        }
+        return false !== strpos(
+            str_replace("\0", ' ', $cmdline),
+            $match
+        );
+    }
+    /**
+     * Waits, bounded, for a process to exit.
+     *
+     * @param resource $procRef The proc_open() handle.
+     * @param int      $tenths  How many tenths of a second to wait.
+     *
+     * @return bool True if it exited within the window.
+     */
+    private function _waitForExit($procRef, $tenths = 30)
+    {
+        for ($i = 0; $i < $tenths; $i++) {
+            if (!$this->isRunning($procRef)) {
+                return true;
+            }
+            usleep(100000);
+        }
+        return !$this->isRunning($procRef);
+    }
+    /**
+     * Terminates a process tree and reports whether it is actually gone.
+     *
+     * SIGTERM the tree, wait, then SIGKILL what is left. Both halves matter:
+     *
+     * - proc_close() BLOCKS until the child is reaped, so a process that
+     *   ignored SIGTERM used to hang the daemon inside the kill itself.
+     * - the answer is only honest once the process has had a chance to go,
+     *   and callers act on it: MulticastTask only releases its ownership
+     *   row when the sender is really gone.
+     *
+     * The handle is deliberately NOT closed when the process survives
+     * everything -- proc_close() would block forever waiting to reap it.
+     * Leaking one handle beats wedging the daemon, and the caller is told.
+     *
+     * @param resource $procRef The proc_open() handle.
+     *
+     * @return bool True when nothing is left running.
+     */
+    private function _terminateProc($procRef)
+    {
+        if (!is_resource($procRef)) {
+            return true;
+        }
+        if (!$this->isRunning($procRef)) {
+            // Already exited; proc_close() only reaps it.
+            proc_close($procRef);
+            return true;
+        }
+        $pid = (int)$this->getPID($procRef);
+        if ($pid > 0) {
+            $this->killAll($pid, SIGTERM);
+        }
+        proc_terminate($procRef, SIGTERM);
+        if (!$this->_waitForExit($procRef)) {
+            if ($pid > 0) {
+                $this->killAll($pid, SIGKILL);
+            }
+            proc_terminate($procRef, SIGKILL);
+            $this->_waitForExit($procRef);
+        }
+        if ($this->isRunning($procRef)) {
+            return false;
+        }
+        proc_close($procRef);
+        return true;
+    }
+    /**
+     * Closes out a set of proc_open() pipes.
+     *
+     * @param mixed $pipes The stored pipe set, if any.
+     *
+     * @return void
+     */
+    private function _closePipes($pipes)
+    {
+        foreach ((array)$pipes as &$close) {
+            if (is_resource($close)) {
+                fclose($close);
+            }
+            unset($close);
+        }
+    }
+    /**
+     * Kills the tasking.
+     *
+     * Returns whether the process is GONE by the time the call finishes:
+     * true when nothing is left running, false when it survived SIGTERM
+     * and SIGKILL. That is the only question a caller can act on, and it
+     * was previously unanswerable -- the old code returned false after a
+     * SUCCESSFUL kill, returned !$isRunning ("was it already dead") from
+     * the itemType branch, and fell off the end returning null when the
+     * process had already exited. MulticastTask::killTask() discarded it
+     * and hardcoded true, which left the "could not be killed" arms in
+     * MulticastManager unreachable.
      *
      * @param int    $index    the index for the item to look into
      * @param mixed  $itemType the type of the item
      * @param string $filename the filename to close out
      *
-     * @return bool
+     * @return bool True when the process is gone.
      */
     public function killTasking(
         $index = 0,
@@ -1030,69 +1155,38 @@ abstract class FOGService extends FOGBase
         $filename = false
     ) {
         if ($itemType === false) {
-            if (count((array)$this->procPipes) > 0) {
-                foreach ((array)$this->procPipes[$index] as $i => &$close) {
-                    fclose($close);
-                    unset($close);
-                }
+            // isset guard: killTask() is also called on a task whose start
+            // FAILED, where no pipes were ever stored -- MulticastManager
+            // does exactly that. Unguarded this warned on every failed
+            // multicast start under PHP 8.
+            if (isset($this->procPipes[$index])) {
+                $this->_closePipes($this->procPipes[$index]);
                 unset($this->procPipes[$index]);
             }
             // procRef may be an array keyed by $index or a single resource
             // (the multicast path collapses it to one resource via
             // array_shift). Resolve to a single reference so we never index
-            // into a resource, which emits a "Trying to access array offset
-            // on resource" warning under PHP 8. Refs #945.
+            // into a resource, which emits a warning under PHP 8.
             $procRef = is_array($this->procRef)
                 ? ($this->procRef[$index] ?? null)
                 : $this->procRef;
-            if ($this->isRunning($procRef)) {
-                $pid = $this->getPID($procRef);
-                if ($pid) {
-                    $this->killAll($pid, SIGTERM);
-                }
-                proc_terminate($procRef, SIGTERM);
-                proc_close($procRef);
-                return false;
-            }
-            // Process already exited — release the resource.
-            if (is_resource($procRef)) {
-                proc_close($procRef);
-            }
-        } else {
-            if (isset($this->procRef[$itemType]) &&
-                isset($this->procRef[$itemType][$filename]) &&
-                isset($this->procRef[$itemType][$filename][$index])
-            ) {
-                $procRef = $this->procRef[$itemType][$filename][$index];
-            } else {
-                return true;
-            }
-            if (isset($this->procPipes[$itemType]) &&
-                isset($this->procPipes[$itemType][$filename]) &&
-                isset($this->procPipes[$itemType][$filename][$index])
-            ) {
-                $pipes = $this->procPipes[$itemType][$filename][$index];
-            } else {
-                return true;
-            }
-            $isRunning = $this->isRunning($procRef);
-            if ($isRunning) {
-                $pid = $this->getPID($procRef);
-                if ($pid) {
-                    $this->killAll($pid, SIGTERM);
-                }
-                proc_terminate($procRef, SIGTERM);
-            }
-            // Always close pipes and release the process resource,
-            // whether it was still running or had already exited.
-            foreach ((array)$pipes as $i => &$close) {
-                fclose($close);
-                unset($close);
-            }
-            unset($pipes);
-            proc_close($procRef);
-            return !$isRunning;
+            return $this->_terminateProc($procRef);
         }
+        if (!isset($this->procRef[$itemType][$filename][$index])) {
+            return true;
+        }
+        $procRef = $this->procRef[$itemType][$filename][$index];
+        if (isset($this->procPipes[$itemType][$filename][$index])) {
+            $this->_closePipes(
+                $this->procPipes[$itemType][$filename][$index]
+            );
+            unset($this->procPipes[$itemType][$filename][$index]);
+        }
+        // Both sides of the pair are dropped, not just the pipes: the
+        // handle is closed below, and cleanupProcList() walks procRef
+        // expecting a live resource with matching pipes still beside it.
+        unset($this->procRef[$itemType][$filename][$index]);
+        return $this->_terminateProc($procRef);
     }
     /**
      * Gets the pid of the running reference
@@ -1164,31 +1258,42 @@ abstract class FOGService extends FOGBase
      */
     public function cleanupProcList()
     {
-        foreach ($this->procRef as $item => &$itemTypes) {
-            foreach ($itemTypes as $image => &$images) {
-                foreach ($images as $i => &$ref) {
+        // count() on a missing key is a TypeError under PHP 8, not a
+        // warning -- an uncaught one, in a daemon, so the replicator would
+        // die outright and the unit would simply stop syncing. empty() is
+        // null-safe and means the same thing at every site here: no entry
+        // and an entry holding nothing both want the key dropped. The two
+        // structures are kept in step by startTasking() and killTasking(),
+        // but nothing enforces that, and this is not the place to find out.
+        foreach ((array)$this->procRef as $item => &$itemTypes) {
+            foreach ((array)$itemTypes as $image => &$images) {
+                foreach ((array)$images as $i => &$ref) {
                     if (!$this->isRunning($images[$i])) {
                         self::outall(" | Sync finished - " . print_r($images[$i], true));
-                        foreach ($this->procPipes[$item][$image][$i] as $j => &$pipe_ref) {
-                            fclose($this->procPipes[$item][$image][$i][$j]);
+                        foreach ((array)($this->procPipes[$item][$image][$i] ?? []) as $j => &$pipe_ref) {
+                            if (is_resource($this->procPipes[$item][$image][$i][$j])) {
+                                fclose($this->procPipes[$item][$image][$i][$j]);
+                            }
                             unset($this->procPipes[$item][$image][$i][$j]);
                         }
                         unset($this->procPipes[$item][$image][$i]);
-                        proc_close($images[$i]);
+                        if (is_resource($images[$i])) {
+                            proc_close($images[$i]);
+                        }
                         unset($images[$i]);
                     }
                 }
-                if (!count($itemTypes[$image])) {
+                if (empty($itemTypes[$image])) {
                     unset($itemTypes[$image]);
                 }
-                if (!count($this->procPipes[$item][$image])) {
+                if (empty($this->procPipes[$item][$image])) {
                     unset($this->procPipes[$item][$image]);
                 }
             }
-            if (!count($this->procRef[$item])) {
+            if (empty($this->procRef[$item])) {
                 unset($this->procRef[$item]);
             }
-            if (!count($this->procPipes[$item])) {
+            if (empty($this->procPipes[$item])) {
                 unset($this->procPipes[$item]);
             }
         }

--- a/packages/web/lib/service/multicastmanager.class.php
+++ b/packages/web/lib/service/multicastmanager.class.php
@@ -174,20 +174,7 @@ class MulticastManager extends FOGService
      */
     private function _isSenderAlive($pid)
     {
-        $pid = (int)$pid;
-        if ($pid < 1) {
-            return false;
-        }
-        $cmdline = @file_get_contents(
-            sprintf('/proc/%d/cmdline', $pid)
-        );
-        if (!$cmdline) {
-            return false;
-        }
-        return strpos(
-            str_replace("\0", ' ', $cmdline),
-            basename(UDPSENDERPATH)
-        ) !== false;
+        return $this->isPidAlive($pid, basename(UDPSENDERPATH));
     }
     /**
      * Reconciles udp-senders this node owns but no longer tracks.
@@ -740,7 +727,10 @@ class MulticastManager extends FOGService
                 // Both loops re-clear the sender reference after the session
                 // is closed out. Every task reaching them has already been
                 // through killTask(), so clearSenderRef() has zeroed
-                // senderpid and sendernode -- but cancel() and complete()
+                // senderpid and sendernode -- unless the sender survived the
+                // kill, in which case it refuses and the reference stays put
+                // for the reconciler. On the normal path cancel() and
+                // complete()
                 // finish with save() on a session object loaded back when the
                 // task was constructed, which still holds the pre-kill pid,
                 // and FOGController::save() writes every field it holds. The

--- a/packages/web/lib/service/multicasttask.class.php
+++ b/packages/web/lib/service/multicasttask.class.php
@@ -1074,12 +1074,16 @@ class MulticastTask extends FOGService
      */
     public function killTask()
     {
-        $this->killTasking();
+        $gone = $this->killTasking();
         if (file_exists($this->getUDPCastLogFile())) {
             unlink($this->getUDPCastLogFile());
         }
+        // clearSenderRef() self-guards on liveness, so this stays
+        // unconditional: on a successful kill it releases the row, and on a
+        // sender that survived it deliberately does nothing, leaving the
+        // reference for _reconcileOrphanedSenders() to find.
         $this->clearSenderRef();
-        return true;
+        return $gone;
     }
     /**
      * Clears the persisted sender ownership for this session.
@@ -1096,10 +1100,24 @@ class MulticastTask extends FOGService
      * name and client count back and hand the session straight back to the
      * daemon to start again.
      *
-     * @return void
+     * @return bool True when the reference was released.
      */
     public function clearSenderRef()
     {
+        // Refuse while the sender is still alive. Zeroing senderpid is
+        // precisely what makes a session invisible to
+        // _reconcileOrphanedSenders(), so doing it to a sender that
+        // survived killTask() strands a udp-sender holding its portbase
+        // with nothing left that would ever clean it up. The pid tested is
+        // the pre-kill one still held on the in-memory session object,
+        // which is the whole reason the manager clears AFTER cancel() and
+        // complete() rather than inside them.
+        $pid = (int)$this->_MultiSess->get('senderpid');
+        if ($pid > 0
+            && $this->isPidAlive($pid, basename(UDPSENDERPATH))
+        ) {
+            return false;
+        }
         self::getClass('MulticastSessionManager')->update(
             array('id' => $this->_intID),
             '',
@@ -1108,6 +1126,7 @@ class MulticastTask extends FOGService
                 'sendernode' => 0
             )
         );
+        return true;
     }
     /**
      * Updates the stats of the tasking

--- a/tests/multicast-kill-contract.test.php
+++ b/tests/multicast-kill-contract.test.php
@@ -38,6 +38,21 @@ if (!is_dir('/proc/self')) {
     fwrite(STDERR, "SKIP: no /proc on this platform\n");
     exit(0);
 }
+// SIGTERM and SIGKILL come from ext-pcntl, not ext-posix. The daemons need
+// pcntl anyway -- service_lib.php forks -- but a bare CLI image can have
+// posix_kill() and still not have the constants, and without them
+// proc_terminate() is handed the string 'SIGTERM' and quietly does nothing.
+if (!defined('SIGTERM') || !defined('SIGKILL')) {
+    fwrite(STDERR, "SKIP: ext-pcntl signal constants unavailable\n");
+    exit(0);
+}
+// killAll() shells out to ps to walk the process tree, and returns without
+// signalling anything if it is missing.
+exec('command -v ps', $psOut, $psRet);
+if (0 !== $psRet) {
+    fwrite(STDERR, "SKIP: no ps on PATH\n");
+    exit(0);
+}
 
 /**
  * Stand-in for the real base class.
@@ -107,23 +122,24 @@ function spawn($cmd)
 }
 
 /**
- * Waits for a freshly forked child to publish its argv.
+ * Waits for a freshly forked child to actually become the thing we asked for.
  *
- * execve() does not make a process visible all at once. The kernel installs
- * the new mm -- so /proc/<pid>/exe already names the new binary -- BEFORE it
- * records where argv lives, and until it does /proc/<pid>/cmdline reads
- * empty for a process that is plainly running. Measured here at roughly
- * four spawns in five.
+ * execve() does not make a process visible all at once, and what you see in
+ * the window before it lands depends on the kernel. Between fork() and exec()
+ * the child still shares the parent's memory map, so /proc/<pid>/cmdline
+ * reads back THIS INTERPRETER'S argv -- and where the mm has been swapped but
+ * argv is not yet recorded, it reads empty. Both were observed: empty on the
+ * dev box for roughly four spawns in five, and the parent's own argv on the
+ * PHP 7.4 CI image, where a first attempt at this that merely waited for
+ * "non-empty" sailed straight through and failed the match.
  *
- * Nothing in the product looks at a pid that young: the reconciler reads one
+ * So the wait is for a cmdline that is non-empty AND is not ours. That is
+ * independent of what the checks below then assert about its contents, which
+ * is the point -- settling on the assertion would prove nothing.
+ *
+ * Nothing in the product looks at a pid this young: the reconciler reads one
  * persisted by a previous daemon run, and clearSenderRef() one that has been
- * sending an image for minutes. But this file spawned and asked immediately,
- * and failed intermittently until it stopped.
- *
- * This does read the same file isPidAlive() reads, so it cannot by itself
- * evidence that a running process reads as alive -- that claim is anchored
- * below on getmypid(), which has no such window. What the wait buys is the
- * cmdline MATCHING checks, which are the part with content.
+ * sending an image for minutes.
  *
  * @param int $pid The pid to wait for.
  *
@@ -131,10 +147,12 @@ function spawn($cmd)
  */
 function settle($pid)
 {
+    $mine = (string)@file_get_contents('/proc/self/cmdline');
     for ($i = 0; $i < 250; $i++) {
-        if ('' !== (string)@file_get_contents(
+        $theirs = (string)@file_get_contents(
             sprintf('/proc/%d/cmdline', $pid)
-        )) {
+        );
+        if ('' !== $theirs && $theirs !== $mine) {
             return;
         }
         usleep(20000);

--- a/tests/multicast-kill-contract.test.php
+++ b/tests/multicast-kill-contract.test.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * killTasking() must answer "is it gone", and be able to say no.
+ *
+ * The multicast manager has three arms that log _('could not be killed')
+ * (multicastmanager.class.php around the startTask/complete/cancel loops).
+ * None of them could ever run: MulticastTask::killTask() called
+ * killTasking(), threw the answer away and returned a hardcoded true. So a
+ * udp-sender that survived proc_terminate() was reported as killed, and
+ * clearSenderRef() then zeroed senderpid -- which is the exact column
+ * _reconcileOrphanedSenders() reads to find orphans. The survivor kept its
+ * portbase and became invisible to the only thing that would have cleaned
+ * it up.
+ *
+ * The contract underneath was worse than missing, it was inverted:
+ * killTasking() returned FALSE after a successful kill, !$isRunning ("was
+ * it already dead") from the itemType branch, and fell off the end
+ * returning null when the process had already exited. Simply forwarding it
+ * would have printed "could not be killed" on every successful kill.
+ *
+ * These checks run REAL child processes -- the point is to exercise the
+ * shipped method, not a copy of its shape. No root, no database and no
+ * daemon: FOGService is loaded against a stub parent and driven directly.
+ *
+ * Ported from working-1.6. This branch is not namespaced, so the stub
+ * parent and the probe class are declared globally; everything else is
+ * identical, because the defect was.
+ *
+ * Usage: php tests/multicast-kill-contract.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+if (!function_exists('proc_open') || !function_exists('posix_kill')) {
+    fwrite(STDERR, "SKIP: proc_open/posix_kill unavailable\n");
+    exit(0);
+}
+if (!is_dir('/proc/self')) {
+    fwrite(STDERR, "SKIP: no /proc on this platform\n");
+    exit(0);
+}
+
+/**
+ * Stand-in for the real base class.
+ *
+ * FOGService's constructor and logging reach the database and the settings
+ * table; none of the process-handling methods under test touch either, so
+ * the parent is stubbed and instances are built without a constructor.
+ */
+abstract class FOGBase
+{
+}
+
+require_once dirname(__DIR__)
+    . '/packages/web/lib/service/fogservice.class.php';
+
+/**
+ * Concrete handle on the abstract service.
+ */
+class KillProbe extends FOGService
+{
+    public static function outall($string)
+    {
+    }
+}
+
+$failures = [];
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $label What is being asserted.
+ * @param bool   $cond  Whether it held.
+ *
+ * @return void
+ */
+function check($label, $cond)
+{
+    global $failures, $checks;
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/**
+ * Starts a shell command and returns [service, pid].
+ *
+ * @param string $cmd The command to run.
+ *
+ * @return array
+ */
+function spawn($cmd)
+{
+    $svc = (new ReflectionClass('KillProbe'))
+        ->newInstanceWithoutConstructor();
+    $descriptor = [
+        0 => ['pipe', 'r'],
+        2 => ['file', '/dev/null', 'a']
+    ];
+    $svc->procRef = [0 => proc_open($cmd, $descriptor, $pipes)];
+    $svc->procPipes = [0 => $pipes];
+    $status = proc_get_status($svc->procRef[0]);
+    $pid = (int)$status['pid'];
+    settle($pid);
+    return [$svc, $pid];
+}
+
+/**
+ * Waits for a freshly forked child to publish its argv.
+ *
+ * execve() does not make a process visible all at once. The kernel installs
+ * the new mm -- so /proc/<pid>/exe already names the new binary -- BEFORE it
+ * records where argv lives, and until it does /proc/<pid>/cmdline reads
+ * empty for a process that is plainly running. Measured here at roughly
+ * four spawns in five.
+ *
+ * Nothing in the product looks at a pid that young: the reconciler reads one
+ * persisted by a previous daemon run, and clearSenderRef() one that has been
+ * sending an image for minutes. But this file spawned and asked immediately,
+ * and failed intermittently until it stopped.
+ *
+ * This does read the same file isPidAlive() reads, so it cannot by itself
+ * evidence that a running process reads as alive -- that claim is anchored
+ * below on getmypid(), which has no such window. What the wait buys is the
+ * cmdline MATCHING checks, which are the part with content.
+ *
+ * @param int $pid The pid to wait for.
+ *
+ * @return void
+ */
+function settle($pid)
+{
+    for ($i = 0; $i < 250; $i++) {
+        if ('' !== (string)@file_get_contents(
+            sprintf('/proc/%d/cmdline', $pid)
+        )) {
+            return;
+        }
+        usleep(20000);
+    }
+}
+
+/**
+ * Is a pid present at all, whatever it is running?
+ *
+ * Deliberately NOT the method under test -- an independent read, so a
+ * mutation to isPidAlive() cannot make its own verification agree with it.
+ *
+ * @param int $pid The pid.
+ *
+ * @return bool
+ */
+function pidPresent($pid)
+{
+    return $pid > 0 && file_exists(sprintf('/proc/%d', $pid));
+}
+
+// --- isPidAlive() ----------------------------------------------------------
+//
+// The primitive both the kill path and _reconcileOrphanedSenders() rest on.
+
+// The unraced anchor: this process has been running long enough that no
+// execve window applies to it.
+$svc = (new ReflectionClass('KillProbe'))->newInstanceWithoutConstructor();
+check('a long-running pid reads as alive', $svc->isPidAlive(getmypid()));
+
+list($svc, $pid) = spawn('sleep 30');
+check('a settled child reads as alive', $svc->isPidAlive($pid));
+check('a live pid matches its own cmdline', $svc->isPidAlive($pid, 'sleep'));
+check(
+    'a live pid does NOT match somebody else\'s cmdline',
+    !$svc->isPidAlive($pid, 'udp-sender')
+);
+check('pid 0 is never alive', !$svc->isPidAlive(0));
+check('a negative pid is never alive', !$svc->isPidAlive(-1));
+check('a non-numeric pid is never alive', !$svc->isPidAlive('nonsense'));
+
+// The cmdline match is what makes a RECYCLED pid answer "gone" rather than
+// killing a stranger's process. Without it _reconcileOrphanedSenders() would
+// SIGKILL whatever inherited the number.
+check(
+    'this very process is alive but is not a udp-sender',
+    $svc->isPidAlive(getmypid()) && !$svc->isPidAlive(getmypid(), 'udp-sender')
+);
+
+// A pid whose cmdline is unreadable answers "gone", and that is the answer
+// we want. It covers a zombie (reaped, holds no port) and a child caught
+// mid-exec. Both are unidentifiable as a udp-sender, and the reconciler
+// SIGKILLs whatever this says is alive -- so "cannot prove it is ours"
+// must mean "leave it alone".
+check(
+    'pid 1 exists but is not matched as a udp-sender',
+    !$svc->isPidAlive(1, 'udp-sender')
+);
+
+check('killTasking() reports a well-behaved child gone', $svc->killTasking());
+check('and it really is gone', !pidPresent($pid));
+
+// --- the case the whole fix exists for -------------------------------------
+//
+// A child that ignores SIGTERM. The old code called proc_close() straight
+// after proc_terminate(), and proc_close() BLOCKS until the child is reaped
+// -- so this shape did not merely misreport, it WEDGED the daemon inside the
+// kill, forever, with the service unit still showing active. The loop keeps
+// the shell alive after each sleep is signalled.
+//
+// It runs in a child interpreter on a wall clock. That is not ceremony: a
+// regression here does not fail, it hangs, and a hang in tests/run-all.sh
+// stops the suite rather than reporting anything. Bounding it turns the
+// worst outcome back into a legible failure.
+
+if (in_array('--kill-sigterm-proof', (array)$argv, true)) {
+    list($svc, $pid) = spawn('trap "" TERM; while :; do sleep 1; done');
+    // Announced before the kill so the parent can clean up after a timeout;
+    // under a regression this process never gets to say anything again.
+    fwrite(STDOUT, 'pid=' . $pid . "\n");
+    $gone = $svc->killTasking();
+    fwrite(
+        STDOUT,
+        ($gone ? 'gone' : 'alive')
+        . ' ' . (pidPresent($pid) ? 'present' : 'absent') . "\n"
+    );
+    exit(0);
+}
+
+$descriptor = [1 => ['pipe', 'w'], 2 => ['file', '/dev/null', 'a']];
+$child = proc_open(
+    [PHP_BINARY, __FILE__, '--kill-sigterm-proof'],
+    $descriptor,
+    $childPipes
+);
+// Non-blocking, or the wall clock below is decorative: stream_get_contents()
+// on a blocking pipe waits for EOF, which under a regression means waiting
+// for the very process that is never going to finish.
+if (isset($childPipes[1]) && is_resource($childPipes[1])) {
+    stream_set_blocking($childPipes[1], false);
+}
+$out = '';
+$timedout = false;
+$began = microtime(true);
+while (is_resource($child)) {
+    $out .= (string)stream_get_contents($childPipes[1]);
+    $status = proc_get_status($child);
+    if (!$status['running']) {
+        $out .= (string)stream_get_contents($childPipes[1]);
+        break;
+    }
+    if (microtime(true) - $began > 30) {
+        $timedout = true;
+        proc_terminate($child, SIGKILL);
+        break;
+    }
+    usleep(50000);
+}
+$took = microtime(true) - $began;
+// Whatever happened, do not leave a SIGTERM-proof loop behind.
+if (preg_match('/pid=(\d+)/', $out, $m)) {
+    @posix_kill((int)$m[1], SIGKILL);
+}
+foreach ((array)$childPipes as $pipe) {
+    if (is_resource($pipe)) {
+        fclose($pipe);
+    }
+}
+if (is_resource($child)) {
+    proc_close($child);
+}
+
+check('the kill of a SIGTERM-proof child returned at all', !$timedout);
+check(
+    'a SIGTERM-proof child is still reported gone (escalated to SIGKILL)',
+    false !== strpos($out, 'gone ')
+);
+check(
+    'and it really is gone',
+    false !== strpos($out, ' absent')
+);
+check('the kill did not block indefinitely', $took < 30);
+
+// --- the start-failed path -------------------------------------------------
+//
+// MulticastManager calls killTask() when startTask() FAILED, so there are no
+// pipes and no handle. Unguarded, killTasking() read procPipes[$index] and
+// warned "Undefined array key" into the daemon log on every failed start.
+
+$warnings = [];
+set_error_handler(
+    function ($errno, $errstr) use (&$warnings) {
+        $warnings[] = $errstr;
+        return true;
+    }
+);
+$svc = (new ReflectionClass('KillProbe'))->newInstanceWithoutConstructor();
+$svc->procRef = [];
+$svc->procPipes = [];
+$never = $svc->killTasking();
+restore_error_handler();
+
+check('a task that never started reports gone', $never);
+check(
+    'and warns about nothing',
+    0 === count($warnings),
+    $warnings
+);
+
+// --- an already-exited child ----------------------------------------------
+//
+// The branch that used to fall off the end of the function returning null.
+// null is falsey, so the caller read it as "could not be killed" -- had the
+// caller ever looked.
+
+list($svc, $pid) = spawn('true');
+usleep(300000);
+check('an already-exited child reports gone', $svc->killTasking());
+
+// --- the itemType branch ---------------------------------------------------
+//
+// Used by the image and snapin replicators. It used to bail out returning
+// true whenever its pipe bookkeeping was missing -- leaving a live lftp
+// running and telling the caller it was gone.
+
+$svc = (new ReflectionClass('KillProbe'))->newInstanceWithoutConstructor();
+$descriptor = [0 => ['pipe', 'r'], 2 => ['file', '/dev/null', 'a']];
+$ref = proc_open('sleep 30', $descriptor, $pipes);
+$status = proc_get_status($ref);
+$pid = (int)$status['pid'];
+$svc->procRef = ['image' => ['disk.img' => [0 => $ref]]];
+$svc->procPipes = [];
+
+check('the itemType branch kills even with no pipes recorded', $svc->killTasking(0, 'image', 'disk.img'));
+check('and that child really is gone', !pidPresent($pid));
+check(
+    'the handle is dropped from procRef, not left for cleanupProcList()',
+    !isset($svc->procRef['image']['disk.img'][0])
+);
+
+check(
+    'an unknown itemType key is a no-op that reports gone',
+    $svc->killTasking(0, 'image', 'nosuchfile')
+);
+
+// The replicators call killTasking() on the itemType path and then keep
+// running; cleanupProcList() walks procRef expecting a live resource with
+// matching pipes beside it. Dropping one half and not the other left it
+// fclose()ing pipes that were gone and proc_close()ing a closed handle, so
+// the two structures are pinned as staying in step.
+$warnings = [];
+set_error_handler(
+    function ($errno, $errstr) use (&$warnings) {
+        $warnings[] = $errstr;
+        return true;
+    }
+);
+$svc->cleanupProcList();
+restore_error_handler();
+check(
+    'cleanupProcList() is clean after an itemType kill',
+    0 === count($warnings)
+);
+
+// --- and the callers -------------------------------------------------------
+//
+// The product wiring, so this file fails if the answer stops being used.
+
+$taskFile = dirname(__DIR__)
+    . '/packages/web/lib/service/multicasttask.class.php';
+$mgrFile = dirname(__DIR__)
+    . '/packages/web/lib/service/multicastmanager.class.php';
+$task = file_get_contents($taskFile);
+$mgr = file_get_contents($mgrFile);
+
+$killTask = '';
+if (preg_match('/public function killTask\(\).*?\n    \}/s', $task, $m)) {
+    $killTask = $m[0];
+}
+check(
+    'killTask() has a body to read',
+    '' !== $killTask
+);
+check(
+    'killTask() returns killTasking()\'s answer, not a hardcoded true',
+    false !== strpos($killTask, '$this->killTasking()')
+    && false === strpos($killTask, 'return true;')
+);
+
+$clear = '';
+if (preg_match('/public function clearSenderRef\(\).*?\n    \}/s', $task, $m)) {
+    $clear = $m[0];
+}
+check(
+    'clearSenderRef() refuses to zero the reference of a live sender',
+    false !== strpos($clear, 'isPidAlive(')
+);
+check(
+    'and the liveness test is pinned to udp-sender, not any pid',
+    false !== strpos($clear, 'UDPSENDERPATH')
+);
+
+check(
+    'the manager still acts on the kill result',
+    substr_count($mgr, '->killTask()') >= 3
+    && false !== strpos($mgr, 'could not be killed')
+);
+
+// --- report ----------------------------------------------------------------
+
+if (count($failures)) {
+    fwrite(STDERR, sprintf("FAIL (%d of %d)\n", count($failures), $checks));
+    foreach ($failures as $failure) {
+        fwrite(STDERR, '  - ' . $failure . "\n");
+    }
+    exit(1);
+}
+
+printf("ok  %d checks passed\n", $checks);
+exit(0);


### PR DESCRIPTION
Port of the working-1.6 fix (42c418c3b). The defect is present on this branch unchanged.

## The bug

`MulticastManager` has three arms that log `could not be killed` — after a failed start, and in the complete and cancel loops. **None of them could ever run.** `MulticastTask::killTask()` called `killTasking()`, discarded the result and returned a hardcoded `true`.

So a `udp-sender` that survived `proc_terminate()` was reported as killed, and `clearSenderRef()` then zeroed `senderpid`/`sendernode` — the exact column `_reconcileOrphanedSenders()` reads on the next start to find orphans. The survivor became invisible to the only thing that would ever have cleaned it up, while still holding its portbase for the next session to collide with.

The contract underneath was **inverted**, not just missing, which is why forwarding it verbatim would have been worse than the bug: `killTasking()` returned `false` after a *successful* kill, `!$isRunning` ("was it already dead") from the itemType branch, and fell off the end returning `null` when the process had already exited.

## The fix

`killTasking()` now answers one question in both branches: **is the process gone by the time this returns.**

Getting an honest answer needs a bounded kill, so `_terminateProc()` does SIGTERM to the tree → wait → SIGKILL → wait → report. The wait is not politeness: `proc_close()` **blocks** until the child is reaped, so the old unconditional `proc_close()` straight after `proc_terminate()` did not merely misreport a SIGTERM-proof child, it **wedged the daemon inside the kill** with the unit still showing `active`.

`clearSenderRef()` self-guards on liveness rather than taking a flag, because the manager also calls it from the complete and cancel loops.

## Also in the same path

- `killTasking()` guarded its pipe cleanup on the *outer* `procPipes` array being non-empty rather than on the key it was about to read, so a start-failed task — exactly when `killTask()` is called — still warned `Undefined array key` under PHP 8.
- The itemType branch (image and snapin replicators) bailed out returning `true` whenever its pipe bookkeeping was missing, leaving a live `lftp` running and telling the caller it was gone.
- `cleanupProcList()` called `count()` on keys that may not exist. Under PHP 8 that is a **TypeError, not a warning** — uncaught, in a daemon, so the replicator dies outright and the unit simply stops syncing.

## Testing

`tests/multicast-kill-contract.test.php` drives the shipped methods against **real child processes** — no root, no database, no daemon; `FOGService` is loaded against a stub parent. 28 checks, and the full suite is 28/28 green.

Three mutations were verified caught: reinstating the hardcoded `true`, removing the SIGKILL escalation, and putting `count()` back in `cleanupProcList()`.

Two things the test itself had to learn, both recorded in the file:
- `execve()` publishes `/proc/<pid>/exe` **before** `/proc/<pid>/cmdline`, so a liveness read taken straight after a spawn returns empty for a process that is plainly running — about four spawns in five on this box.
- The SIGTERM-proof case runs in a child interpreter on a wall clock, because a regression there does not *fail*, it *hangs*, and a hang in `run-all.sh` stops the suite rather than reporting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FuR7nCyBFCCLoQh86MyX5