### PR TITLE
fix(pki): keep the imported root when regenerating the web CA chain

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -7361,6 +7361,18 @@ EOF
     chmod 0644 "${outdir}/${certfile}" >>$error_log 2>&1
     return $st
 }
+# Did ${PKI_root_ca_cert} actually issue ${PKI_web_ca_cert}?
+#
+# The one question that separates a FOG-generated Web CA from one imported with
+# --web-ca-cert, which no comparison of PATHS can answer -- the import lands on
+# the same canonical filenames the generator uses. See the call site in
+# createWebIntermediateCA for what regenerating the chain from the wrong root
+# costs.
+_rootIssuedWebCA() {
+    [[ -n ${PKI_root_ca_cert} && -s ${PKI_root_ca_cert} ]] || return 1
+    [[ -n ${PKI_web_ca_cert} && -s ${PKI_web_ca_cert} ]] || return 1
+    openssl verify -trusted "${PKI_root_ca_cert}" "${PKI_web_ca_cert}" >/dev/null 2>&1
+}
 # The Web zone: an intermediate whose leaf is what the vhost serves. Replacing
 # this zone has zero endpoint impact -- browsers just need the root trusted,
 # and fog-client already trusts it, because the root is what it pins.
@@ -7407,8 +7419,35 @@ $(_nameConstraints)" "FOG Web UI"
     if [[ -z ${PKI_web_trust_chain} || ${PKI_web_trust_chain} == "${cadir}/.fogWebCAchain.pem" \
         || ${PKI_web_trust_chain} == "${webdir}/.fogWebCAchain.pem" || ${PKI_web_trust_chain} == "${PKI_root_ca_cert}" ]]; then
         PKI_web_trust_chain="${cadir}/.fogWebCAchain.pem"
-        cat "${PKI_web_ca_cert}" "${PKI_root_ca_cert}" > "${PKI_web_trust_chain}" 2>>$error_log
-        chmod 0644 "${PKI_web_trust_chain}" >>$error_log 2>&1
+        # The root appended has to be the one that actually ISSUED
+        # ${PKI_web_ca_cert}, and the path guard above cannot tell. Under
+        # --web-ca-cert/--web-ca-key/--web-ca-root the Web CA was issued by
+        # ANOTHER server's root, validateExternalCA imports to this exact
+        # canonical path, and it deliberately leaves ${PKI_root_ca_cert}
+        # pointing at THIS server's own root. So every path test says
+        # "FOG-managed default, safe to regenerate" and the cat then replaces
+        # the imported root with one that does not sign the intermediate above
+        # it.
+        #
+        # Nothing complains at the time. The damage surfaces on the NEXT run,
+        # because _resolveTrustAnchor reads its root back out of this file and
+        # _resolveSelfCacert passes the result as --cacert, which REPLACES
+        # curl's bundle -- so backupDB and updateDB both fail with "unable to
+        # get local issuer certificate" while the served chain is perfectly
+        # fine and every external check passes. That combination is what makes
+        # it hard to place: the box can be verified correct from outside and
+        # still be unable to verify itself.
+        #
+        # Checked as a property, not a path, for the same reason _rootFromChain
+        # selects on self-signedness rather than on file order.
+        #
+        # The -s fallback keeps a fresh install working when there is no chain
+        # on disk yet: a chain built from the wrong root is still better than
+        # no chain at all, and that is the pre-existing behaviour.
+        if _rootIssuedWebCA || [[ ! -s ${PKI_web_trust_chain} ]]; then
+            cat "${PKI_web_ca_cert}" "${PKI_root_ca_cert}" > "${PKI_web_trust_chain}" 2>>$error_log
+            chmod 0644 "${PKI_web_trust_chain}" >>$error_log 2>&1
+        fi
     fi
 }
 # The client communication certificate: the public half of the keypair


### PR DESCRIPTION
## Problem

On a multi-server setup using a shared hub root (`docs/MULTI_SERVER_CA.md` Option B), `installfog.sh` fails on **every run after** the one that imported the CA:

```
 * Backing up database.........................................Failed
 * Updating Database...........................................Failed!
curl: (60) SSL certificate problem: unable to get local issuer certificate
```

`createWebIntermediateCA()` decided whether `.fogWebCAchain.pem` was an admin override by testing its **path**. `validateExternalCA` imports `--web-ca-root` to exactly that canonical path, so the guard read "FOG-managed default, safe to regenerate" and rebuilt the file as `${PKI_web_ca_cert}` + `${PKI_root_ca_cert}` — and the import deliberately leaves `${PKI_root_ca_cert}` pointing at *this* server's own root. The supplied root was replaced by one that does not sign the intermediate above it.

Nothing failed at the time. `_resolveTrustAnchor` reads its root back out of that file and `_resolveSelfCacert` passes the result as `--cacert`, which **replaces** curl's bundle — so the failure landed on the next run, as X509 error 20.

## Why it was hard to place

The **served** chain stayed correct throughout. `_writeWebChainFiles` strips self-signed certificates from what the vhost sends, so the wrong root never reached the wire. `openssl verify` against the served chain from another machine returned `OK` while the server could not verify itself. A server can look correct from outside and still be broken.

## Fix

Decide it as a property, not a path — no path test can distinguish an imported chain from a generated one, because both land on the same filename:

```bash
if _rootIssuedWebCA || [[ ! -s ${PKI_web_trust_chain} ]]; then
    cat "${PKI_web_ca_cert}" "${PKI_root_ca_cert}" > "${PKI_web_trust_chain}"
fi
```

Same reasoning as `_rootFromChain` selecting on self-signedness rather than on file order. The `-s` fallback preserves the fresh-install path, where no chain exists on disk yet.

## Verification

Two FOG servers (Ubuntu, Debian) sharing a hub root via `fog-mint-web-ca`:

- **Before:** `sudo ./installfog.sh -y` failed at "Backing up database" on every run after the import; `.fogWebCAchain.pem` terminated in the local root while the intermediate was signed by the hub root.
- **After:** flagless `sudo ./installfog.sh -y` passes on both — `Backing up database: Done`, `Updating Database: OK`, `Verifying database schema: Done` — and the chain still terminates in the hub root afterwards.
- Predicate checked both directions: hub root vs the imported intermediate → `OK`; local root vs the same intermediate → `error 20 unable to get local issuer certificate`.
- On an ordinary single-server install the predicate stays true, so that path regenerates the chain exactly as before.

No route or schema changes, so no OpenAPI or manifest impact.