### PR TITLE
fix(pki): make an imported Web CA actually work on dev-branch

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3753,6 +3753,18 @@ EOF
     chmod 0644 "${outdir}/${certfile}" >>$error_log 2>&1
     return $st
 }
+# Did $rootCAPem actually issue $sslcapem?
+#
+# The one question that separates a FOG-generated Web CA from one imported with
+# --web-ca-cert, which no comparison of PATHS can answer -- the import lands on
+# the same canonical filenames the generator uses. See the call site in
+# createWebIntermediateCA for what regenerating the chain from the wrong root
+# costs.
+_rootIssuedWebCA() {
+    [[ -n $rootCAPem && -s $rootCAPem ]] || return 1
+    [[ -n $sslcapem && -s $sslcapem ]] || return 1
+    openssl verify -trusted "$rootCAPem" "$sslcapem" >/dev/null 2>&1
+}
 # The Web zone: an intermediate whose leaf is what the vhost serves. Replacing
 # this zone has zero endpoint impact -- browsers just need the root trusted,
 # and fog-client already trusts it, because the root is what it pins.
@@ -3794,8 +3806,29 @@ $(_nameConstraints)" "FOG Web UI"
     # sslprivkey/sslpubcert.
     if [[ -z $sslcachain || $sslcachain == "${cadir}/.fogWebCAchain.pem" || $sslcachain == "$rootCAPem" ]]; then
         sslcachain="${cadir}/.fogWebCAchain.pem"
-        cat "$sslcapem" "$rootCAPem" > "$sslcachain" 2>>$error_log
-        chmod 0644 "$sslcachain" >>$error_log 2>&1
+        # The root appended has to be the one that actually ISSUED $sslcapem,
+        # and the path guard above cannot tell. Under
+        # --web-ca-cert/--web-ca-key/--web-ca-root the Web CA was issued by
+        # ANOTHER server's root, validateExternalCA imports to this exact
+        # canonical path, and it deliberately leaves $rootCAPem pointing at
+        # THIS server's own root (see the comment there -- fog-client pins
+        # $rootCAPem, so it must not move). Every path test therefore says
+        # "FOG-managed default, safe to regenerate", and the cat then replaces
+        # the imported root with one that does not sign the intermediate above
+        # it.
+        #
+        # Nothing complains at the time; the file is only read on later runs.
+        # Checked as a property, not a path, because the import and the
+        # generator write the same filename and no path test can separate
+        # them.
+        #
+        # The -s fallback keeps a fresh install working when there is no chain
+        # on disk yet: a chain built from the wrong root is still better than
+        # no chain at all, and that is the pre-existing behaviour.
+        if _rootIssuedWebCA || [[ ! -s $sslcachain ]]; then
+            cat "$sslcapem" "$rootCAPem" > "$sslcachain" 2>>$error_log
+            chmod 0644 "$sslcachain" >>$error_log 2>&1
+        fi
     fi
 }
 # The client communication certificate: the public half of the keypair

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4022,23 +4022,52 @@ _createWebLeaf() {
     # well-formed certificate that no client will accept. Left undetected it
     # surfaces as a browser error days later with nothing connecting it to the
     # rename.
-    if [[ -n $sslcachain && -e $sslcachain ]] && \
-        ! openssl verify -CAfile "$rootCAPem" -untrusted "$sslcachain" "$sslpubcert" >>$error_log 2>&1; then
+    #
+    # Verified against the root the CHAIN terminates in, not against
+    # $rootCAPem. Under --web-ca-* the leaf chains to the OTHER server's root
+    # while $rootCAPem is still this server's own -- validateExternalCA never
+    # reassigns it -- so the old form failed on every external-CA install and
+    # printed the box below unconditionally, telling the admin to delete a Web
+    # zone that was working correctly.
+    local vtmp vroot=""
+    vtmp=$(mktemp -d 2>>$error_log)
+    if [[ -n $vtmp && -n $sslcachain && -e $sslcachain ]]; then
+        _rootFromChain "$sslcachain" > "${vtmp}/root.pem" 2>>$error_log
+        if [[ -s ${vtmp}/root.pem ]]; then
+            vroot="${vtmp}/root.pem"
+        elif [[ -n $rootCAPem && -f $rootCAPem ]]; then
+            # A chain carrying no root of its own. FOG's is the only anchor
+            # available, and for a FOG-issued leaf it is also the right one.
+            vroot="$rootCAPem"
+        fi
+    fi
+    if [[ -n $vroot ]] && \
+        ! openssl verify -CAfile "$vroot" -untrusted "$sslcachain" "$sslpubcert" >>$error_log 2>&1; then
         echo
         echo "  ###################################################################"
         echo "  # WARNING: the web certificate does not verify against the CA     #"
-        echo "  # that issued it. The usual cause is a name outside that CA's     #"
-        echo "  # name constraints -- this server was renamed, or gained an       #"
-        echo "  # --extra-server-name, after the CA was created.                  #"
-        echo "  #                                                                 #"
-        echo "  # Re-run with the name permitted:                                 #"
-        echo "  #   --internal-domain <domain>                                    #"
-        echo "  # A CA is never re-issued once it exists, so also remove it so    #"
-        echo "  # the new constraints take effect:                                #"
-        echo "  #   rm -rf $(_pkiZoneDir web)"
+        echo "  # that issued it.                                                 #"
+        if [[ $externalca == yes ]]; then
+            echo "  #                                                                 #"
+            echo "  # This server uses an external CA, so check that the leaf, the    #"
+            echo "  # intermediate and the root you supplied really belong together:  #"
+            echo "  #   --web-ca-cert / --web-ca-key / --web-ca-root                  #"
+            echo "  # Nothing under the FOG PKI tree needs removing for this.         #"
+        else
+            echo "  # The usual cause is a name outside that CA's name constraints    #"
+            echo "  # -- this server was renamed, or gained an --extra-server-name,   #"
+            echo "  # after the CA was created.                                       #"
+            echo "  #                                                                 #"
+            echo "  # Re-run with the name permitted:                                 #"
+            echo "  #   --internal-domain <domain>                                    #"
+            echo "  # A CA is never re-issued once it exists, so also remove it so    #"
+            echo "  # the new constraints take effect:                                #"
+            echo "  #   rm -rf $(_pkiZoneDir web)"
+        fi
         echo "  ###################################################################"
         echo
     fi
+    [[ -n $vtmp ]] && rm -rf "$vtmp" >>$error_log 2>&1
     return 0
 }
 # Put the PKI private keys back under root's control, and keep them there.
@@ -4126,6 +4155,88 @@ _caTrustLayout() {
 # Sets $selfCacertOpts, which callers splice in as "${selfCacertOpts[@]}". Empty
 # when there is nothing to anchor, or when the install is serving plain HTTP --
 # which is the default here, so on most installs this is a no-op and the calls
+# Split a PEM bundle into one file per certificate, c1.pem upward, in $2.
+_splitPemBundle() {
+    local src="$1" dir="$2" f found=1
+    [[ -n $src && -f $src && -n $dir && -d $dir ]] || return 1
+    awk -v d="$dir" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' \
+        "$src" 2>>$error_log
+    for f in "$dir"/c*.pem; do
+        [[ -f $f ]] && { found=0; break; }
+    done
+    return $found
+}
+# The self-signed certificate in a chain file, on stdout. That is the root, and
+# it is the only member of the bundle whose identity does not depend on the
+# file's ORDER -- the writers disagree about order (validateExternalCA writes
+# the root first, createWebIntermediateCA appends it last), so selecting on the
+# property is the only way to read either.
+_rootFromChain() {
+    local bundle="$1" tmpd f subj issuer st=1
+    [[ -n $bundle && -f $bundle ]] || return 1
+    tmpd=$(mktemp -d) || return 1
+    if _splitPemBundle "$bundle" "$tmpd"; then
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            subj=$(openssl x509 -in "$f" -noout -subject 2>/dev/null)
+            issuer=$(openssl x509 -in "$f" -noout -issuer 2>/dev/null)
+            [[ -z $subj ]] && continue
+            # -subject prints "subject=..." and -issuer "issuer=...", so compare
+            # the values rather than the whole line.
+            if [[ ${subj#subject=} == "${issuer#issuer=}" ]]; then
+                cat "$f"
+                st=0
+                break
+            fi
+        done
+    fi
+    rm -rf "$tmpd" >>$error_log 2>&1
+    return $st
+}
+# Every root this server should accept for its OWN web certificate, in one
+# file, and $trustAnchorPem naming it.
+#
+# Both roots, not one: $rootCAPem is what _installCATrustAnchor puts in the
+# system store and what fog-client pins, while the root the served leaf
+# actually chains to may be a DIFFERENT one entirely -- that is exactly the
+# case under --web-ca-cert/--web-ca-key/--web-ca-root, where another server's
+# root issued this server's Web CA and $rootCAPem is deliberately left alone.
+# Anchoring on $rootCAPem by itself was therefore wrong on every external-CA
+# install, and wrong in the silent direction: wget's --ca-certificate REPLACES
+# the default bundle, so naming the local root does not add trust, it removes
+# the only trust that would have worked.
+#
+# Deduplicated on fingerprint, not on path: on an ordinary FOG install these
+# are the same certificate reached two ways, and appending it twice is
+# pointless noise in a file an admin may well end up reading.
+_resolveTrustAnchor() {
+    trustAnchorPem=""
+    local out="$(_pkiZoneDir web)/ca/.trustAnchor.pem"
+    local chainroot fp seen=""
+    mkdir -p "$(dirname "$out")" >>$error_log 2>&1
+    : > "$out" 2>>$error_log || return 1
+
+    if [[ -n $rootCAPem && -f $rootCAPem ]]; then
+        fp=$(openssl x509 -in "$rootCAPem" -noout -fingerprint -sha256 2>/dev/null)
+        if [[ -n $fp ]]; then
+            cat "$rootCAPem" >> "$out" 2>>$error_log
+            seen="$fp"
+        fi
+    fi
+    if [[ -n $sslcachain && -f $sslcachain ]]; then
+        chainroot=$(_rootFromChain "$sslcachain")
+        if [[ -n $chainroot ]]; then
+            fp=$(printf '%s\n' "$chainroot" \
+                | openssl x509 -noout -fingerprint -sha256 2>/dev/null)
+            if [[ -n $fp && $fp != "$seen" ]]; then
+                printf '%s\n' "$chainroot" >> "$out" 2>>$error_log
+            fi
+        fi
+    fi
+    [[ -s $out ]] || return 1
+    trustAnchorPem="$out"
+    return 0
+}
 # are unchanged. When it is empty the tool verifies against the system store,
 # which is the right answer for a certificate from a public CA.
 #
@@ -4154,8 +4265,11 @@ _caTrustLayout() {
 _resolveSelfCacert() {
     selfCacertOpts=()
     [[ $httpproto == https ]] || return 0
-    [[ -n $rootCAPem && -s $rootCAPem ]] || return 0
-    selfCacertOpts=(--ca-certificate="$rootCAPem")
+    # The chain's own root as well as $rootCAPem -- see _resolveTrustAnchor for
+    # why naming $rootCAPem alone broke every --web-ca-* install.
+    _resolveTrustAnchor >>$error_log 2>&1 || return 0
+    [[ -s $trustAnchorPem ]] || return 0
+    selfCacertOpts=(--ca-certificate="$trustAnchorPem")
 }
 _installCATrustAnchor() {
     local anchor="$rootCAPem" st=0

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -22,8 +22,14 @@
 #      that has no users yet, and --no-check-certificate handed it to whoever
 #      answered on that address. These cannot simply drop the flag, because
 #      they run before _installCATrustAnchor() has taught the system store
-#      about FOG's CA -- hence _resolveSelfCacert(), which names $rootCAPem
-#      directly.
+#      about FOG's CA -- hence _resolveSelfCacert(), which names a resolved
+#      anchor file directly. That anchor is $rootCAPem AND the root the served
+#      chain terminates in: under --web-ca-cert/--web-ca-key/--web-ca-root
+#      those are two DIFFERENT certificates, and naming $rootCAPem alone
+#      anchored on a root that does not sign the leaf. wget's
+#      --ca-certificate replaces the default bundle rather than adding to it,
+#      so that did not merely fail to help, it removed the only trust that
+#      would have worked.
 #   C. The node/master bootstrap -- registerStorageNode() and
 #      updateStorageNodeCredentials(). A genuine chicken-and-egg: on a fresh
 #      storage node they run BEFORE _installCATrustAnchor(), so there is no
@@ -174,10 +180,25 @@ if printf '%s' "$helper" | grep -q -- '--ca-certificate'; then
 else
     bad "_resolveSelfCacert does not pass --ca-certificate -- it is not anchoring anything"
 fi
-if printf '%s' "$helper" | grep -q 'rootCAPem'; then
-    ok "_resolveSelfCacert anchors on \$rootCAPem, the same file _installCATrustAnchor uses"
+if printf '%s' "$helper" | grep -q '_resolveTrustAnchor'; then
+    ok "_resolveSelfCacert anchors on the resolved trust anchor"
 else
-    bad "_resolveSelfCacert does not read \$rootCAPem"
+    bad "_resolveSelfCacert does not call _resolveTrustAnchor -- nothing resolves the chain's root"
+fi
+# Pin the RESOLVER's definition too, not just that the helper calls it. A
+# _resolveTrustAnchor rewritten to emit $rootCAPem alone would satisfy the
+# assertion above while restoring the whole bug, silently, on every
+# external-CA install.
+resolver=$(body _resolveTrustAnchor "$FUNCS")
+if printf '%s' "$resolver" | grep -q 'rootCAPem'; then
+    ok "_resolveTrustAnchor includes \$rootCAPem, the file _installCATrustAnchor uses"
+else
+    bad "_resolveTrustAnchor does not read \$rootCAPem"
+fi
+if printf '%s' "$resolver" | grep -q 'sslcachain'; then
+    ok "_resolveTrustAnchor also includes the root the served chain ends in"
+else
+    bad "_resolveTrustAnchor does not read \$sslcachain -- an imported Web CA would not verify"
 fi
 if printf '%s' "$helper" | grep -qE -- '--insecure|--no-check-certificate|(^|[[:space:]])-[a-zA-Z]*k[a-zA-Z]*([[:space:]]|$)'; then
     bad "_resolveSelfCacert hands back an insecure flag"
@@ -257,12 +278,54 @@ if command -v openssl >/dev/null 2>&1; then
         -keyout "$tmp/ca.key" -out "$tmp/ca.pem" \
         -subj "/CN=fog-tls-gate-test" >/dev/null 2>&1
     rootCAPem="$tmp/ca.pem"
+    # _resolveTrustAnchor writes under $(_pkiZoneDir web), so the zone has to
+    # live somewhere writable for the duration of the test.
+    fogprogramdir="$tmp/fog"
+    anchor="$tmp/fog/pki/web/ca/.trustAnchor.pem"
+    sslcachain=""
     selfCacertOpts=()
     _resolveSelfCacert
-    if [[ ${#selfCacertOpts[@]} -eq 1 && ${selfCacertOpts[0]} == "--ca-certificate=$tmp/ca.pem" ]]; then
-        ok "https with a root on disk: --ca-certificate points at it"
+    if [[ ${#selfCacertOpts[@]} -eq 1 && ${selfCacertOpts[0]} == "--ca-certificate=$anchor" ]]; then
+        ok "https with a root on disk: --ca-certificate points at the anchor"
     else
         bad "https with a root on disk: got '${selfCacertOpts[*]}'"
+    fi
+    if [[ $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null) -eq 1 ]]; then
+        ok "no separate chain root: the anchor holds exactly one certificate"
+    else
+        bad "no separate chain root: anchor holds $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null), expected 1"
+    fi
+
+    # The regression this whole change exists for: an imported Web CA, whose
+    # chain terminates in ANOTHER server's root. Both roots must reach the
+    # anchor, or the server cannot verify its own certificate and backupDB and
+    # the schema deploy fail with "unable to get local issuer certificate".
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+        -keyout "$tmp/hub.key" -out "$tmp/hub.pem" \
+        -subj "/CN=fog-tls-gate-hub" >/dev/null 2>&1
+    cat "$tmp/hub.pem" > "$tmp/chain.pem"
+    sslcachain="$tmp/chain.pem"
+    selfCacertOpts=()
+    _resolveSelfCacert
+    if [[ $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null) -eq 2 ]]; then
+        ok "imported Web CA: the anchor holds the local root AND the chain's"
+    else
+        bad "imported Web CA: anchor holds $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null), expected 2"
+    fi
+    if openssl verify -CAfile "$anchor" "$tmp/hub.pem" >/dev/null 2>&1; then
+        ok "imported Web CA: the foreign root verifies against the anchor"
+    else
+        bad "imported Web CA: the foreign root does not verify against the anchor"
+    fi
+
+    # Same certificate reached two ways must not be listed twice.
+    cat "$tmp/ca.pem" > "$tmp/chain.pem"
+    selfCacertOpts=()
+    _resolveSelfCacert
+    if [[ $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null) -eq 1 ]]; then
+        ok "chain root == \$rootCAPem: deduplicated to one certificate"
+    else
+        bad "chain root == \$rootCAPem: anchor holds $(grep -c 'BEGIN CERTIFICATE' "$anchor" 2>/dev/null), expected 1"
     fi
 else
     echo "  SKIP  openssl absent, cannot build a throwaway CA"


### PR DESCRIPTION
Port of #1302 (working-1.6), plus the two adjacent defects that stopped the port being user-visible on its own. Three commits, each independently reviewable.

All three were **verified present on this branch** before changing anything.

## 1. The chain clobber (the port)

`createWebIntermediateCA()` decided whether `.fogWebCAchain.pem` was an admin override by testing its **path**. `validateExternalCA` imports `--web-ca-root` to exactly that canonical path, so the guard read "FOG-managed default, safe to regenerate" and rebuilt the file as `$sslcapem` + `$rootCAPem` — replacing the supplied root with one that does not sign the intermediate above it.

Decided as a property now: only rebuild from `$rootCAPem` when that root actually issued `$sslcapem`. The import and the generator write the same filename, so no path test can separate them. The `-s` fallback preserves the fresh-install path.

## 2. `_resolveSelfCacert()` named `$rootCAPem` directly

Under an imported Web CA the served leaf chains to *another* server's root, while `$rootCAPem` is deliberately left pointing at this server's own — fog-client pins it, so it must not move. wget's `--ca-certificate` **replaces** the default bundle, so naming the local root did not add trust, it removed the only trust that would have worked. `backupDB` and the schema deploy both failed with `unable to get local issuer certificate`.

Adds `_resolveTrustAnchor()`, which writes both roots to one file, deduplicated on fingerprint so an ordinary install still gets exactly one. Backported from `working-1.6` with the `_rootFromChain`/`_splitPemBundle` pair it needs — `_rootFromChain` selects the self-signed member rather than a fixed position, because the two writers disagree about order.

## 3. The post-issue leaf check used the same wrong root

`openssl verify -CAfile "$rootCAPem" …` warned on **every** external-CA install, and the warning told the admin to `rm -rf` a Web zone that was working correctly. Now anchored on the chain's root, with a message that says something useful when `$externalca` is set instead of blaming name constraints.

## Verification

The 1.5 lab servers here allow no privileged execution, so this was **not** run through a full install on this branch. The real functions were extracted from this checkout with `awk` and driven against certificate fixtures, so what is tested is the shipped code rather than a copy:

```
_rootFromChain chain_int_first.pem              PASS
_rootFromChain chain_root_first.pem             PASS   (order must not matter)
anchor cert count (imported)                    PASS   2
leaf verifies vs anchor (imported)              PASS
OLD behaviour would have failed                 PASS   nonzero
anchor cert count (ordinary, deduped)           PASS   1
leaf verifies vs anchor (ordinary)              PASS
selfCacertOpts uses anchor                      PASS
plain http -> no opts                           PASS
leaf-verify anchored on chain root              PASS
  ...and still catches a real mismatch          PASS   nonzero
```

And for the clobber, patched vs unpatched:

| case | want | patched | unpatched |
|---|---|---|---|
| Web CA from a foreign root, correct chain on disk | foreign | foreign ✅ | **local ❌** |
| ordinary Web CA from the local root | local | local ✅ | local ✅ |
| fresh install, no chain | local | local ✅ | local ✅ |

The equivalent of change 1 on `working-1.6` (#1302) **was** verified end to end, on two servers sharing a hub root: repeated flagless `installfog.sh -y` runs pass and the chain still terminates in the hub root afterwards.

Two fixture traps worth recording, both of which produced a false PASS first time round:
- `openssl verify` exits **2** on an unknown issuer, not 1 — assert non-zero.
- Two intermediates minted from the same CSR/key are interchangeable to OpenSSL (issuer matched on name + key), so a "should fail" case built that way passes. A negative fixture needs its own key.