### PR TITLE
fix(snapinhash): stop saving a hash for a file that is not there

### DIFF
--- a/packages/web/lib/service/snapinhash.class.php
+++ b/packages/web/lib/service/snapinhash.class.php
@@ -188,6 +188,30 @@ class SnapinHash extends FOGService
                         $path,
                         $file
                     );
+                    // ImageSize has had this guard for years; SnapinHash
+                    // never grew it. Without it hash_file() on a file that
+                    // is not there -- deleted, or storage unmounted when
+                    // the pass ran -- returns FALSE with a warning, and
+                    // false was then SAVED as the hash. A client comparing
+                    // against an empty hash fails the snapin every time,
+                    // with nothing in the log to say why. Blanking both
+                    // columns says the file is not currently there, which
+                    // is true, and the next pass repairs it.
+                    if (!file_exists($filepath) || !is_readable($filepath)) {
+                        self::outall(
+                            sprintf(
+                                '| %s: %s',
+                                $Snapin->get('name'),
+                                _('Path is unavailable')
+                            )
+                        );
+                        $Snapin
+                            ->set('hash', '')
+                            ->set('size', 0)
+                            ->save();
+                        unset($path, $file);
+                        continue;
+                    }
                     self::outall(
                         sprintf(
                             ' * %s: %s.',

--- a/tests/fixtures/snapinhash-transcript.txt
+++ b/tests/fixtures/snapinhash-transcript.txt
@@ -1,0 +1,41 @@
+=== SnapinHash :: globally disabled ===
+log=/var/log/fogcustom/fogsnapinhash.log dev=/dev/tty6 zzz=1800
+   *  * Snapin hash is globally disabled
+  [serviceRun end]
+
+=== SnapinHash :: nothing primary to this group ===
+log=/var/log/fogcustom/fogsnapinhash.log dev=/dev/tty6 zzz=1800
+   * Starting Snapin Hashing Service.
+   * We are group ID: 3. We are group name: GroupOne
+   * We are node ID: 7. We are node name: NodeSeven
+   * Finding any snapins associated with this group as its primary group
+  [getSubObjectIDs SnapinGroupAssociation field=snapinID]
+  [count SnapinManager]
+   * No snapins associated with this group as master.
+   * Completed.
+  [serviceRun end]
+
+=== SnapinHash :: one file present, one missing ===
+log=/var/log/fogcustom/fogsnapinhash.log dev=/dev/tty6 zzz=1800
+   * Starting Snapin Hashing Service.
+   * We are group ID: 3. We are group name: GroupOne
+   * We are node ID: 7. We are node name: NodeSeven
+   * Finding any snapins associated with this group as its primary group
+  [getSubObjectIDs SnapinGroupAssociation field=snapinID]
+  [count SnapinManager]
+   * Found 2 snapins to update hash values as needed.
+  [find SnapinManager]
+   * Trying Snapin hash for: snapin11, ID: 11
+   * Getting snapin hash and size for: snapin11.
+   | Hash: a9dfcf1fb9a20e928fb6dda0254594db64fd2ed627cc56c5419fa11df4ece59f36bdab465b121c2a35ec5e3e2a94aedc8cf5fbdbc8bc1ea043a551af9adf0a41
+  [set Snapin#11 hash='<128 hex chars>']
+  [set Snapin#11 size=3]
+  [save Snapin#11]
+   * Trying Snapin hash for: snapin22, ID: 22
+  | snapin22: Path is unavailable
+  [set Snapin#22 hash='']
+  [set Snapin#22 size=0]
+  [save Snapin#22]
+   * Completed.
+  [serviceRun end]
+

--- a/tests/lib/snapinhash-transcript.php
+++ b/tests/lib/snapinhash-transcript.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Runs SnapinHash against stubs and prints everything it would do.
+ *
+ * SnapinHash is a daemon with no coverage, and the thing worth pinning is
+ * not what it logs but what it WRITES BACK: hash_file() on a file that is
+ * not there returns false, and false being saved as a snapin's hash is
+ * invisible in every log and fatal to every client that compares against it.
+ * Every set()/save() is therefore recorded.
+ *
+ * Takes a directory so the same harness can be pointed at an older copy of
+ * the daemon out of git and the two transcripts diffed directly.
+ *
+ * Usage: php tests/lib/snapinhash-transcript.php [<dir>]
+ */
+
+if (!function_exists('_')) {
+    /**
+     * Stands in for ext-gettext when it is absent.
+     *
+     * @param string $msgid The message.
+     *
+     * @return string
+     */
+    function _($msgid)
+    {
+        return $msgid;
+    }
+}
+
+define('FOG_LOG_DIR', '/var/log/fog/');
+define('DS', '/');
+
+/**
+ * Scenario state, read by the stubs below.
+ */
+class Scenario
+{
+    public static $enabled = 1;
+    public static $snapinIDs = array();
+    public static $files = array();
+    public static $dir = '';
+    public static $out = array();
+}
+
+/**
+ * Records reads and writes against a row.
+ */
+class RowStub
+{
+    private $_kind = '';
+    private $_data = array();
+    /**
+     * Builds the stub.
+     *
+     * @param string $kind The record type.
+     * @param array  $data The fields.
+     */
+    public function __construct($kind, $data = array())
+    {
+        $this->_kind = $kind;
+        $this->_data = $data;
+    }
+    /**
+     * Reads a field.
+     *
+     * @param string $key The field.
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        return isset($this->_data[$key]) ? $this->_data[$key] : '';
+    }
+    /**
+     * Records a field write.
+     *
+     * @param string $key   The field.
+     * @param mixed  $value The value.
+     *
+     * @return RowStub
+     */
+    public function set($key, $value)
+    {
+        // Hashes are recorded by length so the transcript does not depend
+        // on the contents of a fixture file.
+        if ('hash' === $key && is_string($value) && strlen($value) > 16) {
+            $value = sprintf('<%d hex chars>', strlen($value));
+        }
+        Scenario::$out[] = sprintf(
+            '[set %s#%d %s=%s]',
+            $this->_kind,
+            (int)$this->get('id'),
+            $key,
+            var_export($value, true)
+        );
+        return $this;
+    }
+    /**
+     * Records the save.
+     *
+     * @return RowStub
+     */
+    public function save()
+    {
+        Scenario::$out[] = sprintf(
+            '[save %s#%d]',
+            $this->_kind,
+            (int)$this->get('id')
+        );
+        return $this;
+    }
+    /**
+     * Returns this node's storage group.
+     *
+     * @return RowStub
+     */
+    public function getStorageGroup()
+    {
+        return new RowStub('StorageGroup', array('id' => 3, 'name' => 'GroupOne'));
+    }
+}
+
+/**
+ * Stands in for SnapinManager.
+ */
+class ManagerStub
+{
+    /**
+     * Counts matching rows.
+     *
+     * @param array $find The filter.
+     *
+     * @return int
+     */
+    public function count($find = array())
+    {
+        Scenario::$out[] = '[count SnapinManager]';
+        return count(Scenario::$snapinIDs);
+    }
+    /**
+     * Returns matching rows.
+     *
+     * @param array $find The filter.
+     *
+     * @return array
+     */
+    public function find($find = array())
+    {
+        Scenario::$out[] = '[find SnapinManager]';
+        $rows = array();
+        foreach (Scenario::$snapinIDs as $id) {
+            $rows[] = new RowStub(
+                'Snapin',
+                array(
+                    'id' => $id,
+                    'name' => 'snapin' . $id,
+                    'file' => isset(Scenario::$files[$id])
+                        ? Scenario::$files[$id]
+                        : 'missing' . $id
+                )
+            );
+        }
+        return $rows;
+    }
+}
+
+/**
+ * Stands in for the real service base.
+ */
+abstract class FOGService
+{
+    public static $sleeptime = '';
+    public static $logpath = '/var/log/fogcustom/';
+    public static $log = '';
+    public static $dev = '';
+    public static $zzz = 0;
+    /**
+     * Builds the stub.
+     */
+    public function __construct()
+    {
+    }
+    /**
+     * Returns fixture settings.
+     *
+     * @param mixed $keys One key or a list of them.
+     *
+     * @return mixed
+     */
+    public static function getSetting($keys)
+    {
+        if (is_array($keys)) {
+            return array('', '', '');
+        }
+        if (false !== strpos((string)$keys, 'GLOBALENABLED')) {
+            return Scenario::$enabled;
+        }
+        return '';
+    }
+    /**
+     * Returns a manager stub.
+     *
+     * @param string $class The class.
+     *
+     * @return ManagerStub
+     */
+    public static function getClass($class)
+    {
+        return new ManagerStub();
+    }
+    /**
+     * Returns the associated ids.
+     *
+     * @param string $class The class.
+     * @param array  $find  The filter.
+     * @param string $field The field.
+     *
+     * @return array
+     */
+    public static function getSubObjectIDs($class, $find = array(), $field = '')
+    {
+        Scenario::$out[] = sprintf('[getSubObjectIDs %s field=%s]', $class, $field);
+        return Scenario::$snapinIDs;
+    }
+    /**
+     * Returns a deterministic size.
+     *
+     * @param string $path The file.
+     *
+     * @return int
+     */
+    public static function getFilesize($path)
+    {
+        return (int)@filesize($path);
+    }
+    /**
+     * Records a line.
+     *
+     * @param string $string The line.
+     *
+     * @return void
+     */
+    public static function outall($string)
+    {
+        Scenario::$out[] = $string;
+    }
+    /**
+     * Returns the nodes this host masters.
+     *
+     * @return array
+     */
+    protected function checkIfNodeMaster()
+    {
+        return array(
+            new RowStub(
+                'StorageNode',
+                array(
+                    'id' => 7,
+                    'name' => 'NodeSeven',
+                    'storagegroupID' => 3,
+                    'snapinpath' => Scenario::$dir
+                )
+            )
+        );
+    }
+    /**
+     * Ends the pass.
+     *
+     * @return void
+     */
+    public function serviceRun()
+    {
+        Scenario::$out[] = '[serviceRun end]';
+    }
+}
+
+$dir = isset($argv[1]) ? $argv[1] : (dirname(dirname(__DIR__)) . '/packages/web/lib/service');
+require_once $dir . '/snapinhash.class.php';
+
+// One file that is really there and one that is not. The missing one is the
+// whole point.
+$tmp = sys_get_temp_dir() . '/fog-snapinhash-' . getmypid();
+@mkdir($tmp, 0700, true);
+file_put_contents($tmp . '/present.bin', 'fog');
+Scenario::$dir = $tmp;
+
+$scenarios = array(
+    'globally disabled' => array(
+        'enabled' => 0
+    ),
+    'nothing primary to this group' => array(
+        'snapinIDs' => array()
+    ),
+    'one file present, one missing' => array(
+        'snapinIDs' => array(11, 22),
+        'files' => array(11 => 'present.bin', 22 => 'gone.bin')
+    )
+);
+
+foreach ($scenarios as $name => $state) {
+    Scenario::$enabled = 1;
+    Scenario::$snapinIDs = array();
+    Scenario::$files = array();
+    Scenario::$out = array();
+    foreach ($state as $key => $value) {
+        Scenario::${$key} = $value;
+    }
+    $svc = new SnapinHash();
+    printf("=== SnapinHash :: %s ===\n", $name);
+    printf("log=%s dev=%s zzz=%s\n", $svc::$log, $svc::$dev, $svc::$zzz);
+    $svc->serviceRun();
+    foreach (Scenario::$out as $line) {
+        echo '  ' . str_replace($tmp, '<dir>', $line) . "\n";
+    }
+    echo "\n";
+}
+
+@unlink($tmp . '/present.bin');
+@rmdir($tmp);

--- a/tests/snapinhash-missing-file.test.php
+++ b/tests/snapinhash-missing-file.test.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * SnapinHash must not save a hash for a file that is not there.
+ *
+ * ImageSize has checked file_exists()/is_readable() before touching the file
+ * for years, and records a zero when it is gone. SnapinHash never grew that
+ * guard, so it went straight into hash_file() -- which returns FALSE with a
+ * warning for a missing file -- and false was then SAVED as the hash.
+ *
+ * The consequence is entirely invisible from the server side. The daemon
+ * logs " | Hash: " with nothing after it and moves on; the record now holds
+ * an empty hash; and every client that downloads that snapin compares its
+ * own sha512 against the empty string and fails the deployment, with
+ * nothing anywhere saying why. It is reachable any time a snapin file is
+ * deleted behind FOG's back, or the storage is unmounted when a pass runs.
+ *
+ * This replays the whole daemon against stubs -- no database, no storage
+ * node -- and compares it byte for byte with a recorded transcript. Every
+ * set() and save() is in that transcript, because what gets WRITTEN is the
+ * thing that matters here, not what gets logged.
+ *
+ * tests/lib/snapinhash-transcript.php takes a directory, so the pre-fix
+ * daemon can be run against the same stubs:
+ *
+ *   git show <before>:packages/web/lib/service/snapinhash.class.php \
+ *     > /tmp/old/snapinhash.class.php
+ *   php tests/lib/snapinhash-transcript.php /tmp/old
+ *
+ * which prints the hash_file() warning and `[set Snapin#22 hash=false]`.
+ * Do not edit the fixture until you have done that and satisfied yourself
+ * the difference is one you meant.
+ *
+ * Usage: php tests/snapinhash-missing-file.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$harness = $root . '/tests/lib/snapinhash-transcript.php';
+$fixture = $root . '/tests/fixtures/snapinhash-transcript.txt';
+
+$failures = array();
+$checks = 0;
+
+$checks++;
+if (!is_readable($fixture)) {
+    $failures[] = 'no recorded transcript at ' . $fixture;
+} else {
+    $got = (string)shell_exec(
+        sprintf(
+            '%s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($harness)
+        )
+    );
+    $want = (string)file_get_contents($fixture);
+    if ($got !== $want) {
+        $gotLines = explode("\n", $got);
+        $wantLines = explode("\n", $want);
+        $detail = array();
+        foreach ($wantLines as $i => $line) {
+            if (isset($gotLines[$i]) && $gotLines[$i] === $line) {
+                continue;
+            }
+            $detail[] = sprintf(
+                "      line %d\n        expected: %s\n        got:      %s",
+                $i + 1,
+                $line,
+                isset($gotLines[$i]) ? $gotLines[$i] : '<end of output>'
+            );
+            if (count($detail) >= 5) {
+                break;
+            }
+        }
+        $failures[] = "transcript changed:\n" . implode("\n", $detail);
+    }
+}
+
+// The two specific things that must never come back, stated directly so a
+// reader of a failure knows what the transcript was protecting.
+$checks++;
+$src = (string)file_get_contents(
+    $root . '/packages/web/lib/service/snapinhash.class.php'
+);
+// Comments are stripped first. The guard carries an explanation that names
+// hash_file(), and a non-greedy match from $filepath to the first
+// "hash_file" otherwise stops inside that comment -- so the assertion fails
+// on correct code, for the same reason the installer guard test had to do
+// this: the prose describing a fix looks exactly like the code it replaced.
+$src = preg_replace('#^\s*//.*$#m', '', $src);
+$guarded = false;
+if (preg_match('/\$filepath = sprintf\(.*?hash_file/s', $src, $m)) {
+    $guarded = false !== strpos($m[0], 'file_exists($filepath)')
+        && false !== strpos($m[0], 'is_readable($filepath)');
+}
+if (!$guarded) {
+    $failures[] = 'hash_file() is reached without a file_exists/is_readable guard';
+}
+
+$checks++;
+if (false === strpos($src, "->set('hash', '')")) {
+    $failures[] = 'a missing file no longer blanks the stored hash';
+}
+
+if (count($failures)) {
+    fwrite(STDERR, sprintf("FAIL (%d of %d)\n", count($failures), $checks));
+    foreach ($failures as $failure) {
+        fwrite(STDERR, '  - ' . $failure . "\n");
+    }
+    exit(1);
+}
+
+printf("ok  %d checks passed\n", $checks);
+exit(0);


### PR DESCRIPTION
`ImageSize` has checked `file_exists()`/`is_readable()` before touching the file for years, and records a zero when it is gone. **`SnapinHash` never grew that guard.** It goes straight into `hash_file()`, which returns `false` with a warning for a missing file — and `false` is then **saved as the snapin's hash**.

Nothing about that is visible from the server. The daemon logs `| Hash: ` with nothing after it and carries on; the record holds an empty hash; and every client that downloads that snapin compares its own sha512 against the empty string, fails the deployment, and says nothing that points back here. Reachable any time a snapin file is deleted behind FOG's back, or the storage is unmounted when a pass runs — and once it has happened the record stays wrong, because the next pass overwrites the empty hash with another empty hash.

The guard now matches `ImageSize`'s, and a missing file blanks both `hash` and `size` rather than recording a `false`. Blank says "not currently there", which is true, and the next pass repairs it once the file is back.

## Scope

Found while surveying the daemons on `working-1.6`, where the same asymmetry exists and was fixed by giving `ImageSize` and `SnapinHash` a shared body (0b583bb2b). **That refactor is deliberately not ported here** — this is the maintenance line, 1.5 uses the older `Manager`/`->get()` API throughout so it would not port cleanly, and restructuring four daemons on a stable branch is risk with no user-visible benefit. The bug is user-visible, so the bug is what ports.

## Testing

`tests/lib/snapinhash-transcript.php` replays the whole daemon against stubs — no database, no storage node — recording every log line **and every `set()`/`save()`**, because what gets written is the thing that matters here.

It takes a directory, so the pre-fix daemon runs against the same stubs and the transcripts diff directly. Doing that prints the bug as output rather than as an argument:

```
-PHP Warning:  hash_file(.../gone.bin): Failed to open stream: No such file or directory
-   * Getting snapin hash and size for: snapin22.
-   | Hash:
-  [set Snapin#22 hash=false]
+  | snapin22: Path is unavailable
+  [set Snapin#22 hash='']
   [set Snapin#22 size=0]
   [save Snapin#22]
```

Three mutations checked, all three caught: reverting the file, keeping the guard but writing `false` anyway, and dropping `is_readable()` from it. Suite is 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FuR7nCyBFCCLoQh86MyX5