### PR TITLE
fix(session): give FOG its own PHP session store so GC stops reaping logins (1.5 port)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -924,6 +924,31 @@ installFOGServices() {
     # Outside the dots/errorStat pair, like every other caller, and the _rw_
     # label is as load-bearing here as it is for fos above (GH-964).
     setSELinuxContext "$servicelogs/faults" httpd_sys_rw_content_t
+    # FOG's own PHP session store (FOG_SESSION_DIR in commons/init.php, which
+    # points session.save_path here at runtime). FOG used to share the distro's
+    # session directory, where session.gc_maxlifetime is 1440 -- 24 minutes on
+    # every distro we support -- so PHP reaped the session file long before
+    # FOG_INACTIVITY_TIMEOUT said to, and the user was silently bounced to the
+    # login page. gc_maxlifetime applies to the whole save_path, so FOG cannot
+    # raise it without imposing its retention on every other PHP application on
+    # the box. Hence a private directory.
+    dots "Creating FOG session directory"
+    mkdir -p $fogprogramdir/sessions >>$error_log 2>&1
+    # 0700 and owned by the pool user -- stricter than the 0750 above, because
+    # a session file IS an authentication token: anything that can read this
+    # directory can resume an admin session, and unlike the fault log there is
+    # no second writer to accommodate. Safe as a single-owner directory because
+    # the php-fpm pool is pinned to $apacheuser further down this same install
+    # (the `user = ${apacheuser}` rewrite in the pool file), which is the same
+    # variable used here.
+    chown ${apacheuser}:${apacheuser} $fogprogramdir/sessions >>$error_log 2>&1
+    chmod 0700 $fogprogramdir/sessions >>$error_log 2>&1
+    errorStat $?
+    # Same GH-964 reasoning as the fault log above: /opt/fog inherits usr_t and
+    # httpd_t may read but not write it. Unlabelled, PHP cannot write a session
+    # file on an enforcing host -- which does not degrade, it means nobody can
+    # log in at all, with only an AVC denial to say so.
+    setSELinuxContext "$fogprogramdir/sessions" httpd_sys_rw_content_t
 }
 configureUDPCast() {
     dots "Setting up UDPCast"

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -78,6 +78,21 @@ class Initiator
         if (is_readable($fogPaths)) {
             require_once $fogPaths;
         }
+        // _configureSessionStorage() needs the base path below, and it has to
+        // run before session_start() at the end of this constructor -- which is
+        // long before System::__construct applies its own /opt/fog fallback. So
+        // apply the identical fallback here, guarded, and System then defers to
+        // it: both sites use if (!defined(...)), so whichever runs first wins
+        // and they cannot disagree.
+        if (!defined('FOG_BASE_DIR')) {
+            define('FOG_BASE_DIR', '/opt/fog');
+        }
+        // FOG's own PHP session store. Created 0700 by the installer and
+        // pointed at by _configureSessionStorage() below; see that method for
+        // why FOG stops sharing the distro's session directory.
+        if (!defined('FOG_SESSION_DIR')) {
+            define('FOG_SESSION_DIR', FOG_BASE_DIR . DS . 'sessions');
+        }
 
         $regext = '#^.*\.(report|event|class|hook|page)\.php$#';
         $paths = new RegexIterator(
@@ -92,6 +107,8 @@ class Initiator
         set_include_path(implode(PATH_SEPARATOR, $allpaths) . PATH_SEPARATOR . get_include_path());
         spl_autoload_extensions('.class.php,.page.php,.event.php,.hook.php,.report.php');
         spl_autoload_register();
+
+        self::_configureSessionStorage();
 
         /*
          * Start a session only when there is one to resume or something has
@@ -122,6 +139,122 @@ class Initiator
             && ($hasSession || defined('FOG_WANTS_SESSION'))
         ) {
             session_start();
+        }
+    }
+
+    /**
+     * Point PHP's session store at FOG's own directory and give it a lifetime
+     * that matches FOG's own session policy.
+     *
+     * WHY THIS EXISTS
+     *
+     * FOG offers FOG_ALWAYS_LOGGED_IN and FOG_INACTIVITY_TIMEOUT ("Between 1
+     * and 24 by hours") and enforces them itself in User::_isLoggedIn(). But
+     * PHP deletes the session FILE out from under that on its own schedule,
+     * and the stock session.gc_maxlifetime is 1440 seconds -- 24 minutes.
+     * Verified identical on Fedora 44, Rocky 9.8, Rocky 10.2 and Ubuntu 26.04.
+     *
+     * So on every supported distro, any FOG idle policy longer than 24 minutes
+     * was a lie: the collector reaped the file, session.use_strict_mode
+     * (set above) then refused the browser's now-orphaned cookie and issued a
+     * fresh empty session, and the user was bounced to the login page. Silently
+     * -- the "You were logged out due to inactivity" toast comes from FOG's own
+     * inactivity branch, which had not fired and, with FOG_ALWAYS_LOGGED_IN on,
+     * cannot fire at all. Absence of that toast is the tell that PHP did it.
+     *
+     * WHY A PRIVATE DIRECTORY AND NOT JUST A LONGER LIFETIME
+     *
+     * gc_maxlifetime is a property of the save_path, not of the application:
+     * PHP's collector scans the whole directory. Raising it while sharing the
+     * distro's session directory imposes FOG's retention on every other PHP
+     * application on the box. Taking our own directory makes the setting mean
+     * what it says and confines the blast radius to FOG.
+     *
+     * It also fixes the ownership problem the installer works around today.
+     * Session files ARE authentication tokens, so this directory is 0700 and
+     * owned by the pool user -- deliberately NOT the sticky 1777 that
+     * FOG_CACHE_DIR uses, because world-readable session files would let any
+     * local account steal an admin session.
+     *
+     * WHY THE COLLECTOR SETTINGS COME WITH IT
+     *
+     * Owning the path means owning its garbage collection, and this is the
+     * trap: Debian and Ubuntu ship session.gc_probability = 0 and clean up
+     * from cron instead, via /usr/lib/php/sessionclean. That script discovers
+     * what to clean by running `php -c <sapi>/php.ini` and reading
+     * session.save_path out of the INI -- so a path set at runtime here is
+     * invisible to it. With PHP's in-process collector disabled and the cron
+     * job looking elsewhere, nothing would ever clean this directory and
+     * expired session files would accumulate forever. Re-enabling the
+     * in-process collector is what makes the directory self-maintaining on
+     * every distro. (Confirmed on Ubuntu 26.04: gc_probability = 0, timer
+     * phpsessionclean.timer present.)
+     *
+     * 86400 is the ceiling of FOG_INACTIVITY_TIMEOUT's own documented range,
+     * chosen so PHP can never contradict whatever policy is set in the UI.
+     * FOG_INACTIVITY_TIMEOUT stays the authority on when a user is logged out;
+     * this is only the floor that stops PHP pre-empting it.
+     *
+     * @return void
+     */
+    private static function _configureSessionStorage(): void
+    {
+        // Nothing to do once a session is running -- these are all read at
+        // session_start() and ini_set() on them would silently do nothing.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            return;
+        }
+        // Created by the installer, but created here too so an install whose
+        // installer predates this still gets a working private store rather
+        // than falling back and keeping the 24-minute bug. 0700 before any
+        // session file can land in it, never afterwards.
+        if (!is_dir(FOG_SESSION_DIR)) {
+            @mkdir(FOG_SESSION_DIR, 0700, true);
+        }
+        // A directory we cannot write is worse than the shared one: every
+        // session_start() would fail and nobody could log in at all. Fall back
+        // to PHP's configured path, which is exactly today's behaviour, and say
+        // why -- a silent fallback here would look identical to the bug being
+        // fixed.
+        if (!is_dir(FOG_SESSION_DIR) || !is_writable(FOG_SESSION_DIR)) {
+            error_log(
+                sprintf(
+                    'FOG: session directory %s is missing or not writable by %s;'
+                    . ' falling back to the system session store, where PHP will'
+                    . ' expire sessions after session.gc_maxlifetime (%ss)'
+                    . ' regardless of FOG_INACTIVITY_TIMEOUT.',
+                    FOG_SESSION_DIR,
+                    (get_current_user() ?: 'the web user'),
+                    ini_get('session.gc_maxlifetime')
+                )
+            );
+            return;
+        }
+        ini_set('session.save_path', FOG_SESSION_DIR);
+        ini_set('session.gc_maxlifetime', '86400');
+        // See the docblock: Debian/Ubuntu disable the in-process collector.
+        // These are PHP's own upstream defaults, restored for our path.
+        ini_set('session.gc_probability', '1');
+        ini_set('session.gc_divisor', '1000');
+        // ini_set() on session.* returns false and changes nothing once output
+        // has been flushed, and a pool declaring session.save_path with
+        // php_admin_value rather than php_value makes it unsettable outright.
+        // Either way PHP keeps the system store and its 24-minute lifetime --
+        // which is the bug this method exists to fix, so it must not pass
+        // unremarked. Read the value back rather than trusting the return.
+        if (ini_get('session.save_path') !== FOG_SESSION_DIR) {
+            error_log(
+                sprintf(
+                    'FOG: could not point session.save_path at %s (it is still'
+                    . ' %s). A php_admin_value in the php-fpm pool, or output'
+                    . ' already flushed this request, will do this. Sessions'
+                    . ' will expire after %ss regardless of'
+                    . ' FOG_INACTIVITY_TIMEOUT.',
+                    FOG_SESSION_DIR,
+                    (ini_get('session.save_path') ?: 'the system default'),
+                    ini_get('session.gc_maxlifetime')
+                )
+            );
         }
     }
 


### PR DESCRIPTION
1.5 port of #1306. `dev-branch` carries the same bug, verified before porting.

## The bug

`commons/init.php` sets `session.use_only_cookies` and `use_strict_mode` but never `session.gc_maxlifetime`, so PHP's stock **1440 seconds — 24 minutes** applies while `User::_isLoggedIn()` enforces `FOG_INACTIVITY_TIMEOUT` ("Between 1 and 24 by hours").

Verified identical on **Fedora 44, Rocky 9.8, Rocky 10.2 and Ubuntu 26.04**, so any FOG idle policy longer than 24 minutes was a lie on every supported distro.

**It fails silently.** Once PHP collects the file, `use_strict_mode` refuses the browser's orphaned cookie and issues a fresh empty session, so the user is bounced to login with no *"Session Expired"* toast — that toast comes from FOG's own inactivity branch, which never fired. **Absence of the toast is the tell that PHP did it rather than FOG.**

## Why a private directory rather than just a longer lifetime

`gc_maxlifetime` is a property of the `save_path`, not of the application — PHP's collector scans the whole directory. Raising it while sharing the distro's session directory imposes FOG's retention on every other PHP application on the box.

| File | Change |
|---|---|
| `commons/init.php` | `FOG_SESSION_DIR` (`FOG_BASE_DIR/sessions`) + `_configureSessionStorage()` |
| `lib/common/functions.sh` | `installFOGServices()` creates it `0700` owned by the pool user, labelled `httpd_sys_rw_content_t` |

## Differences from the 1.6 change

- **`FOG_BASE_DIR` is defined in `init.php` here.** On 1.6 it already was; on 1.5 it lives in `System::__construct`, which loads long after the constructor needs it. Both sites guard with `if (!defined(...))`, so whichever runs first wins and they cannot disagree — and `fogpaths.php` (GH-850), already required just above, still overrides both on a relocated install.
- **The dir is created after the fault-log block** rather than after the cache block: 1.5 has no `$fogprogramdir/cache` creation to sit beside. Same function (`installFOGServices()`), same `dots`/`errorStat`/`setSELinuxContext` shape as its neighbour.

## Why 0700

A session file **is** an authentication token — anything able to read this directory can resume an admin session. Stricter than the `0750` the fault log carries because, unlike that one, there is no second writer to accommodate. Safe as single-owner because the php-fpm pool is pinned to `$apacheuser` later in the same install (`functions.sh:4770`), the same variable the `chown` uses.

## The trap worth naming: owning the path means owning its GC

**Debian and Ubuntu ship `session.gc_probability = 0`** and clean up from cron via `/usr/lib/php/sessionclean`. That script discovers what to clean by running `php -c <sapi>/php.ini` and reading `session.save_path` **out of the INI** — so a path set at runtime is invisible to it. With the in-process collector disabled and the cron job looking elsewhere, nothing would ever clean the new directory and expired session files would accumulate forever.

So `gc_probability`/`gc_divisor` are restored to PHP's own upstream defaults for our path. (Confirmed on Ubuntu 26.04: `gc_probability = 0`, `phpsessionclean.timer` present.)

## Verified

Exercised `_configureSessionStorage()` against **this** tree, all arms:

| Arm | Result |
|---|---|
| writable dir | `save_path` repointed, `gc_maxlifetime` 86400, dir `0700`, real session file lands in it |
| dir exists, unwritable | falls back to system store, logs reason |
| dir uncreatable | falls back to system store, logs reason |

No PHP 8-only syntax — the file is `declare(strict_types=1)` and 7.4 is still a supported target here.

## Upgrade notes

- **This moves the session store, so everyone is logged out once.**
- A server updated by copying the web tree only (no installer run) has no directory to use — `/opt/fog` is `root:root 0755`, so the runtime `mkdir` cannot help the pool user. It logs the fallback and keeps the old 24-minute behaviour until the installer runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)