### PR TITLE
fix(session): stop an empty session cookie minting a throwaway session

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -199,7 +199,22 @@ class Initiator
          * reg-task, lib/client or lib/service, and setMessage() already
          * returns early when no session is active (fogbase.class.php).
          */
-        $hasSession = isset($_COOKIE[session_name()]);
+        /*
+         * An EMPTY cookie value is not a session to resume. isset() is true for
+         * "PHPSESSID=", so the gate opened for it, session.use_strict_mode found
+         * no id to resume, and PHP minted a fresh empty session -- exactly the
+         * per-request throwaway this gate exists to prevent, just arriving
+         * through a header instead of through the unconditional session_start()
+         * it replaced.
+         *
+         * FOGURLRequests was sending precisely that from every session-less
+         * caller (fixed at source there too, but the check belongs here: this is
+         * the chokepoint all 62 entry points reach, and a sender is easy to
+         * reintroduce). Browsers are unaffected -- a real session presents a
+         * non-empty id -- and a browser holding an emptied cookie now gets the
+         * same treatment as one holding none, which is the correct answer.
+         */
+        $hasSession = ($_COOKIE[session_name()] ?? '') !== '';
         if (session_status() !== PHP_SESSION_ACTIVE
             && ($hasSession || defined('FOG_WANTS_SESSION'))
         ) {

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -610,7 +610,30 @@ class FOGURLRequests extends FOGBase
          * reason to send it to a node, and not a reason to send it anywhere
          * else.
          */
-        if ($isFogHost && !isset($options[CURLOPT_COOKIE])) {
+        /*
+         * Only when there is actually a session to forward. session_id() is ''
+         * in any caller that never started one -- every CLI daemon, and any API
+         * request authenticated by token rather than cookie -- and the header
+         * was still being sent, as the bare "PHPSESSID=".
+         *
+         * An empty value is not nothing. isset($_COOKIE[session_name()]) is
+         * TRUE for it, so the receiving end's "resume a session only if one was
+         * presented" gate in commons/init.php opened, session_start() ran, and
+         * session.use_strict_mode -- having no id to resume -- minted a brand
+         * new empty session. Initiator::language() then wrote FOG_LANG into it
+         * and nothing ever read it again: an 18-byte file per request, left for
+         * gc. StorageNode::_getData() alone made ~3,000 of them an hour on a
+         * three-node install, because FOGMulticastManager re-reads its nodes
+         * every MULTICASTSLEEPTIME (10s by default).
+         *
+         * Sending nothing is also the honest signal. The request is
+         * unauthenticated either way -- getfiles.php answers 401 to both -- but
+         * an absent cookie says so without minting a session to prove it.
+         */
+        if ($isFogHost
+            && !isset($options[CURLOPT_COOKIE])
+            && session_id() !== ''
+        ) {
             $options[CURLOPT_COOKIE] = session_name() . '=' . session_id();
         }
         if ($available) {

--- a/tests/url-requests-tls.test.php
+++ b/tests/url-requests-tls.test.php
@@ -151,12 +151,30 @@ if (!preg_match(
         . ' itself';
 }
 if (!preg_match(
-    '#if \(\$isFogHost && !isset\(\$options\[CURLOPT_COOKIE\]\)\) \{\s*\n\s*\$options\[CURLOPT_COOKIE\]#',
+    '#if \(\$isFogHost\s*\n?\s*&& !isset\(\$options\[CURLOPT_COOKIE\]\)#',
     $src
 )) {
     $fails[] = "the session cookie is no longer gated on \$isFogHost; the"
         . " signed-in administrator's session id would be sent to every"
         . ' third-party host this class fetches from';
+}
+/*
+ * And only when there IS a session to forward. session_id() is '' in every
+ * CLI daemon and in any API request authenticated by token rather than by
+ * cookie, and the header still went out as the bare "PHPSESSID=". An empty
+ * value satisfies isset() on the far side, so init.php's browser-less gate
+ * opened, use_strict_mode found no id to resume, and PHP minted a throwaway
+ * session per request -- ~3,000 an hour from the multicast daemon's node
+ * reads alone. Pinned by shape for the same reason as the gate above: what
+ * must not come back is a cookie line that runs with no session.
+ */
+if (!preg_match(
+    '#!isset\(\$options\[CURLOPT_COOKIE\]\)\s*\n\s*&& session_id\(\) !== \x27\x27#',
+    $src
+)) {
+    $fails[] = 'the session cookie is no longer gated on there being a'
+        . ' session to send; a session-less caller would again send'
+        . ' "PHPSESSID=", which mints an empty session on the far side';
 }
 if (false === strpos($src, 'X-CSRF-Token:')) {
     $fails[] = 'the CSRF token is no longer filtered out for third-party'


### PR DESCRIPTION
Found while investigating why `/opt/fog/sessions` was filling up after #1306.

## The bug

`FOGURLRequests` forwards the caller's session cookie to FOG-owned hosts so a node's status endpoint can authorise the request. It built that header **unconditionally**, and `session_id()` is `''` in any caller that never started a session — every CLI daemon, and any API request authenticated by token rather than by cookie. Those requests went out carrying the bare `PHPSESSID=`.

**An empty value is not nothing.** `isset($_COOKIE[session_name()])` is TRUE for it, so `commons/init.php`'s *"resume a session only if one was presented"* gate opened, `session_start()` ran, and `session.use_strict_mode` — with no id to resume — minted a brand new empty session. `Initiator::language()` wrote `FOG_LANG` into it and nothing ever read it again: an **18-byte file per request**, left for gc.

That gate exists precisely to stop browser-less entry points allocating a session per request. It was being defeated by a header FOG sends to itself.

## Scale

Measured on a three-node lab install: `StorageNode::_getData()` alone made **~3,000 of these an hour**.

`Route::getItem('storagenode')` eagerly loads `images` and `snapinfiles` (`route.class.php:4765-4766`), each an outbound GET to `status/getfiles.php` on that node, and `FOGMulticastManager` re-reads its master nodes every `MULTICASTSLEEPTIME` — **10 seconds** by default. Every one answered 401, and every one left a session file behind.

```
[23/Aug/2026:05  6156 lines/hr      [23/Aug/2026:07  6362
[23/Aug/2026:06  6308               [23/Aug/2026:08  6428
```

302 of the 312 files in the session store were exactly 18 bytes; **one** carried a real `FOG_USER`.

## Fixed at both ends, deliberately

| File | Change |
|---|---|
| `fogurlrequests.class.php` | send the cookie only when there is a session to send |
| `commons/init.php` | treat an empty cookie value as no cookie |

The sender fix alone would do it today, but the gate is the chokepoint all 62 entry points reach and a sender is easy to reintroduce — the gate should not depend on every caller getting it right. An absent cookie is also the honest signal: the request is unauthenticated either way, but it no longer mints a session to prove it.

## Verified

Against the running lab server, before the fix:

| request | session files |
|---|---|
| no `Cookie` header | +0 |
| `Cookie: PHPSESSID=` | **+1** |
| no `Cookie` header | +0 |
| `Cookie: PHPSESSID=` | **+1** |

After, exercising the real gate in `Initiator::__construct()`:

| cookie | session started | files on disk |
|---|---|---|
| absent | no | 0 |
| empty | **no** (was YES) | **0** (was 1) |
| real id | YES | 1 |

Browsers are unaffected — a real session presents a non-empty id. A browser holding an emptied cookie now gets the same treatment as one holding none, which is the correct answer.

## Scope

This does **not** change the 401, which is correct — those callers are genuinely unauthenticated. It stops them leaving evidence of it on disk.

Two related problems found in the same investigation are deliberately **not** in this PR, because fixing them means changing how a session-less caller authenticates:

- `GET /storagenode/{id}` under token auth returns **empty `images` and `snapinfiles` for every online node**, for the same root cause — no session to forward, so the inner request 401s and the list comes back empty. Browser UI works because it forwards a real cookie.
- `FOGMulticastManager` does a synchronous HTTP fan-out to every master node every 10s for data it does not use.

No route or schema change, so `OpenAPI::document()` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)