### PR TITLE
fix(session): stop an empty session cookie minting a throwaway session (1.5 port)

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -134,7 +134,22 @@ class Initiator
          * reg-task, lib/client or lib/service, and setMessage() already
          * returns early when no session is active (fogbase.class.php).
          */
-        $hasSession = isset($_COOKIE[session_name()]);
+        /*
+         * An EMPTY cookie value is not a session to resume. isset() is true for
+         * "PHPSESSID=", so the gate opened for it, session.use_strict_mode found
+         * no id to resume, and PHP minted a fresh empty session -- exactly the
+         * per-request throwaway this gate exists to prevent, just arriving
+         * through a header instead of through the unconditional session_start()
+         * it replaced.
+         *
+         * FOGURLRequests was sending precisely that from every session-less
+         * caller (fixed at source there too, but the check belongs here: this is
+         * the chokepoint every entry point reaches, and a sender is easy to
+         * reintroduce). Browsers are unaffected -- a real session presents a
+         * non-empty id -- and a browser holding an emptied cookie now gets the
+         * same treatment as one holding none, which is the correct answer.
+         */
+        $hasSession = ($_COOKIE[session_name()] ?? '') !== '';
         if (session_status() !== PHP_SESSION_ACTIVE
             && ($hasSession || defined('FOG_WANTS_SESSION'))
         ) {

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -553,7 +553,28 @@ class FOGURLRequests extends FOGBase
          * reason to send it to a node, and not a reason to send it anywhere
          * else.
          */
-        if ($isFogHost && !isset($options[CURLOPT_COOKIE])) {
+        /*
+         * Only when there is actually a session to forward. session_id() is ''
+         * in any caller that never started one -- every CLI daemon, and any API
+         * request authenticated by token rather than cookie -- and the header
+         * was still being sent, as the bare "PHPSESSID=".
+         *
+         * An empty value is not nothing. isset($_COOKIE[session_name()]) is
+         * TRUE for it, so the receiving end's "resume a session only if one was
+         * presented" gate in commons/init.php opened, session_start() ran, and
+         * session.use_strict_mode -- having no id to resume -- minted a brand
+         * new empty session. Initiator::language() then wrote FOG_LANG into it
+         * and nothing ever read it again: an 18-byte file per request, left for
+         * gc.
+         *
+         * Sending nothing is also the honest signal. The request is
+         * unauthenticated either way -- getfiles.php answers 401 to both -- but
+         * an absent cookie says so without minting a session to prove it.
+         */
+        if ($isFogHost
+            && !isset($options[CURLOPT_COOKIE])
+            && session_id() !== ''
+        ) {
             $options[CURLOPT_COOKIE] = session_name() . '=' . session_id();
         }
         /*

--- a/tests/url-requests-tls.test.php
+++ b/tests/url-requests-tls.test.php
@@ -151,12 +151,29 @@ if (!preg_match(
         . ' itself';
 }
 if (!preg_match(
-    '#if \(\$isFogHost && !isset\(\$options\[CURLOPT_COOKIE\]\)\) \{\s*\n\s*\$options\[CURLOPT_COOKIE\]#',
+    '#if \(\$isFogHost\s*\n?\s*&& !isset\(\$options\[CURLOPT_COOKIE\]\)#',
     $src
 )) {
     $fails[] = "the session cookie is no longer gated on \$isFogHost; the"
         . " signed-in administrator's session id would be sent to every"
         . ' third-party host this class fetches from';
+}
+/*
+ * And only when there IS a session to forward. session_id() is '' in every
+ * CLI daemon and in any API request authenticated by token rather than by
+ * cookie, and the header still went out as the bare "PHPSESSID=". An empty
+ * value satisfies isset() on the far side, so init.php's browser-less gate
+ * opened, use_strict_mode found no id to resume, and PHP minted a throwaway
+ * session per request. Pinned by shape for the same reason as the gate
+ * above: what must not come back is a cookie line that runs with no session.
+ */
+if (!preg_match(
+    '#!isset\(\$options\[CURLOPT_COOKIE\]\)\s*\n\s*&& session_id\(\) !== \x27\x27#',
+    $src
+)) {
+    $fails[] = 'the session cookie is no longer gated on there being a'
+        . ' session to send; a session-less caller would again send'
+        . ' "PHPSESSID=", which mints an empty session on the far side';
 }
 if (false === strpos($src, 'X-CSRF-Token:')) {
     $fails[] = 'the CSRF token is no longer filtered out for third-party'


### PR DESCRIPTION
1.5 port of #1308. `dev-branch` carries both halves identically — the gate at `commons/init.php:137` and the cookie forwarding at `fogurlrequests.class.php:556` — verified before porting.

## The bug

`FOGURLRequests` forwards the caller's session cookie to FOG-owned hosts so a node's status endpoint can authorise the request. It built that header **unconditionally**, and `session_id()` is `''` in any caller that never started a session — every CLI daemon, and any API request authenticated by token rather than by cookie. Those requests went out carrying the bare `PHPSESSID=`.

**An empty value is not nothing.** `isset($_COOKIE[session_name()])` is TRUE for it, so init.php's *"resume a session only if one was presented"* gate opened, `session_start()` ran, and `session.use_strict_mode` — with no id to resume — minted a brand new empty session. `Initiator::language()` wrote `FOG_LANG` into it and nothing ever read it again: an **18-byte file per request**, left for gc.

That gate exists precisely to stop browser-less entry points allocating a session per request. It was being defeated by a header FOG sends to itself.

## Fixed at both ends, deliberately

| File | Change |
|---|---|
| `fogurlrequests.class.php` | send the cookie only when there is a session to send |
| `commons/init.php` | treat an empty cookie value as no cookie |

The sender fix alone would do it today, but the gate is the chokepoint every entry point reaches and a sender is easy to reintroduce — it should not depend on every caller getting it right.

## Verified

Exercising the real gate against **this** tree:

| cookie | session started | files on disk |
|---|---|---|
| absent | no | 0 |
| empty | **no** (was YES) | **0** (was 1) |
| real id | YES | 1 |

Browsers are unaffected — a real session presents a non-empty id.

## Scope

The 401 those callers receive is unchanged and correct — they are genuinely unauthenticated; they simply stop leaving evidence of it on disk.

Note the 1.5 blast radius is smaller than 1.6's: `dev-branch` has no `storagenode` block in `Route`'s serializer, so it lacks the `FOGMulticastManager` fan-out that made this ~3,000 sessions/hour on 1.6. The sender bug is identical, so any session-less caller here leaks the same way.

No route or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)