### PR TITLE
fix(audit): show the permission in the grid and record why a failure failed

### DIFF
--- a/packages/web/lib/fog/audit.class.php
+++ b/packages/web/lib/fog/audit.class.php
@@ -81,6 +81,10 @@ class Audit extends FOGBase
     const TOKEN_REJECTED = 'auth.token.rejected';
     const API_DENIED = 'auth.api.denied';
     /**
+     * How much of a failure reason markOutcome() stores.
+     */
+    const MAX_DETAIL = 512;
+    /**
      * The synthetic actor for a write no person made.
      *
      * Not a new convention: FOGController::save()'s createdBy auto-fill
@@ -262,11 +266,26 @@ class Audit extends FOGBase
      * is no path here that revises an OLDER row, and none that lowers a
      * denial to anything else.
      *
+     * $detail is why. Without it a `failed` row says only that something
+     * went wrong, and the trail cannot answer the first question anybody
+     * asks of it -- every call site below already holds the reason (the
+     * HTTP status it is about to send, the message it is about to throw)
+     * and used to discard it on the way past.
+     *
+     * Untranslated, like every other alText: this is machine detail, and a
+     * reason stored in the locale of whoever happened to trip it is not
+     * greppable six months later.
+     *
+     * It does NOT overwrite. A row whose text was set at record() time
+     * carries a more specific reason than anything known here, so the
+     * detail fills an empty field and otherwise stands aside.
+     *
      * @param string $outcome one of the outcome constants
+     * @param string $detail  untranslated reason, or '' when none is known
      *
      * @return void
      */
-    public static function markOutcome($outcome)
+    public static function markOutcome($outcome, $detail = '')
     {
         if (!self::$_current instanceof AuditLog
             || !self::$_current->isValid()
@@ -280,10 +299,31 @@ class Audit extends FOGBase
             return;
         }
         try {
-            self::$_current->set('outcome', (string)$outcome)->save();
+            self::$_current->set('outcome', (string)$outcome);
+            $detail = (string)$detail;
+            if ('' !== $detail && '' === (string)self::$_current->get('text')) {
+                // alText is longtext, so the cap is not about the column. A
+                // PDOException carries the whole failing statement and every
+                // bound placeholder, and this row is read in a grid.
+                self::$_current->set('text', self::_trim($detail));
+            }
+            self::$_current->save();
         } catch (\Exception $e) {
             self::_writeFailed((string)$e->getMessage());
         }
+    }
+    /**
+     * Bounds a reason string to something a log viewer can print.
+     *
+     * @param string $detail the reason
+     *
+     * @return string
+     */
+    private static function _trim($detail)
+    {
+        return strlen($detail) > self::MAX_DETAIL
+            ? substr($detail, 0, self::MAX_DETAIL) . '...'
+            : $detail;
     }
     /**
      * Records the change rows for one subject.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 356);
-        define('FOG_BCACHE_VER', 299);
+        define('FOG_BCACHE_VER', 300);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/auditmanagement.page.php
+++ b/packages/web/lib/pages/auditmanagement.page.php
@@ -79,15 +79,24 @@ class AuditManagement extends FOGPage
     {
         $this->title = _('Audit Log');
 
+        // Action and Permission sit next to each other on purpose. Action is
+        // where the request came from (`access.api`, `access.page`,
+        // `auth.login`) and on its own it says nothing about what happened --
+        // every API write in the install reads `access.api`. Permission is
+        // what was actually exercised (`host.delete`, `image.create`), and
+        // without it in the grid the only way to tell a create from a delete
+        // was to open the row.
         $this->headerData = [
             _('When'),
             _('Who'),
             _('Action'),
+            _('Permission'),
             _('Outcome'),
             _('Subject'),
             _('From')
         ];
         $this->attributes = [
+            [],
             [],
             [],
             [],

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -264,7 +264,7 @@ class Registration extends FOGBase
                 // "A registration was attempted and failed" is invisible
                 // today, and it is the shape of both a misconfiguration and
                 // a probe.
-                Audit::markOutcome(Audit::FAILED);
+                Audit::markOutcome(Audit::FAILED, 'host save failed');
                 throw new \Exception(
                     _('Failed to create Host!')
                 );
@@ -478,7 +478,7 @@ class Registration extends FOGBase
                 // "A registration was attempted and failed" is invisible
                 // today, and it is the shape of both a misconfiguration and
                 // a probe.
-                Audit::markOutcome(Audit::FAILED);
+                Audit::markOutcome(Audit::FAILED, 'host save failed');
                 throw new \Exception(
                     _('Failed to create Host!')
                 );
@@ -535,7 +535,7 @@ class Registration extends FOGBase
                 // "A registration was attempted and failed" is invisible
                 // today, and it is the shape of both a misconfiguration and
                 // a probe.
-                Audit::markOutcome(Audit::FAILED);
+                Audit::markOutcome(Audit::FAILED, 'host save failed');
                 throw new \Exception(
                     _('Failed to create Host!')
                 );

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -254,7 +254,7 @@ class TaskQueue extends TaskingElement
                 ->set('stateID', self::getProgressState())
                 ->set('checkInTime', self::niceDate()->format('Y-m-d H:i:s'));
             if (!$this->Task->save()) {
-                Audit::markOutcome(Audit::FAILED);
+                Audit::markOutcome(Audit::FAILED, 'task save failed');
                 throw new \Exception(_('Failed to update Task'));
             }
             if (!$this->taskLog()) {
@@ -628,7 +628,7 @@ class TaskQueue extends TaskingElement
             // update, the task save, the task log or the imaging log failed.
             // The task is left short of Complete and FOS is told, but until
             // now nobody watching notifications was. See #1202.
-            Audit::markOutcome(Audit::FAILED);
+            Audit::markOutcome(Audit::FAILED, (string)$e->getMessage());
             $this->_notifyImagingOutcome($e->getMessage());
             echo $e->getMessage();
         }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1639,7 +1639,16 @@ class Route extends FOGBase
                 true
             )
         ) {
-            Audit::markOutcome(Audit::FAILED);
+            // The code and the message are both in hand here and both used
+            // to be dropped, so every `failed` row in the trail read
+            // "something went wrong" with no way to find out what. A delete
+            // of an id that is already gone and a delete that hit a
+            // constraint are the same row without this.
+            $why = 'HTTP ' . (int)$code;
+            if (is_string($msg) && '' !== $msg) {
+                $why .= ': ' . $msg;
+            }
+            Audit::markOutcome(Audit::FAILED, $why);
         }
         HTTPResponseCodes::breakHead(
             $code,

--- a/packages/web/management/js/fog/audit/fog.audit.list.js
+++ b/packages/web/management/js/fog/audit/fog.audit.list.js
@@ -48,6 +48,24 @@
     unknown: 'text-bg-secondary'
   };
 
+  // An empty permission is not a missing value -- it is the record of a write
+  // that reached no authorization gate at all (the FOS and registration
+  // endpoints, ADR 0021 Decision 4). The grid says "none"; the modal below
+  // spells out why. An empty cell would read as a bug.
+  function permissionColumn() {
+    return {
+      data: 'permission',
+      render: function(d, t) {
+        var v = d === null ? '' : String(d);
+        if (t !== 'display') {
+          return v;
+        }
+        return v ? $.escapeHtml(v)
+          : '<em class="text-muted">' + $.escapeHtml('none') + '</em>';
+      }
+    };
+  }
+
   function outcomeColumn() {
     return {
       data: 'outcome',
@@ -85,6 +103,7 @@
       escaped('createdTime'),
       escaped('createdBy'),
       escaped('type'),
+      permissionColumn(),
       outcomeColumn(),
       {
         data: 'subjectLabel',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5798,6 +5798,10 @@ msgid "Pending..."
 msgstr "Ausstehend..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Version"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Sitzungsname"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5796,6 +5796,10 @@ msgid "Pending..."
 msgstr "Pending..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Version"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Session Name"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5932,6 +5932,10 @@ msgid "Pending..."
 msgstr "macs pendientes"
 
 #, fuzzy
+msgid "Permission"
+msgstr "Versión"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Nombre de sesión"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5799,6 +5799,10 @@ msgid "Pending..."
 msgstr "Ausstehend..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Version"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Sitzungsname"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5798,6 +5798,10 @@ msgid "Pending..."
 msgstr "En attendant..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Version"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Nom de session"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5601,6 +5601,10 @@ msgid "Pending..."
 msgstr "In attesa di..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Versione"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Nome sessione"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5563,6 +5563,10 @@ msgid "Pending..."
 msgstr "保留中..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "バージョン"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "アクセス拒否"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4928,6 +4928,9 @@ msgstr ""
 msgid "Pending..."
 msgstr ""
 
+msgid "Permission"
+msgstr ""
+
 msgid "Permission denied"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5797,6 +5797,10 @@ msgid "Pending..."
 msgstr "Pendente..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "Versão"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "Nome da sessão"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5797,6 +5797,10 @@ msgid "Pending..."
 msgstr "待..."
 
 #, fuzzy
+msgid "Permission"
+msgstr "版"
+
+#, fuzzy
 msgid "Permission denied"
 msgstr "会话名称"
 

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -140,7 +140,7 @@ try {
             ->set('hdserial', $hdserial);
     }
     if (!$Inventory->save()) {
-        Audit::markOutcome(Audit::FAILED);
+        Audit::markOutcome(Audit::FAILED, 'inventory save failed');
         throw new \Exception(
             _('Failed to create inventory for this host')
         );


### PR DESCRIPTION
## Problem

Two gaps found while reading the audit log on a live 1.6 server.

**1. The grid showed Action but not Permission.** Action is *where the request came from* — `access.api`, `access.page`, `auth.login`. Every API write in the install therefore read `access.api` and nothing more, and whether a row was a create or a delete lived only in the modal. Finding a specific change meant opening rows one at a time:

| When | Action | Outcome | Subject |
|---|---|---|---|
| 07:56:33 | access.api | allowed | group |
| 07:56:34 | access.api | failed | groupassociation |
| 07:56:34 | access.api | allowed | host |

**2. A `failed` row never said why.** `Audit::markOutcome()` took the outcome and nothing else, while all seven of its call sites already held the reason and discarded it — `Route::sendResponse()` has both the HTTP status and the message; the registration, task and inventory paths hold the exception they throw on the very next line.

On the server this was found on: **11 of 11 `failed` rows carried no explanation.** A delete of an id that was already gone (HTTP 404) and a delete that hit a constraint were the same indistinguishable row.

## Fix

**Permission column**, between Action and Outcome. The `listem()` payload already carried `permission` — the modal was reading it — so this is a column, not a query change. Empty renders as a muted "none" rather than a blank cell, because `auth.login` and the FOS/registration endpoints legitimately reach no authorization gate (ADR 0021 Decision 4) and a blank reads as a bug.

**`markOutcome($outcome, $detail = '')`**, with every call site now passing its reason. Untranslated, matching the existing `alText` convention. It writes only when `alText` is empty — a reason recorded at `record()` time is more specific than anything known at the response — and caps at 512 chars, because a `PDOException` message carries the whole failing statement and every bound value and this field renders in a log viewer. `alText` is already `longtext`, **so there is no schema change**.

The example above now reads `HTTP 404` in the modal's Detail row.

**Denials are left alone deliberately.** The reason for a gate denial is "you do not hold this permission", and the new column states it outright.

## Notes

- `FOG_BCACHE_VER` 299 → 300. The grid gains a seventh column and cached JS would draw six against a seven-column header.
- No route added or changed, so `OpenAPI::document()` needs no edit.
- Existing `failed` rows stay blank. `markOutcome()` only ever revises the row from the request still running — deliberately, per its docblock — so there is no backfill.

## Verification

- `php -l` clean on all five PHP files; `node --check` clean on the JS.
- `permission` confirmed present in the live `?node=audit&sub=getList` payload before the change, so the column has data on day one.
- The worked example was traced end to end against the live database: `groupMembers` id 57 is absent, audit row 131 (`group.delete`, allowed) is what removed it, and row 133 one second later is the repeat that hit `Route::delete()`'s `getCount()` guard.
- **Not exercised in a browser or against a live failing API call yet** — needs a deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)