### PR TITLE
fix(menu): a lone "List All X" is not a sub-menu

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -994,6 +994,30 @@ abstract class FOGPage extends FOGBase
                 unset($menu[$subKey]);
             }
         }
+
+        // A lone "List All X" is not a sub-menu. It expands the parent to
+        // offer one child that goes where the parent already goes, so it
+        // costs a click and a chevron to arrive at the same page -- "Audit
+        // Log -> List All Audits". _renderMenuNode() turns a childless node
+        // into a direct link, which is how Tasks has always behaved.
+        //
+        // Derived rather than added to the hand-kept case list above,
+        // because that list is where this keeps going wrong. It already
+        // carries home, client, schema, service, hwinfo, apidocs and task
+        // for related reasons, and the registry block above had to be
+        // written separately for the same failure one step earlier. The
+        // condition is the honest one: `list` is the DEFAULT sub every node
+        // gets, so a node left holding only that has nothing to navigate.
+        //
+        // Applies after the two filters on purpose. A node whose `add` was
+        // stripped for lacking `create` (the read-only log viewers) and one
+        // whose `add` was stripped because THIS user may not create are the
+        // same situation from the menu's point of view, and both should
+        // collapse. Runs after the plugin hooks too, so a sub a plugin adds
+        // keeps the node expanded.
+        if (['list'] === array_keys($menu)) {
+            $menu = [];
+        }
         return $menu;
     }
 


### PR DESCRIPTION
## Problem

`Audit Log` and `Activity` each expand to exactly one child that goes where the parent already goes:

```
Audit Log  ▸  List All Audits
Activity   ▸  List All Activitys      <- sic
```

Both are single-page log viewers. Reaching one costs a chevron and an extra click to arrive at the page the parent link would have opened. Tasks has never behaved this way — `_buildSubMenuItems()` carries an explicit `case 'task': $menu = [];`, and `_renderMenuNode()` turns a childless node into a direct `ajax-page-link`.

## Fix

Collapse the menu when `list` is the only sub left. `list` is the **default** sub every node is handed, so a node holding nothing else has nothing to navigate to.

Derived rather than added to the hand-kept `switch`, because that list is where this keeps going wrong. It already carries `home`, `client`, `schema`, `service`, `hwinfo`, `apidocs` and `task` for related reasons, and the registry block immediately above it had to be written separately to stop these same two nodes advertising "Create New Audit" for a route that does not exist.

Applied **after** both filters on purpose:

- a node whose `add` was stripped for declaring no `create` action (the read-only log viewers), and
- a node whose `add` was stripped because *this user* may not create

are the same situation from the menu's point of view, and both should collapse. It also runs after `SUB_MENULINK_DATA` / `DELETE_MENULINK_DATA`, so a sub a plugin adds keeps its node expanded.

## Scope — measured, not assumed

Every node rendered in the sidebar of a full install with all plugins enabled was enumerated. **`activity` and `audit` are the only two holding a lone `list`:**

| children | nodes |
|---|---|
| **1 (`list` only)** | **activity, audit** ← flattened |
| 2+ | host, image, group, user, printer, module, snapin, storagenode, storagegroup, ipxe, role, usergroup, site, plugin, report, about, and every plugin node (ldap, ldapgroup, oidc, oidcgroup, ou, ntfy, location, windowskey) |

Nodes that already render flat (`task`, `apidocs`, `client`, `service`, `home`) are unaffected — their menu was already empty before this runs.

## Notes

- No JS or CSS change, so no `FOG_BCACHE_VER` bump.
- `?node=audit` and `?node=audit&sub=list` both resolve to `index()` — `list` has never been a real method on these pages — so no link breaks.

## Verification

- `php -l` clean.
- The input side is confirmed against a live 1.6 install: the sidebar census above was taken from the rendered HTML, so the set of nodes this condition fires on is measured rather than reasoned about.
- **The rendered result is not yet confirmed in a browser** — needs a deploy. The parent-becomes-a-direct-link half is already proven by Tasks, which renders as `node=task` today through the identical `$hasChildren` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)