### PR TITLE
fix(auth): let FOG's own components authenticate without a session

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -4409,6 +4409,204 @@ abstract class FOGBase
             || (self::schemaNeedsDeploy() && self::installTokenParam());
     }
     /**
+     * The globalSettings key holding the shared node-signing secret.
+     *
+     * Deliberately NOT a config.class.php constant like
+     * FOG_SCHEMA_INSTALL_TOKEN: every storage node's installer generates its
+     * own config.class.php with its own random values, so a constant would
+     * differ on every machine and never verify. globalSettings is the one
+     * store master and node genuinely share -- functions.sh points a node's
+     * DATABASE_HOST at the master (see `[[ -z ${DB_host} ]] &&
+     * DB_host="$snmysqlhost"`), so a row written once is readable everywhere
+     * with nothing to distribute.
+     *
+     * @var string
+     */
+    const NODE_API_KEY_SETTING = 'FOG_NODE_API_KEY';
+    /**
+     * How far, in seconds, a signed request's timestamp may be from ours.
+     *
+     * This is the property service/nodecert.php does NOT have: its HMAC
+     * covers only the payload, so a captured request is replayable forever.
+     * Node traffic runs with CURLOPT_SSL_VERIFYPEER off (NODE_TLS_OPTIONS in
+     * FOGURLRequests -- a node's certificate is self-signed and there is no
+     * chain to check), so a capture is a realistic thing to defend against.
+     *
+     * Five minutes rather than something tighter because master and node
+     * clocks are not disciplined to each other by anything FOG installs, and
+     * the failure mode of too-tight is a node that silently serves nothing.
+     * It bounds replay to the same method on the same path -- for the reads
+     * this authenticates, that is a re-read of a directory listing.
+     *
+     * @var int
+     */
+    const NODE_SIGNATURE_WINDOW = 300;
+    /**
+     * The shared secret FOG's own components sign inter-node requests with,
+     * created on first use if it is not there yet.
+     *
+     * Purpose-scoped on purpose. The obvious existing secret to reuse was
+     * FOG_STORAGENODE_MYSQLPASS, which is what service/nodecert.php signs
+     * with -- but that password is direct database access. Leaking it during
+     * transport hands an attacker the whole schema; leaking this hands them
+     * the ability to list directories on a node, which is all it authorises.
+     *
+     * INSERT IGNORE rather than setSetting(), for two reasons. setSetting()
+     * is an UPDATE through SettingManager and does nothing at all when the
+     * row is absent, which is exactly the case being healed here. And the
+     * UNIQUE KEY on settingKey makes the INSERT the arbiter when two
+     * processes race -- both then re-read and agree, instead of the loser
+     * signing with a key the verifier has already replaced.
+     *
+     * @return string The key, or '' if one could not be established.
+     */
+    public static function nodeApiKey()
+    {
+        $key = trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($key !== '') {
+            return $key;
+        }
+        try {
+            $candidate = bin2hex(random_bytes(32));
+        } catch (\Exception $e) {
+            // No CSPRNG means no key. Returning '' leaves callers
+            // unauthenticated, which is the safe direction: an unsigned
+            // request is refused, a weakly signed one would not be.
+            return '';
+        }
+        self::$DB->query(
+            sprintf(
+                "INSERT IGNORE INTO `globalSettings` (`settingKey`, "
+                . "`settingDesc`, `settingValue`, `settingCategory`) "
+                . "VALUES (%s, %s, %s, %s)",
+                self::$DB->escape(self::NODE_API_KEY_SETTING),
+                self::$DB->escape(
+                    'Shared secret FOG signs its own server-to-server '
+                    . 'requests with. Generated automatically; there is '
+                    . 'nothing to set here, and the FOG Configuration page '
+                    . 'does not show it. Delete the row to rotate the key -- '
+                    . 'every component reads it from this table, so the next '
+                    . 'request regenerates one and they agree again.'
+                ),
+                self::$DB->escape($candidate),
+                self::$DB->escape('FOG Storage Nodes')
+            )
+        );
+        // Re-read rather than trusting $candidate: on a race the INSERT was
+        // ignored and the row holds the other process's value. No cache
+        // flush is needed -- getSetting() never caches a key it did not
+        // find, so this reads the row that just landed.
+        return trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
+    }
+    /**
+     * The exact bytes both ends run through hash_hmac().
+     *
+     * Method and path are in the signed material so a captured signature
+     * cannot be lifted onto a different request -- a GET of a directory
+     * listing must not become a POST of anything. The timestamp is in it so
+     * it cannot be adjusted to widen the window it was issued for.
+     *
+     * @param string $method    The HTTP method, upper case.
+     * @param string $uri       Path plus query string, exactly as sent.
+     * @param string $timestamp Unix seconds, as a decimal string.
+     *
+     * @return string
+     */
+    private static function _nodeSignaturePayload($method, $uri, $timestamp)
+    {
+        return $timestamp . "\n" . $method . "\n" . $uri;
+    }
+    /**
+     * Headers proving a request came from this FOG installation.
+     *
+     * Header-only, for the reason installTokenHeader() already sets out: a
+     * header cannot be set by a cross-site form, a link or an <img>, and it
+     * never lands in browser history, a bookmark, a Referer or an access
+     * log. A query parameter would put a long-lived shared secret in every
+     * one of those.
+     *
+     * The signature covers path-and-query rather than the whole URL, so the
+     * http -> https redirect FOG's own vhost issues does not invalidate it.
+     *
+     * @param string $url    The URL about to be requested.
+     * @param string $method The HTTP method that will be used.
+     *
+     * @return array Header lines, or an empty array when unavailable.
+     */
+    public static function nodeSignatureHeaders($url, $method = 'GET')
+    {
+        $key = self::nodeApiKey();
+        if ($key === '') {
+            return [];
+        }
+        $parts = parse_url((string) $url);
+        if ($parts === false) {
+            return [];
+        }
+        $uri = ($parts['path'] ?? '/');
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $uri .= '?' . $parts['query'];
+        }
+        $timestamp = (string) time();
+        $signature = hash_hmac(
+            'sha256',
+            self::_nodeSignaturePayload(
+                strtoupper((string) $method),
+                $uri,
+                $timestamp
+            ),
+            $key
+        );
+        return [
+            'X-Fog-Node-Timestamp: ' . $timestamp,
+            'X-Fog-Node-Signature: ' . $signature
+        ];
+    }
+    /**
+     * Is this request signed by a FOG component that holds the node key?
+     *
+     * Authentication, not authorisation: it says the caller is part of this
+     * installation, and nothing about what it may do. Endpoints accepting it
+     * must still be ones a node is entitled to reach -- the same split
+     * service/nodecert.php makes when it checks the HMAC and then separately
+     * matches the source IP against a registered node.
+     *
+     * getSetting() rather than nodeApiKey() deliberately: verification must
+     * never mint a key. If no key exists there is nothing this request can
+     * have signed with, and the answer is no.
+     *
+     * @return bool
+     */
+    public static function validNodeSignature()
+    {
+        $timestamp = $_SERVER['HTTP_X_FOG_NODE_TIMESTAMP'] ?? null;
+        $signature = $_SERVER['HTTP_X_FOG_NODE_SIGNATURE'] ?? null;
+        if (!is_string($timestamp)
+            || !is_string($signature)
+            || $signature === ''
+            || !ctype_digit($timestamp)
+        ) {
+            return false;
+        }
+        if (abs(time() - (int) $timestamp) > self::NODE_SIGNATURE_WINDOW) {
+            return false;
+        }
+        $key = trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($key === '') {
+            return false;
+        }
+        $expected = hash_hmac(
+            'sha256',
+            self::_nodeSignaturePayload(
+                strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET')),
+                (string) ($_SERVER['REQUEST_URI'] ?? ''),
+                $timestamp
+            ),
+            $key
+        );
+        return hash_equals($expected, $signature);
+    }
+    /**
      * Is the current session a FOG administrator?
      *
      * Deliberately not is_authorized(), which is true for any valid user --

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -649,6 +649,44 @@ class FOGURLRequests extends FOGBase
             $options[CURLOPT_NOSIGNAL] = true;
         }
         /*
+         * Prove to FOG's own hosts that this request came from FOG.
+         *
+         * The cookie above only works when a browser session exists to
+         * forward. Every CLI daemon and every token-authenticated API call
+         * has none, so StorageNode::_getData() went out unauthenticated,
+         * getfiles.php answered 401, and the loader turned that into an
+         * empty file list -- wrong data rather than an error. This is the
+         * credential those callers can actually hold: a shared secret in
+         * globalSettings, which master and node both read (GH-1312).
+         *
+         * Signed for every FOG host, not only the session-less case, so the
+         * browser path exercises the same code. A signature that stops
+         * verifying then shows up in the UI immediately instead of only in a
+         * daemon nobody is watching.
+         *
+         * Bound to the method actually about to be sent. $available turns the
+         * request into a HEAD via CURLOPT_NOBODY, which is why this sits
+         * after that block rather than beside the cookie it belongs with.
+         */
+        if ($isFogHost) {
+            if (!empty($options[CURLOPT_CUSTOMREQUEST])) {
+                $method = (string)$options[CURLOPT_CUSTOMREQUEST];
+            } elseif (!empty($options[CURLOPT_NOBODY])) {
+                $method = 'HEAD';
+            } elseif (!empty($options[CURLOPT_POST])) {
+                $method = 'POST';
+            } else {
+                $method = 'GET';
+            }
+            $signature = self::nodeSignatureHeaders($url, $method);
+            if (count($signature) > 0) {
+                $options[CURLOPT_HTTPHEADER] = array_merge(
+                    (array)($options[CURLOPT_HTTPHEADER] ?? []),
+                    $signature
+                );
+            }
+        }
+        /*
          * The TLS exemption for FOG's own nodes. Applied here rather than in
          * the defaults so it is decided by the URL: a caller cannot acquire
          * it by not thinking about it, which is how every request this class

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -724,8 +724,41 @@ class OpenAPI extends FOGBase
                 ),
                 implode(', ', $additional)
             );
+            $note = self::_additionalFieldsNote($class);
+            if ('' !== $note) {
+                $out['description'] .= ' ' . $note;
+            }
         }
         return $out;
+    }
+    /**
+     * What the generic additionalFields sentence above cannot know.
+     *
+     * "Responses MAY carry" is derived from the model and is true as far as
+     * it goes, but for a class whose computed fields are opt-in it says
+     * nothing about how to ask for them -- and a client generated from this
+     * document would look for a field that is simply not in the payload.
+     *
+     * Deliberately a short hand-kept list, for the same reason
+     * _applyModelConstraint() is one: the condition lives in Route::getter(),
+     * not in anything schema-expected.php or the model can be read for.
+     *
+     * @param string $class The lowercase route class name.
+     *
+     * @return string A sentence to append, or '' for nothing to add.
+     */
+    private static function _additionalFieldsNote($class)
+    {
+        switch (strtolower((string)$class)) {
+            case 'storagenode':
+                return _(
+                    'images and snapinfiles are opt-in: each is an outbound '
+                    . 'request to the node itself, so they are returned only '
+                    . 'for expand=images, expand=snapinfiles or expand=all. '
+                    . 'logfiles is not returned by this route at all.'
+                );
+        }
+        return '';
     }
 
     /**

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -2567,6 +2567,14 @@ class FOGConfigurationPage extends FOGPage
             ) {
                 continue;
             }
+            // Never shown, to anyone. FOG generates and consumes this
+            // key itself (FOGBase::nodeApiKey(), inherited here); there is
+            // no value an admin could usefully type, and printing a shared
+            // secret into a form field is a leak with no upside. Rotation
+            // is deleting the row -- the next request regenerates one.
+            if ($row['settingKey'] === self::NODE_API_KEY_SETTING) {
+                continue;
+            }
             $cat = trim((string) $row['settingCategory']);
             if ($cat === '') {
                 $cat = _('Uncategorized');

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -374,6 +374,12 @@ class Route extends FOGBase
      */
     public static $sensitiveSettings = [
         'FOG_STORAGENODE_MYSQLPASS',
+        // FOGBase::NODE_API_KEY_SETTING, as a literal: a class constant here
+        // would autoload FOGCore while Route's own class body is still being
+        // built. SENSITIVE_SETTING_PATTERN does not cover it -- adding KEY to
+        // that pattern would mask unrelated settings -- and it is a shared
+        // HMAC secret, so it must not be readable over REST.
+        'FOG_NODE_API_KEY',
     ];
     /**
      * Settings the pattern catches that are not credentials.
@@ -3604,11 +3610,16 @@ class Route extends FOGBase
                 );
             }
             self::$data = [];
+            // Before getter(), not after: getter() now asks wantsExpand()
+            // whether to build storagenode's images/snapinfiles, and reading
+            // that before it is parsed answers "no" on every request. Nothing
+            // else in getter() consults expansion state, and expandRelations()
+            // below is unaffected by the move.
+            self::parseExpand();
             self::$data = self::getter(
                 $classname,
                 $class
             );
-            self::parseExpand();
             self::$data = self::expandRelations(
                 $classname,
                 $class,
@@ -4766,22 +4777,48 @@ class Route extends FOGBase
                     );
                     break;
                 case 'storagenode':
-                    $data = FOGCore::fastmerge(
-                        $class->get(),
-                        [
-                            'online' => $class->get('online'),
-                            //'logfiles' => $class->get('logfiles'),
-                            'snapinfiles' => $class->get('snapinfiles'),
-                            'images' => $class->get('images'),
-                            'storagegroup' => $class->get('storagegroup')->get(),
-                            'location_url' => sprintf(
-                                '%s://%s/%s',
-                                self::$httpproto,
-                                $class->get('ip'),
-                                $class->get('webroot')
-                            )
-                        ]
-                    );
+                    $extra = [
+                        'online' => $class->get('online'),
+                        //'logfiles' => $class->get('logfiles'),
+                        'storagegroup' => $class->get('storagegroup')->get(),
+                        'location_url' => sprintf(
+                            '%s://%s/%s',
+                            self::$httpproto,
+                            $class->get('ip'),
+                            $class->get('webroot')
+                        )
+                    ];
+                    /*
+                     * images/snapinfiles/logfiles are not columns. Each one
+                     * is an outbound HTTP GET to status/getfiles.php on that
+                     * node, so serialising a node used to cost two round
+                     * trips to a machine that may be down -- paid by every
+                     * caller, including ones that never look at the answer.
+                     * FOGMulticastManager re-reads its master nodes every
+                     * MULTICASTSLEEPTIME (10s), and the storagegroup grid
+                     * serialises a master node per row.
+                     *
+                     * logfiles was already commented out for exactly this
+                     * cost, which is the tell that the other two should have
+                     * been opt-in rather than deleted a third time. Left
+                     * commented as it was; making it an expand token is a
+                     * separate decision from stopping the fan-out.
+                     *
+                     * images and snapinfiles are still reachable, by
+                     * ?expand=images,snapinfiles or ?expand=all. Callers that
+                     * want the objects rather than the payload are unaffected:
+                     * the UI reads them off StorageNode itself
+                     * ($StorageNode->get('snapinfiles') in
+                     * snapinmanagement.page.php), which never went through
+                     * this serializer.
+                     */
+                    if (self::wantsExpand('images')) {
+                        $extra['images'] = $class->get('images');
+                    }
+                    if (self::wantsExpand('snapinfiles')) {
+                        $extra['snapinfiles'] = $class->get('snapinfiles');
+                    }
+                    $data = FOGCore::fastmerge($class->get(), $extra);
                     break;
                 case 'storagegroup':
                     $data = FOGCore::fastmerge(

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -22,7 +22,29 @@
  * @link     https://fogproject.org
  */
 require '../commons/base.inc.php';
-FOGCore::checkAuthAndCSRF();
+/*
+ * Two callers, two credentials.
+ *
+ * A browser reaches this with a session, and nothing about that changes.
+ * FOG's own components reach it with no session at all -- StorageNode's
+ * image/snapin listings are built by CLI daemons and by API requests
+ * authenticated with a token -- and until GH-1312 there was no credential
+ * they could present. They got a 401, _getData() read that as an empty
+ * response, and every such caller was silently handed an empty file list.
+ *
+ * The signature is checked first because it is the cheaper answer and
+ * because is_authorized() is what would otherwise redirect a machine caller
+ * to a sign-in page. It authenticates only -- it says the caller belongs to
+ * this installation. What it is allowed to read is still decided below, by
+ * the same $validPaths list that has always bounded this endpoint.
+ *
+ * No CSRF check on the signed path: CSRF defends a browser being made to
+ * act with its ambient cookie, and there is no cookie here. The signature
+ * has to be computed, which is the thing a cross-site request cannot do.
+ */
+if (!FOGCore::validNodeSignature()) {
+    FOGCore::checkAuthAndCSRF();
+}
 $path = filter_input(INPUT_GET, 'path');
 if (!is_string($path)) {
     echo json_encode(

--- a/tests/node-signature-auth.test.php
+++ b/tests/node-signature-auth.test.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * FOG's own components must be able to authenticate without a session.
+ *
+ * StorageNode's image and snapin listings are built by asking the node for
+ * them over HTTP -- status/getfiles.php, one request per listing. That
+ * endpoint required a signed-in session, and the only credential
+ * FOGURLRequests had to offer was the caller's own session cookie. Every
+ * caller that has no session -- every CLI daemon, and any API request
+ * authenticated by token rather than by cookie -- therefore got a 401, which
+ * StorageNode::_getData() turned into an empty list. Not an error: wrong
+ * data, silently, for the multicast manager and for every token client
+ * reading GET /storagenode/{id}.
+ *
+ * The credential those callers can hold is a shared secret in globalSettings
+ * -- master and node read the same database, so there is nothing to
+ * distribute -- used to sign the request rather than to be presented. It is
+ * purpose scoped: service/nodecert.php signs with FOG_STORAGENODE_MYSQLPASS,
+ * and that password is direct database access, so leaking it in transport
+ * costs the whole schema. Leaking this one costs the ability to list
+ * directories on a node.
+ *
+ * WHAT IS ACTUALLY EXERCISED HERE. The three signing/verifying methods are
+ * lifted out of FOGBase and run for real against a stubbed key, so the sign
+ * -> verify round trip and every tamper case are executed, not described.
+ * Only the parts that need a database (nodeApiKey's INSERT) are pinned by
+ * source shape, and the shapes chosen are the ones whose loss reintroduces a
+ * specific defect.
+ *
+ * Usage: php tests/node-signature-auth.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$baseFile = 'packages/web/lib/fog/fogbase.class.php';
+$base = (string)file_get_contents($baseFile);
+
+/*
+ * 1. Build a probe out of the shipped methods.
+ *
+ * getSetting() and nodeApiKey() are the only things they reach for that a
+ * test cannot have, so those two are stubbed and everything else -- the
+ * payload layout, the window arithmetic, the header names, hash_equals --
+ * is the real code.
+ */
+$consts = [];
+foreach (['NODE_API_KEY_SETTING', 'NODE_SIGNATURE_WINDOW'] as $name) {
+    if (!preg_match(
+        '#\n    const ' . $name . ' = (.+?);\n#',
+        $base,
+        $m
+    )) {
+        $fails[] = "FOGBase::$name is gone";
+        continue;
+    }
+    $consts[$name] = trim($m[1]);
+}
+
+$methods = [];
+foreach (
+    [
+        '_nodeSignaturePayload',
+        'nodeSignatureHeaders',
+        'validNodeSignature'
+    ] as $name
+) {
+    if (!preg_match(
+        '#\n    (?:public|private) static function '
+        . preg_quote($name, '#')
+        . '\(.*?\n    \}#s',
+        $base,
+        $m
+    )) {
+        $fails[] = "FOGBase::$name() is gone; nothing else can authenticate"
+            . ' a session-less FOG component';
+        continue;
+    }
+    $methods[$name] = $m[0];
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+eval(
+    'class NodeSigProbe {'
+    . ' const NODE_API_KEY_SETTING = ' . $consts['NODE_API_KEY_SETTING'] . ';'
+    . ' const NODE_SIGNATURE_WINDOW = '
+    . $consts['NODE_SIGNATURE_WINDOW'] . ';'
+    . ' public static $key = \'\';'
+    . ' public static function nodeApiKey() { return self::$key; }'
+    . ' public static function getSetting($k) { return self::$key; }'
+    . implode("\n", $methods)
+    . ' }'
+);
+
+/**
+ * Presents a set of headers as an inbound request.
+ *
+ * @param string $method  The request method.
+ * @param string $uri     REQUEST_URI, path and query.
+ * @param array  $headers Header lines as nodeSignatureHeaders() returns.
+ *
+ * @return void
+ */
+function nodeSigPresent($method, $uri, array $headers)
+{
+    $_SERVER['REQUEST_METHOD'] = $method;
+    $_SERVER['REQUEST_URI'] = $uri;
+    unset(
+        $_SERVER['HTTP_X_FOG_NODE_TIMESTAMP'],
+        $_SERVER['HTTP_X_FOG_NODE_SIGNATURE']
+    );
+    foreach ($headers as $line) {
+        list($name, $value) = explode(': ', $line, 2);
+        $key = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+        $_SERVER[$key] = $value;
+    }
+}
+
+$key = str_repeat('a1', 32);
+NodeSigProbe::$key = $key;
+
+$url = 'https://10.0.0.9/fog/status/getfiles.php?path=%2Fimages';
+$uri = '/fog/status/getfiles.php?path=%2Fimages';
+$headers = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+
+if (count($headers) !== 2) {
+    $fails[] = 'nodeSignatureHeaders() no longer returns both a timestamp'
+        . ' and a signature header';
+}
+
+/*
+ * The channel is headers, not a query parameter, for the reason
+ * installTokenHeader() already documents: a header cannot be set by a
+ * cross-site form or an <img>, and it never lands in browser history, a
+ * bookmark, a Referer or an access log. A long-lived shared secret in a URL
+ * would be in all of them.
+ */
+foreach ($headers as $line) {
+    if (0 !== strpos($line, 'X-Fog-Node-')) {
+        $fails[] = 'nodeSignatureHeaders() emits something other than an'
+            . ' X-Fog-Node-* header: ' . $line;
+    }
+}
+
+// The happy path.
+nodeSigPresent('GET', $uri, $headers);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a request signed by this installation does not verify;'
+        . ' every session-less caller is back to a 401 and an empty list';
+}
+
+// A signature lifted onto a different path. This is the whole reason the
+// path is in the signed material: a captured listing request must not become
+// a read of somewhere else.
+nodeSigPresent('GET', '/fog/status/getfiles.php?path=%2Fetc', $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature verifies against a path it was not issued for';
+}
+
+// ...or onto a different method. A GET must not become a POST.
+nodeSigPresent('POST', $uri, $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature issued for GET verifies as a POST';
+}
+
+// The timestamp is signed, so it cannot be edited to widen its own window.
+$moved = [
+    'X-Fog-Node-Timestamp: ' . (string)(time() - 10),
+    $headers[1]
+];
+nodeSigPresent('GET', $uri, $moved);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'the presented timestamp is not covered by the signature; a'
+        . ' captured request could be re-dated indefinitely';
+}
+
+// Outside the window, correctly signed. This is the property
+// service/nodecert.php does not have -- its HMAC covers the payload only, so
+// a captured request replays forever.
+$stale = (string)(time() - (NodeSigProbe::NODE_SIGNATURE_WINDOW + 60));
+$staleSig = hash_hmac(
+    'sha256',
+    $stale . "\n" . 'GET' . "\n" . $uri,
+    $key
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . $stale,
+        'X-Fog-Node-Signature: ' . $staleSig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a correctly signed request from outside the replay window'
+        . ' is accepted; replay is unbounded again';
+}
+
+// Clock skew in the other direction has to be refused too, or the window is
+// only half a window.
+$future = (string)(time() + (NodeSigProbe::NODE_SIGNATURE_WINDOW + 60));
+$futureSig = hash_hmac(
+    'sha256',
+    $future . "\n" . 'GET' . "\n" . $uri,
+    $key
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . $future,
+        'X-Fog-Node-Signature: ' . $futureSig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a request dated beyond the window into the future is'
+        . ' accepted';
+}
+
+// A different installation's key.
+NodeSigProbe::$key = str_repeat('b2', 32);
+nodeSigPresent('GET', $uri, $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature verifies under a key it was not made with';
+}
+
+/*
+ * No key at all must be a refusal, not an opening. An install that has not
+ * yet generated one, or whose row was deleted to rotate it, must not accept
+ * whatever turns up -- and hash_hmac() with an empty key is a perfectly
+ * ordinary MAC that an attacker can compute.
+ */
+NodeSigProbe::$key = '';
+$emptyKeySig = hash_hmac(
+    'sha256',
+    (string)time() . "\n" . 'GET' . "\n" . $uri,
+    ''
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . (string)time(),
+        'X-Fog-Node-Signature: ' . $emptyKeySig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'an install with no node key accepts a signature computed'
+        . ' with the empty key';
+}
+NodeSigProbe::$key = $key;
+
+// Malformed and absent input.
+nodeSigPresent('GET', $uri, []);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'an unsigned request verifies';
+}
+/*
+ * A non-numeric timestamp. Over-determined on purpose and worth saying so:
+ * removing the ctype_digit() guard alone does not make this pass, because
+ * (int)'not-a-number' is 0 and the window check then refuses it. The guard
+ * is input hygiene rather than the control; the window and the signature
+ * are the controls, and both are pinned above on their own.
+ */
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: not-a-number',
+        'X-Fog-Node-Signature: ' . str_repeat('0', 64)
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a non-numeric timestamp is not rejected';
+}
+
+/*
+ * 2. Verification must never mint a key.
+ *
+ * nodeApiKey() creates one when it is missing, which is right for the
+ * sending side and wrong here: an endpoint that generates a secret because
+ * an unauthenticated caller asked it to is writing attacker-triggered rows,
+ * and on a fresh install it would create the key the very request being
+ * checked could not have known.
+ */
+if (isset($methods['validNodeSignature'])) {
+    if (false !== strpos($methods['validNodeSignature'], 'nodeApiKey(')) {
+        $fails[] = 'validNodeSignature() calls nodeApiKey(); verification'
+            . ' must read the key, never create it';
+    }
+    if (false === strpos($methods['validNodeSignature'], 'hash_equals(')) {
+        $fails[] = 'validNodeSignature() no longer compares with'
+            . ' hash_equals(); a timing-variable compare leaks the expected'
+            . ' signature a byte at a time';
+    }
+}
+
+/*
+ * 3. The key itself.
+ *
+ * random_bytes() rather than anything seedable, and INSERT IGNORE rather
+ * than setSetting() -- setSetting() is an UPDATE through SettingManager and
+ * does nothing at all when the row is absent, which is precisely the case
+ * being healed. The UNIQUE KEY on settingKey then makes the INSERT the
+ * arbiter of a race, so two processes reaching this at once agree instead of
+ * one signing with a key the other has replaced.
+ */
+if (!preg_match(
+    '#public static function nodeApiKey\(\).*?\n    \}#s',
+    $base,
+    $mk
+)) {
+    $fails[] = 'FOGBase::nodeApiKey() is gone';
+} else {
+    if (false === strpos($mk[0], 'random_bytes(')) {
+        $fails[] = 'nodeApiKey() no longer uses random_bytes(); the node key'
+            . ' has to be unguessable';
+    }
+    if (false === strpos($mk[0], 'INSERT IGNORE')) {
+        $fails[] = 'nodeApiKey() no longer creates the row with INSERT'
+            . ' IGNORE; setSetting() cannot create it, and a plain INSERT'
+            . ' makes concurrent generation a lost update';
+    }
+}
+
+/*
+ * 4. The receiving endpoint.
+ *
+ * A browser still needs a session and a CSRF token. What must not come back
+ * is checkAuthAndCSRF() being the only gate (session-less callers get wrong
+ * data again) or the signature being the only gate (the endpoint stops
+ * caring about sessions entirely).
+ */
+$getfiles = (string)file_get_contents('packages/web/status/getfiles.php');
+if (!preg_match(
+    '#if \(!FOGCore::validNodeSignature\(\)\) \{\s*\n\s*'
+    . 'FOGCore::checkAuthAndCSRF\(\);\s*\n\s*\}#',
+    $getfiles
+)) {
+    $fails[] = 'status/getfiles.php no longer falls back to'
+        . ' checkAuthAndCSRF() when the request is unsigned, or no longer'
+        . ' accepts a signature at all';
+}
+
+/*
+ * 5. The sending side signs FOG's own hosts and nobody else's.
+ *
+ * Same reasoning as the session cookie and the CSRF token beside it: this is
+ * a credential, and a credential handed to api.github.com is a credential
+ * given away. isFogHost() is the one answer all three key off.
+ */
+$requests = (string)file_get_contents(
+    'packages/web/lib/fog/fogurlrequests.class.php'
+);
+if (!preg_match(
+    '#if \(\$isFogHost\) \{.*?nodeSignatureHeaders\(#s',
+    $requests
+)) {
+    $fails[] = 'FOGURLRequests no longer signs for FOG hosts, or signs'
+        . ' without gating on $isFogHost -- the node key would go to every'
+        . ' third-party host this class fetches from';
+}
+if (false === strpos($requests, 'CURLOPT_CUSTOMREQUEST')) {
+    $fails[] = 'FOGURLRequests signs without consulting'
+        . ' CURLOPT_CUSTOMREQUEST/CURLOPT_NOBODY; the method in the'
+        . ' signature would not be the method sent';
+}
+
+/*
+ * 6. The key must not be readable back out.
+ *
+ * SENSITIVE_SETTING_PATTERN matches PASSWORD/PASSWD/PWD/SECRET/TOKEN and not
+ * KEY -- widening it to KEY would mask FOG_KEYMAP and FOG_KEY_SEQUENCE,
+ * which are not secrets -- so this one has to be named explicitly, and the
+ * configuration page has to drop the row rather than render it.
+ */
+$route = (string)file_get_contents(
+    'packages/web/lib/router/route.class.php'
+);
+if (!preg_match(
+    '#\$sensitiveSettings = \[.*?\'FOG_NODE_API_KEY\'.*?\];#s',
+    $route
+)) {
+    $fails[] = 'FOG_NODE_API_KEY is not in Route::$sensitiveSettings; the'
+        . ' shared node secret would be readable over REST';
+}
+$configPage = (string)file_get_contents(
+    'packages/web/lib/pages/fogconfigurationpage.page.php'
+);
+if (false === strpos($configPage, 'NODE_API_KEY_SETTING')) {
+    $fails[] = 'the FOG Configuration page no longer drops the node key'
+        . ' row; the secret would be printed into a form field';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: FOG components authenticate to each other without a session\n";
+exit(0);

--- a/tests/storagenode-listings-opt-in.test.php
+++ b/tests/storagenode-listings-opt-in.test.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Serializing a storage node must not fan out to that node.
+ *
+ * `images` and `snapinfiles` are not columns. Each is an outbound HTTP GET
+ * to status/getfiles.php on the node itself, so Route::getter() building
+ * them meant two round trips to a possibly-dead machine every time anything
+ * turned a StorageNode into a payload -- paid by every caller, including the
+ * many that never look at the answer. FOGMulticastManager re-reads its
+ * master nodes every MULTICASTSLEEPTIME (10 seconds by default), and the
+ * storage group grid serializes a master node per row.
+ *
+ * `logfiles` was already commented out for exactly this cost. That is the
+ * tell: the answer was never "delete the field", it was "stop making every
+ * caller pay for it". So they are now behind ?expand=, and the commented
+ * line is left as it was.
+ *
+ * THE SUBTLE HALF. getter() now asks wantsExpand(), so parseExpand() has to
+ * have run before getter() is called. indiv() used to call it after, which
+ * was harmless while nothing in getter() consulted it and is a silent
+ * regression now: the fields would be absent even when the caller asked for
+ * them, with no error anywhere. That ordering is pinned here, because it is
+ * the kind of thing a later tidy-up reverses without noticing.
+ *
+ * Usage: php tests/storagenode-listings-opt-in.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$file = 'packages/web/lib/router/route.class.php';
+$src = (string)file_get_contents($file);
+
+/*
+ * 1. The expand parser and its predicate, run for real. queryParam() is the
+ *    only thing they reach for that a test cannot have.
+ */
+$methods = [];
+foreach (['parseExpand', 'wantsExpand'] as $name) {
+    if (!preg_match(
+        '#\n    public static function '
+        . preg_quote($name, '#')
+        . '\(.*?\n    \}#s',
+        $src,
+        $m
+    )) {
+        $fails[] = "Route::$name() is gone; the opt-in has no gate";
+        continue;
+    }
+    $methods[$name] = $m[0];
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+eval(
+    'class ExpandProbe {'
+    . ' public static $expand = []; public static $expandAll = false;'
+    . ' public static $expandDepth = 0; public static $raw = null;'
+    . ' public static function queryParam($k) { return self::$raw; }'
+    . implode("\n", $methods)
+    . ' }'
+);
+
+$cases = [
+    // raw ?expand= value      images  snapinfiles
+    [null,                     false,  false],
+    ['',                       false,  false],
+    ['images',                 true,   false],
+    ['snapinfiles',            false,  true],
+    ['images,snapinfiles',     true,   true],
+    ['all',                    true,   true],
+    ['IMAGES',                 true,   false],
+    [' images ',               true,   false],
+    ['snapins',                false,  false],
+];
+foreach ($cases as list($raw, $wantImages, $wantSnapins)) {
+    ExpandProbe::$raw = $raw;
+    ExpandProbe::parseExpand();
+    $label = $raw === null ? '(absent)' : "'$raw'";
+    if (ExpandProbe::wantsExpand('images') !== $wantImages) {
+        $fails[] = "expand=$label gives the wrong answer for images";
+    }
+    if (ExpandProbe::wantsExpand('snapinfiles') !== $wantSnapins) {
+        $fails[] = "expand=$label gives the wrong answer for snapinfiles";
+    }
+}
+
+/*
+ * 2. getter() actually gates on it.
+ *
+ * Pinned by shape: what must not come back is an unconditional
+ * $class->get('images'), which is what shipped.
+ */
+if (!preg_match(
+    '#public static function getter\(\$classname, \$class\).*?\n    \}#s',
+    $src,
+    $g
+)) {
+    $fails[] = 'Route::getter() is gone';
+    $case = '';
+} elseif (!preg_match(
+    '#\n                case \'storagenode\':.*?\n                    break;#s',
+    $g[0],
+    $m
+)) {
+    $fails[] = "Route::getter()'s storagenode case is gone";
+    $case = '';
+} else {
+    $case = $m[0];
+}
+if ('' !== $case) {
+    foreach (['images', 'snapinfiles'] as $field) {
+        if (!preg_match(
+            '#if \(self::wantsExpand\(\'' . $field . '\'\)\) \{\s*\n\s*'
+            . '\$extra\[\'' . $field . '\'\] = \$class->get\(\''
+            . $field . '\'\);#',
+            $case
+        )) {
+            $fails[] = "storagenode's $field is not gated on"
+                . " wantsExpand('$field'); serializing a node fans out to"
+                . ' the node again';
+        }
+    }
+    // Left exactly as it was found, per the repo's own rule about
+    // commented-out code. It is also the evidence for why the other two are
+    // opt-in rather than deleted.
+    if (false === strpos($case, "//'logfiles' => \$class->get('logfiles'),")) {
+        $fails[] = "the commented-out logfiles line has been removed from"
+            . ' the storagenode case';
+    }
+}
+
+/*
+ * 3. parseExpand() must precede getter() inside indiv().
+ */
+if (!preg_match(
+    '#public static function indiv\(\$class, \$id\).*?\n    \}#s',
+    $src,
+    $m
+)) {
+    $fails[] = 'Route::indiv() is gone';
+} else {
+    $body = $m[0];
+    $parse = strpos($body, 'self::parseExpand();');
+    $get = strpos($body, 'self::getter(');
+    if ($parse === false) {
+        $fails[] = 'indiv() no longer calls parseExpand(); ?expand= would be'
+            . ' ignored entirely';
+    } elseif ($get === false) {
+        $fails[] = 'indiv() no longer calls getter()';
+    } elseif ($parse > $get) {
+        $fails[] = 'indiv() calls parseExpand() after getter(); getter()'
+            . ' reads the expansion state, so storagenode images and'
+            . ' snapinfiles would be absent even when asked for -- silently,'
+            . ' with no error anywhere';
+    }
+}
+
+/*
+ * 4. The document has to say so. A client generated from a spec that still
+ *    promises these fields unconditionally looks for something that is not
+ *    in the payload.
+ */
+$openapi = (string)file_get_contents(
+    'packages/web/lib/fog/openapi.class.php'
+);
+if (!preg_match('#case \'storagenode\':.*?expand=all#s', $openapi)) {
+    $fails[] = 'OpenAPI no longer records that storagenode images and'
+        . ' snapinfiles are expand-only';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: storage node file listings are opt-in\n";
+exit(0);


### PR DESCRIPTION
Closes #1312.

## The bug

`GET /storagenode/{id}` returns empty `images` and `snapinfiles` for every
online node when the caller has no browser session — every CLI daemon, and any
API request authenticated by token. A normal 200. Nothing logged.

Neither field is a column: `StorageNode::_getData()` builds each by asking
`status/getfiles.php` on the node, and that endpoint required a session. The
only credential `FOGURLRequests` had was the caller's own session cookie, which
is `''` in a session-less caller, so the inner request 401'd and
`json_decode($response[0], true) ?? []` served the failure back as "this node
has no images". Wrong data, not an error.

Found while fixing #1308/#1309. Stopping the empty-cookie leak did not fix
authentication — it made the 401 honest.

## The credential

`FOG_NODE_API_KEY`: 32 random bytes in `globalSettings`, signed over
`timestamp \n METHOD \n path?query` with HMAC-SHA256, presented as
`X-Fog-Node-Timestamp` / `X-Fog-Node-Signature`.

| Decision | Why |
|---|---|
| globalSettings, not `config.class.php` | a node's installer generates its own config with its own randoms, so a constant would never match. `functions.sh` points a node's `DATABASE_HOST` at the master, so one row is readable everywhere with nothing to distribute. |
| Purpose scoped, not `FOG_STORAGENODE_MYSQLPASS` | `nodecert.php` signs with the MySQL password. Leaking that in transport costs the whole schema; leaking this costs the ability to list directories on a node. |
| Signed, not presented | node traffic runs with `CURLOPT_SSL_VERIFYPEER` off (`NODE_TLS_OPTIONS` — a node is a bare IP with a self-signed cert), so a bearer token on that channel is a token handed to whoever is listening. |
| Timestamp in the signed material | the gap `nodecert.php` has: its HMAC covers the payload only, so a captured request replays forever. Five minutes, bounded to the same method on the same path. |
| `INSERT IGNORE`, not `setSetting()` | `setSetting()` is an UPDATE through `SettingManager` and does nothing when the row is absent — precisely the case being healed. The `UNIQUE KEY` on `settingKey` then arbitrates a race, so two processes agree instead of one signing with a key the other replaced. |
| Header only | the reason `installTokenHeader()` already documents: not settable cross-site, and never in history, a bookmark, a Referer or an access log. |
| Not in REST output, not on the config page | `SENSITIVE_SETTING_PATTERN` matches PASSWORD/PASSWD/PWD/SECRET/TOKEN and not KEY — widening it would mask `FOG_KEYMAP` and `FOG_KEY_SEQUENCE` — so it is named in `Route::$sensitiveSettings`, and the configuration page drops the row rather than rendering the secret into a form field. Rotation is deleting the row. |

Browsers are unchanged: `getfiles.php` still calls `checkAuthAndCSRF()` for
anything unsigned. No CSRF check on the signed path — CSRF defends a browser
acting with its ambient cookie, and there is no cookie here; the signature has
to be computed, which is the thing a cross-site request cannot do.

**No schema step and no `FOG_SCHEMA` bump**, deliberately, and this is a change
from the shape I first proposed. A closure step generating the key would be a
second copy of `nodeApiKey()`'s body, and it would make every existing install
run the updater for a row that appears on its own on the first request. The
self-heal covers fresh installs and upgrades identically.

## The fan-out

`images` and `snapinfiles` are now behind `?expand=`. Each is an outbound HTTP
GET to a machine that may be down, and every caller paid for both:
`FOGMulticastManager` re-reads its master nodes every `MULTICASTSLEEPTIME`
(10s), and the storage group grid serializes a master node per row.

`logfiles` was already commented out in `Route::getter()` for exactly this cost
— which is the tell that the other two should be opt-in rather than deleted a
third time. It is left commented, as found.

`indiv()` now calls `parseExpand()` before `getter()`. That is load-bearing:
`getter()` reads the expansion state, so the old ordering would make the fields
absent even when asked for, silently. Pinned by a test for that reason.

UI callers are unaffected — `snapinmanagement.page.php` reads
`$StorageNode->get('snapinfiles')` off the object, which never went through
this serializer.

## Verification

- Both new tests **mutation verified**: 13/14 and 9/9. The one survivor is the
  `ctype_digit` guard, which the replay window already refuses — annotated in
  the test as over-determined rather than left looking like a gate.
- The signing/verifying methods are lifted out of `FOGBase` and **run for
  real** against a stubbed key, so the round trip and every tamper case are
  executed: wrong path, wrong method, re-dated timestamp, stale timestamp,
  future timestamp, wrong key, empty key, unsigned, malformed.
- `parseExpand()`/`wantsExpand()` likewise run for real over nine `?expand=`
  inputs.
- The `INSERT IGNORE` was executed against the **live 1.6 database** inside a
  transaction and rolled back: statement valid, 64-char value stores, second
  insert affects 0 rows, nothing left behind.
- Full `tests/*.test.php` suite green.

Not yet exercised end-to-end against a running install — that needs a deploy.

## Downstream

`darksidemilk/FogApi` keeps its own hardcoded 1.6 class list in
`Private/Get-DynmicParam.ps1`. **No class was added or removed here**, so that
list needs no sync — but any FogApi code reading `images`/`snapinfiles` off
`GET /storagenode/{id}` must now send `?expand=images,snapinfiles` (or
`?expand=all`). Worth noting because until this PR those fields came back
*empty* for token callers, so nothing downstream can have been relying on their
contents.

A `dev-branch` port follows.
