### PR TITLE
fix(auth): let FOG's own components authenticate without a session (1.5 port)

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -3260,6 +3260,210 @@ abstract class FOGBase
             || (self::schemaNeedsDeploy() && self::installTokenParam());
     }
     /**
+     * The globalSettings key holding the shared node-signing secret.
+     *
+     * Deliberately NOT a config.class.php constant like
+     * FOG_SCHEMA_INSTALL_TOKEN: every storage node's installer generates its
+     * own config.class.php with its own random values, so a constant would
+     * differ on every machine and never verify. globalSettings is the one
+     * store master and node genuinely share -- functions.sh points a node's
+     * DATABASE_HOST at the master (see `[[ -z ${DB_host} ]] &&
+     * DB_host="$snmysqlhost"`), so a row written once is readable everywhere
+     * with nothing to distribute.
+     *
+     * @var string
+     */
+    const NODE_API_KEY_SETTING = 'FOG_NODE_API_KEY';
+    /**
+     * How far, in seconds, a signed request's timestamp may be from ours.
+     *
+     * This is the property service/nodecert.php does NOT have: its HMAC
+     * covers only the payload, so a captured request is replayable forever.
+     * Node traffic runs with CURLOPT_SSL_VERIFYPEER off (NODE_TLS_OPTIONS in
+     * FOGURLRequests -- a node's certificate is self-signed and there is no
+     * chain to check), so a capture is a realistic thing to defend against.
+     *
+     * Five minutes rather than something tighter because master and node
+     * clocks are not disciplined to each other by anything FOG installs, and
+     * the failure mode of too-tight is a node that silently serves nothing.
+     * It bounds replay to the same method on the same path -- for the reads
+     * this authenticates, that is a re-read of a directory listing.
+     *
+     * @var int
+     */
+    const NODE_SIGNATURE_WINDOW = 300;
+    /**
+     * The shared secret FOG's own components sign inter-node requests with,
+     * created on first use if it is not there yet.
+     *
+     * Purpose-scoped on purpose. The obvious existing secret to reuse was
+     * FOG_STORAGENODE_MYSQLPASS, which is what service/nodecert.php signs
+     * with -- but that password is direct database access. Leaking it during
+     * transport hands an attacker the whole schema; leaking this hands them
+     * the ability to list directories on a node, which is all it authorises.
+     *
+     * INSERT IGNORE rather than setSetting(), for two reasons. setSetting()
+     * is an UPDATE through ServiceManager and does nothing at all when the
+     * row is absent, which is exactly the case being healed here. And the
+     * UNIQUE INDEX schema step 225 put on settingKey makes the INSERT the
+     * arbiter when two processes race -- both then re-read and agree,
+     * instead of the loser signing with a key the verifier has replaced.
+     *
+     * @return string The key, or '' if one could not be established.
+     */
+    public static function nodeApiKey()
+    {
+        $key = trim((string)self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($key !== '') {
+            return $key;
+        }
+        try {
+            $candidate = bin2hex(random_bytes(32));
+        } catch (Exception $e) {
+            // No CSPRNG means no key. Returning '' leaves callers
+            // unauthenticated, which is the safe direction: an unsigned
+            // request is refused, a weakly signed one would not be.
+            return '';
+        }
+        self::$DB->query(
+            sprintf(
+                "INSERT IGNORE INTO `globalSettings` (`settingKey`, "
+                . "`settingDesc`, `settingValue`, `settingCategory`) "
+                . "VALUES (%s, %s, %s, %s)",
+                self::$DB->escape(self::NODE_API_KEY_SETTING),
+                self::$DB->escape(
+                    'Shared secret FOG signs its own server-to-server '
+                    . 'requests with. Generated automatically; there is '
+                    . 'nothing to set here, and the FOG Configuration page '
+                    . 'does not show it. Delete the row to rotate the key -- '
+                    . 'every component reads it from this table, so the next '
+                    . 'request regenerates one and they agree again.'
+                ),
+                self::$DB->escape($candidate),
+                self::$DB->escape('FOG Storage Nodes')
+            )
+        );
+        // Re-read rather than trusting $candidate: on a race the INSERT was
+        // ignored and the row holds the other process's value.
+        return trim((string)self::getSetting(self::NODE_API_KEY_SETTING));
+    }
+    /**
+     * The exact bytes both ends run through hash_hmac().
+     *
+     * Method and path are in the signed material so a captured signature
+     * cannot be lifted onto a different request -- a GET of a directory
+     * listing must not become a POST of anything. The timestamp is in it so
+     * it cannot be adjusted to widen the window it was issued for.
+     *
+     * @param string $method    The HTTP method, upper case.
+     * @param string $uri       Path plus query string, exactly as sent.
+     * @param string $timestamp Unix seconds, as a decimal string.
+     *
+     * @return string
+     */
+    private static function _nodeSignaturePayload($method, $uri, $timestamp)
+    {
+        return $timestamp . "\n" . $method . "\n" . $uri;
+    }
+    /**
+     * Headers proving a request came from this FOG installation.
+     *
+     * Header-only, for the reason installTokenHeader() already sets out: a
+     * header cannot be set by a cross-site form, a link or an <img>, and it
+     * never lands in browser history, a bookmark, a Referer or an access
+     * log. A query parameter would put a long-lived shared secret in every
+     * one of those.
+     *
+     * The signature covers path-and-query rather than the whole URL, so the
+     * http -> https redirect FOG's own vhost issues does not invalidate it.
+     *
+     * @param string $url    The URL about to be requested.
+     * @param string $method The HTTP method that will be used.
+     *
+     * @return array Header lines, or an empty array when unavailable.
+     */
+    public static function nodeSignatureHeaders($url, $method = 'GET')
+    {
+        $key = self::nodeApiKey();
+        if ($key === '') {
+            return array();
+        }
+        $parts = parse_url((string)$url);
+        if ($parts === false) {
+            return array();
+        }
+        $uri = isset($parts['path']) ? $parts['path'] : '/';
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $uri .= '?' . $parts['query'];
+        }
+        $timestamp = (string)time();
+        $signature = hash_hmac(
+            'sha256',
+            self::_nodeSignaturePayload(
+                strtoupper((string)$method),
+                $uri,
+                $timestamp
+            ),
+            $key
+        );
+        return array(
+            'X-Fog-Node-Timestamp: ' . $timestamp,
+            'X-Fog-Node-Signature: ' . $signature
+        );
+    }
+    /**
+     * Is this request signed by a FOG component that holds the node key?
+     *
+     * Authentication, not authorisation: it says the caller is part of this
+     * installation, and nothing about what it may do. Endpoints accepting it
+     * must still be ones a node is entitled to reach -- the same split
+     * service/nodecert.php makes when it checks the HMAC and then separately
+     * matches the source IP against a registered node.
+     *
+     * getSetting() rather than nodeApiKey() deliberately: verification must
+     * never mint a key. If no key exists there is nothing this request can
+     * have signed with, and the answer is no.
+     *
+     * @return bool
+     */
+    public static function validNodeSignature()
+    {
+        $timestamp = isset($_SERVER['HTTP_X_FOG_NODE_TIMESTAMP'])
+            ? $_SERVER['HTTP_X_FOG_NODE_TIMESTAMP']
+            : null;
+        $signature = isset($_SERVER['HTTP_X_FOG_NODE_SIGNATURE'])
+            ? $_SERVER['HTTP_X_FOG_NODE_SIGNATURE']
+            : null;
+        if (!is_string($timestamp)
+            || !is_string($signature)
+            || $signature === ''
+            || !ctype_digit($timestamp)
+        ) {
+            return false;
+        }
+        if (abs(time() - (int)$timestamp) > self::NODE_SIGNATURE_WINDOW) {
+            return false;
+        }
+        $key = trim((string)self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($key === '') {
+            return false;
+        }
+        $method = isset($_SERVER['REQUEST_METHOD'])
+            ? $_SERVER['REQUEST_METHOD']
+            : 'GET';
+        $uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+        $expected = hash_hmac(
+            'sha256',
+            self::_nodeSignaturePayload(
+                strtoupper((string)$method),
+                (string)$uri,
+                $timestamp
+            ),
+            $key
+        );
+        return hash_equals($expected, $signature);
+    }
+    /**
      * Is the acting user a FOG administrator (uType 0)?
      *
      * Deliberately not is_authorized(), which is true for any valid user --

--- a/packages/web/lib/fog/fogurlrequests.class.php
+++ b/packages/web/lib/fog/fogurlrequests.class.php
@@ -578,6 +578,47 @@ class FOGURLRequests extends FOGBase
             $options[CURLOPT_COOKIE] = session_name() . '=' . session_id();
         }
         /*
+         * Prove to FOG's own hosts that this request came from FOG.
+         *
+         * The cookie above only works when a browser session exists to
+         * forward. Every CLI daemon and every token-authenticated API call
+         * has none, so StorageNode::_getData() went out unauthenticated,
+         * getfiles.php answered 401, and the loader turned that into an
+         * empty file list -- wrong data rather than an error. This is the
+         * credential those callers can actually hold: a shared secret in
+         * globalSettings, which master and node both read (GH-1312).
+         *
+         * Signed for every FOG host, not only the session-less case, so the
+         * browser path exercises the same code. A signature that stops
+         * verifying then shows up in the UI immediately instead of only in a
+         * daemon nobody is watching.
+         *
+         * Bound to the method actually about to be sent, so a signature
+         * issued for a GET cannot be presented as anything else.
+         */
+        if ($isFogHost) {
+            if (!empty($options[CURLOPT_CUSTOMREQUEST])) {
+                $method = (string)$options[CURLOPT_CUSTOMREQUEST];
+            } elseif (!empty($options[CURLOPT_NOBODY])) {
+                $method = 'HEAD';
+            } elseif (!empty($options[CURLOPT_POST])) {
+                $method = 'POST';
+            } else {
+                $method = 'GET';
+            }
+            $signature = self::nodeSignatureHeaders($url, $method);
+            if (count($signature) > 0) {
+                $options[CURLOPT_HTTPHEADER] = array_merge(
+                    (array)(
+                        isset($options[CURLOPT_HTTPHEADER])
+                        ? $options[CURLOPT_HTTPHEADER]
+                        : array()
+                    ),
+                    $signature
+                );
+            }
+        }
+        /*
          * The TLS exemption for FOG's own nodes. Applied here rather than in
          * the defaults so it is decided by the URL: a caller cannot acquire
          * it by not thinking about it, which is how every request this class

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -2720,6 +2720,17 @@ class FOGConfigurationPage extends FOGPage
         $Services = $Services->services;
         $divTab = false;
         foreach ((array)$Services as &$Service) {
+            // Never shown, to anyone. FOG generates and consumes this key
+            // itself (FOGBase::nodeApiKey(), inherited here); there is no
+            // value an admin could usefully type, and printing a shared
+            // secret into a form field is a leak with no upside -- support
+            // threads are full of screenshots of this page. Rotation is
+            // deleting the row; the next request regenerates one. Skipped
+            // before $curcat is read so it cannot open a panel of its own.
+            if ($Service->name === self::NODE_API_KEY_SETTING) {
+                unset($Service);
+                continue;
+            }
             $curcat = $Service->category;
             if (!$divTab) {
                 $divTab = preg_replace(
@@ -3410,6 +3421,18 @@ class FOGConfigurationPage extends FOGPage
                         }
                         break;
                     case 'FOG_CLIENT_BANNER_SHA':
+                        continue 2;
+                    case self::NODE_API_KEY_SETTING:
+                        /*
+                         * This saver walks every setting rather than the
+                         * posted ones, and $set falls back to 0 for anything
+                         * absent from $_POST. The node key is deliberately
+                         * not rendered, so saving any panel in its category
+                         * would replace a working shared secret with the
+                         * string "0" -- and both ends would then agree on
+                         * "0", so nothing would look broken until someone
+                         * guessed it. Same shape as the banner SHA above.
+                         */
                         continue 2;
                     case 'FOG_CLIENT_BANNER_IMAGE':
                         $banner = filter_input(INPUT_POST, 'banner');

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -22,7 +22,29 @@
  * @link     https://fogproject.org
  */
 require '../commons/base.inc.php';
-FOGCore::checkAuthAndCSRF();
+/*
+ * Two callers, two credentials.
+ *
+ * A browser reaches this with a session, and nothing about that changes.
+ * FOG's own components reach it with no session at all -- StorageNode's
+ * image/snapin listings are built by CLI daemons and by API requests
+ * authenticated with a token -- and until GH-1312 there was no credential
+ * they could present. They got a 401, _getData() read that as an empty
+ * response, and every such caller was silently handed an empty file list.
+ *
+ * The signature is checked first because it is the cheaper answer and
+ * because is_authorized() is what would otherwise redirect a machine caller
+ * to a sign-in page. It authenticates only -- it says the caller belongs to
+ * this installation. What it is allowed to read is still decided below, by
+ * the same $validPaths list that has always bounded this endpoint.
+ *
+ * No CSRF check on the signed path: CSRF defends a browser being made to
+ * act with its ambient cookie, and there is no cookie here. The signature
+ * has to be computed, which is the thing a cross-site request cannot do.
+ */
+if (!FOGCore::validNodeSignature()) {
+    FOGCore::checkAuthAndCSRF();
+}
 $path = filter_input(INPUT_GET, 'path');
 if (!is_string($path)) {
     echo json_encode(

--- a/tests/node-signature-auth.test.php
+++ b/tests/node-signature-auth.test.php
@@ -1,0 +1,421 @@
+<?php
+/**
+ * FOG's own components must be able to authenticate without a session.
+ *
+ * StorageNode's image and snapin listings are built by asking the node for
+ * them over HTTP -- status/getfiles.php, one request per listing. That
+ * endpoint required a signed-in session, and the only credential
+ * FOGURLRequests had to offer was the caller's own session cookie. Every
+ * caller that has no session -- every CLI daemon, and any API request
+ * authenticated by token rather than by cookie -- therefore got a 401, which
+ * StorageNode::_getData() turned into an empty list. Not an error: wrong
+ * data, silently, for the multicast manager and for every token client
+ * reading GET /storagenode/{id}.
+ *
+ * The credential those callers can hold is a shared secret in globalSettings
+ * -- master and node read the same database, so there is nothing to
+ * distribute -- used to sign the request rather than to be presented. It is
+ * purpose scoped: service/nodecert.php signs with FOG_STORAGENODE_MYSQLPASS,
+ * and that password is direct database access, so leaking it in transport
+ * costs the whole schema. Leaking this one costs the ability to list
+ * directories on a node.
+ *
+ * WHAT IS ACTUALLY EXERCISED HERE. The three signing/verifying methods are
+ * lifted out of FOGBase and run for real against a stubbed key, so the sign
+ * -> verify round trip and every tamper case are executed, not described.
+ * Only the parts that need a database (nodeApiKey's INSERT) are pinned by
+ * source shape, and the shapes chosen are the ones whose loss reintroduces a
+ * specific defect.
+ *
+ * Usage: php tests/node-signature-auth.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$baseFile = 'packages/web/lib/fog/fogbase.class.php';
+$base = (string)file_get_contents($baseFile);
+
+/*
+ * 1. Build a probe out of the shipped methods.
+ *
+ * getSetting() and nodeApiKey() are the only things they reach for that a
+ * test cannot have, so those two are stubbed and everything else -- the
+ * payload layout, the window arithmetic, the header names, hash_equals --
+ * is the real code.
+ */
+$consts = [];
+foreach (['NODE_API_KEY_SETTING', 'NODE_SIGNATURE_WINDOW'] as $name) {
+    if (!preg_match(
+        '#\n    const ' . $name . ' = (.+?);\n#',
+        $base,
+        $m
+    )) {
+        $fails[] = "FOGBase::$name is gone";
+        continue;
+    }
+    $consts[$name] = trim($m[1]);
+}
+
+$methods = [];
+foreach (
+    [
+        '_nodeSignaturePayload',
+        'nodeSignatureHeaders',
+        'validNodeSignature'
+    ] as $name
+) {
+    if (!preg_match(
+        '#\n    (?:public|private) static function '
+        . preg_quote($name, '#')
+        . '\(.*?\n    \}#s',
+        $base,
+        $m
+    )) {
+        $fails[] = "FOGBase::$name() is gone; nothing else can authenticate"
+            . ' a session-less FOG component';
+        continue;
+    }
+    $methods[$name] = $m[0];
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+eval(
+    'class NodeSigProbe {'
+    . ' const NODE_API_KEY_SETTING = ' . $consts['NODE_API_KEY_SETTING'] . ';'
+    . ' const NODE_SIGNATURE_WINDOW = '
+    . $consts['NODE_SIGNATURE_WINDOW'] . ';'
+    . ' public static $key = \'\';'
+    . ' public static function nodeApiKey() { return self::$key; }'
+    . ' public static function getSetting($k) { return self::$key; }'
+    . implode("\n", $methods)
+    . ' }'
+);
+
+/**
+ * Presents a set of headers as an inbound request.
+ *
+ * @param string $method  The request method.
+ * @param string $uri     REQUEST_URI, path and query.
+ * @param array  $headers Header lines as nodeSignatureHeaders() returns.
+ *
+ * @return void
+ */
+function nodeSigPresent($method, $uri, array $headers)
+{
+    $_SERVER['REQUEST_METHOD'] = $method;
+    $_SERVER['REQUEST_URI'] = $uri;
+    unset(
+        $_SERVER['HTTP_X_FOG_NODE_TIMESTAMP'],
+        $_SERVER['HTTP_X_FOG_NODE_SIGNATURE']
+    );
+    foreach ($headers as $line) {
+        list($name, $value) = explode(': ', $line, 2);
+        $key = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+        $_SERVER[$key] = $value;
+    }
+}
+
+$key = str_repeat('a1', 32);
+NodeSigProbe::$key = $key;
+
+$url = 'https://10.0.0.9/fog/status/getfiles.php?path=%2Fimages';
+$uri = '/fog/status/getfiles.php?path=%2Fimages';
+$headers = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+
+if (count($headers) !== 2) {
+    $fails[] = 'nodeSignatureHeaders() no longer returns both a timestamp'
+        . ' and a signature header';
+}
+
+/*
+ * The channel is headers, not a query parameter, for the reason
+ * installTokenHeader() already documents: a header cannot be set by a
+ * cross-site form or an <img>, and it never lands in browser history, a
+ * bookmark, a Referer or an access log. A long-lived shared secret in a URL
+ * would be in all of them.
+ */
+foreach ($headers as $line) {
+    if (0 !== strpos($line, 'X-Fog-Node-')) {
+        $fails[] = 'nodeSignatureHeaders() emits something other than an'
+            . ' X-Fog-Node-* header: ' . $line;
+    }
+}
+
+// The happy path.
+nodeSigPresent('GET', $uri, $headers);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a request signed by this installation does not verify;'
+        . ' every session-less caller is back to a 401 and an empty list';
+}
+
+// A signature lifted onto a different path. This is the whole reason the
+// path is in the signed material: a captured listing request must not become
+// a read of somewhere else.
+nodeSigPresent('GET', '/fog/status/getfiles.php?path=%2Fetc', $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature verifies against a path it was not issued for';
+}
+
+// ...or onto a different method. A GET must not become a POST.
+nodeSigPresent('POST', $uri, $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature issued for GET verifies as a POST';
+}
+
+// The timestamp is signed, so it cannot be edited to widen its own window.
+$moved = [
+    'X-Fog-Node-Timestamp: ' . (string)(time() - 10),
+    $headers[1]
+];
+nodeSigPresent('GET', $uri, $moved);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'the presented timestamp is not covered by the signature; a'
+        . ' captured request could be re-dated indefinitely';
+}
+
+// Outside the window, correctly signed. This is the property
+// service/nodecert.php does not have -- its HMAC covers the payload only, so
+// a captured request replays forever.
+$stale = (string)(time() - (NodeSigProbe::NODE_SIGNATURE_WINDOW + 60));
+$staleSig = hash_hmac(
+    'sha256',
+    $stale . "\n" . 'GET' . "\n" . $uri,
+    $key
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . $stale,
+        'X-Fog-Node-Signature: ' . $staleSig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a correctly signed request from outside the replay window'
+        . ' is accepted; replay is unbounded again';
+}
+
+// Clock skew in the other direction has to be refused too, or the window is
+// only half a window.
+$future = (string)(time() + (NodeSigProbe::NODE_SIGNATURE_WINDOW + 60));
+$futureSig = hash_hmac(
+    'sha256',
+    $future . "\n" . 'GET' . "\n" . $uri,
+    $key
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . $future,
+        'X-Fog-Node-Signature: ' . $futureSig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a request dated beyond the window into the future is'
+        . ' accepted';
+}
+
+// A different installation's key.
+NodeSigProbe::$key = str_repeat('b2', 32);
+nodeSigPresent('GET', $uri, $headers);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature verifies under a key it was not made with';
+}
+
+/*
+ * No key at all must be a refusal, not an opening. An install that has not
+ * yet generated one, or whose row was deleted to rotate it, must not accept
+ * whatever turns up -- and hash_hmac() with an empty key is a perfectly
+ * ordinary MAC that an attacker can compute.
+ */
+NodeSigProbe::$key = '';
+$emptyKeySig = hash_hmac(
+    'sha256',
+    (string)time() . "\n" . 'GET' . "\n" . $uri,
+    ''
+);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . (string)time(),
+        'X-Fog-Node-Signature: ' . $emptyKeySig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'an install with no node key accepts a signature computed'
+        . ' with the empty key';
+}
+NodeSigProbe::$key = $key;
+
+// Malformed and absent input.
+nodeSigPresent('GET', $uri, []);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'an unsigned request verifies';
+}
+/*
+ * A non-numeric timestamp. Over-determined on purpose and worth saying so:
+ * removing the ctype_digit() guard alone does not make this pass, because
+ * (int)'not-a-number' is 0 and the window check then refuses it. The guard
+ * is input hygiene rather than the control; the window and the signature
+ * are the controls, and both are pinned above on their own.
+ */
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: not-a-number',
+        'X-Fog-Node-Signature: ' . str_repeat('0', 64)
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a non-numeric timestamp is not rejected';
+}
+
+/*
+ * 2. Verification must never mint a key.
+ *
+ * nodeApiKey() creates one when it is missing, which is right for the
+ * sending side and wrong here: an endpoint that generates a secret because
+ * an unauthenticated caller asked it to is writing attacker-triggered rows,
+ * and on a fresh install it would create the key the very request being
+ * checked could not have known.
+ */
+if (isset($methods['validNodeSignature'])) {
+    if (false !== strpos($methods['validNodeSignature'], 'nodeApiKey(')) {
+        $fails[] = 'validNodeSignature() calls nodeApiKey(); verification'
+            . ' must read the key, never create it';
+    }
+    if (false === strpos($methods['validNodeSignature'], 'hash_equals(')) {
+        $fails[] = 'validNodeSignature() no longer compares with'
+            . ' hash_equals(); a timing-variable compare leaks the expected'
+            . ' signature a byte at a time';
+    }
+}
+
+/*
+ * 3. The key itself.
+ *
+ * random_bytes() rather than anything seedable, and INSERT IGNORE rather
+ * than setSetting() -- setSetting() is an UPDATE through SettingManager and
+ * does nothing at all when the row is absent, which is precisely the case
+ * being healed. The UNIQUE KEY on settingKey then makes the INSERT the
+ * arbiter of a race, so two processes reaching this at once agree instead of
+ * one signing with a key the other has replaced.
+ */
+if (!preg_match(
+    '#public static function nodeApiKey\(\).*?\n    \}#s',
+    $base,
+    $mk
+)) {
+    $fails[] = 'FOGBase::nodeApiKey() is gone';
+} else {
+    if (false === strpos($mk[0], 'random_bytes(')) {
+        $fails[] = 'nodeApiKey() no longer uses random_bytes(); the node key'
+            . ' has to be unguessable';
+    }
+    if (false === strpos($mk[0], 'INSERT IGNORE')) {
+        $fails[] = 'nodeApiKey() no longer creates the row with INSERT'
+            . ' IGNORE; setSetting() cannot create it, and a plain INSERT'
+            . ' makes concurrent generation a lost update';
+    }
+}
+
+/*
+ * 4. The receiving endpoint.
+ *
+ * A browser still needs a session and a CSRF token. What must not come back
+ * is checkAuthAndCSRF() being the only gate (session-less callers get wrong
+ * data again) or the signature being the only gate (the endpoint stops
+ * caring about sessions entirely).
+ */
+$getfiles = (string)file_get_contents('packages/web/status/getfiles.php');
+if (!preg_match(
+    '#if \(!FOGCore::validNodeSignature\(\)\) \{\s*\n\s*'
+    . 'FOGCore::checkAuthAndCSRF\(\);\s*\n\s*\}#',
+    $getfiles
+)) {
+    $fails[] = 'status/getfiles.php no longer falls back to'
+        . ' checkAuthAndCSRF() when the request is unsigned, or no longer'
+        . ' accepts a signature at all';
+}
+
+/*
+ * 5. The sending side signs FOG's own hosts and nobody else's.
+ *
+ * Same reasoning as the session cookie and the CSRF token beside it: this is
+ * a credential, and a credential handed to api.github.com is a credential
+ * given away. isFogHost() is the one answer all three key off.
+ */
+$requests = (string)file_get_contents(
+    'packages/web/lib/fog/fogurlrequests.class.php'
+);
+if (!preg_match(
+    '#if \(\$isFogHost\) \{.*?nodeSignatureHeaders\(#s',
+    $requests
+)) {
+    $fails[] = 'FOGURLRequests no longer signs for FOG hosts, or signs'
+        . ' without gating on $isFogHost -- the node key would go to every'
+        . ' third-party host this class fetches from';
+}
+if (false === strpos($requests, 'CURLOPT_CUSTOMREQUEST')) {
+    $fails[] = 'FOGURLRequests signs without consulting'
+        . ' CURLOPT_CUSTOMREQUEST/CURLOPT_NOBODY; the method in the'
+        . ' signature would not be the method sent';
+}
+
+/*
+ * 6. The configuration page must neither print the key nor overwrite it.
+ *
+ * Two halves, and the second is the one that bites. This branch's saver
+ * walks EVERY setting rather than the posted ones, and $set falls back to 0
+ * for anything absent from $_POST -- so hiding the field without also
+ * skipping it in the saver replaces the shared secret with the string "0"
+ * the first time an admin saves that category. Both ends would then agree
+ * on "0" and nothing would look broken.
+ *
+ * There is no REST redaction layer on this branch to add the key to. GET
+ * /service already returns FOG_STORAGENODE_MYSQLPASS and FOG_API_TOKEN in
+ * the clear, so an API caller who could read this key already holds strictly
+ * more; building that layer here is a separate change.
+ */
+$configPage = (string)file_get_contents(
+    'packages/web/lib/pages/fogconfigurationpage.class.php'
+);
+if (!preg_match(
+    '#if \(\$Service->name === self::NODE_API_KEY_SETTING\) \{#',
+    $configPage
+)) {
+    $fails[] = 'the FOG Configuration page no longer drops the node key'
+        . ' row; the secret would be printed into a form field';
+}
+if (!preg_match(
+    '#case self::NODE_API_KEY_SETTING:.*?continue 2;#s',
+    $configPage
+)) {
+    $fails[] = 'the settings saver no longer skips the node key; it walks'
+        . ' every setting and defaults an unposted one to 0, so saving the'
+        . ' page would overwrite the shared secret with "0"';
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: FOG components authenticate to each other without a session\n";
+exit(0);


### PR DESCRIPTION
1.5 port of #1313. Same issue: #1312.

## The bug, here

`StorageNode::_getData()` builds `images` and `snapinfiles` by asking
`status/getfiles.php` on the node. That endpoint calls
`FOGCore::checkAuthAndCSRF()`, and the only credential `FOGURLRequests` had to
offer was the caller's own session cookie — `''` in every CLI daemon and in any
token-authenticated API request. The inner call 401'd and
`json_decode($response[0], true) ?? []` served the failure back as "this node
has no images".

## The fix, here

`FOG_NODE_API_KEY`: 32 random bytes in `globalSettings`, signed over
`timestamp \n METHOD \n path?query` with HMAC-SHA256, presented as
`X-Fog-Node-Timestamp` / `X-Fog-Node-Signature`, sent only to hosts
`isFogHost()` recognises. Purpose scoped rather than reusing
`FOG_STORAGENODE_MYSQLPASS` (which `nodecert.php` signs with): leaking the
MySQL password in transport costs the whole schema, leaking this costs the
ability to list directories on a node. Signed rather than presented because
node traffic runs with `CURLOPT_SSL_VERIFYPEER` off. Timestamp in the signed
material closes the replay gap `nodecert.php` has.

Created with `INSERT IGNORE` on first use — `setSetting()` is an UPDATE through
`ServiceManager` and does nothing when the row is absent, which is exactly the
case being healed, and the unique index makes the INSERT the arbiter of a race.

Browsers unchanged: `getfiles.php` still calls `checkAuthAndCSRF()` for anything
unsigned.

## What differs from #1313, and why

**This branch needs one thing 1.6 does not.** `settingsPost()` on 1.6 iterates
the *posted* keys, so an unrendered setting is simply never written. This
branch's saver iterates *every* setting and does
`$set = filter_var(isset($_POST[$key]) ? $_POST[$key] : 0);` — so hiding the
field without also skipping it in the saver would replace the shared secret with
the string `"0"` the first time an admin saved that category. Both ends would
then agree on `"0"` and nothing would look broken until someone guessed it.
Skipped the same way `FOG_CLIENT_BANNER_SHA` already is, and pinned by test.

**Two things 1.6 needed that this branch does not.**

- No expand change. `Route::getter()` here already takes `$item` and only emits
  the file listings for `$item == 'all'` or a named item, so there is no eager
  fan-out to remove. Verified before porting.
- No REST redaction. There is no `Route::$sensitiveSettings` on this branch, and
  `GET /service` already returns `FOG_STORAGENODE_MYSQLPASS` and `FOG_API_TOKEN`
  in the clear — verified, not assumed. An API caller who could read the node key
  already holds strictly more, so this adds no exposure. Building a redaction
  layer on a maintenance branch is a separate change; flagging it rather than
  doing it.

## Verification

- Test **mutation verified 13/13**, including both config-page halves.
- The signing/verifying methods are lifted out of `FOGBase` and **run for real**:
  round trip, wrong path, wrong method, re-dated timestamp, stale, future, wrong
  key, empty key, unsigned, malformed.
- The `INSERT IGNORE` was executed **against the 1.5.10 lab database**
  (10.253.25.2) inside a transaction and rolled back: unique index on
  `settingKey` present, `settingValue` is `longtext`, 64-char value stores, a
  second `INSERT IGNORE` leaves the first value intact, nothing left behind.
- Full `tests/*.test.php` suite green.

Not yet exercised end-to-end against a running install — that needs a deploy.

## Downstream

No route class added or removed, so `darksidemilk/FogApi`'s hardcoded class list
in `Private/Get-DynmicParam.ps1` needs no sync. No response shape changes on this
branch either (the expand change is 1.6-only).
