### PR TITLE
fix(api): stop returning credential setting values over REST

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -118,6 +118,70 @@ class Route extends FOGBase
         'virus'
     );
     /**
+     * globalSettings rows whose VALUE is a credential.
+     *
+     * Settings are the odd one out: they are key/value rows, so the secret
+     * is the value of a particular *row* rather than a column present on
+     * every row. A setting matched here has its 'value' removed from API
+     * output while its name, description and category stay, so a consumer
+     * can still see that the setting exists.
+     *
+     * Matching is a pattern plus a short explicit list rather than a hand
+     * maintained enumeration of every key, so a credential setting added
+     * later is masked by default instead of leaking silently until someone
+     * remembers to add it.
+     *
+     * The pattern deliberately requires PASSWORD/PASSWD/PWD and not a bare
+     * "PASS": FOG_USER_MINPASSLENGTH is password *policy* and the UI has to
+     * be able to describe its own rules. KEY is deliberately absent for the
+     * same reason -- FOG_KEYMAP, FOG_KEY_SEQUENCE, FOG_HOSTKEY_ALLOWED_
+     * SOURCES and FOG_QUICKREG_PROD_KEY_BIOS are all configuration.
+     *
+     * Checked against a real 1.5.10 install: the five keys this pattern
+     * catches (FOG_AD_DEFAULT_PASSWORD, _LEGACY, FOG_API_TOKEN,
+     * FOG_PROXY_PASSWORD, FOG_TFTP_FTP_PASSWORD) are all genuine
+     * credentials, and nothing it catches is not one.
+     *
+     * @var string
+     */
+    const SENSITIVE_SETTING_PATTERN = '#(PASSWORD|PASSWD|PWD|SECRET|TOKEN)#i';
+    /**
+     * Credential settings the pattern does not catch.
+     *
+     * @var array
+     */
+    public static $sensitiveSettings = array(
+        // "PASS", not "PASSWORD" -- outside the pattern by one word.
+        'FOG_STORAGENODE_MYSQLPASS',
+        // The shared HMAC secret FOG signs its own server-to-server
+        // requests with. See FOGBase::nodeApiKey().
+        'FOG_NODE_API_KEY',
+    );
+    /**
+     * Settings the pattern matches that are NOT credentials.
+     *
+     * Empty on this branch -- verified against a real 1.5.10 install, the
+     * pattern has no false positives here. Kept so the predicate has the
+     * same three parts it has on working-1.6: this is the one function that
+     * decides whether something is a secret, and a shape that differs
+     * between the branches is a port waiting to go wrong.
+     *
+     * @var array
+     */
+    public static $sensitiveSettingsExempt = array();
+    /**
+     * True once api/index.php has constructed this class.
+     *
+     * The seam between "FOG is answering an HTTP API request" and "a page is
+     * calling Route as a library". Nothing but api/index.php does `new
+     * Route`, and 116 in-tree call sites reach listem()/indiv()/getData()
+     * statically without ever constructing it -- FOG Configuration among
+     * them, which is why credential masking cannot simply be unconditional.
+     *
+     * @var bool
+     */
+    private static $_isApiRequest = false;
+    /**
      * Valid Tasking classes.
      *
      * @var array
@@ -214,6 +278,9 @@ class Route extends FOGBase
      */
     public function __construct()
     {
+        // Everything below this point is serving an HTTP API request. See
+        // the property's docblock for why that has to be distinguishable.
+        self::$_isApiRequest = true;
         list(
             self::$_enabled,
             self::$_token
@@ -1076,10 +1143,16 @@ class Route extends FOGBase
             ) {
                 continue;
             }
-            self::$data[$classname.'s'][] = self::getter(
+            $row = self::getter(
                 $classname,
                 $class
             );
+            // A hit on a masked credential is itself the disclosure.
+            if (!self::_settingHitIsVisible($classname, $row, $item)) {
+                unset($class, $row);
+                continue;
+            }
+            self::$data[$classname.'s'][] = $row;
             self::$data['count']++;
             unset($class);
         }
@@ -1866,6 +1939,8 @@ class Route extends FOGBase
      */
     public static function getsearchbody($class)
     {
+        // Captured before $class is reassigned to an instance below.
+        $classname = strtolower((string)$class);
         $classVars = self::getClass(
             $class,
             '',
@@ -1883,6 +1958,7 @@ class Route extends FOGBase
             }
             unset($key);
         }
+        self::_refuseSettingValueFilter($classname, array_keys($find));
         return $find;
     }
     /**
@@ -2004,6 +2080,124 @@ class Route extends FOGBase
      *
      * @return object|array
      */
+    /**
+     * Refuses a filter that would probe a masked setting value.
+     *
+     * Masking the value in the response is only half a fix. `value` is a
+     * declared field of Service, so /service/ids/value=guess and a
+     * {"value":"guess"} body were both exact-match oracles: the value never
+     * appears in the answer, but whether a row comes back tells you whether
+     * the guess was right, one guess at a time and with no rate limit.
+     *
+     * Refused with a 400 that names the field rather than silently dropped.
+     * A dropped term is the worse failure -- the filter vanishes, the whole
+     * table comes back, and the caller reads that as "no such value".
+     *
+     * @param string $classname The lowercase class being filtered.
+     * @param array  $keys      The filter keys the caller supplied.
+     *
+     * @return void
+     */
+    private static function _refuseSettingValueFilter($classname, $keys)
+    {
+        if (!self::$_isApiRequest || 'service' !== strtolower((string)$classname)) {
+            return;
+        }
+        if (!in_array('value', (array)$keys, true)) {
+            return;
+        }
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_BAD_REQUEST,
+            json_encode(
+                array(
+                    'error' => 'Filtering settings by value is not permitted: '
+                        . 'it would confirm the credential values that are '
+                        . 'masked out of the response.'
+                )
+            )
+        );
+    }
+    /**
+     * Should this search hit be shown, given what it matched on?
+     *
+     * FOGManagerController::search() fills its WHERE from EVERY declared
+     * field -- array_fill_keys(array_keys($this->databaseFields), $keyword)
+     * -- so a substring of a masked credential brings its row back. The row
+     * carries no value, but its arrival is the answer.
+     *
+     * A sensitive setting is therefore kept only when the term is visible in
+     * something the caller is allowed to read. Every field except the value,
+     * rather than a list of the four this class has today, so a field added
+     * later is covered by default instead of by remembering.
+     *
+     * @param string $classname The lowercase class searched.
+     * @param mixed  $row       The serialized row.
+     * @param string $term      The search keyword.
+     *
+     * @return bool
+     */
+    private static function _settingHitIsVisible($classname, $row, $term)
+    {
+        if (!self::$_isApiRequest
+            || 'service' !== strtolower((string)$classname)
+            || !is_array($row)
+        ) {
+            return true;
+        }
+        if (!self::isSensitiveSetting((string)($row['name'] ?? ''))) {
+            return true;
+        }
+        $term = trim((string)$term);
+        if ('' === $term) {
+            return true;
+        }
+        foreach ($row as $field => $cell) {
+            if ('value' === $field || !is_scalar($cell)) {
+                continue;
+            }
+            if (false !== stripos((string)$cell, $term)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * Is this globalSettings key's value a credential?
+     *
+     * @param string $key The setting name.
+     *
+     * @return bool
+     */
+    public static function isSensitiveSetting($key)
+    {
+        if (in_array($key, self::$sensitiveSettingsExempt, true)) {
+            return false;
+        }
+        if (in_array($key, self::$sensitiveSettings, true)) {
+            return true;
+        }
+        return 1 === preg_match(self::SENSITIVE_SETTING_PATTERN, $key);
+    }
+    /**
+     * Drops the value of a globalSettings row that holds a credential.
+     *
+     * The name, description and category stay -- only the value goes -- so
+     * a consumer can still see the setting exists and what it is for.
+     *
+     * @param mixed $data A serialized setting row.
+     *
+     * @return mixed
+     */
+    public static function maskSensitiveSetting($data)
+    {
+        if (!is_array($data) || !isset($data['name'])) {
+            return $data;
+        }
+        if (self::isSensitiveSetting((string)$data['name'])) {
+            unset($data['value']);
+        }
+        return $data;
+    }
     public static function getter($classname, $class, $item = '')
     {
         if (!$class instanceof $classname) {
@@ -2277,6 +2471,29 @@ class Route extends FOGBase
                     'class' => &$class
                 )
             );
+        /*
+         * A credential setting's value never leaves over the API.
+         *
+         * GET /service returned every globalSettings row with its value, so
+         * any authenticated API caller read FOG_API_TOKEN, the AD default
+         * password, the proxy password, the TFTP FTP password, the storage
+         * node MySQL password and (as of GH-1312) the node signing key. A
+         * uType 1 mobile user could do it too.
+         *
+         * Gated on this being an actual API request, which is the whole
+         * reason it is here rather than unconditional: FOG Configuration
+         * builds its own form from Route::listem('service', ...) and reads
+         * $Service->value back out to render and to save. Masking that would
+         * blank every credential field in the UI and then write the blank
+         * back. Only api/index.php constructs this class, so the flag it
+         * sets is exactly "the answer is going to an HTTP client".
+         *
+         * After API_GETTER, not before: a listener may legitimately want the
+         * real value in process, and none of them may put it back.
+         */
+        if (self::$_isApiRequest && 'service' === $classname) {
+            $data = self::maskSensitiveSetting($data);
+        }
         return $data;
     }
     /**
@@ -2339,6 +2556,7 @@ class Route extends FOGBase
                 )
             );
         }
+        self::_refuseSettingValueFilter($class, array_keys($whereItems));
         return $whereItems;
     }
     /**

--- a/tests/setting-value-disclosure.test.php
+++ b/tests/setting-value-disclosure.test.php
@@ -1,0 +1,387 @@
+<?php
+/**
+ * A credential setting's value must not leave over the API.
+ *
+ * globalSettings is a key/value table, so the secret is the value of a
+ * particular ROW rather than a column present on every row -- which is why
+ * nothing on this branch was masking it. GET /service returned every setting
+ * with its value: FOG_API_TOKEN, the AD default password, the proxy password,
+ * the TFTP FTP password, the storage node MySQL password, and the node
+ * signing key added in GH-1312. Any authenticated API caller could read all
+ * of them, uType 1 mobile users included.
+ *
+ * THREE DOORS, NOT ONE. Masking the response is the obvious half and on its
+ * own it is cosmetic:
+ *
+ *   1. GET /service and GET /service/{id} returned the value outright.
+ *   2. FOGManagerController::search() fills its WHERE from EVERY declared
+ *      field, so /service/search/<guess> brought the row back on a substring
+ *      of a masked value. The row carries no value; its arrival is the
+ *      answer.
+ *   3. `value` is a declared field, so /service/ids/value=<guess> and a
+ *      {"value":"<guess>"} list body were exact-match oracles for the same
+ *      reason.
+ *
+ * AND THE THING THAT MAKES IT AWKWARD. FOG Configuration builds its own form
+ * from Route::listem('service', ...) and reads $Service->value back out to
+ * render each field and to save it. Masking unconditionally would blank every
+ * credential in the UI and then write the blank back. Only api/index.php does
+ * `new Route`, so construction is the seam: masking applies to HTTP API
+ * answers and not to the 116 in-tree call sites that use Route as a library.
+ * That gate is pinned here, in both directions.
+ *
+ * Usage: php tests/setting-value-disclosure.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$file = 'packages/web/lib/router/route.class.php';
+$src = (string)file_get_contents($file);
+
+/*
+ * 1. Build a probe from the shipped predicate and its data.
+ *
+ * The pattern and both lists are lifted rather than restated -- a test that
+ * carries its own copy of the rule cannot tell you the rule changed.
+ */
+if (!preg_match(
+    '#\n    const SENSITIVE_SETTING_PATTERN = (.+?);\n#',
+    $src,
+    $m
+)) {
+    $fails[] = 'Route::SENSITIVE_SETTING_PATTERN is gone';
+}
+$pattern = isset($m[1]) ? trim($m[1]) : "''";
+
+$lists = [];
+foreach (['sensitiveSettings', 'sensitiveSettingsExempt'] as $name) {
+    if (!preg_match(
+        '#\n    public static \$' . $name . ' = array\((.*?)\);\n#s',
+        $src,
+        $lm
+    )) {
+        $fails[] = "Route::\$$name is gone";
+        $lists[$name] = '';
+        continue;
+    }
+    $lists[$name] = $lm[1];
+}
+
+$methods = [];
+foreach (
+    [
+        'isSensitiveSetting',
+        'maskSensitiveSetting',
+        '_settingHitIsVisible',
+        '_refuseSettingValueFilter'
+    ] as $name
+) {
+    if (!preg_match(
+        '#\n    (?:public|private) static function '
+        . preg_quote($name, '#')
+        . '\(.*?\n    \}#s',
+        $src,
+        $mm
+    )) {
+        $fails[] = "Route::$name() is gone";
+        continue;
+    }
+    $methods[$name] = $mm[0];
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+/**
+ * Stands in for HTTPResponseCodes so a refusal is observable.
+ *
+ * The real sendResponse() exits, which is the correct behaviour and an
+ * untestable one. Throwing preserves the only property under test: that the
+ * request does not continue.
+ */
+class SettingProbeRefused extends Exception
+{
+}
+
+eval(
+    'class SettingProbe {'
+    . ' const SENSITIVE_SETTING_PATTERN = ' . $pattern . ';'
+    . ' public static $sensitiveSettings = array('
+    . $lists['sensitiveSettings'] . ');'
+    . ' public static $sensitiveSettingsExempt = array('
+    . $lists['sensitiveSettingsExempt'] . ');'
+    . ' public static $_isApiRequest = true;'
+    . ' public static function sendResponse($code, $msg = false) {'
+    . ' throw new SettingProbeRefused((string)$msg); }'
+    // The probe calls two of these from outside the class; visibility is
+    // not what is under test.
+    . str_replace(
+        'private static function',
+        'public static function',
+        implode("\n", $methods)
+    )
+    . ' }'
+);
+// The real class reads these off HTTPResponseCodes; the probe only needs the
+// one it can be handed.
+if (!class_exists('HTTPResponseCodes')) {
+    eval('class HTTPResponseCodes { const HTTP_BAD_REQUEST = 400; }');
+}
+
+/*
+ * 2. The predicate, against the keys a real 1.5.10 install actually has.
+ *
+ * Both directions matter and the false-positive side is the one that breaks
+ * the product: FOG_USER_MINPASSLENGTH is password POLICY and the UI has to
+ * describe its own rules, FOG_KEYMAP and FOG_KEY_SEQUENCE are boot config,
+ * and FOG_HOSTKEY_ALLOWED_SOURCES is an address list. All four are why the
+ * pattern requires PASSWORD/PASSWD/PWD rather than PASS, and why KEY is not
+ * in it at all.
+ */
+$secret = [
+    'FOG_AD_DEFAULT_PASSWORD',
+    'FOG_AD_DEFAULT_PASSWORD_LEGACY',
+    'FOG_API_TOKEN',
+    'FOG_PROXY_PASSWORD',
+    'FOG_TFTP_FTP_PASSWORD',
+    'FOG_STORAGENODE_MYSQLPASS',
+    'FOG_NODE_API_KEY',
+];
+$notSecret = [
+    'FOG_USER_MINPASSLENGTH',
+    'FOG_USER_VALIDPASSCHARS',
+    'FOG_USER_VALIDPASSHELPMSG',
+    'FOG_KEYMAP',
+    'FOG_KEY_SEQUENCE',
+    'FOG_HOSTKEY_ALLOWED_SOURCES',
+    'FOG_QUICKREG_PROD_KEY_BIOS',
+    'FOG_TFTP_FTP_USERNAME',
+    'FOG_REAUTH_ON_DELETE',
+    'FOG_WEB_HOST',
+];
+foreach ($secret as $key) {
+    if (!SettingProbe::isSensitiveSetting($key)) {
+        $fails[] = "$key is not treated as a credential; its value would be"
+            . ' returned by the API';
+    }
+}
+foreach ($notSecret as $key) {
+    if (SettingProbe::isSensitiveSetting($key)) {
+        $fails[] = "$key is treated as a credential; the UI cannot read a"
+            . ' setting it needs and the page renders wrong';
+    }
+}
+
+/*
+ * 3. The mask drops the value and keeps everything else. A consumer must
+ *    still be able to see that the setting exists and what it is for --
+ *    that is the difference between masking and hiding.
+ */
+$row = [
+    'id' => '42',
+    'name' => 'FOG_API_TOKEN',
+    'description' => 'The API token',
+    'value' => 'super-secret',
+    'category' => 'API System'
+];
+$masked = SettingProbe::maskSensitiveSetting($row);
+if (isset($masked['value'])) {
+    $fails[] = 'maskSensitiveSetting() still returns the value of a'
+        . ' credential setting';
+}
+foreach (['id', 'name', 'description', 'category'] as $keep) {
+    if (!isset($masked[$keep])) {
+        $fails[] = "maskSensitiveSetting() dropped '$keep'; only the value"
+            . ' should go';
+    }
+}
+$plain = [
+    'id' => '7',
+    'name' => 'FOG_KEYMAP',
+    'description' => 'Keymap',
+    'value' => 'us',
+    'category' => 'FOG Boot Settings'
+];
+if (!isset(SettingProbe::maskSensitiveSetting($plain)['value'])) {
+    $fails[] = 'maskSensitiveSetting() blanked an ordinary setting';
+}
+// A row that is not a setting at all must pass through untouched -- getter()
+// hands this whatever the class produced.
+if (SettingProbe::maskSensitiveSetting(['ip' => '10.0.0.1']) !== ['ip' => '10.0.0.1']) {
+    $fails[] = 'maskSensitiveSetting() altered a row with no name';
+}
+
+/*
+ * 4. The search oracle. A masked row may come back only when the term is
+ *    visible in something the caller is allowed to read.
+ */
+$hit = [
+    'id' => '42',
+    'name' => 'FOG_API_TOKEN',
+    'description' => 'The API token',
+    'category' => 'API System'
+];
+$visibleCases = [
+    // term                    keep?  why
+    ['API_TOKEN',              true,  'matched the name'],
+    ['API System',             true,  'matched the category'],
+    ['The API',                true,  'matched the description'],
+    ['super-secret',           false, 'matched only the masked value'],
+    ['aBcD1234',               false, 'matched nothing visible'],
+];
+foreach ($visibleCases as list($term, $keep, $why)) {
+    $got = SettingProbe::_settingHitIsVisible('service', $hit, $term);
+    if ($got !== $keep) {
+        $fails[] = sprintf(
+            'search hit for "%s" (%s) should%s be returned',
+            $term,
+            $why,
+            $keep ? '' : ' not'
+        );
+    }
+}
+/*
+ * The same, on a row that still carries its value.
+ *
+ * In the shipped flow getter() has already masked by the time this runs, so
+ * the field is gone -- which makes the 'value' skip inside the loop look
+ * dead. It is the backstop for the mask being bypassed or reordered, and
+ * without exercising it here the skip could be deleted with every test still
+ * green.
+ */
+$unmasked = $hit + ['value' => 'super-secret'];
+if (SettingProbe::_settingHitIsVisible('service', $unmasked, 'super-secret')) {
+    $fails[] = 'a search hit is kept because the term matched the value,'
+        . ' when the value happens still to be on the row';
+}
+if (!SettingProbe::_settingHitIsVisible('service', $unmasked, 'API System')) {
+    $fails[] = 'a search hit on a visible field was dropped';
+}
+
+// An ordinary setting is never dropped, whatever it matched on.
+if (!SettingProbe::_settingHitIsVisible('service', $plain, 'us')) {
+    $fails[] = 'a non-credential setting was dropped from search results';
+}
+// And no other class is touched.
+if (!SettingProbe::_settingHitIsVisible('host', $hit, 'super-secret')) {
+    $fails[] = '_settingHitIsVisible() filters classes other than service';
+}
+
+/*
+ * 5. The filter oracle. Refused, not silently dropped -- a dropped term
+ *    returns the whole table, which a caller reads as "no such value".
+ */
+$refused = function ($classname, array $keys) {
+    try {
+        SettingProbe::_refuseSettingValueFilter($classname, $keys);
+    } catch (SettingProbeRefused $e) {
+        return true;
+    }
+    return false;
+};
+if (!$refused('service', ['value'])) {
+    $fails[] = 'filtering settings by value is not refused; it is an'
+        . ' exact-match oracle for every masked credential';
+}
+if (!$refused('service', ['name', 'value'])) {
+    $fails[] = 'a value filter alongside another field is not refused';
+}
+if ($refused('service', ['name', 'category'])) {
+    $fails[] = 'an ordinary settings filter is refused';
+}
+if ($refused('host', ['value'])) {
+    $fails[] = 'a value filter on another class is refused';
+}
+if ($refused('service', [])) {
+    $fails[] = 'an unfiltered settings list is refused';
+}
+
+/*
+ * 6. None of it applies when Route is used as a library.
+ *
+ * This is the half that breaks FOG Configuration if it goes wrong, and it
+ * fails open by design -- the page must keep reading real values.
+ */
+SettingProbe::$_isApiRequest = false;
+if ($refused('service', ['value'])) {
+    $fails[] = 'a value filter is refused for an in-process caller; FOG'
+        . ' Configuration filters settings as a library call';
+}
+if (!SettingProbe::_settingHitIsVisible('service', $hit, 'super-secret')) {
+    $fails[] = 'an in-process search drops credential rows; the settings'
+        . ' page would lose them from its own results';
+}
+SettingProbe::$_isApiRequest = true;
+
+/*
+ * 7. The wiring, pinned by shape -- each of these needs a live router.
+ */
+if (!preg_match(
+    '#if \(self::\$_isApiRequest && \'service\' === \$classname\) \{\s*\n\s*'
+    . '\$data = self::maskSensitiveSetting\(\$data\);#',
+    $src
+)) {
+    $fails[] = 'getter() no longer masks credential settings on the way out,'
+        . ' or no longer gates that on the request being an API request';
+}
+if (!preg_match('#public function __construct\(\)\s*\n\s*\{.*?'
+    . 'self::\$_isApiRequest = true;#s', $src)) {
+    $fails[] = 'the API-request flag is no longer set when api/index.php'
+        . ' constructs Route; nothing would ever be masked';
+}
+if (!preg_match(
+    '#if \(!self::_settingHitIsVisible\(\$classname, \$row, \$item\)\) \{#',
+    $src
+)) {
+    $fails[] = 'search() no longer drops a hit that matched only a masked'
+        . ' value';
+}
+/*
+ * Bounded to each function's own body. A `.*?` reaching forward from the
+ * function header finds the helper's own DEFINITION further down the file
+ * and matches whether or not the call is still there -- which is a gate that
+ * cannot fail, and was one until a mutation run said so.
+ */
+foreach (['handleWhereItems', 'getsearchbody'] as $fn) {
+    if (!preg_match(
+        '#\n    public static function ' . $fn . '\(.*?\n    \}#s',
+        $src,
+        $fm
+    )) {
+        $fails[] = "Route::$fn() is gone";
+        continue;
+    }
+    if (false === strpos($fm[0], '_refuseSettingValueFilter(')) {
+        $fails[] = "$fn() no longer refuses a filter on a setting's value";
+    }
+}
+/*
+ * getsearchbody() reassigns $class to an instance partway through, so the
+ * classname has to be captured before that. Passing the reassigned variable
+ * is not an error PHP reports -- the refusal simply never fires.
+ */
+if (preg_match('#function getsearchbody\(.*?\n    \}#s', $src, $gm)) {
+    if (!preg_match('#\$classname = strtolower\(\(string\)\$class\);#', $gm[0])) {
+        $fails[] = 'getsearchbody() no longer captures the class name before'
+            . ' reassigning $class; the refusal would silently never fire';
+    }
+}
+
+if (count($fails) > 0) {
+    fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok: credential setting values do not leave over the API\n";
+exit(0);


### PR DESCRIPTION
Follow-up to #1314, which flagged this rather than fixing it.

## What was exposed

`globalSettings` is a key/value table, so the secret is the value of a
particular *row* rather than a column present on every row — which is why
nothing on this branch was masking it. Any authenticated API caller, uType 1
mobile users included, could read every credential FOG keeps as a setting.

Demonstrated on a running 1.5.10 install before writing any code:

| Request | Leaked |
|---|---|
| `GET /fog/service/list` | `FOG_STORAGENODE_MYSQLPASS` (20), `FOG_TFTP_FTP_PASSWORD` (20) |
| `GET /fog/service/194` | `FOG_API_TOKEN` (128) |
| `GET /fog/service/378` | `FOG_NODE_API_KEY` (64) |

`FOG_API_TOKEN` and `FOG_NODE_API_KEY` are missing from the *list* only
because `listem()`/`search()` skip any name containing `_api_`. That is a
substring accident — rename-fragile, and it does not cover the single-item
route at all, which is exactly where both came back in full.

## Three doors

Masking the response on its own is cosmetic. All three are closed.

**1 — the value in the response.** Dropped for any setting the predicate calls
a credential. Name, description and category stay, so a consumer can still see
the setting exists and what it is for.

The predicate is a pattern plus a short explicit list, so a credential setting
added later is masked by default rather than leaking until someone remembers:

- `#(PASSWORD|PASSWD|PWD|SECRET|TOKEN)#i` — deliberately *not* a bare `PASS`,
  because `FOG_USER_MINPASSLENGTH` is password policy the UI has to describe;
  and deliberately no `KEY`, or `FOG_KEYMAP`, `FOG_KEY_SEQUENCE`,
  `FOG_HOSTKEY_ALLOWED_SOURCES` and `FOG_QUICKREG_PROD_KEY_BIOS` all get
  masked. Checked against the real key list on a running 1.5.10: the five it
  catches are all genuine credentials and it catches nothing that isn't.
- Explicit: `FOG_STORAGENODE_MYSQLPASS` (one word off the pattern) and
  `FOG_NODE_API_KEY`.
- An exempt list, empty here, kept so the predicate has the same three parts it
  has on working-1.6. This is the one function that decides whether something
  is a secret; a shape that differs between the branches is a port waiting to
  go wrong.

**2 — the search oracle.** `FOGManagerController::search()` fills its WHERE
from *every* declared field, so `/service/search/<prefix-of-a-masked-value>`
brought the row back. The row carries no value; its arrival is the answer.
Confirmed live: **count=1** for a correct 10-character prefix of
`FOG_TFTP_FTP_PASSWORD`, **count=0** for a wrong one. A sensitive row is now
returned only when the term is visible in a field the caller may read.

**3 — the filter oracle.** `value` is a declared field, so
`/service/ids/value=<guess>` and a `{"value":"<guess>"}` list body were
exact-match oracles. Refused with a 400 that names the field — not silently
dropped, because a dropped term returns the whole table and a caller reads
that as "no such value".

## The awkward half

FOG Configuration builds its own form from `Route::listem('service', ...)` and
reads `$Service->value` back out to render each field *and to save it*. Masking
unconditionally would blank every credential in the UI and then write the blank
back.

Only `api/index.php` does `new Route`; the 116 in-tree call sites use `Route`
statically as a library. So **construction is the seam** — masking applies to
HTTP API answers and to nothing else. That gate is pinned by test in both
directions, because failing it open is a security hole and failing it closed
breaks the settings page.

## Verification

The shipped methods were driven against a real 1.5 database, on both sides of
the seam:

```
=== API request ===
  indiv FOG_TFTP_FTP_PASSWORD   value ABSENT
  indiv FOG_API_TOKEN           value ABSENT
  indiv FOG_KEYMAP              value PRESENT
  list: 182 rows, 177 carry a value, masked: FOG_AD_DEFAULT_PASSWORD,
        FOG_AD_DEFAULT_PASSWORD_LEGACY, FOG_API_TOKEN, FOG_PROXY_PASSWORD,
        FOG_TFTP_FTP_PASSWORD
  search on a real credential prefix: count=0
  filter on value: refused 400;  filter on name+category: allowed

=== page (library call) ===
  indiv FOG_TFTP_FTP_PASSWORD   value PRESENT (len 20)
  indiv FOG_API_TOKEN           value PRESENT (len 128)
  list: 182 rows, 182 carry a value, masked: (none)
  same search: count=1
```

- Test **mutation verified 17/17**. Two started as survivors and both were real
  gate defects: one assertion could not observe the `'value'` skip because
  masking had already removed the field, and one regex reached past its own
  function body to the helper's definition and so could never fail.
- The predicate runs for real over the actual key list from a 1.5.10 install,
  in both directions — seven that must be masked, ten that must not.
- Full `tests/*.test.php` suite green.

## Downstream

**Behaviour change, and the point of the PR.** Anything reading a credential
setting's value out of `GET /service`, `GET /service/{id}` or
`/service/search/...` now gets the row without its `value`. Any code filtering
settings by value gets a 400.

`darksidemilk/FogApi` is the consumer to check — `Get-FogSettings` and anything
built on it. No route class was added or removed, so the hardcoded class list in
`Private/Get-DynmicParam.ps1` needs no sync.

Not ported to working-1.6: it already has this layer
(`Route::$sensitiveSettings`, `maskSensitiveSetting()`,
`_applySettingValueScope()`), and #1313 added `FOG_NODE_API_KEY` to it.
