### PR TITLE
fix(api): close the setting value oracle and resolve node image ids

### DIFF
--- a/packages/web/lib/fog/storagenode.class.php
+++ b/packages/web/lib/fog/storagenode.class.php
@@ -357,8 +357,14 @@ class StorageNode extends FOGController
     {
         $response = $this->_getData('images');
         $values = array_map('basename', (array)$response);
+        // 'image', not 'storagenode'. These are image DIRECTORY basenames
+        // read off the node; a storagenode's own `path` is the share root
+        // (/images) on every node FOG has ever installed, so the lookup
+        // could never match and this field was always []. dev-branch still
+        // carries the original getSubObjectIDs('Image', ...) -- the class
+        // name was lost when this call moved to Route::getIds().
         $values = Route::getIds(
-            'storagenode',
+            'image',
             ['path' => $values]
         );
         $this->set('images', $values);

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2043,7 +2043,8 @@ class Route extends FOGBase
             self::_applySiteScope($classname);
             self::_applySettingValueScope(
                 $classname,
-                isset($pass_vars) ? $pass_vars : []
+                isset($pass_vars) ? $pass_vars : [],
+                is_array($whereItems) ? $whereItems : []
             );
             self::$data['_lang'] = $classname;
             if (self::$getterDepth === 0
@@ -5565,6 +5566,38 @@ class Route extends FOGBase
             }
 
             $whereItems = self::handleWhereItems($whereItems, $class);
+            // The value oracle again -- see names(). Refused here rather
+            // than dropped per row, because this route projects $getField
+            // and nothing else: on the default /setting/ids the setting NAME
+            // is not in the result at all, so there is no row to ask
+            // isSensitiveSetting() about. Refusing costs a caller nothing --
+            // /setting?filter=value=<x> still answers, with the credential
+            // rows removed.
+            //
+            // SAPI-gated exactly like the sensitive-getField refusal below:
+            // sendResponse() exits, and a daemon that exits is a restart
+            // loop. Off-request this returns no rows and logs, fail-closed.
+            if ('setting' === $classname
+                && is_array($whereItems)
+                && array_key_exists('value', $whereItems)
+            ) {
+                if ('cli' === PHP_SAPI) {
+                    self::error(
+                        'Route::ids: refusing a setting filter on value.'
+                        . ' Returning no rows.'
+                    );
+                    self::$data = [];
+                    return;
+                }
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_BAD_REQUEST,
+                    json_encode(
+                        [
+                            'error' => _('Cannot filter setting ids on: value')
+                        ]
+                    )
+                );
+            }
             if (false !== $whereItems && count($whereItems ?: []) < 1) {
                 $whereItems = self::getsearchbody($classname);
             }
@@ -6663,11 +6696,28 @@ class Route extends FOGBase
      *
      * @return void
      */
-    private static function _applySettingValueScope($classname, $vars)
-    {
+    private static function _applySettingValueScope(
+        $classname,
+        $vars,
+        $whereItems = []
+    ) {
         if ('setting' !== strtolower((string)$classname)) {
             return;
         }
+        // ?filter=value=<guess> is the same oracle asked as an equality
+        // rather than a substring, and it arrives by a different door:
+        // handleWhereItems(), not the DataTables search box. It is not
+        // refused per FIELD -- unfilterableFields() deliberately leaves
+        // settings out so ?filter=value=/images keeps working -- so it is
+        // answered per ROW here, like everything else in this function.
+        //
+        // Stricter than the search arm, and deliberately so. A search term
+        // is ORed across the columns, so a sensitive row that matched on
+        // its NAME is kept. Filter terms are ANDed, so `value=x&name=y`
+        // matching on name does not make the value any less load bearing --
+        // the row's presence still confirms the guess. Once a request
+        // filters on value at all, every sensitive row goes.
+        $valueFiltered = array_key_exists('value', (array)$whereItems);
         $terms = [];
         if ('' !== trim((string)($vars['search']['value'] ?? ''))) {
             $terms[] = (string)$vars['search']['value'];
@@ -6677,7 +6727,7 @@ class Route extends FOGBase
                 $terms[] = (string)$col['search']['value'];
             }
         }
-        if (!count($terms)) {
+        if (!count($terms) && !$valueFiltered) {
             return;
         }
         $payload = self::$data;
@@ -6689,6 +6739,9 @@ class Route extends FOGBase
             $arr = (array)$row;
             if (!self::isSensitiveSetting((string)($arr['name'] ?? ''))) {
                 $kept[] = $row;
+                continue;
+            }
+            if ($valueFiltered) {
                 continue;
             }
             // Every field EXCEPT the value, rather than a list of the four
@@ -6992,10 +7045,28 @@ class Route extends FOGBase
                 )
             );
             $vals = self::$DB->query($sqlResult['sql'], [], $sqlResult['params'])->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+            // Same value oracle listem() answers per row, and worse here:
+            // this route returns only id and name, so there is no value for
+            // maskSensitiveSetting() to strip and the row's mere presence IS
+            // the whole answer. `?filter=value=<guess>` against a credential
+            // key would confirm the guess outright.
+            //
+            // Dropped rather than refused because the name is right here in
+            // the projection, so the real predicate can be asked. Only when
+            // the request filtered on value at all -- a plain /setting/names
+            // must still list every key.
+            $dropSensitive = 'setting' === $classname
+                && is_array($whereItems)
+                && array_key_exists('value', $whereItems);
             foreach ($vals as &$val) {
+                $name = $val[$classVars['databaseFields']['name']];
+                if ($dropSensitive && self::isSensitiveSetting((string)$name)) {
+                    unset($val);
+                    continue;
+                }
                 $data[] = [
                     'id' => $val[$classVars['databaseFields']['id']],
-                    'name' => $val[$classVars['databaseFields']['name']]
+                    'name' => $name
                 ];
                 unset($val);
             }

--- a/tests/search-no-value-match.test.php
+++ b/tests/search-no-value-match.test.php
@@ -112,8 +112,14 @@ if (false === $scopeStart) {
 
     // No search term at all must be a no-op: a plain listing has to keep
     // returning every setting, values masked, as it always has.
+    //
+    // Matched loosely on purpose. The guard has since grown a second arm
+    // for ?filter=value= (see setting-value-filter-oracle.test.php), which
+    // is a NEW reason to act, not a lost reason to bail -- pinning the
+    // condition as one literal line failed on the extra clause while the
+    // property it guards was intact.
     $checks++;
-    if (false === strpos($scope, 'if (!count($terms)) {')) {
+    if (!preg_match('/if \(!count\(\$terms\)[^)]*\) \{/', $scope)) {
         $failures[] = '_applySettingValueScope() lost its early return for a '
             . 'request with no search terms, so a plain settings list would '
             . 'start hiding credential rows entirely';

--- a/tests/setting-value-filter-oracle.test.php
+++ b/tests/setting-value-filter-oracle.test.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Filtering settings by value must not confirm a credential.
+ *
+ * maskSensitiveSetting() strips `value` from FOG_TFTP_FTP_PASSWORD and its
+ * kin, and _applySettingValueScope() already drops a sensitive row that a
+ * DataTables SEARCH matched only on that stripped value. The equality form
+ * of the same question arrived by a different door and was not covered:
+ *
+ *   GET /setting?filter=value=<guess>        -> recordsFiltered 1 or 0
+ *   GET /setting/names?filter=value=<guess>  -> the row, or []
+ *   GET /setting/ids?filter=value=<guess>    -> the id, or []
+ *
+ * The response carries no value in any of the three, and it does not need
+ * to: the row's PRESENCE is the answer, and an attacker holding setting.view
+ * can ask it as many times as they like. /names and /ids are the worse two,
+ * because they never return a value at all, so masking is not even in play.
+ *
+ * The fix is per ROW, not per FIELD, matching the reasoning already written
+ * on unfilterableFields(): a setting's value is ordinary configuration for
+ * all but a handful of keys, and blocking the field outright would take
+ * "which setting holds bzImage" away to protect four passwords. ids() is the
+ * one exception and is refused instead -- it projects $getField alone, so on
+ * the default /setting/ids the setting NAME is not in the result and there is
+ * no row to ask isSensitiveSetting() about.
+ *
+ * Executable, not just a source gate: the shipped filtering logic is lifted
+ * out of route.class.php and run against synthetic rows, so a change that
+ * keeps the shape and breaks the behaviour still fails.
+ *
+ * DB-free: reads the source, executes the lifted method.
+ *
+ * Usage: php tests/setting-value-filter-oracle.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+$routeFile = $webroot . '/lib/router/route.class.php';
+
+if (!is_readable($routeFile)) {
+    fwrite(STDERR, "FAIL: cannot read $routeFile\n");
+    exit(1);
+}
+$route = file_get_contents($routeFile);
+
+$failures = [];
+$checks = 0;
+
+/**
+ * Returns the source of a named method, signature to the following one.
+ */
+$bodyOf = function ($src, $needle) {
+    $start = strpos($src, $needle);
+    if (false === $start) {
+        return null;
+    }
+    $next = preg_match(
+        '/\n    (?:public|private|protected)[ a-z]* function /',
+        $src,
+        $m,
+        PREG_OFFSET_CAPTURE,
+        $start + strlen($needle)
+    );
+    return $next
+        ? substr($src, $start, $m[0][1] - $start)
+        : substr($src, $start);
+};
+
+// ---------------------------------------------------------------------
+// 1. listem() must hand the parsed filter to the scope function. Without
+//    this the function cannot see a ?filter= term at all and the whole
+//    fix is inert while still looking present.
+// ---------------------------------------------------------------------
+$checks++;
+$listem = $bodyOf($route, 'public static function listem(');
+if (null === $listem) {
+    $failures[] = 'listem() not found';
+} elseif (!preg_match(
+    '/_applySettingValueScope\(\s*\$classname,\s*[^;]*?\$whereItems/s',
+    $listem
+)) {
+    $failures[] = 'listem() does not pass $whereItems to '
+        . '_applySettingValueScope(); a ?filter= term is invisible to it';
+}
+
+// ---------------------------------------------------------------------
+// 2. Lift _applySettingValueScope() and RUN it.
+// ---------------------------------------------------------------------
+$scope = $bodyOf($route, 'private static function _applySettingValueScope(');
+if (null === $scope) {
+    $failures[] = '_applySettingValueScope() not found';
+} else {
+    // Stub only what the method reaches out to: the predicate and the
+    // payload. The filtering itself is the shipped code.
+    eval(
+        'class ScopeProbe {'
+        . ' public static $data = [];'
+        . ' public static function isSensitiveSetting($k) {'
+        . '     return 1 === preg_match('
+        . '         "#(PASSWORD|PASSWD|PWD|SECRET|TOKEN)#i", (string)$k'
+        . '     );'
+        . ' }'
+        . ' public static function run($c, $v, $w = []) {'
+        . '     return self::_applySettingValueScope($c, $v, $w);'
+        . ' }'
+        . str_replace('self::', 'static::', $scope)
+        . '}'
+    );
+
+    $rows = [
+        ['id' => 5, 'name' => 'FOG_TFTP_PXE_KERNEL', 'value' => 'bzImage'],
+        ['id' => 3, 'name' => 'FOG_TFTP_FTP_PASSWORD'],
+    ];
+    $envelope = function ($rows) {
+        return [
+            'data' => $rows,
+            'recordsTotal' => count($rows),
+            'recordsFiltered' => count($rows),
+        ];
+    };
+
+    // 2a. A value FILTER drops the credential row and keeps the ordinary one.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run('setting', [], ['value' => 'whatever']);
+    $names = array_column(ScopeProbe::$data['data'], 'name');
+    if (in_array('FOG_TFTP_FTP_PASSWORD', $names, true)) {
+        $failures[] = 'filter=value: the credential row survived -- its '
+            . 'presence confirms the guess';
+    }
+    if (!in_array('FOG_TFTP_PXE_KERNEL', $names, true)) {
+        $failures[] = 'filter=value: dropped an ordinary setting; filtering '
+            . 'settings by value must keep working';
+    }
+
+    // 2b. A value filter ANDed with a name filter still drops it. Filter
+    //     terms are conjunctive, so matching the name does not make the
+    //     value any less load bearing -- this is where the search arm's
+    //     "matched on a visible field" rescue must NOT apply.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run(
+        'setting',
+        [],
+        ['value' => 'whatever', 'name' => 'FOG_TFTP_FTP_PASSWORD']
+    );
+    if (in_array(
+        'FOG_TFTP_FTP_PASSWORD',
+        array_column(ScopeProbe::$data['data'], 'name'),
+        true
+    )) {
+        $failures[] = 'filter=value&name=: the credential row survived on a '
+            . 'name match; filter terms are ANDed, not ORed';
+    }
+
+    // 2c. recordsTotal is rewritten too. Leaving the SQL count behind
+    //     answers the question the dropped row was dropped for.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run('setting', [], ['value' => 'whatever']);
+    if (ScopeProbe::$data['recordsTotal'] !== 1
+        || ScopeProbe::$data['recordsFiltered'] !== 1
+    ) {
+        $failures[] = 'filter=value: counts not rewritten ('
+            . ScopeProbe::$data['recordsTotal'] . '/'
+            . ScopeProbe::$data['recordsFiltered'] . '), the row count leaks '
+            . 'the hit';
+    }
+
+    // 2d. No value filter and no search term: a plain listing is untouched.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run('setting', [], ['name' => 'FOG_TFTP_FTP_PASSWORD']);
+    if (count(ScopeProbe::$data['data']) !== 2) {
+        $failures[] = 'a listing with no value filter lost rows; every '
+            . 'setting must still be listable with its value masked';
+    }
+
+    // 2e. The search arm still rescues a sensitive row matched on its name.
+    //     Searching "PASSWORD" should find FOG_TFTP_FTP_PASSWORD -- the key
+    //     was never the secret -- so 2b must not have broken it.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run('setting', ['search' => ['value' => 'PASSWORD']], []);
+    if (!in_array(
+        'FOG_TFTP_FTP_PASSWORD',
+        array_column(ScopeProbe::$data['data'], 'name'),
+        true
+    )) {
+        $failures[] = 'search on the KEY no longer finds the credential row; '
+            . 'the name was never the secret';
+    }
+
+    // 2g. A value filter BEATS the search arm's visible-field rescue.
+    //     This is the case the explicit skip exists for: searching
+    //     "PASSWORD" would normally keep FOG_TFTP_FTP_PASSWORD (2e), but
+    //     if the same request ALSO filters value=<guess> then the row is
+    //     only present because the guess was right, and saying so is the
+    //     leak. Without this case the skip is over-determined -- with no
+    //     search term the visible-field loop drops the row anyway -- and a
+    //     regression here would go unnoticed.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run(
+        'setting',
+        ['search' => ['value' => 'PASSWORD']],
+        ['value' => 'whatever']
+    );
+    if (in_array(
+        'FOG_TFTP_FTP_PASSWORD',
+        array_column(ScopeProbe::$data['data'], 'name'),
+        true
+    )) {
+        $failures[] = 'search=PASSWORD + filter=value: the credential row '
+            . 'was rescued by the name match, but the value filter is what '
+            . 'put it there';
+    }
+
+    // 2f. Another class is not touched.
+    $checks++;
+    ScopeProbe::$data = $envelope($rows);
+    ScopeProbe::run('host', [], ['value' => 'whatever']);
+    if (count(ScopeProbe::$data['data']) !== 2) {
+        $failures[] = 'a non-setting class was filtered';
+    }
+}
+
+// ---------------------------------------------------------------------
+// 3. names() drops the row itself -- it returns id and name only, so
+//    masking never applies and the presence of the row is the answer.
+// ---------------------------------------------------------------------
+$checks++;
+$names = $bodyOf($route, 'public static function names(');
+if (null === $names) {
+    $failures[] = 'names() not found';
+} else {
+    if (!preg_match('/isSensitiveSetting/', $names)) {
+        $failures[] = 'names() does not consult isSensitiveSetting(); '
+            . '/setting/names?filter=value=<guess> is an oracle';
+    }
+    if (!preg_match("/array_key_exists\(\s*'value'/", $names)) {
+        $failures[] = 'names() does not gate on a value filter; it must '
+            . 'drop credential rows only when value was filtered on';
+    }
+}
+
+// ---------------------------------------------------------------------
+// 4. ids() refuses instead -- it projects $getField alone, so the setting
+//    name is not in the result to test.
+// ---------------------------------------------------------------------
+$checks++;
+$ids = $bodyOf($route, 'public static function ids(');
+if (null === $ids) {
+    $failures[] = 'ids() not found';
+} else {
+    if (!preg_match(
+        "/'setting' === \\\$classname\s*\n\s*&& is_array\(\\\$whereItems\)"
+        . "\s*\n\s*&& array_key_exists\(\s*'value'/",
+        $ids
+    )) {
+        $failures[] = 'ids() does not refuse a setting filter on value; '
+            . '/setting/ids?filter=value=<guess> is an oracle';
+    }
+    // sendResponse() exits, and a daemon that exits is a restart loop.
+    if (!preg_match("/'cli' === PHP_SAPI/", $ids)) {
+        $failures[] = 'ids() refusal is not SAPI-gated';
+    }
+}
+
+if (count($failures) > 0) {
+    fwrite(STDERR, "FAIL (" . count($failures) . " of $checks checks)\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+fwrite(STDOUT, "PASS: $checks checks\n");
+exit(0);

--- a/tests/storagenode-listings-opt-in.test.php
+++ b/tests/storagenode-listings-opt-in.test.php
@@ -52,6 +52,7 @@ foreach (['parseExpand', 'wantsExpand'] as $name) {
     $methods[$name] = $m[0];
 }
 
+
 if (count($fails) > 0) {
     fwrite(STDERR, 'FAIL: ' . count($fails) . " problem(s):\n");
     foreach ($fails as $f) {
@@ -175,6 +176,29 @@ $openapi = (string)file_get_contents(
 if (!preg_match('#case \'storagenode\':.*?expand=all#s', $openapi)) {
     $fails[] = 'OpenAPI no longer records that storagenode images and'
         . ' snapinfiles are expand-only';
+}
+
+/*
+ * 5. And when a caller does ask for them, images must resolve. getImages()
+ *    maps the node's directory basenames to image ids, and it looked them
+ *    up against the 'storagenode' class -- whose own `path` is the share
+ *    root, /images, on every node FOG has ever installed. The lookup could
+ *    not match, so this field came back [] whatever the node returned,
+ *    which is indistinguishable from the auth failure this test's subject
+ *    was fixing. dev-branch still carries the original
+ *    getSubObjectIDs('Image', ...); the class name was lost when the call
+ *    moved to Route::getIds().
+ */
+$storagenode = (string)file_get_contents(
+    'packages/web/lib/fog/storagenode.class.php'
+);
+if (preg_match('/function getImages\(\).*?\n    \}/s', $storagenode, $m)) {
+    if (!preg_match("/getIds\(\s*'image'/", $m[0])) {
+        $fails[] = 'StorageNode::getImages() does not resolve basenames'
+            . ' against the image class; the field will always be empty';
+    }
+} else {
+    $fails[] = 'StorageNode::getImages() not found';
 }
 
 if (count($fails) > 0) {


### PR DESCRIPTION
Two defects found while verifying #1313 against the live 1.6 master.

## 1. Filtering settings by value confirmed a credential

`maskSensitiveSetting()` strips `value` from `FOG_TFTP_FTP_PASSWORD` and its kin, and `_applySettingValueScope()` already dropped a sensitive row that a DataTables **search** matched only on that stripped value. The equality form of the same question arrives through `handleWhereItems()` instead, and was not covered:

| Request | Answer |
|---|---|
| `GET /setting?filter=value=<guess>` | `recordsFiltered` 1 or 0 |
| `GET /setting/names?filter=value=<guess>` | the row, or `[]` |
| `GET /setting/ids?filter=value=<guess>` | the id, or `[]` |

None of the three returns the value, and none needs to — the row's *presence* is the answer, and `setting.view` is enough to ask it as often as you like. `/names` and `/ids` are the worse two, because they never return a value at all, so masking is not even in play.

Confirmed on the live master before the fix:

```
GET /setting/names?filter=value=bzImage  -> [{"id":5,"name":"FOG_TFTP_PXE_KERNEL"}]
GET /setting?filter=value=<miss>         -> recordsFiltered 0
GET /setting?filter=value=bzImage        -> recordsFiltered 1
```

This is the door #1315 closed on `dev-branch`. It was left open here because 1.6 handles settings **per row** rather than **per field**, and only the search half had been written.

### Fixed per row, keeping that reasoning

A setting's value is ordinary configuration for all but a handful of keys, so blocking the field outright would take "which setting holds bzImage" away to protect four passwords — the argument already written on `unfilterableFields()`.

- **`listem()`** passes the parsed filter to `_applySettingValueScope()`, which drops every sensitive row once the request filters on `value`. Stricter than the search arm deliberately: search terms are ORed, so a row matched on its **name** is kept (searching "PASSWORD" should still find `FOG_TFTP_FTP_PASSWORD`); filter terms are ANDed, so matching the name does not make the value any less load bearing.
- **`names()`** drops the row itself — the name is in its projection.
- **`ids()`** refuses with a 400 instead. It projects `$getField` alone, so on the default `/setting/ids` the name is not in the result and there is no row to ask `isSensitiveSetting()` about. SAPI-gated like the neighbouring sensitive-`getField` refusal, because `sendResponse()` exits and a daemon that exits is a restart loop.

## 2. `StorageNode::getImages()` looked up the wrong class

It maps the node's image directory basenames to image ids, and asked for them against `'storagenode'` — whose own `path` is the share root, `/images`, on every node FOG has ever installed. The lookup could not match, so the field was `[]` whatever the node returned.

Proven against the live database:

```
getIds('image',       path=[test, win11-split, Win11BaseTPM]) -> [1, 32, 27]
getIds('storagenode', path=[test, win11-split, Win11BaseTPM]) -> []
```

`dev-branch` still carries the original `getSubObjectIDs('Image', ...)`; the class name was lost when the call moved to `Route::getIds()`.

**Behaviour change:** `?expand=images` on a storage node now returns the ids it always claimed to. It has been empty since the `getIds()` refactor, so nothing can have depended on the values — only on the emptiness. This is also what made #1313 look like it had not worked: `snapinfiles` filled in, `images` stayed empty.

## OpenAPI

No change. Both are behaviour on existing generic CRUD operations that `_paths()` already emits — no route, schema, permission or request body moved. The `/setting/ids` refusal is a 400 on one filter value, not a new operation.

## Tests

- `tests/setting-value-filter-oracle.test.php` (new) lifts `_applySettingValueScope()` out of the router and runs it against synthetic rows, so a change that keeps the shape and breaks the behaviour still fails. 10 checks; 7 mutations verified killed, including the combined `search=PASSWORD` + `filter=value=` case that the explicit skip exists for.
- `tests/storagenode-listings-opt-in.test.php` gains the `getImages()` class gate (mutation-verified).
- `tests/search-no-value-match.test.php` pinned the early return as one literal line and failed on the added clause while the property it guards was intact. Loosened, then mutation-verified that removing the return outright still fails it.

Full suite: 100/100 PHP tests pass.

## Downstream

None. FogApi does not filter settings by value and does not read a storage node's `images`, so neither change reaches it.

## dev-branch

Item 1 is already fixed there by #1315. Item 2 does not exist there — `dev-branch` never lost the class name. No port needed.