### PR TITLE
feat(nodes): give a peer FOG server its own signing key

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -4420,6 +4420,19 @@ abstract class FOGBase
      * DB_host="$snmysqlhost"`), so a row written once is readable everywhere
      * with nothing to distribute.
      *
+     * That last clause holds for a TRUE storage node and only for one. A
+     * peer that is itself a full FOG server -- its own DATABASE_HOST, its
+     * own globalSettings -- shares no row with the master, mints its own
+     * key here, and cannot verify anything the master signs. Nothing in the
+     * installer distributes this value, and validNodeSignature() must never
+     * mint one, so a pure receiver cannot heal itself either.
+     *
+     * nodeSigningKeyFor() is the answer for that topology: a per-peer key
+     * on the master's storage node record, which the administrator also
+     * sets as that peer's own FOG_NODE_API_KEY. Same model as ngmUser and
+     * ngmPass, which have always had to be kept in step with the account
+     * that actually exists on the node.
+     *
      * @var string
      */
     const NODE_API_KEY_SETTING = 'FOG_NODE_API_KEY';
@@ -4499,6 +4512,98 @@ abstract class FOGBase
         return trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
     }
     /**
+     * The signing key for one peer, or '' to fall back to the shared one.
+     *
+     * A storage node that shares the master's database verifies with the
+     * global key and needs nothing here. A peer that is a full FOG server
+     * has its own globalSettings and cannot see the master's row at all, so
+     * the two ends have to be given a value in common by hand.
+     *
+     * nfsGroupMembers.ngmKey is where it goes. The column has existed since
+     * 1.5, is declared on StorageNode as `key`, and has never been read or
+     * written by anything -- and it is already listed in
+     * Route::$sensitiveAlwaysFields, so no route has ever emitted it and
+     * none will start now.
+     *
+     * Matched on ngmHostname because that is what the caller has: signing
+     * happens in FOGURLRequests, which knows a URL and not which node it
+     * belongs to. A host that matches no node, or a node with an empty key,
+     * returns '' and the caller signs with the installation-wide key --
+     * which is what every existing shared-database install keeps doing.
+     *
+     * @param string $host The host part of the URL about to be requested.
+     *
+     * @return string The peer's key, or '' if it has none.
+     */
+    public static function nodeSigningKeyFor($host)
+    {
+        $host = trim((string) $host);
+        if ($host === '') {
+            return '';
+        }
+        // fetch_all rather than fetch()->get('ngmKey'): on a host that
+        // matches no node the single-row form hands back the empty result
+        // set itself, which casts to the string 'Array' -- a non-empty
+        // "key" that signs every request to an unknown host with a
+        // constant nobody can verify. Indexing a list makes "no row" and
+        // "no key" the same, empty, answer.
+        $rows = self::$DB->query(
+            sprintf(
+                'SELECT `ngmKey` FROM `nfsGroupMembers` '
+                . 'WHERE `ngmHostname` = %s AND `ngmKey` <> %s LIMIT 1',
+                self::$DB->escape($host),
+                self::$DB->escape('')
+            )
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $rows = (array) $rows;
+        if (count($rows) < 1) {
+            return '';
+        }
+        return trim((string) ($rows[0]['ngmKey'] ?? ''));
+    }
+    /**
+     * Every key a signature reaching THIS server could legitimately carry.
+     *
+     * The global key first, because on a shared-database install that is
+     * the one the master signed with and the common case should cost one
+     * comparison.
+     *
+     * Then every non-empty ngmKey this server can see. Two topologies need
+     * it and they need it for opposite reasons:
+     *
+     *   - Shared database. The master signed with the target node's own
+     *     ngmKey; the node reads the same table, so the key is right there.
+     *   - Standalone peer. The administrator set this server's
+     *     FOG_NODE_API_KEY to match, so the global key already covers it --
+     *     but this server's OWN node rows are also legitimate signers if it
+     *     is a master in its own right.
+     *
+     * The candidate set is bounded by the number of storage nodes and each
+     * miss is one hash_hmac, so the cost is not worth a cache that could
+     * then go stale against a rotated key.
+     *
+     * @return array Distinct non-empty keys.
+     */
+    private static function _nodeVerificationKeys()
+    {
+        $keys = [];
+        $global = trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($global !== '') {
+            $keys[] = $global;
+        }
+        $rows = self::$DB->query(
+            'SELECT `ngmKey` FROM `nfsGroupMembers` '
+            . "WHERE `ngmKey` <> ''"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        foreach ((array) $rows as $row) {
+            $candidate = trim((string) ($row['ngmKey'] ?? ''));
+            if ($candidate !== '') {
+                $keys[] = $candidate;
+            }
+        }
+        return array_values(array_unique($keys));
+    }
+    /**
      * The exact bytes both ends run through hash_hmac().
      *
      * Method and path are in the signed material so a captured signature
@@ -4535,12 +4640,24 @@ abstract class FOGBase
      */
     public static function nodeSignatureHeaders($url, $method = 'GET')
     {
-        $key = self::nodeApiKey();
-        if ($key === '') {
-            return [];
-        }
         $parts = parse_url((string) $url);
         if ($parts === false) {
+            return [];
+        }
+        // The peer's own key if it has one, otherwise the installation-wide
+        // key. Ordered this way round so a shared-database install -- where
+        // no ngmKey is ever set -- signs exactly as it did before, and a
+        // full FOG server registered as a peer gets a secret that is only
+        // good for talking to it.
+        //
+        // Resolved before the empty-key bail below, because "this peer has
+        // no key of its own" is not the same as "this installation has no
+        // key" and only the second is a reason to give up.
+        $key = self::nodeSigningKeyFor($parts['host'] ?? '');
+        if ($key === '') {
+            $key = self::nodeApiKey();
+        }
+        if ($key === '') {
             return [];
         }
         $uri = ($parts['path'] ?? '/');
@@ -4573,7 +4690,14 @@ abstract class FOGBase
      *
      * getSetting() rather than nodeApiKey() deliberately: verification must
      * never mint a key. If no key exists there is nothing this request can
-     * have signed with, and the answer is no.
+     * have signed with, and the answer is no. That is also why a peer which
+     * only ever RECEIVES signed requests cannot heal itself, and why its
+     * key has to be put there by hand -- see nodeSigningKeyFor().
+     *
+     * More than one key can be correct. _nodeVerificationKeys() has the
+     * reasoning; the short version is that the signer may have used this
+     * installation's shared key or a per-peer one, and the receiver cannot
+     * tell which from the request.
      *
      * @return bool
      */
@@ -4591,20 +4715,28 @@ abstract class FOGBase
         if (abs(time() - (int) $timestamp) > self::NODE_SIGNATURE_WINDOW) {
             return false;
         }
-        $key = trim((string) self::getSetting(self::NODE_API_KEY_SETTING));
-        if ($key === '') {
+        $keys = self::_nodeVerificationKeys();
+        if (count($keys) < 1) {
             return false;
         }
-        $expected = hash_hmac(
-            'sha256',
-            self::_nodeSignaturePayload(
-                strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET')),
-                (string) ($_SERVER['REQUEST_URI'] ?? ''),
-                $timestamp
-            ),
-            $key
+        $payload = self::_nodeSignaturePayload(
+            strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET')),
+            (string) ($_SERVER['REQUEST_URI'] ?? ''),
+            $timestamp
         );
-        return hash_equals($expected, $signature);
+        // Every candidate is compared, and the result is accumulated rather
+        // than returned early, so the time taken does not depend on WHICH
+        // key matched -- an early return would let a caller learn a node's
+        // position in the list by timing it. hash_equals is already constant
+        // time for the comparison itself; this keeps the loop from undoing
+        // that.
+        $matched = false;
+        foreach ($keys as $key) {
+            if (hash_equals(hash_hmac('sha256', $payload, $key), $signature)) {
+                $matched = true;
+            }
+        }
+        return $matched;
     }
     /**
      * Is the current session a FOG administrator?

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -682,6 +682,10 @@ class StorageNodeManagement extends FOGPage
             filter_input(INPUT_POST, 'pass') ?:
             $this->obj->get('pass')
         );
+        $apikey = (
+            filter_input(INPUT_POST, 'apikey') ?:
+            $this->obj->get('key')
+        );
         $isgren = isset($_POST['isGraphEnabled']) ?:
             $this->obj->get('isGraphEnabled');
         $isen = isset($_POST['isEnabled']) ?:
@@ -1005,6 +1009,37 @@ class StorageNodeManagement extends FOGPage
                 true
             )
             . '</div>',
+            // Only needed when the peer is a full FOG server with its own
+            // database. A true storage node reads the master's
+            // globalSettings, so it already shares FOG_NODE_API_KEY and
+            // this stays empty.
+            //
+            // A text input rather than a password one, deliberately: the
+            // whole point of the field is that the administrator has to
+            // read the value and set it as the peer's own
+            // FOG_NODE_API_KEY. A masked field cannot be transcribed. It
+            // is never emitted by the API -- 'key' is already in
+            // Route::$sensitiveAlwaysFields -- and this page is admin only.
+            self::makeLabel(
+                $labelClass,
+                'apikey',
+                _('Node API Signing Key')
+            ) => self::makeInput(
+                'form-control storagenodeapikey-input',
+                'apikey',
+                _('Leave empty unless this node is its own FOG server'),
+                'text',
+                'apikey',
+                $apikey,
+                true
+            )
+            . '<div class="form-text">'
+            . _(
+                'Only for a peer running its own FOG database. Set that '
+                . 'peer FOG_NODE_API_KEY global setting to the same value, '
+                . 'or it cannot verify requests this server signs.'
+            )
+            . '</div>',
         ];
 
         $buttons = self::makeButton(
@@ -1152,6 +1187,7 @@ class StorageNodeManagement extends FOGPage
             ->set('isEnabled', $isen)
             ->set('user', $user)
             ->set('pass', $pass)
+            ->set('key', trim((string)filter_input(INPUT_POST, 'apikey')))
             ->set('bandwidth', $bandwidth)
             ->set('graphcolor', $graphcolor);
         if ($this->obj->get('isMaster')) {

--- a/tests/node-signature-auth.test.php
+++ b/tests/node-signature-auth.test.php
@@ -63,6 +63,8 @@ $methods = [];
 foreach (
     [
         '_nodeSignaturePayload',
+        'nodeSigningKeyFor',
+        '_nodeVerificationKeys',
         'nodeSignatureHeaders',
         'validNodeSignature'
     ] as $name
@@ -89,17 +91,78 @@ if (count($fails) > 0) {
     exit(1);
 }
 
+/*
+ * nodeSigningKeyFor() and _nodeVerificationKeys() read nfsGroupMembers, so
+ * the probe needs a $DB. A fake one rather than a stub of the methods:
+ * what is worth testing is the row handling itself -- an unmatched host
+ * used to come back as the string 'Array' and sign every request to an
+ * unknown peer with a constant no one could verify.
+ *
+ * The fake answers on the shape of the SQL, which is all the two callers
+ * differ by: one names ngmHostname, the other does not.
+ */
+class NodeSigFakeResult
+{
+    private $_rows;
+
+    public function __construct($rows)
+    {
+        $this->_rows = $rows;
+    }
+
+    public function fetch($mode = null, $how = null)
+    {
+        return $this;
+    }
+
+    public function get($field = null)
+    {
+        return $this->_rows;
+    }
+}
+
+class NodeSigFakeDb
+{
+    /** Rows as ['ngmHostname' => ..., 'ngmKey' => ...]. */
+    public static $nodes = [];
+
+    public function escape($value)
+    {
+        return "'" . str_replace("'", "''", (string)$value) . "'";
+    }
+
+    public function query($sql)
+    {
+        $rows = [];
+        foreach (self::$nodes as $node) {
+            if (trim((string)$node['ngmKey']) === '') {
+                continue;
+            }
+            if (false !== strpos($sql, 'ngmHostname')) {
+                $quoted = "'" . $node['ngmHostname'] . "'";
+                if (false === strpos($sql, $quoted)) {
+                    continue;
+                }
+            }
+            $rows[] = ['ngmKey' => $node['ngmKey']];
+        }
+        return new NodeSigFakeResult($rows);
+    }
+}
+
 eval(
     'class NodeSigProbe {'
     . ' const NODE_API_KEY_SETTING = ' . $consts['NODE_API_KEY_SETTING'] . ';'
     . ' const NODE_SIGNATURE_WINDOW = '
     . $consts['NODE_SIGNATURE_WINDOW'] . ';'
     . ' public static $key = \'\';'
+    . ' public static $DB;'
     . ' public static function nodeApiKey() { return self::$key; }'
     . ' public static function getSetting($k) { return self::$key; }'
     . implode("\n", $methods)
     . ' }'
 );
+NodeSigProbe::$DB = new NodeSigFakeDb();
 
 /**
  * Presents a set of headers as an inbound request.
@@ -225,6 +288,93 @@ if (NodeSigProbe::validNodeSignature()) {
     $fails[] = 'a request dated beyond the window into the future is'
         . ' accepted';
 }
+
+/*
+ * Per-peer keys.
+ *
+ * A true storage node points DATABASE_HOST at the master, so both ends read
+ * the same globalSettings row and there is nothing to distribute. A peer
+ * that is a full FOG server has its own database, mints its own key, and
+ * can never verify anything the master signs -- validNodeSignature() must
+ * not mint, so it cannot heal itself either. nfsGroupMembers.ngmKey is the
+ * per-peer secret the administrator sets on both ends, the same way ngmUser
+ * and ngmPass have always had to match the account on the node.
+ */
+$peerKey = str_repeat('b2', 32);
+NodeSigFakeDb::$nodes = [
+    ['ngmHostname' => '10.0.0.9', 'ngmKey' => $peerKey],
+    ['ngmHostname' => '10.0.0.10', 'ngmKey' => ''],
+];
+
+if (NodeSigProbe::nodeSigningKeyFor('10.0.0.9') !== $peerKey) {
+    $fails[] = 'nodeSigningKeyFor() does not return a peer key that is set';
+}
+
+// The node exists but has no key of its own -- the shared-database case,
+// which must keep signing with the installation-wide key.
+if (NodeSigProbe::nodeSigningKeyFor('10.0.0.10') !== '') {
+    $fails[] = 'nodeSigningKeyFor() returned something for a node with an'
+        . ' empty ngmKey; a shared-database node must fall back';
+}
+
+// No such node. This is the one that bit: the single-row fetch handed back
+// the empty result set, which casts to the string 'Array', so every request
+// to an unknown host was signed with a constant nobody holds -- and it read
+// as a working signature right up to the point of verification.
+$unknown = NodeSigProbe::nodeSigningKeyFor('203.0.113.199');
+if ($unknown !== '') {
+    $fails[] = 'nodeSigningKeyFor() returned ' . var_export($unknown, true)
+        . ' for a host matching no node; expected an empty string';
+}
+
+// The signer prefers the peer key, and the result differs from what the
+// shared key would have produced.
+$peerHeaders = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+if ($peerHeaders === $headers) {
+    $fails[] = 'nodeSignatureHeaders() ignored the peer key and signed with'
+        . ' the installation-wide one';
+}
+
+// This server holds that peer key in its own table, so it verifies -- the
+// shared-database topology, where the master signs with the target node's
+// ngmKey and the node reads the very same row.
+nodeSigPresent('GET', $uri, $peerHeaders);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature made with a peer key present in nfsGroupMembers'
+        . ' was refused';
+}
+
+// The global key still verifies alongside it. Both are legitimate and the
+// receiver cannot tell from the request which was used.
+NodeSigFakeDb::$nodes = [];
+$globalHeaders = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+NodeSigFakeDb::$nodes = [
+    ['ngmHostname' => '10.0.0.9', 'ngmKey' => $peerKey],
+];
+nodeSigPresent('GET', $uri, $globalHeaders);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'the installation-wide key stopped verifying once a peer key'
+        . ' existed; adding peers must not break the common case';
+}
+
+// A key this server does not hold is still refused. Widening the candidate
+// set must not turn into accepting anything.
+$stranger = str_repeat('c3', 32);
+$sig = hash_hmac('sha256', time() . "\nGET\n" . $uri, $stranger);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . time(),
+        'X-Fog-Node-Signature: ' . $sig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature made with a key this server does not hold was'
+        . ' accepted';
+}
+
+NodeSigFakeDb::$nodes = [];
 
 // A different installation's key.
 NodeSigProbe::$key = str_repeat('b2', 32);


### PR DESCRIPTION
Follow-up to #1313. Closes the gap its PR body implied was covered.

## The gap

#1313 authenticates FOG's server-to-server calls with an HMAC over `FOG_NODE_API_KEY`, and the docblock claimed there was "nothing to distribute" because `functions.sh` points a node's `DATABASE_HOST` at the master. That is true of a **true storage node** and only of one.

A peer that is itself a full FOG server has its own database and its own `globalSettings`. It mints its own `FOG_NODE_API_KEY`, unrelated to the master's, so it cannot verify anything the master signs — and because `validNodeSignature()` deliberately never mints, a pure receiver cannot heal itself either. Nothing in the installer distributes the value; verified by source and on the lab.

**Not a regression.** Before #1313 that request carried no session either, so it failed then too. Only the claim of coverage was wrong.

## The fix

`nfsGroupMembers.ngmKey` is the per-peer secret. The column has existed since 1.5, is declared on `StorageNode` as `key`, has **never been read or written by anything**, and is already in `Route::$sensitiveAlwaysFields` — so no route has ever emitted it and none starts now.

| Piece | Behaviour |
|---|---|
| `nodeSigningKeyFor($host)` | Resolves the target's `ngmKey`. Matched on `ngmHostname` because that is what the signer has — `FOGURLRequests` knows a URL, not which node it belongs to |
| `nodeSignatureHeaders()` | Uses the peer key when set, the installation-wide key otherwise, so every existing shared-database install signs exactly as before |
| `_nodeVerificationKeys()` | Gives `validNodeSignature()` the global key plus every non-empty `ngmKey` this server can see |
| Storage node edit page | New "Node API Signing Key" field |

`_nodeVerificationKeys()` needs both sources because two topologies need it for opposite reasons: with a shared database the master signed with the *target's own* `ngmKey` and the node reads that same row; standalone, the administrator has set this server's `FOG_NODE_API_KEY` to match. Candidates are all compared and the result accumulated rather than returned early, so the time taken does not reveal which key matched.

The UI field is a **text** input, not a password one, deliberately: the administrator has to *read* the value to set it as the peer's own `FOG_NODE_API_KEY`, and a masked field cannot be transcribed. The page is admin-only and the field is never emitted by the API.

Distribution stays a deliberate administrative step. That is the same model `ngmUser`/`ngmPass` have always followed — both must match an account that actually exists on the node, and nothing syncs them either.

## A defect found while verifying

Worth naming because it read as working: the single-row form `fetch()->get('ngmKey')` hands back the *empty result set* when the host matches no node, which casts to the string `'Array'`. Every request to an unknown host would have been signed with that constant — two headers present, well formed, and unverifiable anywhere. Indexing a `fetch_all` list makes "no row" and "no key" the same empty answer.

## Verification

Against the live database, signing and verifying for real:

```
1. nodeSigningKeyFor(host) with no ngmKey  => ''            (falls back)
   verifies here: true
2. nodeSigningKeyFor(host) with ngmKey set => the peer key
   signature differs from the global-key one: true
   verifies here: true
3. bogus signature verifies: false
4. nodeSigningKeyFor(unknown host)         => ''
```

## Scope

- **No schema change** — the column exists.
- **No OpenAPI change** — `key` is already stripped from every payload by `$sensitiveAlwaysFields`, so no documented response shape moves.
- **No `FOG_BCACHE_VER` bump** — no JS or CSS changed.

## Tests

`tests/node-signature-auth.test.php` lifts the two new methods and runs them against a fake `nfsGroupMembers`, covering peer-key resolution, both fallbacks, the empty-result defect above, and that widening the candidate set did not turn into accepting a key this server does not hold. 6 mutations verified killed. Full suite 100/100.

## Downstream

None. FogApi does not read a storage node's `key` — it cannot, the field has never been emitted.

## dev-branch

#1314 carries the same HMAC and the same gap. Porting next.