### PR TITLE
feat(nodes): give a peer FOG server its own signing key

### DIFF
--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -3271,6 +3271,19 @@ abstract class FOGBase
      * DB_host="$snmysqlhost"`), so a row written once is readable everywhere
      * with nothing to distribute.
      *
+     * That last clause holds for a TRUE storage node and only for one. A
+     * peer that is itself a full FOG server -- its own DATABASE_HOST, its
+     * own globalSettings -- shares no row with the master, mints its own
+     * key here, and cannot verify anything the master signs. Nothing in the
+     * installer distributes this value, and validNodeSignature() must never
+     * mint one, so a pure receiver cannot heal itself either.
+     *
+     * nodeSigningKeyFor() is the answer for that topology: a per-peer key
+     * on the master's storage node record, which the administrator also
+     * sets as that peer's own FOG_NODE_API_KEY. Same model as ngmUser and
+     * ngmPass, which have always had to be kept in step with the account
+     * that actually exists on the node.
+     *
      * @var string
      */
     const NODE_API_KEY_SETTING = 'FOG_NODE_API_KEY';
@@ -3361,6 +3374,98 @@ abstract class FOGBase
      *
      * @return string
      */
+    /**
+     * The signing key for one peer, or '' to fall back to the shared one.
+     *
+     * A storage node that shares the master's database verifies with the
+     * global key and needs nothing here. A peer that is a full FOG server
+     * has its own globalSettings and cannot see the master's row at all, so
+     * the two ends have to be given a value in common by hand.
+     *
+     * nfsGroupMembers.ngmKey is where it goes. The column has existed since
+     * 1.5, is declared on StorageNode as `key`, and has never been read or
+     * written by anything.
+     *
+     * Matched on ngmHostname because that is what the caller has: signing
+     * happens in FOGURLRequests, which knows a URL and not which node it
+     * belongs to. A host that matches no node, or a node with an empty key,
+     * returns '' and the caller signs with the installation-wide key --
+     * which is what every existing shared-database install keeps doing.
+     *
+     * @param string $host The host part of the URL about to be requested.
+     *
+     * @return string The peer's key, or '' if it has none.
+     */
+    public static function nodeSigningKeyFor($host)
+    {
+        $host = trim((string)$host);
+        if ($host === '') {
+            return '';
+        }
+        // fetch_all rather than fetch()->get('ngmKey'): on a host that
+        // matches no node the single-row form hands back the empty result
+        // set itself, which casts to the string 'Array' -- a non-empty
+        // "key" that signs every request to an unknown host with a
+        // constant nobody can verify. Indexing a list makes "no row" and
+        // "no key" the same, empty, answer.
+        $rows = self::$DB->query(
+            sprintf(
+                'SELECT `ngmKey` FROM `nfsGroupMembers` '
+                . 'WHERE `ngmHostname` = %s AND `ngmKey` <> %s LIMIT 1',
+                self::$DB->escape($host),
+                self::$DB->escape('')
+            )
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $rows = (array)$rows;
+        if (count($rows) < 1) {
+            return '';
+        }
+        return trim((string)(isset($rows[0]['ngmKey']) ? $rows[0]['ngmKey'] : ''));
+    }
+    /**
+     * Every key a signature reaching THIS server could legitimately carry.
+     *
+     * The global key first, because on a shared-database install that is
+     * the one the master signed with and the common case should cost one
+     * comparison.
+     *
+     * Then every non-empty ngmKey this server can see. Two topologies need
+     * it and they need it for opposite reasons:
+     *
+     *   - Shared database. The master signed with the target node's own
+     *     ngmKey; the node reads the same table, so the key is right there.
+     *   - Standalone peer. The administrator set this server's
+     *     FOG_NODE_API_KEY to match, so the global key already covers it --
+     *     but this server's OWN node rows are also legitimate signers if it
+     *     is a master in its own right.
+     *
+     * The candidate set is bounded by the number of storage nodes and each
+     * miss is one hash_hmac, so the cost is not worth a cache that could
+     * then go stale against a rotated key.
+     *
+     * @return array Distinct non-empty keys.
+     */
+    private static function _nodeVerificationKeys()
+    {
+        $keys = array();
+        $global = trim((string)self::getSetting(self::NODE_API_KEY_SETTING));
+        if ($global !== '') {
+            $keys[] = $global;
+        }
+        $rows = self::$DB->query(
+            'SELECT `ngmKey` FROM `nfsGroupMembers` '
+            . "WHERE `ngmKey` <> ''"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        foreach ((array)$rows as $row) {
+            $candidate = trim(
+                (string)(isset($row['ngmKey']) ? $row['ngmKey'] : '')
+            );
+            if ($candidate !== '') {
+                $keys[] = $candidate;
+            }
+        }
+        return array_values(array_unique($keys));
+    }
     private static function _nodeSignaturePayload($method, $uri, $timestamp)
     {
         return $timestamp . "\n" . $method . "\n" . $uri;
@@ -3384,12 +3489,22 @@ abstract class FOGBase
      */
     public static function nodeSignatureHeaders($url, $method = 'GET')
     {
-        $key = self::nodeApiKey();
-        if ($key === '') {
-            return array();
-        }
         $parts = parse_url((string)$url);
         if ($parts === false) {
+            return array();
+        }
+        // The peer's own key if it has one, otherwise the installation-wide
+        // key. Ordered this way round so a shared-database install -- where
+        // no ngmKey is ever set -- signs exactly as it did before, and a
+        // full FOG server registered as a peer gets a secret that is only
+        // good for talking to it.
+        $key = self::nodeSigningKeyFor(
+            isset($parts['host']) ? $parts['host'] : ''
+        );
+        if ($key === '') {
+            $key = self::nodeApiKey();
+        }
+        if ($key === '') {
             return array();
         }
         $uri = isset($parts['path']) ? $parts['path'] : '/';
@@ -3444,24 +3559,32 @@ abstract class FOGBase
         if (abs(time() - (int)$timestamp) > self::NODE_SIGNATURE_WINDOW) {
             return false;
         }
-        $key = trim((string)self::getSetting(self::NODE_API_KEY_SETTING));
-        if ($key === '') {
+        $keys = self::_nodeVerificationKeys();
+        if (count($keys) < 1) {
             return false;
         }
         $method = isset($_SERVER['REQUEST_METHOD'])
             ? $_SERVER['REQUEST_METHOD']
             : 'GET';
         $uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
-        $expected = hash_hmac(
-            'sha256',
-            self::_nodeSignaturePayload(
-                strtoupper((string)$method),
-                (string)$uri,
-                $timestamp
-            ),
-            $key
+        $payload = self::_nodeSignaturePayload(
+            strtoupper((string)$method),
+            (string)$uri,
+            $timestamp
         );
-        return hash_equals($expected, $signature);
+        // Every candidate is compared, and the result is accumulated rather
+        // than returned early, so the time taken does not depend on WHICH
+        // key matched -- an early return would let a caller learn a node's
+        // position in the list by timing it. hash_equals is already constant
+        // time for the comparison itself; this keeps the loop from undoing
+        // that.
+        $matched = false;
+        foreach ($keys as $key) {
+            if (hash_equals(hash_hmac('sha256', $payload, $key), $signature)) {
+                $matched = true;
+            }
+        }
+        return $matched;
     }
     /**
      * Is the acting user a FOG administrator (uType 0)?

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -683,6 +683,8 @@ class StorageManagementPage extends FOGPage
             $this->obj->get('user');
         $pass = filter_input(INPUT_POST, 'pass') ?:
             $this->obj->get('pass');
+        $apikey = filter_input(INPUT_POST, 'apikey') ?:
+            $this->obj->get('key');
         $isgren = isset($_POST['isGraphEnabled']) ?:
             $this->obj->get('isGraphEnabled');
         $isen = isset($_POST['isEnabled']) ?:
@@ -868,6 +870,26 @@ class StorageManagementPage extends FOGPage
             . Initiator::e($pass)
             . '" autocomplete="off" class="form-control" required/>'
             . '</div>',
+            // Only needed when the peer is a full FOG server with its own
+            // database. A true storage node reads the master's
+            // globalSettings, so it already shares FOG_NODE_API_KEY and
+            // this stays empty.
+            //
+            // type=text rather than password, deliberately: the whole point
+            // is that the administrator reads the value and sets it as the
+            // peer's own FOG_NODE_API_KEY, and a masked field cannot be
+            // transcribed. stripNodeSecrets() keeps it out of every API
+            // payload, and this page is admin only.
+            '<label for="apikey">'
+            . _('Node API Signing Key')
+            . '</label>' => '<div class="input-group">'
+            . '<input type="text" name="apikey" id="apikey" value="'
+            . Initiator::e($apikey)
+            . '" autocomplete="off" class="form-control" '
+            . 'placeholder="'
+            . _('Leave empty unless this node is its own FOG server')
+            . '"/>'
+            . '</div>',
             '<label for="update">'
             . _('Make Changes?')
             . '</label>' => '<button name="update" id="update" type="submit" '
@@ -993,6 +1015,7 @@ class StorageManagementPage extends FOGPage
                 ->set('isEnabled', $isen)
                 ->set('user', $user)
                 ->set('pass', $pass)
+                ->set('key', trim((string)filter_input(INPUT_POST, 'apikey')))
                 ->set('bandwidth', $bandwidth);
             if (!$this->obj->save()) {
                 throw new Exception(_('Storage Node update failed!'));

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2179,6 +2179,37 @@ class Route extends FOGBase
         return 1 === preg_match(self::SENSITIVE_SETTING_PATTERN, $key);
     }
     /**
+     * Strips a storage node's credentials from an outbound payload.
+     *
+     * ngmPass is the node's FTP credential. It reaches the root-running
+     * replicator's lftp invocation and the SSH helpers in Snapin and
+     * TaskQueue, so holding it is holding the node -- the same credential
+     * class as GHSA-2hqx-5ffg-w4c3. It was being returned in full by
+     * GET /storagenode/{id} and, less obviously, embedded in every task
+     * payload, to any caller the API let in.
+     *
+     * ngmKey joins it now that nodeSigningKeyFor() gives that column a
+     * meaning: it is the secret a peer FOG server verifies signed requests
+     * with, so publishing it would hand over the thing the signature
+     * proves.
+     *
+     * Nothing reads either back over the API. Every consumer is server-side
+     * PHP with the object already in hand -- snapin.class.php,
+     * taskqueue.class.php, snapinclient.class.php, logviewerhook and the
+     * node edit page all call $StorageNode->get('pass') directly -- so
+     * there is no legitimate reader to carve out for.
+     *
+     * @param array $data The payload about to be emitted.
+     *
+     * @return array
+     */
+    public static function stripNodeSecrets($data)
+    {
+        $data = (array)$data;
+        unset($data['pass'], $data['key']);
+        return $data;
+    }
+    /**
      * Drops the value of a globalSettings row that holds a credential.
      *
      * The name, description and category stay -- only the value goes -- so
@@ -2314,7 +2345,7 @@ class Route extends FOGBase
                     );
                 }
                 $data = FOGCore::fastmerge(
-                    $class->get(),
+                    self::stripNodeSecrets($class->get()),
                     $extra,
                     array(
                         'storagegroup' => self::getter(
@@ -2347,7 +2378,9 @@ class Route extends FOGBase
                         ),
                         'type' => $class->get('type')->get(),
                         'state' => $class->get('state')->get(),
-                        'storagenode' => $class->get('storagenode')->get(),
+                        'storagenode' => self::stripNodeSecrets(
+                            $class->get('storagenode')->get()
+                        ),
                         'storagegroup' => $class->get('storagegroup')->get()
                     )
                 );

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3706,6 +3706,9 @@ msgstr "Neueste Version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Level muss eine integer sein."
@@ -4504,6 +4507,9 @@ msgstr "Keine brauchbaren Speichergruppen gefunden"
 
 msgid "Node"
 msgstr "Knoten"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3707,6 +3707,9 @@ msgstr "Latest Version"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 #, fuzzy
 msgid "Level must be an integer"
 msgstr "Event must be a string"
@@ -4504,6 +4507,9 @@ msgstr ""
 
 msgid "Node"
 msgstr "Node"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3715,6 +3715,9 @@ msgstr "Última versión"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr ""
 
@@ -4516,6 +4519,9 @@ msgstr ""
 
 msgid "Node"
 msgstr "Nodo"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 #, fuzzy
 msgid "Node Offline"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3278,6 +3278,9 @@ msgstr "Dernière version "
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "Le niveau doit être un nombre entier"
 
@@ -3996,6 +3999,9 @@ msgstr "Aucun groupe de stockage viable n'a été trouvé"
 
 msgid "Node"
 msgstr "Nœud"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr "Nœud hors-ligne"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3345,6 +3345,9 @@ msgstr "Ultima versione"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "Livello deve essere una stringa"
 
@@ -4070,6 +4073,9 @@ msgstr "Nessun gruppo di storage disponibile trovato"
 
 msgid "Node"
 msgstr "Nodo"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3240,6 +3240,9 @@ msgstr "最新バージョン"
 msgid "Leave a field blank to keep each host's current value."
 msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "レベルは整数である必要があります"
 
@@ -3957,6 +3960,9 @@ msgstr "使用可能なストレージグループが見つかりません"
 
 msgid "Node"
 msgstr "ノード"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr "ノードはオフラインです"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3212,6 +3212,9 @@ msgstr ""
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr ""
 
@@ -3922,6 +3925,9 @@ msgid "No viable storage groups found"
 msgstr ""
 
 msgid "Node"
+msgstr ""
+
+msgid "Node API Signing Key"
 msgstr ""
 
 msgid "Node Offline"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3260,6 +3260,9 @@ msgstr "Última Versão"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "Nível deve ser um inteiro"
 
@@ -3978,6 +3981,9 @@ msgstr "Nenhum grupo de armazenamento viável encontrado"
 
 msgid "Node"
 msgstr "Nó"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr "Nó Offline"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3260,6 +3260,9 @@ msgstr "最新版本"
 msgid "Leave a field blank to keep each host's current value."
 msgstr ""
 
+msgid "Leave empty unless this node is its own FOG server"
+msgstr ""
+
 msgid "Level must be an integer"
 msgstr "等级必须是整数"
 
@@ -3978,6 +3981,9 @@ msgstr "找不到可用的存储组"
 
 msgid "Node"
 msgstr "节点"
+
+msgid "Node API Signing Key"
+msgstr ""
 
 msgid "Node Offline"
 msgstr "节点已下线"

--- a/tests/node-signature-auth.test.php
+++ b/tests/node-signature-auth.test.php
@@ -63,6 +63,8 @@ $methods = [];
 foreach (
     [
         '_nodeSignaturePayload',
+        'nodeSigningKeyFor',
+        '_nodeVerificationKeys',
         'nodeSignatureHeaders',
         'validNodeSignature'
     ] as $name
@@ -89,17 +91,78 @@ if (count($fails) > 0) {
     exit(1);
 }
 
+/*
+ * nodeSigningKeyFor() and _nodeVerificationKeys() read nfsGroupMembers, so
+ * the probe needs a $DB. A fake one rather than a stub of the methods:
+ * what is worth testing is the row handling itself -- an unmatched host
+ * used to come back as the string 'Array' and sign every request to an
+ * unknown peer with a constant no one could verify.
+ *
+ * The fake answers on the shape of the SQL, which is all the two callers
+ * differ by: one names ngmHostname, the other does not.
+ */
+class NodeSigFakeResult
+{
+    private $_rows;
+
+    public function __construct($rows)
+    {
+        $this->_rows = $rows;
+    }
+
+    public function fetch($mode = null, $how = null)
+    {
+        return $this;
+    }
+
+    public function get($field = null)
+    {
+        return $this->_rows;
+    }
+}
+
+class NodeSigFakeDb
+{
+    /** Rows as ['ngmHostname' => ..., 'ngmKey' => ...]. */
+    public static $nodes = [];
+
+    public function escape($value)
+    {
+        return "'" . str_replace("'", "''", (string)$value) . "'";
+    }
+
+    public function query($sql)
+    {
+        $rows = [];
+        foreach (self::$nodes as $node) {
+            if (trim((string)$node['ngmKey']) === '') {
+                continue;
+            }
+            if (false !== strpos($sql, 'ngmHostname')) {
+                $quoted = "'" . $node['ngmHostname'] . "'";
+                if (false === strpos($sql, $quoted)) {
+                    continue;
+                }
+            }
+            $rows[] = ['ngmKey' => $node['ngmKey']];
+        }
+        return new NodeSigFakeResult($rows);
+    }
+}
+
 eval(
     'class NodeSigProbe {'
     . ' const NODE_API_KEY_SETTING = ' . $consts['NODE_API_KEY_SETTING'] . ';'
     . ' const NODE_SIGNATURE_WINDOW = '
     . $consts['NODE_SIGNATURE_WINDOW'] . ';'
     . ' public static $key = \'\';'
+    . ' public static $DB;'
     . ' public static function nodeApiKey() { return self::$key; }'
     . ' public static function getSetting($k) { return self::$key; }'
     . implode("\n", $methods)
     . ' }'
 );
+NodeSigProbe::$DB = new NodeSigFakeDb();
 
 /**
  * Presents a set of headers as an inbound request.
@@ -224,6 +287,127 @@ nodeSigPresent(
 if (NodeSigProbe::validNodeSignature()) {
     $fails[] = 'a request dated beyond the window into the future is'
         . ' accepted';
+}
+
+/*
+ * Per-peer keys.
+ *
+ * A true storage node points DATABASE_HOST at the master, so both ends read
+ * the same globalSettings row and there is nothing to distribute. A peer
+ * that is a full FOG server has its own database, mints its own key, and
+ * can never verify anything the master signs -- validNodeSignature() must
+ * not mint, so it cannot heal itself either. nfsGroupMembers.ngmKey is the
+ * per-peer secret the administrator sets on both ends, the same way ngmUser
+ * and ngmPass have always had to match the account on the node.
+ */
+$peerKey = str_repeat('b2', 32);
+NodeSigFakeDb::$nodes = [
+    ['ngmHostname' => '10.0.0.9', 'ngmKey' => $peerKey],
+    ['ngmHostname' => '10.0.0.10', 'ngmKey' => ''],
+];
+
+if (NodeSigProbe::nodeSigningKeyFor('10.0.0.9') !== $peerKey) {
+    $fails[] = 'nodeSigningKeyFor() does not return a peer key that is set';
+}
+
+// The node exists but has no key of its own -- the shared-database case,
+// which must keep signing with the installation-wide key.
+if (NodeSigProbe::nodeSigningKeyFor('10.0.0.10') !== '') {
+    $fails[] = 'nodeSigningKeyFor() returned something for a node with an'
+        . ' empty ngmKey; a shared-database node must fall back';
+}
+
+// No such node. This is the one that bit: the single-row fetch handed back
+// the empty result set, which casts to the string 'Array', so every request
+// to an unknown host was signed with a constant nobody holds -- and it read
+// as a working signature right up to the point of verification.
+$unknown = NodeSigProbe::nodeSigningKeyFor('203.0.113.199');
+if ($unknown !== '') {
+    $fails[] = 'nodeSigningKeyFor() returned ' . var_export($unknown, true)
+        . ' for a host matching no node; expected an empty string';
+}
+
+// The signer prefers the peer key, and the result differs from what the
+// shared key would have produced.
+$peerHeaders = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+if ($peerHeaders === $headers) {
+    $fails[] = 'nodeSignatureHeaders() ignored the peer key and signed with'
+        . ' the installation-wide one';
+}
+
+// This server holds that peer key in its own table, so it verifies -- the
+// shared-database topology, where the master signs with the target node's
+// ngmKey and the node reads the very same row.
+nodeSigPresent('GET', $uri, $peerHeaders);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature made with a peer key present in nfsGroupMembers'
+        . ' was refused';
+}
+
+// The global key still verifies alongside it. Both are legitimate and the
+// receiver cannot tell from the request which was used.
+NodeSigFakeDb::$nodes = [];
+$globalHeaders = NodeSigProbe::nodeSignatureHeaders($url, 'GET');
+NodeSigFakeDb::$nodes = [
+    ['ngmHostname' => '10.0.0.9', 'ngmKey' => $peerKey],
+];
+nodeSigPresent('GET', $uri, $globalHeaders);
+if (!NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'the installation-wide key stopped verifying once a peer key'
+        . ' existed; adding peers must not break the common case';
+}
+
+// A key this server does not hold is still refused. Widening the candidate
+// set must not turn into accepting anything.
+$stranger = str_repeat('c3', 32);
+$sig = hash_hmac('sha256', time() . "\nGET\n" . $uri, $stranger);
+nodeSigPresent(
+    'GET',
+    $uri,
+    [
+        'X-Fog-Node-Timestamp: ' . time(),
+        'X-Fog-Node-Signature: ' . $sig
+    ]
+);
+if (NodeSigProbe::validNodeSignature()) {
+    $fails[] = 'a signature made with a key this server does not hold was'
+        . ' accepted';
+}
+
+NodeSigFakeDb::$nodes = [];
+
+/*
+ * ngmKey must never leave the server.
+ *
+ * 1.6 has $sensitiveAlwaysFields and lists 'key' there; this branch has no
+ * such registry, and Route emitted a node's whole row -- ngmPass included --
+ * from two places. Giving ngmKey a meaning without closing that would
+ * publish the very secret the signature proves.
+ *
+ * Asserted on the emitter rather than on a field list, because a field list
+ * is what this branch does not have.
+ */
+$route = (string)file_get_contents(
+    'packages/web/lib/router/route.class.php'
+);
+if (!preg_match(
+    "/function stripNodeSecrets\\(.*?unset\\(\\\$data\\['pass'\\], \\\$data\\['key'\\]\\);/s",
+    $route
+)) {
+    $fails[] = 'Route::stripNodeSecrets() no longer removes both pass and'
+        . ' key; a node credential would be emitted';
+}
+foreach (
+    [
+        "self::stripNodeSecrets(\$class->get())" =>
+            'the storagenode payload',
+        "'storagenode' => self::stripNodeSecrets(" =>
+            "a task's embedded storage node",
+    ] as $needle => $where
+) {
+    if (false === strpos($route, $needle)) {
+        $fails[] = 'node credentials are no longer stripped from ' . $where;
+    }
 }
 
 // A different installation's key.


### PR DESCRIPTION
Port of #1317, with one prerequisite this branch needs and that one does not.

## The gap (same as #1317)

#1314 authenticates FOG's server-to-server calls with an HMAC over `FOG_NODE_API_KEY`, and the docblock claimed there was "nothing to distribute" because `functions.sh` points a node's `DATABASE_HOST` at the master. That is true of a **true storage node** and only of one. A peer that is itself a full FOG server has its own database and its own `globalSettings`, mints its own key, and cannot verify anything the master signs — and because `validNodeSignature()` must never mint, a pure receiver cannot heal itself either.

**Not a regression:** before #1314 that request carried no session either.

`nfsGroupMembers.ngmKey` is the per-peer secret. The column has existed since 1.5, is declared on `StorageNode` as `key`, and has never been read or written by anything.

- `nodeSigningKeyFor($host)` resolves the target's `ngmKey`, matched on `ngmHostname` because that is what the signer has.
- `nodeSignatureHeaders()` uses it when set, the installation-wide key otherwise, so every existing shared-database install signs as before.
- `_nodeVerificationKeys()` gives `validNodeSignature()` the global key plus every non-empty `ngmKey` this server can see, compared without an early return so the time taken does not reveal which one matched.
- The storage node edit page gains a **Node API Signing Key** field — a text input rather than a password one, because the administrator has to *read* the value to set it as the peer's own `FOG_NODE_API_KEY`.

## The prerequisite: `ngmPass` and `ngmKey` were being emitted

working-1.6 has `Route::$sensitiveAlwaysFields` and already lists both. **This branch has no such registry**, and `Route` emitted a storage node's whole row from two places:

- `GET /storagenode/{id}`
- the `storagenode` embedded in every **task** payload

…to any caller the API let in. That published `ngmPass`, the node's FTP credential, which reaches the root-running replicator's `lftp` invocation and the SSH helpers in Snapin and TaskQueue — holding it is holding the node, the same credential class as GHSA-2hqx-5ffg-w4c3.

Giving `ngmKey` a meaning without closing that would have published the very secret the signature proves, so `stripNodeSecrets()` removes both at both emission points.

### Behaviour change, stated plainly

`GET /storagenode/{id}` and any task payload no longer carry `pass`, and never carry `key`.

Nothing reads either back over the API. Every consumer is server-side PHP with the object already in hand:

```
packages/web/lib/client/snapinclient.class.php:591
packages/web/lib/pages/storagemanagementpage.class.php:685
packages/web/lib/fog/snapin.class.php:184,551,720
packages/web/lib/hooks/logviewerhook.hook.php:96
packages/web/lib/pages/snapinmanagementpage.class.php:805,1569
packages/web/lib/reg-task/taskqueue.class.php:407
```

`enablednodes` and `allnodes` are **id arrays**, so they were never a leak and are untouched.

## Scope

- **No schema change** — the column exists.
- **No OpenAPI document on this branch** — nothing to update.

## Tests

`tests/node-signature-auth.test.php` gains the per-peer cases from #1317 — key resolution, both fallbacks, the empty-result defect where an unmatched host came back as the string `'Array'`, and that widening the candidate set did not turn into accepting a key this server does not hold — plus a gate on **both** strip call sites, asserted on the emitter because a field registry is what this branch does not have. Both mutations verified killed. Suite 28/28.

## Downstream

None. FogApi reads neither `pass` nor `key` off a storage node.