### PR TITLE
feat(nodes): give a peer a way to be handed its signing key

### DIFF
--- a/bin/fog-node-key.php
+++ b/bin/fog-node-key.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Reads or sets FOG_NODE_API_KEY on the install this runs against.
+ *
+ * The key FOG signs its own server-to-server requests with. A storage node
+ * points DATABASE_HOST at the master and so reads the master's row, which
+ * is why there is normally nothing to set and no UI for it -- the FOG
+ * Configuration page hides the row deliberately, because printing a shared
+ * secret into a form field on every page load is not worth it for a value
+ * that generates itself.
+ *
+ * A peer that is a full FOG server is the exception. It has its own
+ * database, mints its own unrelated key, and cannot verify anything the
+ * master signs. The master signs to that peer with the peer's ngmKey --
+ * "Node API Signing Key" on the master's storage node edit page -- so the
+ * peer needs the same value in its own FOG_NODE_API_KEY. This is the way
+ * to put it there.
+ *
+ * Two reasons it cannot be done with FOG's own setSetting():
+ *
+ *   - setSetting() is an UPDATE through Setting/ServiceManager and does
+ *     nothing at all when the row is absent, which is exactly the state a
+ *     pure receiver is in. It never signs anything, so nodeApiKey() has
+ *     never run there and no row exists.
+ *   - validNodeSignature() deliberately never mints, so the peer cannot
+ *     heal itself on the first signed request either. That is the correct
+ *     behaviour -- a verifier that invents keys verifies nothing -- and it
+ *     is what makes this a manual step.
+ *
+ * Deliberately does NOT boot FOG. It reads the DB constants straight out of
+ * config.class.php, the same way bin/schema-manifest.php does. Booting
+ * would pull in the autoloader, the session layer and LoadGlobals to write
+ * one row, and every one of those is a way for this to fail on a machine
+ * that is by definition not fully working yet.
+ *
+ * Usage:
+ *   php bin/fog-node-key.php [--web /var/www/html/fog] [--show]
+ *   php bin/fog-node-key.php [--web /var/www/html/fog] --set <key>
+ *
+ * Running daemons cache settings for FOG_SETTING_CACHE_TTL (300s default),
+ * so a change can take up to five minutes to reach one that is already up.
+ *
+ * PHP version 7.4+
+ *
+ * @category Utility
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+/**
+ * Loads the DB constants out of a FOG install's config.class.php.
+ *
+ * Same reader as bin/schema-manifest.php, and for the same reason: the
+ * constants are the only thing needed and parsing them is cheaper and far
+ * more robust than booting the application to reach them.
+ *
+ * @param string $root The web root of the FOG install.
+ *
+ * @return PDO
+ */
+function fogNodeKeyConnect($root)
+{
+    $config = rtrim($root, '/') . '/lib/fog/config.class.php';
+    if (!file_exists($config)) {
+        fwrite(STDERR, "No config.class.php under $root\n");
+        fwrite(STDERR, "Pass the web root with --web /path/to/fog\n");
+        exit(1);
+    }
+    $src = file_get_contents($config);
+    $vals = [];
+    foreach (['HOST', 'NAME', 'USERNAME', 'PASSWORD'] as $key) {
+        if (preg_match(
+            "/define\(\s*'DATABASE_$key'\s*,\s*'(.*?)'\s*\)/s",
+            $src,
+            $m
+        )) {
+            $vals[$key] = $m[1];
+        }
+    }
+    if (!isset($vals['NAME'])) {
+        fwrite(STDERR, "Could not read DATABASE_* from $config\n");
+        exit(1);
+    }
+    return new \PDO(
+        sprintf(
+            'mysql:host=%s;dbname=%s',
+            $vals['HOST'] ?: 'localhost',
+            $vals['NAME']
+        ),
+        $vals['USERNAME'],
+        $vals['PASSWORD'],
+        [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+    );
+}
+
+$roots = [
+    '/var/www/html/fog',
+    '/var/www/fog',
+];
+$root = '';
+$set = null;
+$show = false;
+
+$argvv = array_slice($argv, 1);
+for ($i = 0; $i < count($argvv); $i++) {
+    switch ($argvv[$i]) {
+    case '--web':
+        $root = isset($argvv[$i + 1]) ? $argvv[++$i] : '';
+        break;
+    case '--set':
+        $set = isset($argvv[$i + 1]) ? $argvv[++$i] : '';
+        break;
+    case '--show':
+        $show = true;
+        break;
+    case '-h':
+    case '--help':
+        fwrite(
+            STDOUT,
+            "Usage:\n"
+            . "  php bin/fog-node-key.php [--web <root>] [--show]\n"
+            . "  php bin/fog-node-key.php [--web <root>] --set <key>\n\n"
+            . "Reads or sets FOG_NODE_API_KEY. Needed only on a peer that\n"
+            . "runs its own FOG database; set it to the value held in the\n"
+            . "master's storage node record for this peer.\n"
+        );
+        exit(0);
+    default:
+        fwrite(STDERR, "Unknown argument: {$argvv[$i]}\n");
+        exit(1);
+    }
+}
+
+// Validated here rather than next to the write, so a bad invocation is
+// rejected on any machine -- before locating a web root, before opening a
+// connection, and without needing either to be working.
+if (null !== $set) {
+    $set = trim((string)$set);
+    if ($set === '') {
+        fwrite(STDERR, "--set needs a value\n");
+        exit(1);
+    }
+    // The master generates these as 32 random bytes hex encoded. Not
+    // enforced, because an administrator is entitled to choose their own
+    // and a length rule here would be a second opinion about a value the
+    // other end already accepted -- but short enough to be a typo is worth
+    // saying out loud.
+    if (strlen($set) < 32) {
+        fwrite(
+            STDERR,
+            'Warning: that key is ' . strlen($set) . " characters. FOG\n"
+            . "generates 64. Setting it anyway.\n"
+        );
+    }
+}
+
+if ($root === '') {
+    foreach ($roots as $candidate) {
+        if (file_exists($candidate . '/lib/fog/config.class.php')) {
+            $root = $candidate;
+            break;
+        }
+    }
+}
+if ($root === '') {
+    fwrite(
+        STDERR,
+        "Could not find a FOG web root. Pass one with --web /path/to/fog\n"
+    );
+    exit(1);
+}
+
+$db = fogNodeKeyConnect($root);
+
+if (null === $set) {
+    $stmt = $db->prepare(
+        'SELECT `settingValue` FROM `globalSettings` WHERE `settingKey` = ?'
+    );
+    $stmt->execute(['FOG_NODE_API_KEY']);
+    $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+    $value = $row ? trim((string)$row['settingValue']) : '';
+    if ($value === '') {
+        fwrite(STDOUT, "FOG_NODE_API_KEY: (not set)\n");
+        fwrite(
+            STDOUT,
+            "This install has never signed a request, or is a peer that\n"
+            . "only receives them. If it is a peer, set this to the value\n"
+            . "in the master's storage node record for it.\n"
+        );
+        exit(0);
+    }
+    // Printed in full on purpose: the only reason to run --show is to
+    // compare or copy the value, and a truncated secret cannot be either.
+    // This needs shell access to the server already.
+    fwrite(STDOUT, "FOG_NODE_API_KEY: $value\n");
+    exit(0);
+}
+
+// INSERT ... ON DUPLICATE KEY UPDATE rather than an UPDATE, because the row
+// is normally absent on the machine that needs this run -- see the header.
+// The UNIQUE KEY on settingKey is what makes the upsert well defined.
+$stmt = $db->prepare(
+    'INSERT INTO `globalSettings` '
+    . '(`settingKey`, `settingDesc`, `settingValue`, `settingCategory`) '
+    . 'VALUES (?, ?, ?, ?) '
+    . 'ON DUPLICATE KEY UPDATE `settingValue` = VALUES(`settingValue`)'
+);
+$stmt->execute(
+    [
+        'FOG_NODE_API_KEY',
+        'Shared secret FOG signs its own server-to-server requests with. '
+        . 'On a peer running its own database this must match the Node API '
+        . 'Signing Key held in the master storage node record for this peer.',
+        $set,
+        'FOG Storage Nodes',
+    ]
+);
+
+$stmt = $db->prepare(
+    'SELECT `settingValue` FROM `globalSettings` WHERE `settingKey` = ?'
+);
+$stmt->execute(['FOG_NODE_API_KEY']);
+$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+// Read back rather than trusting the write: this is the whole point of the
+// utility, and a silent no-op here would look identical to success and then
+// fail later as an unexplained 401 on the node.
+if (!$row || trim((string)$row['settingValue']) !== $set) {
+    fwrite(STDERR, "The key did not land. Nothing has been changed.\n");
+    exit(1);
+}
+fwrite(STDOUT, "FOG_NODE_API_KEY set on $root\n");
+fwrite(
+    STDOUT,
+    "Running daemons cache settings for up to FOG_SETTING_CACHE_TTL\n"
+    . "(300s by default), so give them that long to pick it up.\n"
+);
+exit(0);

--- a/packages/web/lib/pages/storagemanagementpage.class.php
+++ b/packages/web/lib/pages/storagemanagementpage.class.php
@@ -883,6 +883,13 @@ class StorageManagementPage extends FOGPage
             '<label for="apikey">'
             . _('Node API Signing Key')
             . '</label>' => '<div class="input-group">'
+            . '<i class="input-group-addon icon fa fa-question hand" title="'
+            . _(
+                'Only for a peer running its own FOG database. On that '
+                . 'peer run bin/fog-node-key.php --set with this same '
+                . 'value, or it cannot verify requests this server signs.'
+            )
+            . '" data-toggle="tooltip" data-placement="left"></i>'
             . '<input type="text" name="apikey" id="apikey" value="'
             . Initiator::e($apikey)
             . '" autocomplete="off" class="form-control" '

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4622,6 +4622,9 @@ msgstr "Nur zugewiesene Drucker"
 msgid "Only allowed to have"
 msgstr "Sie dürfen nur"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "Open Source Computer-Cloning-Lösung"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4622,6 +4622,9 @@ msgstr "Only Assigned Printers"
 msgid "Only allowed to have"
 msgstr "You are only allowed to assign"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "Open Source Computer Cloning Solution"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4633,6 +4633,9 @@ msgstr "Impresoras"
 msgid "Only allowed to have"
 msgstr ""
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4102,6 +4102,9 @@ msgstr "Imprimantes attribuées uniquement"
 msgid "Only allowed to have"
 msgstr "Seulement autorisé à avoir"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "Solution open-source de clonage d'ordinateurs"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4177,6 +4177,9 @@ msgstr "Solo stampanti assegnate"
 msgid "Only allowed to have"
 msgstr "Permesso solo di avere"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "Open Source Computer Clonazione Soluzione"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4063,6 +4063,9 @@ msgstr "割り当てられたプリンターのみ"
 msgid "Only allowed to have"
 msgstr "使用できるのは次のみです"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "オープンソースのコンピュータークローニングソリューション"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4029,6 +4029,9 @@ msgstr ""
 msgid "Only allowed to have"
 msgstr ""
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4084,6 +4084,9 @@ msgstr "Apenas Impressoras Atribuídas"
 msgid "Only allowed to have"
 msgstr "Apenas permitido ter"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "Solução de Clonagem de Computadores de Código Aberto"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4084,6 +4084,9 @@ msgstr "只分配打印机"
 msgid "Only allowed to have"
 msgstr "您只能拥有"
 
+msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
 msgid "Open Source Computer Cloning Solution"
 msgstr "开源计算机克隆解决方案"
 

--- a/tests/node-signature-auth.test.php
+++ b/tests/node-signature-auth.test.php
@@ -410,6 +410,45 @@ foreach (
     }
 }
 
+/*
+ * A peer must have SOME way to be given the key.
+ *
+ * FOG_NODE_API_KEY is hidden from the FOG Configuration page on purpose --
+ * printing a shared secret into a form field on every page load is not
+ * worth it for a value that generates itself -- and setSetting() is an
+ * UPDATE that does nothing when the row is absent, which is exactly the
+ * state a pure receiver is in: it never signs, so nodeApiKey() has never
+ * run there. Without bin/fog-node-key.php the per-peer key can be set on
+ * the master and nowhere else, which makes the whole feature inoperable in
+ * the one topology it exists for.
+ */
+if (!is_readable('bin/fog-node-key.php')) {
+    $fails[] = 'bin/fog-node-key.php is gone; a peer FOG server would have'
+        . ' no way to be given its FOG_NODE_API_KEY';
+} else {
+    $cli = (string)file_get_contents('bin/fog-node-key.php');
+    // An upsert, not an UPDATE. The row is normally absent on the machine
+    // that needs this run, and an UPDATE there is a silent no-op.
+    if (false === strpos($cli, 'ON DUPLICATE KEY UPDATE')) {
+        $fails[] = 'bin/fog-node-key.php no longer upserts; on a peer the'
+            . ' row does not exist yet and an UPDATE would do nothing';
+    }
+    // It must read back what it wrote: a silent no-op here looks exactly
+    // like success and then fails later as an unexplained 401 on the node.
+    if (false === strpos($cli, 'The key did not land')) {
+        $fails[] = 'bin/fog-node-key.php no longer verifies its own write';
+    }
+}
+
+// ...and the UI has to say where to run it, or the value is a dead end.
+$nodePage = (string)file_get_contents(
+    'packages/web/lib/pages/storagemanagementpage.class.php'
+);
+if (false === strpos($nodePage, 'fog-node-key.php')) {
+    $fails[] = 'the storage node page no longer tells the administrator how'
+        . ' to set the matching key on the peer';
+}
+
 // A different installation's key.
 NodeSigProbe::$key = str_repeat('b2', 32);
 nodeSigPresent('GET', $uri, $headers);


### PR DESCRIPTION
Follow-up to #1317 / #1318. Those gave the master a per-peer signing key in `nfsGroupMembers.ngmKey` and left the receiving end with **no way to be told what it is** — which makes the feature inoperable in the one topology it exists for.

## Why the peer cannot just be configured

Two things stand in the way, both of them deliberate and neither worth reversing:

- **`FOG_NODE_API_KEY` is hidden from the FOG Configuration page.** Printing a shared secret into a form field on every page load is not worth it for a value that normally generates itself. That reasoning has not changed.
- **`setSetting()` is an UPDATE** through Setting/ServiceManager and does nothing when the row is absent — which is exactly the state a pure receiver is in. It never signs anything, so `nodeApiKey()` has never run there and no row exists. And `validNodeSignature()` must never mint, or a verifier would be inventing the keys it checks against.

So the value has to be put there by hand, and there needs to be a supported way to do it.

## `bin/fog-node-key.php`

```
php bin/fog-node-key.php [--web <root>] [--show]
php bin/fog-node-key.php [--web <root>] --set <key>
```

- **Does not boot FOG.** It reads the DB constants straight out of `config.class.php`, the way `bin/schema-manifest.php` already does. Booting would pull in the autoloader, the session layer and LoadGlobals to write one row, and every one of those is a way to fail on a machine that is by definition not finished being set up.
- **`INSERT ... ON DUPLICATE KEY UPDATE`**, not an UPDATE, for the reason above. The `UNIQUE KEY` on `settingKey` makes the upsert well defined.
- **Reads the write back** before reporting success. A silent no-op here looks identical to success and then surfaces much later as an unexplained 401 on the node.
- **`--show` prints the key in full.** The only reason to run it is to compare or copy the value, a truncated secret can do neither, and it already requires shell access to the server.
- **Argument validation runs before** the web root is located and before any connection is opened, so a bad invocation is rejected on any machine without needing either to work.

The node edit page now names the script in its hint, so the field is not a dead end: read the key on the master, run one command on the peer.

## Verification

Against the live master:

- `--show` reports a 64-character hex value
- `--set` with that same value round-trips **byte-identically** through the upsert and the read-back
- autodetection finds the web root with no `--web`
- short-key warning, empty `--set`, unknown argument and missing-root paths all behave

The fresh-INSERT branch is the same statement as the upsert, and `globalSettings` has exactly the four columns it supplies plus the auto-increment id, so there is no other NOT NULL column for a new row to trip on. Stated explicitly because I could not create a scratch database to exercise it directly — `fogmaster` holds no CREATE privilege, and I was not going to mutate a live settings table to test a utility.

## Tests

Four gates in `tests/node-signature-auth.test.php`: the script exists, it upserts rather than updates, it verifies its own write, and the UI says where to run it. All mutation verified.

Port of the working-1.6 change; the script is identical. The node edit page uses this branch's existing `fa-question` tooltip pattern rather than 1.6's `form-text` block, and the test's page path is adjusted for `storagemanagementpage.class.php`. Suite 28/28.