### PR TITLE
fix(service): let cleanupProcList actually empty the process lists

### DIFF
--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -1258,6 +1258,21 @@ abstract class FOGService extends FOGBase
      */
     public function cleanupProcList()
     {
+        // Iterated over key SNAPSHOTS, with every read and write going to
+        // $this->procRef / $this->procPipes by full path.
+        //
+        // The obvious form -- foreach ((array)$this->procRef as &$x) -- does
+        // not work: casting produces a TEMPORARY, so &$x binds into the copy
+        // and every unset() through it is silently discarded. A finished
+        // transfer then stays in the list forever, and since housekeeping
+        // runs every 100ms the daemon re-reports it about ten times a
+        // second for the life of the process, filling the log while
+        // proc_close() is called again and again on the same handle. The
+        // casts were added for PHP 8 null safety and are still wanted;
+        // array_keys() gives that plus a stable iteration order that is
+        // safe to unset from. (The procPipes unsets below already wrote
+        // through by path and were never affected; procRef was.)
+        //
         // count() on a missing key is a TypeError under PHP 8, not a
         // warning -- an uncaught one, in a daemon, so the replicator would
         // die outright and the unit would simply stop syncing. empty() is
@@ -1265,26 +1280,28 @@ abstract class FOGService extends FOGBase
         // and an entry holding nothing both want the key dropped. The two
         // structures are kept in step by startTasking() and killTasking(),
         // but nothing enforces that, and this is not the place to find out.
-        foreach ((array)$this->procRef as $item => &$itemTypes) {
-            foreach ((array)$itemTypes as $image => &$images) {
-                foreach ((array)$images as $i => &$ref) {
-                    if (!$this->isRunning($images[$i])) {
-                        self::outall(" | Sync finished - " . print_r($images[$i], true));
-                        foreach ((array)($this->procPipes[$item][$image][$i] ?? []) as $j => &$pipe_ref) {
-                            if (is_resource($this->procPipes[$item][$image][$i][$j])) {
-                                fclose($this->procPipes[$item][$image][$i][$j]);
-                            }
-                            unset($this->procPipes[$item][$image][$i][$j]);
-                        }
-                        unset($this->procPipes[$item][$image][$i]);
-                        if (is_resource($images[$i])) {
-                            proc_close($images[$i]);
-                        }
-                        unset($images[$i]);
+        foreach (array_keys((array)$this->procRef) as $item) {
+            foreach (array_keys((array)$this->procRef[$item]) as $image) {
+                foreach (array_keys((array)$this->procRef[$item][$image]) as $i) {
+                    $proc = $this->procRef[$item][$image][$i];
+                    if ($this->isRunning($proc)) {
+                        continue;
                     }
+                    self::outall(" | Sync finished - " . print_r($proc, true));
+                    $pipes = (array)($this->procPipes[$item][$image][$i] ?? []);
+                    foreach (array_keys($pipes) as $j) {
+                        if (is_resource($pipes[$j])) {
+                            fclose($pipes[$j]);
+                        }
+                    }
+                    unset($this->procPipes[$item][$image][$i]);
+                    if (is_resource($proc)) {
+                        proc_close($proc);
+                    }
+                    unset($this->procRef[$item][$image][$i]);
                 }
-                if (empty($itemTypes[$image])) {
-                    unset($itemTypes[$image]);
+                if (empty($this->procRef[$item][$image])) {
+                    unset($this->procRef[$item][$image]);
                 }
                 if (empty($this->procPipes[$item][$image])) {
                     unset($this->procPipes[$item][$image]);

--- a/tests/service-proclist-cleanup.test.php
+++ b/tests/service-proclist-cleanup.test.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * cleanupProcList() actually empties the process lists.
+ *
+ * The daemons record each spawned transfer in $this->procRef and its pipes
+ * in $this->procPipes, and doHousekeeping() -- which runs every 100ms while
+ * a service waits for its next cycle -- calls cleanupProcList() to reap the
+ * finished ones.
+ *
+ * The trap it fell into is worth stating plainly, because the broken form
+ * reads as correct:
+ *
+ *     foreach ((array)$this->procRef as $item => &$itemTypes) { ... }
+ *
+ * The cast produces a TEMPORARY array. `&$itemTypes` therefore binds into
+ * that copy, not into the property, and every unset() made through it is
+ * discarded when the loop ends. Nothing errors. The entry simply stays, and
+ * because housekeeping runs ten times a second the daemon re-reports the
+ * same finished transfer about ten times a second for as long as it lives
+ * -- an unbounded log, and proc_close() called repeatedly on one handle.
+ *
+ * Observed on the 1.6 lab, where 'Sync finished - Resource id #1348' filled
+ * the log at roughly ten lines a second as soon as a transfer completed.
+ * The same change reached this branch in ac4bd48e7 on the same day, so the
+ * defect is identical here -- and this branch's replication has always run,
+ * which makes it the one that hits it in the field. The casts were added for
+ * PHP 8 null safety, which is a real need, so the fix keeps them and
+ * iterates over array_keys() snapshots instead, writing through
+ * $this->procRef by path. Note the procPipes unsets already went through by
+ * full path and were never affected; procRef was.
+ *
+ * This runs the REAL method, lifted from the shipped file.
+ *
+ * Usage: php tests/service-proclist-cleanup.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$src = __DIR__ . '/../packages/web/lib/service/fogservice.class.php';
+$code = file_get_contents($src);
+if (false === $code) {
+    fwrite(STDERR, "cannot read $src\n");
+    exit(1);
+}
+
+$start = strpos($code, '    public function cleanupProcList()');
+if (false === $start) {
+    fwrite(STDERR, "cleanupProcList() not found in $src\n");
+    exit(1);
+}
+$open = strpos($code, '{', $start);
+$depth = 0;
+$end = null;
+for ($i = $open, $n = strlen($code); $i < $n; $i++) {
+    if ('{' === $code[$i]) {
+        $depth++;
+    } elseif ('}' === $code[$i]) {
+        $depth--;
+        if (0 === $depth) {
+            $end = $i;
+            break;
+        }
+    }
+}
+if (null === $end) {
+    fwrite(STDERR, "could not brace-match cleanupProcList()\n");
+    exit(1);
+}
+$method = substr($code, $start, $end - $start + 1);
+
+$harness = "namespace FOGTest;\n"
+    . "class Svc {\n"
+    . "    public \$procRef = [];\n"
+    . "    public \$procPipes = [];\n"
+    . "    public \$running = [];\n"
+    . "    public \$reported = 0;\n"
+    // A "process" here is a string tag; running-ness is looked up by tag so
+    // a test can have one finished and one still going.
+    . "    public function isRunning(\$p) { return !empty(\$this->running[\$p]); }\n"
+    . "    public static \$log = [];\n"
+    . "    public static function outall(\$s) { self::\$log[] = \$s; }\n"
+    . $method
+    . "\n}\n";
+
+eval($harness);
+
+$failures = [];
+
+// 1. One finished transfer: it must be gone after ONE pass, and reported
+//    exactly once.
+$svc = new \FOGTest\Svc();
+$svc->procRef = ['group' => ['test' => [0 => 'PROC-A']]];
+$svc->procPipes = ['group' => ['test' => [0 => []]]];
+$svc->running = ['PROC-A' => false];
+\FOGTest\Svc::$log = [];
+$svc->cleanupProcList();
+
+if (!empty($svc->procRef)) {
+    $failures[] = "  a finished transfer was not removed from procRef\n    "
+        . 'left behind: ' . json_encode($svc->procRef)
+        . "\n    (the classic cause is foreach over a (array) cast, whose "
+        . 'unsets go to a temporary)';
+}
+if (!empty($svc->procPipes)) {
+    $failures[] = '  a finished transfer was not removed from procPipes: '
+        . json_encode($svc->procPipes);
+}
+if (1 !== count(\FOGTest\Svc::$log)) {
+    $failures[] = sprintf(
+        "  one finished transfer should report once, got %d line(s)",
+        count(\FOGTest\Svc::$log)
+    );
+}
+
+// 2. The repeat-report symptom, stated directly: a second housekeeping pass
+//    over the same state must say nothing, because there is nothing left.
+\FOGTest\Svc::$log = [];
+$svc->cleanupProcList();
+if (0 !== count(\FOGTest\Svc::$log)) {
+    $failures[] = sprintf(
+        "  a second pass re-reported %d finished transfer(s); housekeeping "
+        . 'runs every 100ms, so this is an unbounded log',
+        count(\FOGTest\Svc::$log)
+    );
+}
+
+// 3. A transfer still running must be left completely alone.
+$svc2 = new \FOGTest\Svc();
+$svc2->procRef = ['group' => ['test' => [0 => 'PROC-B']]];
+$svc2->procPipes = ['group' => ['test' => [0 => []]]];
+$svc2->running = ['PROC-B' => true];
+\FOGTest\Svc::$log = [];
+$svc2->cleanupProcList();
+if (($svc2->procRef['group']['test'][0] ?? null) !== 'PROC-B') {
+    $failures[] = '  a RUNNING transfer was reaped: '
+        . json_encode($svc2->procRef);
+}
+if (0 !== count(\FOGTest\Svc::$log)) {
+    $failures[] = '  a running transfer was reported as finished';
+}
+
+// 4. Mixed: reap the finished one, keep the running one, and keep the
+//    parent keys that still hold something.
+$svc3 = new \FOGTest\Svc();
+$svc3->procRef = ['group' => ['test' => [0 => 'DONE', 1 => 'BUSY']]];
+$svc3->procPipes = ['group' => ['test' => [0 => [], 1 => []]]];
+$svc3->running = ['DONE' => false, 'BUSY' => true];
+\FOGTest\Svc::$log = [];
+$svc3->cleanupProcList();
+$left = $svc3->procRef['group']['test'] ?? [];
+if (array_values($left) !== ['BUSY']) {
+    $failures[] = '  mixed state reaped wrongly, expected only BUSY left: '
+        . json_encode($svc3->procRef);
+}
+
+if ($failures) {
+    fwrite(
+        STDERR,
+        "FAIL: service proclist cleanup\n" . implode("\n", $failures) . "\n"
+    );
+    exit(1);
+}
+
+echo "PASS: service proclist cleanup (7 checks)\n";
+exit(0);


### PR DESCRIPTION
`cleanupProcList()` iterated:

```php
foreach ((array)$this->procRef as $item => &$itemTypes) {
    foreach ((array)$itemTypes as $image => &$images) {
        foreach ((array)$images as $i => &$ref) {
            ...
            unset($images[$i]);
```

The cast produces a **temporary** array, so `&$itemTypes` / `&$images` bind into the copy and every `unset()` made through them is discarded when the loop ends. Nothing errors.

A finished transfer therefore never leaves the list. `doHousekeeping()` runs every 100 ms while a service waits for its next cycle, so the daemon re-reports the same completed transfer roughly **ten times a second for as long as it lives** — an unbounded log, and `proc_close()` called again and again on one handle.

The `procPipes` side was never affected: those unsets already addressed `$this->procPipes[...]` by full path. Only `procRef` was going through the reference.

Reproduced in isolation:

```php
$procRef = ["group" => ["test" => [0 => "RES"]]];
foreach ((array)$procRef as $item => &$itemTypes) {
    foreach ((array)$itemTypes as $image => &$images) {
        foreach ((array)$images as $i => &$ref) { unset($images[$i]); unset($ref); }
        if (empty($itemTypes[$image])) { unset($itemTypes[$image]); }
        unset($images);
    }
    if (empty($procRef[$item])) { unset($procRef[$item]); }
    unset($itemTypes);
}
// {"group":{"test":["RES"]}}   -- nothing was removed
```

## Origin

Introduced **today** in ac4bd48e7, which added the casts for PHP 8 null safety. That need is real and the casts stay; iterating over `array_keys()` snapshots gives the same safety, a stable order that is safe to unset from, and writes that reach the property.

## Why this branch

Observed on the 1.6 lab as `Sync finished - Resource id #1348` filling the log at about ten lines a second the moment a transfer completed. `working-1.6` took the identical change in 42c418c3b, and its half is in FOGProject/fogproject#1321 alongside three older Group -> Group defects.

This branch matters *more*, not less: 1.5 replication has always actually run, so this is the line where the symptom reaches users.

## Test

`tests/service-proclist-cleanup.test.php` lifts the real method out of the shipped file and asserts on behaviour, not on how it is written:

- one pass empties `procRef` and `procPipes` and reports exactly once
- a **second** pass says nothing — the direct statement of the repeat-report symptom
- a running transfer is left completely alone
- a mixed list reaps only the finished entry

Mutation-verified: restoring the cast-temporary loop, or reaping running transfers, fails it. Suite **33 passed, 0 failed**.

No route or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)