### PR TITLE
fix(api): strip secrets once, at the emitter, and follow the nesting

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -136,6 +136,24 @@ class Route extends FOGBase
      */
     protected static $getterDepth = 0;
     /**
+     * Which serialized key of which class holds another entity.
+     *
+     * `parent class => [ key => child class ]`, recorded by embed() at the
+     * moment it serializes a nested object. It is not hand-maintained on
+     * purpose: the emitter has to know what class every nested object is in
+     * order to strip its secrets, and a table someone must remember to update
+     * whenever getter() gains an embed is a credential leak waiting for the
+     * one time they forget. Deriving it from the object being embedded means
+     * it cannot drift from the code that creates the nesting.
+     *
+     * Keyed by class rather than by path, so it stays small and applies
+     * wherever that parent appears -- a list row, a single GET, or nested
+     * inside something else.
+     *
+     * @var array
+     */
+    protected static $nestedClasses = [];
+    /**
      * Set while count() is borrowing listem() to reach recordsFiltered. The
      * row query and every per-row formatter are then skipped -- see the note
      * in FOGManagerController::complex(). Refs GH-707.
@@ -172,6 +190,16 @@ class Route extends FOGBase
      * and cannot recurse back onto the parent entity.
      */
     const EXPAND_MAX_DEPTH = 1;
+    /**
+     * How far stripEntity() will walk into a payload's nesting.
+     *
+     * Well above the three levels anything reaches today (task -> host ->
+     * inventory). See stripEntity() for why this is a backstop rather than a
+     * real bound.
+     *
+     * @var int
+     */
+    const STRIP_MAX_DEPTH = 8;
     /**
      * Hard cap on how many items a single expanded relation (or an expanded
      * list) will materialize, to bound memory. Overflow is truncated and
@@ -2089,12 +2117,16 @@ class Route extends FOGBase
                     // which defeats the selective contract of ?expand=token.
                     $exp = self::expandRelations($classname, $robj, $row);
                     $exp = self::enrichPluginItems($classname, $robj, $exp);
-                    // Strip AFTER expanding so sensitive columns are removed
-                    // whether they arrive on the raw grid row (which may carry
-                    // the encrypted column) or on an inlined related object.
-                    // List rows never expose secrets, matching the bare-grid
-                    // contract.
-                    $rows[$i] = self::stripSensitive($classname, $exp);
+                    // No strip here, and none anywhere else in listem().
+                    // listem() is shared with the web tier -- the LDAP login
+                    // path needs bindPwd to bind at all, the Product Keys
+                    // report needs productKey to report anything -- so it
+                    // hands the row back whole and the emitter removes
+                    // secrets on the way out, expanded relations included.
+                    // That was already how a PLAIN list behaved; stripping
+                    // here as well meant an ?expand= caller inside the server
+                    // got a redacted row where a plain one did not.
+                    $rows[$i] = $exp;
                 }
                 $listData['data'] = $rows;
                 self::$data = $listData;
@@ -2969,7 +3001,13 @@ class Route extends FOGBase
                         } catch (\Exception $e) {
                             $sn = new StorageNode();
                         }
-                        return self::getter('storagenode', $sn);
+                        // embed(), not getter(): this is a nested entity on
+                        // a storagegroup LIST row, and the emitter can only
+                        // strip its FTP credential if it is told what class
+                        // it is. This one is the reason the registry exists
+                        // -- the node's password used to reach anyone with
+                        // storagegroup.view through this column.
+                        return self::embed('storagegroup', 'masternode', $sn);
                     }
                 ];
                 $columns[] = [
@@ -4680,14 +4718,128 @@ class Route extends FOGBase
             return $data;
         }
         if (isset($data['data']) && is_array($data['data'])) {
-            // List payload: both tiers, every row.
+            // List payload: both tiers, every row, and every entity nested
+            // inside a row.
             foreach ($data['data'] as $i => $row) {
-                $data['data'][$i] = self::stripSensitive($classname, $row);
+                $data['data'][$i] = self::stripEntity($classname, $row, false);
             }
             return $data;
         }
         // Single-entity payload: only the fields no client may read back.
-        return self::stripSensitive($classname, $data, true);
+        // Its nested entities are not covered by that carve-out -- see
+        // stripEntity().
+        return self::stripEntity($classname, $data, true);
+    }
+    /**
+     * Strips one serialized entity, then everything nested inside it.
+     *
+     * The nesting comes from self::$nestedClasses, which embed() and
+     * expandRelations() fill in as they build the payload, so this knows what
+     * class each nested object is without a hand-kept table to fall out of
+     * date. Both the one-object and the many-objects shapes are handled: an
+     * expanded to-many relation is a list of entities under a single key.
+     *
+     * $alwaysOnly is TRUE only for the payload's top-level object on a direct
+     * single-entity GET, and never propagates into the nesting. That is the
+     * whole of the tier-1 carve-out: fog-client reads a host's ADPass back
+     * from GET /host/{id} to join a domain, so tier 1 survives there -- but a
+     * host nested inside a task is not that request, and GET /task/{id} was
+     * handing out the host's client token and the storage node's FTP password
+     * because nothing walked into it.
+     *
+     * Depth is capped rather than tracked by identity. The recursion follows
+     * the DATA, which is finite and already built, so it terminates on its
+     * own; the cap is there so a future embed that does contain a cycle
+     * degrades into an unstripped inner object rather than an exhausted
+     * stack, and it sits well above the three levels anything reaches today
+     * (task -> host -> inventory).
+     *
+     * @param string $classname  The class this data is.
+     * @param mixed  $data       The serialized entity.
+     * @param bool   $alwaysOnly Tier 2 only, for the top-level single GET.
+     * @param int    $depth      Recursion guard.
+     *
+     * @return mixed
+     */
+    protected static function stripEntity(
+        $classname,
+        $data,
+        $alwaysOnly = false,
+        $depth = 0
+    ) {
+        if (!is_array($data) || $depth > self::STRIP_MAX_DEPTH) {
+            return $data;
+        }
+        $data = self::stripSensitive($classname, $data, $alwaysOnly);
+        $nested = (array)(self::$nestedClasses[strtolower((string)$classname)]
+            ?? self::$nestedClasses[$classname]
+            ?? []);
+        foreach ($nested as $key => $child) {
+            if (!isset($data[$key]) || !is_array($data[$key])) {
+                continue;
+            }
+            $value = $data[$key];
+            // A to-many relation is a list of entities; a to-one is the
+            // entity itself. An entity is an associative array, so a list
+            // is the case where the keys are 0..n-1.
+            $isList = $value === []
+                || array_keys($value) === range(0, count($value) - 1);
+            if ($isList) {
+                foreach ($value as $j => $item) {
+                    $value[$j] = self::stripEntity(
+                        $child,
+                        $item,
+                        false,
+                        $depth + 1
+                    );
+                }
+                $data[$key] = $value;
+                continue;
+            }
+            $data[$key] = self::stripEntity($child, $value, false, $depth + 1);
+        }
+        return $data;
+    }
+    /**
+     * Serializes one embedded entity and records what class it is.
+     *
+     * Every nested object in a payload goes through here. The recording is
+     * the point: stripSensitivePayload() strips secrets at the emitter, and
+     * to do that on a NESTED object it has to know that class. getter() is
+     * the only code that knows -- so it says so here, once, beside the
+     * embed itself, and the emitter reads it back out of $nestedClasses.
+     *
+     * The class is derived from the object rather than passed in, so an
+     * embed cannot be registered under the wrong name and a new one cannot
+     * be added without registering it at all.
+     *
+     * Non-objects answer [] rather than fataling. Several call sites here
+     * guard the same case by hand today -- a snapin task whose job row is
+     * gone resolves get('snapinjob') to a STRING and get() on that is fatal
+     * (#895) -- and one guard in one place is easier to keep right than
+     * five.
+     *
+     * @param string $parentClass Class of the entity being built.
+     * @param string $key         Key the child is stored under.
+     * @param mixed  $obj         The related object, possibly not one.
+     * @param bool   $useGetter   Shape the child with getter() rather than
+     *                            its plain get(); matches what each call
+     *                            site did before.
+     *
+     * @return array The serialized child.
+     */
+    protected static function embed($parentClass, $key, $obj, $useGetter = false)
+    {
+        if (!is_object($obj) || !$obj instanceof FOGController) {
+            return [];
+        }
+        $child = strtolower(FOGCore::shortName($obj));
+        self::$nestedClasses[$parentClass][$key] = $child;
+        if (!$useGetter) {
+            return (array) $obj->get();
+        }
+        $data = self::getter($child, $obj);
+        return is_array($data) ? $data : [];
     }
     /**
      * This is a commonizing element so list/search/getinfo
@@ -4730,13 +4882,27 @@ class Route extends FOGBase
                         [
                             'ADPass' => $pass,
                             'productKey' => $productKey,
-                            'hostscreen' => $class->get('hostscreen')->get(),
-                            'hostalo' => $class->get('hostalo')->get(),
-                            'inventory' => self::getter(
-                                'inventory',
-                                $class->get('inventory')
+                            'hostscreen' => self::embed(
+                                $classname,
+                                'hostscreen',
+                                $class->get('hostscreen')
                             ),
-                            'image' => $class->get('imagename')->get(),
+                            'hostalo' => self::embed(
+                                $classname,
+                                'hostalo',
+                                $class->get('hostalo')
+                            ),
+                            'inventory' => self::embed(
+                                $classname,
+                                'inventory',
+                                $class->get('inventory'),
+                                true
+                            ),
+                            'image' => self::embed(
+                                $classname,
+                                'image',
+                                $class->get('imagename')
+                            ),
                             'imagename' => $class->getImageName(),
                             'primac' => $class->get('mac')->__toString(),
                             'macs' => $class->getMyMacs(),
@@ -4759,9 +4925,21 @@ class Route extends FOGBase
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            'os' => $class->get('os')->get(),
-                            'imagepartitiontype' => $class->get('imagepartitiontype')->get(),
-                            'imagetype' => $class->get('imagetype')->get(),
+                            'os' => self::embed(
+                                $classname,
+                                'os',
+                                $class->get('os')
+                            ),
+                            'imagepartitiontype' => self::embed(
+                                $classname,
+                                'imagepartitiontype',
+                                $class->get('imagepartitiontype')
+                            ),
+                            'imagetype' => self::embed(
+                                $classname,
+                                'imagetype',
+                                $class->get('imagetype')
+                            ),
                             'imagetypename' => $class->getImageType()->get('name'),
                             'imageparttypename' => $class->getImagePartitionType()->get(
                                 'name'
@@ -4781,7 +4959,11 @@ class Route extends FOGBase
                     $extra = [
                         'online' => $class->get('online'),
                         //'logfiles' => $class->get('logfiles'),
-                        'storagegroup' => $class->get('storagegroup')->get(),
+                        'storagegroup' => self::embed(
+                            $classname,
+                            'storagegroup',
+                            $class->get('storagegroup')
+                        ),
                         'location_url' => sprintf(
                             '%s://%s/%s',
                             self::$httpproto,
@@ -4835,15 +5017,37 @@ class Route extends FOGBase
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            'image' => $class->get('image')->get(),
-                            'host' => self::getter(
-                                'host',
-                                $class->get('host')
+                            'image' => self::embed(
+                                $classname,
+                                'image',
+                                $class->get('image')
                             ),
-                            'type' => $class->get('type')->get(),
-                            'state' => $class->get('state')->get(),
-                            'storagenode' => $class->get('storagenode')->get(),
-                            'storagegroup' => $class->get('storagegroup')->get()
+                            'host' => self::embed(
+                                $classname,
+                                'host',
+                                $class->get('host'),
+                                true
+                            ),
+                            'type' => self::embed(
+                                $classname,
+                                'type',
+                                $class->get('type')
+                            ),
+                            'state' => self::embed(
+                                $classname,
+                                'state',
+                                $class->get('state')
+                            ),
+                            'storagenode' => self::embed(
+                                $classname,
+                                'storagenode',
+                                $class->get('storagenode')
+                            ),
+                            'storagegroup' => self::embed(
+                                $classname,
+                                'storagegroup',
+                                $class->get('storagegroup')
+                            )
                         ]
                     );
                     break;
@@ -4885,18 +5089,28 @@ class Route extends FOGBase
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            'snapin' => is_object($snapin)
-                                ? $snapin->get()
-                                : [],
-                            'snapinjob' => self::getter(
+                            'snapin' => self::embed(
+                                $classname,
+                                'snapin',
+                                $snapin
+                            ),
+                            'snapinjob' => self::embed(
+                                $classname,
                                 'snapinjob',
-                                $sj
+                                $sj,
+                                true
                             ),
-                            'host' => self::getter(
+                            'host' => self::embed(
+                                $classname,
                                 'host',
-                                $host
+                                $host,
+                                true
                             ),
-                            'state' => $class->get('state')->get()
+                            'state' => self::embed(
+                                $classname,
+                                'state',
+                                $class->get('state')
+                            )
                         ]
                     );
                     break;
@@ -4911,13 +5125,17 @@ class Route extends FOGBase
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            'host' => self::getter(
+                            'host' => self::embed(
+                                $classname,
                                 'host',
-                                $class->get('host')
+                                $class->get('host'),
+                                true
                             ),
-                            'state' => is_object($sjState)
-                                ? $sjState->get()
-                                : []
+                            'state' => self::embed(
+                                $classname,
+                                'state',
+                                $sjState
+                            )
                         ]
                     );
                     break;
@@ -4934,9 +5152,11 @@ class Route extends FOGBase
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            'host' => self::getter(
+                            'host' => self::embed(
+                                $classname,
                                 'host',
-                                $utHost
+                                $utHost,
+                                true
                             ),
                             'hostname' => is_object($utHost)
                                 ? $utHost->get('name')
@@ -4949,32 +5169,43 @@ class Route extends FOGBase
                         $class->get(),
                         [
                             'imageID' => $class->get('image'),
-                            'image' => $class->get('imagename')->get(),
-                            'state' => $class->get('state')->get()
+                            'image' => self::embed(
+                                $classname,
+                                'image',
+                                $class->get('imagename')
+                            ),
+                            'state' => self::embed(
+                                $classname,
+                                'state',
+                                $class->get('state')
+                            )
                         ]
                     );
                     unset($data['imagename']);
                     break;
                 case 'scheduledtask':
+                    // Lifted out of the nested ternaries it used to be: the
+                    // key and the object have to agree, and embed() has to be
+                    // told the key it is registering under.
+                    $stGroupBased = $class->isGroupBased();
+                    $stKey = $stGroupBased ? 'group' : 'host';
+                    $stObj = $stGroupBased
+                        ? $class->getGroup()
+                        : $class->getHost();
                     $data = FOGCore::fastmerge(
                         $class->get(),
                         [
-                            (
-                                $class->isGroupBased() ?
-                                'group' :
-                                'host'
-                            ) => (
-                                $class->isGroupBased() ?
-                                self::getter(
-                                    'group',
-                                    $class->getGroup()
-                                ) :
-                                self::getter(
-                                    'host',
-                                    $class->getHost()
-                                )
+                            $stKey => self::embed(
+                                $classname,
+                                $stKey,
+                                $stObj,
+                                true
                             ),
-                            'tasktype' => $class->getTaskType()->get(),
+                            'tasktype' => self::embed(
+                                $classname,
+                                'tasktype',
+                                $class->getTaskType()
+                            ),
                             'runtime' => $class->getTime()
                         ]
                     );
@@ -5006,22 +5237,34 @@ class Route extends FOGBase
                     'class' => &$class
                 ]
             );
-            // Tier 2 is stripped HERE, not only in the emitter, because
-            // getter() is the one place that knows what class it is
-            // shaping regardless of what payload the result ends up
-            // nested inside. stripSensitivePayload() keys off the
-            // payload's own '_lang' stamp, so a storagenode embedded in a
-            // storagegroup row was stripped as a storagegroup -- which is
-            // to say not at all, and the node's FTP password went out in
-            // the storage group grid to anyone holding storagegroup.view.
-            // Same shape for task.host, task.image and host.inventory.
+            // NOTHING is stripped here. Secrets come out at the emitter,
+            // once, and that is the whole of the rule -- printer() says so
+            // for lists and it now holds for single entities and for every
+            // nested object as well.
             //
-            // Tier 2 only. Tier 1 exists precisely so a single-entity GET
-            // still carries it (fog-client reads host ADPass back to join
-            // a domain), and that carve-out is applied by the emitter,
-            // which knows whether it is emitting a list or one record.
-            // getter() does not and must not guess.
-            $data = self::stripSensitive($classname, $data, true);
+            // It used to strip tier 2 here, because the emitter keyed off
+            // the payload's '_lang' stamp and so read a storagenode nested
+            // in a storagegroup row as a storagegroup, which is to say not
+            // at all. That fixed the nesting in the wrong layer and cost
+            // twice:
+            //
+            //   - it only ever covered embeds built by recursing into
+            //     getter(). The 14 that were a plain ->get() -- task's
+            //     storagenode among them -- were stripped at no level, and
+            //     GET /task/{id} returned the node's FTP password and the
+            //     host's client token in the clear.
+            //   - it made getItem() and getList() disagree. getList() reads
+            //     listem()'s rows before the emitter and so sees everything;
+            //     getItem() came through here and saw a redacted object. The
+            //     replicator asked getItem() for the node it was about to
+            //     send to and got no password, so every transfer was refused
+            //     at login and blamed on the admin's stored credential.
+            //
+            // embed() records what class each nested object is instead, and
+            // stripSensitivePayload() walks that on the way out. Internal
+            // callers -- the daemons, the LDAP bind, the Product Keys report
+            // -- get the whole object, consistently, whichever wrapper they
+            // used to ask for it.
             return $data;
         } catch (\Exception $e) {
             self::_sendCaught($e);
@@ -5395,7 +5638,8 @@ class Route extends FOGBase
      * objects are added under their relation token. One-to-many relations
      * become a capped array plus companion `<token>_total`/`<token>_truncated`
      * keys. Related objects are serialized one level deep (no further
-     * expansion) and have their secrets stripped.
+     * expansion). Their secrets are removed at the emitter like every other
+     * nested object's, via the class this records in $nestedClasses.
      *
      * @param string $classname The entity classname.
      * @param object $class      The loaded entity object.
@@ -5425,7 +5669,12 @@ class Route extends FOGBase
                 if ($obj instanceof FOGController && $obj->isValid()) {
                     $g = self::getter($rel['class'], $obj);
                     if (is_array($g)) {
-                        $data[$token] = self::stripSensitive($rel['class'], $g);
+                        // Registered, not stripped. Same rule as embed():
+                        // the emitter removes secrets, and it can only do
+                        // that on a related object if it knows the class.
+                        self::$nestedClasses[$classname][$token]
+                            = $rel['class'];
+                        $data[$token] = $g;
                     }
                 }
                 continue;
@@ -5450,7 +5699,8 @@ class Route extends FOGBase
                 }
                 $g = self::getter($rel['class'], $robj);
                 if (is_array($g)) {
-                    $items[] = self::stripSensitive($rel['class'], $g);
+                    self::$nestedClasses[$classname][$token] = $rel['class'];
+                    $items[] = $g;
                 }
             }
             $data[$token] = $items;

--- a/packages/web/lib/service/fogservice.class.php
+++ b/packages/web/lib/service/fogservice.class.php
@@ -465,16 +465,18 @@ abstract class FOGService extends FOGBase
                 continue;
             }
             // Take the FTP credential off the LIST row, before the re-fetch
-            // below replaces the object. The two wrappers disagree about
-            // secrets: getList() hands back what listem() built and the
-            // emitter strips them on the way out to HTTP, so an internal
-            // caller still sees them; getItem() goes through getter(), which
-            // strips tier-2 fields -- storagenode pass and key -- at the
-            // source, so what it returns has no password in it at all.
-            // Reading pass off the re-fetched object left
-            // self::$FOGFTP->password empty and every replication login was
-            // refused, reported as a stale password for the node when the
-            // stored one was correct all along.
+            // below replaces the object. It is the row this loop actually
+            // selected on, and reading it here means the credential does not
+            // depend on what a second trip through the router hands back.
+            //
+            // It used to be load-bearing rather than tidy: getItem() went
+            // through getter(), which stripped storagenode pass and key at
+            // the source, so the re-fetched object had no password on it and
+            // every replication login was refused -- reported as a stale
+            // password for the node when the stored one was correct all
+            // along. That asymmetry is gone; getItem() and getList() now both
+            // hand internal callers the whole object and the API emitter is
+            // the only thing that removes secrets.
             $nodeUser = $StorageNode->user;
             $nodePass = $StorageNode->pass;
             // getItem(), not indiv(): a node that vanished between the list

--- a/tests/api-nested-secret-strip.test.php
+++ b/tests/api-nested-secret-strip.test.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * Secrets are removed once, at the emitter, and the strip follows the nesting.
+ *
+ * There is exactly one rule now and this file is where it is written down:
+ *
+ *   listem(), getter() and expandRelations() NEVER strip. They hand back the
+ *   whole object, because the daemons, the LDAP bind and the Product Keys
+ *   report are all internal callers that legitimately need the value.
+ *   stripSensitivePayload(), on the way out of printer(), removes secrets --
+ *   from the top-level object AND from every entity nested inside it.
+ *
+ * It did not used to hold, and both halves of the breakage were real:
+ *
+ *   - getter() stripped tier 2 as it built each level. That covered embeds
+ *     made by recursing into getter() and nothing else, so the 14 that were a
+ *     plain `$class->get('x')->get()` were stripped at no level. Proven on the
+ *     live lab: GET /task/66 returned the storage node's FTP password and the
+ *     host's 128-character client token in the clear.
+ *   - because getter() stripped, Route::getItem() -- which goes through it --
+ *     handed internal callers a redacted object, while Route::getList() --
+ *     which reads listem()'s rows before the emitter -- handed them a whole
+ *     one. The replicator asked getItem() for the node it was about to send
+ *     to, got no password, and every transfer was refused at login and
+ *     blamed on the admin's stored credential.
+ *
+ * The fix is that embed() records what class each nested object is, at the
+ * point it serializes it, and the emitter walks that. Nothing here asserts
+ * the shape of a line: the registry is seeded and the real
+ * stripSensitivePayload() is run.
+ *
+ * Usage: php tests/api-nested-secret-strip.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+FogTestHarness::boot('nested-secret-strip');
+// sensitiveFieldMap() fires API_SENSITIVE_FIELDS, and HookManager
+// resolves its known-events list through Route::getIds() -- so even the
+// declaration reads below need a database to answer.
+FogTestHarness::fakeDb();
+
+use FOG\Route;
+
+$failures = [];
+
+$nestedProp = new \ReflectionProperty('FOG\\Route', 'nestedClasses');
+$nestedProp->setAccessible(true);
+$emitProp = new \ReflectionProperty('FOG\\Route', 'emitClassname');
+$emitProp->setAccessible(true);
+
+/**
+ * Runs the real emitter strip with a given nesting registry.
+ *
+ * @param array  $nested  parent => [key => child class]
+ * @param string $emit    the emitter's fallback classname
+ * @param array  $payload the payload to strip
+ *
+ * @return array
+ */
+function emit(array $nested, $emit, array $payload)
+{
+    global $nestedProp, $emitProp;
+    $nestedProp->setValue(null, $nested);
+    $emitProp->setValue(null, $emit);
+    return (array) Route::stripSensitivePayload($payload);
+}
+
+/**
+ * Records a failed expectation.
+ *
+ * @param string $label what was being checked
+ * @param bool   $ok    whether it held
+ * @param string $extra optional detail
+ *
+ * @return void
+ */
+function check($label, $ok, $extra = '')
+{
+    global $failures;
+    if (!$ok) {
+        $failures[] = '  ' . $label . ($extra ? "\n    " . $extra : '');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The declarations everything else depends on. If these stop naming the
+// fields as secret, every check below passes for the wrong reason.
+// ---------------------------------------------------------------------------
+$node = Route::unfilterableFields('storagenode');
+check(
+    'storagenode pass and key are declared sensitive',
+    in_array('pass', $node, true) && in_array('key', $node, true)
+);
+$host = Route::unfilterableFields('host');
+check(
+    'host ADPass and token are declared sensitive',
+    in_array('ADPass', $host, true) && in_array('token', $host, true)
+);
+
+// ---------------------------------------------------------------------------
+// 1. The exact payload that leaked: GET /task/{id}.
+// ---------------------------------------------------------------------------
+$taskNesting = [
+    'task' => ['storagenode' => 'storagenode', 'host' => 'host'],
+];
+$task = emit(
+    $taskNesting,
+    'task',
+    [
+        'id' => 66,
+        '_lang' => 'task',
+        'storagenode' => [
+            'id' => 1,
+            'name' => 'DefaultMember',
+            'user' => 'fogproject',
+            'pass' => 'P>gTKZQ4T7jYsxsoUr6W',
+            'key' => 'NODEHMACKEY',
+        ],
+        'host' => [
+            'id' => 154,
+            'name' => 'fos-deploy-test',
+            'ADPass' => 'JOINPW',
+            'token' => str_repeat('a', 128),
+            'sec_tok' => 'SECTOK',
+        ],
+    ]
+);
+check(
+    'task.storagenode.pass is stripped',
+    !array_key_exists('pass', $task['storagenode']),
+    'this is the field GET /task/66 returned in the clear'
+);
+check('task.storagenode.key is stripped', !array_key_exists('key', $task['storagenode']));
+check('task.host.token is stripped', !array_key_exists('token', $task['host']));
+check('task.host.ADPass is stripped', !array_key_exists('ADPass', $task['host']));
+check('task.host.sec_tok is stripped', !array_key_exists('sec_tok', $task['host']));
+check(
+    'the rest of the payload is untouched',
+    66 === ($task['id'] ?? null)
+    && 'DefaultMember' === ($task['storagenode']['name'] ?? null)
+    && 'fogproject' === ($task['storagenode']['user'] ?? null)
+    && 'fos-deploy-test' === ($task['host']['name'] ?? null)
+);
+
+// ---------------------------------------------------------------------------
+// 2. The tier-1 carve-out: top level keeps it, nesting never does.
+//    fog-client reads a host's ADPass back from GET /host/{id} to join a
+//    domain. Propagating $alwaysOnly into the nesting would re-open case 1;
+//    dropping it at the top would break domain joins silently.
+// ---------------------------------------------------------------------------
+$single = emit([], 'host', ['id' => 9, 'name' => 'pc', 'ADPass' => 'JOINPW']);
+check(
+    'a direct single-entity GET still carries tier 1 (fog-client ADPass)',
+    'JOINPW' === ($single['ADPass'] ?? null)
+);
+$row = emit([], 'host', ['_lang' => 'host', 'data' => [
+    ['id' => 9, 'name' => 'pc', 'ADPass' => 'JOINPW'],
+]]);
+check(
+    'a LIST row does not carry tier 1',
+    !array_key_exists('ADPass', $row['data'][0])
+);
+
+// ---------------------------------------------------------------------------
+// 3. Nesting inside a list row -- the storagegroup grid's masternode column,
+//    which is the leak the old getter()-side strip was written for and which
+//    must stay closed.
+// ---------------------------------------------------------------------------
+$grid = emit(
+    ['storagegroup' => ['masternode' => 'storagenode']],
+    'storagegroup',
+    [
+        '_lang' => 'storagegroup',
+        'data' => [
+            [
+                'id' => 1,
+                'name' => 'default',
+                'masternode' => [
+                    'id' => 1,
+                    'name' => 'DefaultMember',
+                    'pass' => 'NODEFTPPW',
+                    'key' => 'NODEHMACKEY',
+                ],
+            ],
+        ],
+    ]
+);
+check(
+    'storagegroup list: masternode.pass is stripped',
+    !array_key_exists('pass', $grid['data'][0]['masternode'])
+);
+check(
+    'storagegroup list: masternode.key is stripped',
+    !array_key_exists('key', $grid['data'][0]['masternode'])
+);
+check(
+    'storagegroup list: the master node is still identifiable',
+    'DefaultMember' === ($grid['data'][0]['masternode']['name'] ?? null)
+);
+
+// ---------------------------------------------------------------------------
+// 4. A to-many expanded relation is a LIST of entities under one key. The
+//    single-object shape and the list shape are different code paths and
+//    only one of them was ever exercised by hand.
+// ---------------------------------------------------------------------------
+$many = emit(
+    ['group' => ['hosts' => 'host']],
+    'group',
+    [
+        'id' => 2,
+        '_lang' => 'group',
+        'hosts' => [
+            ['id' => 1, 'name' => 'a', 'ADPass' => 'PW1'],
+            ['id' => 2, 'name' => 'b', 'ADPass' => 'PW2'],
+        ],
+    ]
+);
+check(
+    'every entity in a to-many relation is stripped, not just the first',
+    !array_key_exists('ADPass', $many['hosts'][0])
+    && !array_key_exists('ADPass', $many['hosts'][1])
+);
+check(
+    'a to-many relation keeps all of its members',
+    2 === count($many['hosts'])
+    && 'a' === ($many['hosts'][0]['name'] ?? null)
+    && 'b' === ($many['hosts'][1]['name'] ?? null)
+);
+
+// ---------------------------------------------------------------------------
+// 5. Depth. task -> host -> inventory is three levels today; the walk has to
+//    keep going rather than stop after one.
+// ---------------------------------------------------------------------------
+$deep = emit(
+    [
+        'task' => ['host' => 'host'],
+        'host' => ['image' => 'image'],
+        'image' => ['storagenode' => 'storagenode'],
+    ],
+    'task',
+    [
+        'id' => 1,
+        '_lang' => 'task',
+        'host' => [
+            'id' => 9,
+            'image' => [
+                'id' => 3,
+                'storagenode' => ['id' => 1, 'name' => 'n', 'pass' => 'DEEPPW'],
+            ],
+        ],
+    ]
+);
+check(
+    'the walk reaches a secret three levels down',
+    !array_key_exists(
+        'pass',
+        $deep['host']['image']['storagenode'] ?? ['pass' => 'still here']
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 6. A registry entry naming a key that is not an entity, or is absent, must
+//    not disturb the payload -- the registry is filled in at runtime and a
+//    given payload carries only some of what it lists.
+// ---------------------------------------------------------------------------
+$sparse = emit(
+    ['task' => ['storagenode' => 'storagenode', 'host' => 'host']],
+    'task',
+    ['id' => 1, '_lang' => 'task', 'host' => null, 'pct' => '0000000000']
+);
+check(
+    'a registered key that is absent or not an array is left alone',
+    // array_key_exists, not ?? -- the value under test IS null, and ??
+    // cannot tell "present and null" from "not there".
+    array_key_exists('host', $sparse)
+    && null === $sparse['host']
+    && '0000000000' === ($sparse['pct'] ?? null)
+);
+
+// ---------------------------------------------------------------------------
+// 7. The registry is what drives the walk. An unregistered nested entity is
+//    NOT stripped -- which is exactly why embed() derives the class from the
+//    object instead of leaving a table for someone to update by hand. This
+//    check states the consequence plainly rather than pretending the walk is
+//    magic.
+// ---------------------------------------------------------------------------
+$unreg = emit(
+    [],
+    'task',
+    ['id' => 1, '_lang' => 'task', 'storagenode' => ['pass' => 'PW']]
+);
+check(
+    'an UNREGISTERED nested entity keeps its secret -- registration is'
+    . ' load-bearing, so embed() must derive it and never be bypassed',
+    'PW' === ($unreg['storagenode']['pass'] ?? null)
+);
+
+// So embed() itself is driven here, not just the walk it feeds. Seeding
+// the registry by hand and asserting only on the walk left the single most
+// important mutation alive: deleting embed()'s registration line passed the
+// whole file.
+$embedMethod = new \ReflectionMethod('FOG\\Route', 'embed');
+$embedMethod->setAccessible(true);
+$nestedProp->setValue(null, []);
+
+$sn = new FOG\StorageNode();
+$embedded = $embedMethod->invoke(null, 'task', 'storagenode', $sn);
+$recorded = $nestedProp->getValue();
+check(
+    'embed() registers the child class under the parent and key',
+    'storagenode' === ($recorded['task']['storagenode'] ?? null),
+    'got: ' . json_encode($recorded)
+);
+check('embed() still returns the serialized child', is_array($embedded));
+
+// Derived from the OBJECT, never from the key -- that is the property that
+// makes a wrong registration impossible, and the storagegroup grid's
+// masternode column depends on it.
+$nestedProp->setValue(null, []);
+$embedMethod->invoke(null, 'storagegroup', 'masternode', new FOG\StorageNode());
+$derived = $nestedProp->getValue();
+check(
+    'embed() derives the class from the object, not from the key name',
+    'storagenode' === ($derived['storagegroup']['masternode'] ?? null),
+    'got: ' . json_encode($derived)
+);
+
+// A relation that did not resolve is the #895 shape: get() on a string is
+// fatal. It must answer [] and register nothing.
+$nestedProp->setValue(null, []);
+$none = $embedMethod->invoke(null, 'snapintask', 'snapinjob', 'a string');
+check(
+    'embed() answers [] for a relation that did not resolve',
+    [] === $none
+);
+check(
+    'embed() registers nothing for a relation that did not resolve',
+    [] === $nestedProp->getValue()
+);
+
+// The registration and the walk, end to end: no hand-seeded registry.
+$nestedProp->setValue(null, []);
+$embedMethod->invoke(null, 'task', 'storagenode', $sn);
+$emitProp->setValue(null, 'task');
+$endToEnd = (array) Route::stripSensitivePayload(
+    [
+        'id' => 1,
+        '_lang' => 'task',
+        'storagenode' => ['id' => 1, 'name' => 'n', 'pass' => 'REALPW'],
+    ]
+);
+check(
+    'embed() registering is what lets the emitter strip -- end to end, with'
+    . ' nothing seeded by hand',
+    !array_key_exists('pass', $endToEnd['storagenode'])
+);
+
+// Every embed inside getter() has to go through embed(); a raw
+// ->get()->get() would produce exactly the unregistered case above.
+$src = file_get_contents(
+    dirname(__DIR__) . '/packages/web/lib/router/route.class.php'
+);
+$gs = strpos($src, 'public static function getter($classname, $class)');
+$depth = 0;
+$gend = null;
+for ($i = strpos($src, '{', $gs), $n = strlen($src); $i < $n; $i++) {
+    if ('{' === $src[$i]) {
+        $depth++;
+    } elseif ('}' === $src[$i]) {
+        $depth--;
+        if (0 === $depth) {
+            $gend = $i;
+            break;
+        }
+    }
+}
+$getterBody = false === $gs ? '' : substr($src, $gs, $gend - $gs + 1);
+check(
+    'getter() was found so the sweep below means something',
+    '' !== $getterBody
+);
+preg_match_all(
+    "/\\\$class->get\('[A-Za-z_]+'\\)->get\(\)|\\\$[A-Za-z_]+->get\(\)\s*:/",
+    $getterBody,
+    $rawEmbeds
+);
+check(
+    'no embed in getter() bypasses embed() with a raw ->get()->get()',
+    empty($rawEmbeds[0]),
+    empty($rawEmbeds[0]) ? '' : 'found: ' . implode(', ', $rawEmbeds[0])
+);
+check(
+    'getter() no longer strips -- that is what made getItem() and getList()'
+    . ' disagree',
+    false === strpos($getterBody, 'self::stripSensitive(')
+);
+
+$nestedProp->setValue(null, []);
+$emitProp->setValue(null, '');
+
+if ($failures) {
+    fwrite(
+        STDERR,
+        "FAIL: api nested secret strip\n" . implode("\n", $failures) . "\n"
+    );
+    exit(1);
+}
+
+echo "PASS: api nested secret strip (27 checks)\n";
+exit(0);

--- a/tests/replication-node-credential.test.php
+++ b/tests/replication-node-credential.test.php
@@ -15,11 +15,19 @@
  *                 storagenode pass and key). The object handed back has no
  *                 password on it at all.
  *
- * So `$StorageNode->pass` after the re-fetch is the empty string, lftp is
- * given no password, and every transfer is refused at login. Because the
+ * So `$StorageNode->pass` after the re-fetch was the empty string, lftp was
+ * given no password, and every transfer was refused at login. Because the
  * replicator reports a refused login as "check the password stored for this
- * node", the symptom points at the admin's configuration -- the stored
- * password is fine and the daemon simply never reads it.
+ * node", the symptom pointed at the admin's configuration -- the stored
+ * password was fine and the daemon simply never read it.
+ *
+ * The router asymmetry itself has since been closed: getter() no longer
+ * strips, so getItem() and getList() both hand internal callers the whole
+ * object and only the API emitter removes secrets (see
+ * tests/api-nested-secret-strip.test.php). This stays as the regression gate
+ * for the DAEMON's half -- it fakes the old asymmetry deliberately, so it
+ * still fails if the credential read moves back onto the re-fetched object,
+ * whatever the router happens to be doing that week.
  *
  * This runs the REAL method body, lifted from the shipped file, against
  * fakes that reproduce exactly that asymmetry, and asserts on the credential

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -593,26 +593,67 @@ $t->check(
     in_array('pass', $nodeBlocked, true) && in_array('key', $nodeBlocked, true)
 );
 
-// That getter() APPLIES it is a source assertion, and the comment says
-// so rather than dressing it up: getter('storagenode', ...) and
-// getter('image', ...) both run live lookups (node online state, image
-// storage groups) that this DB-free fixture cannot serve, so driving the
-// real call here is not available. The end-to-end proof is the live run
-// recorded in the commit -- storagegroup/list carrying the node's FTP
-// password before and clean after. What is worth pinning cheaply is that
-// the call is still there and is still the ALWAYS-ONLY form: passing
-// false would strip tier 1 too and silently break domain joins.
-$getterSrc = file_get_contents(
-    dirname(__DIR__) . '/packages/web/lib/router/route.class.php'
+// That a nested entity is stripped as WHAT IT IS used to be asserted here
+// against getter()'s source, because getter('storagenode', ...) runs live
+// lookups this DB-free fixture cannot serve. It no longer has to be: the
+// strip happens at the emitter now, over the class registry embed() fills
+// in, and stripSensitivePayload() takes plain arrays. So this is the real
+// behaviour rather than a regex over the shape of a line.
+//
+// Why the move: getter()'s per-level strip only ever reached embeds built
+// by recursing into getter(). The ones that were a plain ->get() -- task's
+// storagenode among them -- were stripped at no level at all, and it also
+// made Route::getItem() hand redacted objects to internal callers while
+// Route::getList() handed whole ones. See
+// tests/api-nested-secret-strip.test.php for the full set.
+$nestedProp = new \ReflectionProperty('FOG\\Route', 'nestedClasses');
+$nestedProp->setAccessible(true);
+$nestedProp->setValue(null, ['task' => ['storagenode' => 'storagenode']]);
+$emitClass = new \ReflectionProperty('FOG\\Route', 'emitClassname');
+$emitClass->setAccessible(true);
+$emitClass->setValue(null, 'task');
+
+$nestedOut = Route::stripSensitivePayload(
+    [
+        'id' => 1,
+        '_lang' => 'task',
+        'storagenode' => [
+            'id' => 3,
+            'name' => 'debian',
+            'pass' => 'NODEFTPPW',
+            'key' => 'NODEHMACKEY',
+        ],
+    ]
 );
 $t->check(
-    'getter() strips tier 2 before returning, so a nested entity is'
-    . ' stripped as what it is',
-    (bool)preg_match(
-        '/\$data = self::stripSensitive\(\$classname, \$data, true\);\s*\n\s*return \$data;/',
-        $getterSrc
-    )
+    'a storagenode nested in a task is stripped as a storagenode, not as'
+    . ' a task',
+    !array_key_exists('pass', $nestedOut['storagenode'])
+    && !array_key_exists('key', $nestedOut['storagenode'])
 );
+$t->check(
+    'stripping the nested entity leaves its non-secret columns alone',
+    'debian' === ($nestedOut['storagenode']['name'] ?? null)
+);
+
+// The tier-1 carve-out must NOT follow the nesting. A host reached through
+// GET /host/{id} keeps ADPass so fog-client can join a domain; the same
+// host reached as task.host is a different request and keeps nothing.
+$nestedProp->setValue(null, ['task' => ['host' => 'host']]);
+$emitClass->setValue(null, 'task');
+$nestedHost = Route::stripSensitivePayload(
+    [
+        'id' => 1,
+        '_lang' => 'task',
+        'host' => ['id' => 9, 'name' => 'pc', 'ADPass' => 'JOINPW'],
+    ]
+);
+$t->check(
+    'tier 1 does NOT survive in a nested position (task.host.ADPass)',
+    !array_key_exists('ADPass', $nestedHost['host'])
+);
+$nestedProp->setValue(null, []);
+$emitClass->setValue(null, '');
 
 // Tier 1 must NOT be dropped by the always-only pass -- that carve-out is
 // why fog-client can still read a host's ADPass back to join a domain,


### PR DESCRIPTION
Follow-up to #1321. That PR fixed the replicator's symptom; this fixes the cause, which turned out to also be leaking credentials over the API.

`printer()` already states the rule — secrets come off at the emitter, deliberately **not** in `listem()`, because the LDAP bind and the Product Keys report are internal callers that need the value and stripping there *"would have broken LDAP authentication outright"*. `getter()` did not follow it, and applied its own strip as it built each level.

## What that cost

### 1. Nested objects went out in the clear

`getter()`'s per-level strip reaches embeds made by **recursing into `getter()`** and nothing else. Most of the 25 embed sites are a plain `$class->get('x')->get()`, and those were stripped at no level at all.

Verified on the live lab before this change, `GET /task/66`:

```json
"storagenode": { "user": "fogproject", "pass": "P>gTKZQ4T7jYsxsoUr6W", ... },
"host":        { "token": "eead586c54cadb3b8ec321d5048a6f18...", ... }
```

Same credential class as GHSA-2hqx-5ffg-w4c3 — that FTP password reaches the root-running replicator's `lftp` and the SSH helpers — and the same leak #1318 closed on `dev-branch`.

### 2. `Route::getItem()` and `Route::getList()` disagreed

| wrapper | path | what an internal caller saw |
|---|---|---|
| `getList()` | `listem()`, read before the emitter | the whole object |
| `getItem()` | `indiv()` → `getter()`, stripped at the source | a redacted object |

Nothing said so. The replicator asked `getItem()` for the node it was about to send to, got no password, and every transfer was refused at login — reported as a stale credential the admin should go and fix. That is the bug #1321 worked around at the call site.

## The rule now

> `listem()`, `getter()` and `expandRelations()` never strip. `stripSensitivePayload()` strips the top-level object and walks into every entity nested inside it.

One exception, and it is the reason the tiers exist: **tier 1 survives only on a direct single-entity GET**, because fog-client reads a host's `ADPass` back from `GET /host/{id}` to join a domain. It does **not** propagate into the nesting — a host inside a task is not that request, which is precisely how `task.host.token` was getting out.

## Why the nesting map is recorded, not declared

For the emitter to strip a nested object it must know its class. `embed()` derives that from the object it is serializing and registers it as it goes, so the map cannot drift from the code that creates the nesting.

A hand-kept table was the obvious alternative and I think it would have leaked. While converting the 25 sites, **three were missed by successive regexes over the same file** — including a whole case (`scheduledtask`) hidden behind a ternary key:

```php
($class->isGroupBased() ? 'group' : 'host') => ($class->isGroupBased() ? ... : ...)
```

If a regex written while *looking for them* missed three, a table someone updates months later while adding a feature will miss one. `embed()` also absorbs the by-hand null guards several sites carried for #895, so those cases get shorter rather than longer.

## Behaviour that does not change

What any API response contains, except that nested secrets are now absent. The storagegroup grid's `masternode` column — the leak `getter()`'s strip was originally written for — stays closed, checked against the live database.

## Verification

On the 1.6 lab against the real database, from a shadow tree (nothing under `/var/www` touched):

| check | result |
|---|---|
| `getList` / `getItem` on a storagenode | both return the password, and agree |
| `GET /task/66` nested `storagenode.pass` / `.key` | stripped (`ip`, `name` survive) |
| `GET /task/66` nested `host.token` / `.ADPass` / `.sec_tok` | stripped (`inventory` survives) |
| `GET /host/154` top level `ADPass` | **present** — carve-out intact |
| storagegroup list `masternode.pass` | stripped, node still identifiable |
| storagenode list `pass` / `key` | stripped, `name` survives |

The host **list** row could not be exercised from the CLI — site scope answers zero rows with no user, on the stock tree as well, so an assertion there passes vacuously. That case is covered synthetically instead, and I mention it because an earlier run of mine reported it "stripped" when it was really just empty.

## Tests

`tests/api-nested-secret-strip.test.php` — 27 checks, driving the real emitter and the real `embed()`, no source-shape assertions for the behaviour itself. Eleven mutations, all killed:

- not walking the nesting; propagating tier 1 into it; stripping only the first member of a to-many; depth cap of zero
- `embed()` not registering; registering the key name instead of the derived class; dropping its non-object guard
- one embed reverting to a raw `->get()->get()`; reinstating `getter()`'s strip; the emitter not stripping at all

`embed()` not registering is worth calling out: it **survived** the first version of the gate, because the tests seeded the registry by hand and never drove `embed()`. Registration is the load-bearing half, so the gate now drives it end to end with nothing seeded.

`route-read-path-guards.test.php`'s assertion on this moved with the code. It pinned `getter()`'s strip as a regex over the source, because that call needs a database the DB-free fixture cannot serve — its own comment says so. The emitter's version takes plain arrays, so it is behaviour now, plus the case that regex could never have covered: tier 1 must **not** survive nested.

Suite **135 passed, 0 failed**.

## No dev-branch port

`dev-branch` has no sensitive-field tiers at all, so neither the asymmetry nor the tier-1 question exists there. Its one reachable leak of this shape — the node FTP credential in the task payload — was closed in #1318 with `stripNodeSecrets()`. Adding a tier registry to 1.5 would be a new feature, not a consistency fix.

No route or schema change, so `OpenAPI::document()` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)