### PR TITLE
feat(api): accept Authorization: Bearer as a standalone API credential

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -266,8 +266,12 @@ class OpenAPI extends FOGBase
                 'including any a plugin has added.',
                 '',
                 'Enable under FOG Configuration > FOG Settings > API System.',
-                'Authenticate with the `fog-api-token` (server-wide) and',
-                '`fog-user-token` (per user) headers, or with HTTP basic auth.',
+                'Preferred: send the per-user API token as',
+                '`Authorization: Bearer <token>`, which needs nothing else.',
+                'Otherwise the `fog-api-token` (server-wide) header is',
+                'required, plus one caller identity -- either the',
+                '`fog-user-token` header or HTTP basic auth. Basic auth does',
+                'not replace the `fog-api-token` header.',
                 '',
                 'Field names: every property is also addressable by its raw',
                 'database column name, because the model layer flips',
@@ -307,17 +311,24 @@ class OpenAPI extends FOGBase
     }
 
     /**
-     * Both token headers are required together; basic auth is the
-     * alternative. Two entries in the list means OR, two keys inside one
-     * entry means AND.
+     * Three ways in, listed strongest first.
+     *
+     * A Bearer token stands alone: it is a 512-bit random per-user secret.
+     * The other two carry a weaker credential -- a legacy header pair, or a
+     * human-chosen password -- and both keep the server-wide fog-api-token
+     * gate. See Route::_testBearer() for why that asymmetry is deliberate
+     * rather than an oversight.
+     *
+     * Two entries in the list means OR, two keys inside one entry means AND.
      *
      * @return array
      */
     private static function _globalSecurity()
     {
         return [
+            ['bearerAuth' => []],
             ['fogApiToken' => [], 'fogUserToken' => []],
-            ['basicAuth' => []]
+            ['fogApiToken' => [], 'basicAuth' => []]
         ];
     }
 
@@ -327,6 +338,19 @@ class OpenAPI extends FOGBase
     private static function _securitySchemes()
     {
         return [
+            'bearerAuth' => [
+                'type' => 'http',
+                'scheme' => 'bearer',
+                'description' => implode(' ', [
+                    'The per-user API token from the API tab of a user with',
+                    'API access enabled, sent as `Authorization: Bearer`.',
+                    'Sufficient on its own -- no fog-api-token header is',
+                    'needed alongside it. Send the value exactly as the UI',
+                    'displays it: it is already base64 encoded, and a raw',
+                    'token is indistinguishable from an encoded one because',
+                    'hex is itself valid base64.'
+                ])
+            ],
             'fogApiToken' => [
                 'type' => 'apiKey',
                 'in' => 'header',

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -692,13 +692,21 @@ class Route extends FOGBase
             && !$isunauth
         ) {
             /**
-             * Test our token.
+             * A Bearer token authenticates on its own -- see _testBearer for
+             * why it does not additionally need the server-wide token. The
+             * legacy schemes apply only when no Bearer credential is offered,
+             * so every existing client is unaffected.
              */
-            self::_testToken();
-            /**
-             * Test our authentication.
-             */
-            self::_testAuth();
+            if (!self::_testBearer()) {
+                /**
+                 * Test our token.
+                 */
+                self::_testToken();
+                /**
+                 * Test our authentication.
+                 */
+                self::_testAuth();
+            }
         }
         /**
          * A valid session cookie authenticates API calls with no token,
@@ -1533,6 +1541,123 @@ class Route extends FOGBase
         return ['', ''];
     }
     /**
+     * Reads an RFC 6750 Bearer credential from the Authorization header.
+     *
+     * The value is the same per-user API token the fog-user-token header
+     * carries, sent the standard way and with the same base64 encoding the
+     * API tab displays. Deliberately not raw: a 128-character hex token is
+     * ITSELF valid base64 (a-f and 0-9 are all in the alphabet), so a strict
+     * decode of one succeeds and cannot be told apart from an encoded token.
+     * Accepting both spellings would therefore mean two lookups per request
+     * to resolve an ambiguity we do not have to create. Send exactly what
+     * the UI shows.
+     *
+     * REDIRECT_HTTP_AUTHORIZATION is read for the reason _basicAuthCredentials
+     * explains -- under FastCGI the Authorization header does not arrive on
+     * its own, and Apache prefixes REDIRECT_ onto what survives the vhost's
+     * internal rewrite. That plumbing is why Bearer needs no new webserver
+     * config: it rides the header basic auth already had to recover by hand.
+     *
+     * @return string|null The decoded token, or null when no Bearer
+     *                     credential was presented at all. An empty string
+     *                     means one was presented and was malformed, which
+     *                     is a failed attempt rather than an absent one.
+     */
+    private static function _bearerCredential()
+    {
+        $keys = [
+            'HTTP_AUTHORIZATION',
+            'REDIRECT_HTTP_AUTHORIZATION'
+        ];
+        foreach ($keys as $key) {
+            $header = trim(self::_serverVar($key));
+            if (stripos($header, 'bearer') !== 0) {
+                continue;
+            }
+            $rest = substr($header, 6);
+            // The scheme must be followed by whitespace or by nothing at all.
+            // 'Bearertoken' is not a Bearer credential and must fall through
+            // to the other schemes; a bare 'Bearer' with no value IS one --
+            // it is what a client that built the header from an unset config
+            // value sends, and answering 401 tells them that, where falling
+            // through answers 403 about a server token they never heard of.
+            if ('' !== $rest && !preg_match('/^\s/', $rest)) {
+                continue;
+            }
+            $rest = trim($rest);
+            if ('' === $rest) {
+                return '';
+            }
+            // strict base64 decode: a malformed header is not a credential,
+            // but it IS an attempt -- return '' rather than null so the
+            // caller refuses it instead of falling through to another scheme.
+            $decoded = base64_decode($rest, true);
+            if ($decoded === false) {
+                return '';
+            }
+            return trim($decoded);
+        }
+        return null;
+    }
+    /**
+     * Test Bearer authentication.
+     *
+     * A per-user API token is a 512-bit random secret (FOGBase::createSecToken)
+     * and stands on its own, so a Bearer request does NOT additionally need
+     * the server-wide fog-api-token. HTTP basic auth still does: its
+     * credential is a human-chosen password, and that server-wide gate is
+     * the only thing keeping every FOG password from being a standalone API
+     * credential. The asymmetry is deliberate, and it is also forced -- one
+     * Authorization header carries one credential, so the legacy two-header
+     * pair has no Bearer spelling.
+     *
+     * Once a Bearer credential is PRESENTED it decides the request. Falling
+     * through to the other schemes would let a bad Bearer plus good legacy
+     * headers still authenticate, which no real client does and which makes
+     * a failure impossible to reason about from the status code.
+     *
+     * Nothing has to migrate: fog-api-token plus fog-user-token, and basic
+     * auth, are unchanged.
+     *
+     * @return bool Whether the request authenticated. False means no Bearer
+     *              credential was offered -- a presented one that failed
+     *              does not return at all.
+     */
+    private static function _testBearer()
+    {
+        $token = self::_bearerCredential();
+        if (null === $token) {
+            return false;
+        }
+        $user = self::getClass('User')
+            ->set('token', $token)
+            ->load('token');
+        if ($user->isValid() && $user->get('api')) {
+            // Bind the token's owner as the acting user so role-based
+            // authorization applies, exactly as the fog-user-token path does.
+            self::$FOGUser = $user;
+            return true;
+        }
+        // Presented and refused. Recorded for the same reason the
+        // fog-user-token rejection is, and the presented token is NOT
+        // written down -- a rejected credential is still a credential,
+        // which is the mistake #1261/#1262 fixed in the SQL fault log.
+        Audit::record(
+            [
+                'type' => Audit::TOKEN_REJECTED,
+                'outcome' => Audit::DENIED,
+                'subjectType' => 'user',
+                'subjectID' => (int)$user->get('id'),
+                'subjectLabel' => (string)$user->get('name'),
+                'authSource' => 'bearer',
+                'renderable' => 1
+            ]
+        );
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_UNAUTHORIZED
+        );
+    }
+    /**
      * Test authentication.
      *
      * @return void
@@ -1767,8 +1892,8 @@ class Route extends FOGBase
      * "Export Database" button (management/export.php?type=sql), which
      * requires a logged-in session and CSRF token and so cannot be used
      * by scripts. This endpoint relies only on the standard API auth
-     * already enforced in the constructor (fog-api-token plus an
-     * api-enabled fog-user-token, or HTTP basic auth) and reuses
+     * already enforced in the constructor (a Bearer token, or fog-api-token
+     * plus an api-enabled fog-user-token, or HTTP basic auth) and reuses
      * Schema::exportdb() so the dump matches the web UI byte-for-byte.
      *
      * The dump is streamed as an attachment; we exit afterward to keep


### PR DESCRIPTION
## Problem

The API requires two disparate credentials — a server-wide `fog-api-token`
header plus a per-user `fog-user-token` header — in FOG's own custom headers.
Most HTTP APIs take a single `Authorization: Bearer` token, and every client,
Swagger UI and Postman handles that natively.

While looking at this, the OpenAPI document also turned out to be wrong: it
listed `basicAuth` as a standalone alternative to the token pair. It never was.
`Route::_testToken()` runs unconditionally and answers 403 before
`Route::_testAuth()` is ever reached, so basic auth on its own has always been
refused.

## Fix

Accept `Authorization: Bearer <token>` as a standalone credential, carrying the
per-user API token.

A per-user token is a 512-bit random secret (`FOGBase::createSecToken`), so it
stands on its own. HTTP basic auth deliberately keeps the `fog-api-token` gate:
its credential is a human-chosen password, and that gate is the only thing
stopping every FOG password from being a standalone API credential. The
asymmetry is also forced — one `Authorization` header carries one credential,
so the legacy two-header pair has no Bearer spelling.

| Scheme | `fog-api-token` required? |
|---|---|
| `Authorization: Bearer <token>` | no |
| `fog-api-token` + `fog-user-token` | yes |
| HTTP basic auth | yes |
| Session cookie (browser) | no — CSRF applies instead |

**Nothing has to migrate.** Both legacy schemes are untouched, and a request
offering no Bearer credential takes exactly the path it did before.

No new webserver config either: Bearer rides the `HTTP_AUTHORIZATION` /
`REDIRECT_HTTP_AUTHORIZATION` recovery that `_basicAuthCredentials()` already
had to hand-roll for FastCGI.

### Behaviour decisions

- **A presented Bearer credential decides the request** and does not fall
  through to the other schemes. A bad Bearer plus good legacy headers answers
  401, so a failure can be reasoned about from the status code.
- **A bare `Bearer` with no value answers 401**, not a 403 about a server token
  the caller never heard of. That header is what a client built from an unset
  config value sends. `Bearertoken` with no space is not a Bearer credential and
  does fall through.
- **The value stays base64 encoded**, exactly as the API tab displays it. A raw
  128-character hex token is itself valid base64, so a strict decode of one
  succeeds and is indistinguishable from an encoded token — accepting both
  spellings would mean two lookups per request to resolve an ambiguity that does
  not need to exist.

## OpenAPI

Updated in the same commit, per the standing rule. Gains a `bearerAuth` scheme
and a standalone `security` entry, and the `basicAuth`-alone error above is
corrected. Still OAS 3.0.3 — `type: http` / `scheme: bearer` is native there,
no version bump needed.

## Done when

`Authorization: Bearer <token>` authenticates an API request with no other
header, and every existing client keeps working.

## Verification

Against the lab database from a shadow tree (uncommitted code, live DB, nothing
written to `/var/www`). Re-runnable:
`scripts/background_scripts/probe_bearer_auth.sh` — 17/17.

```
Bearer:  valid 200 · garbage 401 · raw-unencoded 401 · empty 401
         'Bearertoken' falls through 403 · non-base64 401
         bad bearer + good legacy 401 · lowercase scheme 200
Legacy:  api+user 200 · user alone 403 · api alone 401
         basic alone 403 · no credentials 403
Other:   system/info still public 200 · host list returns 86 rows
         acting user bound, so RBAC applies
         bearerAuth present in the served document
```

Rejections record to `auditLog` with `alAuthSource = 'bearer'`,
`alType = 'auth.token.rejected'` — confirmed present.

## Not doing

- **No port to `dev-branch`.** 1.5 shares the call site but reads
  `$_SERVER['PHP_AUTH_USER']` raw, with no `_serverVar()` /
  `_basicAuthCredentials()` layer, so the header recovery would have to be
  written from scratch on the actively-patched line. 1.5 clients keep the legacy
  scheme.
- **No OAuth.** FOG becoming an authorization server — token issuance, refresh,
  client registration, consent — is a large security-critical subsystem, and a
  half-built one is worse than a 512-bit random string in a header. The useful
  subset is FOG as a *resource server*, validating a JWT minted by an IdP it
  already trusts via the Phase 2 OIDC seam; that is additive, belongs in the
  plugin, and is still Bearer transport. Possible follow-up, deliberately not
  here.

## Downstream

FogApi (`darksidemilk/FogApi`) sends the legacy header pair and is unaffected —
no sync is required. It could adopt `Authorization: Bearer` to drop its
dependency on the server-wide token, but that is its call and its release.
