### PR TITLE
fix(api): stop returning the user password hash on a single-entity GET

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -242,9 +242,6 @@ class Route extends FOGBase
             'sec_time',
             'token',
         ],
-        'user' => [
-            'password',
-        ],
     ];
     /**
      * Fields stripped from EVERY API payload, a direct single-entity GET
@@ -284,15 +281,25 @@ class Route extends FOGBase
         // Found leaking through the storage GROUP list, not the node list:
         // the group's `masternode` column embeds the whole node object,
         // password included, to anyone holding storagegroup.view.
-        // A user's API token. Tier 2 rather than tier 1 because nothing
-        // reads it back over the API: the API tab renders it server-side
-        // from the object (UserManagement::userAPI), and the reset button
-        // posts to management/status/newtoken.php -- neither goes through
-        // a REST payload. It is a complete standalone credential now that
+        // A user's API token and password hash. Tier 2 rather than tier 1
+        // because nothing reads either back over the API.
+        //
+        // token: the API tab renders it server-side from the object
+        // (UserManagement::userAPI) and the reset button posts to
+        // management/status/newtoken.php -- neither goes through a REST
+        // payload. It is a complete standalone credential now that
         // Authorization: Bearer accepts it, so a single-entity GET handing
         // it to any holder of user.view was the whole account.
+        //
+        // password: the bcrypt hash. Every consumer of a password is
+        // INBOUND -- service/checkcredentials.php and the iPXE advanced
+        // menu read a submitted parameter, never the stored value -- so
+        // there is nothing to carve out for. A hash is not a credential
+        // you can present, but it is offline-crackable, and it has no
+        // business leaving the server at all.
         'user' => [
             'token',
+            'password',
         ],
         'storagenode' => [
             'pass',

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -344,11 +344,28 @@ $userBlocked = Route::unfilterableFields('user');
 
 $t->check(
     'unfilterableFields(host) carries the tier-1 fields',
-    count(array_diff(Route::$sensitiveFields['host'], $hostBlocked)) === 0
+    count(
+        array_diff(
+            (array)(Route::$sensitiveFields['host'] ?? []),
+            $hostBlocked
+        )
+    ) === 0
 );
+/*
+ * user has no tier-1 entry at all as of GH-1326: token and password are both
+ * tier 2, so the class is simply absent from $sensitiveFields the way image
+ * and snapin are. Assert the derived list directly rather than diffing a tier
+ * that is not there -- diffing it would be vacuous even if it did not fatal,
+ * and this pins the property that actually matters: both user secrets are
+ * blocked, wherever they are declared.
+ *
+ * It DID fatal, which is the second reason to write it this way.
+ * array_diff(null, ...) is a TypeError on PHP 8 and only a warning on 7.4, so
+ * the 7.4 job passed and the 8.3 job died -- the null-to-internal-param class.
+ */
 $t->check(
-    'unfilterableFields(user) carries the tier-1 fields',
-    count(array_diff(Route::$sensitiveFields['user'], $userBlocked)) === 0
+    'unfilterableFields(user) carries both user secrets',
+    count(array_diff(['token', 'password'], $userBlocked)) === 0
 );
 $t->check(
     'unfilterableFields folds in what a plugin declared (tier 1)',


### PR DESCRIPTION
## Problem

Follow-on to #1325. Verifying that fix on a deployed server showed the API token
correctly gone from `GET /fog/user/{id}` while the bcrypt hash was still there:

```
name      PRESENT len=3
token     (absent)
password  PRESENT len=60
```

`user.password` sat in tier 1, which strips from lists but carves out the direct
single-entity GET. That carve-out exists for exactly one reason — fog-client
reads a host's `ADPass` back to join a domain. A user's password hash has no
equivalent reader: every consumer of a password is **inbound**
(`service/checkcredentials.php` and the iPXE advanced menu read a *submitted*
parameter, never the stored value), so there is nothing to carve out for.

## Fix

Move `user.password` to tier 2. `user` now has no tier-1 entry at all, so it is
dropped from that list entirely — the way `image`, `snapin` and `printer` already
are.

## Done when

`GET /fog/user/{id}` returns neither `token` nor `password`.

## Why this is separate from #1325

A bcrypt hash is not a credential you can present, so this is a lesser exposure
than the API token and the storage node key that #1325 closed — it is
offline-crackable rather than directly usable. It is still not something that
should leave the server, and #1325 already stopped the *export* emitting it.
Leaving the API emitting it was the inconsistency.

## Verification

`Route::unfilterableFields()` after the move:

| Class | Stripped everywhere |
| --- | --- |
| `User` | `token`, `password` |
| `Host` | `ADPass`, `ADPassLegacy`, `productKey`, `pub_key`, `sec_tok`, `prev_sec_tok`, `sec_time`, `token` |
| `StorageNode` | `pass`, `key` |

Export column alignment re-checked after the move — `user`, `host` and
`storagenode` all still aligned, so the export tables keep rendering.