### PR TITLE
feat(api): hashed, revocable API tokens as the only Bearer credential

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -88,6 +88,19 @@ return [
                 'acRedacted' => 'tinyint(1) unsigned NOT NULL DEFAULT 0',
             ],
         ],
+        'apiTokens' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `apiTokens` ( `atID` int(11) NOT NULL AUTO_INCREMENT, `atUserID` int(11) NOT NULL DEFAULT 0, `atName` varchar(255) NOT NULL DEFAULT \'\', `atHash` char(64) NOT NULL DEFAULT \'\', `atEnabled` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `atCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `atCreatedBy` varchar(255) NOT NULL DEFAULT \'\', `atLastUsed` datetime DEFAULT NULL, PRIMARY KEY (`atID`), UNIQUE KEY `atHash` (`atHash`), KEY `atUserID` (`atUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'atID' => 'int(11) NOT NULL',
+                'atUserID' => 'int(11) NOT NULL DEFAULT 0',
+                'atName' => 'varchar(255) NOT NULL DEFAULT \'\'',
+                'atHash' => 'char(64) NOT NULL DEFAULT \'\'',
+                'atEnabled' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
+                'atCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'atCreatedBy' => 'varchar(255) NOT NULL DEFAULT \'\'',
+                'atLastUsed' => 'datetime DEFAULT NULL',
+            ],
+        ],
         'auditLog' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `auditLog` ( `alID` int(11) NOT NULL AUTO_INCREMENT, `alCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `alCreatedBy` varchar(255) NOT NULL DEFAULT \'\', `alIP` varchar(45) NOT NULL DEFAULT \'\', `alAuthSource` varchar(64) NOT NULL DEFAULT \'\', `alType` varchar(64) NOT NULL DEFAULT \'\', `alSubjectType` varchar(64) NOT NULL DEFAULT \'\', `alSubjectID` int(11) NOT NULL DEFAULT 0, `alSubjectLabel` varchar(255) NOT NULL DEFAULT \'\', `alPermission` varchar(128) NOT NULL DEFAULT \'\', `alOutcome` enum(\'unknown\',\'allowed\',\'denied\',\'failed\',\'partial\') NOT NULL DEFAULT \'unknown\', `alCorrelationID` varchar(32) NOT NULL DEFAULT \'\', `alAffectedCount` int(11) NOT NULL DEFAULT 0, `alRenderable` tinyint(1) unsigned NOT NULL DEFAULT 1, `alText` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`alID`), KEY `alCreatedTime` (`alCreatedTime`), KEY `alCreatedBy` (`alCreatedBy`), KEY `alCorrelationID` (`alCorrelationID`), KEY `alOutcome` (`alOutcome`), KEY `alSubject` (`alSubjectType`,`alSubjectID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7483,3 +7483,70 @@ $this->schema[] = [
     . "runner service. (Default /dev/tty3)','/dev/tty3',"
     . "'FOG Linux Service TTY Output')",
 ];
+
+// 359
+$this->schema[] = [
+    // ADR 0027: a Bearer token becomes its own credential, stored HASHED.
+    //
+    // users.uAPIToken stays exactly as it is -- plaintext, shown in the UI,
+    // sent as fog-user-token beside fog-api-token. That pair was sound
+    // because obtaining either half required an authenticated UI session, so
+    // a leaked half is not a way in. What broke that property was GH-1324
+    // making the same plaintext value a COMPLETE standalone credential, and
+    // the two disclosures found immediately after (GH-1325, GH-1326) are
+    // what a plaintext credential costs when any emitter forgets it.
+    //
+    // So this table is not a replacement for uAPIToken and there is no
+    // migration: nothing existing changes, and Bearer stops accepting
+    // uAPIToken once it accepts these instead. Each credential ends up with
+    // exactly one spelling.
+    //
+    // atHash is SHA-256 of the token, unsalted, and that is deliberate
+    // rather than an oversight. A salt defeats PRECOMPUTATION, which needs a
+    // guessable input; these are 512-bit CSPRNG secrets with no dictionary
+    // and no constructible table, so a salt buys nothing while costing the
+    // ability to look a token up by hash at all -- with a per-row salt you
+    // cannot compute the hash until you already know which row to check.
+    // CHAR(64) because hex SHA-256 is always 64 characters.
+    //
+    // THE INVARIANT THAT DECISION RESTS ON: the token must stay
+    // CSPRNG-generated and at least 256 bits. Shorten it, make it
+    // user-choosable, or derive it from anything predictable, and salting
+    // becomes necessary. See APIToken::generate().
+    //
+    // UNIQUE on atHash is integrity, not just an index: two rows sharing a
+    // hash would make a token ambiguous about who it authenticates as.
+    //
+    // atLastUsed is NULL-able and only ever written with a real datetime.
+    // FOG has a standing defect class where save() puts '' into a date
+    // column and the cleared sql_mode accepts it as 0000-00-00; "never
+    // used" has to stay distinguishable from "used at the epoch".
+    "CREATE TABLE IF NOT EXISTS `apiTokens` ("
+    . "`atID` INT NOT NULL AUTO_INCREMENT,"
+    // The owner. Every token acts with this user's roles -- there are no
+    // ownerless tokens, because FOG's authorization is entirely per-user and
+    // an unowned token would need a parallel permission model AND would
+    // blind auditLog, which keys every row off the acting user.
+    . "`atUserID` INT NOT NULL DEFAULT 0,"
+    // What the token is for, chosen by whoever created it. The point of N
+    // tokens per user is that one integration can be rotated without
+    // touching the others, which only works if you can tell them apart.
+    . "`atName` VARCHAR(255) NOT NULL DEFAULT '',"
+    . "`atHash` CHAR(64) NOT NULL DEFAULT '',"
+    // Per-token kill switch, independent of users.uAllowAPI. That flag
+    // governs fog-user-token and keeps doing exactly that; this one parks a
+    // single integration. Kept as a flag rather than only offering delete so
+    // a disabled row still says the token existed and when it was last used
+    // -- a deleted one leaves auditLog referring to something nobody can
+    // identify.
+    . "`atEnabled` ENUM('0','1') NOT NULL DEFAULT '1',"
+    . "`atCreatedTime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+    . "`atCreatedBy` VARCHAR(255) NOT NULL DEFAULT '',"
+    . "`atLastUsed` DATETIME NULL DEFAULT NULL,"
+    . "PRIMARY KEY (`atID`),"
+    . "UNIQUE KEY `atHash` (`atHash`),"
+    . "KEY `atUserID` (`atUserID`)"
+    . ") ENGINE=InnoDB "
+    . "DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci "
+    . "ROW_FORMAT=DYNAMIC",
+];

--- a/packages/web/lib/fog/apitoken.class.php
+++ b/packages/web/lib/fog/apitoken.class.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * One hashed API token belonging to one user.
+ *
+ * PHP version 7.4+
+ *
+ * @category APIToken
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * One hashed API token belonging to one user.
+ *
+ * ADR 0027. A Bearer credential, separate from users.uAPIToken rather than a
+ * new spelling of it: uAPIToken stays plaintext, stays visible in the UI and
+ * keeps working as fog-user-token beside fog-api-token, untouched. These are
+ * stored hashed, shown once, and are the only thing Authorization: Bearer
+ * accepts.
+ *
+ * DELIBERATELY ABSENT FROM Route::$validClasses. A token-management REST
+ * surface would let one API credential mint another, which turns any leaked
+ * token into a permanent foothold that survives revoking the one that leaked.
+ * Creation and revocation are UI actions, behind a session and CSRF.
+ *
+ * @category APIToken
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class APIToken extends FOGController
+{
+    /**
+     * Prefix every issued token carries.
+     *
+     * Present so a token is recognisable on sight -- in a log, a pasted
+     * config, a support ticket -- and so leaked-credential scanners have
+     * something to match. It is part of the token: the hash covers the whole
+     * string, so there is nothing to parse at verification time.
+     *
+     * @var string
+     */
+    const PREFIX = 'fog_';
+
+    /**
+     * How stale atLastUsed may get before a request refreshes it.
+     *
+     * Recording last use is what makes it safe to delete a token nobody can
+     * account for. Writing it on EVERY request would put an UPDATE on the
+     * hot path of every API call, so it is refreshed at most this often --
+     * the question the column answers is "was this used this month", and
+     * five minutes of resolution answers it just as well.
+     *
+     * @var int
+     */
+    const LAST_USED_TTL = 300;
+
+    /**
+     * The table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'apiTokens';
+
+    /**
+     * Friendly names to column names.
+     *
+     * createdTime and createdBy are spelled as history, taskLog and auditLog
+     * spell them, so one viewer reads all of them.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'atID',
+        'userID' => 'atUserID',
+        'name' => 'atName',
+        'hash' => 'atHash',
+        'enabled' => 'atEnabled',
+        'createdTime' => 'atCreatedTime',
+        'createdBy' => 'atCreatedBy',
+        'lastUsed' => 'atLastUsed'
+    ];
+
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'userID',
+        'hash'
+    ];
+
+    /**
+     * Hashes a presented token into what the table stores.
+     *
+     * Unsalted SHA-256, and that is a decision rather than an omission.
+     *
+     * A salt defeats PRECOMPUTATION -- one rainbow table or one dictionary
+     * pass cracking many hashes at once -- and that requires a guessable
+     * input. A token from generate() is 512 bits of CSPRNG output: there is
+     * no dictionary and no constructible table, so a salt protects against
+     * nothing here while costing the ability to look a token up at all. With
+     * a per-row salt you cannot compute the hash until you already know
+     * which row you are checking, which means either scanning every token
+     * per request or embedding a lookup id in the token.
+     *
+     * A pepper is the same story plus a rotation problem: changing the key
+     * invalidates every token at once. bcrypt is wrong for a different
+     * reason -- it is deliberately slow, and that cost would be paid on
+     * every API request rather than once per login.
+     *
+     * THE INVARIANT THIS RESTS ON: tokens stay CSPRNG-generated and at least
+     * 256 bits. If one is ever shortened, made user-choosable, or derived
+     * from anything predictable, this reasoning is void and salting becomes
+     * necessary. See ADR 0027.
+     *
+     * @param string $token The presented token, exactly as sent.
+     *
+     * @return string 64 hex characters.
+     */
+    public static function hashToken($token)
+    {
+        return hash('sha256', (string)$token);
+    }
+
+    /**
+     * Issues a new token for a user and stores only its hash.
+     *
+     * Returns the plaintext, which is the ONLY time it exists anywhere. The
+     * caller shows it once; nothing -- not this class, not the UI, not the
+     * database -- can produce it again.
+     *
+     * @param int    $userID The owner.
+     * @param string $name   What the token is for.
+     *
+     * @return string|false The plaintext token, or false if it did not store.
+     */
+    public static function generate($userID, $name = '')
+    {
+        $userID = (int)$userID;
+        if ($userID < 1) {
+            return false;
+        }
+        // 512 bits, the same generator users.uAPIToken uses. The prefix is
+        // part of the token and therefore part of what gets hashed.
+        $token = self::PREFIX . bin2hex(random_bytes(64));
+        $row = self::getClass('APIToken')
+            ->set('userID', $userID)
+            ->set('name', trim((string)$name))
+            ->set('hash', self::hashToken($token))
+            ->set('enabled', '1');
+        if (!$row->save()) {
+            // save() has a history of returning $this over a swallowed SQL
+            // error, so a token whose hash did not store must not be handed
+            // back as though it works -- it would authenticate nothing and
+            // the user would have no way to tell.
+            return false;
+        }
+        return $token;
+    }
+
+    /**
+     * Resolves a presented token to the user it authenticates as.
+     *
+     * @param string $token The presented token, exactly as sent.
+     *
+     * @return User|null The owner, or null when the token is unusable.
+     */
+    public static function resolve($token)
+    {
+        $token = trim((string)$token);
+        if ('' === $token) {
+            return null;
+        }
+        $row = self::getClass('APIToken')
+            ->set('hash', self::hashToken($token))
+            ->load('hash');
+        if (!$row->isValid()) {
+            return null;
+        }
+        // The per-token kill switch. Independent of users.uAllowAPI, which
+        // governs fog-user-token and is not consulted here (ADR 0027).
+        if ('1' !== (string)$row->get('enabled')) {
+            return null;
+        }
+        $user = self::getClass('User', (int)$row->get('userID'));
+        if (!$user->isValid()) {
+            // The owner is gone but the token is not. Destroying a user is
+            // supposed to destroy its tokens; refuse rather than authenticate
+            // as nobody, so a missed cascade fails closed instead of leaving
+            // a working ownerless credential.
+            return null;
+        }
+        $row->touch();
+        return $user;
+    }
+
+    /**
+     * Records that this token was used, at most once per LAST_USED_TTL.
+     *
+     * @return void
+     */
+    public function touch()
+    {
+        $last = trim((string)$this->get('lastUsed'));
+        // Only ever written with a real datetime. FOG has a standing defect
+        // class where save() puts '' into a date column and the cleared
+        // sql_mode stores it as 0000-00-00, which would make "never used"
+        // indistinguishable from "used at the epoch" -- the fact this column
+        // exists to record.
+        if ('' !== $last && strtotime($last) > (time() - self::LAST_USED_TTL)) {
+            return;
+        }
+        $this
+            ->set('lastUsed', self::formatTime('now', 'Y-m-d H:i:s'))
+            ->save();
+    }
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\APIToken', 'APIToken');

--- a/packages/web/lib/fog/apitokenmanager.class.php
+++ b/packages/web/lib/fog/apitokenmanager.class.php
@@ -30,6 +30,54 @@ class APITokenManager extends FOGManagerController
      * @var string
      */
     public $tablename = 'apiTokens';
+
+    /**
+     * Every token belonging to one user, newest first.
+     *
+     * Queried directly rather than through Route::getList(), which is the
+     * usual way a page fetches a set of rows. That path validates its class
+     * against Route::$validClasses, and APIToken is deliberately absent from
+     * it -- a token-management REST surface would let one API credential mint
+     * another (see the model's docblock). So the REST layer cannot answer
+     * this question, and it should not be taught to.
+     *
+     * Direct SQL in a manager is the established shape for exactly that
+     * situation; Retention and Site do the same for the same reason.
+     *
+     * @param int $userID The owner.
+     *
+     * @return array APIToken objects, empty when the user has none. Never
+     *               null, so a foreach over the result is always safe.
+     */
+    public function forUser($userID)
+    {
+        $userID = (int)$userID;
+        if ($userID < 1) {
+            return [];
+        }
+        $rows = self::$DB
+            ->query(
+                'SELECT `atID` FROM `apiTokens` WHERE `atUserID` = :uid'
+                . ' ORDER BY `atCreatedTime` DESC, `atID` DESC',
+                [],
+                [':uid' => $userID]
+            )
+            ->fetch('', 'fetch_all')
+            ->get();
+
+        $tokens = [];
+        foreach ((array)$rows as $row) {
+            $token = self::getClass('APIToken', (int)$row['atID']);
+            // A row that will not load is skipped rather than returned
+            // half-built: every caller reads get('enabled') off these and an
+            // invalid object answers '' to everything, which would render as
+            // a disabled token that cannot be re-enabled.
+            if ($token->isValid()) {
+                $tokens[] = $token;
+            }
+        }
+        return $tokens;
+    }
 }
 
 /*

--- a/packages/web/lib/fog/apitokenmanager.class.php
+++ b/packages/web/lib/fog/apitokenmanager.class.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * API token manager.
+ *
+ * PHP version 7.4+
+ *
+ * @category APITokenManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+/**
+ * API token manager.
+ *
+ * @category APITokenManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class APITokenManager extends FOGManagerController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    public $tablename = 'apiTokens';
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\APITokenManager', 'APITokenManager');

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 358);
+        define('FOG_SCHEMA', 359);
         define('FOG_BCACHE_VER', 301);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 359);
-        define('FOG_BCACHE_VER', 301);
+        define('FOG_BCACHE_VER', 303);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -769,6 +769,113 @@ class UserManagement extends FOGPage
         echo '</div>';
         echo '</div>';
         echo '</form>';
+        $this->_userBearerTokens();
+    }
+    /**
+     * The Bearer token card: issue, list, disable and delete APITokens.
+     *
+     * A SEPARATE card from the one above, deliberately. The field above is
+     * users.uAPIToken -- plaintext, permanently re-readable, sent as
+     * fog-user-token beside fog-api-token. These are ADR 0027 tokens: hashed
+     * at rest, shown once, and the only thing Authorization: Bearer accepts.
+     * Two credentials with different properties should not share a card and
+     * read as one setting.
+     *
+     * @return void
+     */
+    private function _userBearerTokens()
+    {
+        $uid = (int)$this->obj->get('id');
+        // Shown exactly once, on the render immediately after creation. The
+        // plaintext exists nowhere else -- not in the row, not in a log --
+        // so this is the user's only chance to copy it, and the session key
+        // is cleared as it is read rather than on any later event that might
+        // not happen.
+        $fresh = (string)($_SESSION['fog_new_api_token'] ?? '');
+        unset($_SESSION['fog_new_api_token']);
+
+        echo '<form class="form-horizontal" method="post" action="'
+            . self::makeTabUpdateURL('user-api', $uid)
+            . '" id="user-apitoken-form">';
+        echo '<div class="card mt-3">';
+        echo '<div class="card-header">' . _('Bearer API Tokens') . '</div>';
+        echo '<div class="card-body">';
+
+        if ('' !== $fresh) {
+            echo '<div class="alert alert-success">';
+            echo '<h5>' . _('Copy this token now') . '</h5>';
+            echo '<p>'
+                . _('This is the only time it will be shown. FOG stores only '
+                    . 'a hash of it and cannot show it again. If you lose it, '
+                    . 'delete this token and issue another.')
+                . '</p>';
+            echo '<input type="text" class="form-control" readonly '
+                . 'onclick="this.select();" value="'
+                . \Initiator::e($fresh) . '"/>';
+            echo '<p class="mt-2 mb-0"><code>Authorization: Bearer '
+                . \Initiator::e($fresh) . '</code></p>';
+            echo '</div>';
+        }
+
+        echo '<p>'
+            . _('Sent as an Authorization: Bearer header, on its own -- no '
+                . 'fog-api-token header is needed alongside it. Each token '
+                . 'acts with this user\'s roles.')
+            . '</p>';
+
+        $tokens = self::getClass('APITokenManager')
+            ->find(['userID' => $uid]);
+        echo '<table class="table table-sm">';
+        echo '<thead><tr>'
+            . '<th>' . _('Name') . '</th>'
+            . '<th>' . _('Created') . '</th>'
+            . '<th>' . _('Last Used') . '</th>'
+            . '<th>' . _('Enabled') . '</th>'
+            . '<th>' . _('Delete') . '</th>'
+            . '</tr></thead><tbody>';
+        if (count($tokens) < 1) {
+            echo '<tr><td colspan="5">' . _('No tokens issued.') . '</td></tr>';
+        }
+        foreach ((array)$tokens as &$token) {
+            $tid = (int)$token->get('id');
+            $last = trim((string)$token->get('lastUsed'));
+            echo '<tr>';
+            echo '<td>' . \Initiator::e($token->get('name')) . '</td>';
+            echo '<td>' . \Initiator::e($token->get('createdTime')) . '</td>';
+            // A token that has never been used reads as such rather than as
+            // a date, so "issued and forgotten" is visible at a glance --
+            // that is the whole reason the column is recorded.
+            echo '<td>'
+                . ('' === $last ? _('Never') : \Initiator::e($last))
+                . '</td>';
+            echo '<td><input type="checkbox" name="tokenenabled[]" value="'
+                . $tid . '"'
+                . ('1' === (string)$token->get('enabled') ? ' checked' : '')
+                . '/></td>';
+            echo '<td><input type="checkbox" name="tokendelete[]" value="'
+                . $tid . '"/></td>';
+            echo '</tr>';
+            unset($token);
+        }
+        echo '</tbody></table>';
+
+        echo '<div class="input-group">';
+        echo '<input type="text" class="form-control" name="newtokenname" '
+            . 'placeholder="' . _('Name for a new token') . '"/>';
+        echo '<button type="submit" name="createtoken" value="1" '
+            . 'class="btn btn-secondary">' . _('Issue Token') . '</button>';
+        echo '</div>';
+
+        echo '</div>';
+        echo '<div class="card-footer">';
+        echo self::makeButton(
+            'apitoken-send',
+            _('Update'),
+            'btn btn-primary float-end'
+        );
+        echo '</div>';
+        echo '</div>';
+        echo '</form>';
     }
     /**
      * User Change API Post
@@ -778,6 +885,16 @@ class UserManagement extends FOGPage
     public function userAPIPost()
     {
         self::checkAuthAndCSRF();
+        // The Bearer card posts to this same tab URL, so it lands here too.
+        // Routed first and returned from: its submits carry none of the
+        // legacy card's fields, and falling through would read an absent
+        // apienabled checkbox as "unticked" and an absent apitoken as empty
+        // -- silently disabling fog-user-token for the account and wiping
+        // uAPIToken as a side effect of issuing a Bearer token. That is the
+        // control-type/hand-built-form defect class (GH-987) exactly.
+        if ($this->_userBearerTokensPost()) {
+            return;
+        }
         $apien = (int)isset($_POST['apienabled']);
         $apitoken = base64_decode(
             filter_input(INPUT_POST, 'apitoken')
@@ -785,6 +902,62 @@ class UserManagement extends FOGPage
         $this->obj
             ->set('api', $apien)
             ->set('token', $apitoken);
+    }
+    /**
+     * Handles a submit from the Bearer token card.
+     *
+     * @return bool whether this request came from that card.
+     */
+    private function _userBearerTokensPost()
+    {
+        $isCreate = null !== filter_input(INPUT_POST, 'createtoken');
+        $isManage = null !== filter_input(INPUT_POST, 'apitoken-send');
+        if (!$isCreate && !$isManage) {
+            return false;
+        }
+        $uid = (int)$this->obj->get('id');
+        if ($isCreate) {
+            $token = APIToken::generate(
+                $uid,
+                (string)filter_input(INPUT_POST, 'newtokenname')
+            );
+            if (false === $token) {
+                throw new \Exception(_('Could not issue the token!'));
+            }
+            // Carried to the next render and shown once. Not returned in
+            // this response body and not logged: the plaintext should touch
+            // as few places as possible on its way to the screen.
+            $_SESSION['fog_new_api_token'] = $token;
+            return true;
+        }
+        $keepEnabled = array_map(
+            'intval',
+            (array)($_POST['tokenenabled'] ?? [])
+        );
+        $toDelete = array_map(
+            'intval',
+            (array)($_POST['tokendelete'] ?? [])
+        );
+        // Scoped to THIS user's tokens. The ids arrive from a form and a
+        // form is an untrusted list, so acting on them without the userID
+        // filter would let anyone who can edit one user disable or delete
+        // any token on the server by posting its id.
+        $tokens = self::getClass('APITokenManager')
+            ->find(['userID' => $uid]);
+        foreach ((array)$tokens as &$token) {
+            $tid = (int)$token->get('id');
+            if (in_array($tid, $toDelete, true)) {
+                $token->destroy();
+                unset($token);
+                continue;
+            }
+            $want = in_array($tid, $keepEnabled, true) ? '1' : '0';
+            if ($want !== (string)$token->get('enabled')) {
+                $token->set('enabled', $want)->save();
+            }
+            unset($token);
+        }
+        return true;
     }
     /**
      * Present the roles tab.

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -786,13 +786,6 @@ class UserManagement extends FOGPage
     private function _userBearerTokens()
     {
         $uid = (int)$this->obj->get('id');
-        // Shown exactly once, on the render immediately after creation. The
-        // plaintext exists nowhere else -- not in the row, not in a log --
-        // so this is the user's only chance to copy it, and the session key
-        // is cleared as it is read rather than on any later event that might
-        // not happen.
-        $fresh = (string)($_SESSION['fog_new_api_token'] ?? '');
-        unset($_SESSION['fog_new_api_token']);
 
         echo '<form class="form-horizontal" method="post" action="'
             . self::makeTabUpdateURL('user-api', $uid)
@@ -801,30 +794,32 @@ class UserManagement extends FOGPage
         echo '<div class="card-header">' . _('Bearer API Tokens') . '</div>';
         echo '<div class="card-body">';
 
-        if ('' !== $fresh) {
-            echo '<div class="alert alert-success">';
-            echo '<h5>' . _('Copy this token now') . '</h5>';
-            echo '<p>'
-                . _('This is the only time it will be shown. FOG stores only '
-                    . 'a hash of it and cannot show it again. If you lose it, '
-                    . 'delete this token and issue another.')
-                . '</p>';
-            echo '<input type="text" class="form-control" readonly '
-                . 'onclick="this.select();" value="'
-                . \Initiator::e($fresh) . '"/>';
-            echo '<p class="mt-2 mb-0"><code>Authorization: Bearer '
-                . \Initiator::e($fresh) . '</code></p>';
-            echo '</div>';
-        }
+        // Filled in by fog.user.edit.js from issueAPIToken()'s response and
+        // never by PHP. The plaintext reaches the browser once, in the reply
+        // to the click that created it, and is not carried in the session or
+        // re-rendered on any later page load -- so a back button, a refresh
+        // or a second admin opening the same user cannot surface it.
+        echo '<div class="alert alert-success d-none" id="apitoken-fresh">';
+        echo '<h5>' . _('Copy this token now') . '</h5>';
+        echo '<p>'
+            . _('This is the only time it will be shown. FOG stores only a '
+                . 'hash of it and cannot show it again. If you lose it, '
+                . 'delete this token and issue another.')
+            . '</p>';
+        echo '<input type="text" class="form-control" readonly '
+            . 'onclick="this.select();" id="apitoken-fresh-value"/>';
+        echo '<p class="mt-2 mb-0"><code>Authorization: Bearer '
+            . '<span id="apitoken-fresh-header"></span></code></p>';
+        echo '</div>';
 
         echo '<p>'
-            . _('Sent as an Authorization: Bearer header, on its own -- no '
+            . _('Sent as an Authorization: Bearer header, on its own &mdash; no '
                 . 'fog-api-token header is needed alongside it. Each token '
                 . 'acts with this user\'s roles.')
             . '</p>';
 
         $tokens = self::getClass('APITokenManager')
-            ->find(['userID' => $uid]);
+            ->forUser($uid);
         echo '<table class="table table-sm">';
         echo '<thead><tr>'
             . '<th>' . _('Name') . '</th>'
@@ -859,10 +854,32 @@ class UserManagement extends FOGPage
         }
         echo '</tbody></table>';
 
+        // type=button, not submit. Creation does NOT ride this form: it is
+        // its own AJAX call to issueAPIToken(), the same shape the Reset
+        // Token control beside it already uses. Two reasons, and the first
+        // is fatal on its own:
+        //
+        //  - processForm() posts `new FormData(form)`, and FormData omits
+        //    submit buttons unless the submitter is passed to it. A
+        //    name=createtoken submit button therefore never arrives, so the
+        //    handler could not tell a create from a save however it was
+        //    wired.
+        //  - the plaintext is shown once. Routing it through the tab form
+        //    means either putting it in the session and reloading -- which
+        //    lands the user back on the General tab with the secret
+        //    unseen -- or threading it through handleEditPost()'s shared
+        //    fixed-shape response. The dedicated endpoint returns it to the
+        //    click that asked for it and nothing else has to change.
+        // Read by _userBearerTokensPost() to tell this card's save from the
+        // legacy card's. See the comment there for why it cannot be the
+        // button's own name.
+        echo '<input type="hidden" name="tokenaction" value="manage"/>';
+
         echo '<div class="input-group">';
         echo '<input type="text" class="form-control" name="newtokenname" '
-            . 'placeholder="' . _('Name for a new token') . '"/>';
-        echo '<button type="submit" name="createtoken" value="1" '
+            . 'id="newtokenname" placeholder="'
+            . _('Name for a new token') . '"/>';
+        echo '<button type="button" id="issuetoken" '
             . 'class="btn btn-secondary">' . _('Issue Token') . '</button>';
         echo '</div>';
 
@@ -904,32 +921,80 @@ class UserManagement extends FOGPage
             ->set('token', $apitoken);
     }
     /**
+     * Issues one API token and returns its plaintext, once.
+     *
+     * Its own endpoint rather than part of the tab form, for the reasons set
+     * out where the Issue Token button is emitted. Modelled on the Reset
+     * Token control beside it, which has always been a direct AJAX call.
+     *
+     * The plaintext is written to this response and nowhere else -- not the
+     * session, not a log, not the row. If the caller loses it, the token is
+     * unrecoverable by design and the answer is to delete it and issue
+     * another.
+     *
+     * @return void
+     */
+    public function issueAPIToken()
+    {
+        // State-changing and it mints a credential, so it gets the same gate
+        // as any other POST here. Ordinary role checks still apply: reaching
+        // this page at all requires user.edit.
+        self::checkAuthAndCSRF();
+        // Not optional. Without it jQuery reads the body as text, hands
+        // $.notifyFromAPI a STRING, and every res.<key> lookup is undefined
+        // -- so the caller sees no token and no error, just a notification
+        // that says nothing. Every other JSON endpoint here sets it too.
+        header('Content-type: application/json');
+
+        $uid = (int)$this->obj->get('id');
+        $name = trim((string)filter_input(INPUT_POST, 'newtokenname'));
+
+        $token = $uid > 0 ? APIToken::generate($uid, $name) : false;
+        if (false === $token) {
+            // generate() returns false when the row did not store, so this
+            // is "there is no token", not "there might be one you cannot
+            // see". Reported as a server fault because nothing the user
+            // typed can cause it.
+            self::jsonSend(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                json_encode(
+                    [
+                        'error' => _('Could not issue the token!'),
+                        'title' => _('API Token Failed')
+                    ]
+                )
+            );
+        }
+
+        self::jsonSend(
+            HTTPResponseCodes::HTTP_CREATED,
+            json_encode(
+                [
+                    'msg' => _('API token issued!'),
+                    'title' => _('API Token Created'),
+                    'token' => $token,
+                    'name' => $name,
+                    'created' => self::formatTime('now', 'Y-m-d H:i:s')
+                ]
+            )
+        );
+    }
+    /**
      * Handles a submit from the Bearer token card.
      *
      * @return bool whether this request came from that card.
      */
     private function _userBearerTokensPost()
     {
-        $isCreate = null !== filter_input(INPUT_POST, 'createtoken');
-        $isManage = null !== filter_input(INPUT_POST, 'apitoken-send');
-        if (!$isCreate && !$isManage) {
+        // A hidden field, not the button's name. processForm() posts
+        // `new FormData(form)` and FormData omits submit buttons unless the
+        // submitter is passed to it, so a name= on the button never arrives
+        // -- the handler would see every save as "not mine" and fall
+        // through to the legacy card. The JS sets this before posting.
+        if ('manage' !== (string)filter_input(INPUT_POST, 'tokenaction')) {
             return false;
         }
         $uid = (int)$this->obj->get('id');
-        if ($isCreate) {
-            $token = APIToken::generate(
-                $uid,
-                (string)filter_input(INPUT_POST, 'newtokenname')
-            );
-            if (false === $token) {
-                throw new \Exception(_('Could not issue the token!'));
-            }
-            // Carried to the next render and shown once. Not returned in
-            // this response body and not logged: the plaintext should touch
-            // as few places as possible on its way to the screen.
-            $_SESSION['fog_new_api_token'] = $token;
-            return true;
-        }
         $keepEnabled = array_map(
             'intval',
             (array)($_POST['tokenenabled'] ?? [])
@@ -943,7 +1008,7 @@ class UserManagement extends FOGPage
         // filter would let anyone who can edit one user disable or delete
         // any token on the server by posting its id.
         $tokens = self::getClass('APITokenManager')
-            ->find(['userID' => $uid]);
+            ->forUser($uid);
         foreach ((array)$tokens as &$token) {
             $tid = (int)$token->get('id');
             if (in_array($tid, $toDelete, true)) {

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1559,14 +1559,16 @@ class Route extends FOGBase
     /**
      * Reads an RFC 6750 Bearer credential from the Authorization header.
      *
-     * The value is the same per-user API token the fog-user-token header
-     * carries, sent the standard way and with the same base64 encoding the
-     * API tab displays. Deliberately not raw: a 128-character hex token is
-     * ITSELF valid base64 (a-f and 0-9 are all in the alphabet), so a strict
-     * decode of one succeeds and cannot be told apart from an encoded token.
-     * Accepting both spellings would therefore mean two lookups per request
-     * to resolve an ambiguity we do not have to create. Send exactly what
-     * the UI shows.
+     * The value is an APIToken -- a `fog_`-prefixed string shown once at
+     * creation -- sent EXACTLY as issued, with no encoding applied.
+     *
+     * It is deliberately not base64, and this is the one place the two token
+     * systems visibly differ. users.uAPIToken is base64 in its header
+     * because the UI displays it that way and always has. An APIToken is
+     * displayed once, by us, so the string the user copies can simply be the
+     * string the server wants -- there is nothing to encode and nothing to
+     * get wrong. Since Bearer accepts only APITokens (ADR 0027), no
+     * ambiguity arises from the two spellings.
      *
      * REDIRECT_HTTP_AUTHORIZATION is read for the reason _basicAuthCredentials
      * explains -- under FastCGI the Authorization header does not arrive on
@@ -1600,40 +1602,38 @@ class Route extends FOGBase
             if ('' !== $rest && !preg_match('/^\s/', $rest)) {
                 continue;
             }
-            $rest = trim($rest);
-            if ('' === $rest) {
-                return '';
-            }
-            // strict base64 decode: a malformed header is not a credential,
-            // but it IS an attempt -- return '' rather than null so the
-            // caller refuses it instead of falling through to another scheme.
-            $decoded = base64_decode($rest, true);
-            if ($decoded === false) {
-                return '';
-            }
-            return trim($decoded);
+            // Returned as sent. An empty value is still an ATTEMPT -- ''
+            // rather than null -- so the caller refuses it instead of
+            // falling through to another scheme.
+            return trim($rest);
         }
         return null;
     }
     /**
      * Test Bearer authentication.
      *
-     * A per-user API token is a 512-bit random secret (FOGBase::createSecToken)
-     * and stands on its own, so a Bearer request does NOT additionally need
-     * the server-wide fog-api-token. HTTP basic auth still does: its
-     * credential is a human-chosen password, and that server-wide gate is
-     * the only thing keeping every FOG password from being a standalone API
+     * The ONLY credential accepted here is an APIToken (ADR 0027): a 512-bit
+     * CSPRNG secret, stored hashed, shown once, individually revocable. It
+     * stands on its own, so a Bearer request does NOT additionally need the
+     * server-wide fog-api-token. HTTP basic auth still does: its credential
+     * is a human-chosen password, and that server-wide gate is the only
+     * thing keeping every FOG password from being a standalone API
      * credential. The asymmetry is deliberate, and it is also forced -- one
      * Authorization header carries one credential, so the legacy two-header
      * pair has no Bearer spelling.
+     *
+     * users.uAPIToken is NOT accepted here, in any encoding. #1324 shipped
+     * an interim shape that did accept it; that is withdrawn deliberately
+     * rather than by oversight. It stays plaintext in the database and
+     * visible in the UI, which is exactly what a Bearer credential must not
+     * be -- so the two are separate credentials with separate properties,
+     * not two spellings of one. uAPIToken keeps working unchanged as
+     * fog-user-token beside fog-api-token, so nothing has to migrate.
      *
      * Once a Bearer credential is PRESENTED it decides the request. Falling
      * through to the other schemes would let a bad Bearer plus good legacy
      * headers still authenticate, which no real client does and which makes
      * a failure impossible to reason about from the status code.
-     *
-     * Nothing has to migrate: fog-api-token plus fog-user-token, and basic
-     * auth, are unchanged.
      *
      * @return bool Whether the request authenticated. False means no Bearer
      *              credential was offered -- a presented one that failed
@@ -1645,10 +1645,8 @@ class Route extends FOGBase
         if (null === $token) {
             return false;
         }
-        $user = self::getClass('User')
-            ->set('token', $token)
-            ->load('token');
-        if ($user->isValid() && $user->get('api')) {
+        $user = APIToken::resolve($token);
+        if (null !== $user) {
             // Bind the token's owner as the acting user so role-based
             // authorization applies, exactly as the fog-user-token path does.
             self::$FOGUser = $user;
@@ -1658,13 +1656,17 @@ class Route extends FOGBase
         // fog-user-token rejection is, and the presented token is NOT
         // written down -- a rejected credential is still a credential,
         // which is the mistake #1261/#1262 fixed in the SQL fault log.
+        //
+        // No subject: a refused token resolved to no owner, by definition of
+        // having been refused. Naming the account whose DISABLED token was
+        // tried would be useful, but it would mean a second lookup path that
+        // reports why a credential failed, and that is an oracle. "A bearer
+        // token was refused" is the honest fact.
         Audit::record(
             [
                 'type' => Audit::TOKEN_REJECTED,
                 'outcome' => Audit::DENIED,
                 'subjectType' => 'user',
-                'subjectID' => (int)$user->get('id'),
-                'subjectLabel' => (string)$user->get('name'),
                 'authSource' => 'bearer',
                 'renderable' => 1
             ]
@@ -6823,7 +6825,21 @@ class Route extends FOGBase
                     $findWhere = ['userID' => $itemIDs];
                     $removeItems = [
                         'roleuserassociation' => $findWhere,
-                        'usergroupmember' => $findWhere
+                        'usergroupmember' => $findWhere,
+                        // A token outlives its owner as a WORKING credential
+                        // if this is missed, which is why it goes here rather
+                        // than in User::destroy(): destroy() is only the UI
+                        // path, and the REST delete funnels to deletemass()
+                        // without ever calling it. That split is what left
+                        // orphans before (see the snapintask note below), and
+                        // an orphaned API token is a live way in belonging to
+                        // an account that no longer exists.
+                        //
+                        // APIToken::resolve() also refuses a token whose
+                        // owner will not load, so a future miss here fails
+                        // closed rather than authenticating as nobody. Both,
+                        // deliberately: this is the fix and that is the net.
+                        'apitoken' => $findWhere
                     ];
                     break;
                 case 'role':

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -1696,7 +1696,18 @@ $.notifyFromAPI = function(res, isError) {
     }
   }
   var title = res.title,
-    type = 'success';
+    type = 'success',
+    // Declared. It never was: every branch below ASSIGNED it as an implicit
+    // global, and `if (!msg)` READS it -- so any response carrying none of
+    // error/info/warning/msg threw ReferenceError out of the success
+    // handler and took the caller's callback with it. The fallback two
+    // lines down existed precisely for that case and could never run.
+    //
+    // The usual way in is a body jQuery did not parse as JSON (an endpoint
+    // missing its Content-type header): res is then a string, every lookup
+    // is undefined, and the user sees a silent failure rather than
+    // 'Bad Response'.
+    msg;
   if (res.error) {
     type = 'error';
     msg = res.error;

--- a/packages/web/management/js/fog/user/fog.user.edit.js
+++ b/packages/web/management/js/fog/user/fog.user.edit.js
@@ -69,6 +69,63 @@
         });
     });
 
+    // ----------------------------------------------------
+    // BEARER API TOKEN CARD
+    //
+    // Every tab form in this file is wired the same way: suppress the native
+    // submit, and drive the post from a button's click handler. There is no
+    // generic binding that picks a form up automatically -- disableFormDefaults()
+    // only stops the native submit -- so a card with no wiring here renders
+    // fine and silently does nothing when clicked.
+    var apiTokenForm = $('#user-apitoken-form'),
+        apiTokenFormBtn = $('#apitoken-send'),
+        issueTokenBtn = $('#issuetoken');
+
+    apiTokenForm.on('submit', function(e) {
+        e.preventDefault();
+    });
+
+    // Save: enable/disable and delete. Rides the tab form.
+    apiTokenFormBtn.on('click', function(e) {
+        apiTokenFormBtn.prop('disabled', true);
+        apiTokenForm.processForm(function(err) {
+            apiTokenFormBtn.prop('disabled', false);
+            if (err) {
+                return;
+            }
+            // The rows the save acted on are stale now -- a deleted token
+            // still has a row and a toggled one still shows its old state.
+            location.reload();
+        });
+    });
+
+    // Issue: its own endpoint, because the plaintext comes back in this
+    // response and is shown once. See the PHP side for why it cannot ride
+    // the form.
+    issueTokenBtn.on('click', function(e) {
+        var name = $('#newtokenname').val();
+        issueTokenBtn.prop('disabled', true);
+        $.apiCall(
+            'post',
+            '../management/index.php?node=user&sub=issueAPIToken&id=' + Common.id,
+            { newtokenname: name },
+            function(err, data) {
+                issueTokenBtn.prop('disabled', false);
+                if (err || !data || !data.token) {
+                    return;
+                }
+                // Shown, not stored. Nothing here writes the token anywhere
+                // that survives the page: no localStorage, no data attribute
+                // that a later render reuses.
+                $('#apitoken-fresh-value').val(data.token);
+                $('#apitoken-fresh-header').text(data.token);
+                $('#apitoken-fresh').removeClass('d-none');
+                $('#newtokenname').val('');
+                $('#apitoken-fresh-value').trigger('focus').trigger('select');
+            }
+        );
+    });
+
     $('.resettoken').on('click', function(e) {
         e.preventDefault();
         Pace.ignore(function() {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1061,6 +1061,10 @@ msgstr "grundlegende Tasks"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "API-Zugangstoken"
+
 msgid "Bind DN"
 msgstr "DN binden"
 
@@ -1570,6 +1574,9 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 msgid "Copy from existing"
 msgstr "Kopie von bereits existierenden"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1599,6 +1606,10 @@ msgstr "Nichts konnte gefunden werden"
 
 msgid "Could not find temp filename"
 msgstr "Temporärer Dateiname konnte nicht gefunden werden."
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1848,6 +1859,10 @@ msgstr "Benutzer erfolgreich erstellt"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Erstellen"
 
 msgid "Created By"
 msgstr "Erstellt von"
@@ -4246,6 +4261,10 @@ msgstr "Ist ein Paket"
 msgid "Is a"
 msgstr "Ist ein"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "Token zurücksetzen"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4490,6 +4509,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Erfolgreich"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "Zuletzt hochgeladen"
 
 msgid "Last flush"
 msgstr ""
@@ -5056,6 +5079,9 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
@@ -5368,6 +5394,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "Kein valides Image für diesen Host definiert"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6852,6 +6881,9 @@ msgstr "Wählen Sie ein gültiges Abbild"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Seriennummer"
@@ -8432,6 +8464,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -441,11 +441,22 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Ort"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "FTP-Verbindung fehlgeschlagen"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "Ungültiger Token übergeben"
 
 msgid "API?"
 msgstr "API?"
@@ -6882,7 +6893,7 @@ msgstr "Wählen Sie ein gültiges Abbild"
 msgid "Selected tasks cancelled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1065,6 +1065,10 @@ msgstr "Basic Tasks"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "Access Token"
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1572,6 +1576,9 @@ msgstr "Error: Failed to download kernel"
 msgid "Copy from existing"
 msgstr "Could not create printer"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1601,6 +1608,10 @@ msgstr "Could not find temp filename"
 
 msgid "Could not find temp filename"
 msgstr "Could not find temp filename"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1850,6 +1861,10 @@ msgstr "User created"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Create"
 
 msgid "Created By"
 msgstr "Created By"
@@ -4247,6 +4262,10 @@ msgstr "Is a"
 msgid "Is a"
 msgstr "Is a"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "Access Token"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4489,6 +4508,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Successful"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "Host Created"
 
 msgid "Last flush"
 msgstr ""
@@ -5054,6 +5077,9 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "You must enter a name"
@@ -5366,6 +5392,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "No Image defined for this host"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6850,6 +6879,9 @@ msgstr "Select a valid image"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "has been successfully updated"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Serial Number"
@@ -8427,6 +8459,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -445,11 +445,22 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Location"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "FTP Connection has failed"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "Invalid token passed"
 
 msgid "API?"
 msgstr ""
@@ -6880,7 +6891,7 @@ msgstr "Select a valid image"
 msgid "Selected tasks cancelled!"
 msgstr "has been successfully updated"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -443,11 +443,22 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Acción"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "Añadir fallidos SNAPin!"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "unidad no válida pasó"
 
 msgid "API?"
 msgstr ""
@@ -7031,7 +7042,7 @@ msgstr "Seleccionar una imagen válida"
 msgid "Selected tasks cancelled!"
 msgstr "se ha actualizado correctamente"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1080,6 +1080,10 @@ msgstr "Tareas"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "Nombre de usuario"
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1593,6 +1597,9 @@ msgstr "Error: No se pudo descargar kernel"
 msgid "Copy from existing"
 msgstr "No se pudo crear la impresora"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1621,6 +1628,10 @@ msgstr "No se pudo encontrar el nombre de archivo temporal"
 
 msgid "Could not find temp filename"
 msgstr "No se pudo encontrar el nombre de archivo temporal"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1870,6 +1881,10 @@ msgstr "creado por el usuario"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Crear"
 
 #, fuzzy
 msgid "Created By"
@@ -4339,6 +4354,10 @@ msgstr ""
 msgid "Is a"
 msgstr ""
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "impresora iPrint"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4589,6 +4608,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Exitoso"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "Creado"
 
 msgid "Last flush"
 msgstr ""
@@ -5176,6 +5199,9 @@ msgstr ""
 msgid "Name"
 msgstr "Nombre"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Evento debe ser una cadena"
@@ -5493,6 +5519,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "No se ha definido de este alojamiento imagen"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -7001,6 +7030,9 @@ msgstr "Seleccionar una imagen válida"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "se ha actualizado correctamente"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr ""
@@ -8613,6 +8645,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1061,6 +1061,10 @@ msgstr "grundlegende Tasks"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "API-Zugangstoken"
+
 msgid "Bind DN"
 msgstr "DN binden"
 
@@ -1570,6 +1574,9 @@ msgstr "Fehler: Herunterladen des Kernels fehlgeschlagen"
 msgid "Copy from existing"
 msgstr "Kopie von bereits existierenden"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1599,6 +1606,10 @@ msgstr "Nichts konnte gefunden werden"
 
 msgid "Could not find temp filename"
 msgstr "Temporärer Dateiname konnte nicht gefunden werden."
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1848,6 +1859,10 @@ msgstr "Benutzer erfolgreich erstellt"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Erstellen"
 
 msgid "Created By"
 msgstr "Erstellt von"
@@ -4247,6 +4262,10 @@ msgstr "Ist ein Paket"
 msgid "Is a"
 msgstr "Ist ein"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "Token zurücksetzen"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4491,6 +4510,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Erfolgreich"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "Zuletzt hochgeladen"
 
 msgid "Last flush"
 msgstr ""
@@ -5057,6 +5080,9 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
@@ -5369,6 +5395,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "Kein valides Image für diesen Host definiert"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6853,6 +6882,9 @@ msgstr "Wählen Sie ein gültiges Abbild"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Seriennummer"
@@ -8433,6 +8465,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -441,11 +441,22 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Ort"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "FTP-Verbindung fehlgeschlagen"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "Ungültiger Token übergeben"
 
 msgid "API?"
 msgstr "API?"
@@ -6883,7 +6894,7 @@ msgstr "Wählen Sie ein gültiges Abbild"
 msgid "Selected tasks cancelled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1066,6 +1066,10 @@ msgstr "Tâches de base"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "Jeton d'accès"
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1574,6 +1578,9 @@ msgstr "Erreur: Impossible de télécharger le noyau"
 msgid "Copy from existing"
 msgstr "Impossible de créer l'imprimante"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1603,6 +1610,10 @@ msgstr "Impossible de trouver le nom de fichier temporaire"
 
 msgid "Could not find temp filename"
 msgstr "Impossible de trouver le nom de fichier temporaire"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1852,6 +1863,10 @@ msgstr "utilisateur créé"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Créer"
 
 msgid "Created By"
 msgstr "Créé par"
@@ -4249,6 +4264,10 @@ msgstr "Est un"
 msgid "Is a"
 msgstr "Est un"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "Jeton d'accès"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4491,6 +4510,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Réussi"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "hôte Créé"
 
 msgid "Last flush"
 msgstr ""
@@ -5056,6 +5079,9 @@ msgstr ""
 msgid "Name"
 msgstr "prénom"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Vous devez entrer un nom"
@@ -5368,6 +5394,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "Pas d'image définie pour cet hôte"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6852,6 +6881,9 @@ msgstr "Sélectionnez une image valide"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "a été mis à jour avec succès"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Numéro de série"
@@ -8429,6 +8461,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -446,11 +446,22 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Emplacement"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "Connexion FTP a échoué"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "jeton non valide transmis"
 
 msgid "API?"
 msgstr ""
@@ -6882,7 +6893,7 @@ msgstr "Sélectionnez une image valide"
 msgid "Selected tasks cancelled!"
 msgstr "a été mis à jour avec succès"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -432,11 +432,22 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Luogo"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "Connessione FTP non è riuscita"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "Token non valido passato"
 
 msgid "API?"
 msgstr "API?"
@@ -6655,7 +6666,7 @@ msgstr "Selezionare un'immagine valida"
 msgid "Selected tasks cancelled!"
 msgstr "Attività pianificate create con successo"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1034,6 +1034,10 @@ msgstr "Operazioni di base"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "API Utente Token"
+
 msgid "Bind DN"
 msgstr "Bind DN"
 
@@ -1520,6 +1524,9 @@ msgstr "Errore: Impossibile scaricare il kernel"
 msgid "Copy from existing"
 msgstr "Copia da esistenti"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1546,6 +1553,10 @@ msgstr "Impossibile trovare"
 
 msgid "Could not find temp filename"
 msgstr "Impossibile trovare il nome del file temporaneo"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1791,6 +1802,10 @@ msgstr "Creazione utente riuscita"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Creare"
 
 msgid "Created By"
 msgstr "Creato da"
@@ -4107,6 +4122,10 @@ msgstr "È Pack"
 msgid "Is a"
 msgstr "È un"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "Reset Token"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4340,6 +4359,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Riuscito"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "Ultima cattura"
 
 msgid "Last flush"
 msgstr ""
@@ -4883,6 +4906,9 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Il parametro Diff deve essere numerico"
@@ -5186,6 +5212,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "Nessuna Imagine valida definita per questo host"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6625,6 +6654,9 @@ msgstr "Selezionare un'immagine valida"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "Attività pianificate create con successo"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Numero di serie"
@@ -8139,6 +8171,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -417,11 +417,22 @@ msgstr "API？"
 msgid "API Documentation"
 msgstr "詳細ドキュメント"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "FTP 接続に失敗しました"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "無効なトークンが渡されました"
 
 msgid "API?"
 msgstr "API？"
@@ -6607,7 +6618,7 @@ msgstr "有効なイメージを選択してください"
 msgid "Selected tasks cancelled!"
 msgstr "スケジュール済みタスクを作成しました"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1017,6 +1017,10 @@ msgstr "基本タスク"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "ユーザー API トークン"
+
 msgid "Bind DN"
 msgstr "バインド DN"
 
@@ -1502,6 +1506,9 @@ msgstr "エラー: カーネルのダウンロードに失敗しました"
 msgid "Copy from existing"
 msgstr "既存の項目からコピー"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1528,6 +1535,10 @@ msgstr "見つかりませんでした"
 
 msgid "Could not find temp filename"
 msgstr "一時ファイル名が見つかりません"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1772,6 +1783,10 @@ msgstr "タスク状態を作成"
 #, fuzzy
 msgid "Create tasking succeeded"
 msgstr "タスク状態を作成"
+
+#, fuzzy
+msgid "Created"
+msgstr "作成"
 
 msgid "Created By"
 msgstr "作成者"
@@ -4062,6 +4077,10 @@ msgstr "パック"
 msgid "Is a"
 msgstr "次の種類です"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "トークンをリセット"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4298,6 +4317,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "タスクを正常に設定しました"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "最終キャプチャ"
 
 msgid "Last flush"
 msgstr ""
@@ -4840,6 +4863,9 @@ msgstr "フォーラムは、最も一般的で迅速なサポートを受ける
 msgid "Name"
 msgstr "名前"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff パラメーターは数値で指定してください"
@@ -5144,6 +5170,9 @@ msgstr ""
 
 msgid "No token passed to authenticate this host"
 msgstr "このホストを認証するためのトークンが渡されていません"
+
+msgid "No tokens issued."
+msgstr ""
 
 #, fuzzy
 msgid "No type information available for this column."
@@ -6577,6 +6606,9 @@ msgstr "有効なイメージを選択してください"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "スケジュール済みタスクを作成しました"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "シリアル番号"
@@ -8075,6 +8107,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -376,10 +376,19 @@ msgstr ""
 msgid "API Documentation"
 msgstr ""
 
+msgid "API Token Created"
+msgstr ""
+
+msgid "API Token Failed"
+msgstr ""
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
+msgstr ""
+
+msgid "API token issued!"
 msgstr ""
 
 msgid "API?"
@@ -5849,7 +5858,7 @@ msgstr ""
 msgid "Selected tasks cancelled!"
 msgstr ""
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -908,6 +908,9 @@ msgstr ""
 msgid "Batch Script"
 msgstr ""
 
+msgid "Bearer API Tokens"
+msgstr ""
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1343,6 +1346,9 @@ msgstr ""
 msgid "Copy from existing"
 msgstr ""
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1366,6 +1372,9 @@ msgid "Could not find any"
 msgstr ""
 
 msgid "Could not find temp filename"
+msgstr ""
+
+msgid "Could not issue the token!"
 msgstr ""
 
 msgid "Could not link plugin assets"
@@ -1563,6 +1572,9 @@ msgid "Create task form success"
 msgstr ""
 
 msgid "Create tasking succeeded"
+msgstr ""
+
+msgid "Created"
 msgstr ""
 
 msgid "Created By"
@@ -3599,6 +3611,9 @@ msgstr ""
 msgid "Is a"
 msgstr ""
 
+msgid "Issue Token"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -3801,6 +3816,9 @@ msgid "Last Ping"
 msgstr ""
 
 msgid "Last Successful Ping"
+msgstr ""
+
+msgid "Last Used"
 msgstr ""
 
 msgid "Last flush"
@@ -4282,6 +4300,9 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+msgid "Name for a new token"
+msgstr ""
+
 msgid "Name. Must be unique."
 msgstr ""
 
@@ -4552,6 +4573,9 @@ msgid "No such object."
 msgstr ""
 
 msgid "No token passed to authenticate this host"
+msgstr ""
+
+msgid "No tokens issued."
 msgstr ""
 
 msgid "No type information available for this column."
@@ -5823,6 +5847,9 @@ msgid "Select a valid image"
 msgstr ""
 
 msgid "Selected tasks cancelled!"
+msgstr ""
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"
@@ -7166,6 +7193,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -445,11 +445,22 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Localização"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "Conexão FTP falhou"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "Token inválido passado"
 
 msgid "API?"
 msgstr ""
@@ -6881,7 +6892,7 @@ msgstr "Selecione uma imagem válida"
 msgid "Selected tasks cancelled!"
 msgstr "foi atualizado com sucesso"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1065,6 +1065,10 @@ msgstr "Tarefas básicas"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "token de acesso"
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1573,6 +1577,9 @@ msgstr "Erro: falha ao baixar do kernel"
 msgid "Copy from existing"
 msgstr "Não foi possível criar impressora"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1602,6 +1609,10 @@ msgstr "Não foi possível encontrar temporário filename"
 
 msgid "Could not find temp filename"
 msgstr "Não foi possível encontrar temporário filename"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1851,6 +1862,10 @@ msgstr "usuário criado"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "Crio"
 
 msgid "Created By"
 msgstr "Criado por"
@@ -4248,6 +4263,10 @@ msgstr "É uma"
 msgid "Is a"
 msgstr "É uma"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "token de acesso"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4490,6 +4509,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "Bem sucedido"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "host criado"
 
 msgid "Last flush"
 msgstr ""
@@ -5055,6 +5078,9 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Você deve digitar um nome"
@@ -5367,6 +5393,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "Sem Imagem definida para este alojamento"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6851,6 +6880,9 @@ msgstr "Selecione uma imagem válida"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "foi atualizado com sucesso"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "Número de série"
@@ -8428,6 +8460,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -445,11 +445,22 @@ msgstr ""
 msgid "API Documentation"
 msgstr "位置"
 
+msgid "API Token Created"
+msgstr ""
+
+#, fuzzy
+msgid "API Token Failed"
+msgstr "FTP连接失败"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy
+msgid "API token issued!"
+msgstr "无效的令牌传递"
 
 msgid "API?"
 msgstr ""
@@ -6881,7 +6892,7 @@ msgstr "选择一个有效的图像"
 msgid "Selected tasks cancelled!"
 msgstr "已成功更新"
 
-msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1065,6 +1065,10 @@ msgstr "基本任务"
 msgid "Batch Script"
 msgstr ""
 
+#, fuzzy
+msgid "Bearer API Tokens"
+msgstr "访问令牌"
+
 msgid "Bind DN"
 msgstr ""
 
@@ -1573,6 +1577,9 @@ msgstr "错误：无法下载内核"
 msgid "Copy from existing"
 msgstr "无法创建打印机"
 
+msgid "Copy this token now"
+msgstr ""
+
 msgid "Copyright"
 msgstr ""
 
@@ -1602,6 +1609,10 @@ msgstr "找不到临时文件名"
 
 msgid "Could not find temp filename"
 msgstr "找不到临时文件名"
+
+#, fuzzy
+msgid "Could not issue the token!"
+msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not link plugin assets"
@@ -1851,6 +1862,10 @@ msgstr "用户创建"
 
 msgid "Create tasking succeeded"
 msgstr ""
+
+#, fuzzy
+msgid "Created"
+msgstr "创建"
 
 msgid "Created By"
 msgstr "由...制作"
@@ -4248,6 +4263,10 @@ msgstr "是"
 msgid "Is a"
 msgstr "是"
 
+#, fuzzy
+msgid "Issue Token"
+msgstr "访问令牌"
+
 msgid "Issuer"
 msgstr ""
 
@@ -4490,6 +4509,10 @@ msgstr ""
 #, fuzzy
 msgid "Last Successful Ping"
 msgstr "成功"
+
+#, fuzzy
+msgid "Last Used"
+msgstr "主机创建"
 
 msgid "Last flush"
 msgstr ""
@@ -5055,6 +5078,9 @@ msgstr ""
 msgid "Name"
 msgstr "名称"
 
+msgid "Name for a new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "您必须输入一个名称"
@@ -5367,6 +5393,9 @@ msgstr ""
 #, fuzzy
 msgid "No token passed to authenticate this host"
 msgstr "没有找到主机定义图片"
+
+msgid "No tokens issued."
+msgstr ""
 
 msgid "No type information available for this column."
 msgstr ""
@@ -6851,6 +6880,9 @@ msgstr "选择一个有效的图像"
 #, fuzzy
 msgid "Selected tasks cancelled!"
 msgstr "已成功更新"
+
+msgid "Sent as an Authorization: Bearer header, on its own -- no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
 
 msgid "Serial Number"
 msgstr "序列号"
@@ -8428,6 +8460,9 @@ msgid "This is the catch-all site. Its members are in scope for everything, incl
 msgstr ""
 
 msgid "This is the minimum space for the host this is deploying to."
+msgstr ""
+
+msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * The API token store must stay a SEPARATE credential from users.uAPIToken.
+ *
+ * ADR 0027. The whole value of an APIToken comes from four properties that
+ * uAPIToken deliberately does not have: it is hashed at rest, shown once,
+ * individually revocable, and there can be many per user. Each of those is
+ * one line away from being lost, and losing any of them is silent -- a token
+ * that authenticates still authenticates whether or not its plaintext also
+ * sits in a column, whether or not its per-token kill switch is consulted,
+ * and whether or not Bearer still takes the old plaintext token as well.
+ *
+ * That silence is the reason this file exists. The probes that verified the
+ * feature end to end (scripts/background_scripts/probe_api_token_store.sh and
+ * probe_api_token_lifecycle.php) need a live database and a running server,
+ * so they cannot run in CI. These checks pin the same contract with no
+ * database, in the suite's usual style.
+ *
+ * WHAT IS PINNED, and the failure each one catches:
+ *
+ *  1. Bearer accepts APIToken and NOTHING else. The regression to fear is a
+ *     well-meaning "also accept uAPIToken for compatibility" -- which sounds
+ *     harmless and quietly restores a plaintext, UI-visible, non-revocable
+ *     credential as a standalone Bearer secret. #1324 shipped exactly that
+ *     shape; withdrawing it was the point of ADR 0027.
+ *  2. The credential is not base64-decoded. The legacy pair is base64 and
+ *     this is not, and mixing them is unfixable rather than merely wrong:
+ *     hex is itself valid base64, so base64_decode($hex, true) SUCCEEDS with
+ *     garbage. Encoded and raw are therefore indistinguishable and accepting
+ *     both would need two lookups per request.
+ *  3. Only the hash is stored. Pinned by asserting the column set and that
+ *     generate() sets no field from the plaintext except through hashToken().
+ *  4. The hash column is UNIQUE. Without it two rows can carry one hash and
+ *     load('hash') silently picks one -- so revoking a token could leave a
+ *     working duplicate.
+ *  5. Tokens carry >= 256 bits of CSPRNG output. This is the invariant the
+ *     decision NOT to salt rests on; shortening the token or making it
+ *     user-choosable voids that reasoning, and this is where that gets
+ *     noticed.
+ *  6. Deleting a user deletes its tokens, AND resolve() fails closed on an
+ *     ownerless token. Both, because the second is what makes a mistake in
+ *     the first survivable.
+ *  7. APIToken is not a REST class. A token-management API surface lets one
+ *     leaked credential mint another, so revoking the leaked one fixes
+ *     nothing.
+ *  8. The token form posts do not silently clobber the legacy card. Two
+ *     controls sharing one endpoint is the GH-987 defect class: the fields
+ *     the OTHER form owns are absent from the request, get read as 0, and
+ *     the user is told it saved.
+ *
+ * Usage: php tests/api-token-store.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('api-token-store');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$modelSrc = file_get_contents($web . '/lib/fog/apitoken.class.php');
+$routeSrc = file_get_contents($web . '/lib/router/route.class.php');
+$schemaSrc = file_get_contents($web . '/commons/schema.php');
+$pageSrc = file_get_contents($web . '/lib/pages/usermanagement.page.php');
+
+// ---------------------------------------------------------------------------
+// 1. Bearer accepts APIToken and nothing else.
+// ---------------------------------------------------------------------------
+$bearerBody = '';
+if (preg_match(
+    '/private static function _testBearer\(\)\s*\{(.*?)\n    \}/s',
+    $routeSrc,
+    $m
+)) {
+    $bearerBody = $m[1];
+}
+
+$t->check('_testBearer() exists', '' !== $bearerBody);
+$t->check(
+    '_testBearer() resolves through APIToken',
+    (bool)preg_match('/APIToken::resolve\s*\(/', $bearerBody)
+);
+// The old shape looked the user up by uAPIToken. Any of these reappearing in
+// this function means the withdrawn credential is back.
+foreach (['uAPIToken', "'token'", 'getUserByToken', 'APIToken::class'] as $gone) {
+    $t->check(
+        "_testBearer() does not reach for $gone",
+        false === strpos($bearerBody, $gone)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. The presented credential is passed through verbatim.
+// ---------------------------------------------------------------------------
+$credBody = '';
+if (preg_match(
+    '/private static function _bearerCredential\(\)\s*\{(.*?)\n    \}/s',
+    $routeSrc,
+    $m
+)) {
+    $credBody = $m[1];
+}
+$t->check('_bearerCredential() exists', '' !== $credBody);
+$t->check(
+    '_bearerCredential() does not base64-decode',
+    false === strpos($credBody, 'base64_decode')
+);
+
+// Behavioural, not just textual: drive the real function through $_SERVER.
+$cred = new \ReflectionMethod('FOG\\Route', '_bearerCredential');
+$cred->setAccessible(true);
+
+$sample = 'fog_' . str_repeat('ab', 64);
+$cases = [
+    // header value                        expected return
+    ['Bearer ' . $sample,                  $sample],
+    ['bearer ' . $sample,                  $sample],
+    ['Bearer   ' . $sample . '  ',         $sample],
+    // Presented but empty: an attempt, so '' rather than null.
+    ['Bearer',                             ''],
+    ['Bearer ',                            ''],
+    // Not the Bearer scheme -> not our credential, fall through.
+    ['Bearer' . $sample,                   null],
+    ['Basic ' . base64_encode('a:b'),      null],
+    ['',                                   null]
+];
+foreach ($cases as $i => $case) {
+    list($header, $want) = $case;
+    $_SERVER['HTTP_AUTHORIZATION'] = $header;
+    unset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+    $got = $cred->invoke(null);
+    $t->check(
+        sprintf(
+            '_bearerCredential(%s) === %s',
+            var_export($header, true),
+            var_export($want, true)
+        ),
+        $got === $want
+    );
+}
+unset($_SERVER['HTTP_AUTHORIZATION']);
+
+// A base64 of a plausible token must come back UNCHANGED. If anyone
+// reintroduces decoding, this is the check that fails.
+$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . base64_encode($sample);
+$t->check(
+    'a base64 value is returned as sent, not decoded',
+    $cred->invoke(null) === base64_encode($sample)
+);
+unset($_SERVER['HTTP_AUTHORIZATION']);
+
+// ---------------------------------------------------------------------------
+// 3/5. Only the hash is stored; the token is CSPRNG and long enough.
+// ---------------------------------------------------------------------------
+$t->check(
+    'hashToken() is sha256',
+    (bool)preg_match("/hash\(\s*'sha256'/", $modelSrc)
+);
+$t->check(
+    'generate() uses random_bytes',
+    (bool)preg_match('/random_bytes\(\s*(\d+)\s*\)/', $modelSrc, $rb)
+);
+$bytes = isset($rb[1]) ? (int)$rb[1] : 0;
+$t->check(
+    "generate() draws >= 32 bytes of entropy (got $bytes)",
+    $bytes >= 32
+);
+$t->check(
+    'generate() stores the hash, never the token',
+    (bool)preg_match("/->set\(\s*'hash',\s*self::hashToken\(\\\$token\)\s*\)/", $modelSrc)
+    && !preg_match("/->set\(\s*'[a-z]+',\s*\\\$token\s*\)/i", $modelSrc)
+);
+$t->check(
+    'generate() refuses to hand back a token whose row did not save',
+    (bool)preg_match('/if\s*\(!\$row->save\(\)\)\s*\{\s*(\/\/[^\n]*\n\s*)*return false;/', $modelSrc)
+);
+
+// No column may hold the plaintext. `hash` is the only secret-bearing field.
+$fields = [];
+if (preg_match('/\$databaseFields = \[(.*?)\];/s', $modelSrc, $m)) {
+    preg_match_all("/'([a-zA-Z]+)' =>/", $m[1], $f);
+    $fields = $f[1];
+}
+$t->check('model declares a hash field', in_array('hash', $fields, true));
+$t->check(
+    'model declares no plaintext token field',
+    !in_array('token', $fields, true) && !in_array('secret', $fields, true)
+);
+$t->check(
+    'model declares a per-token enabled field',
+    in_array('enabled', $fields, true)
+);
+
+// ---------------------------------------------------------------------------
+// 4. The hash column is unique, so revocation cannot leave a twin.
+// ---------------------------------------------------------------------------
+$create = '';
+if (preg_match('/CREATE TABLE IF NOT EXISTS `apiTokens`(.*?)ROW_FORMAT/s', $schemaSrc, $m)) {
+    $create = $m[1];
+}
+$t->check('schema creates apiTokens', '' !== $create);
+$t->check(
+    'apiTokens.atHash is UNIQUE',
+    (bool)preg_match('/UNIQUE KEY.*?atHash/s', $create)
+);
+$t->check(
+    'apiTokens.atHash is wide enough for sha256 hex',
+    (bool)preg_match('/atHash`?\s+CHAR\(64\)/i', $create)
+);
+$t->check(
+    'apiTokens is indexed by owner',
+    (bool)preg_match('/KEY.*?atUserID/s', $create)
+);
+
+// ---------------------------------------------------------------------------
+// 6. Cascade on user delete, and fail closed if it is ever missed.
+// ---------------------------------------------------------------------------
+// Anchored on the $findWhere assignment rather than on `case 'user':`,
+// which also matches an unrelated switch earlier in the file.
+$userCase = '';
+if (preg_match(
+    '/case \'user\':\s*\n\s*\$findWhere = \[\'userID\' => \$itemIDs\];(.*?)break;/s',
+    $routeSrc,
+    $m
+)) {
+    $userCase = $m[1];
+}
+$t->check('the user delete cascade block was found', '' !== $userCase);
+$t->check(
+    'deleting a user cascades to its api tokens',
+    (bool)preg_match('/[\'"]apitoken[\'"]\s*=>/i', $userCase)
+);
+$t->check(
+    'resolve() refuses a token whose owner is gone',
+    (bool)preg_match(
+        '/\$user\s*=\s*self::getClass\(\s*\'User\'.*?if\s*\(!\$user->isValid\(\)\)\s*\{(.*?)return null;/s',
+        $modelSrc
+    )
+);
+$t->check(
+    'resolve() consults the per-token enabled flag',
+    (bool)preg_match("/\\\$row->get\('enabled'\)/", $modelSrc)
+);
+
+// ---------------------------------------------------------------------------
+// 7. Not reachable as a REST resource.
+// ---------------------------------------------------------------------------
+$validClasses = [];
+if (preg_match('/\$validClasses = \[(.*?)\];/s', $routeSrc, $m)) {
+    preg_match_all("/'([a-z0-9_]+)'/i", $m[1], $c);
+    $validClasses = array_map('strtolower', $c[1]);
+}
+$t->check('route class list was parsed', count($validClasses) > 10);
+$t->check(
+    'apitoken is not a REST class',
+    !in_array('apitoken', $validClasses, true)
+);
+
+// ---------------------------------------------------------------------------
+// 8. The token form does not clobber the legacy card (GH-987 shape).
+// ---------------------------------------------------------------------------
+$apiPost = '';
+if (preg_match('/function userAPIPost\((.*?)\n    \}/s', $pageSrc, $m)) {
+    $apiPost = $m[1];
+}
+$t->check('userAPIPost() exists', '' !== $apiPost);
+$t->check(
+    'userAPIPost() hands off to the token handler before touching uAPIToken',
+    (bool)preg_match(
+        '/_userBearerTokensPost\(.*?\)(.*?)return;/s',
+        $apiPost
+    )
+);
+// The READ of the legacy field, not the word -- it also appears in the
+// comment that explains why the ordering matters.
+$legacyPos = strpos($apiPost, "\$_POST['apienabled']");
+$bearerPos = strpos($apiPost, '$this->_userBearerTokensPost(');
+$t->check(
+    'the token handler runs first, so absent legacy fields are never read as 0',
+    false !== $bearerPos
+    && (false === $legacyPos || $bearerPos < $legacyPos)
+);
+// Posted token ids must be constrained to the user whose page this is,
+// otherwise one user's form deletes another's credentials.
+$t->check(
+    'token management is scoped to the owning user',
+    (bool)preg_match("/'userID'\s*=>\s*\\\$uid/", $pageSrc)
+);
+
+$t->finish();

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -282,10 +282,76 @@ $t->check(
     && (false === $legacyPos || $bearerPos < $legacyPos)
 );
 // Posted token ids must be constrained to the user whose page this is,
-// otherwise one user's form deletes another's credentials.
+// otherwise one user's form deletes another's credentials. The manage loop
+// iterates the OWNER'S tokens and matches posted ids against them, rather
+// than loading whatever id was posted.
 $t->check(
-    'token management is scoped to the owning user',
-    (bool)preg_match("/'userID'\s*=>\s*\\\$uid/", $pageSrc)
+    'token management iterates the owning user\'s tokens',
+    (bool)preg_match(
+        '/getClass\(\'APITokenManager\'\)\s*\n?\s*->forUser\(\$uid\)/',
+        $pageSrc
+    )
+);
+$mgrSrc = file_get_contents($web . '/lib/fog/apitokenmanager.class.php');
+$t->check(
+    'forUser() filters on the owner column',
+    (bool)preg_match('/WHERE `atUserID` = :uid/', $mgrSrc)
+);
+
+// ---------------------------------------------------------------------------
+// 9. The two form-plumbing bugs a real deploy found, which no source read
+// would have.
+//
+// Both were invisible to every other check in this file: the page rendered,
+// the buttons drew, and clicking them did nothing whatsoever. Pinned because
+// the failure mode is silence -- no error, no log line, no failed request.
+// ---------------------------------------------------------------------------
+$jsSrc = file_get_contents(
+    $web . '/management/js/fog/user/fog.user.edit.js'
+);
+
+// (a) FOG has no generic binding that picks a tab form up. disableFormDefaults()
+//     only suppresses the native submit; every card is wired by hand in its
+//     page's JS, and an unwired one renders perfectly and does nothing.
+$t->check(
+    'the token card form is wired in JS',
+    false !== strpos($jsSrc, '#user-apitoken-form')
+);
+$t->check(
+    'the save button is wired',
+    false !== strpos($jsSrc, '#apitoken-send')
+);
+$t->check(
+    'the issue button is wired',
+    false !== strpos($jsSrc, '#issuetoken')
+);
+
+// (b) processForm() posts `new FormData(form)`, and FormData omits submit
+//     buttons unless the submitter is handed to it. So the save discriminator
+//     has to be a real field, and creation cannot be a submit button at all.
+$t->check(
+    'the save discriminator is a posted field, not a button name',
+    false !== strpos($pageSrc, "filter_input(INPUT_POST, 'tokenaction')")
+    && false !== strpos($pageSrc, 'name="tokenaction" value="manage"')
+);
+$t->check(
+    'the issue control is not a submit button',
+    false !== strpos($pageSrc, 'type="button" id="issuetoken"')
+);
+$t->check(
+    'issuing a token is its own CSRF-gated endpoint',
+    (bool)preg_match(
+        '/public function issueAPIToken\(\)\s*\{\s*(\/\/[^\n]*\n\s*)*self::checkAuthAndCSRF\(\);/',
+        $pageSrc
+    )
+);
+
+// The plaintext must reach the browser exactly once, in the reply to the
+// click that created it. Anything that persists it across renders -- a
+// session key, a data attribute -- defeats show-once.
+$t->check(
+    'the plaintext is not carried in the session',
+    false === strpos($pageSrc, 'fog_new_api_token')
 );
 
 $t->finish();


### PR DESCRIPTION
Implements [ADR 0027](../blob/feat-api-token-store/docs/adr/0027-api-tokens-are-a-separate-hashed-credential.md), merged in #1327.

## What this adds

A new `apiTokens` table and `APIToken` model, and `Authorization: Bearer` repointed at it. A Bearer credential is now a distinct thing from `users.uAPIToken` rather than a second spelling of it:

| Property | `uAPIToken` (fog-user-token) | `APIToken` (Bearer) |
|---|---|---|
| At rest | plaintext | SHA-256 |
| Visible in the UI | yes, any time | once, at creation |
| Per user | exactly one | as many as you like |
| Revocable individually | no | yes, per-token enabled flag |
| Independent of `uAllowAPI` | n/a | yes |
| Needs `fog-api-token` alongside | yes | no |

Tokens carry a `fog_` prefix so they are recognisable in a log or a paste, and so leaked-credential scanners have something to match.

## What does not change

`users.uAPIToken` is **untouched**. It stays plaintext, stays visible in the UI, and keeps working as `fog-user-token` beside `fog-api-token`. Nothing has to migrate, and no existing client that uses the legacy pair is affected.

## Behaviour change for one interim case

#1324 accepted `uAPIToken` as a standalone Bearer value. **That is withdrawn.** A plaintext, UI-visible, non-revocable secret is exactly what a Bearer credential must not be, so accepting it there gave the scheme none of the properties in the table above. The legacy two-header pair remains the supported path for that token.

This is worth flagging explicitly for anyone who adopted Bearer between #1324 and this PR: swap to a token issued from the API tab, or fall back to the header pair.

## Design notes

- **Unsalted SHA-256, deliberately.** A salt defeats precomputation, which needs a guessable input; these are 512 bits of CSPRNG output, so a salt protects nothing while costing the ability to look a token up at all. The full reasoning, and the invariant it rests on, are in `APIToken::hashToken()`'s docblock. If a token is ever shortened or made user-choosable that reasoning is void — the test enforces the entropy floor so that gets noticed.
- **`APIToken` is not in `Route::$validClasses`.** A token-management REST surface lets one leaked credential mint another, so revoking the one that leaked would fix nothing. Creation and revocation are UI actions, behind a session and CSRF.
- **`userAPIPost()` routes to the token handler first and returns.** Both cards post to the same tab URL; falling through would read the legacy card's absent fields as "unticked" and "empty", silently disabling `fog-user-token` and wiping `uAPIToken` as a side effect of issuing a Bearer token. That is the GH-987 control-type defect class exactly.
- **`resolve()` fails closed on an ownerless token** as well as cascading on user delete. The cascade is the fix; the fail-closed is what makes a mistake in it survivable.

## Verification

Against the local 1.6 lab, over real HTTP and through the model. Probes are committed at `scripts/background_scripts/probe_api_token_store.sh` and `probe_api_token_lifecycle.php` in the maintainer's script tree.

```
== 1. new APIToken, standalone Bearer, raw ==
  ok    GET /host with Bearer fog_...                              200
  ok    GET /user/1 with Bearer fog_...                            200
== 2. legacy pair still works, untouched ==
  ok    GET /host with fog-api-token + fog-user-token              200
== 3. uAPIToken is no longer a Bearer credential ==
  ok    Bearer <uAPIToken raw>                                     401
  ok    Bearer <uAPIToken base64>                                  401
== 4. malformed and absent Bearer ==
  ok    no Authorization header                                    403
  ok    bare 'Bearer' with no value                                401
  ok    'Bearertoken' (no delimiter)                               403
  ok    garbage Bearer value                                       401
== 5. secrets are not echoed back ==
  ok    GET /user/1 omits 'token'                                  absent
  ok    GET /user/1 omits 'password'                               absent

passed 11, failed 0
```

```
== A. per-token enabled flag is independent of uAllowAPI ==
  ok    enabled token resolves                                   117
  ok    disabled token refused                                   NULL
  ok    ...while the user is still API-enabled                   '1'
  ok    re-enabled token resolves again                          117
== B. lastUsed is stamped, and never as an empty date ==
  ok    atLastUsed is set                                        true
  ok    atLastUsed is a real datetime, not an empty string       true
== C. cascade on user delete ==
  ok    token exists before delete                               1
  ok    tokens removed with their owner                          0
  ok    orphaned token fails closed                              NULL

passed 9, failed 0
```

`tests/api-token-store.test.php` pins the same contract in CI, where no database is available — 39 checks. Mutation-verified: reintroducing `base64_decode`, dropping the cascade entry, removing either guard in `resolve()`, dropping `UNIQUE` from `atHash`, and shortening the token are all caught.

Full suite: **136 passed, 0 failed** on PHP 8.3.33.

## Schema

Adds element `// 359` (`apiTokens`) and bumps `FOG_SCHEMA` to match, with the manifest entry in `schema-expected.php`.

## OpenAPI

No REST route changed, so `OpenAPI::document()` still describes the API correctly. The `bearerAuth` scheme it already advertises (added in #1324) is now backed by this store rather than by `uAPIToken`.

## Downstream

None. `Route::$validClasses` is unchanged, so FogApi's hardcoded class list needs no sync.

## Follow-up

`docs/kb/integrations/api.md` in fog-docs describes the Bearer token as `uAPIToken` sent raw. That needs updating to the new format and the issue-from-the-UI flow — I'll open that PR separately so this one isn't gated on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqpPXAk7bEm8huH9WkiGk6
