### PR TITLE
feat(api): central API token pane, on its own permission node

### DIFF
--- a/packages/web/lib/fog/apitoken.class.php
+++ b/packages/web/lib/fog/apitoken.class.php
@@ -162,7 +162,111 @@ class APIToken extends FOGController
             // the user would have no way to tell.
             return false;
         }
+        $row->audit(Audit::TOKEN_ISSUED, 'apitoken.create');
         return $token;
+    }
+
+    /**
+     * Enables or disables this token, recording the change.
+     *
+     * Here rather than at the call sites because there are two of them --
+     * the user's API tab and the central pane -- and an audit trail with a
+     * hole in it is worse than none: it invites the conclusion that nothing
+     * happened.
+     *
+     * @param bool $enabled What to set it to.
+     *
+     * @return bool Whether anything changed.
+     */
+    public function setEnabled($enabled)
+    {
+        $want = $enabled ? '1' : '0';
+        if ($want === (string)$this->get('enabled')) {
+            // Not a no-op worth recording. A save button that touches
+            // nothing should not fill the audit log with rows saying so.
+            return false;
+        }
+        $this->set('enabled', $want)->save();
+        $this->audit(
+            $enabled ? Audit::TOKEN_ENABLED : Audit::TOKEN_DISABLED,
+            'apitoken.edit'
+        );
+        return true;
+    }
+
+    /**
+     * Deletes this token, recording it first.
+     *
+     * Recorded before the destroy because afterwards there is nothing left
+     * to read the owner and name off, and nothing else in the system
+     * remembers that this token existed. What that ordering costs, and why
+     * the row is shaped the way it is, is in audit() below.
+     *
+     * @return void
+     */
+    public function revoke()
+    {
+        $this->audit(Audit::TOKEN_DELETED, 'apitoken.delete');
+        $this->destroy();
+    }
+
+    /**
+     * Writes one audit row about this token.
+     *
+     * WHY THE SUBJECT IS THE TOKEN AND THE OWNER IS IN THE TEXT, which is
+     * the opposite of what it looks like it should be.
+     *
+     * Audit::record() sets itself as Audit::$_current, and
+     * FOGController::destroy() calls Audit::identify() -- which REVISES
+     * $_current in place, stamping the destroyed object's own type, id and
+     * name over whatever was there (ADR 0021 Decision 7: a delete's header
+     * is the only record it leaves). So a row written here naming the OWNER
+     * as its subject silently becomes a row naming the TOKEN, moments
+     * later, with nothing logged and no error.
+     *
+     * Reordering does not fix it. Recording AFTER destroy() works for one
+     * token and corrupts the previous one in a loop, because the next
+     * destroy()'s identify() reaches back into the row the last record()
+     * left as $_current -- which is exactly what the central pane's
+     * multi-delete does.
+     *
+     * So every row here uses the subject identify() would impose anyway.
+     * The two agree, the rewrite is a no-op, and the owner goes in `text`,
+     * which identify() does not touch. All four token events are written
+     * the same way so the log reads uniformly rather than the delete being
+     * shaped differently from its siblings.
+     *
+     * The token and its hash are never recorded: a credential does not go
+     * in a log (#1261/#1262).
+     *
+     * @param string $type       An Audit TOKEN_* constant.
+     * @param string $permission The permission this exercised.
+     *
+     * @return void
+     */
+    public function audit($type, $permission)
+    {
+        $ownerID = (int)$this->get('userID');
+        $owner = self::getClass('User', $ownerID);
+        Audit::record(
+            [
+                'type' => $type,
+                'subjectType' => 'apitoken',
+                'subjectID' => (int)$this->get('id'),
+                'subjectLabel' => (string)$this->get('name'),
+                'permission' => $permission,
+                // The fact the subject cannot carry. A token id means
+                // nothing once the row is gone; whose credential it was is
+                // the whole question anybody brings to this log.
+                'text' => sprintf(
+                    'owner=%s (%d)',
+                    $owner->isValid() ? $owner->get('name') : '(deleted user)',
+                    $ownerID
+                ),
+                'affectedCount' => 1,
+                'renderable' => 1
+            ]
+        );
     }
 
     /**

--- a/packages/web/lib/fog/apitokenmanager.class.php
+++ b/packages/web/lib/fog/apitokenmanager.class.php
@@ -78,6 +78,117 @@ class APITokenManager extends FOGManagerController
         }
         return $tokens;
     }
+
+    /**
+     * Every token on the server the acting user is allowed to see.
+     *
+     * The question the per-user tab cannot answer: "what credentials exist
+     * here, and which has nothing touched in months". Returns plain rows
+     * rather than model objects because this is a read-only inventory of
+     * potentially hundreds, and the owner's name comes from a join that no
+     * model carries.
+     *
+     * SITE SCOPING. A scoped admin must not learn the account names and
+     * integration names of users outside their scope -- an inventory is a
+     * disclosure surface even when every value in it is a hash. The tri-state
+     * here is the trap, and it is the one this codebase has been bitten by
+     * before: allInScopeIDs() returns [] BOTH for "this user is unscoped"
+     * and for "this user is in no site", which mean opposite things. So
+     * isUnscoped() is asked FIRST, and only after it says no does an empty
+     * list get read as "sees nothing".
+     *
+     * @param int $actingUserID Whose visibility applies.
+     *
+     * @return array Rows: id, userID, userName, name, enabled, createdTime,
+     *               createdBy, lastUsed. Empty when the user may see none.
+     */
+    public function visibleTo($actingUserID)
+    {
+        $actingUserID = (int)$actingUserID;
+        $where = '';
+
+        if (!SiteScope::isUnscoped($actingUserID)) {
+            $ids = SiteScope::allInScopeIDs('user', $actingUserID);
+            if (count($ids) < 1) {
+                // Scoped, and in scope of nothing. Deny rather than fall
+                // through to an unfiltered query -- the empty list means
+                // "no users", not "no filter".
+                return [];
+            }
+            $where = ' WHERE `t`.`atUserID` IN ('
+                . implode(',', array_map('intval', $ids))
+                . ')';
+        }
+
+        // LEFT JOIN, not INNER: a token whose owner has gone is exactly the
+        // row an administrator most needs to see. resolve() already refuses
+        // such a token, but refusing it silently and never showing it would
+        // leave a credential nobody can find in order to delete it.
+        $sql = 'SELECT `t`.`atID`, `t`.`atUserID`, `t`.`atName`,'
+            . ' `t`.`atEnabled`, `t`.`atCreatedTime`, `t`.`atCreatedBy`,'
+            . ' `t`.`atLastUsed`, `u`.`uName`'
+            . ' FROM `apiTokens` `t`'
+            . ' LEFT JOIN `users` `u` ON `u`.`uID` = `t`.`atUserID`'
+            . $where
+            . ' ORDER BY `u`.`uName` ASC, `t`.`atCreatedTime` DESC';
+
+        $rows = self::$DB->query($sql)->fetch('', 'fetch_all')->get();
+
+        $out = [];
+        foreach ((array)$rows as $row) {
+            $out[] = [
+                'id' => (int)$row['atID'],
+                'userID' => (int)$row['atUserID'],
+                // The owner is gone but the token is not. Named rather than
+                // blanked so the row is actionable.
+                'userName' => (string)($row['uName'] ?? '') !== ''
+                    ? (string)$row['uName']
+                    : _('(deleted user)'),
+                'name' => (string)$row['atName'],
+                'enabled' => '1' === (string)$row['atEnabled'],
+                'createdTime' => (string)$row['atCreatedTime'],
+                'createdBy' => (string)$row['atCreatedBy'],
+                'lastUsed' => trim((string)$row['atLastUsed'])
+            ];
+        }
+        return $out;
+    }
+
+    /**
+     * One token, but only if the acting user is allowed to touch it.
+     *
+     * The central pane posts ids from a form, and a form is an untrusted
+     * list. Every mutation goes through this rather than loading the posted
+     * id directly, so a scoped admin cannot disable or delete a credential
+     * belonging to a user they cannot even see.
+     *
+     * @param int $tokenID      The token.
+     * @param int $actingUserID Whose visibility applies.
+     *
+     * @return APIToken|null The token, or null when out of scope/absent.
+     */
+    public function visibleToken($tokenID, $actingUserID)
+    {
+        $tokenID = (int)$tokenID;
+        if ($tokenID < 1) {
+            return null;
+        }
+        $token = self::getClass('APIToken', $tokenID);
+        if (!$token->isValid()) {
+            return null;
+        }
+        $actingUserID = (int)$actingUserID;
+        if (SiteScope::isUnscoped($actingUserID)) {
+            return $token;
+        }
+        $ids = SiteScope::allInScopeIDs('user', $actingUserID);
+        // Same tri-state as visibleTo(): scoped with an empty list sees
+        // nothing, so in_array against [] correctly denies.
+        if (!in_array((int)$token->get('userID'), $ids, true)) {
+            return null;
+        }
+        return $token;
+    }
 }
 
 /*

--- a/packages/web/lib/fog/audit.class.php
+++ b/packages/web/lib/fog/audit.class.php
@@ -80,6 +80,20 @@ class Audit extends FOGBase
     const LOGIN_FAILED = 'auth.login.failed';
     const TOKEN_REJECTED = 'auth.token.rejected';
     const API_DENIED = 'auth.api.denied';
+    /*
+     * API token lifecycle (ADR 0027). Recorded because the credential
+     * itself cannot be: the table holds only a hash, so once a token is
+     * gone there is no artefact left to reason about. These rows are the
+     * only record that it ever existed, who minted it and who took it away.
+     *
+     * TOKEN_ISSUED carries the OWNER as its subject and the issuer as
+     * createdBy, so "an admin minted a credential for somebody else" is
+     * never ambiguous after the fact.
+     */
+    const TOKEN_ISSUED = 'apitoken.issued';
+    const TOKEN_ENABLED = 'apitoken.enabled';
+    const TOKEN_DISABLED = 'apitoken.disabled';
+    const TOKEN_DELETED = 'apitoken.deleted';
     /**
      * How much of a failure reason markOutcome() stores.
      */

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -140,7 +140,23 @@ class Authorization extends FOGBase
      */
     const GLOBAL_SUB_OVERRIDES = [
         'kernelfetch' => 'settings.edit',
-        'initrdfetch' => 'settings.edit'
+        'initrdfetch' => 'settings.edit',
+        // The API token pane lives under FOG Configuration for where an
+        // administrator looks, not for who may see it: it is gated on
+        // apitoken.*, not on that node's own permission. Overridden here
+        // rather than by moving the page, because the alternative is
+        // settings.edit deciding who can read a census of every credential
+        // on the server -- and SIX page nodes already map onto that one
+        // permission.
+        //
+        // apitokens resolves to view for BOTH verbs; a global override
+        // cannot vary by method. That is deliberate rather than a
+        // limitation worked around: reaching the pane needs view, and the
+        // edit and delete grants are checked per action inside
+        // apitokensPost(), which is the only place that can tell an
+        // enable from a revoke anyway.
+        'apitokens' => 'apitoken.view',
+        'issueapitokenfor' => 'apitoken.create'
     ];
     /**
      * API route name => permission action, for the class-parameterized
@@ -373,6 +389,24 @@ class Authorization extends FOGBase
             'printer' => ['view', 'create', 'edit', 'delete'],
             'module' => ['view', 'create', 'edit', 'delete'],
             'user' => ['view', 'create', 'edit', 'delete'],
+            // API tokens are their own node rather than an extension of
+            // user.*, because "can edit users" and "can inventory every API
+            // credential on this server" are different powers and only one
+            // of them is a credential census.
+            //
+            // The four actions are deliberately separate, and delete is the
+            // one to hand out narrowly: DISABLE IS REVERSIBLE AND DELETE IS
+            // NOT. A mass-disable is downtime somebody undoes with one
+            // click; a mass-delete means every integration on the estate
+            // needs a fresh token minted and redeployed to wherever it is
+            // configured, and nothing can bring the old ones back. Same
+            // grant for both would price them the same.
+            //
+            // create is issuing on behalf of another user -- see
+            // FOGConfigurationPage::apitokens(), which hands the plaintext
+            // to the issuer rather than the owner, which is why it is not
+            // folded into edit.
+            'apitoken' => ['view', 'create', 'edit', 'delete'],
             'usergroup' => ['view', 'create', 'edit', 'delete'],
             'role' => ['view', 'create', 'edit', 'delete'],
             // Sites came in from the site plugin. The node keeps the name

--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -886,6 +886,17 @@ abstract class FOGPage extends FOGBase
                     'certificates' => _('Certificates'),
                     'pxemenu' => self::$foglang['PXEBootMenu'],
                     'maclist' => self::$foglang['MACAddrList'],
+                    // Beside FOG Settings, which is where the server-wide
+                    // fog-api-token lives -- so both halves of API
+                    // credentials are found in one place.
+                    //
+                    // Here as well as in SubMenuData::subMenu() for the
+                    // reason spelled out against secureBoot above: that hook
+                    // carries the same 'about' list and never runs, so an
+                    // entry added only there is invisible. Both copies are
+                    // kept in step so the dead one does not become a
+                    // different menu that somebody later revives.
+                    'apitokens' => _('API Tokens'),
                     'settings' => self::$foglang['FOGSettings'],
                     'logviewer' => self::$foglang['LogViewer'],
                     'config' => self::$foglang['ConfigSave']

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 359);
-        define('FOG_BCACHE_VER', 303);
+        define('FOG_BCACHE_VER', 304);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -96,6 +96,10 @@ class SubMenuData extends Hook
                     'customizepxe' => self::$foglang['PXEConfiguration'],
                     'newMenu' => self::$foglang['NewMenu'],
                     'maclist' => self::$foglang['MACAddrList'],
+                    // Beside FOG Settings, which is where the server-wide
+                    // fog-api-token lives -- so both halves of API
+                    // credentials are found in one place.
+                    'apitokens' => _('API Tokens'),
                     'settings' => self::$foglang['FOGSettings'],
                     'logviewer' => self::$foglang['LogViewer'],
                     'config' => self::$foglang['ConfigSave']

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -1236,6 +1236,343 @@ class FOGConfigurationPage extends FOGPage
         $this->jsonSend($code, $msg);
     }
     /**
+     * The estate-wide API token inventory.
+     *
+     * The per-user API tab answers "what does this user have". This answers
+     * the question that actually drives revocation: "what credentials exist
+     * on this server, and which has nothing touched in months". Without it
+     * that is only answerable by opening every user in turn, which is why
+     * atLastUsed was worth recording in the first place.
+     *
+     * Sits under FOG Configuration because the server-wide fog-api-token
+     * already lives there, so it is where an administrator already goes for
+     * API credentials.
+     *
+     * WHAT IT CANNOT DO, because people will ask: show a token. The table
+     * holds hashes. This is inventory and revocation, never recovery.
+     *
+     * @return void
+     */
+    public function apitokens()
+    {
+        $this->title = _('API Tokens');
+
+        if (!Authorization::can('apitoken.view')) {
+            echo $this->_box(
+                _('API Tokens'),
+                '<p>' . _('You do not have permission to view API tokens.')
+                . '</p>',
+                ['color' => 'warning']
+            );
+            return;
+        }
+
+        $uid = (int)self::$FOGUser->get('id');
+        $tokens = self::getClass('APITokenManager')->visibleTo($uid);
+
+        $mayEdit = Authorization::can('apitoken.edit');
+        $mayDelete = Authorization::can('apitoken.delete');
+        $mayCreate = Authorization::can('apitoken.create');
+
+        $body = '<p>'
+            . _('Every API token on this server. Tokens are stored hashed '
+                . '&mdash; a token cannot be shown again after it is issued, '
+                . 'so this page can revoke one but never recover it.')
+            . '</p>';
+
+        // Filled by the JS from issueAPITokenFor()'s reply. Only ever
+        // populated in the response to the click that minted the token; it
+        // is not carried in the session and not re-rendered later.
+        if ($mayCreate) {
+            $body .= '<div class="alert alert-success d-none" '
+                . 'id="central-token-fresh">';
+            $body .= '<h5>' . _('Copy this token now') . '</h5>';
+            $body .= '<p>'
+                . _('This is the only time it will be shown. Hand it to the '
+                    . 'person or service it was issued for &mdash; you are '
+                    . 'seeing a credential that belongs to another account.')
+                . '</p>';
+            $body .= '<input type="text" class="form-control" readonly '
+                . 'onclick="this.select();" id="central-token-fresh-value"/>';
+            $body .= '</div>';
+        }
+
+        $body .= '<table class="table table-sm" id="apitoken-table">';
+        $body .= '<thead><tr>'
+            . '<th>' . _('User') . '</th>'
+            . '<th>' . _('Name') . '</th>'
+            . '<th>' . _('Created') . '</th>'
+            . '<th>' . _('Created By') . '</th>'
+            . '<th>' . _('Last Used') . '</th>'
+            . '<th>' . _('Enabled') . '</th>';
+        if ($mayDelete) {
+            $body .= '<th>' . _('Delete') . '</th>';
+        }
+        $body .= '</tr></thead><tbody>';
+
+        if (count($tokens) < 1) {
+            $body .= '<tr><td colspan="7">'
+                . _('No API tokens have been issued.')
+                . '</td></tr>';
+        }
+
+        foreach ($tokens as $token) {
+            $body .= '<tr>';
+            $body .= '<td>' . \Initiator::e($token['userName']) . '</td>';
+            $body .= '<td>' . \Initiator::e($token['name']) . '</td>';
+            $body .= '<td>' . \Initiator::e($token['createdTime']) . '</td>';
+            $body .= '<td>' . \Initiator::e($token['createdBy']) . '</td>';
+            // "Never" is a different fact from "used at the epoch", and the
+            // column exists precisely to tell them apart -- so an empty
+            // value is spelled out rather than rendered as a blank cell the
+            // reader has to interpret.
+            $body .= '<td>'
+                . ('' === $token['lastUsed']
+                    ? _('Never')
+                    : \Initiator::e($token['lastUsed']))
+                . '</td>';
+            $body .= '<td><input type="checkbox" name="tokenenabled[]" '
+                . 'value="' . $token['id'] . '"'
+                . ($token['enabled'] ? ' checked' : '')
+                . ($mayEdit ? '' : ' disabled')
+                . '/></td>';
+            if ($mayDelete) {
+                $body .= '<td><input type="checkbox" name="tokendelete[]" '
+                    . 'value="' . $token['id'] . '"/></td>';
+            }
+            $body .= '</tr>';
+        }
+        $body .= '</tbody></table>';
+
+        if ($mayCreate) {
+            $body .= '<hr/>';
+            $body .= '<h5>' . _('Issue a token on behalf of a user') . '</h5>';
+            $body .= '<p>'
+                . _('For service accounts and unattended integrations. The '
+                    . 'token acts with that user\'s roles, and the audit log '
+                    . 'records that you issued it for them.')
+                . '</p>';
+            $body .= '<div class="input-group">';
+            $body .= self::getClass('UserManager')
+                ->buildSelectBox('', 'issuefor', 'id');
+            $body .= '<input type="text" class="form-control" '
+                . 'id="centraltokenname" placeholder="'
+                . _('Name for the new token') . '"/>';
+            $body .= self::makeButton(
+                'centralissuetoken',
+                _('Issue Token'),
+                'btn btn-secondary'
+            );
+            $body .= '</div>';
+        }
+
+        $footer = '';
+        if ($mayEdit || $mayDelete) {
+            $footer = self::makeButton(
+                'apitoken-central-send',
+                _('Update'),
+                'btn btn-primary float-end'
+            );
+        }
+
+        echo '<form class="form-horizontal" method="post" action="'
+            . $this->formAction
+            . '" id="apitoken-central-form">';
+        echo $this->_box(_('API Tokens'), $body, ['footer' => $footer]);
+        echo '</form>';
+    }
+
+    /**
+     * Applies enable/disable and delete from the central pane.
+     *
+     * Every id is resolved through visibleToken(), never loaded directly:
+     * the ids arrive from a form, and a scoped administrator must not be
+     * able to touch a credential belonging to a user they cannot see just
+     * by posting its number.
+     *
+     * @return void
+     */
+    public function apitokensPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+
+        $uid = (int)self::$FOGUser->get('id');
+        $manager = self::getClass('APITokenManager');
+
+        $keepEnabled = array_map(
+            'intval',
+            (array)($_POST['tokenenabled'] ?? [])
+        );
+        $toDelete = array_map(
+            'intval',
+            (array)($_POST['tokendelete'] ?? [])
+        );
+
+        $mayEdit = Authorization::can('apitoken.edit');
+        $mayDelete = Authorization::can('apitoken.delete');
+
+        $deleted = 0;
+        $changed = 0;
+
+        // Deletes first, so a token ticked for both does not get an
+        // enable/disable row written about it moments before it ceases to
+        // exist -- which would read, later, as two administrators
+        // disagreeing about one credential.
+        if ($mayDelete) {
+            foreach ($toDelete as $tokenID) {
+                $token = $manager->visibleToken($tokenID, $uid);
+                if (null === $token) {
+                    continue;
+                }
+                $token->revoke();
+                $deleted++;
+            }
+        }
+
+        if ($mayEdit) {
+            foreach ($manager->visibleTo($uid) as $row) {
+                if (in_array($row['id'], $toDelete, true) && $mayDelete) {
+                    continue;
+                }
+                $token = $manager->visibleToken($row['id'], $uid);
+                if (null === $token) {
+                    continue;
+                }
+                if ($token->setEnabled(in_array($row['id'], $keepEnabled, true))) {
+                    $changed++;
+                }
+            }
+        }
+
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => sprintf(
+                    _('%1$d token(s) updated, %2$d deleted.'),
+                    $changed,
+                    $deleted
+                ),
+                'title' => _('API Tokens Updated')
+            ]
+        );
+    }
+
+    /**
+     * GET half of the issue endpoint. Exists so the POST half can run.
+     *
+     * NOT dead code. FOGPageManager::render() resolves the sub to a method
+     * and, finding none, silently rewrites it to index() -- and only THEN
+     * appends 'Post'. So with sub=issueAPITokenFor and no base method here,
+     * the POST answers 200 from this page's default view having done
+     * nothing, which at the browser is indistinguishable from success. That
+     * is exactly how this shipped broken the first time.
+     *
+     * The two cache endpoints below take the other way out of the same
+     * trap: their sub is literally named cacheFlushPost, so the resolved
+     * method exists and no base is needed. Both work; this one is preferred
+     * for a new endpoint because a GET then gets an honest 405 instead of
+     * quietly rendering the version page.
+     *
+     * Issuing is POST-only, so the GET says so rather than rendering a form
+     * that cannot work.
+     *
+     * @return void
+     */
+    public function issueAPITokenFor()
+    {
+        header('Content-type: application/json');
+        $this->jsonSend(
+            HTTPResponseCodes::HTTP_METHOD_NOT_ALLOWED,
+            json_encode(
+                [
+                    'error' => _('Issuing a token requires a POST.'),
+                    'title' => _('API Token Failed')
+                ]
+            )
+        );
+    }
+
+    /**
+     * Issues a token on behalf of another user and returns it once.
+     *
+     * Its own permission (apitoken.create) rather than part of edit,
+     * because this is the one action here that produces a plaintext
+     * credential and hands it to somebody who is not its owner. The audit
+     * row generate() writes carries the owner as subject and the issuer as
+     * createdBy, so that asymmetry is legible afterwards.
+     *
+     * @return void
+     */
+    public function issueAPITokenForPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+
+        if (!Authorization::can('apitoken.create')) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                [
+                    'error' => _('You do not have permission to issue API '
+                        . 'tokens.'),
+                    'title' => _('API Token Failed')
+                ]
+            );
+        }
+
+        $forUserID = (int)filter_input(INPUT_POST, 'issuefor');
+        $name = trim((string)filter_input(INPUT_POST, 'newtokenname'));
+
+        // The target must be in scope. Without this a scoped administrator
+        // could mint a working credential for an account they are not
+        // allowed to see, which is a privilege escalation dressed up as a
+        // convenience feature.
+        $user = self::getClass('User', $forUserID);
+        $unscoped = SiteScope::isUnscoped((int)self::$FOGUser->get('id'));
+        $inScope = $unscoped
+            || in_array(
+                $forUserID,
+                SiteScope::allInScopeIDs(
+                    'user',
+                    (int)self::$FOGUser->get('id')
+                ),
+                true
+            );
+
+        if (!$user->isValid() || !$inScope) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => _('No such user.'),
+                    'title' => _('API Token Failed')
+                ]
+            );
+        }
+
+        $token = APIToken::generate($forUserID, $name);
+        if (false === $token) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                [
+                    'error' => _('Could not issue the token!'),
+                    'title' => _('API Token Failed')
+                ]
+            );
+        }
+
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_CREATED,
+            [
+                'msg' => sprintf(
+                    _('API token issued for %s.'),
+                    $user->get('name')
+                ),
+                'title' => _('API Token Created'),
+                'token' => $token
+            ]
+        );
+    }
+    /**
      * Presents mac listing information.
      *
      * @return void

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -787,6 +787,17 @@ class UserManagement extends FOGPage
     {
         $uid = (int)$this->obj->get('id');
 
+        // Gated on apitoken.*, NOT on the user.edit that got us to this
+        // page. Otherwise the central pane's permissions are decorative:
+        // anyone who could edit a user could delete their credentials from
+        // here regardless of holding apitoken.delete.
+        if (!Authorization::can('apitoken.view')) {
+            return;
+        }
+        $mayEdit = Authorization::can('apitoken.edit');
+        $mayCreate = Authorization::can('apitoken.create');
+        $mayDelete = Authorization::can('apitoken.delete');
+
         echo '<form class="form-horizontal" method="post" action="'
             . self::makeTabUpdateURL('user-api', $uid)
             . '" id="user-apitoken-form">';
@@ -826,7 +837,7 @@ class UserManagement extends FOGPage
             . '<th>' . _('Created') . '</th>'
             . '<th>' . _('Last Used') . '</th>'
             . '<th>' . _('Enabled') . '</th>'
-            . '<th>' . _('Delete') . '</th>'
+            . ($mayDelete ? '<th>' . _('Delete') . '</th>' : '')
             . '</tr></thead><tbody>';
         if (count($tokens) < 1) {
             echo '<tr><td colspan="5">' . _('No tokens issued.') . '</td></tr>';
@@ -846,9 +857,12 @@ class UserManagement extends FOGPage
             echo '<td><input type="checkbox" name="tokenenabled[]" value="'
                 . $tid . '"'
                 . ('1' === (string)$token->get('enabled') ? ' checked' : '')
+                . ($mayEdit ? '' : ' disabled')
                 . '/></td>';
-            echo '<td><input type="checkbox" name="tokendelete[]" value="'
-                . $tid . '"/></td>';
+            if ($mayDelete) {
+                echo '<td><input type="checkbox" name="tokendelete[]" '
+                    . 'value="' . $tid . '"/></td>';
+            }
             echo '</tr>';
             unset($token);
         }
@@ -875,21 +889,26 @@ class UserManagement extends FOGPage
         // button's own name.
         echo '<input type="hidden" name="tokenaction" value="manage"/>';
 
-        echo '<div class="input-group">';
-        echo '<input type="text" class="form-control" name="newtokenname" '
-            . 'id="newtokenname" placeholder="'
-            . _('Name for a new token') . '"/>';
-        echo '<button type="button" id="issuetoken" '
-            . 'class="btn btn-secondary">' . _('Issue Token') . '</button>';
-        echo '</div>';
+        if ($mayCreate) {
+            echo '<div class="input-group">';
+            echo '<input type="text" class="form-control" '
+                . 'name="newtokenname" id="newtokenname" placeholder="'
+                . _('Name for a new token') . '"/>';
+            echo '<button type="button" id="issuetoken" '
+                . 'class="btn btn-secondary">' . _('Issue Token')
+                . '</button>';
+            echo '</div>';
+        }
 
         echo '</div>';
         echo '<div class="card-footer">';
-        echo self::makeButton(
-            'apitoken-send',
-            _('Update'),
-            'btn btn-primary float-end'
-        );
+        if ($mayEdit || $mayDelete) {
+            echo self::makeButton(
+                'apitoken-send',
+                _('Update'),
+                'btn btn-primary float-end'
+            );
+        }
         echo '</div>';
         echo '</div>';
         echo '</form>';
@@ -940,6 +959,19 @@ class UserManagement extends FOGPage
         // as any other POST here. Ordinary role checks still apply: reaching
         // this page at all requires user.edit.
         self::checkAuthAndCSRF();
+        if (!Authorization::can('apitoken.create')) {
+            header('Content-type: application/json');
+            self::jsonSend(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                json_encode(
+                    [
+                        'error' => _('You do not have permission to issue '
+                            . 'API tokens.'),
+                        'title' => _('API Token Failed')
+                    ]
+                )
+            );
+        }
         // Not optional. Without it jQuery reads the body as text, hands
         // $.notifyFromAPI a STRING, and every res.<key> lookup is undefined
         // -- so the caller sees no token and no error, just a notification
@@ -994,6 +1026,16 @@ class UserManagement extends FOGPage
         if ('manage' !== (string)filter_input(INPUT_POST, 'tokenaction')) {
             return false;
         }
+        // Returns true either way: the request WAS this card's, so it must
+        // not fall through to the legacy card's handler even when the user
+        // may not act on it. Falling through would read the legacy card's
+        // absent fields as empty and wipe uAPIToken -- turning a permission
+        // denial into data loss on a different credential.
+        if (!Authorization::can('apitoken.view')) {
+            return true;
+        }
+        $mayEdit = Authorization::can('apitoken.edit');
+        $mayDelete = Authorization::can('apitoken.delete');
         $uid = (int)$this->obj->get('id');
         $keepEnabled = array_map(
             'intval',
@@ -1011,14 +1053,15 @@ class UserManagement extends FOGPage
             ->forUser($uid);
         foreach ((array)$tokens as &$token) {
             $tid = (int)$token->get('id');
-            if (in_array($tid, $toDelete, true)) {
-                $token->destroy();
+            if ($mayDelete && in_array($tid, $toDelete, true)) {
+                // revoke(), not destroy(): it writes the audit row first,
+                // while the owner and name can still be read off the row.
+                $token->revoke();
                 unset($token);
                 continue;
             }
-            $want = in_array($tid, $keepEnabled, true) ? '1' : '0';
-            if ($want !== (string)$token->get('enabled')) {
-                $token->set('enabled', $want)->save();
+            if ($mayEdit) {
+                $token->setEnabled(in_array($tid, $keepEnabled, true));
             }
             unset($token);
         }

--- a/packages/web/management/js/fog/about/fog.about.apitokens.js
+++ b/packages/web/management/js/fog/about/fog.about.apitokens.js
@@ -1,0 +1,68 @@
+(function($) {
+  // The estate-wide API token pane. Auto-loaded by the js/fog/<node>/
+  // fog.<node>.<sub>.js convention, so nothing registers this file.
+  //
+  // Two controls, wired separately for the same reason they are separate on
+  // the user's own API tab:
+  //
+  //   - Update rides the form. processForm() posts new FormData(form), which
+  //     carries the checkbox arrays and omits submit buttons -- so the save
+  //     needs no discriminator here, because this form has only one submit
+  //     path.
+  //   - Issue does NOT ride the form. It returns a plaintext credential in
+  //     its reply and that value is shown once, so it goes to its own
+  //     endpoint rather than through a save that re-renders the page.
+  //
+  // FOG has no generic binding that picks a tab or page form up --
+  // disableFormDefaults() only suppresses the native submit -- so an unwired
+  // control here renders perfectly and does nothing at all on click.
+  var form = $('#apitoken-central-form'),
+    saveBtn = $('#apitoken-central-send'),
+    issueBtn = $('#centralissuetoken');
+
+  form.on('submit', function(e) {
+    e.preventDefault();
+  });
+
+  saveBtn.on('click', function(e) {
+    saveBtn.prop('disabled', true);
+    form.processForm(function(err) {
+      saveBtn.prop('disabled', false);
+      if (err) {
+        return;
+      }
+      // Every row on screen is stale after a save: a deleted token still has
+      // a row and a toggled one still shows its old state. Nothing here can
+      // patch that up correctly from the client, because the server decides
+      // which ids were in scope.
+      location.reload();
+    });
+  });
+
+  issueBtn.on('click', function(e) {
+    var forUser = $('#issuefor').val(),
+      name = $('#centraltokenname').val();
+    issueBtn.prop('disabled', true);
+    $.apiCall(
+      'post',
+      '../management/index.php?node=about&sub=issueAPITokenFor',
+      {
+        issuefor: forUser,
+        newtokenname: name
+      },
+      function(err, data) {
+        issueBtn.prop('disabled', false);
+        if (err || !data || !data.token) {
+          return;
+        }
+        // Shown, never stored. Deliberately not written to localStorage, a
+        // data attribute, or anywhere else a later render could recover it
+        // from -- the server cannot show it again and neither should this.
+        $('#central-token-fresh-value').val(data.token);
+        $('#central-token-fresh').removeClass('d-none');
+        $('#centraltokenname').val('');
+        $('#central-token-fresh-value').trigger('focus').trigger('select');
+      }
+    );
+  });
+})(jQuery);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -51,6 +51,10 @@ msgid " | Unable to find image path"
 msgstr "Fehler beim Finden des Master Storage Nodes"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -170,6 +174,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -448,11 +455,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "FTP-Verbindung fehlgeschlagen"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "API-Zugangstoken"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "FTP-Verbindung fehlgeschlagen"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "Ungültiger Token übergeben"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2376,6 +2395,9 @@ msgstr "Ereignisdaten müssen ein Array sein."
 msgid "Event must be a string"
 msgstr "Ereignisname muss eine Zeichenfolge sein."
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2798,6 +2820,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4276,12 +4301,18 @@ msgstr "Ist ein"
 msgid "Issue Token"
 msgstr "Token zurücksetzen"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Server-Shell"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5093,6 +5124,9 @@ msgstr "Name"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
@@ -5176,6 +5210,10 @@ msgstr "Knoten"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "Ungültiger Token übergeben"
 
 #, fuzzy
 msgid "No Action"
@@ -5400,6 +5438,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8480,6 +8521,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9411,10 +9455,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -56,6 +56,10 @@ msgid " | Unable to find image path"
 msgstr "Failed to destroy Storage Node"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -175,6 +179,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -452,11 +459,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "FTP Connection has failed"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "Access Token"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "FTP Connection has failed"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "Invalid token passed"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2377,6 +2396,9 @@ msgstr "Event must be a string"
 msgid "Event must be a string"
 msgstr "Event must be a string"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2799,6 +2821,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4277,12 +4302,18 @@ msgstr "Is a"
 msgid "Issue Token"
 msgstr "Access Token"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Server Shell"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5091,6 +5122,9 @@ msgstr "Name"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "You must enter a name"
@@ -5174,6 +5208,10 @@ msgstr "Node"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "Invalid token passed"
 
 #, fuzzy
 msgid "No Action"
@@ -5398,6 +5436,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "The image storage group assigned is not valid"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8475,6 +8516,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9407,10 +9451,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -54,6 +54,10 @@ msgid " | Unable to find image path"
 msgstr "No se ha podido destruir nodo de almacenamiento"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -173,6 +177,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -450,11 +457,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "Añadir fallidos SNAPin!"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "Nombre de usuario"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "Añadir fallidos SNAPin!"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "unidad no válida pasó"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2414,6 +2433,9 @@ msgstr "Evento debe ser una cadena"
 msgid "Event must be a string"
 msgstr "Evento debe ser una cadena"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2851,6 +2873,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4369,12 +4394,18 @@ msgstr ""
 msgid "Issue Token"
 msgstr "impresora iPrint"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Servidor web"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5213,6 +5244,9 @@ msgstr "Nombre"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Evento debe ser una cadena"
@@ -5297,6 +5331,10 @@ msgstr "Modelo"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "unidad no válida pasó"
 
 #, fuzzy
 msgid "No Action"
@@ -5525,6 +5563,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8661,6 +8702,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9592,10 +9636,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -51,6 +51,10 @@ msgid " | Unable to find image path"
 msgstr "Fehler beim Finden des Master Storage Nodes"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -170,6 +174,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -448,11 +455,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "FTP-Verbindung fehlgeschlagen"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "API-Zugangstoken"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "FTP-Verbindung fehlgeschlagen"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "Ungültiger Token übergeben"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2376,6 +2395,9 @@ msgstr "Ereignisdaten müssen ein Array sein."
 msgid "Event must be a string"
 msgstr "Ereignisname muss eine Zeichenfolge sein."
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2798,6 +2820,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4277,12 +4302,18 @@ msgstr "Ist ein"
 msgid "Issue Token"
 msgstr "Token zurücksetzen"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Server-Shell"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5094,6 +5125,9 @@ msgstr "Name"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
@@ -5177,6 +5211,10 @@ msgstr "Knoten"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "Ungültiger Token übergeben"
 
 #, fuzzy
 msgid "No Action"
@@ -5401,6 +5439,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8481,6 +8522,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9412,10 +9456,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -57,6 +57,10 @@ msgid " | Unable to find image path"
 msgstr "Impossible de détruire le nœud de stockage"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -176,6 +180,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -453,11 +460,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "Connexion FTP a échoué"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "Jeton d'accès"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "Connexion FTP a échoué"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "jeton non valide transmis"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2379,6 +2398,9 @@ msgstr "Événement doit être une chaîne"
 msgid "Event must be a string"
 msgstr "Événement doit être une chaîne"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2801,6 +2823,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4279,12 +4304,18 @@ msgstr "Est un"
 msgid "Issue Token"
 msgstr "Jeton d'accès"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "serveur Shell"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5093,6 +5124,9 @@ msgstr "prénom"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Vous devez entrer un nom"
@@ -5176,6 +5210,10 @@ msgstr "Nœud"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "jeton non valide transmis"
 
 #, fuzzy
 msgid "No Action"
@@ -5400,6 +5438,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "Le groupe de stockage d'images attribuée est non valable"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8477,6 +8518,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9409,10 +9453,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -56,6 +56,10 @@ msgid " | Unable to find image path"
 msgstr "Impossibile trovare il Nodo Archiviazione master"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -175,6 +179,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -439,11 +446,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "Connessione FTP non è riuscita"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "API Utente Token"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "Connessione FTP non è riuscita"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "Token non valido passato"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2310,6 +2329,9 @@ msgstr "Event data deve essere un array"
 msgid "Event must be a string"
 msgstr "Evento deve essere una stringa"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2718,6 +2740,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4137,12 +4162,18 @@ msgstr "È un"
 msgid "Issue Token"
 msgstr "Reset Token"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Server Shell"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -4920,6 +4951,9 @@ msgstr "Nome"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Il parametro Diff deve essere numerico"
@@ -5002,6 +5036,10 @@ msgstr "Nodo"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "Token non valido passato"
 
 #, fuzzy
 msgid "No Action"
@@ -5218,6 +5256,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "Il gruppo di archiviazione immagine assegnato non è valido"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8187,6 +8228,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9087,10 +9131,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -47,6 +47,10 @@ msgid " | Unable to find image path"
 msgstr "| イメージパスが見つかりません"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -167,6 +171,10 @@ msgstr ""
 
 msgid "(default on all)"
 msgstr ""
+
+#, fuzzy
+msgid "(deleted user)"
+msgstr "選択したユーザーを追加"
 
 msgid "(empty on all)"
 msgstr ""
@@ -424,11 +432,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "FTP 接続に失敗しました"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "ユーザー API トークン"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "FTP 接続に失敗しました"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "無効なトークンが渡されました"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2291,6 +2311,9 @@ msgstr "イベントデータは配列である必要があります"
 msgid "Event must be a string"
 msgstr "イベントは文字列で指定してください"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2691,6 +2714,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4092,12 +4118,18 @@ msgstr "次の種類です"
 msgid "Issue Token"
 msgstr "トークンをリセット"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "サーバーシェル"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -4877,6 +4909,9 @@ msgstr "名前"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Diff パラメーターは数値で指定してください"
@@ -4959,6 +4994,10 @@ msgstr "いいえ"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "無効なトークンが渡されました"
 
 #, fuzzy
 msgid "No Action"
@@ -5177,6 +5216,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "割り当てられたイメージのストレージグループが無効です"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 msgid "No token passed to authenticate this host"
@@ -8123,6 +8165,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9020,11 +9065,19 @@ msgstr "少なくとも 1 つのグループを関連付ける必要がありま
 msgid "You do not have permission to change site grants."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
+#, fuzzy
+msgid "You do not have permission to issue API tokens."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 #, fuzzy
 msgid "You do not have permission to read any activity source."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
+msgid "You do not have permission to view API tokens."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 msgid "You may use _, ., -, or a space between."
@@ -10013,9 +10066,6 @@ msgstr ""
 
 #~ msgid "Add selected rules"
 #~ msgstr "選択したルールを追加"
-
-#~ msgid "Add selected users"
-#~ msgstr "選択したユーザーを追加"
 
 #~ msgid "Additional MACs"
 #~ msgstr "追加の MAC アドレス"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -32,6 +32,10 @@ msgid " | Unable to find image path"
 msgstr ""
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -151,6 +155,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -382,10 +389,20 @@ msgstr ""
 msgid "API Token Failed"
 msgstr ""
 
+msgid "API Tokens"
+msgstr ""
+
+msgid "API Tokens Updated"
+msgstr ""
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
+msgstr ""
+
+#, php-format
+msgid "API token issued for %s."
 msgstr ""
 
 msgid "API token issued!"
@@ -2023,6 +2040,9 @@ msgstr ""
 msgid "Event must be a string"
 msgstr ""
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2381,6 +2401,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -3623,10 +3646,16 @@ msgstr ""
 msgid "Issue Token"
 msgstr ""
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 msgid "Issuer URL"
+msgstr ""
+
+msgid "Issuing a token requires a POST."
 msgstr ""
 
 msgid "It can no longer be joined"
@@ -4312,6 +4341,9 @@ msgstr ""
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 msgid "Name. Must be unique."
 msgstr ""
 
@@ -4383,6 +4415,9 @@ msgstr ""
 
 #, php-format
 msgid "No %1$s exists with ID %2$s"
+msgstr ""
+
+msgid "No API tokens have been issued."
 msgstr ""
 
 msgid "No Action"
@@ -4579,6 +4614,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr ""
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 msgid "No token passed to authenticate this host"
@@ -7207,6 +7245,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -8011,10 +8052,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -56,6 +56,10 @@ msgid " | Unable to find image path"
 msgstr "Falha ao destruir Storage Node"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -175,6 +179,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -452,11 +459,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "Conexão FTP falhou"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "token de acesso"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "Conexão FTP falhou"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "Token inválido passado"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2378,6 +2397,9 @@ msgstr "Evento deve ser uma string"
 msgid "Event must be a string"
 msgstr "Evento deve ser uma string"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2800,6 +2822,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4278,12 +4303,18 @@ msgstr "É uma"
 msgid "Issue Token"
 msgstr "token de acesso"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "Shell servidor"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5092,6 +5123,9 @@ msgstr "Nome"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "Você deve digitar um nome"
@@ -5175,6 +5209,10 @@ msgstr "Nó"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "Token inválido passado"
 
 #, fuzzy
 msgid "No Action"
@@ -5399,6 +5437,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "O grupo de armazenamento de imagens atribuído não é válido"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8476,6 +8517,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9408,10 +9452,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -56,6 +56,10 @@ msgid " | Unable to find image path"
 msgstr "未能摧毁存储节点"
 
 #, php-format
+msgid "%1$d token(s) updated, %2$d deleted."
+msgstr ""
+
+#, php-format
 msgid "%1$s \"%2$s\" (ID %3$s) failed to delete"
 msgstr ""
 
@@ -175,6 +179,9 @@ msgid "(all)"
 msgstr ""
 
 msgid "(default on all)"
+msgstr ""
+
+msgid "(deleted user)"
 msgstr ""
 
 msgid "(empty on all)"
@@ -452,11 +459,23 @@ msgstr ""
 msgid "API Token Failed"
 msgstr "FTP连接失败"
 
+#, fuzzy
+msgid "API Tokens"
+msgstr "访问令牌"
+
+#, fuzzy
+msgid "API Tokens Updated"
+msgstr "FTP连接失败"
+
 msgid "API class is not mapped to a permission node"
 msgstr ""
 
 msgid "API route is not mapped to a permission"
 msgstr ""
+
+#, fuzzy, php-format
+msgid "API token issued for %s."
+msgstr "无效的令牌传递"
 
 #, fuzzy
 msgid "API token issued!"
@@ -2378,6 +2397,9 @@ msgstr "事件必须是字符串"
 msgid "Event must be a string"
 msgstr "事件必须是字符串"
 
+msgid "Every API token on this server. Tokens are stored hashed &mdash; a token cannot be shown again after it is issued, so this page can revoke one but never recover it."
+msgstr ""
+
 msgid "Every configured multicast port is already in use"
 msgstr ""
 
@@ -2800,6 +2822,9 @@ msgid "For a network/SMB share use its path, e.g."
 msgstr ""
 
 msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
+msgstr ""
+
+msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4278,12 +4303,18 @@ msgstr "是"
 msgid "Issue Token"
 msgstr "访问令牌"
 
+msgid "Issue a token on behalf of a user"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
 #, fuzzy
 msgid "Issuer URL"
 msgstr "服务器外壳"
+
+msgid "Issuing a token requires a POST."
+msgstr ""
 
 msgid "It can no longer be joined"
 msgstr ""
@@ -5092,6 +5123,9 @@ msgstr "名称"
 msgid "Name for a new token"
 msgstr ""
 
+msgid "Name for the new token"
+msgstr ""
+
 #, fuzzy
 msgid "Name. Must be unique."
 msgstr "您必须输入一个名称"
@@ -5175,6 +5209,10 @@ msgstr "节点"
 #, php-format
 msgid "No %1$s exists with ID %2$s"
 msgstr ""
+
+#, fuzzy
+msgid "No API tokens have been issued."
+msgstr "无效的令牌传递"
 
 #, fuzzy
 msgid "No Action"
@@ -5399,6 +5437,9 @@ msgid "No storagegroups assigned to this snapin"
 msgstr "分配图像存储组无效"
 
 msgid "No such object."
+msgstr ""
+
+msgid "No such user."
 msgstr ""
 
 #, fuzzy
@@ -8476,6 +8517,9 @@ msgstr ""
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
+msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9408,10 +9452,16 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to issue API tokens."
+msgstr ""
+
 msgid "You do not have permission to perform this action."
 msgstr ""
 
 msgid "You do not have permission to read any activity source."
+msgstr ""
+
+msgid "You do not have permission to view API tokens."
 msgstr ""
 
 msgid "You may use _, ., -, or a space between."

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -354,4 +354,140 @@ $t->check(
     false === strpos($pageSrc, 'fog_new_api_token')
 );
 
+// ---------------------------------------------------------------------------
+// 10. The central pane (FOG Configuration -> API Tokens).
+//
+// A credential census is a different power from editing users, so it has its
+// own permission node -- and the pane is only as good as the four things
+// below, each of which fails silently if it regresses.
+// ---------------------------------------------------------------------------
+$authSrc = file_get_contents($web . '/lib/fog/authorization.class.php');
+$configSrc = file_get_contents(
+    $web . '/lib/pages/fogconfigurationpage.page.php'
+);
+$auditSrc = file_get_contents($web . '/lib/fog/audit.class.php');
+$paneJs = file_get_contents(
+    $web . '/management/js/fog/about/fog.about.apitokens.js'
+);
+
+$t->check(
+    'apitoken is a permission node',
+    (bool)preg_match("/'apitoken' => \['view', 'create', 'edit', 'delete'\]/", $authSrc)
+);
+// delete separate from edit is the whole point: disable is reversible and
+// delete is not, so they must not share a grant.
+$t->check(
+    'delete is its own action, not folded into edit',
+    (bool)preg_match("/'apitoken' => \[[^\]]*'delete'[^\]]*\]/", $authSrc)
+);
+$t->check(
+    'the pane is gated on apitoken.view, not the config page permission',
+    false !== strpos($authSrc, "'apitokens' => 'apitoken.view'")
+);
+$t->check(
+    'issuing on behalf of is gated on apitoken.create',
+    false !== strpos($authSrc, "'issueapitokenfor' => 'apitoken.create'")
+);
+
+// FOGPageManager rewrites an unknown sub to index() and only THEN appends
+// 'Post'. A *Post method whose base does not exist is never dispatched: the
+// request answers 200 from the default view having done nothing. That is how
+// this shipped broken once already.
+$t->check(
+    'issueAPITokenFor has a base method so its Post half dispatches',
+    (bool)preg_match('/public function issueAPITokenFor\(\)/', $configSrc)
+    && (bool)preg_match('/public function issueAPITokenForPost\(\)/', $configSrc)
+);
+$t->check(
+    'apitokens has a base method too',
+    (bool)preg_match('/public function apitokens\(\)/', $configSrc)
+);
+
+// Site scoping. allInScopeIDs() returns [] BOTH for "unscoped" and for "in
+// no site" -- opposite meanings -- so isUnscoped() must be consulted first
+// or a scoped admin with no sites silently sees the whole estate.
+$mgrSrc = file_get_contents($web . '/lib/fog/apitokenmanager.class.php');
+$unscopedPos = strpos($mgrSrc, 'SiteScope::isUnscoped');
+$allIDsPos = strpos($mgrSrc, 'SiteScope::allInScopeIDs');
+$t->check(
+    'the pane consults site scope at all',
+    false !== $unscopedPos && false !== $allIDsPos
+);
+$t->check(
+    'isUnscoped() is checked before an empty scope list is trusted',
+    false !== $unscopedPos && $unscopedPos < $allIDsPos
+);
+$t->check(
+    'an empty scope list denies rather than falling through unfiltered',
+    (bool)preg_match('/if \(count\(\$ids\) < 1\) \{\s*(\/\/[^\n]*\n\s*)*return \[\];/', $mgrSrc)
+);
+// Posted ids are an untrusted list. Every mutation resolves through
+// visibleToken(), never a direct load of whatever number was posted.
+$t->check(
+    'central mutations resolve ids through visibleToken()',
+    substr_count($configSrc, 'visibleToken(') >= 2
+    && !preg_match('/getClass\(\'APIToken\',\s*\$tokenID/', $configSrc)
+);
+
+// ---------------------------------------------------------------------------
+// 11. Audit rows must survive destroy()'s rewrite.
+//
+// Audit::record() makes its row Audit::$_current, and
+// FOGController::destroy() calls Audit::identify(), which REVISES $_current
+// in place with the destroyed object's own type/id/name. So a token audit
+// row naming the OWNER as subject silently becomes one naming the TOKEN --
+// no error, nothing logged. Reordering does not help: recording after
+// destroy() corrupts the PREVIOUS row in a multi-delete loop.
+//
+// The resolution is that these rows use the subject identify() would impose
+// anyway, so the rewrite is a no-op, and carry the owner in `text`.
+// ---------------------------------------------------------------------------
+$auditFn = '';
+if (preg_match(
+    '/public function audit\(\$type, \$permission\)\s*\{(.*?)\n    \}/s',
+    $modelSrc,
+    $m
+)) {
+    $auditFn = $m[1];
+}
+$t->check('APIToken::audit() exists', '' !== $auditFn);
+$t->check(
+    "audit rows use the token as subject, matching identify()'s rewrite",
+    (bool)preg_match("/'subjectType' => 'apitoken'/", $auditFn)
+    && (bool)preg_match('/\'subjectID\' => \(int\)\$this->get\(\'id\'\)/', $auditFn)
+);
+$t->check(
+    'the owner is carried in text, which identify() does not touch',
+    (bool)preg_match("/'text' =>/", $auditFn)
+    && false !== strpos($auditFn, 'owner=')
+);
+// identify() sets exactly these three; anything else this row needs must
+// live outside them. If that ever changes, this is the check that notices.
+$t->check(
+    'identify() still rewrites only subjectType/subjectID/subjectLabel',
+    (bool)preg_match(
+        "/function identify\(.*?\)\s*\{.*?->set\('subjectType'.*?->set\('subjectID'.*?->set\('subjectLabel'.*?->save\(\)/s",
+        $auditSrc
+    )
+);
+$t->check(
+    'every token lifecycle event goes through the one audit helper',
+    3 === substr_count($modelSrc, '$this->audit(')
+        + substr_count($modelSrc, '$row->audit(')
+);
+foreach (['TOKEN_ISSUED', 'TOKEN_ENABLED', 'TOKEN_DISABLED', 'TOKEN_DELETED'] as $c) {
+    $t->check(
+        "Audit::$c is defined",
+        (bool)preg_match("/const $c = 'apitoken\./", $auditSrc)
+    );
+}
+
+// The pane's controls need wiring for the same reason the user tab's did.
+$t->check(
+    'the central pane form is wired in JS',
+    false !== strpos($paneJs, '#apitoken-central-form')
+    && false !== strpos($paneJs, '#apitoken-central-send')
+    && false !== strpos($paneJs, '#centralissuetoken')
+);
+
 $t->finish();

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -490,4 +490,34 @@ $t->check(
     && false !== strpos($paneJs, '#centralissuetoken')
 );
 
+// WHERE THE MENU ENTRY HAS TO LIVE, which is the defect this pins.
+//
+// There are TWO copies of the 'about' sub-menu list. SubMenuData::subMenu()
+// in lib/hooks/submenudata.hook.php reads like the obvious place and NEVER
+// RUNS: the hook sets $active = false and HookManager only force-activates
+// files under plugins/. The list the sidebar is actually built from is the
+// switch in FOGPage::_buildSubMenuItems(). An entry added only to the hook
+// renders nowhere, with no error -- the page itself answers fine by URL, so
+// it looks like a permission problem rather than a missing menu item.
+//
+// customizepxe and newMenu are in the dead copy only and have been missing
+// from the sidebar for exactly this reason; secureBoot carries a comment
+// about it. Both files are checked so the two lists cannot drift apart
+// again.
+$subMenuLive = file_get_contents($web . '/lib/fog/fogpage.class.php');
+$subMenuHook = file_get_contents($web . '/lib/hooks/submenudata.hook.php');
+$t->check(
+    "the API Tokens entry is in FOGPage::_buildSubMenuItems(), the list the "
+    . "sidebar actually builds from",
+    (bool)preg_match(
+        "/function _buildSubMenuItems\(.*?case 'about':.*?"
+        . "'apitokens' => _\('API Tokens'\).*?case '/s",
+        $subMenuLive
+    )
+);
+$t->check(
+    'the API Tokens entry is also in the SubMenuData copy, kept in step',
+    false !== strpos($subMenuHook, "'apitokens' => _('API Tokens')")
+);
+
 $t->finish();


### PR DESCRIPTION
Follows #1328. Adds **FOG Configuration → API Tokens**: every token on the server, with its owner, who issued it, and when it was last used.

## Why

The per-user API tab answers *"what does this user have"*. This answers the question that actually drives revocation — **"what credentials exist here, and which has nothing touched in months"** — which was otherwise only answerable by opening every user in turn. That is what `atLastUsed` was recorded for in #1328, and there was nowhere to read it.

It can revoke a token but never recover one. The table holds hashes.

## Permissions: a new `apitoken` node

Not `user.edit`, because "can edit users" and "can inventory every API credential on this server" are different powers.

| Grant | Powers | Hand out |
|---|---|---|
| `apitoken.view` | see the inventory | freely |
| `apitoken.edit` | enable/disable | to your admins |
| `apitoken.create` | issue on behalf of | to your admins |
| `apitoken.delete` | permanent removal | **narrowly** |

The split is the point: **disable is reversible and delete is not.** A mass-disable is downtime somebody undoes with one click; a mass-delete means every integration on the estate needs a fresh token minted and redeployed, and nothing brings the old ones back. `create` is separate again because it is the only action that produces a plaintext credential and hands it to somebody who is not its owner.

**The per-user tab is now gated on the same node.** Without that the pane's permissions are decorative — anyone who could edit a user could delete their credentials from the user page regardless of holding `apitoken.delete`. Holders of `*` are unaffected.

## Site scoping

An inventory is a disclosure surface even when every value in it is a hash, so a scoped admin sees only tokens owned by users in their scope, and every posted id resolves through `visibleToken()` rather than being loaded directly. `allInScopeIDs()` returns `[]` both for "unscoped" and for "in no site" — opposite meanings — so `isUnscoped()` is consulted first.

## Audit

Four new types cover the lifecycle. That matters more here than usual: the table holds only a hash, so once a token is gone these rows are the only record it ever existed. `TOKEN_ISSUED` names the owner alongside the issuer, so *an admin minted a credential for someone else* stays legible.

## Two defects found by deploying and clicking, both silent

**1. A `*Post` method whose base method does not exist is never dispatched.** `FOGPageManager` rewrites an unknown sub to `index()` and *only then* appends `Post`, so the POST answered **200 from the version page having done nothing** — indistinguishable from success at the browser. Added `issueAPITokenFor()`. (The two cache endpoints in the same file dodge this by naming their sub `cacheFlushPost`; both work, but a base method gives a GET an honest 405.)

**2. Audit rows were being rewritten out from under themselves.** `Audit::record()` makes its row `Audit::$_current`, and `FOGController::destroy()` calls `Audit::identify()`, which revises `$_current` **in place** with the destroyed object's own type/id/name (ADR 0021 Decision 7). So a delete row naming the OWNER silently became one naming the TOKEN.

Reordering does not fix it — recording *after* `destroy()` corrupts the **previous** row in a multi-delete loop, which is exactly what this pane does. Resolved by using the subject `identify()` would impose anyway, so the rewrite is a no-op, and carrying the owner in `text`, which `identify()` does not touch.

## Verified on a real install

| Step | Result |
|---|---|
| Pane lists tokens | owner and issuer both shown |
| Issue for `telliott` while signed in as `fog` | token authenticates, **200** |
| The resulting row | `User: telliott`, `Created By: fog` |
| Audit row | `subjectID` = token, `text` = `owner=telliott (116)`, `createdBy` = `fog` |
| Untick Enabled → Update | token **401** |
| Tick Delete → Update | row gone |
| Two-token delete in one loop | both audit rows intact, owners preserved |

`tests/api-token-store.test.php` grows to **67 checks**. Mutation-verified — reverting the audit subject, dropping the owner from the text, folding delete into edit, re-gating the pane on `settings.edit`, removing the base method, removing the `isUnscoped` check, letting an empty scope list fall through unfiltered, and unwiring the pane JS are all caught.

Suite: 136 passed, 0 failed.

## Not included

**API-only users** — accounts that cannot sign into the UI at all. That came up alongside this and is a genuinely separate change (it touches the login path, not the token store), so it is not folded in here. The service-account case this pane supports still uses an ordinary user that can also log in with a password.

## Downstream

None. `Route::$validClasses` is unchanged — `APIToken` is deliberately not a REST class — so FogApi needs no sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqpPXAk7bEm8huH9WkiGk6
