### PR TITLE
feat(users): API-only accounts that cannot sign in

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -925,7 +925,7 @@ return [
             ],
         ],
         'users' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `users` ( `uId` int(11) NOT NULL AUTO_INCREMENT, `uName` varchar(255) DEFAULT NULL, `uPass` longtext NOT NULL, `uCreateDate` datetime NOT NULL DEFAULT current_timestamp(), `uCreateBy` varchar(255) DEFAULT NULL, `uType` int(11) NOT NULL DEFAULT 0, `uDisplay` varchar(255) NOT NULL DEFAULT \'\', `uAllowAPI` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `uAPIToken` varchar(255) NOT NULL DEFAULT \'\', `uAuthSource` varchar(32) NOT NULL DEFAULT \'\', PRIMARY KEY (`uId`), UNIQUE KEY `name` (`uName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `users` ( `uId` int(11) NOT NULL AUTO_INCREMENT, `uName` varchar(255) DEFAULT NULL, `uPass` longtext NOT NULL, `uCreateDate` datetime NOT NULL DEFAULT current_timestamp(), `uCreateBy` varchar(255) DEFAULT NULL, `uType` int(11) NOT NULL DEFAULT 0, `uDisplay` varchar(255) NOT NULL DEFAULT \'\', `uAllowAPI` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `uAPIToken` varchar(255) NOT NULL DEFAULT \'\', `uAuthSource` varchar(32) NOT NULL DEFAULT \'\', `uAPIOnly` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`uId`), UNIQUE KEY `name` (`uName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'uId' => 'int(11) NOT NULL',
                 'uName' => 'varchar(255) DEFAULT NULL',
@@ -937,6 +937,7 @@ return [
                 'uAllowAPI' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
                 'uAPIToken' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'uAuthSource' => 'varchar(32) NOT NULL DEFAULT \'\'',
+                'uAPIOnly' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
             ],
         ],
         'userTracking' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7550,3 +7550,40 @@ $this->schema[] = [
     . "DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci "
     . "ROW_FORMAT=DYNAMIC",
 ];
+// Guarded for the same reason as steps 312 and 314: working-1.6 and
+// dev-branch number the same migration differently, so an install that has
+// crossed between them may already carry the column.
+$columnuAPIOnly = array_filter(
+    (array)DatabaseManager::getColumns(
+        'users',
+        'uAPIOnly'
+    )
+);
+// 360
+$this->schema[] = count($columnuAPIOnly ?: []) ? [] : [
+    // An account that holds API credentials and cannot sign in.
+    //
+    // The case is a service account: an unattended integration wants a
+    // token and a set of roles, and nothing else. Until now the only way to
+    // give it those was an ordinary account, which meant a working password
+    // sitting on the login form for a credential nobody was ever going to
+    // type -- and, if the password was left at whatever the creator chose,
+    // an interactive way in that nobody was watching.
+    //
+    // A flag on the account rather than an absent password, because "no
+    // password" is not a state FOG can hold: uPass is NOT NULL, an empty
+    // hash fails password_verify() by accident rather than by rule, and
+    // nothing stops the next admin setting one. This says what is meant.
+    //
+    // DEFAULT '0' so every existing account is unaffected: the flag has to
+    // be set deliberately, and an upgrade must never take a login away from
+    // somebody who had one.
+    //
+    // It is NOT users.uAllowAPI inverted. That flag governs whether the
+    // fog-user-token header works for this account; this one governs
+    // whether a browser session may be made for it. An account can be any
+    // combination of the two, including API-only with uAllowAPI off, which
+    // is a service account reachable only through an issued Bearer token.
+    "ALTER TABLE `users` "
+    . "ADD COLUMN `uAPIOnly` ENUM('0','1') NOT NULL DEFAULT '0'",
+];

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -1947,6 +1947,17 @@ class Authorization extends FOGBase
         if (!empty($changes['localOnly'])) {
             $users = array_diff($users, self::_externalUsers($changes));
         }
+        /*
+         * Independent of localOnly, and deliberately so. They answer
+         * different questions: localOnly asks who can get in without the
+         * directory, this asks who can reach the UI at all. An API-only
+         * account with a local password is still a local administrator --
+         * it just cannot use a browser -- and a directory-sourced account
+         * that can sign in interactively is still an interactive one.
+         */
+        if (!empty($changes['interactiveOnly'])) {
+            $users = array_diff($users, self::_apiOnlyUsers($changes));
+        }
         // Direct membership as roleID => [userIDs].
         $membership = [];
         $rows = self::$DB
@@ -2112,6 +2123,117 @@ class Authorization extends FOGBase
         return $external;
     }
     /**
+     * The user ids barred from interactive sign-in, after applying any
+     * proposed users.uAPIOnly changes.
+     *
+     * Reads the column directly for the reason _externalUsers() does: this
+     * is a query whose wrong answer either bricks the install or lets it be
+     * bricked, so it owns its SQL rather than inheriting the query
+     * builder's wildcard handling.
+     *
+     * @param array $changes the proposed changes; 'apiOnly' is honoured
+     *
+     * @return array user ids
+     */
+    private static function _apiOnlyUsers($changes = [])
+    {
+        $rows = self::$DB
+            ->query('SELECT `uID`, `uAPIOnly` FROM `users`')
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        $stored = [];
+        foreach ((array)$rows as $row) {
+            $stored[(int)$row['uID']] = (string)$row['uAPIOnly'];
+        }
+        return self::apiOnlyUsersGiven(
+            $stored,
+            (array)($changes['apiOnly'] ?? [])
+        );
+    }
+    /**
+     * Which of these accounts would be barred from signing in.
+     *
+     * The decision half of _apiOnlyUsers(), split out for the same reason
+     * externalUsersGiven() is: it is the part with rules in it and the only
+     * part testable without a database. A proposed value REPLACES the
+     * stored one, and anything that is not the string '1' means the account
+     * can still sign in -- so an absent column, a null and a '0' all read
+     * as interactive, which is the direction that cannot lock anyone out.
+     *
+     * @param array $stored   userID => stored users.uAPIOnly
+     * @param array $proposed userID => proposed users.uAPIOnly
+     *
+     * @return array user ids
+     */
+    public static function apiOnlyUsersGiven(array $stored, array $proposed)
+    {
+        foreach ($proposed as $uid => $flag) {
+            $stored[(int)$uid] = $flag ? '1' : '0';
+        }
+        $apiOnly = [];
+        foreach ($stored as $uid => $flag) {
+            if ('1' === (string)$flag) {
+                $apiOnly[] = (int)$uid;
+            }
+        }
+        return $apiOnly;
+    }
+    /**
+     * Is there an administrator who can actually sign in to the UI?
+     *
+     * @param array $changes the proposed changes (see adminExistsGiven())
+     *
+     * @return bool
+     */
+    public static function interactiveAdminExists($changes = [])
+    {
+        $changes['interactiveOnly'] = true;
+        return self::adminExistsGiven($changes);
+    }
+    /**
+     * Refuses a change that would leave nobody able to sign in and
+     * administer FOG.
+     *
+     * An API-only administrator is not locked out -- it can still work over
+     * REST -- so this is a weaker property than the other two guards and
+     * has to be, or marking a service account API-only on an install that
+     * has no interactive administrator would be refused for no reason. What
+     * it protects against is the plausible accident: marking the account
+     * you are signed in as, or the last one anybody signs in as, and
+     * discovering that the only way back is a token that may not exist yet.
+     * A brand-new API-only account has no token until somebody issues one,
+     * and issuing one takes a UI session.
+     *
+     * PRESERVES rather than REQUIRES, exactly like
+     * assertLocalAdminRemains(): an install that already has no interactive
+     * administrator has nothing here to protect, and refusing its
+     * operations would brick it to defend a property it already gave up.
+     *
+     * @param array $changes the proposed changes (see adminExistsGiven())
+     *
+     * @throws Exception when the last interactive administrator would be lost
+     * @return void
+     */
+    public static function assertInteractiveAdminRemains($changes = [])
+    {
+        if (!self::interactiveAdminExists()) {
+            return;
+        }
+        if (self::interactiveAdminExists($changes)) {
+            return;
+        }
+        self::_auditRefusal(
+            'guard.lastinteractiveadmin',
+            'no account would be able to sign in and administer FOG'
+        );
+        throw new \Exception(
+            _(
+                'This would leave no account able to sign in and administer '
+                . 'FOG.'
+            )
+        );
+    }
+    /**
      * Is there an administrator who can sign in without a directory?
      *
      * @param array $changes the proposed changes (see adminExistsGiven())
@@ -2203,6 +2325,11 @@ class Authorization extends FOGBase
                 // directory-sourced admins passes it while being one
                 // outage away from locked out.
                 self::assertLocalAdminRemains($changes);
+                // And can be what takes away the last account anybody signs
+                // in as, which the check below equally would not notice: an
+                // install left holding nothing but API-only administrators
+                // passes it while having no way into its own UI.
+                self::assertInteractiveAdminRemains($changes);
                 break;
             case 'role':
                 $changes = ['removeRoles' => $ids];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 359);
+        define('FOG_SCHEMA', 360);
         define('FOG_BCACHE_VER', 304);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/fog/user.class.php
+++ b/packages/web/lib/fog/user.class.php
@@ -67,7 +67,10 @@ class User extends FOGController
         'token' => 'uAPIToken',
         // '' = local account. Non-empty names the external provider that
         // authenticates this user (e.g. 'ldap'); see schema step 314.
-        'authsource' => 'uAuthSource'
+        'authsource' => 'uAuthSource',
+        // '1' = this account may hold API credentials but may not sign in.
+        // See isAPIOnly() and schema step 360.
+        'apionly' => 'uAPIOnly'
     ];
     /**
      * The required fields
@@ -180,6 +183,34 @@ class User extends FOGController
             ]
         );
     }
+    /**
+     * Whether this account is barred from interactive sign-in.
+     *
+     * An API-only account is a service account: it may hold API tokens and
+     * act with its roles over REST, and no browser session may ever be made
+     * for it. Three separate places enforce that, because FOG has three
+     * separate ways a session comes into existence and no single one of
+     * them sits downstream of the other two:
+     *
+     *   - passwordValidate(), which is where the local password and the
+     *     iPXE menu login both land, and which is the ONLY one of the three
+     *     that runs before the remember-me cookie is minted;
+     *   - establishSession(), where a provider that proves an identity by
+     *     itself (OIDC today) hands over;
+     *   - _isLoggedIn(), which every browser request passes through, and
+     *     which is the only thing that catches a remember-me cookie issued
+     *     before the flag was set.
+     *
+     * Reads the column rather than caching the answer: the flag can be set
+     * while the account is signed in, and the point of the third check is
+     * that the very next request stops.
+     *
+     * @return bool
+     */
+    public function isAPIOnly()
+    {
+        return '1' === (string)$this->get('apionly');
+    }
     public function passwordValidate(
         $username,
         $password,
@@ -229,6 +260,26 @@ class User extends FOGController
         // LDAP plugin's own isLdapType() guard, which never fired because
         // USER_TYPE_HOOK rewrote the type it tested one block earlier.
         if ($isExternal && true !== $authenticated) {
+            self::_auditLoginFailure($username, $tmpUser);
+            return false;
+        }
+        /*
+         * An API-only account has no interactive login, whoever vouches for
+         * it. Refused HERE rather than only at establishSession() because
+         * this method mints the remember-me cookie and its userAuths row a
+         * few lines below: refusing downstream would leave a working
+         * two-day credential behind for a login that was rejected.
+         *
+         * Placed after the external check so a directory-sourced service
+         * account is still refused for the reason that applies first, and
+         * before the password compare so nothing is learned about the
+         * stored credential either way.
+         *
+         * Recorded as an ordinary failed login, which is what it is: the
+         * row carries the presented name and the attempt is visible beside
+         * every other one rather than in a category of its own.
+         */
+        if ($tmpUser->isValid() && $tmpUser->isAPIOnly()) {
             self::_auditLoginFailure($username, $tmpUser);
             return false;
         }
@@ -411,6 +462,25 @@ class User extends FOGController
             session_start();
         }
         $source = self::normalizeAuthSource($source);
+        /*
+         * The provider-facing half of the API-only refusal. A provider that
+         * proves an identity by its own means never reaches
+         * passwordValidate() -- OIDC calls straight in here -- so without
+         * this an API-only account would still get a browser session from
+         * any configured identity provider.
+         *
+         * Throws rather than returning an invalid user because the callers
+         * differ in what they do with a return value and agree on what they
+         * do with an exception: OIDC's flow ignores the return entirely and
+         * wraps the whole callback in a catch that shows the message, and
+         * ProcessLogin::loginPost() does the same. A quiet return would be
+         * a sign-in that appears to succeed and lands nowhere.
+         */
+        if ($this->isAPIOnly()) {
+            throw new \Exception(
+                _('This account is for API access only and cannot sign in.')
+            );
+        }
         if (self::$FOGUser->isValid()) {
             $type = self::$FOGUser->get('type');
             self::$HookManager->processEvent(
@@ -570,6 +640,21 @@ class User extends FOGController
     private function _isLoggedIn()
     {
         if (!$this->isValid() || session_status() !== PHP_SESSION_ACTIVE) {
+            return false;
+        }
+        /*
+         * The catch-all half of the API-only refusal, and the only one that
+         * covers a session this request did not create. Two cases reach it:
+         * a remember-me cookie minted before the flag was set, which
+         * ProcessLogin::processMainLogin() replays without ever calling
+         * establishSession(); and an account marked API-only while it is
+         * signed in, which stops on its very next request rather than at
+         * the end of the inactivity timeout.
+         *
+         * Cheap enough to sit on every authenticated request: the object is
+         * already loaded, so this reads a field and issues no query.
+         */
+        if ($this->isAPIOnly()) {
             return false;
         }
         $keys = [
@@ -825,6 +910,7 @@ class User extends FOGController
     public function save()
     {
         $this->_assertAuthSourceKeepsBreakGlass();
+        $this->_assertApiOnlyKeepsInteractiveLogin();
         // Captured before the save, because that is what stamps the id on.
         $isNew = (int)$this->get('id') < 1;
         // Propagate a failed write rather than reporting success; the
@@ -895,6 +981,49 @@ class User extends FOGController
          */
         Authorization::assertLocalAdminRemains(
             ['authSources' => [$id => $pending]]
+        );
+    }
+    /**
+     * Refuses to take the last administrator anybody signs in as.
+     *
+     * Writing users.uAPIOnly takes the UI away from the account it is
+     * written to (see isAPIOnly() above). Doing that to the last
+     * administrator who can still reach the UI leaves the install
+     * administrable only over REST -- which is fine if a token already
+     * exists, and a brick if one does not, because issuing one takes a UI
+     * session. The failure mode this is really guarding is the ordinary
+     * one: ticking the box on your own account.
+     *
+     * It sits on save() for the same reason the auth-source guard does:
+     * uAPIOnly is an ordinary field and is not in Route::$serverOwnedFields,
+     * so a REST PUT /fog/user/{id}, a plugin's own set()/save() and the CSV
+     * import all reach it and have nothing in common. Guarding the write is
+     * what makes it a standing property rather than something each new
+     * caller has to remember. Delete is covered separately, by
+     * Authorization::assertAdminRemainsAfterDelete().
+     *
+     * @throws Exception when the last interactive administrator would be lost
+     * @return void
+     */
+    private function _assertApiOnlyKeepsInteractiveLogin()
+    {
+        $id = (int)$this->get('id');
+        /*
+         * A row with no id yet is a new account, which cannot take a login
+         * away from anybody -- the same reasoning as the auth-source guard,
+         * and it holds here for the same reason: users.uName carries a plain
+         * KEY and not a UNIQUE one, so there is no INSERT ... ON DUPLICATE
+         * KEY UPDATE by name for an update to ride in on.
+         */
+        if ($id < 1 || !$this->isDirty('apionly')) {
+            return;
+        }
+        // Clearing it only ever gives an account its sign-in back.
+        if (!$this->isAPIOnly()) {
+            return;
+        }
+        Authorization::assertInteractiveAdminRemains(
+            ['apiOnly' => [$id => true]]
         );
     }
     /**

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -181,6 +181,42 @@ class UserManagement extends FOGPage
                 -1,
                 -1,
                 (isset($_POST['apienabled']) ? 'checked' : '')
+            ),
+            /*
+             * Offered at creation, not only on edit, because the account
+             * this exists for is created for the purpose: an unattended
+             * integration that wants roles and a token and never a browser.
+             * Creating it interactive and then turning the sign-in off is
+             * the same end state reached through a window in which the
+             * password chosen here is a working login nobody is watching.
+             *
+             * A password is still required by the form above and is
+             * deliberately not made optional: uPass is NOT NULL, an empty
+             * hash fails password_verify() by accident rather than by rule,
+             * and the flag is what makes the credential unusable. Weakening
+             * the field would put an account one unticked box away from a
+             * blank-password login.
+             */
+            self::makeLabel(
+                $labelClass,
+                'apionly',
+                _('API Only Account')
+                . '<br/>('
+                . _('a service account: it may hold API tokens and can '
+                    . 'never sign in to this interface')
+                . ')'
+            ) => self::makeInput(
+                'apionly-input',
+                'apionly',
+                '',
+                'checkbox',
+                'apionly',
+                '',
+                false,
+                false,
+                -1,
+                -1,
+                (isset($_POST['apionly']) ? 'checked' : '')
             )
         ];
 
@@ -245,6 +281,7 @@ class UserManagement extends FOGPage
             filter_input(INPUT_POST, 'display')
         );
         $apien = (int)isset($_POST['apienabled']);
+        $apionly = (int)isset($_POST['apionly']);
         $token = self::createSecToken();
 
         $serverFault = false;
@@ -264,6 +301,7 @@ class UserManagement extends FOGPage
                 ->set('password', $password)
                 ->set('display', $friendly)
                 ->set('api', $apien)
+                ->set('apionly', $apionly)
                 ->set('type', 0)
                 ->set('token', $token);
             if (!$User->save()) {
@@ -367,6 +405,42 @@ class UserManagement extends FOGPage
                 false
             )
         ];
+
+        /*
+         * Whether this account may sign in at all.
+         *
+         * Editable here rather than read-only like the auth source below,
+         * because unlike an auth source this IS a plain two-state
+         * administrative decision with no external system behind it, and
+         * both directions are safe to expose: setting it is guarded by
+         * User::save(), clearing it only ever gives a sign-in back.
+         *
+         * A password is not offered alongside it and the Password tab
+         * disappears while it is set (see edit()), so there is no way to
+         * arrive at "I set them a password" for an account that could never
+         * use one.
+         */
+        $fields[self::makeLabel(
+            $labelClass,
+            'apionly',
+            _('API Only Account')
+            . '<br/>('
+            . _('a service account: it may hold API tokens and can never '
+                . 'sign in to this interface')
+            . ')'
+        )] = self::makeInput(
+            'apionly-input',
+            'apionly',
+            '',
+            'checkbox',
+            'apionly',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            ($this->obj->isAPIOnly() ? ' checked' : '')
+        );
 
         /*
          * Where this account authenticates, read-only.
@@ -512,7 +586,16 @@ class UserManagement extends FOGPage
         }
         $this->obj
             ->set('name', $user)
-            ->set('display', $display);
+            ->set('display', $display)
+            /*
+             * Set from presence, like every other checkbox on this form.
+             * Both directions run on every Update, which is what makes the
+             * box able to clear the flag as well as set it -- and the
+             * refusal that protects the last interactive administrator
+             * lives in User::save(), so it applies to the REST and CSV
+             * paths identically rather than only to this one.
+             */
+            ->set('apionly', (int)isset($_POST['apionly']));
 
         /*
          * Return the account to FOG's own password, if asked.
@@ -1174,10 +1257,17 @@ class UserManagement extends FOGPage
          * User::save() deliberately permits it (see
          * _assertAuthSourceKeepsBreakGlass).
          *
-         * The General tab shows the auth source, so the missing tab has an
-         * explanation on the same page.
+         * An API-only account is refused by the same method for its own
+         * reason, so it is in exactly the same position and the tab is
+         * hidden for it too. To give such an account a usable password,
+         * untick API Only first.
+         *
+         * The General tab shows both the auth source and the API-only box,
+         * so the missing tab has an explanation on the same page.
          */
-        if ('' === trim((string)$this->obj->get('authsource'))) {
+        if ('' === trim((string)$this->obj->get('authsource'))
+            && !$this->obj->isAPIOnly()
+        ) {
             $tabData[] = [
                 'name' => _('Password'),
                 'id' => 'user-changepw',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -448,6 +448,10 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Ort"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8448,6 +8452,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr "IP(s) dieses Servers"
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8624,6 +8631,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 msgid "Those images should be activated with the associated"
@@ -9488,6 +9498,9 @@ msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 
 msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
+msgstr ""
 
 #, fuzzy
 msgid "access"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -452,6 +452,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Location"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8443,6 +8447,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8619,6 +8626,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 #, fuzzy
@@ -9483,6 +9493,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -450,6 +450,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Acción"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Añadir nueva cuenta de usuario"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8631,6 +8635,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8800,6 +8807,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 #, fuzzy
@@ -9669,6 +9679,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -448,6 +448,10 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Ort"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8449,6 +8453,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr "IP(s) dieses Servers"
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8625,6 +8632,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 msgid "Those images should be activated with the associated"
@@ -9489,6 +9499,9 @@ msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 
 msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
+msgstr ""
 
 #, fuzzy
 msgid "access"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -453,6 +453,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Emplacement"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Comptes Slack"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8445,6 +8449,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8621,6 +8628,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 #, fuzzy
@@ -9485,6 +9495,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -439,6 +439,10 @@ msgstr "API?"
 msgid "API Documentation"
 msgstr "Luogo"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8157,6 +8161,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr "IP di questo server"
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8328,6 +8335,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 msgid "Those images should be activated with the associated"
@@ -9163,6 +9173,9 @@ msgstr "Il tuo schema di database FOG non è aggiornato"
 
 msgid "Your database connection appears to be invalid"
 msgstr "La connessione al database sembra non valida"
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
+msgstr ""
 
 #, fuzzy
 msgid "access"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -425,6 +425,10 @@ msgstr "API？"
 msgid "API Documentation"
 msgstr "詳細ドキュメント"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Slack アカウント"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8095,6 +8099,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr "このサーバーの IP アドレス"
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8266,6 +8273,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 msgid "Those images should be activated with the associated"
@@ -9100,6 +9110,9 @@ msgstr "FOG データベースのスキーマが最新ではありません"
 
 msgid "Your database connection appears to be invalid"
 msgstr "データベース接続が無効のようです"
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
+msgstr ""
 
 #, fuzzy
 msgid "access"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -383,6 +383,9 @@ msgstr ""
 msgid "API Documentation"
 msgstr ""
 
+msgid "API Only Account"
+msgstr ""
+
 msgid "API Token Created"
 msgstr ""
 
@@ -7175,6 +7178,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -7340,6 +7346,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 msgid "Those images should be activated with the associated"
@@ -8083,6 +8092,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 msgid "access"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -452,6 +452,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr "Localização"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "Contas Slack"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8444,6 +8448,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8620,6 +8627,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 #, fuzzy
@@ -9484,6 +9494,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -452,6 +452,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr "位置"
 
+#, fuzzy
+msgid "API Only Account"
+msgstr "斯莱克账户"
+
 msgid "API Token Created"
 msgstr ""
 
@@ -8444,6 +8448,9 @@ msgstr ""
 msgid "This FOG server"
 msgstr ""
 
+msgid "This account is for API access only and cannot sign in."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8620,6 +8627,9 @@ msgid "This would leave no account able to administer FOG without its identity p
 msgstr ""
 
 msgid "This would leave no account able to administer FOG."
+msgstr ""
+
+msgid "This would leave no account able to sign in and administer FOG."
 msgstr ""
 
 #, fuzzy
@@ -9484,6 +9494,9 @@ msgid "Your FOG database schema is not up to date"
 msgstr ""
 
 msgid "Your database connection appears to be invalid"
+msgstr ""
+
+msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 
 #, fuzzy

--- a/tests/api-only-users.test.php
+++ b/tests/api-only-users.test.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * An API-only account must never get a browser session.
+ *
+ * The flag is one column and its whole meaning is three refusals. Each of
+ * them guards a DIFFERENT way a session comes into existence, and no one of
+ * them sits downstream of the other two -- so losing any single one is a
+ * silent hole rather than a broken feature: the account signs in normally
+ * and nothing anywhere says the flag was ignored.
+ *
+ * WHAT IS PINNED, and the failure each one catches:
+ *
+ *  1. All three refusals exist -- User::passwordValidate() (local password
+ *     and the iPXE menu login), User::establishSession() (a provider that
+ *     proves an identity itself, OIDC today) and User::_isLoggedIn() (a
+ *     remember-me cookie issued before the flag was set, and an account
+ *     marked while it is signed in).
+ *  2. The passwordValidate() refusal comes BEFORE the remember-me cookie is
+ *     minted. This is the load-bearing ordering and the reason the refusal
+ *     is not simply left to establishSession(): passwordValidate() writes
+ *     the foguserauth* cookies and a userAuths row a few lines further down,
+ *     so refusing downstream would reject the login and leave a working
+ *     two-day credential behind.
+ *  3. establishSession() THROWS rather than returning quietly. Its callers
+ *     disagree about return values and agree about exceptions -- OIDC's
+ *     callback ignores the return entirely -- so a quiet return is a
+ *     sign-in that appears to succeed and lands nowhere.
+ *  4. The last administrator who can still sign in cannot be taken away.
+ *     An API-only administrator is not locked out (REST still works), but a
+ *     brand-new API-only account has no token until somebody issues one and
+ *     issuing one takes a UI session.
+ *  5. The guard sits on User::save() and on the delete path, not on the
+ *     pages. uAPIOnly is an ordinary field and is not in
+ *     Route::$serverOwnedFields, so PUT /fog/user/{id}, a plugin's own
+ *     save() and the CSV import all reach it.
+ *  6. apiOnlyUsersGiven() reads anything that is not '1' as interactive.
+ *     Executed rather than pattern-matched, because getting it backwards
+ *     makes the guard answer confidently and wrongly in the direction that
+ *     locks an install out.
+ *  7. The Password tab is hidden while the flag is set, for the same reason
+ *     it is hidden for a directory-owned account: a password stored there
+ *     could never be accepted, and a tab that stores one reads as "I have
+ *     set them a password".
+ *
+ * Usage: php tests/api-only-users.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('api-only-users');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$userSrc = file_get_contents($web . '/lib/fog/user.class.php');
+$authSrc = file_get_contents($web . '/lib/fog/authorization.class.php');
+$schemaSrc = file_get_contents($web . '/commons/schema.php');
+$manifestSrc = file_get_contents($web . '/commons/schema-expected.php');
+$sysSrc = file_get_contents($web . '/lib/fog/system.class.php');
+$pageSrc = file_get_contents($web . '/lib/pages/usermanagement.page.php');
+
+// ---------------------------------------------------------------------------
+// 0. The column exists and the model can read it.
+// ---------------------------------------------------------------------------
+$t->check(
+    'schema step 360 adds users.uAPIOnly, defaulting to interactive',
+    (bool)preg_match(
+        "/ADD COLUMN `uAPIOnly` ENUM\('0','1'\) NOT NULL DEFAULT '0'/",
+        $schemaSrc
+    )
+);
+$t->check(
+    'the column is guarded so an install that already has it is skipped',
+    (bool)preg_match(
+        "/getColumns\(\s*'users',\s*'uAPIOnly'/s",
+        $schemaSrc
+    )
+);
+$t->check(
+    'FOG_SCHEMA is at least 360',
+    (bool)preg_match("/define\('FOG_SCHEMA', (\d+)\)/", $sysSrc, $m)
+    && (int)$m[1] >= 360
+);
+$t->check(
+    'the manifest carries uAPIOnly',
+    false !== strpos($manifestSrc, "'uAPIOnly' =>")
+);
+$t->check(
+    'User maps apionly to uAPIOnly',
+    (bool)preg_match("/'apionly' => 'uAPIOnly'/", $userSrc)
+);
+$t->check(
+    "isAPIOnly() tests for the string '1' rather than truthiness",
+    (bool)preg_match(
+        "/function isAPIOnly\(\)\s*\{\s*return '1' === \(string\)"
+        . "\\\$this->get\('apionly'\);/s",
+        $userSrc
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 1. All three refusals exist.
+// ---------------------------------------------------------------------------
+$bodyOf = function ($src, $signature) {
+    $at = strpos($src, $signature);
+    if (false === $at) {
+        return '';
+    }
+    // Enough to cover the method without depending on brace counting; each
+    // of these is well under this length.
+    return substr($src, $at, 9000);
+};
+
+$pwBody = $bodyOf($userSrc, 'public function passwordValidate(');
+$esBody = $bodyOf($userSrc, 'public function establishSession(');
+$liBody = $bodyOf($userSrc, 'private function _isLoggedIn()');
+
+$t->check(
+    'passwordValidate() refuses an API-only account',
+    (bool)preg_match("/isAPIOnly\(\)\s*\)\s*\{\s*self::_auditLoginFailure/s", $pwBody)
+);
+$t->check(
+    'establishSession() refuses an API-only account',
+    false !== strpos($esBody, '$this->isAPIOnly()')
+);
+$t->check(
+    '_isLoggedIn() refuses an API-only account',
+    (bool)preg_match(
+        "/if \(\\\$this->isAPIOnly\(\)\) \{\s*return false;/s",
+        substr($liBody, 0, 2000)
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 2. The password refusal precedes the remember-me minting. THE ordering.
+// ---------------------------------------------------------------------------
+$refusalAt = strpos($pwBody, 'isAPIOnly()');
+$cookieAt = strpos($pwBody, 'foguserauthpass');
+$t->check(
+    'the API-only refusal precedes the remember-me cookie in '
+    . 'passwordValidate()',
+    false !== $refusalAt
+    && false !== $cookieAt
+    && $refusalAt < $cookieAt
+);
+// Same request, the other artifact: a userAuths row outlives the response
+// even if the cookie somehow did not reach the browser.
+$authRowAt = strpos($pwBody, "getClass('UserAuth')");
+$t->check(
+    'the refusal also precedes the userAuths row',
+    false !== $refusalAt && false !== $authRowAt && $refusalAt < $authRowAt
+);
+
+// ---------------------------------------------------------------------------
+// 3. establishSession() throws.
+// ---------------------------------------------------------------------------
+$t->check(
+    'establishSession() throws rather than returning quietly',
+    (bool)preg_match(
+        "/if \(\\\$this->isAPIOnly\(\)\) \{\s*throw new \\\\Exception/s",
+        $esBody
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 4/5. The guard, and where it sits.
+// ---------------------------------------------------------------------------
+$t->check(
+    'User::save() runs the interactive-login guard',
+    (bool)preg_match(
+        "/function save\(\)\s*\{.{0,400}?"
+        . "_assertApiOnlyKeepsInteractiveLogin\(\);/s",
+        $userSrc
+    )
+);
+$t->check(
+    'the guard only fires when the flag is actually being SET',
+    (bool)preg_match(
+        "/function _assertApiOnlyKeepsInteractiveLogin\(\).*?"
+        . "!\\\$this->isDirty\('apionly'\).*?"
+        . "if \(!\\\$this->isAPIOnly\(\)\) \{\s*return;/s",
+        $userSrc
+    )
+);
+$t->check(
+    'the guard delegates to Authorization::assertInteractiveAdminRemains',
+    (bool)preg_match(
+        "/function _assertApiOnlyKeepsInteractiveLogin\(\).*?"
+        . "Authorization::assertInteractiveAdminRemains\(\s*"
+        . "\['apiOnly' => \[\\\$id => true\]\]/s",
+        $userSrc
+    )
+);
+$t->check(
+    'deleting a user is guarded too',
+    (bool)preg_match(
+        "/case 'user':.{0,1200}?assertInteractiveAdminRemains\(\\\$changes\);/s",
+        $authSrc
+    )
+);
+$t->check(
+    'adminExistsGiven() honours interactiveOnly',
+    (bool)preg_match(
+        "/if \(!empty\(\\\$changes\['interactiveOnly'\]\)\) \{\s*"
+        . "\\\$users = array_diff\(\\\$users, self::_apiOnlyUsers\(\\\$changes\)\);/s",
+        $authSrc
+    )
+);
+// PRESERVES rather than REQUIRES: an install that already has no interactive
+// administrator must not have every subsequent operation refused.
+$t->check(
+    'the guard returns rather than refusing when there is nothing to protect',
+    (bool)preg_match(
+        "/function assertInteractiveAdminRemains\(.*?\)\s*\{\s*"
+        . "if \(!self::interactiveAdminExists\(\)\) \{\s*return;/s",
+        $authSrc
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 6. The decision half, executed.
+// ---------------------------------------------------------------------------
+$given = ['FOG\\Authorization', 'apiOnlyUsersGiven'];
+$t->check(
+    'apiOnlyUsersGiven() is callable without a database',
+    is_callable($given)
+);
+if (is_callable($given)) {
+    // The 'x' case is the one that carries this check. '0', '' and null are
+    // all falsy in PHP, so they cannot tell a strict '1' comparison apart
+    // from plain truthiness -- a mutation to (bool)$flag passes on them. A
+    // value that is truthy and is NOT '1' is what separates the two, and the
+    // strict form is required because this must agree with User::isAPIOnly(),
+    // which is also strict. If the guard's model of who can sign in disagrees
+    // with the refusal that actually stops them, the guard protects the wrong
+    // set of accounts.
+    $t->check(
+        "only the string '1' bars an account",
+        [2] === call_user_func(
+            $given,
+            [1 => '0', 2 => '1', 3 => '', 4 => null, 5 => 'x'],
+            []
+        )
+    );
+    $t->check(
+        'a proposed value replaces the stored one, both ways',
+        [1] === call_user_func(
+            $given,
+            [1 => '0', 2 => '1'],
+            [1 => true, 2 => false]
+        )
+    );
+    $t->check(
+        'an account with no stored row is only barred if proposed so',
+        [9] === call_user_func($given, [], [9 => true])
+    );
+    $t->check(
+        'no accounts, no answer',
+        [] === call_user_func($given, [], [])
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. The Password tab, and the create form.
+// ---------------------------------------------------------------------------
+$t->check(
+    'the Password tab is hidden while the account is API-only',
+    (bool)preg_match(
+        "/'' === trim\(\(string\)\\\$this->obj->get\('authsource'\)\)\s*"
+        . "&& !\\\$this->obj->isAPIOnly\(\)/s",
+        $pageSrc
+    )
+);
+$t->check(
+    'the flag can be set when the account is created',
+    (bool)preg_match("/->set\('apionly', \\\$apionly\)/", $pageSrc)
+    && (bool)preg_match(
+        "/\\\$apionly = \(int\)isset\(\\\$_POST\['apionly'\]\);/",
+        $pageSrc
+    )
+);
+$t->check(
+    'and cleared as well as set from the General tab',
+    (bool)preg_match(
+        "/->set\('apionly', \(int\)isset\(\\\$_POST\['apionly'\]\)\)/",
+        $pageSrc
+    )
+);
+
+$t->finish();

--- a/tests/fixtures/route-column-contract.txt
+++ b/tests/fixtures/route-column-contract.txt
@@ -572,6 +572,7 @@ user	6	uType	type	-	-
 user	7	uDisplay	display	-	-
 user	8	uAllowAPI	api	-	-
 user	9	uAuthSource	authsource	-	-
+user	10	uAPIOnly	apionly	-	-
 usergroup	0	ugID	id	-	-
 usergroup	1	ugID	DT_RowId	f	-
 usergroup	2	ugName	name	-	-


### PR DESCRIPTION
A service account is an account that holds API credentials and roles and
nothing else. Until now the only way to have one was an ordinary account,
which meant a working password sitting on the login form for a credential
nobody was ever going to type — and, left at whatever the creator chose, an
interactive way in that nobody was watching.

This is the other half of the API token work (#1328, #1329): the central pane
can issue a token on behalf of a user, and this is the kind of user it should
be issuing them to.

## The flag

`users.uAPIOnly`, schema step 360, `ENUM('0','1') DEFAULT '0'` so no existing
account changes and an upgrade can never take a login away from anybody.

A flag rather than an absent password, because "no password" is not a state
FOG can hold: `uPass` is `NOT NULL`, an empty hash fails `password_verify()`
by accident rather than by rule, and nothing stops the next admin setting one.

It is **not** `users.uAllowAPI` inverted. That flag governs whether
`fog-user-token` works for the account and keeps doing exactly that; this one
governs whether a browser session may be made for it. Any combination is
valid, including API-only with `uAllowAPI` off — a service account reachable
only through an issued Bearer token.

## Three refusals

FOG has three ways a session comes into existence and none of them sits
downstream of the other two, so losing any single guard is a silent hole: the
account signs in normally and nothing says the flag was ignored.

| Where | Covers |
|---|---|
| `User::passwordValidate()` | the local password form, and the iPXE menu login |
| `User::establishSession()` | a provider that proves an identity itself — OIDC today |
| `User::_isLoggedIn()` | a remember-me cookie issued before the flag was set; an account marked while it is signed in |

The **placement** of the first is load-bearing and is the reason it is not
simply left to `establishSession()`: `passwordValidate()` mints the
`foguserauth*` cookies and a `userAuths` row a few lines further down, so
refusing downstream would reject the login and leave a working two-day
credential behind. There is a test pinning that ordering.

`establishSession()` throws rather than returning quietly. Its callers
disagree about return values and agree about exceptions — OIDC's callback
ignores the return entirely and wraps the flow in a catch that shows the
message.

## The lockout guard

An API-only administrator is not locked out; REST still works. But a
brand-new API-only account has no token until somebody issues one, and
issuing one takes a UI session. So the accident worth refusing is the
ordinary one: ticking the box on your own account, or on the last account
anybody signs in as.

`Authorization::assertInteractiveAdminRemains()` **preserves rather than
requires**, exactly like the existing `assertLocalAdminRemains()`: an install
that already has no interactive administrator has nothing here to protect,
and refusing its operations would brick it to defend a property it already
gave up. The two are independent — a local admin can be API-only and a
directory admin can be interactive — so they are separate checks rather than
one wearing two names.

It sits on `User::save()` and on `assertAdminRemainsAfterDelete()`, not on the
pages, because `uAPIOnly` is an ordinary field and is not in
`Route::$serverOwnedFields`: a `PUT /fog/user/{id}`, a plugin's own `save()`
and the CSV import all reach it.

## UI

- **General tab** and the **create form** both carry the checkbox. Offered at
  creation because the account this exists for is created for the purpose —
  creating it interactive and turning sign-in off afterwards passes through a
  window where the chosen password is a live login.
- The **Password tab disappears** while the flag is set, for the same reason
  it is hidden for a directory-owned account: a password stored there could
  never be accepted, and a tab that stores one reads as "I have set them a
  password".

## Verified on a live 1.6 install

- schema 360 applied; `uAPIOnly enum('0','1') NOT NULL DEFAULT '0'` present
- API-only account refused at the login form with **403**, leaving **no**
  `foguserauth` cookie and **no** `userAuths` row
- clearing the flag lets the **same password** in with **202** — so the
  refusal is the flag, not a broken credential
- the Password tab disappears and returns with the flag
- a token issued for the API-only account **does** authenticate over Bearer
  (`atLastUsed` stamped, which `resolve()` only reaches after loading a valid
  owner), while a bogus token still 401s
- the guard was exercised by **simulation** against the real admin set
  (`probe_interactive_admin_guard.php`) rather than by leaving the server with
  one administrator: refuses when every wildcard holder would be marked,
  permits when one would remain, and leaves the local-admin guard's answer
  unchanged

## Tests

`tests/api-only-users.test.php`, 26 checks. Five mutation-verified — dropping
each of the three refusals, making `establishSession()` return instead of
throw, and relaxing the strict `'1'` comparison in `apiOnlyUsersGiven()` all
fail the suite.

The `'x'` case in the `apiOnlyUsersGiven()` check exists because `'0'`, `''`
and `null` are all falsy in PHP and so cannot tell a strict comparison apart
from truthiness — the first version of that check passed its own mutation.

`tests/fixtures/route-column-contract.txt` picks up the new field.

## Downstream

None. This adds a field to an existing route class rather than a class, so
FogApi's hardcoded class list is unaffected.