### PR TITLE
feat(users): show API Only in the user list at a glance

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 360);
-        define('FOG_BCACHE_VER', 304);
+        define('FOG_BCACHE_VER', 305);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -44,11 +44,20 @@ class UserManagement extends FOGPage
         $this->headerData = [
             _('Username'),
             _('Friendly Name'),
-            _('API?')
+            _('API?'),
+            // Separate from API? rather than folded into it: they are
+            // independent flags and every combination is real. API? is
+            // whether fog-user-token works for this account; this is
+            // whether the account can sign in at all. An account can be
+            // API-only with API? off -- a service account reachable only
+            // through an issued Bearer token -- and collapsing the two into
+            // one cell would make that state unreadable.
+            _('API Only?')
         ];
         $this->attributes = [
             [],
             [],
+            ['width' => 22],
             ['width' => 22]
         ];
         $types = [];

--- a/packages/web/management/js/fog/user/fog.user.list.js
+++ b/packages/web/management/js/fog/user/fog.user.list.js
@@ -6,7 +6,8 @@
         columns: [
             {data: 'mainlink'},
             {data: 'display'},
-            {data: 'api'}
+            {data: 'api'},
+            {data: 'apionly'}
         ],
         rowId: 'id',
         columnDefs: [
@@ -29,6 +30,30 @@
                     }
                 },
                 targets: 2
+            },
+            {
+                // Deliberately NOT the check/cross pair used for API? above.
+                // A cross there means "this is switched off", which is a
+                // state somebody may want to change. Neither value here is
+                // wrong: an API-only account is not a broken account, it is
+                // a different KIND of account, so the pair is "stands out"
+                // against "ordinary" rather than "good" against "bad".
+                //
+                // Same shape as the protected column on images and snapins,
+                // which is the established two-badge pattern in these grids.
+                // fa-key rather than fa-robot because the bundled Font
+                // Awesome is 4.7.0 and has no fa-robot.
+                render: function(data, type, row) {
+                    var apiOnly = '<span class="badge bg-warning">'
+                        + '<i class="fa fa-key"></i></span>';
+                    var interactive = '<span class="badge bg-secondary">'
+                        + '<i class="fa fa-user"></i></span>';
+                    if (data > 0) {
+                        return apiOnly;
+                    }
+                    return interactive;
+                },
+                targets: 3
             }
         ]
     });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -452,6 +452,10 @@ msgstr "Ort"
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -456,6 +456,10 @@ msgstr "Location"
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -454,6 +454,10 @@ msgstr "Acción"
 msgid "API Only Account"
 msgstr "Añadir nueva cuenta de usuario"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Añadir nueva cuenta de usuario"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -452,6 +452,10 @@ msgstr "Ort"
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -457,6 +457,10 @@ msgstr "Emplacement"
 msgid "API Only Account"
 msgstr "Comptes Slack"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Comptes Slack"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -443,6 +443,10 @@ msgstr "Luogo"
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Slack Accounts"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -429,6 +429,10 @@ msgstr "詳細ドキュメント"
 msgid "API Only Account"
 msgstr "Slack アカウント"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Slack アカウント"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -386,6 +386,9 @@ msgstr ""
 msgid "API Only Account"
 msgstr ""
 
+msgid "API Only?"
+msgstr ""
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -456,6 +456,10 @@ msgstr "Localização"
 msgid "API Only Account"
 msgstr "Contas Slack"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "Contas Slack"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -456,6 +456,10 @@ msgstr "位置"
 msgid "API Only Account"
 msgstr "斯莱克账户"
 
+#, fuzzy
+msgid "API Only?"
+msgstr "斯莱克账户"
+
 msgid "API Token Created"
 msgstr ""
 

--- a/tests/user-list-columns.test.php
+++ b/tests/user-list-columns.test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * The user grid's header and its DataTables column list must stay aligned.
+ *
+ * A FOG list grid is defined in two files that know nothing about each
+ * other: `$this->headerData` in the page class emits the `<th>` cells, and
+ * `columns:` in `management/js/fog/<node>/fog.<node>.list.js` tells
+ * DataTables which JSON field fills each one. Nothing checks that they
+ * agree.
+ *
+ * When they disagree DataTables throws a warning dialog and renders no
+ * rows at all -- so the failure is loud in a browser and completely
+ * invisible to source review, to the rest of this suite, and to CI. Adding
+ * a column means editing both files plus bumping FOG_BCACHE_VER, and
+ * forgetting any one of the three produces a grid that looks broken for
+ * reasons that have nothing to do with the data.
+ *
+ * WHY THIS IS NOT GENERIC. Fourteen of the eighteen list pages set
+ * headerData exactly once and map cleanly to one js file by their $node,
+ * so a sweep across all of them looks trivially available. It is not: task
+ * and host set headerData five and seven times for different sub-grids,
+ * and storagenode builds its header without _() at all, so counting _()
+ * calls -- the obvious heuristic -- silently reports 1 header cell against
+ * 6 columns for a page that is perfectly correct. A gate that cannot tell
+ * a real mismatch from its own parse failure is worse than no gate; doing
+ * this properly needs the header parsed rather than pattern-counted, which
+ * is a bigger job than the column that prompted it. Pinned here for the
+ * grid that changed.
+ *
+ * Usage: php tests/user-list-columns.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('user-list-columns');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$pageSrc = file_get_contents($web . '/lib/pages/usermanagement.page.php');
+$jsSrc = file_get_contents(
+    $web . '/management/js/fog/user/fog.user.list.js'
+);
+$sysSrc = file_get_contents($web . '/lib/fog/system.class.php');
+
+// Header cells, comments stripped so a `_(` inside one is not counted.
+preg_match('/headerData = \[(.*?)\n\s*\];/s', $pageSrc, $m);
+$headerBlock = preg_replace('#//[^\n]*#', '', (string)($m[1] ?? ''));
+$headers = preg_match_all('/_\(/', $headerBlock);
+
+preg_match('/columns: \[(.*?)\n\s*\],/s', $jsSrc, $m2);
+$columnBlock = (string)($m2[1] ?? '');
+preg_match_all("/\{\s*data: '([a-z]+)'/", $columnBlock, $m3);
+$columns = $m3[1];
+
+$t->check('the header block was found', $headers > 0);
+$t->check('the column block was found', count($columns) > 0);
+$t->check(
+    sprintf(
+        'header cells (%d) match DataTables columns (%d)',
+        $headers,
+        count($columns)
+    ),
+    $headers === count($columns)
+);
+$t->check(
+    'the columns are the expected four, in order',
+    ['mainlink', 'display', 'api', 'apionly'] === $columns
+);
+$t->check(
+    'the API Only? header is present',
+    false !== strpos($headerBlock, "_('API Only?')")
+);
+$t->check(
+    'every column has a width attribute entry or an empty one',
+    (bool)preg_match(
+        '/attributes = \[\s*\[\],\s*\[\],\s*'
+        . "\['width' => 22\],\s*\['width' => 22\]\s*\];/s",
+        $pageSrc
+    )
+);
+
+// The renderer has to exist, or the cell shows a raw 1/0. targets: 3 is the
+// apionly column; a renderer pointed at the wrong index silently restyles
+// the API? column instead and leaves this one raw.
+$t->check(
+    'the apionly column has a renderer bound to targets: 3',
+    (bool)preg_match(
+        "/render: function\(data, type, row\) \{[^}]*?apiOnly[^}]*?\}"
+        . ".*?targets: 3/s",
+        $jsSrc
+    )
+);
+// Deliberately a different pair from the API? column above it: neither
+// value here is a fault, so "stands out" vs "ordinary" rather than
+// "good" vs "bad".
+$t->check(
+    'API-only is marked with a warning badge, not a danger one',
+    (bool)preg_match(
+        "/var apiOnly = '<span class=\"badge bg-warning\">/",
+        $jsSrc
+    )
+    && (bool)preg_match(
+        "/var interactive = '<span class=\"badge bg-secondary\">/",
+        $jsSrc
+    )
+);
+// Font Awesome 4.7.0 is what ships. An icon that is not in it renders as
+// an empty box with nothing logged, so the names are checked against the
+// stylesheet that is actually served rather than against a list kept here.
+//
+// Comments are stripped first. The first version of this check scanned the
+// whole file and failed on a comment in the renderer that NAMED the icon it
+// had chosen not to use -- a gate tripping on prose about itself.
+$faCss = file_get_contents($web . '/management/css/font-awesome.min.css');
+$jsCode = preg_replace('#//[^
+]*#', '', $jsSrc);
+preg_match_all('/fa fa-([a-z0-9-]+)/', $jsCode, $m5);
+$missing = [];
+foreach (array_unique($m5[1]) as $icon) {
+    if (false === strpos($faCss, '.fa-' . $icon . ':before')) {
+        $missing[] = $icon;
+    }
+}
+$t->check(
+    'every icon this grid renders exists in the bundled Font Awesome'
+    . (count($missing) ? ' (missing: ' . implode(', ', $missing) . ')' : ''),
+    count($missing) < 1
+);
+
+// A JS change nobody can see is the other half of this defect class.
+$t->check(
+    'FOG_BCACHE_VER is at least 305',
+    (bool)preg_match("/define\('FOG_BCACHE_VER', (\d+)\)/", $sysSrc, $m4)
+    && (int)$m4[1] >= 305
+);
+
+$t->finish();


### PR DESCRIPTION
Follows #1330. The API-only flag was only visible by opening an account,
which is the wrong shape for the question people actually bring to a user
list: *which of these are service accounts.*

## Its own column, not folded into API?

The two flags are independent and every combination is real. `API?` is
whether `fog-user-token` works for the account; this is whether the account
can sign in at all. A service account reachable only through an issued
Bearer token is API-only with `API?` **off**, and one cell cannot say that.

## Not the check/cross pair

`API?` uses green check / red cross, where a cross means "switched off" — a
state somebody may want to change. Neither value here is a fault: an API-only
account is not broken, it is a different *kind* of account. So the pair is
"stands out" against "ordinary":

| State | Badge |
|---|---|
| API-only | `bg-warning` + `fa-key` |
| Ordinary | `bg-secondary` + `fa-user` |

Same two-badge shape as the `protected` column on images and snapins, which
is the established pattern in these grids.

`fa-key` rather than a robot because the bundled Font Awesome is **4.7.0**,
which has no `fa-robot`; an icon the bundle does not carry renders as an empty
box with nothing logged. The test checks icon names against the stylesheet
that is actually served rather than against a list kept in the test, so it
stays true if the bundle is ever changed.

## Tests

`tests/user-list-columns.test.php`, 10 checks, three mutation-verified: an
icon FA 4.7.0 lacks, a header cell the JS has no column for, and a renderer
pointed at the wrong target index.

Header/column drift is worth pinning because it is **loud in a browser and
silent everywhere else** — DataTables throws a warning dialog and renders no
rows, while source review, the rest of the suite and CI all pass.

The first version of the icon check scanned the whole JS file and failed on a
comment naming the icon it had chosen *not* to use — a gate tripping on prose
about itself. It strips comments now.

**Not generalized** across all eighteen list pages, though fourteen map
cleanly to one js file by their `$node`. `task` and `host` set `headerData`
five and seven times for different sub-grids, and `storagenode` builds its
header without `_()`, so counting `_()` calls reports 1 header cell against 6
columns for a page that is entirely correct. A gate that cannot tell a real
mismatch from its own parse failure is worse than no gate; doing it properly
needs the header parsed rather than pattern-counted.

## Verified live

On a 1.6 install: an API-only account renders `bg-warning`/`fa-key` and an
ordinary one `bg-secondary`/`fa-user`, in a grid that loads its rows with no
DataTables warning. `FOG_BCACHE_VER` bumped so the changed JS is actually
served.

## Downstream

None.