### PR TITLE
fix(api): answer 401 for a missing or wrong credential, not 403

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1468,10 +1468,23 @@ class Route extends FOGBase
             filter_input(INPUT_SERVER, 'HTTP_FOG_API_TOKEN')
         );
         $passtoken = trim($passtoken);
-        if (!hash_equals((string)self::$_token, (string)$passtoken)) {
-            // Before sendResponse(), which exits. The presented token is
-            // NOT recorded -- a rejected credential is still a credential,
-            // and #1261/#1262 was exactly this mistake in the SQL fault log.
+        if (hash_equals((string)self::$_token, (string)$passtoken)) {
+            return;
+        }
+        // Only when something was actually presented. An absent header is
+        // not an attempt, which is the rule _testAuth() already applies to
+        // the user token one method below -- this method did not, and it
+        // runs FIRST, so every unauthenticated API request wrote a rejection
+        // row. On the lab server that was 73 api-token rows against 1
+        // user-token row, which is not a difference in traffic: it is this
+        // method recording the ordinary case of nobody presenting anything.
+        // Rejections matter because they are rare, and burying the real ones
+        // under the routine ones is how a log stops being read.
+        //
+        // Before sendResponse(), which exits. The presented token is NOT
+        // recorded -- a rejected credential is still a credential, and
+        // #1261/#1262 was exactly this mistake in the SQL fault log.
+        if ('' !== $passtoken) {
             Audit::record(
                 [
                     'type' => Audit::TOKEN_REJECTED,
@@ -1481,10 +1494,30 @@ class Route extends FOGBase
                     'renderable' => 1
                 ]
             );
-            self::sendResponse(
-                HTTPResponseCodes::HTTP_FORBIDDEN
-            );
         }
+        // 401, not 403. Nothing here has authenticated anybody: this method
+        // runs before _testAuth() and its failure means the credential was
+        // missing or wrong, which is precisely what 401 is for. 403 says
+        // "I know who you are and you may not", and answering it to a caller
+        // who presented nothing sends whoever is debugging that client
+        // looking for a permission they do not have rather than for the
+        // credential they did not send.
+        //
+        // It also made the router disagree with itself. _testBearer() and
+        // _testAuth() both answer 401 for a missing or bad credential; this
+        // was the one arm that did not, and because it runs first it decided
+        // the response for EVERY unauthenticated request -- so an API call
+        // with no headers at all came back 403 while a merely wrong Bearer
+        // token came back 401.
+        //
+        // Deliberately no WWW-Authenticate header, which RFC 7235 would
+        // otherwise want on a 401: it is what makes a browser throw up a
+        // native basic-auth prompt, and the management UI reaches these same
+        // routes over XHR. That is a real regression traded against a header
+        // no FOG client reads.
+        self::sendResponse(
+            HTTPResponseCodes::HTTP_UNAUTHORIZED
+        );
     }
     /**
      * Reads a $_SERVER value, preferring filter_input.

--- a/tests/api-unauthenticated-401.test.php
+++ b/tests/api-unauthenticated-401.test.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * An API call with no usable credential must answer 401, and must not
+ * write an audit row for having presented nothing.
+ *
+ * Route's three auth arms all mean the same thing when they fail -- the
+ * credential was missing or wrong -- and RFC 7235 spells that 401. 403
+ * means "I know who you are and you may not", which nothing here can have
+ * established, because all three run BEFORE any principal is bound.
+ *
+ * _testToken() was the one arm answering 403, and it runs first, so it
+ * decided the response for every unauthenticated request: a call with no
+ * headers at all came back 403 while a merely wrong Bearer token came back
+ * 401. Anybody debugging a client from the status code was sent looking for
+ * a permission rather than a credential.
+ *
+ * WHAT IS PINNED:
+ *
+ *  1. All three arms answer 401. Pinned as "no arm sends 403" rather than
+ *     by naming them, so a fourth auth mechanism cannot reintroduce the
+ *     inconsistency by being written to a different rule.
+ *  2. The audit row is conditional on something having been presented.
+ *     _testAuth() already had that rule and _testToken() did not, and
+ *     because _testToken() runs first the ordinary no-credential request
+ *     wrote a rejection row every time -- 73 api-token rows against 1
+ *     user-token row on the lab server, which is this method recording
+ *     nobody presenting anything. Rejections are worth reading because they
+ *     are rare.
+ *  3. The presented token is still never written into the row. That is
+ *     #1261/#1262's mistake and it must not come back through an edit that
+ *     is only meant to move a status code.
+ *  4. No WWW-Authenticate header. RFC 7235 wants one on a 401; it is also
+ *     what makes a browser throw a native basic-auth prompt, and the
+ *     management UI reaches these routes over XHR. The omission is a
+ *     decision, so it is pinned rather than left to be "fixed" later.
+ *
+ * Usage: php tests/api-unauthenticated-401.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('api-unauthenticated-401');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$routeSrc = file_get_contents($web . '/lib/router/route.class.php');
+
+$bodyOf = function ($src, $signature, $len = 6000) {
+    $at = strpos($src, $signature);
+    return false === $at ? '' : substr($src, $at, $len);
+};
+
+$tokenBody = $bodyOf($routeSrc, 'private static function _testToken()');
+$bearerBody = $bodyOf($routeSrc, 'private static function _testBearer()');
+$authBody = $bodyOf($routeSrc, 'private static function _testAuth()');
+
+$t->check('the three auth arms were found', '' !== $tokenBody
+    && '' !== $bearerBody && '' !== $authBody);
+
+// 1. Every arm answers 401 and none answers 403.
+foreach ([
+    '_testToken' => $tokenBody,
+    '_testBearer' => $bearerBody,
+    '_testAuth' => $authBody
+] as $name => $body) {
+    $t->check(
+        "$name() answers HTTP_UNAUTHORIZED",
+        false !== strpos($body, 'HTTPResponseCodes::HTTP_UNAUTHORIZED')
+    );
+    // Comments stripped: the docblocks here discuss 403 on purpose, and a
+    // gate that trips on prose about itself is a gate that gets deleted.
+    $code = preg_replace('#//[^\n]*#', '', $body);
+    $t->check(
+        "$name() does not answer HTTP_FORBIDDEN",
+        false === strpos($code, 'HTTPResponseCodes::HTTP_FORBIDDEN')
+    );
+}
+
+// 2. Nothing presented is not an attempt, in BOTH token arms.
+$t->check(
+    '_testToken() only audits when a token was actually presented',
+    (bool)preg_match(
+        "/if \('' !== \\\$passtoken\) \{\s*Audit::record\(/s",
+        $tokenBody
+    )
+);
+$t->check(
+    '_testAuth() keeps the same rule for the user token',
+    (bool)preg_match(
+        "/if \('' !== \\\$usertoken\) \{\s*Audit::record\(/s",
+        $authBody
+    )
+);
+// The early return is what makes the audit block reachable only on failure.
+$t->check(
+    '_testToken() returns on a match rather than inverting the compare',
+    (bool)preg_match(
+        "/if \(hash_equals\(\(string\)self::\\\$_token, \(string\)"
+        . "\\\$passtoken\)\) \{\s*return;\s*\}/s",
+        $tokenBody
+    )
+);
+
+// 3. The credential is never the audit payload.
+foreach (['_testToken' => $tokenBody, '_testBearer' => $bearerBody] as $name => $body) {
+    $t->check(
+        "$name() does not put the presented token in the audit row",
+        false === strpos($body, "'text' => \$passtoken")
+        && false === strpos($body, "'subjectLabel' => \$passtoken")
+        && false === strpos($body, "'text' => \$token")
+        && false === strpos($body, "'subjectLabel' => \$token")
+    );
+}
+
+// 4. The WWW-Authenticate omission is deliberate.
+$t->check(
+    'no arm sends a WWW-Authenticate header',
+    false === stripos(
+        preg_replace('#//[^\n]*#', '', $tokenBody . $bearerBody . $authBody),
+        'WWW-Authenticate'
+    )
+);
+
+$t->finish();


### PR DESCRIPTION
Found while probing the API token work. `Route` has three auth arms and they
all mean the same thing when they fail — the credential was missing or wrong.
RFC 7235 spells that **401**. **403** means "I know who you are and you may
not", which none of them can have established: all three run *before* any
principal is bound.

`_testToken()` was the one arm answering 403, and it runs **first**, so it
decided the response for every unauthenticated request:

```
GET /fog/user                          -> 403, empty body
GET /fog/user  (bogus Bearer token)    -> 401
```

Anyone debugging a client from the status code was sent looking for a
permission they did not have, rather than for the credential they had not
sent.

## Second half: the audit row

`_testToken()` recorded a rejection **unconditionally**, so "nobody presented
anything" was written down as a rejected credential. `_testAuth()` already has
the rule one method below — *an empty header is not an attempt* — and
`_testToken()` did not.

On the lab server that is **73 api-token rejection rows against 1 user-token
row**. That is not a difference in traffic; it is this method recording the
ordinary case of an unauthenticated request. Rejections are worth reading
because they are rare, and this buried them.

## Authentication behavior is unchanged

Only the status code and the audit row change. Verified on a live 1.6 install:

| Request | Now | Before |
|---|---|---|
| server token + valid basic auth | 200 | 200 |
| server token + wrong basic auth | 401 | 401 |
| no server token + valid basic auth | 401 | 401 |
| no auth at all | **401** | 403 |
| wrong `fog-api-token` | **401** | 403 |
| empty `fog-api-token` | **401** | 403 |
| bogus Bearer | 401 | 401 |
| `system/info` (unauthenticated route) | 200 | 200 |

Both credentials were always required together — the third row is not a
regression, it is the pre-existing design, and the 200 in the first row is the
proof the change did not break the path.

Those four unauthenticated calls added **one** audit row between them, the
wrong-token attempt, where previously each would have added its own. The
bearer arm's auditing is untouched and still records.

## No WWW-Authenticate

RFC 7235 would otherwise want one on a 401. It is also what makes a browser
throw a native basic-auth prompt, and the management UI reaches these same
routes over XHR — a real regression traded against a header no FOG client
reads. The omission is pinned so it does not get "fixed" later by accident.

## Not changed, and why

`hash_equals()` against an empty `FOG_API_TOKEN` matches an absent header, so
on a server with that setting blank `_testToken()` always passes. That is
**not** a bypass: `_testToken()` and `_testAuth()` both have to pass, so a user
credential is still required. Left alone rather than hardened speculatively —
the sequencing is the real defense — but worth knowing if that sequencing is
ever refactored.

## Tests

`tests/api-unauthenticated-401.test.php`, 13 checks, three mutation-verified:
reverting to 403, auditing unconditionally again, and adding a
`WWW-Authenticate` header. The no-403 assertion strips comments first, because
these docblocks discuss 403 on purpose.

Pinned as **"no arm sends 403"** rather than by naming the three, so a fourth
auth mechanism cannot reintroduce the inconsistency by being written to a
different rule.

## Downstream

Clients that branch on 403 vs 401 for these routes would see the change. FOG's
own client does not reach these routes; FogApi should be checked, but it
treats both as failure.