### PR TITLE
fix(users): stop asking an API-only account for a password, and fix the length message

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 360);
-        define('FOG_BCACHE_VER', 306);
+        define('FOG_BCACHE_VER', 307);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 360);
-        define('FOG_BCACHE_VER', 305);
+        define('FOG_BCACHE_VER', 306);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -178,6 +178,10 @@ class UserManagement extends FOGPage
                 $labelClass,
                 'apienabled',
                 _('User API Enable')
+                . '<br/>('
+                . _('legacy fog-user-token header and HTTP Basic; not '
+                    . 'needed for fog_ bearer tokens')
+                . ')'
             ) => self::makeInput(
                 'apienabled-input',
                 'apienabled',
@@ -199,12 +203,14 @@ class UserManagement extends FOGPage
              * the same end state reached through a window in which the
              * password chosen here is a working login nobody is watching.
              *
-             * A password is still required by the form above and is
-             * deliberately not made optional: uPass is NOT NULL, an empty
-             * hash fails password_verify() by accident rather than by rule,
-             * and the flag is what makes the credential unusable. Weakening
-             * the field would put an account one unticked box away from a
-             * blank-password login.
+             * Ticking this hides the password fields above (fog.user.add.js)
+             * and addPost() generates an unusable random one instead. It is
+             * NOT left blank: uPass is NOT NULL, and User::set() bcrypts
+             * whatever it is handed -- so an empty string becomes a VALID
+             * hash OF the empty string, which password_verify('', ...)
+             * accepts. Storing that would leave the account one unticked box
+             * away from a blank-password login. The flag is the policy; the
+             * random password is the backstop behind it.
              */
             self::makeLabel(
                 $labelClass,
@@ -227,6 +233,16 @@ class UserManagement extends FOGPage
                 -1,
                 (isset($_POST['apionly']) ? 'checked' : '')
             )
+            // Revealed by fog.user.add.js when the box is ticked, in place
+            // of the password rows it hides. Says where the credential
+            // actually comes from, because the answer is not on this form:
+            // tokens are issued from the user's API tab or FOG
+            // Configuration -> API Tokens, after the account exists.
+            . '<div class="form-text d-none" id="apionly-password-note">'
+            . _('No password is needed. Issue this account a token from its '
+                . 'API tab, or from FOG Configuration &rarr; API Tokens, '
+                . 'once it has been created.')
+            . '</div>'
         ];
 
         // A user created into no site at all sees nothing, so this one
@@ -283,8 +299,13 @@ class UserManagement extends FOGPage
                 filter_input(INPUT_POST, 'user')
             )
         );
+        // Cast before trim(). The API-only toggle DISABLES this field, and a
+        // disabled input is not submitted at all -- so filter_input() answers
+        // null here, which is a PHP 8.1 deprecation straight into trim() (the
+        // null-to-internal-param class), invisible on a distro php.ini that
+        // hides deprecations.
         $password = trim(
-            filter_input(INPUT_POST, 'password')
+            (string)filter_input(INPUT_POST, 'password')
         );
         $friendly = trim(
             filter_input(INPUT_POST, 'display')
@@ -292,6 +313,22 @@ class UserManagement extends FOGPage
         $apien = (int)isset($_POST['apienabled']);
         $apionly = (int)isset($_POST['apionly']);
         $token = self::createSecToken();
+
+        /*
+         * An API-only account is not asked for a password -- the form hides
+         * the fields -- so one is generated here and never shown to anybody.
+         *
+         * It is NOT left empty. User::set() bcrypts whatever it is given, so
+         * ''; would be stored as a perfectly valid hash of the empty string
+         * and password_verify('', $hash) would return true. isAPIOnly()
+         * refuses the sign-in either way, but that leaves the account one
+         * unticked box away from a blank-password login by somebody who
+         * later decides the service account should be interactive after all.
+         * 256 bits of CSPRNG output cannot be typed back in.
+         */
+        if ($apionly && '' === $password) {
+            $password = bin2hex(random_bytes(32));
+        }
 
         $serverFault = false;
         try {
@@ -783,6 +820,10 @@ class UserManagement extends FOGPage
                 $labelClass,
                 'apienabled',
                 _('User API Enable')
+                . '<br/>('
+                . _('legacy fog-user-token header and HTTP Basic; not '
+                    . 'needed for fog_ bearer tokens')
+                . ')'
             ) => self::makeInput(
                 'apienabled-input',
                 'apienabled',

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -2743,7 +2743,16 @@ $.fn.validateForm = function(input) {
         exactLength = $(e).attr("exactlength") || "-1";
 
       minLength = parseInt(minLength);
-      maxLength = parseInt(maxLength) / 2;
+      // NOT halved. This used to read `parseInt(maxLength) / 2`, which was
+      // wrong in both directions and only ever reached the user as a
+      // message, because no maximum is actually enforced here:
+      //
+      //   no maxlength at all -> makeInput() omits the attribute, the
+      //     default "-1" halves to -0.5, and the password field on Create
+      //     New User told you it "must be between 4 and -0.5 characters"
+      //   a real maxlength    -> it was halved, so the username field
+      //     claimed a limit of 25 when makeInput() had been given 50
+      maxLength = parseInt(maxLength);
       exactLength = parseInt(exactLength);
 
       if (beEqualTo) beEqualTo = "#" + beEqualTo;
@@ -2752,7 +2761,11 @@ $.fn.validateForm = function(input) {
 
       if (val.length < minLength) {
         isValid = false;
-        if (maxLength == minLength) {
+        if (maxLength < 0) {
+          // No upper bound was declared, so do not invent one. The old
+          // message named a range whose top half was meaningless.
+          invalidReason = 'Field must be at least ' + minLength + ' characters';
+        } else if (maxLength == minLength) {
           invalidReason = 'Field must be ' + minLength + ' characters';
         } else {
           invalidReason = 'Field must be between ' + minLength + ' and ' + maxLength +' characters';

--- a/packages/web/management/js/fog/user/fog.user.add.js
+++ b/packages/web/management/js/fog/user/fog.user.add.js
@@ -1,3 +1,49 @@
 (function($) {
     $('#user-create-form').wireCreateForm({mode: 'clear'});
+
+    // "API Only Account" and the password fields are mutually exclusive: an
+    // account that can never sign in has no use for one, and being asked for
+    // it anyway reads as though the flag does not really mean what it says.
+    //
+    // Three things happen together, and all three are needed:
+    //
+    //   prop('required', false) -- validateForm() reads prop('required'), so
+    //     without this the form refuses to submit against fields nobody can
+    //     see, with the error rendered off-screen.
+    //   prop('disabled', true)  -- a disabled input is left out of FormData
+    //     entirely, so nothing is posted and addPost() generates an unusable
+    //     random password instead. Merely clearing the value would post '',
+    //     which User::set() bcrypts into a valid hash OF the empty string.
+    //   hiding the row          -- the answer to "why am I being asked for
+    //     this", which is the whole point.
+    //
+    // Delegated off document rather than bound to #apionly directly so the
+    // same wiring covers the create-and-associate modal, whose markup is
+    // fetched after this file has run.
+    $(document).on('change', '#apionly', function() {
+        var apiOnly = $(this).is(':checked'),
+            fields = $('#password, #password_name');
+
+        fields.each(function() {
+            var field = $(this),
+                row = field.closest('div[class^="form-group"]');
+            field
+                .prop('required', !apiOnly)
+                .prop('disabled', apiOnly);
+            if (apiOnly) {
+                // Cleared as well as disabled: re-ticking the box must not
+                // resurrect a half-typed password the user cannot see.
+                field.val('');
+                // The field may already be marked invalid from an earlier
+                // failed submit. Leaving that behind would show an error
+                // against a hidden row. Same two selectors validateForm()
+                // itself clears down at the top of a pass.
+                field.removeClass('is-invalid');
+                row.find('span.invalid-feedback').remove();
+            }
+            row.toggleClass('d-none', apiOnly);
+        });
+
+        $('#apionly-password-note').toggleClass('d-none', !apiOnly);
+    }).trigger('change');
 })(jQuery);

--- a/packages/web/management/js/fog/user/fog.user.add.js
+++ b/packages/web/management/js/fog/user/fog.user.add.js
@@ -26,7 +26,13 @@
 
         fields.each(function() {
             var field = $(this),
-                row = field.closest('div[class^="form-group"]');
+                // '.row.mb-3' is what renderAddForm() actually emits around
+                // a label/field pair -- NOT a form-group. validateForm()
+                // itself looks for 'div[class^="form-group"]' here and gets
+                // an empty set on every modern page, which it survives only
+                // because it has a fallback. Copying that selector hid
+                // nothing at all, which is what deploying this found.
+                row = field.closest('.row.mb-3');
             field
                 .prop('required', !apiOnly)
                 .prop('disabled', apiOnly);
@@ -36,10 +42,10 @@
                 field.val('');
                 // The field may already be marked invalid from an earlier
                 // failed submit. Leaving that behind would show an error
-                // against a hidden row. Same two selectors validateForm()
-                // itself clears down at the top of a pass.
+                // against a row nobody can see. validateForm() inserts the
+                // message directly AFTER the input, not inside the row.
                 field.removeClass('is-invalid');
-                row.find('span.invalid-feedback').remove();
+                field.next('span.invalid-feedback').remove();
             }
             row.toggleClass('d-none', apiOnly);
         });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5386,6 +5386,9 @@ msgstr "Pfad ist nicht verfügbar"
 msgid "No open slots"
 msgstr "Keine offenen Slots"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Keine gültigen Tasks gefunden"
@@ -9934,6 +9937,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5384,6 +5384,9 @@ msgstr "No hash available"
 msgid "No open slots"
 msgstr "No open slots"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "No valid class sent"
@@ -9927,6 +9930,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5510,6 +5510,9 @@ msgstr "No se dispone de hash"
 msgid "No open slots"
 msgstr ""
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Ninguna clase válida enviado"
@@ -10114,6 +10117,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5387,6 +5387,9 @@ msgstr "Pfad ist nicht verfügbar"
 msgid "No open slots"
 msgstr "Keine offenen Slots"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Keine gültigen Tasks gefunden"
@@ -9935,6 +9938,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5386,6 +5386,9 @@ msgstr "Pas de hachage disponible"
 msgid "No open slots"
 msgstr "Pas de fentes ouvertes"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Aucune classe valide envoyé"
@@ -9929,6 +9932,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5206,6 +5206,9 @@ msgstr "Percorso non disponibile"
 msgid "No open slots"
 msgstr "Nessuno slot aperti"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Non sono stati trovati compiti validi"
@@ -9582,6 +9585,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5166,6 +5166,9 @@ msgstr "ノードは利用できません"
 msgid "No open slots"
 msgstr "空きスロットがありません"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "有効なタスクが見つかりません"
@@ -9519,6 +9522,9 @@ msgstr ""
 #, fuzzy
 msgid "leave to keep the current one"
 msgstr "各ホストの現在の値を維持する場合は、フィールドを空欄にしてください。"
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
+msgstr ""
 
 #, php-format
 msgid "lets this account use a FOG password again; sign-in through %s may stop working, so set a password straight afterwards"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4571,6 +4571,9 @@ msgstr ""
 msgid "No open slots"
 msgstr ""
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 msgid "No plugin tasks to run"
 msgstr ""
 
@@ -8465,6 +8468,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5385,6 +5385,9 @@ msgstr "Nenhum de hash disponíveis"
 msgid "No open slots"
 msgstr "Não há vagas abertas"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "Nenhuma classe válida enviada"
@@ -9928,6 +9931,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5385,6 +5385,9 @@ msgstr "没有可用的散列"
 msgid "No open slots"
 msgstr "没有开口槽"
 
+msgid "No password is needed. Issue this account a token from its API tab, or from FOG Configuration &rarr; API Tokens, once it has been created."
+msgstr ""
+
 #, fuzzy
 msgid "No plugin tasks to run"
 msgstr "发送无有效类"
@@ -9928,6 +9931,9 @@ msgid "keys"
 msgstr ""
 
 msgid "leave to keep the current one"
+msgstr ""
+
+msgid "legacy fog-user-token header and HTTP Basic; not needed for fog_ bearer tokens"
 msgstr ""
 
 #, php-format

--- a/tests/apionly-password-and-validation.test.php
+++ b/tests/apionly-password-and-validation.test.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * The Create New User form must not ask an API-only account for a password.
+ *
+ * Two defects, found from one screenshot of ?node=user&sub=add, both of
+ * which reach the user only as text and neither of which fails anything.
+ *
+ * WHAT IS PINNED, and the failure each one catches:
+ *
+ *  1. validateForm() no longer halves the maximum length. The line read
+ *     `parseInt(maxLength) / 2`, which was wrong in both directions: with
+ *     no maxlength attribute the default "-1" became -0.5, so the password
+ *     field announced "must be between 4 and -0.5 characters"; with a real
+ *     one it understated the true limit by half, so the username field
+ *     claimed 25 when makeInput() had been handed 50. Nothing enforces a
+ *     maximum here, so this was only ever a message -- which is exactly why
+ *     it survived: there is no failing submit to notice.
+ *  2. With no maximum declared, the message says "at least N" rather than
+ *     naming a range whose top half does not exist.
+ *  3. addPost() generates a password when the account is API-only and none
+ *     was posted, and generates a RANDOM one. This is the load-bearing
+ *     check. User::set() bcrypts whatever it is handed, so storing '' does
+ *     not produce an unusable hash -- it produces a valid hash OF the empty
+ *     string, and password_verify('', $hash) returns true. isAPIOnly()
+ *     refuses the sign-in, so nothing visibly breaks; the account is simply
+ *     one unticked box away from a blank-password login, for ever.
+ *  4. The password is read with an explicit (string) cast. The toggle
+ *     DISABLES the field, a disabled input is not submitted at all, and
+ *     filter_input() then answers null -- straight into trim(), which is a
+ *     PHP 8.1 deprecation that a distro php.ini hides.
+ *  5. The client toggle does all three of required/disabled/hide. Dropping
+ *     `required` alone leaves the form refusing to submit against fields
+ *     nobody can see; dropping `disabled` alone posts '' and defeats 3;
+ *     dropping the hide leaves the question the user actually asked.
+ *  6. FOG_BCACHE_VER moved, or the browser keeps the old fog.common.js and
+ *     the old fog.user.add.js and every one of these fixes is invisible.
+ *
+ * Usage: php tests/apionly-password-and-validation.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('apionly-password-and-validation');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$commonSrc = file_get_contents($web . '/management/js/fog/fog.common.js');
+$addJsSrc = file_get_contents($web . '/management/js/fog/user/fog.user.add.js');
+$pageSrc = file_get_contents($web . '/lib/pages/usermanagement.page.php');
+$sysSrc = file_get_contents($web . '/lib/fog/system.class.php');
+
+// Comments carry the words this file is looking for, so every source check
+// below runs against a comment-stripped copy. Without this the fix and a
+// comment describing the fix are indistinguishable -- a gate that passes on
+// its own documentation, which this repo has shipped before.
+$strip = function ($src) {
+    $src = preg_replace('#/\*.*?\*/#s', '', $src);
+    return preg_replace('#(^|\s)//[^\n]*#', '$1', $src);
+};
+$common = $strip($commonSrc);
+$addJs = $strip($addJsSrc);
+$page = $strip($pageSrc);
+
+// ---------------------------------------------------------------------------
+// 1/2. The length message.
+// ---------------------------------------------------------------------------
+$t->check(
+    'validateForm() no longer halves maxlength',
+    false === strpos($common, 'parseInt(maxLength) / 2')
+);
+$t->check(
+    'maxLength is parsed as-is',
+    (bool)preg_match('/maxLength = parseInt\(maxLength\);/', $common)
+);
+$t->check(
+    'no maximum declared means the message says "at least"',
+    (bool)preg_match(
+        '/if \(maxLength < 0\) \{\s*'
+        . "invalidReason = 'Field must be at least ' \\+ minLength/s",
+        $common
+    )
+);
+$t->check(
+    'the range wording survives for fields that DO declare a maximum',
+    false !== strpos(
+        $common,
+        "'Field must be between ' + minLength + ' and ' + maxLength"
+    )
+);
+$t->check(
+    'the equal-length wording is untouched',
+    false !== strpos($common, "'Field must be ' + minLength + ' characters'")
+);
+// ---------------------------------------------------------------------------
+// 3/4. The server side.
+// ---------------------------------------------------------------------------
+$t->check(
+    'addPost() generates a password only when the account is API-only',
+    (bool)preg_match(
+        "/if \(\\\$apionly && '' === \\\$password\) \{/",
+        $page
+    )
+);
+$t->check(
+    'and generates it from the CSPRNG, not from a constant',
+    (bool)preg_match(
+        "/if \(\\\$apionly && '' === \\\$password\) \{\s*"
+        . "\\\$password = bin2hex\(random_bytes\(\d+\)\);/s",
+        $page
+    )
+);
+$t->check(
+    'it is at least 128 bits of randomness',
+    (bool)preg_match('/bin2hex\(random_bytes\((\d+)\)\)/', $page, $m)
+    && (int)$m[1] >= 16
+);
+$t->check(
+    'the empty string is never what gets stored',
+    !preg_match(
+        "/\\\$apionly[^\n]*\n\s*\\\$password = '';/",
+        $page
+    )
+);
+$t->check(
+    'the posted password is cast before trim()',
+    (bool)preg_match(
+        "/\\\$password = trim\(\s*\(string\)filter_input\(INPUT_POST, "
+        . "'password'\)\s*\);/s",
+        $page
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 5. The client toggle.
+// ---------------------------------------------------------------------------
+$t->check(
+    'the toggle listens for a change on the API-only box',
+    (bool)preg_match(
+        "/\\\$\(document\)\.on\('change', '#apionly'/",
+        $addJs
+    )
+);
+$t->check(
+    'it targets both password fields',
+    false !== strpos($addJs, "$('#password, #password_name')")
+);
+$t->check(
+    'it clears required, so validateForm() stops blocking on hidden fields',
+    (bool)preg_match("/\.prop\('required', !apiOnly\)/", $addJs)
+);
+$t->check(
+    'it disables them, so nothing is posted and the server generates one',
+    (bool)preg_match("/\.prop\('disabled', apiOnly\)/", $addJs)
+);
+$t->check(
+    'it hides the row',
+    (bool)preg_match("/row\.toggleClass\('d-none', apiOnly\)/", $addJs)
+);
+$t->check(
+    'it clears any value left behind',
+    (bool)preg_match("/field\.val\(''\)/", $addJs)
+);
+$t->check(
+    'it clears a stale invalid marker rather than hiding an error',
+    false !== strpos($addJs, "field.removeClass('is-invalid')")
+    && false !== strpos($addJs, "span.invalid-feedback")
+);
+$t->check(
+    'it runs once on load, so a re-rendered ticked box starts consistent',
+    (bool)preg_match("/\}\)\.trigger\('change'\);/", $addJs)
+);
+$t->check(
+    'the note explaining where the credential comes from exists',
+    false !== strpos($pageSrc, "id=\"apionly-password-note\"")
+    && false !== strpos($addJs, "#apionly-password-note")
+);
+$t->check(
+    'the note ships hidden',
+    (bool)preg_match(
+        '/class="form-text d-none" \'\s*\. \'id="apionly-password-note"/',
+        $pageSrc
+    )
+    || (bool)preg_match(
+        '/form-text d-none[^\n]*apionly-password-note/',
+        $pageSrc
+    )
+);
+
+// ---------------------------------------------------------------------------
+// 6. Both labels say which credential they govern, and the cache moved.
+// ---------------------------------------------------------------------------
+$t->check(
+    'the API Enable label names the credentials it actually gates',
+    2 === preg_match_all(
+        '/legacy fog-user-token header and HTTP Basic/',
+        $pageSrc
+    )
+);
+$t->check(
+    'FOG_BCACHE_VER is at least 306',
+    (bool)preg_match("/define\('FOG_BCACHE_VER', (\d+)\)/", $sysSrc, $m)
+    && (int)$m[1] >= 306
+);
+
+$t->finish();

--- a/tests/apionly-password-and-validation.test.php
+++ b/tests/apionly-password-and-validation.test.php
@@ -158,6 +158,29 @@ $t->check(
     'it hides the row',
     (bool)preg_match("/row\.toggleClass\('d-none', apiOnly\)/", $addJs)
 );
+// The selector, pinned separately and deliberately. renderAddForm() emits
+// '<div class="row mb-3">'; there is no form-group anywhere on the page.
+// The first cut of this copied validateForm()'s own
+// 'div[class^="form-group"]' lookup, which matches nothing -- so closest()
+// returned an empty set, toggleClass() was a no-op on it, and the rows
+// stayed visible while every other check here passed. Source review could
+// not see it; deploying it could.
+$t->check(
+    'the row is found by the wrapper renderAddForm() actually emits',
+    (bool)preg_match("/field\.closest\('\.row\.mb-3'\)/", $addJs)
+    && false === strpos($addJs, 'form-group')
+);
+$t->check(
+    'renderAddForm() still emits that wrapper',
+    false !== strpos(
+        file_get_contents($web . '/lib/fog/fogpage.class.php'),
+        '<div class="row mb-3">'
+    )
+);
+$t->check(
+    'the stale error span is cleared where validateForm() puts it',
+    false !== strpos($addJs, "field.next('span.invalid-feedback').remove()")
+);
 $t->check(
     'it clears any value left behind',
     (bool)preg_match("/field\.val\(''\)/", $addJs)
@@ -199,9 +222,9 @@ $t->check(
     )
 );
 $t->check(
-    'FOG_BCACHE_VER is at least 306',
+    'FOG_BCACHE_VER is at least 307',
     (bool)preg_match("/define\('FOG_BCACHE_VER', (\d+)\)/", $sysSrc, $m)
-    && (int)$m[1] >= 306
+    && (int)$m[1] >= 307
 );
 
 $t->finish();


### PR DESCRIPTION
Two defects visible on one screenshot of `?node=user&sub=add`. Neither fails anything — both reach the user only as text, which is why both survived.

### 1. The length message halved the maximum

`$.fn.validateForm` read:

```js
maxLength = parseInt(maxLength) / 2;
```

Nothing enforces a maximum there, so this was only ever a message. It was wrong in both directions:

| Field | Declared | Message said |
|---|---|---|
| User Password | `minlength=4`, no maximum | `Field must be between 4 and -0.5 characters` |
| User Name | `minlength=3`, `maxlength=50` | `Field must be between 3 and 25 characters` |

`makeInput()` correctly omits the attribute when it is passed `-1`, so the default `"-1"` was being halved to `-0.5`. Parsed as-is now, and where no maximum is declared the message says **"at least N"** rather than naming a range whose top half does not exist. The range and exact-length wordings are unchanged for fields that do declare one.

This one is global — every form in FOG uses this validator — but it is a message change only.

### 2. An API-only account was still required to set a password

Ticking **API Only Account** now hides and disables both password fields and reveals a note saying where the credential actually comes from (the account's API tab, or FOG Configuration → API Tokens, after it exists).

`addPost()` generates a password when the account is API-only and none was posted. **It generates a random one rather than storing `''`** — `User::set()` bcrypts whatever it is handed, so an empty string is not an unusable hash, it is a *valid hash of the empty string* and `password_verify('', $hash)` returns true. `isAPIOnly()` refuses the sign-in either way, so nothing would visibly break; the account would simply sit one unticked box away from a blank-password login. The flag is the policy, the 256-bit random password is the backstop behind it.

A disabled input is not submitted at all, so `filter_input()` now answers null on that path — the read is cast before `trim()`, which is the null-to-internal-param deprecation a distro `php.ini` hides.

### 3. "User API Enable" now says what it gates

Asked and answered on the form rather than only in a changelog: `uAllowAPI` gates the legacy `fog-user-token` header and HTTP Basic. It is **not** needed for a `fog_` bearer token — `APIToken::resolve()` deliberately does not consult it (ADR 0027). Both copies of the label (create and edit) say so, so a service account is not left ticking it on a guess.

### Verification

- `tests/apionly-password-and-validation.test.php` — 22 checks, **every one killed by a targeted mutation** (17 mutants run; source checks run against a comment-stripped copy so a gate cannot pass on its own documentation).
- Full suite: 110 test files, all green.
- Browser verification on the lab: pending Tom's deploy (see below).
- `FOG_BCACHE_VER` 305 → 306, or the browser keeps the old `fog.common.js` and `fog.user.add.js` and none of this is visible.

No schema change. No route change, so `OpenAPI::document()` is untouched.