### PR TITLE
fix(installer): fetch-plugins.sh reported success after doing nothing

### DIFF
--- a/bin/fetch-plugins.sh
+++ b/bin/fetch-plugins.sh
@@ -149,7 +149,28 @@ echo "$pluginsVer" > "$staging/.fog-plugins-version"
 (cd "$staging" && find . -type f | sed 's|^\./||' | grep -v '^\.fog-plugins-') \
     | sort > "$tmp/manifest"
 mv "$tmp/manifest" "$staging/.fog-plugins-manifest"
-rm -rf "$dest"
-mkdir -p "$(dirname "$dest")"
-mv "$staging" "$dest"
+# Checked, unlike the steps above, because this is the only point where a
+# failure produces a WRONG ANSWER rather than an error. `set -e` is
+# deliberately not on -- the download loop needs to tolerate failures and retry
+# -- so an unguarded rm/mv here printed its error to stderr, fell through, and
+# the script still announced success and exited 0. Hit for real on a tree left
+# root-owned by a previous install: every operation failed, "Plugins at
+# v1.6.15" was printed, and v1.6.14 was still on disk. The installer's
+# downloadplugins reports that as done, so the run ships the OLD plugin release
+# against the new core -- after the Font Awesome 7 migration, that is FA4 icon
+# names against a core with no v4 shims, and the version stamp still names the
+# old release, so nothing downstream can tell either.
+if ! rm -rf "$dest"; then
+    echo "Could not replace $dest" >&2
+    echo "Check ownership and permissions on $(dirname "$dest")" >&2
+    exit 1
+fi
+if ! mkdir -p "$(dirname "$dest")"; then
+    echo "Could not create $(dirname "$dest")" >&2
+    exit 1
+fi
+if ! mv "$staging" "$dest"; then
+    echo "Could not move the unpacked plugins into $dest" >&2
+    exit 1
+fi
 say "Plugins at $pluginsVer"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2652,9 +2652,15 @@ downloadplugins() {
         # Guidance first: errorStat exits before returning unless $exitFail is
         # set, so anything printed after it is never seen.
         echo "Failed!"
-        echo " * Could not download the plugins (${pluginsVer}) from $pluginsgit"
+        echo " * Could not install the plugins (${pluginsVer}) from $pluginsgit"
         echo " * For an offline install, place the plugin directories in"
         echo " *   packages/web/lib/plugins/ and re-run"
+        # The fetcher fails for two unrelated reasons -- it could not reach a
+        # verified release, or it could not write the tree -- and only the
+        # first is what the guidance above describes. Both write their reason
+        # to stderr, which --quiet does not touch, so point at the log rather
+        # than guessing which one happened.
+        echo " * Full error in $error_log"
         [[ -z $exitFail ]] && exit 1
         return 1
     fi

--- a/tests/plugin-tree-integrity.test.sh
+++ b/tests/plugin-tree-integrity.test.sh
@@ -151,6 +151,39 @@ has "$DEST/location/hooks/locationdeletemassitems.hook.php" \
     "failed repair left the surviving files alone"
 has "$DEST/.fog-plugins-version" "failed repair left the stamp alone"
 
+# --- a swap that cannot be performed must not report success ----------------
+# The swap at the end of the script is the only step whose failure produces a
+# WRONG ANSWER rather than an error, so it is the only one checked. `set -e` is
+# deliberately off -- the download loop needs to tolerate failures and retry --
+# and with the rm/mv unguarded the script printed its errors to stderr, fell
+# through to "Plugins at <version>" and exited 0 while the old release was
+# still on disk. Hit for real on a tree left root-owned by a previous install,
+# during the pin bump that carried the Font Awesome 7 migration: the installer's
+# downloadplugins reports that run as done, so the server ships FA4 plugin icon
+# names against a core with no v4 shims, and the stamp still names the old
+# release so nothing downstream can tell either.
+#
+# A read-only destination reproduces it without root: rm cannot unlink the
+# children of a directory it has no write bit on. Skipped as root, which
+# ignores the mode entirely.
+if [[ $EUID -eq 0 ]]; then
+    echo "  skip  unwritable destination (running as root)"
+else
+    rm -rf "$DEST"
+    run >/dev/null
+    echo "v0.0.1" > "$DEST/.fog-plugins-version"   # an older pin, so a fetch is due
+    chmod 555 "$DEST"
+    out="$(run)"
+    rc=$?
+    chmod 755 "$DEST"
+    is "$rc" "1" "an unwritable destination fails"
+    case "$out" in
+        *"Plugins at $VER"*) bad "no success line when nothing was written (said: $out)" ;;
+        *) ok "no success line when nothing was written" ;;
+    esac
+    is "$(cat "$DEST/.fog-plugins-version")" "v0.0.1" "the old tree is still in place"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## The bug

`set -e` is deliberately off in `bin/fetch-plugins.sh` — the download loop needs to tolerate curl failures and retry — but the swap at the end was unguarded:

```bash
rm -rf "$dest"
mkdir -p "$(dirname "$dest")"
mv "$staging" "$dest"
say "Plugins at $pluginsVer"     # ← runs regardless
```

Hit for real while verifying the `FOG_PLUGINS_VERSION` bump in #1336, on a tree left root-owned by a previous install:

```
rm: cannot remove '.../packages/web/lib/plugins/.fog-plugins-version': Permission denied
mv: cannot create directory '.../packages/web/lib/plugins/unpack': Permission denied
Plugins at v1.6.15
$ cat packages/web/lib/plugins/.fog-plugins-version
v1.6.14
```

Exit status 0.

## Why it matters

`downloadplugins()` already tests the exit status correctly, so the *installer* reported the step done — the script was the only thing lying. And the version stamp still named the old release, so nothing downstream could tell either: no error, no warning, no artifact anywhere naming the cause.

After #1336 the consequence is concrete. A server in this state runs the **old plugin release's FA4 icon names against a core that ships no v4 shims** — blank icons across every plugin menu entry, from an install that said it succeeded.

## The fix

The swap is the only step whose failure produces a *wrong answer* rather than an error, so it is the only one checked. The download loop keeps its tolerate-and-retry behaviour untouched.

`downloadplugins()`'s failure guidance also now points at the error log: the fetcher fails for two unrelated reasons — could not reach a verified release, could not write the tree — and it was printing the offline-install advice for both.

## Verification

`tests/plugin-tree-integrity.test.sh` gains three gates covering a read-only destination — non-zero exit, no success line, old tree still in place. Skipped as root, which ignores the mode.

Mutation-tested by restoring the original unguarded swap: two of the three gates fail. A fourth defensive check (reading the stamp back after the swap) was written and then **removed** — no mutant could distinguish it, because with the guards in place there is no reachable path where all three commands return 0 and the stamp is still wrong.

```
21 passed, 0 failed
```