### PR TITLE
fix(schema): register steps 361-367 so an upgrade can leave the schema page

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7585,38 +7585,66 @@ $this->schema[] = count($columnuAPIOnly ?: []) ? [] : [
     // combination of the two, including API-only with uAllowAPI off, which
     // is a service account reachable only through an issued Bearer token.
     "ALTER TABLE `users` "
-    . "ADD COLUMN `uAPIOnly` ENUM('0','1') NOT NULL DEFAULT '0'",
-    // The Font Awesome 7 migration renamed the icon *classes* in PHP and JS,
-    // but six task types and one task state carry their icon as DATA -- seeded
-    // by steps 2907-2987 above and rendered as `fa fa-<stored name>` by
-    // fog.task.list.js, the host and group task menus, and Task Management.
-    // Every one of the seven is an FA4 outline variant whose `-o` suffix FA7
-    // dropped outright, so after the migration they resolve to nothing and the
-    // icon renders blank. The prefix is fine: `fa` is still the solid alias.
-    //
-    // Appended rather than corrected in place. Editing steps 2907-2987 would
-    // fix a fresh install and leave every existing one broken, because an
-    // install that has already run them never replays them.
-    //
-    // Guarded on the old value so an administrator who has already picked
-    // their own icon for one of these keeps it -- this repairs FOG's seed, it
-    // does not impose a choice.
+    . "ADD COLUMN `uAPIOnly` ENUM('0','1') NOT NULL DEFAULT '0'"
+];
+// Font Awesome 7: icon names stored as data (steps 361-367 below).
+// The Font Awesome 7 migration renamed the icon *classes* in PHP and JS, but
+// six task types and one task state carry their icon as DATA -- seeded by the
+// steps above and rendered as `fas fa-<stored name>` by fog.task.list.js and
+// the host and group task menus. Every one of the seven is an FA4 outline
+// variant whose `-o` suffix FA7 dropped outright, so after the migration they
+// resolve to nothing and the icon renders blank. The prefix is fine: `fa` is
+// still the solid alias.
+//
+// Appended as steps rather than corrected in place. Editing the historical
+// steps would fix a fresh install and leave every existing one broken, because
+// an install that has already run them never replays them.
+//
+// One `$this->schema[] = []` per step, which is the ONLY thing that makes a
+// statement run on an upgrade. Getting this wrong is not a no-op: FOG_SCHEMA
+// must equal count($this->schema), so raising it without adding a step leaves
+// every server permanently below it, and DatabaseManager::establish() then
+// redirects every request to ?node=schema forever while the updater reports
+// nothing to do. See tests/schema-steps-match-fog-schema.test.php.
+//
+// Each is guarded on the old value so an administrator who has already picked
+// their own icon for one of these keeps it.
+// 361
+$this->schema[] = [
     "UPDATE `taskTypes` SET `ttIcon`='square-plus' "
     . "WHERE `ttID`=4 AND `ttIcon`='plus-square-o'",
+];
+// 362
+$this->schema[] = [
     "UPDATE `taskTypes` SET `ttIcon`='hard-drive' "
     . "WHERE `ttID`=5 AND `ttIcon`='hdd-o'",
+];
+// 363
+$this->schema[] = [
     "UPDATE `taskTypes` SET `ttIcon`='circle-arrow-down' "
     . "WHERE `ttID`=15 AND `ttIcon`='arrow-circle-o-down'",
+];
+// 364
+$this->schema[] = [
     "UPDATE `taskTypes` SET `ttIcon`='circle-arrow-up' "
     . "WHERE `ttID`=16 AND `ttIcon`='arrow-circle-o-up'",
+];
+// 365
+$this->schema[] = [
     // Fast/Normal/Full Wipe are read as a set. Normal already holds
     // `hourglass-2`, which FA7 still resolves as an alias of hourglass-half,
-    // and Full holds `hourglass`, so `hourglass-start` here restores the
+    // and Full holds `hourglass`, so `hourglass-start` restores the
     // progression rather than just picking any surviving hourglass.
     "UPDATE `taskTypes` SET `ttIcon`='hourglass-start' "
     . "WHERE `ttID`=18 AND `ttIcon`='hourglass-o'",
+];
+// 366
+$this->schema[] = [
     "UPDATE `taskTypes` SET `ttIcon`='flag' "
     . "WHERE `ttID`=22 AND `ttIcon`='flag-o'",
+];
+// 367
+$this->schema[] = [
     "UPDATE `taskStates` SET `tsIcon`='bookmark' "
     . "WHERE `tsID`=1 AND `tsIcon`='bookmark-o'",
 ];

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -222,17 +222,45 @@ if (!preg_match(
 }
 $schema = (int)$const[1];
 
-if ($schema < $highest) {
+/*
+ * Compared for EQUALITY, not `<`. Both directions strand a server and the
+ * docblock above says so, but this check was one-directional and only the
+ * low side was enforced -- so the worse half went unguarded and then shipped.
+ *
+ * #1338 raised FOG_SCHEMA 360 -> 367 while appending its seven statements to
+ * the previous step's array instead of writing seven `$this->schema[] = [...]`
+ * of their own. No new label, no new append, nothing for either check above to
+ * catch, and `$schema < $highest` is false when $schema is HIGHER. Every check
+ * in CI passed, a fresh install was correct because the statements still ran
+ * inside that last step, and every EXISTING server was left permanently on
+ * ?node=schema: count($this->schema) == mySchema, so the updater reported
+ * nothing to do and never advanced the version past 360, while
+ * DatabaseManager::establish() went on redirecting every request to it.
+ *
+ * FOG_SCHEMA too HIGH is the unrecoverable direction -- a server cannot leave
+ * the schema page to fix itself -- so it is worth the stricter comparison even
+ * though it means a deliberate skip in the numbering is now a failure. There
+ * has never been one.
+ */
+if ($schema !== $highest) {
+    $why = $schema < $highest
+        ? "  Every step after $schema applies to nobody: the coarse gate\n"
+            . "  (mySchema < FOG_SCHEMA) never sends anyone to the schema\n"
+            . "  updater, so the updater's own count check never runs. There\n"
+            . "  is no error and no log line -- the step is never applied.\n"
+        : "  FOG_SCHEMA is ABOVE the last step, so no server can ever reach\n"
+            . "  it: the updater has nothing to apply, never advances the\n"
+            . "  stored version, and every page redirects to ?node=schema\n"
+            . "  permanently. The usual cause is statements appended INSIDE\n"
+            . "  the previous step's array rather than as new\n"
+            . "  `\$this->schema[] = [...]` entries of their own.\n";
     fwrite(
         STDERR,
         "FAIL: FOG_SCHEMA is $schema but commons/schema.php goes to "
         . "$highest.\n"
-        . "  Every step after $schema applies to nobody: the coarse gate\n"
-        . "  (mySchema < FOG_SCHEMA) never sends anyone to the schema\n"
-        . "  updater, so the updater's own count check never runs. There is\n"
-        . "  no error and no log line -- the step is simply never applied.\n"
+        . $why
         . "  Set FOG_SCHEMA to $highest in packages/web/lib/fog/"
-        . "system.class.php.\n"
+        . "system.class.php, or add the missing step.\n"
     );
     exit(1);
 }


### PR DESCRIPTION
Regression from #1338, reported from a live deploy. **An upgraded server cannot leave `?node=schema`.**

## What I got wrong

`commons/schema.php` is not one large array — it is ~326 separate `$this->schema[] = [...]` statements. I appended #1338's seven UPDATEs before the file's final `];`, so they joined **the previous step's array** and the step count never moved, while `FOG_SCHEMA` went 360 → 367.

```
count($this->schema) == mySchema == 360
  -> $hasIndexed false, updater applies nothing
  -> version written from the loop variable, so never advanced past 360
  -> mySchema < FOG_SCHEMA stays true forever
  -> DatabaseManager::establish() redirects EVERY request to ?node=schema
```

The schema page then reports nothing to do and answers the POST `204`, which jQuery reports as statusText `nocontent` and `$.notifyFromAPI` renders as a red **"Generic Error"** toast, looping.

A **fresh install was fine** — the statements still ran inside that last step. That is exactly why every schema job in CI stayed green: they build from scratch and never replay an upgrade from an existing version.

## The fix

Seven real `$this->schema[] = [...]` entries, labelled 361-367, so `array_slice($this->schema, 360)` yields them and the last sets the version to 367. `FOG_SCHEMA` is unchanged — 367 was always the right number (325 literal appends + the 35 the `keySequences` loop writes = 360 before this).

## The part that matters more

**`tests/schema-gate.test.php` already existed for this exact bug class and did not catch it.** It compared `$schema < $highest`, enforcing only the case where FOG_SCHEMA is too *low*. #1338 made it too *high*, and with no new label and no new append there was nothing for its other two checks to see either.

Its own docblock already said the high side is "worse than stranding a step" — a server cannot leave the schema page to fix itself. The comparison is now equality, and the message says which direction failed and names the usual cause.

Mutation-verified both ways:

- reproducing #1338's exact shape (statements inside the previous step, FOG_SCHEMA 367, no new label/append) → fails, naming the cause
- FOG_SCHEMA too low → still fails as before

Full suite: `144 passed, 0 failed`.