### PR TITLE
fix(logging): stop the web log directory being created root-only

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2852,7 +2852,17 @@ configureTFTPandPXE() {
     chown -R ${SVC_user} $tftpdirdst >>$error_log 2>&1
     chown -R ${SVC_user} $webdirdest/service/ipxe >>$error_log 2>&1
     find $tftpdirdst -type d -exec chmod 755 {} \; >>$error_log 2>&1
-    find $webdirdest -type d -exec chmod 755 {} \; >>$error_log 2>&1
+    # management/logs is pruned: this runs AFTER configureHttpd() on a full
+    # install, and a flat 755 here would strip the setgid bit that makes a
+    # root daemon's log file carry the web group. Losing it denies the web
+    # user today's log for the life of the install.
+    #
+    # ${webdirdest%/} rather than $webdirdest: the variable always carries a
+    # trailing slash, find renders children under the start point verbatim,
+    # and "<dir>//management/logs" matches nothing -- so the prune would
+    # silently do nothing and the setgid bit would be stripped anyway.
+    find $webdirdest -type d -path "${webdirdest%/}/management/logs" -prune -o \
+        -type d -exec chmod 755 {} \; >>$error_log 2>&1
     find $tftpdirdst ! -type d -exec chmod 655 {} \; >>$error_log 2>&1
     configureDefaultiPXEfile
     # GH-963: must come AFTER every file is in place, configureDefaultiPXEfile
@@ -10087,6 +10097,21 @@ die();
     errorStat $?
     [[ -d /var/www/html/ && ! -e /var/www/html/fog/ ]] && ln -s "$webdirdest" /var/www/html/
     [[ -d /var/www/ && ! -e /var/www/fog ]] && ln -s "$webdirdest" /var/www/
+    # FOGBase::_writeLogLine()'s destination. Not shipped in the repo, and the
+    # rm -rf above takes it out on every install, so without this it is created
+    # by whichever FOG process logs first after a deploy -- and ten of the
+    # twelve daemons run as root while the web UI, FOGPluginRunner and
+    # FOGRetentionRunner do not. Root normally wins that race at boot, leaving
+    # a root-owned 0755 directory that denies every non-root writer for the
+    # life of the install.
+    #
+    # Created here so the answer is settled before anything races for it. 2775
+    # rather than 0755 because root daemons legitimately write here too, and
+    # setgid is what makes the files they create carry the web group instead of
+    # root's; _writeLogLine() widens the file mode to match. The chown below
+    # covers this directory, which is why it is created ahead of it.
+    mkdir -p "${webdirdest%/}/management/logs" >>$error_log 2>&1
+    chmod 2775 "${webdirdest%/}/management/logs" >>$error_log 2>&1
     chown -R ${apacheuser}:${apacheuser} "$webdirdest"
     chown -R ${SVC_user}:${apacheuser} "$webdirdest/service/ipxe"
 }

--- a/packages/web/lib/fog/fogbase.class.php
+++ b/packages/web/lib/fog/fogbase.class.php
@@ -928,19 +928,89 @@ abstract class FOGBase
         );
         if (self::$mySchema >= FOG_SCHEMA && self::getSetting($setting) > 0) {
             $log_filename = BASEPATH . 'management/logs';
-            if (!file_exists($log_filename)) {
-                mkdir($log_filename, 0777, true);
+            if (!is_dir($log_filename)) {
+                self::_createLogDir($log_filename);
             }
             $log_file_data = $log_filename
                 . '/' . $prefix . '_'
                 . $date->format('d-m-Y')
                 . '.log';
+            // Whoever creates the day's file owns it, and file_put_contents
+            // creates 0666 masked by the umask -- 0644 under systemd. A root
+            // daemon that logs first therefore locks the web user out of
+            // today's file even when the DIRECTORY is right. Only the creator
+            // can chmod it, so widen it here, at creation, rather than trying
+            // to repair it from the side that has already been denied.
+            $isNew = !file_exists($log_file_data);
             file_put_contents($log_file_data, $string."\n", FILE_APPEND);
+            if ($isNew) {
+                @chmod($log_file_data, 0664);
+            }
         }
         if (self::$service || self::$ajax || !$show) {
             return;
         }
         printf('<div class="debug %s">%s</div>', $cssClass, $string);
+    }
+    /**
+     * Creates the web tree's log directory so every FOG process can write it.
+     *
+     * BASEPATH/management/logs is shared by two sets of writers that do not
+     * share a uid. The web UI runs as the web user; so do FOGPluginRunner and
+     * FOGRetentionRunner. The other ten daemons run as ROOT and boot this same
+     * web tree -- packages/service/etc/config.php points WEBROOT at it and
+     * service_lib.php requires commons/base.inc.php -- so a FOGBase::info()
+     * from any of them lands here too.
+     *
+     * The directory is not shipped in the repo and installfog.sh's
+     * configureHttpd() rm -rf's the web tree, so it is recreated from scratch
+     * after every deploy by whichever process logs first. That is a race, and
+     * root usually wins it: ten of the twelve daemons start at boot.
+     *
+     * Two things make root winning fatal rather than merely untidy:
+     *
+     *   - mkdir()'s mode argument is masked by the process umask (0022 under
+     *     systemd), so mkdir(0777) actually lands 0755. chmod() is NOT masked,
+     *     which is why the mode is asserted separately here instead of being
+     *     passed to mkdir and assumed.
+     *   - the group would otherwise be root's, so widening the mode alone
+     *     would not help the web user either. BASEPATH's own group is the one
+     *     installfog.sh chowns the web tree to, which makes it the right
+     *     answer without this class having to know the distro's web user.
+     *
+     * Get it wrong and every non-root writer is denied for the life of the
+     * install, once per log line, with nothing to explain it but a PHP warning
+     * -- one box produced half a million of them in a day.
+     *
+     * setgid so that files created in here by a root daemon inherit the web
+     * group rather than root's; _writeLogLine() widens the file mode to match.
+     *
+     * Failures are deliberately swallowed. mkdir() warns "File exists" when it
+     * loses the race, and PHP's stat cache makes a long-lived daemon lose it
+     * repeatedly against a directory it created itself. The write that follows
+     * still warns if it genuinely cannot proceed, so no real failure is hidden.
+     *
+     * Only ever called for a directory that does not exist yet, because
+     * repairing one from here is not possible: a non-root process cannot
+     * chmod or chgrp a directory root owns, and root's own is_writable() is
+     * true whatever the mode says, so the process that could repair it never
+     * detects that it needs to. An install left in the old state is fixed by
+     * configureHttpd(), which is where the web tree's permissions belong.
+     *
+     * @param string $dir the directory to create
+     *
+     * @return void
+     */
+    private static function _createLogDir($dir)
+    {
+        if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
+            return;
+        }
+        $gid = @filegroup(BASEPATH);
+        if ($gid !== false) {
+            @chgrp($dir, $gid);
+        }
+        @chmod($dir, 02775);
     }
     /**
      * Prints error.


### PR DESCRIPTION
## Problem

`BASEPATH/management/logs` is written by two sets of processes that do not share a uid:

- the web UI (php-fpm, as the web user), `FOGPluginRunner` and `FOGRetentionRunner` — **non-root**;
- the other ten daemons — **root**, and they boot this same web tree, because `packages/service/etc/config.php` sets `WEBROOT` to it and `service_lib.php` requires `commons/base.inc.php`. A `FOGBase::info()` from any of them lands in the same directory.

The directory isn't in the repo, and `configureHttpd()` does `rm -rf $webdirdest`, so it was recreated after every install by whichever process logged first. `mkdir()`'s mode argument is masked by the process umask (0022 under systemd), so `mkdir($dir, 0777, true)` actually landed **0755 owned by that process** — and with ten of the twelve daemons starting at boot, root normally won the race.

Every non-root writer was then denied for the life of the install, once per log line, with nothing to explain it but a PHP warning:

```
PHP Warning:  file_put_contents(.../management/logs/info_log_23-08-2026.log):
Failed to open stream: Permission denied in .../lib/fog/fogbase.class.php on line 938
```

One server produced **505,581 of them and a 121 MB pool log in a single day**. Journal attribution confirms the split — every denial in a `FOG*` unit is uid 972 (the web user), none from the root units, which never notice because of `CAP_DAC_OVERRIDE`:

```
('FOGPluginRunner.service',   '972')  153
('FOGRetentionRunner.service','972')  153
```

The file matters as much as the directory: `file_put_contents()` creates 0666 masked to 0644, owned by the creator, so a root daemon writing today's log locks the web user out of *that file* even where the directory is right.

Not SELinux (Permissive on the box this was found on), not `open_basedir` (unset), not systemd hardening (`ProtectSystem=no` on the FOG units).

## Fix

- **`FOGBase::_createLogDir()`** — asserts the mode with `chmod` (not umask-masked, unlike `mkdir`'s argument) and takes the group from `BASEPATH`, which is what the installer chowns the web tree to, so this class doesn't have to know the distro's web user. `02775`: setgid, so files a root daemon creates carry the web group rather than root's.
- **`FOGBase::_writeLogLine()`** — widens a log file to `0664` at creation. Only the creator can `chmod` it, so it can't be repaired from the side that has already been denied.
- **`configureHttpd()`** — pre-creates the directory `2775` ahead of its `chown`, so nothing races for it on a fresh install.
- **`configureTFTPandPXE()`** — its recursive `chmod 755` over the web tree runs *after* `configureHttpd()` on a full install and would strip the setgid bit, so it now prunes that one directory. The pattern uses `${webdirdest%/}` because the variable always carries a trailing slash and `find` renders children under the start point verbatim — `"<dir>//management/logs"` would have matched nothing and pruned nothing, silently.

Repairing an existing bad directory from PHP isn't possible: a non-root process can't `chmod`/`chgrp` a directory root owns, and root's own `is_writable()` is true whatever the mode says, so the only process that *could* repair it never detects that it needs to. `configureHttpd()` owns that, which is where the web tree's permissions belong anyway.

## Verification

The two code paths run against a temp tree with `umask(0022)`, with the tree's group standing in for the web group:

```
BEFORE   dir  mode=0755 group=<creator>     file mode=0644 group=<creator>
AFTER    dir  mode=2775 group=<web group>   file mode=0664 group=<web group>
```

The `find` prune verified against a start point with and without a trailing slash — the unfixed pattern pruned nothing.

`php -l` clean; `bash -n lib/common/functions.sh` clean.

## Scope

**working-1.6 only.** `dev-branch` has no copy of this path — its `debug()` writes to no file at all (it `printf`s into the page and returns early on service/ajax) and its fault sink writes under `/opt/fog/log`. Verified by grep against the branch, not assumed.

No route change, so no `OpenAPI::document()` impact. No schema change, no globalSetting, no JS/CSS, so no `FOG_SCHEMA` or `FOG_BCACHE_VER` bump.