### PR TITLE
test(schema): replay the updater from every version a server can hold

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7605,7 +7605,10 @@ $this->schema[] = count($columnuAPIOnly ?: []) ? [] : [
 // must equal count($this->schema), so raising it without adding a step leaves
 // every server permanently below it, and DatabaseManager::establish() then
 // redirects every request to ?node=schema forever while the updater reports
-// nothing to do. See tests/schema-steps-match-fog-schema.test.php.
+// nothing to do. Two tests pin it: schema-gate compares FOG_SCHEMA to
+// the highest `// N` label, and schema-upgrade-replay compares it to
+// the number of elements that really exist, replaying the updater
+// from every version a server can hold.
 //
 // Each is guarded on the old value so an administrator who has already picked
 // their own icon for one of these keeps it.

--- a/tests/lib/fog-schema-collector.php
+++ b/tests/lib/fog-schema-collector.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Builds commons/schema.php's step array outside the application.
+ *
+ * commons/schema.php is not a data file. It is a method body: it is include'd
+ * from inside SchemaUpdaterPage::update() and expects that method's context --
+ * $this->schema[], self::$DB, self::getClass() -- and it issues a query at file
+ * scope before a single step has been collected. That is why every gate written
+ * against it before now read it as TEXT, and why tests/schema-gate.test.php
+ * counts `// N` comment labels rather than array elements: its docblock records
+ * that a real count "was tried and rejected" because the file "wants ~35 config
+ * constants and a couple of core classes, and every one of those is a thing an
+ * unrelated schema commit could add".
+ *
+ * That objection is answered here rather than argued with. Neither dependency is
+ * listed, so neither can be outgrown:
+ *
+ *   - constants are DISCOVERED by tokenising the file and defining a placeholder
+ *     for each bare constant fetch. They only ever reach INSERT statements that
+ *     seed default settings, so the values do not matter. DATABASE_NAME and
+ *     FOG_SCHEMA are passed in for real because they do -- schema.php's step 29
+ *     branches on FOG_SCHEMA.
+ *   - unknown classes are MANUFACTURED on demand by an autoloader. Every call
+ *     answers null, which is what "this database is empty" looks like to the
+ *     introspection schema.php performs while building its steps -- and an empty
+ *     database is the state a fresh install starts from.
+ *
+ * The result is exact: 367 elements at indexes 0-366, contiguous, against a
+ * FOG_SCHEMA of 367. It includes the 35 elements the $keySequences foreach
+ * appends from a single line of source, which no textual count can see.
+ *
+ * Extracted from tests/schema-executes.test.php, which had carried it alone.
+ * There are now two callers and there must stay ONE copy: two hand-kept shims
+ * would drift, and drift between two descriptions of the schema is the exact
+ * failure both of those tests exist to catch.
+ *
+ * Included, never run: run-all.sh globs tests/*.test.php at the top level only,
+ * so a helper in tests/lib/ is invisible to it.
+ */
+
+/**
+ * Bare constant fetches in a PHP file.
+ *
+ * A T_STRING that is not a function call, not method or property access, not a
+ * class reference and not a declaration is a constant read.
+ *
+ * @param string $file the file to scan
+ *
+ * @return array list of constant names
+ */
+function fogDiscoverConstants($file)
+{
+    $tokens = token_get_all(file_get_contents($file));
+    $count = count($tokens);
+    $skipPrev = [
+        T_OBJECT_OPERATOR,
+        T_DOUBLE_COLON,
+        T_FUNCTION,
+        T_CLASS,
+        T_NEW,
+        T_CONST,
+        T_USE,
+        T_NS_SEPARATOR,
+    ];
+    $trivia = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
+    $found = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $token = $tokens[$i];
+        if (!is_array($token) || $token[0] !== T_STRING) {
+            continue;
+        }
+        $prev = null;
+        for ($j = $i - 1; $j >= 0; $j--) {
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $trivia, true)) {
+                continue;
+            }
+            $prev = $tokens[$j];
+            break;
+        }
+        $next = null;
+        for ($j = $i + 1; $j < $count; $j++) {
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $trivia, true)) {
+                continue;
+            }
+            $next = $tokens[$j];
+            break;
+        }
+        $prevType = is_array($prev) ? $prev[0] : $prev;
+        $nextType = is_array($next) ? $next[0] : $next;
+
+        if (in_array($prevType, $skipPrev, true)) {
+            continue;
+        }
+        if ($nextType === T_DOUBLE_COLON || $nextType === '(' || $nextType === T_NS_SEPARATOR) {
+            continue;
+        }
+        if (in_array(strtolower($token[1]), ['true', 'false', 'null'], true)) {
+            continue;
+        }
+        $found[$token[1]] = true;
+    }
+
+    return array_keys($found);
+}
+
+/**
+ * Permissive stand-in for every FOG class schema.php touches while its step
+ * array is being built. Answering null to everything is what an empty database
+ * looks like to the introspection it does, and an empty database is precisely
+ * the state a fresh install starts from.
+ */
+class SchemaStub
+{
+    public function __construct(...$args)
+    {
+    }
+    public function __call($name, $args)
+    {
+        return null;
+    }
+    public static function __callStatic($name, $args)
+    {
+        return null;
+    }
+    public function __get($name)
+    {
+        return null;
+    }
+    public function __set($name, $value)
+    {
+    }
+    public function get($key = null)
+    {
+        return 0;
+    }
+    public function isValid()
+    {
+        return false;
+    }
+    public function save()
+    {
+        return true;
+    }
+}
+
+/**
+ * The real Schema class builds these two from DATABASE_NAME; so does this one,
+ * which is what points the replay at the scratch database.
+ */
+class Schema extends SchemaStub
+{
+    public static function createDatabaseQuery()
+    {
+        return sprintf('CREATE DATABASE IF NOT EXISTS `%s`', DATABASE_NAME);
+    }
+    public static function useDatabaseQuery()
+    {
+        return sprintf('USE `%s`', DATABASE_NAME);
+    }
+}
+
+/**
+ * Stands in for self::$DB. schema.php issues one query at file scope, before a
+ * single step has been collected; swallowing it is the point.
+ */
+class SchemaStubDB extends SchemaStub
+{
+    public function query($query = null, ...$rest)
+    {
+        return $this;
+    }
+    public function fetch($what = null, ...$rest)
+    {
+        return $this;
+    }
+    public function get($key = null)
+    {
+        return [];
+    }
+    public function escape($value)
+    {
+        return $value;
+    }
+    public function sanitize($value)
+    {
+        return $value;
+    }
+    public function __call($name, $args)
+    {
+        return $this;
+    }
+}
+
+/**
+ * Stands in for SchemaUpdaterPage, whose method body schema.php is written to
+ * run inside.
+ */
+class SchemaCollector extends SchemaStub
+{
+    public $schema = [];
+    public static $DB;
+    public static $mySchema = 0;
+
+    public static function getClass($name, ...$args)
+    {
+        return class_exists($name, true) ? new $name() : new SchemaStub();
+    }
+    public static function getManager($name)
+    {
+        return new SchemaStub();
+    }
+    public static function getSetting($key)
+    {
+        return '';
+    }
+    public static function setSetting($key, $value)
+    {
+        return true;
+    }
+    public static function createSecToken()
+    {
+        return '';
+    }
+    public static function fastmerge(...$arrays)
+    {
+        $out = [];
+        foreach ($arrays as $array) {
+            $out = array_merge($out, (array)$array);
+        }
+        return $out;
+    }
+    public function dropDuplicateData(...$args)
+    {
+        return null;
+    }
+    public function collect($file)
+    {
+        include $file;
+        return $this->schema;
+    }
+}
+
+spl_autoload_register(
+    function ($class) {
+        // schema.php is global-namespaced, so anything carrying a separator is
+        // not a name it could have written and not ours to invent.
+        if (strpos($class, '\\') !== false) {
+            return;
+        }
+        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $class)) {
+            return;
+        }
+        eval("class {$class} extends SchemaStub {}");
+    }
+);
+
+/**
+ * Collect commons/schema.php's step array.
+ *
+ * Exits 1 with an explanation rather than returning on failure: a collector
+ * that quietly answered an empty array would turn every caller into a test
+ * that passes by measuring nothing.
+ *
+ * @param string $schemaFile   path to commons/schema.php
+ * @param string $databaseName value for DATABASE_NAME; the statements name it,
+ *                             so a caller that executes them points it at its
+ *                             own scratch database
+ * @param int    $fogSchema    value for FOG_SCHEMA. Pass the real constant to
+ *                             model a real server; PHP_INT_MAX to collect
+ *                             without regard to it
+ *
+ * @return array the steps, keyed 0..n-1
+ */
+function fogCollectSchemaSteps($schemaFile, $databaseName, $fogSchema)
+{
+    // Guarded because these are one-shot and a caller may have set its own.
+    if (!defined('DATABASE_NAME')) {
+        define('DATABASE_NAME', $databaseName);
+    }
+    if (!defined('FOG_SCHEMA')) {
+        define('FOG_SCHEMA', $fogSchema);
+    }
+    if (!defined('DS')) {
+        define('DS', '/');
+    }
+    foreach (fogDiscoverConstants($schemaFile) as $name) {
+        if (defined($name)) {
+            continue;
+        }
+        define($name, '');
+    }
+
+    SchemaCollector::$DB = new SchemaStubDB();
+    $collector = new SchemaCollector();
+    try {
+        return $collector->collect($schemaFile);
+    } catch (\Throwable $e) {
+        fwrite(
+            STDERR,
+            "FAIL: could not collect the schema steps.\n"
+            . '  ' . get_class($e) . ': ' . $e->getMessage() . "\n"
+            . '  at ' . $e->getFile() . ':' . $e->getLine() . "\n\n"
+            . "  This shims the context SchemaUpdaterPage::update() provides.\n"
+            . "  If schema.php started using something the shim does not answer,\n"
+            . "  teach SchemaStub about it -- do not delete the assertion.\n"
+        );
+        exit(1);
+    }
+}

--- a/tests/schema-executes.test.php
+++ b/tests/schema-executes.test.php
@@ -75,23 +75,13 @@
  *
  * HOW commons/schema.php IS LOADED
  *
- * It is include'd from inside SchemaUpdaterPage::update() and expects that
- * method's context: $this->schema[], self::$DB, self::getClass(). It has no
- * `namespace` declaration -- the real FOG classes reach it through class_alias
- * into the global namespace -- so global stubs are what it resolves against.
- *
- * Two of its dependencies are DISCOVERED rather than listed, so that adding a
- * constant or a class reference to schema.php cannot silently break this test:
- *
- *   - constants are found by tokenising the file and defining a placeholder for
- *     each bare constant fetch. They only ever reach INSERT statements that seed
- *     default settings, and only DDL is executed here, so the values do not
- *     matter. DATABASE_NAME and FOG_SCHEMA are set for real because they do.
- *   - unknown classes are manufactured on demand by an autoloader. Every call
- *     answers null, which is exactly what "this database is empty" looks like to
- *     the introspection schema.php performs at build time -- and an empty
- *     database is the correct answer for a fresh install, which is the path
- *     being modelled.
+ * tests/lib/fog-schema-collector.php, which carries the shim that gives
+ * schema.php the context SchemaUpdaterPage::update() would -- $this->schema[],
+ * self::$DB, self::getClass() -- and discovers its constants and classes rather
+ * than listing them. It lived here until tests/schema-upgrade-replay.test.php
+ * needed the same step array; there is one copy on purpose, because two
+ * hand-kept descriptions of the schema drifting apart is the failure both of
+ * these tests exist to catch.
  *
  * The 8 closure steps are NOT executed. They are data migrations that need the
  * full application, and they emit no DDL. That is a real limit of this test,
@@ -142,249 +132,14 @@ $pass = ($pass === false) ? '' : $pass;
 $stepDb = 'fog_schema_steps_test';
 $manifestDb = 'fog_schema_manifest_test';
 
-/**
- * Bare constant fetches in a PHP file.
- *
- * A T_STRING that is not a function call, not method or property access, not a
- * class reference and not a declaration is a constant read.
- *
- * @param string $file the file to scan
- *
- * @return array list of constant names
- */
-function fogDiscoverConstants($file)
-{
-    $tokens = token_get_all(file_get_contents($file));
-    $count = count($tokens);
-    $skipPrev = [
-        T_OBJECT_OPERATOR,
-        T_DOUBLE_COLON,
-        T_FUNCTION,
-        T_CLASS,
-        T_NEW,
-        T_CONST,
-        T_USE,
-        T_NS_SEPARATOR,
-    ];
-    $trivia = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
-    $found = [];
+require __DIR__ . '/lib/fog-schema-collector.php';
 
-    for ($i = 0; $i < $count; $i++) {
-        $token = $tokens[$i];
-        if (!is_array($token) || $token[0] !== T_STRING) {
-            continue;
-        }
-        $prev = null;
-        for ($j = $i - 1; $j >= 0; $j--) {
-            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $trivia, true)) {
-                continue;
-            }
-            $prev = $tokens[$j];
-            break;
-        }
-        $next = null;
-        for ($j = $i + 1; $j < $count; $j++) {
-            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $trivia, true)) {
-                continue;
-            }
-            $next = $tokens[$j];
-            break;
-        }
-        $prevType = is_array($prev) ? $prev[0] : $prev;
-        $nextType = is_array($next) ? $next[0] : $next;
-
-        if (in_array($prevType, $skipPrev, true)) {
-            continue;
-        }
-        if ($nextType === T_DOUBLE_COLON || $nextType === '(' || $nextType === T_NS_SEPARATOR) {
-            continue;
-        }
-        if (in_array(strtolower($token[1]), ['true', 'false', 'null'], true)) {
-            continue;
-        }
-        $found[$token[1]] = true;
-    }
-
-    return array_keys($found);
-}
-
-/**
- * Permissive stand-in for every FOG class schema.php touches while its step
- * array is being built. Answering null to everything is what an empty database
- * looks like to the introspection it does, and an empty database is precisely
- * the state a fresh install starts from.
- */
-class SchemaStub
-{
-    public function __construct(...$args)
-    {
-    }
-    public function __call($name, $args)
-    {
-        return null;
-    }
-    public static function __callStatic($name, $args)
-    {
-        return null;
-    }
-    public function __get($name)
-    {
-        return null;
-    }
-    public function __set($name, $value)
-    {
-    }
-    public function get($key = null)
-    {
-        return 0;
-    }
-    public function isValid()
-    {
-        return false;
-    }
-    public function save()
-    {
-        return true;
-    }
-}
-
-/**
- * The real Schema class builds these two from DATABASE_NAME; so does this one,
- * which is what points the replay at the scratch database.
- */
-class Schema extends SchemaStub
-{
-    public static function createDatabaseQuery()
-    {
-        return sprintf('CREATE DATABASE IF NOT EXISTS `%s`', DATABASE_NAME);
-    }
-    public static function useDatabaseQuery()
-    {
-        return sprintf('USE `%s`', DATABASE_NAME);
-    }
-}
-
-/**
- * Stands in for self::$DB. schema.php issues one query at file scope, before a
- * single step has been collected; swallowing it is the point.
- */
-class SchemaStubDB extends SchemaStub
-{
-    public function query($query = null, ...$rest)
-    {
-        return $this;
-    }
-    public function fetch($what = null, ...$rest)
-    {
-        return $this;
-    }
-    public function get($key = null)
-    {
-        return [];
-    }
-    public function escape($value)
-    {
-        return $value;
-    }
-    public function sanitize($value)
-    {
-        return $value;
-    }
-    public function __call($name, $args)
-    {
-        return $this;
-    }
-}
-
-/**
- * Stands in for SchemaUpdaterPage, whose method body schema.php is written to
- * run inside.
- */
-class SchemaCollector extends SchemaStub
-{
-    public $schema = [];
-    public static $DB;
-    public static $mySchema = 0;
-
-    public static function getClass($name, ...$args)
-    {
-        return class_exists($name, true) ? new $name() : new SchemaStub();
-    }
-    public static function getManager($name)
-    {
-        return new SchemaStub();
-    }
-    public static function getSetting($key)
-    {
-        return '';
-    }
-    public static function setSetting($key, $value)
-    {
-        return true;
-    }
-    public static function createSecToken()
-    {
-        return '';
-    }
-    public static function fastmerge(...$arrays)
-    {
-        $out = [];
-        foreach ($arrays as $array) {
-            $out = array_merge($out, (array)$array);
-        }
-        return $out;
-    }
-    public function dropDuplicateData(...$args)
-    {
-        return null;
-    }
-    public function collect($file)
-    {
-        include $file;
-        return $this->schema;
-    }
-}
-
-spl_autoload_register(
-    function ($class) {
-        // schema.php is global-namespaced, so anything carrying a separator is
-        // not a name it could have written and not ours to invent.
-        if (strpos($class, '\\') !== false) {
-            return;
-        }
-        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $class)) {
-            return;
-        }
-        eval("class {$class} extends SchemaStub {}");
-    }
-);
-
-define('DATABASE_NAME', $stepDb);
-define('FOG_SCHEMA', PHP_INT_MAX);
-define('DS', '/');
-foreach (fogDiscoverConstants($schemaFile) as $name) {
-    if (defined($name)) {
-        continue;
-    }
-    define($name, '');
-}
-
-SchemaCollector::$DB = new SchemaStubDB();
-$collector = new SchemaCollector();
-try {
-    $steps = $collector->collect($schemaFile);
-} catch (\Throwable $e) {
-    fwrite(
-        STDERR,
-        "FAIL: could not collect the schema steps.\n"
-        . '  ' . get_class($e) . ': ' . $e->getMessage() . "\n"
-        . '  at ' . $e->getFile() . ':' . $e->getLine() . "\n\n"
-        . "  This test shims the context SchemaUpdaterPage::update() provides.\n"
-        . "  If schema.php started using something the shim does not answer,\n"
-        . "  teach SchemaStub about it -- do not delete the assertion.\n"
-    );
-    exit(1);
-}
+// FOG_SCHEMA is PHP_INT_MAX rather than the real constant because this test
+// executes DDL and does not care what the version gate says; schema.php's one
+// use of it (step 29) is false either way against the empty-database stub.
+// tests/schema-upgrade-replay.test.php passes the real value, which is where
+// the constant is the subject rather than a dependency.
+$steps = fogCollectSchemaSteps($schemaFile, $stepDb, PHP_INT_MAX);
 
 $stepDdl = [];
 $closures = 0;

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -59,12 +59,21 @@
  * Together they close it: you cannot append without labelling, and you cannot
  * label without appending.
  *
- * Counting the array for real was tried and rejected. commons/schema.php can
- * be included against a stubbed $this and a fake DB, but it also wants ~35
- * config constants and a couple of core classes, and every one of those is a
- * thing an unrelated schema commit could add. A guard that fails for reasons
- * unconnected to what it guards is a guard people learn to ignore, and these
- * two textual checks are exact for every shape the file actually uses.
+ * Counting the array for real was rejected here, on the grounds that
+ * commons/schema.php also wants ~35 config constants and a couple of core
+ * classes and that any of those is a thing an unrelated schema commit could
+ * add -- a guard failing for reasons unconnected to what it guards is a guard
+ * people learn to ignore. That objection has since been ANSWERED rather than
+ * overruled: tests/lib/fog-schema-collector.php DISCOVERS both the constants
+ * and the classes instead of listing them, so neither can be outgrown, and
+ * tests/schema-upgrade-replay.test.php uses it to compare FOG_SCHEMA against
+ * the real element count.
+ *
+ * This test stays as it is, because the two fail on different things. A real
+ * count is label-independent and catches shapes the text cannot see; these
+ * checks cover the LABEL hygiene a count cannot -- an unlabelled append, or a
+ * label with no append -- and they are what keeps the file's own numbering
+ * meaning what it says. Neither subsumes the other.
  *
  * Usage: php tests/schema-gate.test.php
  * Exit status 0 = pass, 1 = fail.

--- a/tests/schema-upgrade-replay.test.php
+++ b/tests/schema-upgrade-replay.test.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * An EXISTING server must be able to leave ?node=schema.
+ *
+ * Everything CI runs against the schema models a FRESH INSTALL. That is not a
+ * gap anyone chose; it is what the code makes easy. SchemaUpdaterPage::update()
+ * slices the step array from self::$mySchema, which is 0 on a new database, so
+ * a fresh install genuinely executes every step from the beginning -- and
+ * tests/schema-executes.test.php therefore sets $mySchema to 0 and FOG_SCHEMA
+ * to PHP_INT_MAX, which neutralises the two expressions an upgrade turns on:
+ *
+ *     $hasIndexed = count($this->schema) > self::$mySchema;
+ *     $items      = $hasIndexed ? array_slice($this->schema, self::$mySchema, null, true) : [];
+ *     ... foreach ($items as $version => $updates) { ... }
+ *     $newSchema->set('version', $version + 1);
+ *
+ * So the DATABASE side of an upgrade is already covered -- a server upgrading
+ * from version N runs steps [0,N) then [N,end), which is the same statements in
+ * the same order as a fresh install, and schema-executes runs exactly that. The
+ * uncovered surface is not the SQL. It is the arithmetic above and the version
+ * it leaves behind, and that is what this replays: for every version a server
+ * could be sitting on, run the updater's own expressions over the real step
+ * array and require the stored version to land on FOG_SCHEMA.
+ *
+ * Land below it and DatabaseManager::establish() goes on redirecting every
+ * request to ?node=schema, while the updater reports "Update not required" --
+ * an HTTP 204 that jQuery hands to $.notifyFromAPI as statusText "nocontent",
+ * so the page loops a Generic Error toast forever. There is no way out from the
+ * browser: the page that would fix the server is the page that is stuck.
+ *
+ * THE BUG THIS WOULD HAVE CAUGHT. #1338 appended seven UPDATE statements before
+ * commons/schema.php's final `];` on the assumption that the file was one
+ * array. It is ~326 separate `$this->schema[] = [...]` statements, so the seven
+ * joined the PREVIOUS step: the element count did not move, FOG_SCHEMA went
+ * 360 -> 367, and every existing server was left permanently on the schema
+ * page. Fresh installs were correct throughout, because the statements still
+ * ran inside that last step -- which is why all seven CI checks were green.
+ *
+ * WHY THIS COUNTS THE ARRAY WHEN tests/schema-gate.test.php COUNTS COMMENTS.
+ * schema-gate's docblock records that a real count "was tried and rejected"
+ * because schema.php "wants ~35 config constants and a couple of core classes,
+ * and every one of those is a thing an unrelated schema commit could add". That
+ * was true when it was written and is not any more:
+ * tests/lib/fog-schema-collector.php DISCOVERS both, so neither can be
+ * outgrown, and it has been executing this file in CI on three database engines
+ * since GH-1221.
+ *
+ * The two gates are kept because they fail on different things and neither
+ * subsumes the other:
+ *
+ *   schema-gate  compares FOG_SCHEMA to the highest `// N` label, and enforces
+ *                that labels and appends come in pairs. Textual, so it also
+ *                covers the label hygiene the collector cannot see.
+ *   this test    compares FOG_SCHEMA to the number of elements that actually
+ *                exist, which is label-independent. #1338 was invisible to the
+ *                label check until the header comment introducing its steps was
+ *                reworded -- a real count never needed telling.
+ *
+ * Needs no database, deliberately. The upgrade-specific surface is arithmetic,
+ * so this runs on the plain PHP matrix and BLOCKS, rather than riding the
+ * schema job where a failure would be one more tolerated leg.
+ *
+ * Usage: php tests/schema-upgrade-replay.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-schema-collector.php';
+
+$root = dirname(__DIR__) . '/packages/web';
+$schemaFile = $root . '/commons/schema.php';
+$systemFile = $root . '/lib/fog/system.class.php';
+
+foreach ([$schemaFile, $systemFile] as $path) {
+    if (!is_readable($path)) {
+        fwrite(STDERR, "FAIL: cannot read $path\n");
+        exit(1);
+    }
+}
+
+// Read from source rather than by booting System, whose constructor also
+// defines FOG_VERSION and FOG_CHANNEL and calls _versionCompare(). The same
+// regex tests/schema-gate.test.php uses, so the two cannot disagree about
+// what the constant says.
+$const = [];
+if (!preg_match(
+    "/define\(\s*'FOG_SCHEMA'\s*,\s*(\d+)\s*\)/",
+    file_get_contents($systemFile),
+    $const
+)) {
+    fwrite(STDERR, "FAIL: no FOG_SCHEMA definition in $systemFile\n");
+    exit(1);
+}
+$fogSchema = (int)$const[1];
+
+// The real constant, not PHP_INT_MAX: this test is about what a server does
+// with it, and schema.php's step 29 branches on it.
+$steps = fogCollectSchemaSteps($schemaFile, 'fog_schema_upgrade_replay', $fogSchema);
+$count = count($steps);
+
+$problems = [];
+
+if (!$count) {
+    fwrite(STDERR, "FAIL: collected no steps from commons/schema.php.\n");
+    exit(1);
+}
+
+/*
+ * Keys 0..n-1, contiguous. array_slice() is called with $preserve_keys = true,
+ * and the stored version is written as `$version + 1` from the KEY -- so the
+ * key is only a version number because the array is a contiguous list. One
+ * `$this->schema[300] = ...` assignment by index and the arithmetic silently
+ * means something else. schema.php already writes index 79 that way (`// 79`),
+ * which is why this is checked rather than assumed.
+ */
+$expectedKeys = range(0, $count - 1);
+if (array_keys($steps) !== $expectedKeys) {
+    $gaps = array_values(array_diff($expectedKeys, array_keys($steps)));
+    $extra = array_values(array_diff(array_keys($steps), $expectedKeys));
+    $problems[] = "  The step array is not a contiguous list keyed from 0.\n"
+        . '    missing key(s): ' . ($gaps ? implode(', ', array_slice($gaps, 0, 10)) : 'none') . "\n"
+        . '    unexpected key(s): ' . ($extra ? implode(', ', array_slice($extra, 0, 10)) : 'none') . "\n"
+        . "    The updater writes the stored version as \$version + 1 from the\n"
+        . "    array KEY, so a gap makes that number mean something other than\n"
+        . "    'steps applied' and a server can land short of FOG_SCHEMA.\n";
+}
+
+if ($count !== $fogSchema) {
+    $problems[] = sprintf(
+        "  FOG_SCHEMA is %d but commons/schema.php holds %d step(s).\n%s",
+        $fogSchema,
+        $count,
+        $fogSchema > $count
+            ? "    FOG_SCHEMA is ABOVE the element count, so the updater runs\n"
+                . "    out of steps before the version reaches the gate. Every\n"
+                . "    existing server is redirected to ?node=schema, the update\n"
+                . "    answers 204 'Update not required', and the page loops.\n"
+                . "    Fresh installs are unaffected, which is why this shape\n"
+                . "    passes every other check. The usual cause is statements\n"
+                . "    appended INSIDE the previous step's array rather than as\n"
+                . "    new `\$this->schema[] = [...]` entries of their own (#1338).\n"
+            : "    FOG_SCHEMA is BELOW the element count, so `mySchema <\n"
+                . "    FOG_SCHEMA` stops being true before the last steps run.\n"
+                . "    Nobody is ever sent to the updater to apply them and the\n"
+                . "    steps above the gate reach no install at all (18edea94f).\n"
+    );
+}
+
+/*
+ * The replay. Every version a server could hold, driven through the updater's
+ * own expressions -- copied in shape, not called, because indexPost() is 300
+ * lines welded to a database, a session and three auth tiers.
+ *
+ * Every start rather than a sample: it is array arithmetic over 367 elements
+ * and costs nothing, and sampling would leave "did you pick the right start"
+ * as a question this test could have answered. Runs past FOG_SCHEMA because a
+ * database can legitimately store a version above the array length -- a 1.5.x
+ * carried count does exactly that (see SchemaReconciler's docblock).
+ */
+$stuck = [];
+$ceiling = max($count, $fogSchema) + 2;
+for ($start = 0; $start <= $ceiling; $start++) {
+    $hasIndexed = $count > $start;
+    $items = $hasIndexed
+        ? array_slice($steps, $start, null, true)
+        : [];
+    // What SchemaUpdaterPage::update() would leave in schemaVersion.vValue:
+    // unchanged if no step ran, otherwise the last key it reached, plus one.
+    $stored = $start;
+    foreach ($items as $version => $updates) {
+        $stored = $version + 1;
+    }
+    // DatabaseManager::establish() / FOGBase::schemaNeedsDeploy(). A server at
+    // or above the gate is never sent to the updater, so it has nothing to
+    // escape from and there is nothing here to require of it.
+    if ($start >= $fogSchema) {
+        continue;
+    }
+    if ($stored < $fogSchema) {
+        $stuck[] = [
+            'from' => $start,
+            'to' => $stored,
+            'ran' => count($items),
+        ];
+    }
+}
+
+if ($stuck) {
+    $lines = [];
+    foreach (array_slice($stuck, 0, 3) as $s) {
+        $lines[] = sprintf(
+            "    a server at version %d applies %d step(s) and lands on %d,"
+            . " still below FOG_SCHEMA (%d)",
+            $s['from'],
+            $s['ran'],
+            $s['to'],
+            $fogSchema
+        );
+    }
+    $problems[] = sprintf(
+        "  %d of the %d reachable starting version(s) can never leave"
+        . " ?node=schema:\n%s\n%s"
+        . "    Those servers are redirected to the updater on every request,\n"
+        . "    and the updater answers 204 with 'Update not required'. jQuery\n"
+        . "    reports that as statusText 'nocontent', which \$.notifyFromAPI\n"
+        . "    renders as a Generic Error toast, on a loop. Nothing is logged\n"
+        . "    and nothing errors -- and the page that would repair the server\n"
+        . "    is the page that is stuck.\n",
+        count($stuck),
+        $fogSchema,
+        implode("\n", $lines),
+        count($stuck) > 3
+            ? sprintf("    ... and %d more\n", count($stuck) - 3)
+            : ''
+    );
+}
+
+if ($problems) {
+    fwrite(
+        STDERR,
+        "FAIL: commons/schema.php and FOG_SCHEMA do not agree, so an\n"
+        . "upgrading server does not end up where it should.\n\n"
+        . implode("\n", $problems) . "\n"
+        . "  Every one of these is invisible to a fresh install, which runs\n"
+        . "  from version 0 and therefore never evaluates the gate. Only a\n"
+        . "  server that already has a version is affected.\n"
+    );
+    exit(1);
+}
+
+printf(
+    "ok  every server from version 0 to %d reaches FOG_SCHEMA (%d)\n",
+    $fogSchema - 1,
+    $fogSchema
+);
+printf(
+    "    %d steps collected, keys 0-%d, %d closure step(s) among them\n",
+    $count,
+    $count - 1,
+    count(array_filter($steps, function ($updates) {
+        foreach ((array)$updates as $update) {
+            if (!is_string($update) && is_callable($update)) {
+                return true;
+            }
+        }
+        return false;
+    }))
+);
+exit(0);


### PR DESCRIPTION
## What this closes

CI has only ever exercised a **fresh install** of the schema, and that is not a gap anyone chose — it is what the code makes easy. `SchemaUpdaterPage::update()` slices its step array from `self::$mySchema`, which is `0` on a new database, so a fresh install really does run every step from the beginning. `tests/schema-executes.test.php` therefore sets `$mySchema = 0` and `FOG_SCHEMA = PHP_INT_MAX`, which neutralises the two expressions an upgrade turns on:

```php
$hasIndexed = count($this->schema) > self::$mySchema;
$items      = $hasIndexed ? array_slice($this->schema, self::$mySchema, null, true) : [];
...
$newSchema->set('version', $version + 1);
```

So the **SQL** side of an upgrade was already covered — a server at version N runs steps `[0,N)` then `[N,end)`, which is the same statements in the same order a fresh install runs, and `schema-executes` runs exactly that against three database engines. What was never covered is the **arithmetic and the version it leaves behind**.

That is what #1338 broke. Seven statements appended inside the previous step's array left the element count unmoved while `FOG_SCHEMA` went 360 → 367. Every existing server was then pinned on `?node=schema` — the updater had nothing to apply, never advanced the stored version, and answered 204, which jQuery reports as `statusText: "nocontent"` and `$.notifyFromAPI` renders as a looping Generic Error toast. All seven CI checks were green, because a fresh install was correct throughout.

## What is added

`tests/schema-upgrade-replay.test.php` builds the real step array and, for **every** version a server could be sitting on, runs the updater's own expressions over it and requires the stored version to land on `FOG_SCHEMA`. It also pins the two properties that make that arithmetic mean anything:

- `count($this->schema) === FOG_SCHEMA` — the real element count, not a proxy
- keys are a contiguous list from zero — the stored version is written as `$version + 1` from the array **key**

**No CI change is needed.** `run-all.sh` globs `tests/*.test.php`, so it runs in the existing blocking `tests (PHP 7.4)` / `tests (PHP 8.3)` jobs. It needs no database on purpose: the upgrade-specific surface is arithmetic, so it blocks rather than riding the schema job where a failure would be one more tolerated leg.

## Mutation-verified, three directions

Restored from copies rather than `git checkout --`.

| Mutant | Result |
|---|---|
| #1338 reproduced exactly — the seven steps merged back into step 360, `FOG_SCHEMA` left at 367 | `FAIL: FOG_SCHEMA is 367 but commons/schema.php holds 360 step(s)`, plus all 367 starting versions reported stuck |
| `FOG_SCHEMA` lowered below the count | the stranded-step failure |
| `$this->schema[400] = [...]` index assignment | the contiguity failure — which the count check alone does not see |

Suite: **145 passed, 0 failed**. Verified on PHP 8.3 locally and PHP 7.4 in a container (identical 367-step result), and `schema-executes` re-verified against MariaDB 11.8 with byte-identical output before and after the refactor.

## Refactor

The shim that loads `commons/schema.php` outside the application moves to `tests/lib/fog-schema-collector.php`. It was carried by `schema-executes` alone; there are two callers now and there must stay **one** copy, because two hand-kept descriptions of the schema drifting apart is the failure both tests exist to catch.

## `schema-gate` is kept, not replaced

The two fail on different things and neither subsumes the other. A real count is label-independent and catches shapes the text cannot see; the label checks cover hygiene a count cannot — an unlabelled append, or a label with no append. `schema-gate`'s docblock recorded that a real count "was tried and rejected" because `schema.php` wants ~35 constants and a couple of core classes; the collector **discovers** both rather than listing them, so that objection is answered rather than overruled, and the docblock now says so.

Also repoints a reference in `commons/schema.php` that #1340 left dangling at a test file that was never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqpPXAk7bEm8huH9WkiGk6