### PR TITLE
fix(installer): stop resurrecting files FOG has dropped from management/other

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -9854,7 +9854,47 @@ configureHttpd() {
     dots "Dropping the stale class file list"
     rm -f $fogprogramdir/cache/filelist.*.json >>$error_log 2>&1
     errorStat $?
-    for i in $(find ${DB_backup_path}/fog_web_${version}.BACKUP/management/other/ -maxdepth 1 -type f -not -name gpl-3.0.txt -a -not -name index.php -a -not -name 'ca.*' 2>>$error_log); do
+    # management/other/ is where an administrator's own files live, and the
+    # rm -rf above took them with it, so they are restored from the backup.
+    #
+    # What must NOT come back is anything FOG owns, and FOG owns three
+    # different kinds of file in here:
+    #
+    #   1. what this release ships there. Asked of the source tree rather than
+    #      named, so the answer cannot drift from what is actually shipped.
+    #      This used to be `gpl-3.0.txt` and `index.php` spelled out in the
+    #      find below -- a second, hand-kept description of the release.
+    #   2. what FOG shipped there in the PAST and has since dropped. The
+    #      source tree CANNOT see these: a file the release no longer ships is
+    #      indistinguishable from one the administrator put there, so
+    #      retirement has to be recorded, and that is what retired_web_other
+    #      is for. Without it a dropped file is copied back out of the backup
+    #      on every upgrade for the rest of the server's life -- which is what
+    #      kept management/other/_variables.scss, a Font Awesome 4 icon list
+    #      dead since the FA7 migration, on every upgraded install with no way
+    #      to leave.
+    #   3. ca.*, which is not shipped in the tree at all but MINTED into this
+    #      directory by _installCATrustAnchor(). Restoring the previous one
+    #      over a freshly generated CA would hand the server a stale trust
+    #      anchor -- the certificate fog-client pins and iPXE is built
+    #      against. Named here rather than derived, because there is nothing
+    #      to derive it from.
+    #
+    # retired_web_other is APPEND-ONLY. Dropping an entry lets the file return
+    # from the backup held by every server that still has one. Add a name here
+    # in the same commit that removes the file from packages/web.
+    local retired_web_other=(_variables.scss)
+    local otherfile
+    for i in $(find ${DB_backup_path}/fog_web_${version}.BACKUP/management/other/ -maxdepth 1 -type f -not -name 'ca.*' 2>>$error_log); do
+        otherfile=$(basename "$i")
+        if [[ -e ${webdirsrc}/management/other/${otherfile} ]]; then
+            continue
+        fi
+        case " ${retired_web_other[*]} " in
+            *" ${otherfile} "*)
+                continue
+                ;;
+        esac
         cp -Rf $i ${webdirdest}/management/other/ >>$error_log 2>&1
     done
     if [[ ${FOG_install_lang} == yes ]]; then

--- a/tests/webroot-preserved-files.test.sh
+++ b/tests/webroot-preserved-files.test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# What survives configureHttpd()'s wipe of the web root.
+#
+#   tests/webroot-preserved-files.test.sh
+#
+# configureHttpd() does `rm -rf $webdirdest` and rebuilds the tree from
+# $webdirsrc, so an upgrade genuinely gets the new release and nothing else --
+# except that management/other/ is where an administrator's own files live, and
+# those have to come back. They are restored from the pre-wipe backup.
+#
+# The question that loop has to answer for each file is "is this ours or
+# theirs", and it used to answer it from a hardcoded list: gpl-3.0.txt and
+# index.php. That is a second description of what the release ships, kept by
+# hand, and it drifted the moment FOG dropped a file it had been shipping
+# there. management/other/_variables.scss -- a Font Awesome 4 icon list, dead
+# since the FA7 migration -- was not on the list, so every install classified
+# it as the administrator's and copied it back out of the backup. It could
+# never leave an upgraded server.
+#
+# The question is now asked of the source tree, which cannot drift from itself.
+# ca.* stays named because it is a different kind of FOG-owned file: not
+# shipped in the tree at all, but minted into that directory by
+# _installCATrustAnchor(). Restoring the old one over a freshly generated CA
+# hands the server a stale trust anchor -- the certificate fog-client pins and
+# iPXE is built against -- so that exclusion is load-bearing and is pinned
+# here rather than left to be tidied away as redundant.
+#
+# The loop is EXECUTED against a fixture, not read. A textual check passes on a
+# loop that names the right variables and gets the logic backwards, and the
+# logic is the whole of this change.
+#
+# No root, no network, no FOG install.
+#
+# Usage: bash tests/webroot-preserved-files.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The loop itself, lifted out of configureHttpd().
+# ---------------------------------------------------------------------------
+snippet=$(awk '
+    /^    local retired_web_other=/ { grab = 1 }
+    grab { print }
+    grab && /^    done$/ { exit }
+' "$functions")
+
+if [[ -z $snippet ]]; then
+    echo "FAIL: could not find the management/other restore loop in" >&2
+    echo "  lib/common/functions.sh. If it moved or was rewritten, point this" >&2
+    echo "  test at it -- do not delete the assertion." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run it against a fixture standing in for one upgrade.
+# ---------------------------------------------------------------------------
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+DB_backup_path="$work/backup"
+version="1.2.3"
+webdirsrc="$work/src"
+webdirdest="$work/dest"
+error_log="$work/error.log"
+backup="$DB_backup_path/fog_web_${version}.BACKUP/management/other"
+
+mkdir -p "$backup" "$webdirsrc/management/other" "$webdirdest/management/other"
+
+# What the NEW release ships there.
+: > "$webdirsrc/management/other/index.php"
+: > "$webdirsrc/management/other/gpl-3.0.txt"
+cp "$webdirsrc/management/other/index.php" "$webdirdest/management/other/index.php"
+cp "$webdirsrc/management/other/gpl-3.0.txt" "$webdirdest/management/other/gpl-3.0.txt"
+
+# What the pre-wipe backup holds.
+echo old > "$backup/index.php"
+echo old > "$backup/gpl-3.0.txt"
+# A file FOG used to ship there and has since dropped -- the actual bug.
+echo dead > "$backup/_variables.scss"
+# The administrator's own.
+echo mine > "$backup/company-logo.png"
+# Minted by the PKI step, never shipped in the tree.
+echo stale > "$backup/ca.cert.pem"
+echo stale > "$backup/ca.cert.der"
+
+# Wrapped in a function, which is where it really runs (configureHttpd) and
+# what makes its `local` declarations legal.
+eval "fog_restore_web_other() {
+$snippet
+}"
+fog_restore_web_other
+
+out="$webdirdest/management/other"
+
+check "a file the release still ships is not overwritten from the backup" \
+    "$([[ ! -s $out/index.php && ! -s $out/gpl-3.0.txt ]]; echo $?)"
+
+check "a file the release has DROPPED is not resurrected from the backup" \
+    "$([[ ! -e $out/_variables.scss ]]; echo $?)"
+
+check "the administrator's own file is restored" \
+    "$([[ -e $out/company-logo.png ]]; echo $?)"
+
+check "a minted ca.* is never restored over the newly generated one" \
+    "$([[ ! -e $out/ca.cert.pem && ! -e $out/ca.cert.der ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# And that the decision is not made from a hand-kept list again.
+#
+# Comments stripped: the prose above the loop names both files while
+# explaining why they are no longer named, and a gate its own documentation
+# satisfies is not a gate.
+# ---------------------------------------------------------------------------
+findline=$(printf '%s\n' "$snippet" | sed 's/#.*//' | grep 'for i in')
+
+check "the restore loop names no individual shipped file" \
+    "$(! printf '%s\n' "$findline" | grep -qE 'gpl-3\.0\.txt|index\.php'; echo $?)"
+
+check "the restore loop still excludes the minted ca.*" \
+    "$(printf '%s\n' "$findline" | grep -q "not -name 'ca\.\*'"; echo $?)"
+
+check "the decision is asked of the source tree" \
+    "$(printf '%s\n' "$snippet" | sed 's/#.*//' | grep -q 'webdirsrc.*management/other'; echo $?)"
+
+total=$((pass + fail))
+if [[ $fail -gt 0 ]]; then
+    printf 'FAIL: %d of %d checks failed\n' "$fail" "$total" >&2
+    exit 1
+fi
+printf 'ok  %d checks passed\n' "$total"
+exit 0


### PR DESCRIPTION
Follow-up to #1344. `_variables.scss` was still on the live tree after an `installfog.sh` run, and this is why.

## What was happening

`configureHttpd()` does `rm -rf $webdirdest` and rebuilds from source, so an upgrade genuinely gets the new release — then it restores loose files from the pre-wipe backup of `management/other/`, which is where an administrator's own files live (`ca.cert.pem`, a logo, whatever they put there).

Deciding "ours or theirs" was done from a hardcoded list:

```bash
find .../management/other/ -maxdepth 1 -type f \
  -not -name gpl-3.0.txt -a -not -name index.php -a -not -name 'ca.*'
```

That list is a second, hand-kept description of what the release ships, and it drifted the first time FOG dropped a file it had been shipping there. `_variables.scss` — the Font Awesome 4 icon list #1344 deleted — was not on it, so every install classified it as the administrator's and copied it back out of the backup. It could never leave an upgraded server, on any install, ever.

## Three kinds of FOG-owned file, three different answers

The first attempt at this got it wrong, and the test is what said so.

1. **What this release ships.** Asked of the source tree now, so it cannot drift from what is actually shipped.
2. **What FOG shipped there in the past and dropped.** The source tree **cannot** see these — a file the release no longer ships is indistinguishable from one the administrator put there. So retirement is recorded in `retired_web_other`, which is **append-only**: add a name there in the same commit that removes the file from `packages/web`.
3. **`ca.*`** — not shipped in the tree at all, but *minted* into that directory by `_installCATrustAnchor()`. Restoring the previous one over a freshly generated CA hands the server a stale trust anchor: the certificate `fog-client` pins and iPXE is built against. Kept named, because there is nothing to derive it from.

**The source-tree test alone does not fix the reported symptom.** With only that change, `_variables.scss` is still absent from the source tree and still restored. Only (2) closes it — that is why the retired list exists rather than being one more thing to remember.

## Pinned

`tests/webroot-preserved-files.test.sh` **executes** the loop against a fixture rather than reading it — a textual check passes on a loop that names the right variables and gets the logic backwards, and the logic is the whole change. It also pins that the decision is not made from a hand-kept list of shipped files again, and that the `ca.*` exclusion survives being tidied away as redundant.

Mutation-verified, four mutants, all killed:

| Mutant | Result |
|---|---|
| drop the retired list | the dropped file is resurrected |
| drop the source-tree test | a shipped file is overwritten from the backup |
| drop the `ca.*` exclusion | the stale CA is restored over the new one |
| invert the source-tree test | shipped files overwritten **and** the administrator's own file lost |

Suite: **146 passed, 0 failed**. No root, no network, no FOG install needed to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqpPXAk7bEm8huH9WkiGk6