### PR TITLE
fix(scope): a request with no user has no user to bound

### DIFF
--- a/packages/service/lib/service_lib.php
+++ b/packages/service/lib/service_lib.php
@@ -56,6 +56,13 @@ ini_set('log_errors', '1');
 // PDO raises 'MySQL server has gone away', which the supervisor logs and
 // recovers from by re-forking (#917).
 ini_set('mysqlnd.net_read_timeout', '300');
+/*
+ * A machine entry point: a daemon runs with no signed-in user and cannot
+ * acquire one. Declared here rather than in each daemon because this file
+ * is what every one of them requires -- see Authorization::_hasNoPrincipal()
+ * for what it licenses and why the distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
 require WEBROOT.'/commons/base.inc.php';
 $service_logpath = sprintf(
     '/%s/%s',

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -1183,6 +1183,48 @@ class Authorization extends FOGBase
         return in_array('*', self::getPermissions($userID), true);
     }
     /**
+     * Is this request carrying no authenticated principal at all?
+     *
+     * Site scope answers "which objects may THIS USER see". Where there is
+     * no user, deny-all is not a conservative reading of that question --
+     * it is a confident answer to a different one, and it is what broke
+     * every machine path when the boundary moved into the query
+     * (46fc53a20, "Enforce the site boundary in the query, not on the
+     * rows"). A PXE client's boot script lost its host identity AND its
+     * task on any server with a site configured: no `set hostname`, no
+     * `set imageID`, a menu banner reading "Host is registered as" with
+     * nothing after it, and a scheduled task that simply never ran. The
+     * FOS progress and hostinfo endpoints, and the task scheduler's
+     * expired-checkin sweep, went the same way.
+     *
+     * Exempting these is safe because it cannot widen what any USER sees:
+     * every route that returns a scoped list to a caller has already made
+     * that caller authenticate. Verified on a live server -- GET /api/host,
+     * /task, /group, /user and /usergroup all answer 401 with no
+     * credentials and with a bad token, so an anonymous caller never
+     * reaches the scope layer through the API at all. The UI binds
+     * $FOGUser from the session (LoadGlobals) and every REST arm binds it
+     * from the token it accepted (Route::_apiAuth and the fog-user-token
+     * path), so an authenticated caller is never mistaken for a machine.
+     *
+     * What is left is exactly the machine surface -- service/ipxe/boot.php,
+     * advanced.php, the FOS protocol endpoints under service/, and the ten
+     * CLI daemons -- none of which has a user to scope by, and each of
+     * which constrains itself by the MAC or token it was handed.
+     *
+     * Only when the caller named no user. A caller that passes a user id
+     * explicitly is asking about THAT user and still gets the boundary.
+     *
+     * @param int|null $userID the user id the caller supplied, if any
+     *
+     * @return bool
+     */
+    private static function _hasNoPrincipal($userID = null)
+    {
+        return null === $userID
+            && !(self::$FOGUser && self::$FOGUser->isValid());
+    }
+    /**
      * Public view of _isUnrestricted for scope-enforcing plugins (Site) that
      * must let global '*' holders bypass list filtering.
      *
@@ -1236,6 +1278,14 @@ class Authorization extends FOGBase
             return true;
         }
         if (self::_isUnrestricted($userID)) {
+            return true;
+        }
+        // No user to bound -- see _hasNoPrincipal(). Stated here as well as
+        // in _boundedUserID() because the single-object and list paths have
+        // to give the same answer: an object hidden from every list but
+        // still served through GET /<class>/<id>, or the reverse, is two
+        // statements of who may see what.
+        if (self::_hasNoPrincipal($userID)) {
             return true;
         }
         if (null === $userID) {
@@ -1402,6 +1452,10 @@ class Authorization extends FOGBase
     private static function _boundedUserID($node, $userID = null)
     {
         if (self::_isUnrestricted($userID)) {
+            return null;
+        }
+        // No user to bound -- see _hasNoPrincipal().
+        if (self::_hasNoPrincipal($userID)) {
             return null;
         }
         if (null === $userID) {

--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -1183,37 +1183,45 @@ class Authorization extends FOGBase
         return in_array('*', self::getPermissions($userID), true);
     }
     /**
-     * Is this request carrying no authenticated principal at all?
+     * Is this a declared machine request that carries no principal?
      *
-     * Site scope answers "which objects may THIS USER see". Where there is
-     * no user, deny-all is not a conservative reading of that question --
-     * it is a confident answer to a different one, and it is what broke
-     * every machine path when the boundary moved into the query
-     * (46fc53a20, "Enforce the site boundary in the query, not on the
-     * rows"). A PXE client's boot script lost its host identity AND its
-     * task on any server with a site configured: no `set hostname`, no
-     * `set imageID`, a menu banner reading "Host is registered as" with
-     * nothing after it, and a scheduled task that simply never ran. The
-     * FOS progress and hostinfo endpoints, and the task scheduler's
-     * expired-checkin sweep, went the same way.
+     * Site scope answers "which objects may THIS USER see". On an entry
+     * point that has no user and cannot acquire one, deny-all is not a
+     * conservative reading of that question -- it is a confident answer to
+     * a different one, and it is what broke every machine path when the
+     * boundary moved into the query (46fc53a20, "Enforce the site boundary
+     * in the query, not on the rows"). A PXE client's boot script lost its
+     * host identity AND its task on any server with a site configured: no
+     * `set hostname`, no `set imageID`, a menu banner reading "Host is
+     * registered as" with nothing after it, and a scheduled task that
+     * simply never ran. The FOS progress and hostinfo endpoints, and the
+     * task scheduler's expired-checkin sweep, went the same way.
      *
-     * Exempting these is safe because it cannot widen what any USER sees:
-     * every route that returns a scoped list to a caller has already made
-     * that caller authenticate. Verified on a live server -- GET /api/host,
-     * /task, /group, /user and /usergroup all answer 401 with no
-     * credentials and with a bad token, so an anonymous caller never
-     * reaches the scope layer through the API at all. The UI binds
-     * $FOGUser from the session (LoadGlobals) and every REST arm binds it
-     * from the token it accepted (Route::_apiAuth and the fog-user-token
-     * path), so an authenticated caller is never mistaken for a machine.
+     * Three conditions, and the first is the one that matters.
      *
-     * What is left is exactly the machine surface -- service/ipxe/boot.php,
-     * advanced.php, the FOS protocol endpoints under service/, and the ten
-     * CLI daemons -- none of which has a user to scope by, and each of
-     * which constrains itself by the MAC or token it was handed.
+     * FOG_MACHINE_REQUEST is DECLARED by the entry point, one line at the
+     * top of each of the 44 files under service/ and once in
+     * packages/service/lib/service_lib.php for the ten daemons, exactly
+     * like FOG_WANTS_SESSION in management/index.php. It is deliberately
+     * not inferred from "no principal is bound", because those two are not
+     * the same statement: a machine entry point HAS no user, while a route
+     * that merely failed to authenticate one is a bug. Keying on absence
+     * would hand that bug the exemption as well, so a route that ever lost
+     * its 401 would silently lose site scoping in the same stroke --
+     * tests/route-read-path-guards.test.php section (j) exists to catch
+     * exactly that, and it still does. A new file under service/ that
+     * forgets the declaration fails the safe way: deny-all, visibly
+     * broken, rather than quietly unbounded.
      *
-     * Only when the caller named no user. A caller that passes a user id
-     * explicitly is asking about THAT user and still gets the boundary.
+     * Nothing outside those files can reach this. The UI binds $FOGUser
+     * from the session (LoadGlobals) and every REST arm binds it from the
+     * token it accepted (Route::_apiAuth and the fog-user-token path), and
+     * neither declares the constant.
+     *
+     * The remaining two conditions keep an authenticated caller bounded
+     * even on a machine entry point -- fog-client endpoints can carry a
+     * user -- and keep a caller that named a user id explicitly bounded,
+     * because it is asking about THAT user.
      *
      * @param int|null $userID the user id the caller supplied, if any
      *
@@ -1221,7 +1229,8 @@ class Authorization extends FOGBase
      */
     private static function _hasNoPrincipal($userID = null)
     {
-        return null === $userID
+        return defined('FOG_MACHINE_REQUEST')
+            && null === $userID
             && !(self::$FOGUser && self::$FOGUser->isValid());
     }
     /**

--- a/packages/web/service/Post_Stage2.php
+++ b/packages/web/service/Post_Stage2.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskQueue::ackIfAlreadyComplete();
 FOGCore::getClass('TaskQueue')

--- a/packages/web/service/Post_Stage3.php
+++ b/packages/web/service/Post_Stage3.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskQueue::ackIfAlreadyComplete();
 FOGCore::getClass('TaskQueue')

--- a/packages/web/service/Post_Wipe.php
+++ b/packages/web/service/Post_Wipe.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 FOGCore::getClass('TaskQueue')
     ->checkout();

--- a/packages/web/service/Pre_Stage1.php
+++ b/packages/web/service/Pre_Stage1.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 FOGCore::getClass('TaskQueue')
     ->checkIn();

--- a/packages/web/service/PrinterManager.php
+++ b/packages/web/service/PrinterManager.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new PrinterClient(
     true,

--- a/packages/web/service/Printers.php
+++ b/packages/web/service/Printers.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 FOGCore::getClass('PrinterClient');

--- a/packages/web/service/Test.php
+++ b/packages/web/service/Test.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 /**
  * Sends the response

--- a/packages/web/service/alo-bg.php
+++ b/packages/web/service/alo-bg.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new ALOBG(
     true,

--- a/packages/web/service/auto.register.php
+++ b/packages/web/service/auto.register.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new Registration();

--- a/packages/web/service/autologout.php
+++ b/packages/web/service/autologout.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new Autologout(
     true,

--- a/packages/web/service/blame.php
+++ b/packages/web/service/blame.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new Blame();

--- a/packages/web/service/capone.php
+++ b/packages/web/service/capone.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new CaponeTasking();

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 
 $remoteIP = filter_input(INPUT_SERVER, 'REMOTE_ADDR');

--- a/packages/web/service/displaymanager.php
+++ b/packages/web/service/displaymanager.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new DisplayManager(
     true,

--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -27,6 +27,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 $clientUpdate = (bool)FOGCore::getSetting('FOG_CLIENT_AUTOUPDATE');
 if (isset($_REQUEST['client'])) {

--- a/packages/web/service/greenfog.php
+++ b/packages/web/service/greenfog.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new GF(
     true,

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 try {
     // asValue(): names() has no wrapper, and its payload is a bare list with

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 header('Content-Type: text/plain');
 try {

--- a/packages/web/service/hostname.php
+++ b/packages/web/service/hostname.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new HostnameChanger(
     true,

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 try {
     $host = $_REQUEST['host'];

--- a/packages/web/service/imagelisting.php
+++ b/packages/web/service/imagelisting.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskingElement::getlisting('image');

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 header('Content-Type: text/plain');
 // The client base64-encodes every value, so decode (and sanitize) the

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../../commons/base.inc.php';
 header('Content-type: text/plain');
 /**

--- a/packages/web/service/ipxe/boot.php
+++ b/packages/web/service/ipxe/boot.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../../commons/base.inc.php';
 header("Content-type: text/plain");
 $items = [

--- a/packages/web/service/jobs.php
+++ b/packages/web/service/jobs.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new Jobs(
     true,

--- a/packages/web/service/locationcheck.php
+++ b/packages/web/service/locationcheck.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 if (in_array('location', FOGCore::$pluginsinstalled)) {
     echo '##';

--- a/packages/web/service/locationlisting.php
+++ b/packages/web/service/locationlisting.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskingElement::getlisting('location');

--- a/packages/web/service/man.hostexists.php
+++ b/packages/web/service/man.hostexists.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new Registration(
     true

--- a/packages/web/service/mc_checkin.php
+++ b/packages/web/service/mc_checkin.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 FOGCore::getClass('TaskQueue')
     ->checkIn();

--- a/packages/web/service/nodecert.php
+++ b/packages/web/service/nodecert.php
@@ -44,6 +44,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 
 header('Content-Type: application/json');

--- a/packages/web/service/oucheck.php
+++ b/packages/web/service/oucheck.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 if (in_array('ou', FOGCore::$pluginsinstalled)) {
     echo '##';

--- a/packages/web/service/oulisting.php
+++ b/packages/web/service/oulisting.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskingElement::getlisting('ou');

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 try {
     // asValue(): names() has no wrapper, and its payload is a bare list with

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 try {
     FOGCore::getHostItem(false);

--- a/packages/web/service/register.php
+++ b/packages/web/service/register.php
@@ -23,6 +23,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new RegisterClient(
     true,

--- a/packages/web/service/servicemodule-active.php
+++ b/packages/web/service/servicemodule-active.php
@@ -21,6 +21,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new ServiceModule(
     true,

--- a/packages/web/service/snapcheck.php
+++ b/packages/web/service/snapcheck.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 try {
     FOGCore::getHostItem(false);

--- a/packages/web/service/snapinlisting.php
+++ b/packages/web/service/snapinlisting.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 TaskingElement::getlisting('snapin');

--- a/packages/web/service/snapins.checkin.php
+++ b/packages/web/service/snapins.checkin.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new SnapinClient(
     true,

--- a/packages/web/service/snapins.file.php
+++ b/packages/web/service/snapins.file.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new SnapinClient(
     true,

--- a/packages/web/service/taskerror.php
+++ b/packages/web/service/taskerror.php
@@ -19,5 +19,14 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new TaskError();

--- a/packages/web/service/updates.php
+++ b/packages/web/service/updates.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new UpdateClient(
     true,

--- a/packages/web/service/usercleanup-users.php
+++ b/packages/web/service/usercleanup-users.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new UserCleaner(
     true,

--- a/packages/web/service/usertracking.report.php
+++ b/packages/web/service/usertracking.report.php
@@ -19,6 +19,15 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+/*
+ * A machine entry point: the caller is a booting NIC, FOS, the fog-client
+ * or a storage node, none of which can present a credential. Declared per
+ * file rather than inferred from the absence of one -- see
+ * Authorization::_hasNoPrincipal() for what it licenses and why the
+ * distinction matters.
+ */
+define('FOG_MACHINE_REQUEST', true);
+
 require '../commons/base.inc.php';
 new UserTrack(
     true,

--- a/tests/machine-request-declared.test.php
+++ b/tests/machine-request-declared.test.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Guards the FOG_MACHINE_REQUEST declaration that site scope keys on.
+ *
+ * Authorization::_hasNoPrincipal() lifts the site boundary for a caller
+ * that has no user and cannot acquire one -- a booting NIC, FOS, the
+ * fog-client, a daemon. It decides that from a constant each of those entry
+ * points DECLARES, not from the absence of a bound $FOGUser, because those
+ * are different statements: a machine entry point has no user, while a
+ * route that merely failed to authenticate one is a bug. Keying on absence
+ * would hand that bug the same exemption, so a route that ever lost its 401
+ * would silently lose site scoping in the same stroke.
+ *
+ * That safety is only real while the declaration is actually present on the
+ * machine surface and absent everywhere else, and neither half announces
+ * itself when it breaks:
+ *
+ *   - a new file under service/ that forgets it is scoped to a user that
+ *     does not exist, so it reaches nothing -- the exact failure 46fc53a20
+ *     caused, one endpoint at a time;
+ *   - a declaration added to management/ or api/ hands every unauthenticated
+ *     caller of that entry point the whole server, which is what
+ *     route-read-path-guards.test.php section (j) exists to prevent.
+ *
+ * Static source check (no DB, no server).
+ *
+ * Usage: php tests/machine-request-declared.test.php [path/to/repo]
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = $argv[1] ?? dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$failures = [];
+
+/**
+ * Does this file bootstrap FOG at all?
+ *
+ * A file that never pulls in base.inc.php has no scope layer to reach, so
+ * it needs no declaration -- service/ipxe/index.php is a bare redirect.
+ *
+ * @param string $src file contents
+ *
+ * @return bool
+ */
+$bootstraps = function ($src) {
+    return 1 === preg_match(
+        "#require(_once)?\s+.{0,40}commons/base\.inc\.php#",
+        $src
+    );
+};
+
+$declares = function ($src) {
+    return 1 === preg_match(
+        "/define\(\s*'FOG_MACHINE_REQUEST'\s*,\s*true\s*\)/",
+        $src
+    );
+};
+
+// 1. Every bootstrapping entry point on the machine surface must declare it.
+$machine = array_merge(
+    (array)glob($web . '/service/*.php'),
+    (array)glob($web . '/service/ipxe/*.php'),
+    [$root . '/packages/service/lib/service_lib.php']
+);
+$declared = 0;
+foreach ($machine as $file) {
+    if (!is_readable($file)) {
+        $failures[] = 'cannot read ' . $file;
+        continue;
+    }
+    $src = file_get_contents($file);
+    if (!$bootstraps($src)) {
+        continue;
+    }
+    if (!$declares($src)) {
+        $failures[] = str_replace($root . '/', '', $file)
+            . ' bootstraps FOG but does not declare FOG_MACHINE_REQUEST'
+            . ' -- it will be scoped to a user that does not exist and'
+            . ' reach nothing';
+        continue;
+    }
+    $declared++;
+}
+if ($declared < 40) {
+    $failures[] = "only $declared machine entry points declare"
+        . ' FOG_MACHINE_REQUEST; the surface has not been that small since'
+        . ' the constant was introduced, so something moved or the glob'
+        . ' above stopped matching';
+}
+
+// 2. No entry point that CAN carry a principal may declare it.
+foreach (['/management', '/api'] as $dir) {
+    foreach ((array)glob($web . $dir . '/*.php') as $file) {
+        if (!is_readable($file) || !$declares(file_get_contents($file))) {
+            continue;
+        }
+        $failures[] = str_replace($root . '/', '', $file)
+            . ' declares FOG_MACHINE_REQUEST -- this entry point can carry a'
+            . ' user, so declaring it exempts every unauthenticated caller'
+            . ' of it from site scope';
+    }
+}
+
+// 3. The predicate must still be gated on the constant. Without this the
+//    two checks above pass while guarding nothing.
+$auth = $web . '/lib/fog/authorization.class.php';
+if (!is_readable($auth)) {
+    $failures[] = 'cannot read ' . $auth;
+} elseif (!preg_match(
+    "/function _hasNoPrincipal\([^)]*\)\s*\{\s*return\s+defined\(\s*"
+    . "'FOG_MACHINE_REQUEST'\s*\)/s",
+    file_get_contents($auth)
+)) {
+    $failures[] = '_hasNoPrincipal() no longer opens on'
+        . " defined('FOG_MACHINE_REQUEST') -- the exemption is back to being"
+        . ' inferred from the absence of a principal';
+}
+
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        fwrite(STDERR, "FAIL: $f\n");
+    }
+    exit(1);
+}
+
+echo "PASS ($declared machine entry points declared)\n";
+exit(0);


### PR DESCRIPTION
`46fc53a20` ("Enforce the site boundary in the query, not on the rows") made `scopedObjectWhere()` resolve an absent user to id 0. SiteScope then finds that "user" reaches no sites and correctly answers deny-all — `1=0` ANDed into every list of a scoped node. Correct for a user; wrong for a caller that is not one.

## What broke

On any server with a site configured, the whole machine surface went dark. Sweeping all 44 endpoints under `service/`, base against fixed, **nine differ — and they are the FOS imaging protocol**:

| Endpoint | What it answered |
|---|---|
| `Pre_Stage1`, `Post_Stage2`, `Post_Stage3`, `Post_Wipe`, `mc_checkin`, `blame`, `progress` | "No Active Task found for Host" — for a host that had one |
| `hostinfo` | "Invalid tasking!" |
| `grouplisting` | "There are no groups on this server", with two groups present |

Plus the PXE path: `Route::getItem('host')` routes through `getIds()`, so no `set hostname`, no `set imageID`, no `set imagename` reached the iPXE script — leaving the menu banner reading "Host is registered as" with nothing after it — and `Host::loadTask()` found nothing, so a **scheduled task simply never ran**. The task scheduler's expired-checkin sweep reads through `Route::getList('task')` and went the same way.

Imaging did not fail at the edges. It could not start.

## Fix

An entry point that has no user and cannot acquire one **declares** itself, one line at the top, exactly like `FOG_WANTS_SESSION` in `management/index.php`:

```php
define('FOG_MACHINE_REQUEST', true);
```

44 files under `service/`, plus once in `packages/service/lib/service_lib.php` — the file all ten daemons require. `Authorization::_hasNoPrincipal()` keys on that constant.

### Why declared rather than inferred

Declared, not inferred from "no `$FOGUser` is bound", because those are different statements. A machine entry point *has* no user; a route that merely failed to authenticate one is a bug. Keying on absence hands that bug the same exemption, so a route that ever lost its 401 would silently lose site scoping in the same stroke.

That is what `tests/route-read-path-guards.test.php` section (j) was written to prevent, and **it passes unchanged** here rather than being rewritten to accommodate this. A new file under `service/` that forgets the declaration fails the safe way: deny-all, visibly broken, rather than quietly unbounded.

`tests/machine-request-declared.test.php` pins both halves, because neither announces itself when it breaks — every bootstrapping file on the machine surface must declare the constant, nothing under `management/` or `api/` may, and `_hasNoPrincipal()` must still open on it. Mutation-verified all three.

## Verification

Two shadow trees of the web root against the live database, differing only by this change:

| Entry point | Principal | scope `where` | `objectInScope` | |
|---|---|---|---|---|
| `service/` | none | `NULL` (was `1=0`) | true | **fixed** |
| `management/` | none | `1=0` | false | unchanged |
| `service/` | explicit id 7 | bounded to site 1 | — | unchanged |
| `service/` | `$FOGUser` site1 | bounded to site 1 | — | unchanged |
| `service/` | `$FOGUser` catch-all | `NULL` | — | unchanged |

End to end: the boot script emits `set hostname` / `set imageID` / `set imagename` again, a queued deploy task reaches the kernel line instead of the menu, and `hostinfo`/`progress` get past the task check to their own token and payload checks. Bisected against `46fc53a20~1` — the same request on the same database emits the kernel line there and the menu on the tip.

Full suite: 148 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)