### PR TITLE
Remove dead code in BootMenu, make its hook arguments mean what they say

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -497,6 +497,15 @@ class BootMenu extends FOGBase
          */
         $bootroot = trim((string)$curroot, '/');
         $curroot = '/' . ($bootroot === '' ? '' : $bootroot . '/');
+        /**
+         * BOOT_ITEM_NEW_SETTINGS passes 'webroot' by reference, but no
+         * $webroot was ever assigned, so PHP created it at the call and
+         * every plugin reading it saw NULL. Bind it to the bare form that
+         * accompanies 'webserver' in the same payload -- the value
+         * 'set fog-webroot' emits -- so the argument means what its name
+         * says.
+         */
+        $webroot = $bootroot;
         $this->_web = sprintf('%s://%s%s', self::$httpproto, $webserver, $curroot);
         $Send['booturl'] = [
             '#!ipxe',
@@ -637,6 +646,7 @@ class BootMenu extends FOGBase
             $exit = 'sanboot';
         }
         $initrd = $imagefile;
+        $hookInitrd = $initrd;
         if (self::$Host->isValid()) {
             self::$HookManager->processEvent(
                 'BOOT_ITEM_NEW_SETTINGS',
@@ -659,8 +669,22 @@ class BootMenu extends FOGBase
                 ]
             );
         }
-        $kernel = $bzImage;
-        $initrd = $imagefile;
+        /**
+         * 'initrd' and 'imagefile' are both passed to the hook by
+         * reference, and this used to reassign $initrd = $imagefile
+         * unconditionally -- so a plugin that set 'initrd' had its value
+         * discarded on the very next line, while one that set 'imagefile'
+         * was honoured. Nothing said which of the two to write to, and
+         * the one named after the thing being chosen was the dead one.
+         *
+         * Follow 'imagefile' only when the hook left 'initrd' alone, so
+         * the working argument keeps working and the documented one
+         * starts to. With no plugin listening both are equal here and
+         * this is a no-op, which is what the golden file pins.
+         */
+        if ($initrd === $hookInitrd) {
+            $initrd = $imagefile;
+        }
         $this->_timeout = $timeout;
         $this->_hiddenmenu = ($hiddenmenu && empty($_REQUEST['menuAccess']));
         $this->_bootexittype = self::$_exitTypes[$exit];
@@ -735,7 +759,7 @@ class BootMenu extends FOGBase
             ),
             $this->_storage
         );
-        $this->_initrd = "imgfetch $imagefile";
+        $this->_initrd = "imgfetch $initrd";
         self::$HookManager
             ->processEvent('BOOT_MENU_ITEM');
         $PXEMenuID = self::maxId(Route::getIds('pxemenuoptions', ['default' => 1]));
@@ -991,7 +1015,6 @@ class BootMenu extends FOGBase
      */
     private function _chainBoot($debug = false, $shortCircuit = false)
     {
-        $debug = $debug;
         if (!$this->_hiddenmenu || $shortCircuit) {
             $Send['chainnohide'] = array_merge(
                 self::_archDetect(),

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -1,0 +1,489 @@
+<?php
+/**
+ * Characterization test for the iPXE script BootMenu emits.
+ *
+ * BootMenu has no return value worth checking: every screen is an array of
+ * strings that _parseMe() flattens straight to stdout, and that stdout IS the
+ * iPXE program the client runs. So the only meaningful assertion is a byte
+ * comparison of the emitted script.
+ *
+ * The golden file was generated from bootmenu.class.php as it stood BEFORE
+ * the dead-code removal it now guards, which is what makes it proof rather
+ * than decoration: the cleanup is correct exactly insofar as the bytes did not
+ * move. It doubles as a regression net for future edits to a file where a
+ * stray line is a client that will not boot.
+ *
+ * Three things the golden cannot cover get their own checks below:
+ *   - what BOOT_ITEM_NEW_SETTINGS hands a plugin (never appears in output);
+ *   - whether a plugin's value survives to the emitted script;
+ *   - that no host secret reaches this unauthenticated endpoint.
+ *
+ * Each scenario runs in its own process: several BootMenu paths end in exit(),
+ * and the architecture profile is memoised in a static that would leak between
+ * scenarios sharing a process.
+ *
+ * Usage:
+ *   php tests/bootmenu-ipxe-output.test.php            # compare to golden
+ *   php tests/bootmenu-ipxe-output.test.php --update   # rewrite golden
+ *   php tests/bootmenu-ipxe-output.test.php --against FILE
+ *
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$renderer = __DIR__ . '/lib/bootmenu-render.php';
+$golden = __DIR__ . '/fixtures/bootmenu-ipxe-output.golden';
+$classFile = $root . '/packages/web/lib/fog/bootmenu.class.php';
+
+$update = in_array('--update', $argv, true);
+$againstAt = array_search('--against', $argv, true);
+if (false !== $againstAt && isset($argv[$againstAt + 1])) {
+    $classFile = $argv[$againstAt + 1];
+}
+
+if (!is_file($classFile)) {
+    fwrite(STDERR, "FAIL: no such class file: $classFile\n");
+    exit(1);
+}
+
+/*
+ * The matrix. Each entry names a branch of BootMenu that renders differently,
+ * so a change that moves any of these bytes shows up as a diff rather than as
+ * a client that silently fails to boot.
+ *
+ * Coverage is deliberate, not exhaustive:
+ *  - every exit type, each a distinct chunk of iPXE built in the constructor;
+ *  - every arch, because the kernel/init keys, the refind loader, memdisk
+ *    availability and the override guard all switch on it;
+ *  - hidden vs shown menu, the only path through _chainBoot();
+ *  - registered / pending / unregistered, which select the pxeRegOnly set;
+ *  - all four Secure Boot file states, which _filterMenus() and
+ *    _enrollSecureBootChoice() read separately (MOK.der gates the attended
+ *    item's body, PK/KEK/db.auth gate whether the unattended item is listed);
+ *  - both arch-mismatch notices, and the _echoSafe() whitelist.
+ */
+$scenarios = [
+    'unregistered-bios-x86' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+    ],
+    'unregistered-efi-x86' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+    ],
+    'unregistered-efi-x86-mok' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'mok' => true,
+    ],
+    'unregistered-efi-x86-mok-authvars' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'mok' => true,
+        'authvars' => true,
+    ],
+    'unregistered-efi-x86-authvars-only' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'authvars' => true,
+    ],
+    'unregistered-efi-i386' => [
+        'request' => ['arch' => 'i386', 'platform' => 'efi'],
+    ],
+    'unregistered-efi-arm64' => [
+        'request' => ['arch' => 'arm64', 'platform' => 'efi'],
+    ],
+    'unregistered-no-platform' => [
+        'request' => ['arch' => 'x86_64'],
+    ],
+    'registered-bios' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'host' => ['id' => 1, 'name' => 'testhost'],
+    ],
+    'registered-efi-mok-authvars' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'host' => ['id' => 1, 'name' => 'testhost'],
+        'mok' => true,
+        'authvars' => true,
+    ],
+    'pending-approval' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'host' => ['id' => 1, 'name' => 'testhost', 'pending' => 1],
+    ],
+    'registered-host-kernel-override' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'host' => [
+            'id' => 1,
+            'name' => 'testhost',
+            'kernel' => 'custom-bzImage',
+            'init' => 'custom-init.xz',
+            'kernelArgs' => 'nomodeset',
+        ],
+    ],
+    'arm64-host-x86-kernel-override' => [
+        'request' => ['arch' => 'arm64', 'platform' => 'efi'],
+        'host' => ['id' => 1, 'name' => 'testhost', 'kernel' => 'custom-bzImage'],
+    ],
+    'arm64-host-arm-kernel-override' => [
+        'request' => ['arch' => 'arm64', 'platform' => 'efi'],
+        'host' => ['id' => 1, 'name' => 'testhost', 'kernel' => 'arm_custom_Image'],
+    ],
+    'x86-host-arm-init-override' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'host' => ['id' => 1, 'name' => 'testhost', 'init' => 'arm_init.cpio.gz'],
+    ],
+    'host-kernel-override-unsafe-chars' => [
+        'request' => ['arch' => 'arm64', 'platform' => 'efi'],
+        'host' => [
+            'id' => 1,
+            'name' => 'testhost',
+            'kernel' => 'evil; echo pwned && chain http://x/`id`',
+        ],
+    ],
+    'debug-requested' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios', 'debug' => 1],
+        'host' => ['id' => 1, 'name' => 'testhost'],
+    ],
+    'registration-disabled' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_REGISTRATION_ENABLED' => '0'],
+    ],
+    'advanced-menu' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_PXE_ADVANCED' => '1'],
+    ],
+    'advanced-menu-login' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => [
+            'FOG_PXE_ADVANCED' => '1', 'FOG_ADVANCED_MENU_LOGIN' => '1',
+        ],
+    ],
+    'hidden-menu' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_PXE_MENU_HIDDEN' => '1'],
+    ],
+    'hidden-menu-keyseq' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => [
+            'FOG_PXE_MENU_HIDDEN' => '1', 'FOG_KEY_SEQUENCE' => 'F12',
+        ],
+    ],
+    'hidden-menu-accessed' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios', 'menuAccess' => 1],
+        'settings' => ['FOG_PXE_MENU_HIDDEN' => '1'],
+    ],
+    'exit-sanboot' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'sanboot'],
+    ],
+    'exit-exit' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'exit'],
+    ],
+    'exit-grub' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'grub'],
+    ],
+    'exit-grub-first-hdd' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'grub_first_hdd'],
+    ],
+    'exit-grub-first-cdrom' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'grub_first_cdrom'],
+    ],
+    'exit-grub-first-found-windows' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'grub_first_found_windows'],
+    ],
+    'exit-refind-efi' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'efi'],
+        'settings' => ['FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi'],
+    ],
+    'exit-refind-efi-i386' => [
+        'request' => ['arch' => 'i386', 'platform' => 'efi'],
+        'settings' => ['FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi'],
+    ],
+    'exit-refind-efi-arm64' => [
+        'request' => ['arch' => 'arm64', 'platform' => 'efi'],
+        'settings' => ['FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi'],
+    ],
+    'exit-unknown-falls-back-to-sanboot' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_BOOT_EXIT_TYPE' => 'not-a-real-exit-type'],
+    ],
+    'host-exit-override' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'host' => ['id' => 1, 'name' => 'testhost', 'biosexit' => 'exit'],
+    ],
+    'no-menu' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'host' => ['id' => 1, 'name' => 'testhost'],
+        'settings' => ['FOG_NO_MENU' => '1'],
+    ],
+    'keymap-set' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_KEYMAP' => 'uk'],
+    ],
+    'kernel-args-and-debug' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => [
+            'FOG_KERNEL_ARGS' => 'acpi=off', 'FOG_KERNEL_DEBUG' => '1',
+        ],
+    ],
+    'nested-webroot' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_WEB_ROOT' => '/apps/fog/'],
+    ],
+    'bare-webroot' => [
+        'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        'settings' => ['FOG_WEB_ROOT' => 'fog'],
+    ],
+];
+
+/**
+ * Renders one scenario in a child process.
+ *
+ * @param string $renderer  path to the renderer
+ * @param array  $scenario  the scenario definition
+ * @param string $classFile the BootMenu source under test
+ *
+ * @return string the emitted iPXE script, plus any stderr
+ */
+function renderScenario($renderer, array $scenario, $classFile)
+{
+    $cmd = sprintf(
+        '%s %s %s %s 2>&1',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg($renderer),
+        escapeshellarg(json_encode($scenario)),
+        escapeshellarg($classFile)
+    );
+    $out = shell_exec($cmd);
+    return null === $out ? '' : $out;
+}
+
+$rendered = [];
+$actual = '';
+foreach ($scenarios as $name => $scenario) {
+    $rendered[$name] = renderScenario($renderer, $scenario, $classFile);
+    $actual .= "########## $name ##########\n";
+    $actual .= rtrim($rendered[$name], "\n");
+    $actual .= "\n\n";
+}
+
+if ($update) {
+    if (!is_dir(dirname($golden))) {
+        mkdir(dirname($golden), 0775, true);
+    }
+    file_put_contents($golden, $actual);
+    printf(
+        "bootmenu-ipxe-output: wrote golden from %s (%d scenarios, %d bytes)\n",
+        str_replace($root . '/', '', $classFile),
+        count($scenarios),
+        strlen($actual)
+    );
+    exit(0);
+}
+
+if (!is_file($golden)) {
+    fwrite(STDERR, "FAIL: golden file missing: $golden\n");
+    fwrite(STDERR, "Generate it with --update against the pre-change source.\n");
+    exit(1);
+}
+
+printf(
+    "bootmenu-ipxe-output: %d scenarios, %d bytes rendered\n",
+    count($scenarios),
+    strlen($actual)
+);
+
+/*
+ * A rendered scenario that is empty, or that carries a PHP diagnostic, means
+ * the harness broke rather than that the output matched. Catch that here so a
+ * silently-empty render can never be mistaken for a pass.
+ */
+$broken = [];
+foreach ($rendered as $name => $chunk) {
+    if ('' === trim($chunk)) {
+        $broken[] = "$name: rendered nothing";
+        continue;
+    }
+    if (preg_match('/(Fatal error|Parse error|Uncaught|harness:)/i', $chunk, $m)) {
+        $broken[] = "$name: {$m[1]} in rendered output";
+    }
+    if (false === strpos($chunk, '#!ipxe')) {
+        $broken[] = "$name: output does not start an iPXE script";
+    }
+}
+if ($broken) {
+    foreach ($broken as $b) {
+        fwrite(STDERR, "\nFAIL: $b\n");
+    }
+    exit(1);
+}
+
+/*
+ * Behaviour checks the golden cannot express.
+ *
+ * Each renders a scenario and asserts on something other than the exact bytes:
+ * what a plugin was handed, whether a plugin's value survived, or whether a
+ * secret escaped. 'expectHook' reads the BOOT_ITEM_NEW_SETTINGS payload;
+ * 'expectLine' / 'refuteLine' match against the emitted script.
+ */
+$checks = [
+    'webroot reaches plugins as the bare form' => [
+        'scenario' => [
+            'hooks' => true,
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+        ],
+        'expectHook' => ['webserver' => '10.0.0.1', 'webroot' => 'fog'],
+    ],
+    'webroot keeps every segment of a nested install' => [
+        'scenario' => [
+            'hooks' => true,
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'settings' => ['FOG_WEB_ROOT' => '/apps/fog/'],
+        ],
+        'expectHook' => ['webroot' => 'apps/fog'],
+    ],
+    "a plugin's initrd survives to imgfetch" => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hookMutations' => [
+                'BOOT_ITEM_NEW_SETTINGS' => ['initrd' => 'plugin-init.xz'],
+            ],
+        ],
+        'expectLine' => ['imgfetch plugin-init.xz', 'initrd=plugin-init.xz'],
+        'refuteLine' => ['imgfetch init.xz'],
+    ],
+    "a plugin's imagefile still wins when it sets only that" => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hookMutations' => [
+                'BOOT_ITEM_NEW_SETTINGS' => ['imagefile' => 'plugin-image.xz'],
+            ],
+        ],
+        'expectLine' => ['imgfetch plugin-image.xz', 'initrd=plugin-image.xz'],
+    ],
+    'initrd wins over imagefile when a plugin sets both' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hookMutations' => [
+                'BOOT_ITEM_NEW_SETTINGS' => [
+                    'initrd' => 'plugin-init.xz',
+                    'imagefile' => 'plugin-image.xz',
+                ],
+            ],
+        ],
+        'expectLine' => ['imgfetch plugin-init.xz'],
+    ],
+    'no host secret reaches this unauthenticated endpoint' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hostRow' => [
+                'token' => 'TOKENSHOULDNOTAPPEAR',
+                'pub_key' => 'PUBKEYSHOULDNOTAPPEAR',
+                'sec_tok' => 'SECTOKSHOULDNOTAPPEAR',
+                'productKey' => 'PRODKEYSHOULDNOTAPPEAR',
+                'ADPass' => 'ADPASSSHOULDNOTAPPEAR',
+                'ADPassLegacy' => 'ADPASSLEGACYSHOULDNOTAPPEAR',
+            ],
+        ],
+        'expectLine' => ['set hostname testhost'],
+        'refuteLine' => [
+            'TOKENSHOULDNOTAPPEAR',
+            'PUBKEYSHOULDNOTAPPEAR',
+            'SECTOKSHOULDNOTAPPEAR',
+            'PRODKEYSHOULDNOTAPPEAR',
+            'ADPASSSHOULDNOTAPPEAR',
+            'ADPASSLEGACYSHOULDNOTAPPEAR',
+        ],
+    ],
+];
+
+$checkFailures = [];
+foreach ($checks as $label => $check) {
+    $raw = renderScenario($renderer, $check['scenario'], $classFile);
+    if (isset($check['expectHook'])) {
+        $fired = json_decode($raw, true);
+        if (!is_array($fired)) {
+            $checkFailures[] = "$label: could not decode hook payloads";
+            continue;
+        }
+        $scalars = null;
+        foreach ($fired as $event) {
+            if ('BOOT_ITEM_NEW_SETTINGS' === ($event['event'] ?? '')) {
+                $scalars = $event['scalars'] ?? [];
+                break;
+            }
+        }
+        if (null === $scalars) {
+            $checkFailures[] = "$label: BOOT_ITEM_NEW_SETTINGS never fired";
+            continue;
+        }
+        foreach ($check['expectHook'] as $key => $want) {
+            $have = array_key_exists($key, $scalars) ? $scalars[$key] : '<absent>';
+            if ($have !== $want) {
+                $checkFailures[] = sprintf(
+                    "%s: '%s' was %s, expected %s",
+                    $label,
+                    $key,
+                    var_export($have, true),
+                    var_export($want, true)
+                );
+            }
+        }
+    }
+    foreach ((array)($check['expectLine'] ?? []) as $needle) {
+        if (false === strpos($raw, $needle)) {
+            $checkFailures[] = "$label: expected to find '$needle'";
+        }
+    }
+    foreach ((array)($check['refuteLine'] ?? []) as $needle) {
+        if (false !== strpos($raw, $needle)) {
+            $checkFailures[] = "$label: '$needle' must NOT appear";
+        }
+    }
+}
+if ($checkFailures) {
+    fwrite(STDERR, "\nFAIL: behaviour checks\n");
+    foreach ($checkFailures as $f) {
+        fwrite(STDERR, "  $f\n");
+    }
+    exit(1);
+}
+printf(
+    "bootmenu-ipxe-output: %d behaviour checks passed\n",
+    count($checks)
+);
+
+$expected = file_get_contents($golden);
+if ($actual === $expected) {
+    echo "PASS\n";
+    exit(0);
+}
+
+fwrite(STDERR, "\nFAIL: emitted iPXE differs from the golden file.\n\n");
+
+$aLines = explode("\n", $expected);
+$bLines = explode("\n", $actual);
+$max = max(count($aLines), count($bLines));
+$shown = 0;
+for ($i = 0; $i < $max && $shown < 40; $i++) {
+    $a = $aLines[$i] ?? '<missing>';
+    $b = $bLines[$i] ?? '<missing>';
+    if ($a === $b) {
+        continue;
+    }
+    fwrite(
+        STDERR,
+        sprintf("  line %d:\n    -golden: %s\n    +actual: %s\n", $i + 1, $a, $b)
+    );
+    $shown++;
+}
+if ($shown >= 40) {
+    fwrite(STDERR, "  ... further differences suppressed\n");
+}
+exit(1);

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -1,0 +1,2666 @@
+########## unregistered-bios-x86 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86-mok ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+imgfetch http://10.0.0.1/fog/service/secureboot/MOK.der MOK.der || echo Could not fetch MOK.der over the network.
+echo MOK.der has been downloaded into memory as MOK.der --
+echo look for it under Enroll key from disk.
+echo MokManager gives up after about 10 seconds with no
+echo keypress, and reboots if left idle for a few minutes --
+echo be ready before it appears.
+echo If it is not listed there, have MOK.der on a
+echo FAT-formatted USB stick in this machine instead.
+sleep 8
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86-mok-authvars ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+item fog.enrollsecurebootunattended Enroll Secure Boot Key (Unattended - secure boot in setup mode required)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+imgfetch http://10.0.0.1/fog/service/secureboot/MOK.der MOK.der || echo Could not fetch MOK.der over the network.
+echo MOK.der has been downloaded into memory as MOK.der --
+echo look for it under Enroll key from disk.
+echo MokManager gives up after about 10 seconds with no
+echo keypress, and reboots if left idle for a few minutes --
+echo be ready before it appears.
+echo If it is not listed there, have MOK.der on a
+echo FAT-formatted USB stick in this machine instead.
+sleep 8
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+:fog.enrollsecurebootunattended
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=enrollsb
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-x86-authvars-only ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+item fog.enrollsecurebootunattended Enroll Secure Boot Key (Unattended - secure boot in setup mode required)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:fog.enrollsecurebootunattended
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=enrollsb
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-i386 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_ia32.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init_32.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-efi-arm64 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.reginput
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.reg
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## unregistered-no-platform ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-bios ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-efi-mok-authvars ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+item fog.enrollsecurebootunattended Enroll Secure Boot Key (Unattended - secure boot in setup mode required)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+imgfetch http://10.0.0.1/fog/service/secureboot/MOK.der MOK.der || echo Could not fetch MOK.der over the network.
+echo MOK.der has been downloaded into memory as MOK.der --
+echo look for it under Enroll key from disk.
+echo MokManager gives up after about 10 seconds with no
+echo keypress, and reboots if left idle for a few minutes --
+echo be ready before it appears.
+echo If it is not listed there, have MOK.der on a
+echo FAT-formatted USB stick in this machine instead.
+sleep 8
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+:fog.enrollsecurebootunattended
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=enrollsb
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## pending-approval ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is pending approval!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.sysinfo Client System Information (Compatibility)
+item fog.approvehost Approve This Host
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.approvehost
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param approveHost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registered-host-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel custom-bzImage loglevel=4 initrd=custom-init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 nomodeset storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch custom-init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## arm64-host-x86-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+echo Ignoring host kernel custom-bzImage -- this machine is 64-bit ARM. Using arm_Image.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## arm64-host-arm-kernel-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel arm_custom_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## x86-host-arm-init-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+echo Ignoring host init arm_init.cpio.gz -- this machine is 64-bit x86. Using init.xz.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## host-kernel-override-unsafe-chars ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+echo Ignoring host kernel evilechopwnedchainhttpxid -- this machine is 64-bit ARM. Using arm_Image.
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## debug-requested ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+item fog.debug Debug Mode
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.debug
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=onlydebug
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## registration-disabled ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## advanced-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.advanced Advanced Menu
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.advanced
+chain -ar http://10.0.0.1/fog/service/ipxe/advanced.php || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## advanced-menu-login ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.advancedlogin Advanced Menu
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.advancedlogin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param advLog 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## hidden-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+iseq ${platform} efi && set key 0x1b || set key 0x1b
+iseq ${platform} efi && set keyName ESC || set keyName Escape
+prompt --key ${key} --timeout 3000 Booting... (Press ${keyName} to access the menu) && goto menuAccess || console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+:menuAccess
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param platform ${platform}
+param username ${username}
+param password ${password}
+param menuaccess 1
+param debug 1
+param sysuuid ${uuid}
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+goto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
+
+########## hidden-menu-keyseq ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+iseq ${platform} efi && set key 0x1b || set key 0x1b
+iseq ${platform} efi && set keyName ESC || set keyName F12
+prompt --key ${key} --timeout 3000 Booting... (Press ${keyName} to access the menu) && goto menuAccess || console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+:menuAccess
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param platform ${platform}
+param username ${username}
+param password ${password}
+param menuaccess 1
+param debug 1
+param sysuuid ${uuid}
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+goto bootme
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
+
+########## hidden-menu-accessed ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-sanboot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-exit ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+exit 0 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="rootnoverify (hd0);chainloader +1" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub-first-hdd ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="rootnoverify (hd0);chainloader +1" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub-first-cdrom ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="cdrom --init;map --hook;root (cd0);chainloader (cd0)"" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-grub-first-found-windows ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/grub.exe --config-file="find --set-root /BOOTMGR;chainloader /BOOTMGR"" || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-refind-efi ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_x64.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-refind-efi-i386 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+imgfetch ${boot-url}/service/ipxe/refind.conf
+chain -ar ${boot-url}/service/ipxe/refind_ia32.efi || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init_32.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage32 loglevel=4 initrd=init_32.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init_32.xz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-refind-efi-arm64 ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+item fog.enrollsecureboot Enroll Secure Boot Key
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+chain -ar ${boot-url}/service/ipxe/refind_aa64.efi || goto MENU
+:fog.reginput
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.reg
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.sysinfo
+kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch arm_init.cpio.gz
+boot || goto MENU
+:fog.enrollsecureboot
+echo Secure Boot signing is not configured on this FOG server.
+echo Nothing to enroll -- returning to the menu...
+sleep 5
+goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## exit-unknown-falls-back-to-sanboot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## host-exit-override ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0x00567a 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is registered as ${hostname}!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.keyreg Update Product Key
+item fog.deployimage Deploy Image
+item fog.multijoin Join Multicast Session
+item fog.quickdel Quick Host Deletion
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+exit 0 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.keyreg
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param keyreg 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.deployimage
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param qihost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.multijoin
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param sessionJoin 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.quickdel
+login
+params
+param mac0 ${net0/mac}
+param arch ${arch}
+param username ${username}
+param password ${password}
+param delhost 1
+isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
+isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+param sysuuid ${uuid}\ngoto bootme
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## no-menu ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set hostname testhost
+set storage-ip 10.0.0.1
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
+
+########## keymap-set ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 keymap=uk web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## kernel-args-and-debug ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0 debug rootfstype=ext4 acpi=off storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## nested-webroot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot apps/fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/apps/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+
+########## bare-webroot ##########
+#!ipxe
+set fog-ip 10.0.0.1
+set fog-webroot fog
+set boot-url http://${fog-ip}/${fog-webroot}
+set setmacto ${net0/mac}
+set storage-ip 10.0.0.1
+set arch ${buildarch}
+iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
+goto get_console
+:console_set
+colour --rgb 0x00567a 1 ||
+colour --rgb 0x00567a 2 ||
+colour --rgb 0x00567a 4 ||
+cpair --foreground 7 --background 2 2 ||
+goto MENU
+:alt_console
+cpair --background 0 1 ||
+cpair --background 1 2 ||
+goto MENU
+:get_console
+console --picture http://10.0.0.1/fog/service/ipxe/bg.png --left 100 --right 80 && goto console_set || goto alt_console
+:MENU
+menu
+colour --rgb 0xff0000 0 ||
+cpair --foreground 1 1 ||
+cpair --foreground 0 3 ||
+cpair --foreground 4 4 ||
+item --gap Host is NOT registered!
+item --gap -- -------------------------------------
+item fog.local Boot from hard disk
+item fog.memtest Run Memtest86+
+item fog.reginput Perform Full Host Registration and Inventory
+item fog.reg Quick Registration and Inventory
+item fog.sysinfo Client System Information (Compatibility)
+choose --default fog.local --timeout 3000 target && goto ${target}
+:fog.local
+console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82 || goto MENU
+:fog.memtest
+kernel memdisk initrd=memtest.bin iso raw
+initrd memtest.bin
+boot || goto MENU
+:fog.reginput
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=manreg
+imgfetch init.xz
+boot || goto MENU
+:fog.reg
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=autoreg
+imgfetch init.xz
+boot || goto MENU
+:fog.sysinfo
+kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
+imgfetch init.xz
+boot || goto MENU
+:bootme
+chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
+goto MENU
+autoboot
+

--- a/tests/lib/bootmenu-harness.php
+++ b/tests/lib/bootmenu-harness.php
@@ -1,0 +1,727 @@
+<?php
+/**
+ * A stub FOG runtime just large enough to render BootMenu's iPXE output.
+ *
+ * BootMenu extends FOGBase and reaches storage only through FOGBase's statics
+ * and the Route facade, so replacing those two replaces the entire world it
+ * can see. Nothing here talks to MySQL, the network, or the filesystem outside
+ * a caller-supplied BASEPATH, which is what lets the boot menu be rendered
+ * byte-for-byte in a test.
+ *
+ * Fidelity notes -- these are the places where a lazy stub would silently
+ * produce the wrong golden file:
+ *
+ * 1. getSetting() has two shapes. A string key returns one value or null; an
+ *    array of keys returns one entry per key IN THE ORDER ASKED FOR, null for
+ *    a row that does not exist. BootMenu destructures the array form
+ *    positionally with list(), so both the ordering and the never-skip rule
+ *    are load-bearing. The stub reproduces them, and additionally throws on a
+ *    key with no fixture: silently returning null for an unknown setting would
+ *    bake a plausible-looking but wrong golden file.
+ * 2. Route::getList() hands back objects with PUBLIC PROPERTIES ($Menu->name,
+ *    $StorageNode->ip), not get()-style models. RouteItem below is that shape;
+ *    using a get() model instead would fatal inside _menuItem().
+ * 3. fastmerge() and arrayInsertAfter() are copied verbatim from FOGBase --
+ *    fastmerge's numeric-vs-string key handling decides menu line ordering.
+ * 4. resolveHostname() never does DNS. A test that resolves a name is a test
+ *    that fails on an airplane.
+ *
+ * Everything lives in namespace FOG because bootmenu.class.php does; the
+ * class_alias at the foot of that file then re-exports BootMenu globally
+ * exactly as it does in production.
+ *
+ * Not a mock framework by design: the house style is a plain PHP script with
+ * an exit status, discovered by tests/run-all.sh.
+ */
+
+namespace FOG;
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
+/*
+ * Route rows are plain stdClass objects, created with (object)[...].
+ *
+ * Not a class with __get: BootMenu::generateIpxeItems() builds its iPXE
+ * output by iterating the row -- foreach ($object as $property => $value) --
+ * which only sees genuinely public properties. A row backed by a private
+ * array with an accessor iterates as empty, so every `set hostname ...` line
+ * would silently vanish from the golden file and the host-info block would
+ * look correctly empty rather than broken.
+ */
+
+/**
+ * Generic record stub standing in for a FOGController model.
+ */
+class StubModel
+{
+    /**
+     * Backing field data.
+     *
+     * @var array
+     */
+    protected $data = [];
+    /**
+     * Instantiates the record.
+     *
+     * @param array $data the field data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+    /**
+     * A record is valid when it carries a non-zero id.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return !empty($this->data['id']);
+    }
+    /**
+     * Reads a field.
+     *
+     * @param string $key the field to read
+     *
+     * @return mixed
+     */
+    public function get($key = '')
+    {
+        if ('' === $key) {
+            return $this->data;
+        }
+        return array_key_exists($key, $this->data) ? $this->data[$key] : '';
+    }
+    /**
+     * Writes a field.
+     *
+     * @param string $key   the field to write
+     * @param mixed  $value the value to write
+     *
+     * @return self
+     */
+    public function set($key, $value)
+    {
+        $this->data[$key] = $value;
+        return $this;
+    }
+    /**
+     * Persistence is a no-op; nothing here has a database.
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        return true;
+    }
+    /**
+     * Destruction is a no-op.
+     *
+     * @return bool
+     */
+    public function destroy()
+    {
+        return true;
+    }
+    /**
+     * Property reads mirror get(), because 1.6 code freely uses both.
+     *
+     * @param string $name the field
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->get($name);
+    }
+}
+
+/**
+ * MAC list stub. BootMenu stringifies this when logging the request.
+ */
+class StubMac extends StubModel
+{
+    /**
+     * Renders the MAC as BootMenu expects.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string)$this->get('mac');
+    }
+    /**
+     * Imaging-ignore flag, read only on the tasking path.
+     *
+     * @return bool
+     */
+    public function isImageIgnored()
+    {
+        return (bool)$this->get('ignored');
+    }
+}
+
+/**
+ * Task stub. The rendering scenarios use invalid tasks so getTasking()
+ * falls through to printDefault(), which is where the menu is built.
+ */
+class StubTask extends StubModel
+{
+    /**
+     * Whether this is a snapin-only tasking.
+     *
+     * @return bool
+     */
+    public function isSnapinTasking()
+    {
+        return (bool)$this->get('snapin');
+    }
+}
+
+/**
+ * Host stub, with the nested objects BootMenu reaches through.
+ */
+class StubHost extends StubModel
+{
+    /**
+     * Reads a field, materialising the nested objects BootMenu expects.
+     *
+     * @param string $key the field to read
+     *
+     * @return mixed
+     */
+    public function get($key = '')
+    {
+        switch ($key) {
+            case 'mac':
+                return new StubMac(
+                    [
+                        'id' => 1,
+                        'mac' => $this->data['mac'] ?? '00:11:22:33:44:55',
+                        'ignored' => $this->data['imageignored'] ?? false,
+                    ]
+                );
+            case 'task':
+                return new StubTask((array)($this->data['task'] ?? []));
+            case 'inventory':
+                return new StubModel(
+                    ['id' => 1, 'sysuuid' => $this->data['sysuuid'] ?? '']
+                );
+        }
+        return parent::get($key);
+    }
+    /**
+     * Returns the assigned image.
+     *
+     * @return StubModel
+     */
+    public function getImage()
+    {
+        return new StubModel((array)($this->data['image'] ?? []));
+    }
+}
+
+/**
+ * Hook manager stub.
+ *
+ * Records every event, and can act as a plugin: `mutate` maps an event name
+ * to argument overrides, applied on fire. Because BOOT_ITEM_NEW_SETTINGS is
+ * built with reference elements (['initrd' => &$initrd]), writing to the
+ * argument array here writes through to the caller's variable -- which is
+ * exactly the mechanism a real plugin uses, and the only way to test whether
+ * a plugin's value actually survives.
+ */
+class StubHookManager
+{
+    /**
+     * Events seen, in order.
+     *
+     * @var array
+     */
+    public $fired = [];
+    /**
+     * Event name => [argument => replacement value].
+     *
+     * @var array
+     */
+    public $mutate = [];
+    /**
+     * Instantiates the manager.
+     *
+     * @param array $mutate the plugin-like overrides to apply
+     */
+    public function __construct(array $mutate = [])
+    {
+        $this->mutate = $mutate;
+    }
+    /**
+     * Records an event, then applies any configured overrides.
+     *
+     * @param string $event     the event name
+     * @param array  $arguments the event arguments
+     *
+     * @return void
+     */
+    public function processEvent($event, $arguments = [])
+    {
+        $scalars = [];
+        foreach ((array)$arguments as $key => $value) {
+            if (null === $value || is_scalar($value)) {
+                $scalars[$key] = $value;
+            }
+        }
+        $this->fired[] = [
+            'event' => $event,
+            'args' => array_keys((array)$arguments),
+            'scalars' => $scalars,
+        ];
+        foreach ((array)($this->mutate[$event] ?? []) as $key => $value) {
+            if (array_key_exists($key, $arguments)) {
+                $arguments[$key] = $value;
+            }
+        }
+    }
+    /**
+     * Registration is a no-op here.
+     *
+     * @param string $event    the event name
+     * @param mixed  $callback the callback
+     *
+     * @return void
+     */
+    public function register($event, $callback)
+    {
+    }
+}
+
+/**
+ * The stub Route facade.
+ */
+class Route
+{
+    /**
+     * Fixture rows, keyed by the lowercase class name Route is asked for.
+     *
+     * @var array
+     */
+    public static $rows = [];
+    /**
+     * Filters fixture rows the way Route would for the equality-on-a-field
+     * cases BootMenu uses. An array filter value means "field IN (...)".
+     *
+     * @param string $class     the class to query
+     * @param mixed  $findWhere the filter
+     * @param string $whereOp   unused; signature parity
+     * @param string $orderBy   field to sort by
+     *
+     * @throws \Exception on a class with no fixture
+     * @return array
+     */
+    public static function getList(
+        $class,
+        $findWhere = [],
+        $whereOp = 'AND',
+        $orderBy = ''
+    ) {
+        $class = strtolower($class);
+        if (!array_key_exists($class, self::$rows)) {
+            throw new \Exception("harness: no fixture rows for '$class'");
+        }
+        $rows = self::$rows[$class];
+        foreach ((array)$findWhere as $field => $want) {
+            $rows = array_values(
+                array_filter(
+                    $rows,
+                    function ($row) use ($field, $want) {
+                        $have = $row->{$field} ?? null;
+                        if (is_array($want)) {
+                            return in_array($have, $want);
+                        }
+                        return $have == $want;
+                    }
+                )
+            );
+        }
+        if ($orderBy) {
+            usort(
+                $rows,
+                function ($a, $b) use ($orderBy) {
+                    return ($a->{$orderBy} ?? null) <=> ($b->{$orderBy} ?? null);
+                }
+            );
+        }
+        return $rows;
+    }
+    /**
+     * Returns the ids of the matching rows.
+     *
+     * @param string $class     the class to query
+     * @param mixed  $findWhere the filter
+     * @param string $getField  the column to return
+     *
+     * @return array
+     */
+    public static function getIds($class, $findWhere = [], $getField = 'id')
+    {
+        return array_map(
+            function ($row) use ($getField) {
+                return $row->{$getField} ?? null;
+            },
+            self::getList($class, $findWhere ?: [])
+        );
+    }
+    /**
+     * Returns one row by id.
+     *
+     * @param string $class the class to query
+     * @param int    $id    the row id
+     *
+     * @return RouteItem|null
+     */
+    public static function getItem($class, $id)
+    {
+        $rows = self::getList($class, ['id' => $id]);
+        return $rows ? $rows[0] : null;
+    }
+    /**
+     * Field names BootMenu must not echo into an iPXE script. Kept small and
+     * real: generateIpxeItems() uses it to decide what to omit.
+     *
+     * @return array
+     */
+    public static function sensitiveFieldMap()
+    {
+        /*
+         * Three tiers, each keyed by class name with a list of that class'
+         * field names -- generateIpxeItems() walks it two levels deep
+         * (foreach tier, foreach class => $fields) and array_merges the
+         * innermost lists, so a flatter stub fatals on array_merge().
+         * Mirrors Route::$sensitiveFields / $sensitiveAlwaysFields /
+         * Redaction::$patternExempt.
+         */
+        return [
+            'fields' => [
+                'host' => [
+                    'ADPass',
+                    'ADPassLegacy',
+                    'productKey',
+                    'pub_key',
+                    'sec_tok',
+                    'prev_sec_tok',
+                    'sec_time',
+                    'token',
+                ],
+            ],
+            'always' => [
+                'storagenode' => ['pass'],
+            ],
+            'exempt' => [],
+        ];
+    }
+}
+
+/**
+ * The stub FOGBase. BootMenu's entire view of the system is these members
+ * plus Route.
+ */
+class FOGBase
+{
+    /**
+     * The host being booted.
+     *
+     * @var StubHost
+     */
+    public static $Host;
+    /**
+     * The hook manager.
+     *
+     * @var StubHookManager
+     */
+    public static $HookManager;
+    /**
+     * The HTTP protocol string.
+     *
+     * @var string
+     */
+    public static $httpproto = 'http';
+    /**
+     * Settings, keyed by name, as globalSettings would hold them.
+     *
+     * @var array
+     */
+    public static $settings = [];
+    /**
+     * Base constructor; nothing to bootstrap.
+     */
+    public function __construct()
+    {
+    }
+    /**
+     * Reads one setting, or several in the order asked for.
+     *
+     * @param string|array $key the setting name(s)
+     *
+     * @throws \Exception on a key with no fixture
+     * @return mixed
+     */
+    public static function getSetting($key)
+    {
+        $keys = (array)$key;
+        $out = [];
+        foreach ($keys as $k) {
+            if (!array_key_exists($k, self::$settings)) {
+                throw new \Exception(
+                    "harness: no fixture for setting '$k'; add it, because a "
+                    . "missing row would otherwise render as null and bake a "
+                    . "wrong golden file"
+                );
+            }
+            $out[] = self::$settings[$k];
+        }
+        return is_string($key) ? $out[0] : $out;
+    }
+    /**
+     * Factory for the classes BootMenu asks for by name.
+     *
+     * @param string $class the class name
+     *
+     * @throws \Exception on an unsupported class
+     * @return mixed
+     */
+    public static function getClass($class)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        switch ($class) {
+            case 'KeySequence':
+                $seq = trim((string)($args[0] ?? ''));
+                if ('' === $seq) {
+                    return new StubModel([]);
+                }
+                return new StubModel(
+                    ['id' => 1, 'ascii' => '0x1b', 'name' => $seq]
+                );
+            case 'Ipxe':
+                return new StubModel(['id' => (int)($args[0] ?? 0)]);
+            case 'StorageNode':
+                return new StorageNode((int)($args[0] ?? 0));
+            case 'Image':
+                return new StubModel((array)($args[0] ?? []));
+        }
+        throw new \Exception("harness: unsupported getClass('$class')");
+    }
+    /**
+     * Copied verbatim from FOGBase: its numeric-vs-string key handling
+     * decides the order menu lines land in.
+     *
+     * @param array $array1 the base array
+     *
+     * @return array
+     */
+    public static function fastmerge($array1)
+    {
+        $others = func_get_args();
+        array_shift($others);
+        foreach ((array)$others as &$other) {
+            foreach ((array)$other as $key => &$oth) {
+                if (is_numeric($key)) {
+                    $array1[] = $oth;
+                    continue;
+                } elseif (isset($array1[$key])) {
+                    $array1[$key] = $oth;
+                    continue;
+                }
+                unset($oth);
+            }
+            $array1 += $other;
+            unset($other);
+        }
+
+        return $array1;
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param string $key       the key to insert after
+     * @param array  $array     the array to work with
+     * @param string $new_key   the key to add
+     * @param mixed  $new_value the value to add
+     *
+     * @throws \Exception
+     * @return void
+     */
+    protected static function arrayInsertAfter(
+        $key,
+        array &$array,
+        $new_key,
+        $new_value
+    ) {
+        if (!is_string($key) && !is_numeric($key)) {
+            throw new \Exception('Key must be a string or index');
+        }
+        $new = [];
+        foreach ($array as $k => &$value) {
+            $new[$k] = $value;
+            if ($k === $key) {
+                $new[$new_key] = $new_value;
+            }
+            unset($k, $value);
+        }
+        $array = $new;
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param mixed $ids the collection to reduce
+     *
+     * @return mixed
+     */
+    public static function minId($ids)
+    {
+        $ids = (array)$ids;
+        return empty($ids) ? 0 : min($ids);
+    }
+    /**
+     * Copied verbatim from FOGBase.
+     *
+     * @param mixed $ids the collection to reduce
+     *
+     * @return mixed
+     */
+    public static function maxId($ids)
+    {
+        $ids = (array)$ids;
+        return empty($ids) ? 0 : max($ids);
+    }
+    /**
+     * Deterministic stand-in: never performs DNS.
+     *
+     * @param string $host the host to resolve
+     *
+     * @return string
+     */
+    public static function resolveHostname($host)
+    {
+        return trim((string)$host);
+    }
+    /**
+     * Authentication is not exercised by the rendering scenarios.
+     *
+     * @param string $user the username
+     * @param string $pass the password
+     *
+     * @return bool
+     */
+    public static function authenticateOnly($user, $pass)
+    {
+        return false;
+    }
+    /**
+     * Task states; only reached on the tasking path.
+     *
+     * @return array
+     */
+    public static function getQueuedStates()
+    {
+        return [1, 2, 3];
+    }
+    /**
+     * Progress state; only reached on the tasking path.
+     *
+     * @return int
+     */
+    public static function getProgressState()
+    {
+        return 3;
+    }
+    /**
+     * Splits a MAC list the way FOGBase does.
+     *
+     * @param string $macs the list to split
+     *
+     * @return array
+     */
+    public static function parseMacList($macs)
+    {
+        return array_values(array_filter(explode('|', (string)$macs)));
+    }
+    /**
+     * Product-key helpers; only reached on the key-registration path.
+     *
+     * @param string $key the key to format
+     *
+     * @return string
+     */
+    public static function productKeyFormat($key)
+    {
+        return (string)$key;
+    }
+    /**
+     * Product-key validity; only reached on the key-registration path.
+     *
+     * @param string $key the key to check
+     *
+     * @return bool
+     */
+    public static function productKeyIsValid($key)
+    {
+        return (bool)$key;
+    }
+}
+
+/**
+ * Storage node, looked up by id from the fixture rows.
+ */
+class StorageNode extends StubModel
+{
+    /**
+     * Looks the node up by id.
+     *
+     * @param int $id the node id
+     */
+    public function __construct($id = 0)
+    {
+        $found = [];
+        foreach ((array)(Route::$rows['storagenode'] ?? []) as $node) {
+            if (($node->id ?? null) == $id) {
+                $found = (array)$node;
+                break;
+            }
+        }
+        parent::__construct($found);
+    }
+    /**
+     * Returns the owning group.
+     *
+     * @return StubModel
+     */
+    public function getStorageGroup()
+    {
+        return new StubModel(['id' => 1, 'name' => 'default']);
+    }
+}
+
+/**
+ * PXE menu option, looked up by id from the fixture rows.
+ */
+class PXEMenuOptions extends StubModel
+{
+    /**
+     * Looks the row up by id.
+     *
+     * @param int $id the row id
+     */
+    public function __construct($id = 0)
+    {
+        $found = [];
+        foreach ((array)(Route::$rows['pxemenuoptions'] ?? []) as $menu) {
+            if (($menu->id ?? null) == $id) {
+                $found = (array)$menu;
+                break;
+            }
+        }
+        parent::__construct($found);
+    }
+}

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Renders one BootMenu scenario and prints the resulting iPXE script.
+ *
+ * Run as a child process by bootmenu-ipxe-output.test.php. It is a separate
+ * process because several BootMenu paths end in exit() -- noMenu() and the
+ * tasking path among them -- which a single-process runner could not survive,
+ * and because BootMenu caches the architecture profile in a static
+ * (self::$_archProfile) that a second scenario in the same process would
+ * inherit.
+ *
+ * Usage: php bootmenu-render.php <scenario-json> <path-to-bootmenu.class.php>
+ */
+
+require_once __DIR__ . '/bootmenu-harness.php';
+
+use FOG\FOGBase;
+use FOG\Route;
+use FOG\StubHookManager;
+use FOG\StubHost;
+
+$scenario = json_decode($argv[1] ?? '{}', true);
+$classFile = $argv[2] ?? '';
+
+if (!is_array($scenario)) {
+    fwrite(STDERR, "render: could not decode scenario json\n");
+    exit(2);
+}
+if (!is_file($classFile)) {
+    fwrite(STDERR, "render: no such class file: $classFile\n");
+    exit(2);
+}
+
+/*
+ * BASEPATH decides which Secure Boot branches render: MOK.der gates the
+ * attended enrol inside _enrollSecureBootChoice(), and PK/KEK/db.auth gate
+ * whether _filterMenus() shows the unattended one at all. Point it at a
+ * scenario-owned temp directory so every combination is reachable without
+ * touching a real install.
+ */
+$base = sys_get_temp_dir() . '/bootmenu-test-' . getmypid() . '/';
+@mkdir($base . 'service/secureboot', 0777, true);
+$sbFiles = [];
+if (!empty($scenario['mok'])) {
+    $sbFiles[] = 'MOK.der';
+}
+if (!empty($scenario['authvars'])) {
+    $sbFiles = array_merge($sbFiles, ['PK.auth', 'KEK.auth', 'db.auth']);
+}
+foreach ($sbFiles as $f) {
+    file_put_contents($base . 'service/secureboot/' . $f, 'test');
+}
+if (!defined('BASEPATH')) {
+    define('BASEPATH', $base);
+}
+
+/*
+ * Several BootMenu paths end in exit(), so the only reliable place to clean
+ * up the scenario's temp tree is a shutdown handler.
+ */
+register_shutdown_function(
+    function () use ($base) {
+        foreach (glob($base . 'service/secureboot/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        foreach (['service/secureboot', 'service', ''] as $dir) {
+            @rmdir($base . $dir);
+        }
+    }
+);
+
+/**
+ * Default globalSettings values, mirroring commons/schema.php so the golden
+ * file reflects what a stock install actually emits.
+ */
+FOGBase::$settings = array_merge(
+    [
+        'FOG_ADVANCED_MENU_LOGIN' => '0',
+        'FOG_BOOT_EXIT_TYPE' => 'sanboot',
+        'FOG_EFI_BOOT_EXIT_TYPE' => 'refind_efi',
+        'FOG_IMAGE_LIST_MENU' => '0',
+        'FOG_IPXE_BG_FILE' => 'bg.png',
+        'FOG_IPXE_HOST_CPAIRS' => "cpair --foreground 1 1 ||\n"
+            . "cpair --foreground 0 3 ||\ncpair --foreground 4 4 ||",
+        'FOG_IPXE_INVALID_HOST_COLOURS' => 'colour --rgb 0xff0000 0 ||',
+        'FOG_IPXE_MAIN_COLOURS' => "colour --rgb 0x00567a 1 ||\n"
+            . "colour --rgb 0x00567a 2 ||\ncolour --rgb 0x00567a 4 ||",
+        'FOG_IPXE_MAIN_CPAIRS' => 'cpair --foreground 7 --background 2 2 ||',
+        'FOG_IPXE_MAIN_FALLBACK_CPAIRS' => "cpair --background 0 1 ||\n"
+            . "cpair --background 1 2 ||",
+        'FOG_IPXE_VALID_HOST_COLOURS' => 'colour --rgb 0x00567a 0 ||',
+        'FOG_KERNEL_ARGS' => '',
+        'FOG_KERNEL_DEBUG' => '',
+        'FOG_KERNEL_LOGLEVEL' => '4',
+        'FOG_KERNEL_RAMDISK_SIZE' => '275000',
+        'FOG_KEYMAP' => '',
+        'FOG_KEY_SEQUENCE' => '',
+        'FOG_MEMTEST_KERNEL' => 'memtest.bin',
+        'FOG_NO_MENU' => '0',
+        'FOG_PXE_ADVANCED' => '0',
+        'FOG_PXE_BOOT_IMAGE' => 'init.xz',
+        'FOG_PXE_BOOT_IMAGE_32' => 'init_32.xz',
+        'FOG_PXE_BOOT_IMAGE_ARM' => 'arm_init.cpio.gz',
+        'FOG_PXE_HIDDENMENU_TIMEOUT' => '3',
+        'FOG_PXE_MENU_HIDDEN' => '0',
+        'FOG_PXE_MENU_TIMEOUT' => '3',
+        'FOG_REGISTRATION_ENABLED' => '1',
+        'FOG_TFTP_PXE_KERNEL' => 'bzImage',
+        'FOG_TFTP_PXE_KERNEL_32' => 'bzImage32',
+        'FOG_TFTP_PXE_KERNEL_ARM' => 'arm_Image',
+        'FOG_WEB_HOST' => '10.0.0.1',
+        'FOG_WEB_ROOT' => '/fog/',
+    ],
+    (array)($scenario['settings'] ?? [])
+);
+
+/**
+ * The stock pxeMenu rows, per commons/schema.php. pxeParams is only set on
+ * the rows schema.php gives one to, because _menuOpt() branches on whether a
+ * row has params at all.
+ *
+ * @param string $extra the distinguishing param line
+ *
+ * @return string
+ */
+$loginParams = function ($extra) {
+    return "login\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\n"
+        . "param username \${username}\nparam password \${password}\n"
+        . "param $extra\n"
+        . "isset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\n"
+        . "isset \${net2/mac} && param mac2 \${net2/mac} || goto bootme";
+};
+$rows = [
+    [1, 'fog.local', 'Boot from hard disk', '1', '2', null, ''],
+    [2, 'fog.memtest', 'Run Memtest86+', '0', '2', null, ''],
+    [3, 'fog.reginput', 'Perform Full Host Registration and Inventory',
+        '0', '0', 'mode=manreg', ''],
+    [4, 'fog.keyreg', 'Update Product Key', '0', '1', null,
+        $loginParams('keyreg 1')],
+    [5, 'fog.reg', 'Quick Registration and Inventory', '0', '0',
+        'mode=autoreg', ''],
+    [6, 'fog.deployimage', 'Deploy Image', '0', '1', null,
+        $loginParams('qihost 1')],
+    [7, 'fog.multijoin', 'Join Multicast Session', '0', '1', null,
+        $loginParams('sessionJoin 1')],
+    [8, 'fog.quickdel', 'Quick Host Deletion', '0', '1', null,
+        $loginParams('delhost 1')],
+    [9, 'fog.sysinfo', 'Client System Information (Compatibility)',
+        '0', '2', 'mode=sysinfo', ''],
+    [10, 'fog.debug', 'Debug Mode', '0', '3', 'mode=onlydebug', ''],
+    [11, 'fog.advanced', 'Advanced Menu', '0', '4', null, ''],
+    [12, 'fog.advancedlogin', 'Advanced Menu', '0', '5', null,
+        $loginParams('advLog 1')],
+    [13, 'fog.approvehost', 'Approve This Host', '0', '6', null,
+        $loginParams('approveHost 1')],
+    [14, 'fog.enrollsecureboot', 'Enroll Secure Boot Key', '0', '2', null, ''],
+    [15, 'fog.enrollsecurebootunattended',
+        'Enroll Secure Boot Key (Unattended - secure boot in setup mode '
+        . 'required)', '0', '2', 'mode=enrollsb', ''],
+];
+
+Route::$rows = [
+    'pxemenuoptions' => array_map(
+        function ($r) {
+            return (object)[
+                'id' => $r[0],
+                'name' => $r[1],
+                'description' => $r[2],
+                'default' => $r[3],
+                'regMenu' => $r[4],
+                'args' => $r[5],
+                'params' => $r[6],
+                'hotkey' => '0',
+                'keysequence' => '',
+            ];
+        },
+        $rows
+    ),
+    'storagenode' => [
+        (object)[
+            'id' => 1,
+            'name' => 'DefaultMember',
+            'ip' => '10.0.0.1',
+            'path' => '/images/',
+            'isEnabled' => 1,
+            'isMaster' => 1,
+        ],
+    ],
+    'image' => [
+        (object)[
+            'id' => 1, 'name' => 'Win11', 'path' => 'win11', 'isEnabled' => 1,
+        ],
+        (object)[
+            'id' => 2, 'name' => 'Ubuntu', 'path' => 'ubuntu', 'isEnabled' => 1,
+        ],
+    ],
+    'host' => [],
+    'inventory' => [],
+    'ipxe' => [],
+    'multicastsessionassociation' => [],
+];
+
+/*
+ * The host row Route::getItem('host', id) returns, which generateIpxeItems()
+ * turns into `set ...` lines. Scenario-supplied extra columns land here too,
+ * so a scenario can plant a secret field and assert it never reaches iPXE.
+ */
+$hostData = (array)($scenario['host'] ?? []);
+if (!empty($hostData['id'])) {
+    $row = ['id' => $hostData['id'], 'name' => $hostData['name'] ?? 'testhost'];
+    foreach ((array)($scenario['hostRow'] ?? []) as $k => $v) {
+        $row[$k] = $v;
+    }
+    Route::$rows['host'][] = (object)$row;
+}
+
+FOGBase::$Host = new StubHost($hostData);
+FOGBase::$HookManager = new StubHookManager(
+    (array)($scenario['hookMutations'] ?? [])
+);
+
+$_REQUEST = (array)($scenario['request'] ?? []);
+$_GET = $_REQUEST;
+
+require_once $classFile;
+
+if (!empty($scenario['hooks'])) {
+    /*
+     * Hook-payload mode: what a plugin receives is not visible in the emitted
+     * script, so it cannot be covered by the golden file. Swallow the script
+     * and report the payloads instead.
+     */
+    ob_start();
+    new \FOG\BootMenu();
+    ob_end_clean();
+    echo json_encode(FOGBase::$HookManager->fired, JSON_PRETTY_PRINT), "\n";
+    exit(0);
+}
+
+new \FOG\BootMenu();


### PR DESCRIPTION
Replaces #1351, which was opened against `dev-branch` first — the wrong way round per `CLAUDE.md`. This is the `working-1.6` change; a `dev-branch` port follows once this lands.

## What this changes

Three write-only or never-assigned statements, and one hook argument that was silently discarded.

| Site | Problem |
|---|---|
| `__construct()` | `$kernel = $bzImage` assigned, never read — `$this->_kernel` is built from `$bzImage` directly |
| `_chainBoot()` | `$debug = $debug;` — self-assignment left over from a signature change |
| `__construct()` | `BOOT_ITEM_NEW_SETTINGS` passed `'webroot'` by reference with no `$webroot` ever assigned, so PHP created it at the call site and every plugin reading it received `NULL` |
| `__construct()` | `'initrd'` handed to the hook by reference, then **overwritten on the next line** |

Two of the five sites from #1351 don't exist here: `$reboot = sprintf('reboot', "\n")` is gone (1.6 has no `reboot` exit type), and `printDefault()`'s discarded query went with the `_filterMenus()` + single `Route::getList` restructure.

### The `initrd` one

`'initrd'` and `'imagefile'` are both passed to `BOOT_ITEM_NEW_SETTINGS` by reference, and the line after it did:

```php
$initrd = $imagefile;
```

unconditionally. So a plugin setting `'initrd'` had its value discarded on the very next line, while one setting `'imagefile'` was honoured — and the dead argument is the one named after the thing being chosen. Demonstrated against the unmodified source:

```
plugin sets initrd    → imgfetch init.xz          (discarded)
plugin sets imagefile → imgfetch plugin-init.xz   (honoured)
```

`$initrd` now follows `$imagefile` only when the hook left it alone, so the argument that worked keeps working and the one that didn't now does. `$this->_initrd` fetches the resolved value rather than `$imagefile`, so the `imgfetch` line and the kernel's `initrd=` agree.

Net: 31 lines changed in the class, 4 of them deletions; the rest is comment.

## How it is proven

The claim for the removals is *"not one byte of emitted iPXE moves"* — and for the `initrd` change, *"not one byte moves when nothing is listening on the hook."* Neither is settleable by inspection on a 2700-line file whose output is a program.

`tests/bootmenu-ipxe-output.test.php` renders 39 scenarios through a stub FOG runtime and byte-compares the emitted iPXE against a golden file. **The golden was generated from this file as it stood before the change**, so a passing run is the proof, not a restatement of the claim.

```
bootmenu-ipxe-output: 39 scenarios, 99683 bytes rendered
bootmenu-ipxe-output: 6 behaviour checks passed
PASS
```

### What the golden cannot cover

Three things never appear in the emitted script, so they get explicit checks:

| Check | Asserts |
|---|---|
| `webroot` reaches plugins as the bare form | `'fog'`, and `'apps/fog'` for a nested install — was `NULL` |
| a plugin's `initrd` survives to `imgfetch` | the fix |
| a plugin's `imagefile` still wins when it sets only that | **no regression** on the path that already worked |
| `initrd` wins over `imagefile` when both are set | precedence is defined, not accidental |
| no host secret reaches this unauthenticated endpoint | `token`, `pub_key`, `sec_tok`, `productKey`, `ADPass`, `ADPassLegacy` planted on the host row, none emitted |

That last one isn't a fix — it's a regression guard for the `sensitiveFieldMap()` sourcing in `generateIpxeItems()`, which is the only control on an endpoint a booting NIC reaches with no credential.

### Scenario coverage

Per rendering branch rather than by cross-product: every exit type; every arch (`x86_64`/`i386`/`arm64`) and the no-`platform` case; hidden vs shown vs hidden-then-accessed; registered/pending/unregistered; **all four Secure Boot file states** (`MOK.der` gates the attended item's body, `PK`/`KEK`/`db.auth` gate whether `_filterMenus()` lists the unattended one, and they're read independently); both arch-mismatch notices from `_hostOverride()`; the `_echoSafe()` whitelist; simple, nested and bare webroots.

### The test has teeth

Checked against the previous source and six deliberate mutations, each caught:

| Mutation | Result |
|---|---|
| pristine `working-1.6` | caught (6 behaviour failures) |
| menu timeout `* 1000` → `* 1001` | caught |
| drop `autoboot` from the bootme block | caught |
| weaken the `_echoSafe()` whitelist | caught |
| stop hiding the unattended Secure Boot item on BIOS | caught |
| stop blocking host secrets in `generateIpxeItems()` | caught |
| revert the `initrd` fix | caught |

Full suite: **149 passed, 0 failed**.

### Running it

```
php tests/bootmenu-ipxe-output.test.php            # compare against golden
php tests/bootmenu-ipxe-output.test.php --update   # regenerate golden
php tests/bootmenu-ipxe-output.test.php --against FILE
```

No database, no network, no PHPUnit — picked up by `tests/run-all.sh` like every other test here. Each scenario runs in its own process: several paths end in `exit()`, and `self::$_archProfile` is memoised in a static that would leak between scenarios sharing one.

Harness fidelity is where a lazy stub quietly bakes a wrong golden, so four things are deliberate:

- `getSetting()` reproduces both shapes, returns array results **in the order asked for**, and **throws** on a key with no fixture rather than rendering it as `null`.
- Route rows are `stdClass` with genuinely public properties, because `generateIpxeItems()` builds its output by iterating the row — a row hiding data behind `__get` iterates as empty, and every `set hostname …` line would have silently vanished from the golden while looking correctly absent. This was a real bug caught while building it.
- `fastmerge()` and `arrayInsertAfter()` are copied verbatim from `FOGBase`; `fastmerge`'s key handling decides menu line ordering.
- `resolveHostname()` never does DNS.

The stub hook manager can also act as a plugin, writing through the reference elements in the event payload exactly as a real one does — which is the only way to test whether a plugin's value survives.

## Risk

Low. The two removals and the `webroot` binding are proven byte-identical across 39 scenarios; `webroot` can only turn a `NULL` read into a real string, and no shipped plugin reads it (`location` and `subnetgroup` are the only `BOOT_ITEM_NEW_SETTINGS` consumers, and neither touches it).

The `initrd` change is the only one with plugin-visible behaviour: a third-party plugin that sets the hook's `initrd` argument goes from being ignored to being honoured. That is the documented intent of the argument, the `imagefile` path is explicitly covered against regression, and with nothing listening the emitted bytes are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmoFC2e9Cf3fa7mo3HLoN2)_