### PR TITLE
Describe computed fields in the schema, not only in prose

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -739,10 +739,27 @@ class OpenAPI extends FOGBase
             $schema = self::_applyModelConstraint($class, $property, $schema);
             $properties[$property] = $schema;
         }
+        // additionalProperties is stated rather than left to the default.
+        //
+        // The default is already true -- an object schema that says nothing
+        // permits extra properties -- so this loosens nothing and changes no
+        // validator's verdict. What it changes is code generation: most
+        // generators emit a catch-all bag ONLY when the keyword is explicitly
+        // present, and silently drop, or refuse, unknown keys when it is
+        // absent. openapi-generator's PowerShell models are the sharp case;
+        // without this they throw on the first key they were not told about.
+        //
+        // Declaring the computed fields above fixes the 80 this document can
+        // enumerate. It cannot enumerate the rest: a plugin contributes its
+        // own classes and its own joined fields at runtime, and a client
+        // generated from a pinned snapshot meets fields added after it was
+        // generated. Both are normal here, so tolerating unknown keys is the
+        // correct standing behaviour for a FOG response, not a workaround.
         $out = [
             'type' => 'object',
             'x-fog-table' => $table,
-            'properties' => $properties
+            'properties' => $properties,
+            'additionalProperties' => true
         ];
         $required = array_values(
             array_filter(

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -342,13 +342,19 @@ class OpenAPI extends FOGBase
                 'type' => 'http',
                 'scheme' => 'bearer',
                 'description' => implode(' ', [
-                    'The per-user API token from the API tab of a user with',
-                    'API access enabled, sent as `Authorization: Bearer`.',
+                    'An API token issued from the API tab of a user with API',
+                    'access enabled, sent as `Authorization: Bearer`.',
                     'Sufficient on its own -- no fog-api-token header is',
-                    'needed alongside it. Send the value exactly as the UI',
-                    'displays it: it is already base64 encoded, and a raw',
-                    'token is indistinguishable from an encoded one because',
-                    'hex is itself valid base64.'
+                    'needed alongside it.',
+                    'Every issued token carries a `fog_` prefix and is shown',
+                    'once, at creation: it is hashed at rest, so a token that',
+                    'has been lost cannot be recovered and must be reissued.',
+                    'A user may hold several, each individually revocable, so',
+                    'one integration can be rotated without disturbing the',
+                    'others.',
+                    'This is NOT the per-user token that fog-user-token',
+                    'carries. That token is a separate credential, is',
+                    'unchanged, and is not accepted here.'
                 ])
             ],
             'fogApiToken' => [
@@ -583,7 +589,21 @@ class OpenAPI extends FOGBase
 
         if (preg_match("/DEFAULT\s+(?!NULL)'?([^'\s]+)'?/i", $sqlType, $dm)) {
             $default = $dm[1];
-            if ('integer' === $schema['type']) {
+            if (preg_match('/^\w+\s*\(/', $default)) {
+                // A SQL function, not a value. DEFAULT current_timestamp()
+                // means "whatever the server clock says at INSERT", which is
+                // not something an OpenAPI default can express -- and copying
+                // it through produces an invalid document, because `default`
+                // must be an instance of the schema it sits on and
+                // "current_timestamp()" is not a date-time.
+                //
+                // Not academic: openapi-generator REFUSES to generate from
+                // this document over exactly nodefailure.failureTime and
+                // snapintask.checkin, both DEFAULT current_timestamp() on a
+                // datetime column. Recorded under an extension so the
+                // information is not simply lost.
+                $schema['x-fog-sql-default'] = $default;
+            } elseif ('integer' === $schema['type']) {
                 $schema['default'] = (int)$default;
             } elseif ('number' === $schema['type']) {
                 $schema['default'] = (float)$default;
@@ -752,6 +772,46 @@ class OpenAPI extends FOGBase
             if ('' !== $note) {
                 $out['description'] .= ' ' . $note;
             }
+            // And say it in the schema, not only in the sentence.
+            //
+            // The sentence above is accurate and stays -- it carries the
+            // "not settable through create/edit" nuance that no keyword
+            // expresses. But a generated client cannot read English. Every
+            // generator builds its deserialiser from `properties`, so a
+            // field named only in a description is a field the generated
+            // model does not have: AutoRest copies this very sentence into
+            // a doc comment and then emits a model that reads none of the
+            // fields it names, and openapi-generator's PowerShell models
+            // THROW on the undeclared key rather than ignoring it. Either
+            // way `GET /host/1` loses macs, imagename, groups and the rest
+            // -- 80 fields across 24 classes.
+            //
+            // readOnly is the precise keyword: OpenAPI defines it as "MAY
+            // be sent in a response and MUST NOT be sent in a request",
+            // which is exactly what a computed field is, and it keeps these
+            // out of the request bodies that $ref this same schema.
+            //
+            // No `type`. An empty schema means "any type", which is honest:
+            // these are computed in Route::getter() rather than derived
+            // from a column, so there is no type source to read. macs is an
+            // array, imagename a string, inventory an object. Asserting a
+            // type here would be a guess, and a wrong guess is worse for a
+            // generated client than no assertion at all.
+            foreach ($additional as $field) {
+                if (isset($properties[$field])) {
+                    // Already a real column; the column definition wins.
+                    continue;
+                }
+                $properties[$field] = [
+                    'readOnly' => true,
+                    'x-fog-computed' => true,
+                    'description' => _(
+                        'Computed field. Returned by the API but not a '
+                        . 'column, and not settable.'
+                    )
+                ];
+            }
+            $out['properties'] = $properties;
         }
         return $out;
     }


### PR DESCRIPTION
Four fixes to the generated OpenAPI document, all of the same kind: it says something in English that a code generator has to read as schema, says something that is no longer true, or leaves something to a default that generators do not treat as one.

Found while generating a client from FOG's own document. All of it is reproducible from a checkout with `spec/tools/dump-openapi.php` — no server needed.

## 1. Computed fields are named only in prose, so every generated client drops them

`_entitySchema()` reflects a model's own `$databaseFields` — its columns — while the route returns that entity **joined to its relations**. `host` declares 33 fields and answers with 49.

The document does name the extra ones, but only in the schema `description`:

> Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: mac, primac, imagename, groups, hostscreen, hostalo, optimalStorageNode, printers, snapins, modules, inventory, task, snapinjob, users, fingerprint, powermanagementtasks.

A generated client cannot read that. Every generator builds its deserialiser from `properties`:

- **AutoRest.PowerShell** copies the sentence into a doc comment and then emits a model that reads none of the fields it names. `Printer.json.cs` documents `hosts` and then reads 13 properties.
- **openapi-generator** (PowerShell) is worse than lossy — its models **throw** on an undeclared key. Measured against a real `printer` row:

  ```
  Error! JSON key 'hosts' not found in the properties: id name description
  port file model config configFile ip pAnon2 pAnon3 pAnon4 pAnon5
  ```

  So `GET /printer/1` fails outright against a stock generated client.

**80 fields across 23 classes** are affected.

This PR emits them as `readOnly` properties. `readOnly` is the precise keyword — OpenAPI defines it as *"MAY be sent in a response and MUST NOT be sent in a request"*, which is exactly what a computed field is, and it keeps them out of the request bodies that `$ref` the same schema. The prose sentence **stays**: it carries the "not settable through the generic create/edit path" nuance that no keyword expresses.

No `type` is asserted. These are computed in `Route::getter()` rather than derived from a column, so there is no type source to read — `mac` is an array, `imagename` a string, `inventory` an object. A wrong guess is worse for a generated client than no assertion at all.

## 2. `additionalProperties` is left to the default, which generators do not treat as one

Declaring the computed fields fixes the 80 this document can *enumerate*. It cannot enumerate the rest, and those are not an edge case:

- a **plugin** contributes its own classes and its own joined fields at runtime, and
- any client generated from a **pinned snapshot** will meet fields added to FOG after it was generated.

Both are ordinary, so tolerating an unknown key is the correct standing behaviour for a FOG response rather than a workaround. Measured, on a `printer` row carrying one plugin-contributed field on top of the now-declared computed ones:

```
before: Error! JSON key 'pluginContributedField' not found in the properties: ...
after:  parsed, value kept in AdditionalProperties
```

The generated model no longer contains a throw-on-unknown-key path at all.

**This loosens nothing.** `additionalProperties` already defaults to true — an object schema that says nothing about it permits extra properties — so no validator reaches a different verdict, and these schemas being `$ref`'d by request bodies as well as responses does not become a looser contract. What the explicit keyword changes is *code generation*: most generators emit a catch-all bag only when it is present, and drop or refuse unknown keys when it is absent.

There is also no runtime effect. `OpenAPI::document()` is called only to serve the document, from Route's `system/openapi` handler; FOG does not validate incoming requests against it.

## 3. A SQL function is emitted as an OpenAPI `default`, so the document does not validate

`_columnSchema()` passes `DEFAULT current_timestamp()` straight through as the `default` of a `date-time` property. `default` must be an instance of the schema it sits on, and `current_timestamp()` is not a date-time:

```
-attribute components.schemas.Nodefailure.default=`current_timestamp()` is not of type `date-time`
-attribute components.schemas.Snapintask.default=`current_timestamp()` is not of type `date-time`
```

openapi-generator **refuses to generate at all** from the document over this, unless you pass `--skip-validate-spec`. The expression is preserved under `x-fog-sql-default` rather than discarded.

## 4. The `bearerAuth` description describes a credential that was withdrawn

It still described the GH-1324 behaviour that ADR 0027 withdrew:

> The per-user API token from the API tab of a user with API access enabled … Sufficient on its own

`Authorization: Bearer` has not accepted `uAPIToken` since `APIToken` landed — `apitoken.class.php` says these are *"the only thing Authorization: Bearer accepts."* So a client generated from the document today tells users to send a credential the server rejects.

The replacement describes what `APIToken` actually is: `fog_` prefixed, hashed at rest, shown once at creation, several per user, individually revocable, and explicitly **not** `fog-user-token` — which, per ADR 0027, is untouched and keeps working.

## Verification

Regenerated the document from this branch with `spec/tools/dump-openapi.php`, then re-ran both generators:

- 80 computed fields declared across 23 classes; `Host` goes 33 → 49 properties, `Printer` gains `hosts`.
- No `default` containing a SQL expression remains; both are recorded as `x-fog-sql-default`.
- **openapi-generator 7.25.0 generates with validation ENABLED** (it refused before). Its `Host` model reads 49 properties including `mac`, `imagename`, `inventory`, `snapins` and `groups`; its `Printer` model keeps both the declared `hosts` and an undeclared plugin field instead of throwing on either.
- **AutoRest.PowerShell 4.0.758** picks up the same change. Its generated `Printer.json.cs` carried no `IAssociativeArray`/`AdditionalProperties` at all before; it now has one on both sides — `FromJson` and `ToJson` — so unknown keys survive a round trip rather than being silently discarded.

Both generators were run against the regenerated document; neither needed a directive, an override, or a patched spec.

`php -l` clean; all added lines within the file's 80-column style.
