### PR TITLE
API Documentation page: request snippets in PowerShell, Python, JavaScript, Ruby and PHP

### DIFF
--- a/packages/web/lib/fog/page.class.php
+++ b/packages/web/lib/fog/page.class.php
@@ -337,8 +337,14 @@ class Page extends FOGBase
             // else on the site uses it. Listed before the node's own list.js
             // so it is defined first, though fog.apidocs.list.js no longer
             // depends on that.
+            //
+            // fog.apidocs.snippets.js goes with it, and before the node's own
+            // list.js, because that file reads FogRequestSnippets at render
+            // time to build the try-it snippet tabs. It degrades to Swagger
+            // UI's built-in curl tabs if it is missing rather than failing.
             if ('apidocs' === $node) {
                 $files[] = 'js/swagger-ui-bundle.js';
+                $files[] = 'js/fog/apidocs/fog.apidocs.snippets.js';
             }
         }
         if (isset($filepaths) && $filepaths && !file_exists($filepaths)) {

--- a/packages/web/management/css/swagger-ui-fog.css
+++ b/packages/web/management/css/swagger-ui-fog.css
@@ -153,3 +153,29 @@
 [data-bs-theme="dark"] .swagger-ui .topbar {
     background: var(--fog-sui-sunken);
 }
+
+/* The request-snippet tabs.
+ *
+ * Swagger UI writes these colours inline -- a near-white chip for an inactive
+ * tab, a near-black one plus white text for the active tab -- so an override
+ * needs !important to reach them, unlike everything above.
+ *
+ * Left alone the tab strip is the one part of the page that ignores the
+ * toggle: the inactive chips stay near-white, and because the rule above
+ * paints .swagger-ui headings in FOG's dim ink, their labels come out light
+ * grey on near-white and are effectively unreadable. Only the active tab can
+ * be read, which is exactly backwards -- the tabs exist to show what else is
+ * on offer. */
+[data-bs-theme="dark"] .swagger-ui .request-snippets .btn {
+    background-color: var(--fog-sui-raised) !important;
+    border-color: var(--fog-sui-hair) !important;
+}
+[data-bs-theme="dark"] .swagger-ui .request-snippets .btn.active {
+    background-color: var(--fog-sui-sunken) !important;
+}
+[data-bs-theme="dark"] .swagger-ui .request-snippets .btn h4 {
+    color: var(--fog-sui-ink-dim) !important;
+}
+[data-bs-theme="dark"] .swagger-ui .request-snippets .btn.active h4 {
+    color: var(--fog-sui-ink) !important;
+}

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.list.js
@@ -17,7 +17,7 @@
  * save a paste, at the cost of writing a live credential into the page for
  * anything with DOM access to read. Use Authorize instead.
  */
-/* global SwaggerUIBundle */
+/* global SwaggerUIBundle, FogRequestSnippets */
 (function () {
     'use strict';
 
@@ -67,8 +67,33 @@
             });
     }
 
+    /**
+     * The snippet panel under an executed request.
+     *
+     * Off by default, and worth turning on here because the reference is the
+     * page an admin lands on to work out how to drive this server from
+     * somewhere else -- the answer being one tab away from the request they
+     * just ran beats reconstructing it from the operation blocks.
+     *
+     * fog.apidocs.snippets.js supplies the generators and the config together,
+     * because the two have to agree: a generator named in the config with no
+     * function behind it is dropped silently. If the file did not load, fall
+     * through to Swagger UI's own three curl tabs rather than rendering
+     * nothing.
+     */
+    function snippetOptions() {
+        if (typeof FogRequestSnippets === 'undefined') {
+            return {};
+        }
+        return {
+            requestSnippetsEnabled: true,
+            requestSnippets: FogRequestSnippets.config(),
+            plugins: [FogRequestSnippets.plugin]
+        };
+    }
+
     function render(specUrl, mount) {
-        SwaggerUIBundle({
+        SwaggerUIBundle(Object.assign({
             url: specUrl,
             // domNode rather than dom_id, because the node this renders into
             // is one we own and keep (see boot()), not the server-rendered
@@ -103,7 +128,7 @@
             // Same-origin, so the browser sends the session cookie and try-it
             // works against this very server.
             withCredentials: true
-        });
+        }, snippetOptions()));
     }
 
     function boot() {

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
@@ -551,6 +551,251 @@
         return lines.join('\n');
     }
 
+    /* ---------------------------------------------------------------- *
+     * Ruby                                                              *
+     * ---------------------------------------------------------------- */
+
+    var RUBY_METHODS = {
+        GET: 'Get',
+        POST: 'Post',
+        PUT: 'Put',
+        PATCH: 'Patch',
+        DELETE: 'Delete',
+        HEAD: 'Head',
+        OPTIONS: 'Options'
+    };
+
+    /**
+     * A double-quoted Ruby string interpolates #{...}, so that sequence has to
+     * be escaped on top of the C-style escapes quoteDouble already applies.
+     * Nothing else in a header or a JSON body can change the meaning.
+     */
+    function quoteRuby(value) {
+        return quoteDouble(value).replace(/#\{/g, '\\#{');
+    }
+
+    function rubyValue(value, pad) {
+        if (value === null) {
+            return 'nil';
+        }
+        if (typeof value === 'boolean' || typeof value === 'number') {
+            return String(value);
+        }
+        if (typeof value === 'string') {
+            return quoteRuby(value);
+        }
+        if (Array.isArray(value)) {
+            if (!value.length) {
+                return '[]';
+            }
+            return '[\n' + value.map(function (item) {
+                return pad + '  ' + rubyValue(item, pad + '  ');
+            }).join(',\n') + '\n' + pad + ']';
+        }
+        if (typeof value === 'object') {
+            var keys = Object.keys(value);
+            if (!keys.length) {
+                return '{}';
+            }
+            return '{\n' + keys.map(function (key) {
+                return pad + '  ' + quoteRuby(key) + ' => '
+                    + rubyValue(value[key], pad + '  ');
+            }).join(',\n') + '\n' + pad + '}';
+        }
+        return quoteRuby(String(value));
+    }
+
+    function rubySnippet(request) {
+        var req = readRequest(request);
+        var body = req.body;
+        var lines = [];
+        var verb = RUBY_METHODS[req.method];
+        var headers = req.headers;
+
+        if (body.kind === 'form' || body.kind === 'file') {
+            // set_form writes the multipart header, boundary included.
+            headers = headers.filter(function (pair) {
+                return pair[0].toLowerCase() !== 'content-type';
+            });
+        }
+
+        // net/http is stdlib, so this runs on a stock Ruby with nothing to
+        // install -- which is the point of a snippet someone pastes once.
+        lines.push('require "json"');
+        lines.push('require "net/http"');
+        lines.push('require "uri"');
+        lines.push('');
+        lines.push('uri = URI(' + quoteRuby(req.url) + ')');
+        lines.push('');
+
+        if (verb) {
+            lines.push('request = Net::HTTP::' + verb + '.new(uri)');
+        } else {
+            // Net::HTTP has no class for an unusual verb; GenericRequest takes
+            // the method as a string instead.
+            lines.push('request = Net::HTTPGenericRequest.new('
+                + quoteRuby(req.method) + ', true, true, uri)');
+        }
+        headers.forEach(function (pair) {
+            lines.push('request[' + quoteRuby(pair[0]) + '] = '
+                + quoteRuby(pair[1]));
+        });
+        lines.push('');
+
+        if (body.kind === 'json') {
+            lines.push('request.body = JSON.generate(' + rubyValue(body.value, '') + ')');
+            lines.push('');
+        } else if (body.kind === 'raw') {
+            lines.push('request.body = ' + quoteRuby(body.raw));
+            lines.push('');
+        } else if (body.kind === 'form' || body.kind === 'file') {
+            var fields = body.kind === 'file'
+                ? [['file', body.file]]
+                : body.fields;
+            lines.push('request.set_form([');
+            fields.forEach(function (pair) {
+                lines.push('  [' + quoteRuby(pair[0]) + ', '
+                    + (isFileLike(pair[1])
+                        ? 'File.open(' + quoteRuby(pair[1].name) + ')'
+                        : quoteRuby(String(pair[1])))
+                    + '],');
+            });
+            lines.push('], "multipart/form-data")');
+            lines.push('');
+        }
+
+        // use_ssl has to be set explicitly; Net::HTTP does not infer it from
+        // the scheme, and without it an https URL is spoken to in plaintext.
+        lines.push('response = Net::HTTP.start('
+            + 'uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|');
+        lines.push('  http.request(request)');
+        lines.push('end');
+        lines.push('');
+        lines.push('puts response.code');
+        lines.push('puts response.body');
+
+        return lines.join('\n');
+    }
+
+    /* ---------------------------------------------------------------- *
+     * PHP                                                               *
+     * ---------------------------------------------------------------- */
+
+    /**
+     * Single-quoted, which in PHP escapes only the backslash and the quote and
+     * interpolates nothing -- so a body containing $foo or \n stays literal.
+     */
+    function quotePhp(value) {
+        return "'" + String(value).replace(/[\\']/g, '\\$&') + "'";
+    }
+
+    function phpValue(value, pad) {
+        if (value === null) {
+            return 'null';
+        }
+        if (typeof value === 'boolean') {
+            return value ? 'true' : 'false';
+        }
+        if (typeof value === 'number') {
+            return String(value);
+        }
+        if (typeof value === 'string') {
+            return quotePhp(value);
+        }
+        if (Array.isArray(value)) {
+            if (!value.length) {
+                return '[]';
+            }
+            return '[\n' + value.map(function (item) {
+                return pad + '    ' + phpValue(item, pad + '    ') + ',';
+            }).join('\n') + '\n' + pad + ']';
+        }
+        if (typeof value === 'object') {
+            var keys = Object.keys(value);
+            if (!keys.length) {
+                return '[]';
+            }
+            return '[\n' + keys.map(function (key) {
+                return pad + '    ' + quotePhp(key) + ' => '
+                    + phpValue(value[key], pad + '    ') + ',';
+            }).join('\n') + '\n' + pad + ']';
+        }
+        return quotePhp(String(value));
+    }
+
+    function phpSnippet(request) {
+        var req = readRequest(request);
+        var body = req.body;
+        var lines = ['<?php', ''];
+        var headers = req.headers;
+
+        if (body.kind === 'form' || body.kind === 'file') {
+            // Handed an array, curl builds the multipart body and sets the
+            // header with its own boundary. Sending the one from here, which
+            // has no boundary, replaces that and the body becomes unreadable.
+            headers = headers.filter(function (pair) {
+                return pair[0].toLowerCase() !== 'content-type';
+            });
+        }
+
+        lines.push('$ch = curl_init(' + quotePhp(req.url) + ');');
+        lines.push('');
+        lines.push('curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '
+            + quotePhp(req.method) + ');');
+        // Without this curl_exec prints the body and returns a bool, which is
+        // the usual first surprise for anyone new to the extension.
+        lines.push('curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);');
+
+        if (headers.length) {
+            lines.push('curl_setopt($ch, CURLOPT_HTTPHEADER, [');
+            headers.forEach(function (pair) {
+                lines.push('    ' + quotePhp(pair[0] + ': ' + pair[1]) + ',');
+            });
+            lines.push(']);');
+        }
+
+        if (body.kind === 'json') {
+            lines.push('');
+            lines.push('$payload = ' + phpValue(body.value, '') + ';');
+            lines.push('');
+            lines.push('curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));');
+        } else if (body.kind === 'raw') {
+            lines.push('');
+            lines.push('curl_setopt($ch, CURLOPT_POSTFIELDS, '
+                + quotePhp(body.raw) + ');');
+        } else if (body.kind === 'form' || body.kind === 'file') {
+            var fields = body.kind === 'file'
+                ? [['file', body.file]]
+                : body.fields;
+            lines.push('');
+            lines.push('curl_setopt($ch, CURLOPT_POSTFIELDS, [');
+            fields.forEach(function (pair) {
+                lines.push('    ' + quotePhp(pair[0]) + ' => '
+                    + (isFileLike(pair[1])
+                        ? 'new CURLFile(' + quotePhp(pair[1].name) + ')'
+                        : quotePhp(String(pair[1])))
+                    + ',');
+            });
+            lines.push(']);');
+        }
+
+        lines.push('');
+        lines.push('$response = curl_exec($ch);');
+        lines.push('');
+        // curl_exec returns false on a transport failure and an error page's
+        // body on an HTTP one; both look like "it worked" to json_decode.
+        lines.push('if ($response === false) {');
+        lines.push('    throw new RuntimeException(curl_error($ch));');
+        lines.push('}');
+        lines.push('');
+        lines.push('$status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);');
+        lines.push('curl_close($ch);');
+        lines.push('');
+        lines.push('var_dump($status, json_decode($response, true));');
+
+        return lines.join('\n');
+    }
+
     /* ---------------------------------------------------------------- */
 
     var GENERATORS = {
@@ -568,6 +813,16 @@
             title: 'JavaScript',
             syntax: 'javascript',
             fn: javascriptSnippet
+        },
+        ruby: {
+            title: 'Ruby',
+            syntax: 'ruby',
+            fn: rubySnippet
+        },
+        php: {
+            title: 'PHP',
+            syntax: 'php',
+            fn: phpSnippet
         }
     };
 
@@ -576,20 +831,37 @@
      *
      * `languages` is doing real work here, not decoration. A `generators` map
      * passed in config is *merged* into Swagger UI's own rather than replacing
-     * it, so listing only the four wanted below still leaves curl_powershell
-     * and curl_cmd in the map and renders six tabs -- including the `curl.exe`
-     * one this exists to displace. `languages` is the allowlist the selector
-     * filters the merged map through, so it is what actually decides the tabs.
+     * it, so a shorter `generators` does not mean fewer tabs -- the built-ins
+     * stay in the merged map and render alongside. `languages` is the allowlist
+     * the selector filters that merged map through, so it is the only thing
+     * that actually decides which tabs appear.
      *
-     * Tab order follows the merged map, which puts the built-ins first: cURL,
-     * then PowerShell, Python, JavaScript. cURL leads deliberately -- it is the
-     * form every reader recognises and the one the FOG docs quote -- and being
-     * first also makes it the tab that opens by default.
+     * Every generator that exists is currently listed, built-ins included, so
+     * the set can be judged on a real server rather than on argument. That is a
+     * starting position and not the intended end state -- eight tabs is more
+     * than a panel this size wears well, and two of them (cURL (PowerShell) and
+     * PowerShell) answer the same question in different ways on purpose, so a
+     * reader can see which one they actually want. Cull by deleting entries
+     * from this list; nothing else has to change, and a generator dropped from
+     * here stays available for a later reversal.
      *
-     * Adding the Windows cmd tab back is one entry in LANGUAGES. curl_powershell
-     * is the one to leave out; see the note at the top of this file.
+     * Order follows the merged map, which puts Swagger UI's three first. cURL
+     * leads, which also makes it the tab that opens by default.
      */
-    var LANGUAGES = ['curl_bash', 'powershell', 'python', 'javascript'];
+    var LANGUAGES = [
+        // Swagger UI's own. curl_powershell is `curl.exe` with PowerShell
+        // quoting rather than PowerShell, which is what the `powershell`
+        // generator below exists to offer instead.
+        'curl_bash',
+        'curl_powershell',
+        'curl_cmd',
+        // FOG's.
+        'powershell',
+        'python',
+        'javascript',
+        'ruby',
+        'php'
+    ];
 
     function config() {
         var generators = {

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
@@ -1,0 +1,629 @@
+/**
+ * Request snippet generators for the API Documentation page.
+ *
+ * Swagger UI's snippet panel is driven by a config block naming generators and
+ * a matching `fn.requestSnippetGenerator_<key>` for each. What is worth knowing
+ * before editing this file is what the bundle does and does not already have:
+ *
+ *  - It ships exactly three generators -- curl_bash, curl_cmd and
+ *    curl_powershell. There is no built-in Python, JavaScript, Ruby or PHP
+ *    generator, and naming one in `requestSnippets.generators` without also
+ *    registering a function does not fail loudly. getSnippetGenerators()
+ *    filters out any entry whose `fn` is not a function, so the tab simply
+ *    never appears and the page looks like the setting did nothing.
+ *  - curl_powershell is `curl.exe`, not PowerShell. It is the same curl command
+ *    line with PowerShell quoting and a backtick line continuation. Someone
+ *    reading it for how to call FOG from PowerShell gets an answer that ignores
+ *    every cmdlet they would actually use, which is why the PowerShell
+ *    generator here emits Invoke-RestMethod and curl_powershell is left out of
+ *    the config.
+ *
+ * The generators below are deliberately generic -- plain Invoke-RestMethod,
+ * `requests`, `fetch` -- rather than FogApi/fog-specific. A FOG-flavoured one
+ * (Connect-FogServer + Get-FogObject, say) is a matter of adding one entry to
+ * GENERATORS and one line to the config in fog.apidocs.list.js.
+ *
+ * On highlighting: the bundle registers only bash, http, javascript, json,
+ * powershell, xml and yaml with highlight.js. An unregistered `syntax` value
+ * does not throw -- react-syntax-highlighter falls back to highlightAuto() --
+ * so Python is declared honestly as 'python' and gets auto-detected colouring
+ * rather than being mislabelled as something that happens to be registered.
+ *
+ * The request object handed to a generator is an Immutable Map with `url`,
+ * `method`, `headers` and `body`. Nothing here reaches for Immutable itself,
+ * because the bundle does not export it; the shapes are duck-typed instead,
+ * which is also what makes tests/apidocs-request-snippets.test.sh able to
+ * exercise these functions under plain node.
+ */
+(function (root, factory) {
+    'use strict';
+    if (typeof module === 'object' && module && module.exports) {
+        module.exports = factory();
+    } else {
+        root.FogRequestSnippets = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    // Swagger UI suffixes duplicated form keys with this marker so that
+    // repeated fields survive a Map; the wire name is everything before it.
+    var ARRAY_MARKER = '_**[]';
+
+    var JSON_CONTENT = /^application\/(?:[\w.+-]+\+)?json\b/i;
+    var MULTIPART_CONTENT = /^multipart\/form-data\b/i;
+
+    /**
+     * Immutable Map, native Map or plain object to an array of [key, value].
+     *
+     * Immutable and native Map both call back as (value, key); a plain object
+     * has no forEach at all, which is how the two are told apart.
+     */
+    function toPairs(map) {
+        var pairs = [];
+        if (!map) {
+            return pairs;
+        }
+        if (typeof map.forEach === 'function' && typeof map.get === 'function') {
+            map.forEach(function (value, key) {
+                pairs.push([key, value]);
+            });
+            return pairs;
+        }
+        if (typeof map !== 'object') {
+            return pairs;
+        }
+        Object.keys(map).forEach(function (key) {
+            pairs.push([key, map[key]]);
+        });
+        return pairs;
+    }
+
+    function extractKey(key) {
+        var name = String(key);
+        return name.indexOf(ARRAY_MARKER) < 0
+            ? name
+            : name.split(ARRAY_MARKER)[0].trim();
+    }
+
+    function isMapLike(value) {
+        return !!value
+            && typeof value === 'object'
+            && typeof value.get === 'function'
+            && typeof value.forEach === 'function';
+    }
+
+    /**
+     * A file the user attached in try-it. Swagger UI uses the browser's File in
+     * a browser and its own stand-in elsewhere, so this tests for the shape
+     * both share rather than for either constructor.
+     */
+    function isFileLike(value) {
+        if (typeof File !== 'undefined' && value instanceof File) {
+            return true;
+        }
+        return !!value
+            && typeof value === 'object'
+            && !isMapLike(value)
+            && typeof value.name === 'string'
+            && (typeof value.size === 'number' || typeof value.type === 'string');
+    }
+
+    function headerValue(headers, name) {
+        var wanted = name.toLowerCase();
+        var found = '';
+        headers.forEach(function (pair) {
+            if (String(pair[0]).toLowerCase() === wanted) {
+                found = String(pair[1]);
+            }
+        });
+        return found;
+    }
+
+    /**
+     * Sort the request into the handful of shapes the generators care about:
+     * no body, a JSON document, a form (multipart or urlencoded), a single
+     * uploaded file, or an opaque string.
+     */
+    function describeBody(request, headers) {
+        var body = request.get('body');
+        var contentType = headerValue(headers, 'content-type');
+
+        if (body === undefined || body === null || body === '') {
+            return { kind: 'none' };
+        }
+        if (isFileLike(body)) {
+            return { kind: 'file', file: body };
+        }
+        if (isMapLike(body)) {
+            return {
+                kind: 'form',
+                multipart: MULTIPART_CONTENT.test(contentType),
+                fields: toPairs(body).map(function (pair) {
+                    return [extractKey(pair[0]), pair[1]];
+                })
+            };
+        }
+        if (typeof body === 'string') {
+            try {
+                return { kind: 'json', value: JSON.parse(body), raw: body };
+            } catch (ignore) {
+                return { kind: 'raw', raw: body };
+            }
+        }
+        // Anything else is already a structure; treat it as the JSON it will
+        // be serialised to.
+        return { kind: 'json', value: body, raw: JSON.stringify(body, null, 2) };
+    }
+
+    function readRequest(request) {
+        var headers = toPairs(request.get('headers')).map(function (pair) {
+            return [String(pair[0]), String(pair[1])];
+        });
+        return {
+            url: String(request.get('url') || ''),
+            method: String(request.get('method') || 'GET').toUpperCase(),
+            headers: headers,
+            contentType: headerValue(headers, 'content-type'),
+            body: describeBody(request, headers)
+        };
+    }
+
+    /**
+     * Escape into a double-quoted literal for the C-derived syntaxes (Python,
+     * JavaScript, PHP all agree on these escapes).
+     *
+     * Non-ASCII is passed through as itself rather than as \uXXXX. JSON's own
+     * escaping would emit surrogate pairs for astral characters, and Python
+     * reads "😀" as two lone surrogates rather than as the character
+     * it came from -- so a hostname with an emoji in it would round-trip
+     * through the snippet as something else.
+     */
+    function quoteDouble(value) {
+        var out = String(value).replace(/[\\"]/g, '\\$&');
+        return '"' + out.replace(/[\x00-\x1f]/g, function (ch) {
+            switch (ch) {
+            case '\n':
+                return '\\n';
+            case '\r':
+                return '\\r';
+            case '\t':
+                return '\\t';
+            default:
+                return '\\u' + ('000' + ch.charCodeAt(0).toString(16)).slice(-4);
+            }
+        }) + '"';
+    }
+
+    /* ---------------------------------------------------------------- *
+     * PowerShell                                                        *
+     * ---------------------------------------------------------------- */
+
+    function quotePowershell(value) {
+        return "'" + String(value).replace(/'/g, "''") + "'";
+    }
+
+    /**
+     * A here-string when the text has newlines in it, a single-quoted string
+     * when it does not.
+     *
+     * @' must be the last thing on its line and '@ the first thing on its own,
+     * so a body containing a line that begins with '@ would terminate the
+     * here-string early. That falls back to the quoted form, which is uglier
+     * but always correct.
+     */
+    function powershellLiteral(text) {
+        var value = String(text);
+        if (value.indexOf('\n') < 0) {
+            return quotePowershell(value);
+        }
+        if (/^'@/m.test(value)) {
+            return quotePowershell(value);
+        }
+        return "@'\n" + value + "\n'@";
+    }
+
+    function powershellHashtable(pairs, pad) {
+        if (!pairs.length) {
+            return '@{}';
+        }
+        var lines = pairs.map(function (pair) {
+            return pad + '    ' + quotePowershell(pair[0])
+                + ' = ' + quotePowershell(pair[1]);
+        });
+        return '@{\n' + lines.join('\n') + '\n' + pad + '}';
+    }
+
+    function powershellSnippet(request) {
+        var req = readRequest(request);
+        var lines = [];
+        var args = ['-Uri ' + quotePowershell(req.url)];
+        var body = req.body;
+
+        // Content-Type is pulled out of the header table on purpose. Windows
+        // PowerShell 5.1 refuses to set restricted headers through -Headers
+        // ("The 'Content-Type' header must be modified using the appropriate
+        // property or method"), and -ContentType is the parameter that exists
+        // for it in every version.
+        var headers = req.headers.filter(function (pair) {
+            return pair[0].toLowerCase() !== 'content-type';
+        });
+
+        if (headers.length) {
+            lines.push('$headers = ' + powershellHashtable(headers, ''));
+            lines.push('');
+        }
+
+        if (body.kind === 'json' || body.kind === 'raw') {
+            lines.push('$body = ' + powershellLiteral(body.raw));
+            lines.push('');
+        } else if (body.kind === 'form') {
+            // -Form is PowerShell 6.1+. Say so rather than handing 5.1 users a
+            // command that fails on a parameter they cannot get.
+            lines.push('# -Form requires PowerShell 6.1 or newer.');
+            lines.push('$form = ' + powershellHashtable(
+                body.fields.filter(function (pair) {
+                    return !isFileLike(pair[1]);
+                }).map(function (pair) {
+                    return [pair[0], String(pair[1])];
+                }),
+                ''
+            ));
+            // File fields are added after the literal, not inside it: -Form
+            // uploads a FileInfo as a file and a string as a text field, so the
+            // value has to be the Get-Item result rather than the name.
+            body.fields.forEach(function (pair) {
+                if (isFileLike(pair[1])) {
+                    lines.push('$form[' + quotePowershell(pair[0])
+                        + '] = Get-Item ' + quotePowershell(pair[1].name));
+                }
+            });
+            lines.push('');
+        } else if (body.kind === 'file') {
+            lines.push('$form = @{ file = Get-Item '
+                + quotePowershell(body.file.name) + ' }');
+            lines.push('');
+        }
+
+        args.push('-Method ' + req.method);
+        if (headers.length) {
+            args.push('-Headers $headers');
+        }
+        if (req.contentType && (body.kind === 'json' || body.kind === 'raw')) {
+            args.push('-ContentType ' + quotePowershell(req.contentType));
+        }
+        if (body.kind === 'json' || body.kind === 'raw') {
+            args.push('-Body $body');
+        } else if (body.kind === 'form' || body.kind === 'file') {
+            args.push('-Form $form');
+        }
+
+        // Backtick continuation, one argument per line: these commands run long
+        // once headers and a body are in play, and the panel does not wrap.
+        lines.push('$response = Invoke-RestMethod `\n    '
+            + args.join(' `\n    '));
+        lines.push('');
+        // FOG's responses nest (a host carries its images, snapins, macs),
+        // and ConvertTo-Json truncates at depth 2 unless told otherwise.
+        lines.push('$response | ConvertTo-Json -Depth 10');
+
+        return lines.join('\n');
+    }
+
+    /* ---------------------------------------------------------------- *
+     * Python                                                            *
+     * ---------------------------------------------------------------- */
+
+    var PYTHON_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
+
+    function pythonValue(value, pad) {
+        if (value === null) {
+            return 'None';
+        }
+        if (value === true) {
+            return 'True';
+        }
+        if (value === false) {
+            return 'False';
+        }
+        if (typeof value === 'number') {
+            return String(value);
+        }
+        if (typeof value === 'string') {
+            return quoteDouble(value);
+        }
+        if (Array.isArray(value)) {
+            if (!value.length) {
+                return '[]';
+            }
+            return '[\n' + value.map(function (item) {
+                return pad + '    ' + pythonValue(item, pad + '    ');
+            }).join(',\n') + '\n' + pad + ']';
+        }
+        if (typeof value === 'object') {
+            var keys = Object.keys(value);
+            if (!keys.length) {
+                return '{}';
+            }
+            return '{\n' + keys.map(function (key) {
+                return pad + '    ' + quoteDouble(key) + ': '
+                    + pythonValue(value[key], pad + '    ');
+            }).join(',\n') + '\n' + pad + '}';
+        }
+        return quoteDouble(String(value));
+    }
+
+    function pythonDict(pairs, pad) {
+        if (!pairs.length) {
+            return '{}';
+        }
+        return '{\n' + pairs.map(function (pair) {
+            return pad + '    ' + quoteDouble(pair[0]) + ': '
+                + quoteDouble(pair[1]);
+        }).join(',\n') + '\n' + pad + '}';
+    }
+
+    function pythonSnippet(request) {
+        var req = readRequest(request);
+        var body = req.body;
+        var lines = ['import requests', ''];
+        var args = ['url'];
+        var headers = req.headers;
+        var call;
+
+        if (body.kind === 'form' || body.kind === 'file') {
+            // requests writes its own multipart/form-data header, boundary and
+            // all. Passing the one Swagger UI sent -- which has no boundary on
+            // it -- overrides that, and the server then cannot parse a body
+            // that was encoded correctly.
+            headers = headers.filter(function (pair) {
+                return pair[0].toLowerCase() !== 'content-type';
+            });
+        }
+
+        lines.push('url = ' + quoteDouble(req.url));
+        lines.push('');
+
+        if (headers.length) {
+            lines.push('headers = ' + pythonDict(headers, ''));
+            lines.push('');
+            args.push('headers=headers');
+        }
+
+        if (body.kind === 'json') {
+            lines.push('payload = ' + pythonValue(body.value, ''));
+            lines.push('');
+            // json= rather than data=json.dumps(...): requests serialises it
+            // and the shape stays readable and editable in the snippet.
+            args.push('json=payload');
+        } else if (body.kind === 'raw') {
+            lines.push('payload = ' + quoteDouble(body.raw));
+            lines.push('');
+            args.push('data=payload');
+        } else if (body.kind === 'form') {
+            var files = body.fields.filter(function (pair) {
+                return isFileLike(pair[1]);
+            });
+            var plain = body.fields.filter(function (pair) {
+                return !isFileLike(pair[1]);
+            });
+            if (plain.length) {
+                lines.push('payload = ' + pythonDict(plain.map(function (pair) {
+                    return [pair[0], String(pair[1])];
+                }), ''));
+                lines.push('');
+                args.push('data=payload');
+            }
+            if (files.length) {
+                lines.push('files = {');
+                files.forEach(function (pair) {
+                    lines.push('    ' + quoteDouble(pair[0]) + ': open('
+                        + quoteDouble(pair[1].name) + ', "rb"),');
+                });
+                lines.push('}');
+                lines.push('');
+                args.push('files=files');
+            }
+        } else if (body.kind === 'file') {
+            lines.push('files = {"file": open('
+                + quoteDouble(body.file.name) + ', "rb")}');
+            lines.push('');
+            args.push('files=files');
+        }
+
+        if (PYTHON_METHODS.indexOf(req.method.toLowerCase()) >= 0) {
+            call = 'requests.' + req.method.toLowerCase() + '(' + args.join(', ') + ')';
+        } else {
+            call = 'requests.request(' + quoteDouble(req.method) + ', '
+                + args.join(', ') + ')';
+        }
+
+        lines.push('response = ' + call);
+        lines.push('response.raise_for_status()');
+        lines.push('print(response.json())');
+
+        return lines.join('\n');
+    }
+
+    /* ---------------------------------------------------------------- *
+     * JavaScript                                                        *
+     * ---------------------------------------------------------------- */
+
+    function jsValue(value, pad) {
+        if (value === null) {
+            return 'null';
+        }
+        if (typeof value === 'boolean' || typeof value === 'number') {
+            return String(value);
+        }
+        if (typeof value === 'string') {
+            return quoteDouble(value);
+        }
+        if (Array.isArray(value)) {
+            if (!value.length) {
+                return '[]';
+            }
+            return '[\n' + value.map(function (item) {
+                return pad + '  ' + jsValue(item, pad + '  ');
+            }).join(',\n') + '\n' + pad + ']';
+        }
+        if (typeof value === 'object') {
+            var keys = Object.keys(value);
+            if (!keys.length) {
+                return '{}';
+            }
+            return '{\n' + keys.map(function (key) {
+                return pad + '  ' + quoteDouble(key) + ': '
+                    + jsValue(value[key], pad + '  ');
+            }).join(',\n') + '\n' + pad + '}';
+        }
+        return quoteDouble(String(value));
+    }
+
+    function jsObject(pairs, pad) {
+        if (!pairs.length) {
+            return '{}';
+        }
+        return '{\n' + pairs.map(function (pair) {
+            return pad + '  ' + quoteDouble(pair[0]) + ': ' + quoteDouble(pair[1]);
+        }).join(',\n') + '\n' + pad + '}';
+    }
+
+    function javascriptSnippet(request) {
+        var req = readRequest(request);
+        var body = req.body;
+        var lines = [];
+        var options = ['method: ' + quoteDouble(req.method)];
+        var headers = req.headers;
+
+        lines.push('const url = ' + quoteDouble(req.url) + ';');
+        lines.push('');
+
+        if (body.kind === 'form' || body.kind === 'file') {
+            // The browser sets multipart/form-data with its own boundary; a
+            // Content-Type copied from here would carry the wrong one and the
+            // request would arrive unparseable.
+            headers = headers.filter(function (pair) {
+                return pair[0].toLowerCase() !== 'content-type';
+            });
+            lines.push('const form = new FormData();');
+            if (body.kind === 'file') {
+                lines.push('// Supply the file yourself; a snippet cannot carry one.');
+                lines.push('form.append("file", fileInput.files[0]);');
+            } else {
+                body.fields.forEach(function (pair) {
+                    if (isFileLike(pair[1])) {
+                        lines.push('form.append(' + quoteDouble(pair[0])
+                            + ', fileInput.files[0]); // ' + pair[1].name);
+                    } else {
+                        lines.push('form.append(' + quoteDouble(pair[0]) + ', '
+                            + quoteDouble(String(pair[1])) + ');');
+                    }
+                });
+            }
+            lines.push('');
+        }
+
+        if (headers.length) {
+            options.push('headers: ' + jsObject(headers, '  '));
+        }
+        if (body.kind === 'json') {
+            options.push('body: JSON.stringify(' + jsValue(body.value, '  ') + ')');
+        } else if (body.kind === 'raw') {
+            options.push('body: ' + quoteDouble(body.raw));
+        } else if (body.kind === 'form' || body.kind === 'file') {
+            options.push('body: form');
+        }
+
+        lines.push('const response = await fetch(url, {');
+        // Each option is already generated at a two-space pad, so only its
+        // first line needs prefixing -- indenting the whole block would push
+        // nested members and their closing brace out of line with it.
+        lines.push(options.map(function (option) {
+            return '  ' + option;
+        }).join(',\n'));
+        lines.push('});');
+        lines.push('');
+        lines.push('if (!response.ok) {');
+        lines.push('  throw new Error(`FOG returned ${response.status}`);');
+        lines.push('}');
+        lines.push('console.log(await response.json());');
+
+        return lines.join('\n');
+    }
+
+    /* ---------------------------------------------------------------- */
+
+    var GENERATORS = {
+        powershell: {
+            title: 'PowerShell',
+            syntax: 'powershell',
+            fn: powershellSnippet
+        },
+        python: {
+            title: 'Python',
+            syntax: 'python',
+            fn: pythonSnippet
+        },
+        javascript: {
+            title: 'JavaScript',
+            syntax: 'javascript',
+            fn: javascriptSnippet
+        }
+    };
+
+    /**
+     * The `requestSnippets` config block.
+     *
+     * `languages` is doing real work here, not decoration. A `generators` map
+     * passed in config is *merged* into Swagger UI's own rather than replacing
+     * it, so listing only the four wanted below still leaves curl_powershell
+     * and curl_cmd in the map and renders six tabs -- including the `curl.exe`
+     * one this exists to displace. `languages` is the allowlist the selector
+     * filters the merged map through, so it is what actually decides the tabs.
+     *
+     * Tab order follows the merged map, which puts the built-ins first: cURL,
+     * then PowerShell, Python, JavaScript. cURL leads deliberately -- it is the
+     * form every reader recognises and the one the FOG docs quote -- and being
+     * first also makes it the tab that opens by default.
+     *
+     * Adding the Windows cmd tab back is one entry in LANGUAGES. curl_powershell
+     * is the one to leave out; see the note at the top of this file.
+     */
+    var LANGUAGES = ['curl_bash', 'powershell', 'python', 'javascript'];
+
+    function config() {
+        var generators = {
+            curl_bash: { title: 'cURL', syntax: 'bash' }
+        };
+        Object.keys(GENERATORS).forEach(function (key) {
+            generators[key] = {
+                title: GENERATORS[key].title,
+                syntax: GENERATORS[key].syntax
+            };
+        });
+        return {
+            generators: generators,
+            defaultExpanded: true,
+            languages: LANGUAGES.slice()
+        };
+    }
+
+    /**
+     * The Swagger UI plugin carrying the functions the config above names.
+     */
+    function plugin() {
+        var fn = {};
+        Object.keys(GENERATORS).forEach(function (key) {
+            fn['requestSnippetGenerator_' + key] = GENERATORS[key].fn;
+        });
+        return { fn: fn };
+    }
+
+    return {
+        config: config,
+        plugin: plugin,
+        // Exposed so tests/apidocs-request-snippets.test.sh can call the
+        // generators directly rather than standing up a browser.
+        generators: GENERATORS
+    };
+}));

--- a/tests/apidocs-request-snippets.test.sh
+++ b/tests/apidocs-request-snippets.test.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+#
+# Guards the API Documentation page's try-it request snippets.
+#
+#   tests/apidocs-request-snippets.test.sh
+#
+# Swagger UI's snippet panel has one failure mode that produces no error
+# anywhere: getSnippetGenerators() looks each configured generator up as
+# fn.requestSnippetGenerator_<key> and *filters out* every entry whose function
+# is missing. Name a language in requestSnippets.generators without registering
+# a function for it and the tab simply never appears -- no console warning, no
+# broken render, just a panel that looks like the config did nothing. That is
+# exactly the trap the AI-written "just set requestSnippetsEnabled" recipes fall
+# into, since the bundle ships only curl_bash, curl_cmd and curl_powershell.
+#
+# The second thing checked here is subtler and cost a round of debugging: a
+# generators map passed in config is MERGED into Swagger UI's own rather than
+# replacing it, so listing four generators still renders six tabs. `languages`
+# is the allowlist that actually decides, which makes it -- not `generators` --
+# what keeps the `curl.exe` PowerShell tab off the page.
+#
+# The rest asserts the generated code itself, in the places where a plausible-
+# looking snippet is wrong: Content-Type through -Headers throws on Windows
+# PowerShell 5.1, Python needs True/None rather than true/null, and a
+# Content-Type copied onto a multipart request overrides the boundary the
+# client would have generated.
+#
+# Needs node. Skips (exit 0) rather than failing when it is absent, the same
+# way secureboot-authvars.test.sh skips without efitools.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+WEB="$REPO/packages/web"
+SNIPPETS="$WEB/management/js/fog/apidocs/fog.apidocs.snippets.js"
+LIST="$WEB/management/js/fog/apidocs/fog.apidocs.list.js"
+PAGE="$WEB/lib/fog/page.class.php"
+
+[[ -f $SNIPPETS ]] || { echo "ERROR: $SNIPPETS not found" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || {
+    echo "SKIP: node is not installed"
+    exit 0
+}
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# --- the two wiring checks that are not about the JS itself ----------------
+
+if grep -q "fog.apidocs.snippets.js" "$PAGE"; then
+    ok "page.class.php serves fog.apidocs.snippets.js on the apidocs node"
+else
+    bad "page.class.php does not serve fog.apidocs.snippets.js; the tabs would silently stay as shipped"
+fi
+
+if grep -q "FogRequestSnippets" "$LIST"; then
+    ok "fog.apidocs.list.js passes the FOG generators to SwaggerUIBundle"
+else
+    bad "fog.apidocs.list.js never references FogRequestSnippets"
+fi
+
+# --- the generators, exercised directly ------------------------------------
+
+node - "$SNIPPETS" <<'NODEEOF'
+'use strict';
+
+const snippets = require(process.argv[2]);
+
+// What the bundle already registers. Anything in `languages` that is neither
+// one of these nor one of ours resolves to no function and drops out.
+const BUILT_IN = ['curl_bash', 'curl_cmd', 'curl_powershell'];
+
+let failed = 0;
+function ok(name) { console.log('PASS: ' + name); }
+function bad(name, detail) {
+    console.log('FAIL: ' + name + (detail ? '\n      ' + detail : ''));
+    failed += 1;
+}
+function check(name, condition, detail) {
+    if (condition) { ok(name); } else { bad(name, detail); }
+}
+
+// Stand-in for the Immutable Map the bundle hands a generator. Only get() and
+// forEach() are used, which is the whole reason the generators duck-type
+// rather than reaching for Immutable.
+function map(obj) {
+    return {
+        get: (key) => obj[key],
+        forEach: (cb) => Object.keys(obj).forEach((key) => cb(obj[key], key)),
+        size: Object.keys(obj).length
+    };
+}
+
+const config = snippets.config();
+const fns = snippets.plugin().fn;
+const known = BUILT_IN.concat(Object.keys(snippets.generators));
+
+// 1. Every generator we declare has a function behind it.
+const orphans = Object.keys(config.generators).filter(
+    (key) => BUILT_IN.indexOf(key) < 0
+        && typeof fns['requestSnippetGenerator_' + key] !== 'function'
+);
+check(
+    'every declared generator has a requestSnippetGenerator_ function',
+    orphans.length === 0,
+    'no function for: ' + orphans.join(', ') + ' -- these tabs would not render'
+);
+
+// 2. Every allowlisted language resolves to something that exists.
+check(
+    'requestSnippets.languages is set',
+    Array.isArray(config.languages) && config.languages.length > 0,
+    'without it the merged generator map wins and Swagger UI renders its own tabs too'
+);
+const unknown = (config.languages || []).filter((key) => known.indexOf(key) < 0);
+check(
+    'every allowlisted language is a real generator',
+    unknown.length === 0,
+    'unknown: ' + unknown.join(', ')
+);
+
+// 3. The whole point: PowerShell means Invoke-RestMethod, not curl.exe.
+check(
+    'curl_powershell is not offered',
+    (config.languages || []).indexOf('curl_powershell') < 0,
+    'the curl.exe tab is back; it is what the PowerShell generator replaces'
+);
+
+const jsonRequest = map({
+    url: 'https://fog.example.org/fog/host/42/edit',
+    method: 'PUT',
+    headers: map({
+        'fog-api-token': 'QUJD',
+        'Content-Type': 'application/json',
+        accept: 'application/json'
+    }),
+    body: JSON.stringify({
+        name: 'lab-pc-01',
+        enforce: true,
+        imageID: 3,
+        ip: null
+    }, null, 2)
+});
+
+const ps = snippets.generators.powershell.fn(jsonRequest);
+const py = snippets.generators.python.fn(jsonRequest);
+const js = snippets.generators.javascript.fn(jsonRequest);
+
+check(
+    'PowerShell calls Invoke-RestMethod',
+    /Invoke-RestMethod/.test(ps) && !/curl/i.test(ps),
+    ps
+);
+
+// Windows PowerShell 5.1 throws "The 'Content-Type' header must be modified
+// using the appropriate property or method" when it arrives via -Headers.
+check(
+    'PowerShell passes Content-Type as -ContentType, not in $headers',
+    /-ContentType 'application\/json'/.test(ps)
+        && !/'Content-Type'\s*=/.test(ps),
+    ps
+);
+
+// @' ... '@ only terminates when '@ starts the line.
+const terminator = ps.split('\n').filter((line) => line.indexOf("'@") >= 0);
+check(
+    'PowerShell here-string terminator sits at column 0',
+    terminator.length > 0 && terminator.every((line) => line.indexOf("'@") === 0),
+    ps
+);
+
+check(
+    'Python uses requests and the verb-named helper',
+    /^import requests$/m.test(py) && /requests\.put\(/.test(py),
+    py
+);
+
+// JSON's literals are not Python's. A snippet carrying `true` or `null`
+// raises NameError on the first line the reader runs.
+check(
+    'Python emits Python literals, not JSON ones',
+    /"enforce": True/.test(py) && /"ip": None/.test(py)
+        && !/\btrue\b/.test(py) && !/\bnull\b/.test(py),
+    py
+);
+
+check(
+    'JavaScript uses fetch with a JSON.stringify body',
+    /await fetch\(url, \{/.test(js) && /JSON\.stringify\(\{/.test(js),
+    js
+);
+
+// A multipart Content-Type has a boundary the client generates. Copying the
+// one Swagger UI sent -- which has none -- overrides that, and the server gets
+// a body it cannot parse.
+const formRequest = map({
+    url: 'https://fog.example.org/fog/image/1/upload',
+    method: 'POST',
+    headers: map({ 'Content-Type': 'multipart/form-data', 'fog-api-token': 'QUJD' }),
+    body: map({
+        name: 'thing',
+        'file_**[]': { name: 'win11.img', size: 12, type: 'application/octet-stream' }
+    })
+});
+
+const pyForm = snippets.generators.python.fn(formRequest);
+const jsForm = snippets.generators.javascript.fn(formRequest);
+const psForm = snippets.generators.powershell.fn(formRequest);
+
+check(
+    'Python drops Content-Type on a multipart request',
+    !/multipart\/form-data/.test(pyForm) && /files=files/.test(pyForm),
+    pyForm
+);
+check(
+    'JavaScript drops Content-Type on a multipart request',
+    !/multipart\/form-data/.test(jsForm) && /new FormData\(\)/.test(jsForm),
+    jsForm
+);
+
+// Swagger UI suffixes repeated form keys; the wire name is what precedes it.
+check(
+    'the _**[] form-key marker is stripped',
+    !/_\*\*\[\]/.test(pyForm + jsForm + psForm),
+    psForm
+);
+
+// -Form uploads a FileInfo as a file and a string as a text field, so a file
+// field listed in the literal as its name would be sent as the name.
+check(
+    'PowerShell attaches files with Get-Item rather than by name',
+    /\$form\['file'\] = Get-Item 'win11\.img'/.test(psForm)
+        && !/'file' = 'win11\.img'/.test(psForm),
+    psForm
+);
+
+// A GET with no body must not grow a -Body or a payload out of nowhere.
+const bare = map({
+    url: 'https://fog.example.org/fog/host',
+    method: 'GET',
+    headers: map({ 'fog-api-token': 'QUJD' })
+});
+check(
+    'a body-less request produces no body',
+    !/-Body/.test(snippets.generators.powershell.fn(bare))
+        && !/payload/.test(snippets.generators.python.fn(bare))
+        && !/body:/.test(snippets.generators.javascript.fn(bare)),
+    snippets.generators.powershell.fn(bare)
+);
+
+process.exit(failed > 0 ? 1 : 0);
+NODEEOF
+
+if [[ $? -eq 0 ]]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+if [[ $FAIL -gt 0 ]]; then
+    echo "$FAIL failed"
+    exit 1
+fi
+echo "all checks passed"
+exit 0

--- a/tests/apidocs-request-snippets.test.sh
+++ b/tests/apidocs-request-snippets.test.sh
@@ -25,8 +25,18 @@
 # Content-Type copied onto a multipart request overrides the boundary the
 # client would have generated.
 #
+# The last section feeds every generated snippet to the real interpreter and
+# asks it to parse. Quoting is where a snippet generator goes wrong -- an
+# apostrophe in a filename, a backslash in a body, a $var that PHP would have
+# interpolated -- and those produce output that reads fine and does not run.
+# php -l, ast.parse, ruby -c and node --check each cost milliseconds and turn
+# that whole class into a test failure. PowerShell has no equivalent here,
+# since pwsh is not a reasonable thing to require; its quoting is covered by
+# the assertions above instead.
+#
 # Needs node. Skips (exit 0) rather than failing when it is absent, the same
-# way secureboot-authvars.test.sh skips without efitools.
+# way secureboot-authvars.test.sh skips without efitools. Each interpreter is
+# independently optional and skips on its own.
 #
 # Exit status 0 = pass or skip, 1 = fail.
 
@@ -123,11 +133,18 @@ check(
     'unknown: ' + unknown.join(', ')
 );
 
-// 3. The whole point: PowerShell means Invoke-RestMethod, not curl.exe.
+// 3. The whole point: a PowerShell tab that is PowerShell.
+//
+// Swagger UI's curl_powershell is currently offered alongside it, on purpose,
+// so the two can be compared on a live server before one is dropped -- so this
+// no longer asserts its absence. What has to stay true either way is that the
+// tab titled PowerShell is ours and is distinct from the curl.exe one.
 check(
-    'curl_powershell is not offered',
-    (config.languages || []).indexOf('curl_powershell') < 0,
-    'the curl.exe tab is back; it is what the PowerShell generator replaces'
+    'a PowerShell tab is offered and is FOG\'s own generator',
+    (config.languages || []).indexOf('powershell') >= 0
+        && typeof fns.requestSnippetGenerator_powershell === 'function'
+        && config.generators.powershell.title === 'PowerShell',
+    JSON.stringify(config.generators.powershell)
 );
 
 const jsonRequest = map({
@@ -139,7 +156,10 @@ const jsonRequest = map({
         accept: 'application/json'
     }),
     body: JSON.stringify({
-        name: 'lab-pc-01',
+        // The apostrophe and the #{} are the fixture, not decoration: they are
+        // what PowerShell's single quotes, PHP's single quotes and Ruby's
+        // interpolation each have to survive.
+        name: "Bill's #{PC}",
         enforce: true,
         imageID: 3,
         ip: null
@@ -149,6 +169,8 @@ const jsonRequest = map({
 const ps = snippets.generators.powershell.fn(jsonRequest);
 const py = snippets.generators.python.fn(jsonRequest);
 const js = snippets.generators.javascript.fn(jsonRequest);
+const rb = snippets.generators.ruby.fn(jsonRequest);
+const php = snippets.generators.php.fn(jsonRequest);
 
 check(
     'PowerShell calls Invoke-RestMethod',
@@ -194,6 +216,51 @@ check(
     js
 );
 
+check(
+    'Ruby uses stdlib net/http, so the snippet needs no gem installed',
+    /^require "net\/http"$/m.test(rb) && /Net::HTTP::Put\.new\(uri\)/.test(rb),
+    rb
+);
+
+// Net::HTTP does not infer TLS from the scheme. Without use_ssl an https URL
+// is spoken to in plaintext, which fails in a way that looks like the server.
+check(
+    'Ruby sets use_ssl from the scheme',
+    /use_ssl: uri\.scheme == "https"/.test(rb),
+    rb
+);
+
+// Not reachable by ruby -c: "#{PC}" parses fine and fails at run time with a
+// NameError, so only an assertion on the text catches it. A description field
+// containing #{...} would otherwise be silently replaced by whatever that
+// evaluated to -- or blow up -- when the snippet is run.
+check(
+    'Ruby escapes #{} so a body is not interpolated',
+    /Bill's \\#\{PC\}/.test(rb),
+    rb
+);
+
+check(
+    'Ruby emits Ruby literals, not JSON ones',
+    /"ip" => nil/.test(rb) && /"enforce" => true/.test(rb) && !/\bnull\b/.test(rb),
+    rb
+);
+
+check(
+    'PHP requests the response body rather than printing it',
+    /CURLOPT_RETURNTRANSFER, true/.test(php)
+        && /CURLOPT_CUSTOMREQUEST, 'PUT'/.test(php),
+    php
+);
+
+// Single-quoted, so nothing in a body is interpolated and only \\ and ' need
+// escaping. A double-quoted literal would eat a $var out of a JSON payload.
+check(
+    'PHP quotes with single quotes and escapes the apostrophe',
+    /'fog-api-token: QUJD'/.test(php) && !/\$payload = \[\s*"/.test(php),
+    php
+);
+
 // A multipart Content-Type has a boundary the client generates. Copying the
 // one Swagger UI sent -- which has none -- overrides that, and the server gets
 // a body it cannot parse.
@@ -210,6 +277,8 @@ const formRequest = map({
 const pyForm = snippets.generators.python.fn(formRequest);
 const jsForm = snippets.generators.javascript.fn(formRequest);
 const psForm = snippets.generators.powershell.fn(formRequest);
+const rbForm = snippets.generators.ruby.fn(formRequest);
+const phpForm = snippets.generators.php.fn(formRequest);
 
 check(
     'Python drops Content-Type on a multipart request',
@@ -221,11 +290,24 @@ check(
     !/multipart\/form-data/.test(jsForm) && /new FormData\(\)/.test(jsForm),
     jsForm
 );
+// set_form and a CURLOPT_POSTFIELDS array both write the header themselves, so
+// both need the boundary-less one out of the way -- but each still names
+// multipart in its own call, which is why these look for the header form.
+check(
+    'Ruby lets set_form write the multipart header',
+    !/request\["Content-Type"\]/.test(rbForm) && /set_form\(\[/.test(rbForm),
+    rbForm
+);
+check(
+    'PHP lets curl write the multipart header',
+    !/'Content-Type: multipart/.test(phpForm) && /new CURLFile\(/.test(phpForm),
+    phpForm
+);
 
 // Swagger UI suffixes repeated form keys; the wire name is what precedes it.
 check(
     'the _**[] form-key marker is stripped',
-    !/_\*\*\[\]/.test(pyForm + jsForm + psForm),
+    !/_\*\*\[\]/.test(pyForm + jsForm + psForm + rbForm + phpForm),
     psForm
 );
 
@@ -248,7 +330,9 @@ check(
     'a body-less request produces no body',
     !/-Body/.test(snippets.generators.powershell.fn(bare))
         && !/payload/.test(snippets.generators.python.fn(bare))
-        && !/body:/.test(snippets.generators.javascript.fn(bare)),
+        && !/body:/.test(snippets.generators.javascript.fn(bare))
+        && !/request\.body/.test(snippets.generators.ruby.fn(bare))
+        && !/CURLOPT_POSTFIELDS/.test(snippets.generators.php.fn(bare)),
     snippets.generators.powershell.fn(bare)
 );
 
@@ -260,6 +344,113 @@ if [[ $? -eq 0 ]]; then
 else
     FAIL=$((FAIL + 1))
 fi
+
+# --- does the generated code actually parse? -------------------------------
+#
+# Written out across four body shapes chosen for their quoting: a JSON document
+# carrying an apostrophe and a #{} that Ruby would interpolate, a bare GET, a
+# multipart upload whose filename has an apostrophe in it, and a raw body with
+# newlines, a backslash, a double quote and a $var in it.
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+node - "$SNIPPETS" "$WORK" <<'NODEEOF'
+'use strict';
+const fs = require('fs');
+const snippets = require(process.argv[2]);
+const out = process.argv[3];
+
+function map(obj) {
+    return {
+        get: (key) => obj[key],
+        forEach: (cb) => Object.keys(obj).forEach((key) => cb(obj[key], key)),
+        size: Object.keys(obj).length
+    };
+}
+
+const cases = {
+    json: map({
+        url: 'https://fog.example.org/fog/host/42/edit',
+        method: 'PUT',
+        headers: map({ 'fog-api-token': 'QUJD', 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+            name: "Bill's #{PC}",
+            imageID: 3,
+            enforce: true,
+            ip: null,
+            macs: ['00:11:22:33:44:55'],
+            nested: { key: 'value' }
+        }, null, 2)
+    }),
+    bare: map({
+        url: 'https://fog.example.org/fog/host',
+        method: 'GET',
+        headers: map({ 'fog-api-token': 'QUJD' })
+    }),
+    form: map({
+        url: 'https://fog.example.org/fog/snapin/createwithfile',
+        method: 'POST',
+        headers: map({ 'Content-Type': 'multipart/form-data' }),
+        body: map({
+            name: 'thing',
+            'file_**[]': { name: "o'brien.exe", size: 1, type: 'application/octet-stream' }
+        })
+    }),
+    raw: map({
+        url: 'https://fog.example.org/fog/system/thing',
+        method: 'POST',
+        headers: map({ 'Content-Type': 'text/plain' }),
+        body: 'line one\nit\'s \\ "quoted" $var\nline three'
+    })
+};
+
+const EXT = {
+    powershell: 'ps1',
+    python: 'py',
+    javascript: 'mjs',
+    ruby: 'rb',
+    php: 'php'
+};
+
+Object.keys(cases).forEach((name) => {
+    Object.keys(snippets.generators).forEach((lang) => {
+        fs.writeFileSync(
+            out + '/' + name + '.' + lang + '.' + EXT[lang],
+            snippets.generators[lang].fn(cases[name])
+        );
+    });
+});
+NODEEOF
+
+# Each interpreter is optional. A machine without ruby still gets every other
+# check rather than the whole section going quiet.
+syntax_check() {
+    local label="$1" tool="$2" glob="$3"
+    shift 3
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "SKIP: $label syntax check ($tool is not installed)"
+        return
+    fi
+    local bad_files=0 f out
+    for f in "$WORK"/*."$glob"; do
+        [[ -f $f ]] || continue
+        if ! out="$("$@" "$f" 2>&1)"; then
+            echo "      $(basename "$f"): $out"
+            bad_files=$((bad_files + 1))
+        fi
+    done
+    if [[ $bad_files -eq 0 ]]; then
+        ok "generated $label parses"
+    else
+        bad "generated $label does not parse ($bad_files snippet(s))"
+    fi
+}
+
+syntax_check PHP php php php -l
+syntax_check Python python3 py     python3 -c 'import ast, sys; ast.parse(open(sys.argv[1]).read())'
+syntax_check Ruby ruby rb ruby -c
+syntax_check JavaScript node mjs node --check
 
 echo
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
Turns on Swagger UI's request-snippet panel on the API Documentation page and adds five generators to it, so the try-it console shows the call you just ran in the language you want to write it in.

Every generator that exists is currently on — eight tabs. That is deliberate and **not the intended end state**: it is a menu to cull from once it can be seen on a real server. Culling is deleting entries from `LANGUAGES` in `fog.apidocs.snippets.js`; a generator dropped from there stays available for a reversal.

| Tab | Source |
|---|---|
| cURL | Swagger UI built-in |
| cURL (PowerShell) | Swagger UI built-in — `curl.exe`, despite the name |
| cURL (CMD) | Swagger UI built-in |
| PowerShell | new — `Invoke-RestMethod` |
| Python | new — `requests` |
| JavaScript | new — `fetch` |
| Ruby | new — `net/http` from stdlib |
| PHP | new — the cURL extension |

## Two things about this feature that fail silently

Both are worth recording, because neither matches the recipe you'll find if you search for how to do this:

1. **The bundle registers exactly three generators** (`curl_bash`, `curl_cmd`, `curl_powershell`). Naming `python` or `ruby` in `requestSnippets.generators` without also registering a matching `fn.requestSnippetGenerator_*` does not warn — `getSnippetGenerators()` filters the entry out and the tab never appears, so the setting looks inert.
2. **A `generators` map passed in config is *merged* into Swagger UI's own, not substituted for it.** Listing four still rendered six tabs. `languages` is the allowlist the selector filters the merged map through, so it is the only thing that actually decides what appears.

Also: the bundle's highlighter only registers bash, http, javascript, json, powershell, xml and yaml. An unregistered `syntax` value doesn't throw — react-syntax-highlighter falls back to `highlightAuto()` — so Python, Ruby and PHP are declared honestly and get auto-detected colouring rather than being mislabelled as something that happens to be registered.

## Details that are load-bearing rather than cosmetic

- **PowerShell**: Content-Type leaves the hashtable and becomes `-ContentType`. Windows PowerShell 5.1 refuses restricted headers through `-Headers`. Here-string terminators are emitted at column 0, with a fallback to a quoted literal when a body would close one early. `-Form` attaches files via `Get-Item`, since a string would upload as a text field.
- **Python**: `True`/`None`, not JSON's `true`/`null`, and the payload is a dict passed as `json=` rather than a pre-serialised string.
- **Python, JavaScript, Ruby, PHP** all drop Content-Type on a multipart request — the header Swagger UI sent has no boundary on it and would override the one the client generates.
- **Ruby**: `use_ssl` is set from the scheme explicitly. `Net::HTTP` does not infer it, and without it an `https` URL is spoken to in plaintext.
- **PHP**: single-quoted literals, so a `$var` or a backslash in a body stays literal; `CURLOPT_RETURNTRANSFER` set so `curl_exec` returns the body instead of printing it; the `false` return checked, since an unchecked `curl_exec` and an error page look alike to `json_decode`.
- Non-ASCII is emitted as itself rather than as `\uXXXX`, because JSON's surrogate pairs do not mean the same thing inside a Python or Ruby literal.

The generators duck-type the request rather than importing Immutable, which the bundle does not export — which is also what lets the test exercise them under plain node.

## Testing

`tests/apidocs-request-snippets.test.sh`, wired into `tests/run-all.sh` (150 passed, 0 failed).

It asserts the wiring traps above, then writes every generator's output across four body shapes — JSON carrying an apostrophe and a `#{}`, a bare GET, a multipart upload whose filename has an apostrophe in it, and a raw body with newlines, a backslash, a quote and a `$var` — and feeds each to `php -l`, `ast.parse`, `ruby -c` and `node --check`. Quoting is where a snippet generator goes wrong, and it goes wrong by producing output that reads fine and does not run. Each interpreter is independently optional and skips when absent; PowerShell has no equivalent (requiring `pwsh` isn't reasonable), so its quoting stays covered by assertions.

Ruby's `#{}` escaping needs an assertion rather than the parse check: `"#{PC}"` is valid Ruby that fails at run time, so `ruby -c` accepts it. Confirmed by mutation — removing the escape passes the parser and fails the assertion.

Verified end to end in headless Chromium against the real bundle: eight tabs, correct order, correct contents, in light and dark, at 1200px and 820px.

## Dark mode

Swagger UI writes the tab colours inline, so the overrides in `swagger-ui-fog.css` need `!important` — unlike everything else in that file. Left alone the inactive tabs were FOG's dim ink on Swagger's near-white chip: only the *active* tab could be read, which is backwards for a strip whose job is showing what else is on offer.

## Not ported to `dev-branch`

Per `CLAUDE.md`, features land on `working-1.6` first. There is nothing to port here — the 1.5 line has no API Documentation page and no OpenAPI generator at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8SYdjTE1d7xjVKwcR89FL)_