### PR TITLE
Make plugins installable over the API

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -222,6 +222,10 @@ class Authorization extends FOGBase
         'pendingmacs' => 'host.view',
         'snapinCreateWithFile' => 'snapin.create',
         'uploadSnapinFiles' => 'snapin.create',
+        // The node the web Install button checks, rather than plugin.edit:
+        // installing runs a plugin's schema migrations, which is a
+        // different authority from editing its row.
+        'pluginInstall' => 'plugin.install',
         'settingsCacheView' => 'settings.view',
         'settingsCacheFlush' => 'settings.edit',
         'settingsCacheRefresh' => 'settings.edit'

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -2009,8 +2009,73 @@ class OpenAPI extends FOGBase
             '/storagegroup/{id}/uploadsnapinfiles' => [
                 'parameters' => [self::_idParameter()],
                 'post' => self::_uploadSnapinFilesOp()
+            ],
+            '/plugin/{id}/install' => [
+                'parameters' => [self::_idParameter()],
+                'post' => self::_pluginInstallOp()
             ]
         ];
+    }
+
+    /**
+     * POST /plugin/{id}/install.
+     *
+     * Written out here rather than falling out of the generic shapes for
+     * the same reason the upload routes are: it is an action, not CRUD on
+     * a row. The generic edit route cannot express it, and deliberately
+     * refuses to pretend it can -- plugins.installed and plugins.schema
+     * are server-owned, because both record what this operation DID.
+     *
+     * @return array
+     */
+    private static function _pluginInstallOp()
+    {
+        return self::_op(
+            '',
+            'pluginInstall',
+            _('Install a plugin'),
+            _('Activates the plugin, applies its schema migrations, and '
+                . 'records the result -- the same three steps, in the same '
+                . 'order, as the Install action in the web UI. Idempotent: '
+                . 'migration steps are append-only and are resumed from the '
+                . 'count already applied, so calling this on an installed '
+                . 'plugin applies only steps it has not seen, which is what '
+                . 'the UI calls Upgrade. Setting `installed` through the '
+                . 'generic edit route instead is refused: that column '
+                . 'records that this operation succeeded, and asserting it '
+                . 'without running the migrations leaves the plugin\'s '
+                . 'routes in this document while its tables do not exist.'),
+            [
+                '204' => ['description' => _('The plugin is installed and '
+                    . 'its schema is up to date.')],
+                '400' => [
+                    'description' => _('The server refuses to activate this '
+                        . 'plugin; the message says why.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ],
+                '404' => [
+                    'description' => _('No plugin with that id.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ],
+                '500' => [
+                    'description' => _('A migration step failed. The plugin '
+                        . 'is left activated and not marked installed.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ]
+            ]
+        );
     }
 
     /**

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1363,6 +1363,10 @@ class Route extends FOGBase
             [__CLASS__, 'uploadSnapinFiles'],
             'uploadSnapinFiles'
         )->post(
+            '/plugin/[i:id]/install',
+            [__CLASS__, 'pluginInstall'],
+            'pluginInstall'
+        )->post(
             "{$expandedw}/[create|new]?",
             [__CLASS__, 'create'],
             'create'
@@ -4479,6 +4483,86 @@ class Route extends FOGBase
                 $e->getMessage()
             );
         } catch (\RuntimeException $e) {
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                $e->getMessage()
+            );
+        }
+    }
+    /**
+     * Installs a plugin: activate, create its tables, then record it.
+     *
+     * POST /plugin/{id}/install.
+     *
+     * The same three steps PluginManagementPage::installPost() performs,
+     * in the same order, because the order is the contract: state first,
+     * then Plugin::installdb() to apply the plugin's schema migrations,
+     * and installed=1 LAST so the column only ever claims an install that
+     * actually happened.
+     *
+     * installdb() is called unconditionally rather than only for a plugin
+     * that is not yet installed. Migration steps are append-only and
+     * idempotent by contract (docs/PLUGIN_SCHEMA_MIGRATIONS.md) and
+     * Schema::applyUpdates() resumes from the stored count, so calling it
+     * on an installed plugin applies only steps it has not seen -- which
+     * is what the Upgrade action does. One route therefore installs, and
+     * brings a plugin whose code ships newer schema() steps up to date,
+     * without a drop and recreate.
+     *
+     * That also makes it the repair for a row whose installed flag was set
+     * without the tables ever being created. The web Install action cannot
+     * do it: installPost() filters on installed IN ('', 0, '0'), so it
+     * skips a plugin that already claims to be installed.
+     *
+     * @param int $id The plugin id.
+     *
+     * @return void
+     */
+    public static function pluginInstall($id)
+    {
+        try {
+            $Plugin = self::getClass('Plugin', (int)$id);
+            if (!$Plugin->isValid()) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_NOT_FOUND,
+                    _('Plugin not found')
+                );
+                return;
+            }
+            // Same gate the page applies. A blocked plugin is one the
+            // server has a reason to refuse -- a conflict with a core
+            // feature that replaced it, for instance -- and the API must
+            // not be the way around it.
+            $blockers = Plugin::activationBlockers([$Plugin->get('id')]);
+            if (count($blockers)) {
+                $reasons = [];
+                foreach ($blockers as $name => $reason) {
+                    $reasons[] = sprintf('%s %s', $name, $reason);
+                }
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_BAD_REQUEST,
+                    implode('; ', $reasons)
+                );
+                return;
+            }
+            $Plugin->set('state', 1)->save();
+            if (!$Plugin->installdb()) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                    sprintf(
+                        // translators: %s is the plugin name.
+                        _('Failed to install %s'),
+                        $Plugin->get('name')
+                    )
+                );
+                return;
+            }
+            // Written here, by the server, having done the work. The
+            // generic edit route refuses this column for exactly that
+            // reason -- see Route::$serverOwnedFields.
+            $Plugin->set('installed', 1)->save();
+            self::sendResponse(HTTPResponseCodes::HTTP_NO_CONTENT);
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
                 $e->getMessage()

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -383,6 +383,36 @@ class Route extends FOGBase
         'user' => [
             'token',
         ],
+        // Both record what the installer DID, and are written by it only
+        // after it succeeded. PluginManagementPage::installPost() sets
+        // state, then runs Plugin::installdb() to create the tables, and
+        // writes installed=1 last; Plugin::installdb() writes schema to
+        // the number of migration steps it applied.
+        //
+        // Accepting them over the generic edit route lets a client assert
+        // an install that never happened. Measured: PUT /plugin/{id}/edit
+        // with installed=1 on an uninstalled plugin registers the plugin's
+        // classes -- so its routes and schemas appear in GET
+        // system/openapi -- while no table is ever created, and every one
+        // of those routes then answers
+        //
+        //   406  SQLSTATE[42S02]: Base table or view not found
+        //
+        // A client generated from that document gets commands guaranteed
+        // to fail. It also hides from the repair path most admins would
+        // reach for: installPost() only calls installdb() for plugins
+        // filtered on installed IN ('', 0, '0'), so the Install button
+        // skips a row that already claims to be installed. upgradePost()
+        // is what fixes it, and nothing says so.
+        //
+        // state is deliberately NOT here. Activating is a column write and
+        // nothing else -- installPost() and the Activate action both just
+        // set state=1 -- so a client writing it does the whole job rather
+        // than half of it.
+        'plugin' => [
+            'installed',
+            'schema',
+        ],
     ];
     /**
      * Memoized union of the list above and what plugins declare through


### PR DESCRIPTION
Makes plugins installable over the API, and stops the API being able to claim an install that never happened. Those are the same problem from two sides, so they are one PR.

## The problem

Install was reachable only as a management-page POST behind a session and CSRF. The REST API exposed the plugin row as a generic entity, so a client could write `installed` and `schema` directly — the two columns that *record what the installer did*.

`PluginManagementPage::installPost()` shows why that ordering matters: it sets `state`, then calls `Plugin::installdb()` to create the tables, and writes `installed = 1` **last**.

Measured against a real server, on the bundled `location` plugin:

```
PUT /plugin/2/edit  {"installed":"1","state":"1"}   -> 200

GET system/openapi     58 schemas -> 60
                       Location, Locationassociation now present

GET /location          406  SQLSTATE[42S02]: Base table or view not found
GET /location/count    406  SQLSTATE[42S02]: ...
GET /locationassociation
                       406  SQLSTATE[42S02]: ...
```

Setting the column registers the plugin's classes — enough for its routes and schemas to appear in the document — while `schema` stays `0` and no table is ever created. **The server's own OpenAPI document then advertises routes that cannot answer**, and a client generated from it gets commands guaranteed to fail.

It also hides from the obvious repair: `installPost()` filters on `installed IN ('', 0, '0')`, so the **Install** button *skips* a row that already claims to be installed.

## 1. `POST /plugin/{id}/install`

The same three steps as `installPost()`, in the same order — activate, `installdb()`, then `installed = 1` last. Activation blockers are refused first, the same gate the page applies, so the API is not a way around a plugin the server has a reason to refuse.

`installdb()` is called **unconditionally** rather than only when the plugin is not yet installed. Migration steps are append-only and idempotent by contract (`docs/PLUGIN_SCHEMA_MIGRATIONS.md`) and `Schema::applyUpdates()` resumes from the stored count, so calling it on an installed plugin applies only steps it has not seen — which is what the UI calls **Upgrade**. One route therefore installs, *and* brings a plugin whose code ships newer `schema()` steps up to date, without a drop and recreate.

That also makes it the repair for a row broken the way the one above was — which the Install button structurally cannot fix.

Permission is **`plugin.install`**, the node the web Install button checks, rather than `plugin.edit`: running a plugin's schema migrations is a different authority from editing its row. Declared in `API_ROUTE_PERMISSIONS` rather than relying on the fail-closed default in `resolveApiPermission()`.

## 2. `plugins.installed` and `plugins.schema` become server-owned

One entry in `Route::$serverOwnedFields`. That list already drives `_refuseServerOwned()`, which answers **400 only when the value would change**, so reading a plugin and sending the object back unmodified still works. `openapi.class.php` reads the same list, so the document marks both `readOnly` with the standard server-owned description.

**`state` is deliberately not included.** Activating is a column write and nothing else — `installPost()` and the Activate action both just set `state = 1` — so a client writing it does the whole job rather than half of it. Activation over the API keeps working exactly as before.

## Verification

Regenerated the document with `spec/tools/dump-openapi.php`:

```
/plugin/{id}/install   operationId=pluginInstall
                       responses 204/400/401/403/404/500
                       x-fog-permission=plugin.install

Plugin.installed  readOnly=True
Plugin.schema     readOnly=True
Plugin.state      readOnly=None
```

373 paths, up from 372. `php -l` clean on all three files; added lines within the 80-column style.

**Not yet exercised at runtime.** I have not run `POST /plugin/{id}/install` against a server built from this branch — the reproduction above was done against a stock server before the fix. The refusal half rides on the pre-existing `_refuseServerOwned()` path, unchanged here and already exercised by the `task`/`host`/`user` entries; the install handler is new code and deserves a real run. Happy to do that once it is deployed somewhere, or tell me if you would rather it come with a test.
