### PR TITLE
Store a PHP boolean as '0'/'1', never as ''

### DIFF
--- a/packages/web/lib/db/pdodb.class.php
+++ b/packages/web/lib/db/pdodb.class.php
@@ -946,6 +946,38 @@ class PDODB extends DatabaseManager
         if (is_null($type)) {
             $type = PDO::PARAM_STR;
         }
+        /*
+         * A PHP boolean bound as a string is the string cast of it, and
+         * (string)false is ''. Every caller reaches this method with the
+         * default PDO::PARAM_STR, so `->set('shutdown', $action ==
+         * 'shutdown')` -- an ordinary comparison, and how Snapin::save() has
+         * always spelled it -- stored '' into `snapins`.`sShutdown`, an
+         * enum('0','1'). That is error 1265, "Data truncated for column
+         * 'sShutdown' at row 1", on any server with STRICT_TRANS_TABLES.
+         *
+         * It is the same defect as GH-1245 arriving by a different door.
+         * save()'s emptyValueFor() only recognises null and '' as empty, so
+         * a boolean walks straight past it, and the manager UPDATE path
+         * (HostManager::update() writing `hosts`.`hostInfoLock` from
+         * ->set('tokenlock', false) at the end of every imaging task) never
+         * went through save() at all. Normalising here is the only place
+         * that covers save(), insertBatch(), the manager builders and
+         * hand-written queries at once.
+         *
+         * '0'/'1' rather than PDO::PARAM_BOOL: bound as an integer, 0
+         * against an ENUM is an *index*, and index 0 is the error value.
+         * As strings they are literal enum members, and a numeric column
+         * coerces them to 0/1. Readers are unaffected either way; '0' is
+         * falsey in PHP exactly as '' was.
+         *
+         * A caller that passes an explicit type is left alone -- it has
+         * said what it means.
+         *
+         * See forum topic 18227.
+         */
+        if (is_bool($value) && $type === PDO::PARAM_STR) {
+            $value = $value ? '1' : '0';
+        }
         self::$_queryResult->bindParam($param, $value, $type);
     }
 }

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -203,9 +203,7 @@ abstract class FOGManagerController extends FOGBase
                 }
                 if (is_array($value) && count($value) > 0) {
                     foreach ($value as $i => &$val) {
-                        if (is_string($val)) {
-                            $val = trim($val);
-                        }
+                        $val = self::_trimValue($val);
                         // Define the key
                         $k = sprintf(
                             '%s_%d',
@@ -249,7 +247,10 @@ abstract class FOGManagerController extends FOGBase
                     if (is_array($value)) {
                         $value = '';
                     }
-                    $value = trim($value);
+                    // Read side, same rule as the write side: a filter
+                    // holding false has to bind the same literal the column
+                    // now stores, or it silently matches nothing.
+                    $value = self::_trimValue($value);
                     $k = sprintf(
                         '%s',
                         $key
@@ -641,6 +642,31 @@ abstract class FOGManagerController extends FOGBase
         return (int)$total;
     }
     /**
+     * Trims a value on its way into a bound parameter, and leaves anything
+     * that is not a string alone.
+     *
+     * Trimming is a string operation, but `trim()` casts first, and the cast
+     * is where the information goes. trim(null) is '' -- and a PHP 8.1
+     * deprecation -- which would put the zero date back into a column being
+     * cleared. trim(false) is also '', which is not how any column in the
+     * schema spells false: enum('0','1') rejects it outright under
+     * STRICT_TRANS_TABLES, and so does the tinyint(1) `hosts`.`hostInfoLock`
+     * that ends every imaging task via ->set('tokenlock', false). And an
+     * array -- a nested IN () list is one -- is a TypeError on PHP 8.
+     *
+     * A boolean is left as a boolean and normalised once, in PDODB::_bind(),
+     * so save() and the builders here cannot disagree about what false
+     * stores. See GH-1245 and forum topic 18227.
+     *
+     * @param mixed $value the value being bound
+     *
+     * @return mixed
+     */
+    private static function _trimValue($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+    /**
      * Inserts data in mass to the database.
      *
      * @param array $fields the fields to insert into
@@ -727,7 +753,7 @@ abstract class FOGManagerController extends FOGBase
                         ':%s',
                         $key
                     );
-                    $val = trim($val);
+                    $val = self::_trimValue($val);
                     $insertVals[$key] = $val;
                     unset($val);
                 }
@@ -818,7 +844,7 @@ abstract class FOGManagerController extends FOGBase
             // GH-1245: null is a value to write, not a string to trim.
             // trim(null) is '' -- and a PHP 8.1 deprecation -- which would
             // put the zero date back into a column being cleared.
-            $value = (null === $value) ? null : trim($value);
+            $value = self::_trimValue($value);
             $updateKey = sprintf(
                 ':update_%s',
                 $field
@@ -843,7 +869,7 @@ abstract class FOGManagerController extends FOGBase
                 $key = trim($field);
                 if (is_array($value) && count($value) > 0) {
                     foreach ($value as $i => &$val) {
-                        $val = trim($val);
+                        $val = self::_trimValue($val);
                         // Define the key
                         $k = sprintf(
                             '%s_%d',
@@ -885,7 +911,10 @@ abstract class FOGManagerController extends FOGBase
                     if (is_array($value)) {
                         $value = '';
                     }
-                    $value = trim($value);
+                    // Read side, same rule as the write side: a filter
+                    // holding false has to bind the same literal the column
+                    // now stores, or it silently matches nothing.
+                    $value = self::_trimValue($value);
                     $k = sprintf(
                         '%s',
                         $key

--- a/tests/booleans-store-as-zero-or-one.test.php
+++ b/tests/booleans-store-as-zero-or-one.test.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * A PHP boolean must never reach a column as ''.
+ *
+ * Forum topic 18227, reported on 1.6.0-beta.4020 and present here too:
+ * creating a snapin answers
+ * "SQLSTATE[01000]: Warning: 1265 Data truncated for column 'sShutdown' at
+ * row 1". Snapin::save() has always written that column as
+ *
+ *     ->set('shutdown', $action == 'shutdown')
+ *
+ * -- an ordinary comparison, so the value is a real PHP boolean. Every value
+ * FOG binds goes out as PDO::PARAM_STR, and (string)false is ''. Into
+ * `snapins`.`sShutdown`, an enum('0','1'), that is error 1265 on any server
+ * with STRICT_TRANS_TABLES.
+ *
+ * It is GH-1245 arriving by a different door. save()'s emptyValueFor() only
+ * recognises null and '' as empty, so a boolean walks past it untouched; and
+ * the two builders in FOGManagerController called trim() first, which casts
+ * before it trims, so false was already '' by the time it reached the binder.
+ * The manager path is the one that ends every imaging task -- TaskQueue does
+ * ->set('tokenlock', false) and hands it to HostManager::update(), against
+ * `hosts`.`hostInfoLock`, a tinyint(1).
+ *
+ * What this pins is the MECHANISM, not today's call sites. Listing the
+ * ->set() calls that currently pass a boolean would go green the moment
+ * someone wrote another one, which is precisely how this arrived.
+ *
+ *   1. PDODB::_bind() normalises a boolean, as a STRING, before binding.
+ *   2. It does not reach for PDO::PARAM_BOOL/PARAM_INT to do it: bound as an
+ *      integer, 0 against an ENUM is an *index*, and index 0 is the error
+ *      value -- the same trap Schema::defaultLiteral() exists for.
+ *   3. Neither builder in FOGManagerController flattens a value with a bare
+ *      trim() on its way into a bind array.
+ *   4. FOGController::save() still guards its own trim with is_string(), so
+ *      the boolean survives as far as the binder.
+ *
+ * DB-free: this reads the source, like insertbatch-required-columns. The
+ * behaviour is proved against a live strict server, through the real ORM,
+ * by background_scripts/prove_boolean_column_writes.php, run against the
+ * 1.5 database.
+ *
+ * Usage: php tests/booleans-store-as-zero-or-one.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $what      what is being asserted
+ * @param bool   $ok        whether it holds
+ * @param array  $failures  collected failures
+ * @param int    $checks    running count
+ *
+ * @return void
+ */
+function bcheck($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+/**
+ * Source with comments removed, so a commented-out line cannot satisfy a
+ * check and a sentence in a docblock cannot fail one.
+ *
+ * @param string $src the file's source
+ *
+ * @return string
+ */
+function bStripComments($src)
+{
+    $clean = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    return $clean;
+}
+
+$pdoSrc = bStripComments(
+    (string) file_get_contents("$root/packages/web/lib/db/pdodb.class.php")
+);
+$manSrc = bStripComments(
+    (string) file_get_contents(
+        "$root/packages/web/lib/fog/fogmanagercontroller.class.php"
+    )
+);
+$ctlSrc = bStripComments(
+    (string) file_get_contents(
+        "$root/packages/web/lib/fog/fogcontroller.class.php"
+    )
+);
+
+// --- 1. the binder normalises, and does it before bindValue() -------------
+$bindBody = '';
+if (preg_match(
+    '#private static function _bind\([^)]*\)\s*\{(.*?)\n    \}#s',
+    $pdoSrc,
+    $m
+)) {
+    $bindBody = $m[1];
+}
+bcheck('PDODB::_bind() was found', $bindBody !== '', $failures, $checks);
+bcheck(
+    'PDODB::_bind() tests the value with is_bool()',
+    (bool) preg_match('#is_bool\(\$value\)#', $bindBody),
+    $failures,
+    $checks
+);
+bcheck(
+    "PDODB::_bind() maps a boolean onto the strings '1' and '0'",
+    (bool) preg_match(
+        "#\\\$value\s*=\s*\\\$value\s*\?\s*'1'\s*:\s*'0'#",
+        $bindBody
+    ),
+    $failures,
+    $checks
+);
+$boolPos = strpos($bindBody, 'is_bool($value)');
+$callPos = strpos($bindBody, 'bindParam(');
+bcheck(
+    'PDODB::_bind() normalises BEFORE it binds',
+    $boolPos !== false && $callPos !== false && $boolPos < $callPos,
+    $failures,
+    $checks
+);
+
+// --- 2. not as an integer -------------------------------------------------
+// An ENUM column takes an integer as a MEMBER INDEX, and index 0 is the
+// error value, so PARAM_BOOL/PARAM_INT would store the very thing this is
+// meant to stop -- silently, because that write succeeds.
+foreach (['PARAM_BOOL', 'PARAM_INT'] as $wrong) {
+    bcheck(
+        "PDODB::_bind() does not reach for PDO::$wrong",
+        strpos($bindBody, $wrong) === false,
+        $failures,
+        $checks
+    );
+}
+
+// --- 3. neither builder flattens a value with a bare trim() ---------------
+// $field/$key are column NAMES and are still trimmed directly; only the
+// values going into a bind array are at issue here.
+foreach (['$val', '$value'] as $var) {
+    bcheck(
+        "FOGManagerController does not assign trim($var) directly",
+        !preg_match(
+            '#' . preg_quote($var, '#') . '\s*=\s*trim\(#',
+            $manSrc
+        ),
+        $failures,
+        $checks
+    );
+}
+
+// --- 4. and the helper it uses instead keeps both non-strings intact ------
+$helper = '';
+if (preg_match(
+    '#private static function _trimValue\(\$value\)\s*\{.*?\n    \}#s',
+    $manSrc,
+    $m
+)) {
+    $helper = $m[0];
+}
+bcheck(
+    'FOGManagerController::_trimValue() was found',
+    $helper !== '',
+    $failures,
+    $checks
+);
+if ($helper !== '') {
+    // Run the shipped method rather than restating its rule.
+    eval('class BtHelper { ' . str_replace('private static', 'public static', $helper) . ' }');
+    $cases = [
+        'null stays null' => [null, null],
+        'false stays false' => [false, false],
+        'true stays true' => [true, true],
+        'a string is still trimmed' => ['  x  ', 'x'],
+        'an int stays an int' => [0, 0],
+        // A nested IN () list arrives here as an array, and trim() on one is
+        // a TypeError -- fatal, not a warning, on PHP 8.
+        'an array is handed back untouched' => [['a'], ['a']],
+    ];
+    foreach ($cases as $what => $case) {
+        list($in, $want) = $case;
+        $got = BtHelper::_trimValue($in);
+        bcheck(
+            "_trimValue(): $what",
+            $got === $want,
+            $failures,
+            $checks
+        );
+    }
+}
+
+// --- 5. save() must not flatten it either --------------------------------
+bcheck(
+    'FOGController::save() guards its trim with is_string()',
+    (bool) preg_match(
+        '#is_string\(\$val\)\s*\)\s*\{\s*\$val\s*=\s*trim\(\$val\);#',
+        $ctlSrc
+    ),
+    $failures,
+    $checks
+);
+
+printf("%d checks\n", $checks);
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        printf("  FAIL  %s\n", $f);
+    }
+    printf("%d failed\n", count($failures));
+    exit(1);
+}
+printf("all passed\n");
+exit(0);

--- a/tests/empty-values-and-strict-sql-mode.test.php
+++ b/tests/empty-values-and-strict-sql-mode.test.php
@@ -198,11 +198,22 @@ evCheck(
         $nullArms
     )
 );
+// perform_update() used to spell this inline as
+// `$value = (null === $value) ? null : trim($value);`. Forum topic 18227
+// moved it to _trimValue(), which additionally has to survive a boolean and
+// an array -- see booleans-store-as-zero-or-one.test.php. What matters here
+// is unchanged: null must reach the bind array as null.
 evCheck(
-    strpos($mSquashed, '$value=(null===$value)?null:trim($value);') !== false,
+    strpos($mSquashed, '$value=self::_trimValue($value);') !== false
+    || strpos($mSquashed, '$value=(null===$value)?null:trim($value);') !== false,
     'FOGManagerController::perform_update() trims the value again. '
     . "trim(null) is '' -- and a PHP 8.1 deprecation -- which puts the zero "
     . 'date straight back into a column being cleared.'
+);
+evCheck(
+    strpos($mSquashed, 'is_string($value)?trim($value):$value') !== false,
+    'FOGManagerController::_trimValue() no longer leaves a non-string alone, '
+    . 'so null goes back to being trimmed into the zero date.'
 );
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
Port of working-1.6 #1361. The defect is present here unchanged.

Reported on the forums against 1.6.0-beta.4020 — https://forums.fogproject.org/topic/18227/fog-supported-os — but the code is the same on this branch:

```
SQLSTATE[01000]: Warning: 1265 Data truncated for column 'sShutdown' at row 1
```

## Cause

`Snapin::save()` writes `->set('shutdown', $action == 'shutdown')`, so the value is a real PHP boolean. `PDODB::_bind()` binds every value as `PDO::PARAM_STR`, and `(string)false` is `''`. Into `snapins`.`sShutdown`, an `enum('0','1')`, that is error 1265 on any server with `STRICT_TRANS_TABLES`.

GH-1245 arriving by a different door: `save()`'s `emptyValueFor()` recognises only `null` and `''` as empty, so a boolean walks past it. It stayed invisible until GH-1245 removed `SET SESSION sql_mode=''` — before that the server coerced `''` to the enum's **error value** and said nothing.

## The worse half

`TaskQueue` ends every imaging task with `->set('tokenlock', false)` handed to `HostManager::update()`, against `hosts`.`hostInfoLock`, a `tinyint(1)`. Both builders called `trim()` on the way into the bind array, and `trim()` casts before it trims — so `false` was already `''` before the binder saw it. Under a strict `sql_mode` that update returns `false` and `Post_Stage*.php` raises `Failed to update host`: imaging completes on the client and is never recorded.

## Fix

At the binder, the only point `save()`, `perform_update()`, `insertBatch()` and hand-written queries all pass through. `'0'`/`'1'` as **strings**, not `PDO::PARAM_BOOL` — bound as an integer, `0` against an `ENUM` is a member *index*, and index 0 is the error value.

`_trimValue()` replaces the value-trims in both WHERE builders as well as the two write builders, so a filter holding `false` binds the literal the column now stores instead of silently matching nothing. It trims strings and hands back everything else untouched, which also preserves `find()`'s existing `is_string()` guard — a nested `IN ()` list is an array, and `trim()` on one is a TypeError on PHP 8.

## Verification

Against a **throwaway copy** of a real 1.5.10 database (dumped, loaded into a podman MariaDB 11 with the stock strict `sql_mode`, brought from schema 278 to 286), driven through the real ORM by `background_scripts/prove_boolean_column_writes.php`. It shadows `snapins`/`hosts`/`history` with `CREATE TEMPORARY TABLE` on the same connection, so no live row is touched.

Before:

```
  FAIL  save(): sShutdown stored NULL
  FAIL  save(): sReboot stored NULL
  FAIL  update(): returned false, hostInfoLock=1
  FAIL  insertBatch() threw: 1366 Incorrect integer value: '' for column `fog-1.5`.`hosts`.`hostInfoLock`
```

After: 4/4 pass. Suite: 36 passed, 0 failed.

`tests/empty-values-and-strict-sql-mode.test.php` pinned `perform_update()`'s old inline ternary by its exact text; it now accepts either spelling and additionally pins `_trimValue()`'s rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)