### PR TITLE
Make plugins installable over the API (fixes #1360)

### DIFF
--- a/packages/web/lib/fog/authorization.class.php
+++ b/packages/web/lib/fog/authorization.class.php
@@ -222,6 +222,10 @@ class Authorization extends FOGBase
         'pendingmacs' => 'host.view',
         'snapinCreateWithFile' => 'snapin.create',
         'uploadSnapinFiles' => 'snapin.create',
+        // The node the web Install button checks, rather than plugin.edit:
+        // installing runs a plugin's schema migrations, which is a
+        // different authority from editing its row.
+        'pluginInstall' => 'plugin.install',
         'settingsCacheView' => 'settings.view',
         'settingsCacheFlush' => 'settings.edit',
         'settingsCacheRefresh' => 'settings.edit'

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -2009,8 +2009,73 @@ class OpenAPI extends FOGBase
             '/storagegroup/{id}/uploadsnapinfiles' => [
                 'parameters' => [self::_idParameter()],
                 'post' => self::_uploadSnapinFilesOp()
+            ],
+            '/plugin/{id}/install' => [
+                'parameters' => [self::_idParameter()],
+                'post' => self::_pluginInstallOp()
             ]
         ];
+    }
+
+    /**
+     * POST /plugin/{id}/install.
+     *
+     * Written out here rather than falling out of the generic shapes for
+     * the same reason the upload routes are: it is an action, not CRUD on
+     * a row. The generic edit route cannot express it, and deliberately
+     * refuses to pretend it can -- plugins.installed and plugins.schema
+     * are server-owned, because both record what this operation DID.
+     *
+     * @return array
+     */
+    private static function _pluginInstallOp()
+    {
+        return self::_op(
+            '',
+            'pluginInstall',
+            _('Install a plugin'),
+            _('Activates the plugin, applies its schema migrations, and '
+                . 'records the result -- the same three steps, in the same '
+                . 'order, as the Install action in the web UI. Idempotent: '
+                . 'migration steps are append-only and are resumed from the '
+                . 'count already applied, so calling this on an installed '
+                . 'plugin applies only steps it has not seen, which is what '
+                . 'the UI calls Upgrade. Setting `installed` through the '
+                . 'generic edit route instead is refused: that column '
+                . 'records that this operation succeeded, and asserting it '
+                . 'without running the migrations leaves the plugin\'s '
+                . 'routes in this document while its tables do not exist.'),
+            [
+                '204' => ['description' => _('The plugin is installed and '
+                    . 'its schema is up to date.')],
+                '400' => [
+                    'description' => _('The server refuses to activate this '
+                        . 'plugin; the message says why.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ],
+                '404' => [
+                    'description' => _('No plugin with that id.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ],
+                '500' => [
+                    'description' => _('A migration step failed. The plugin '
+                        . 'is left activated and not marked installed.'),
+                    'content' => [
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/Error']
+                        ]
+                    ]
+                ]
+            ]
+        );
     }
 
     /**

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -2030,7 +2030,7 @@ class OpenAPI extends FOGBase
      */
     private static function _pluginInstallOp()
     {
-        return self::_op(
+        $op = self::_op(
             '',
             'pluginInstall',
             _('Install a plugin'),
@@ -2050,7 +2050,10 @@ class OpenAPI extends FOGBase
                     . 'its schema is up to date.')],
                 '400' => [
                     'description' => _('The server refuses to activate this '
-                        . 'plugin; the message says why.'),
+                        . 'plugin, or the plugin declares no schema() '
+                        . 'migrations and is already installed, so '
+                        . 're-running its installer would drop and recreate '
+                        . 'its tables. The message says which.'),
                     'content' => [
                         'application/json' => [
                             'schema' => ['$ref' => '#/components/schemas/Error']
@@ -2076,6 +2079,14 @@ class OpenAPI extends FOGBase
                 ]
             ]
         );
+        // Grouped under plugin rather than system, the same way the two
+        // upload routes are grouped under snapin and storagegroup. _op()
+        // takes the tag from its class argument, which has to stay empty
+        // here so the operation id and the permission lookup both key off
+        // the fixed-route name -- but a reader looking for this opens the
+        // plugin tag, not system.
+        $op['tags'] = ['plugin'];
+        return $op;
     }
 
     /**

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -1363,6 +1363,10 @@ class Route extends FOGBase
             [__CLASS__, 'uploadSnapinFiles'],
             'uploadSnapinFiles'
         )->post(
+            '/plugin/[i:id]/install',
+            [__CLASS__, 'pluginInstall'],
+            'pluginInstall'
+        )->post(
             "{$expandedw}/[create|new]?",
             [__CLASS__, 'create'],
             'create'
@@ -4479,6 +4483,86 @@ class Route extends FOGBase
                 $e->getMessage()
             );
         } catch (\RuntimeException $e) {
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                $e->getMessage()
+            );
+        }
+    }
+    /**
+     * Installs a plugin: activate, create its tables, then record it.
+     *
+     * POST /plugin/{id}/install.
+     *
+     * The same three steps PluginManagementPage::installPost() performs,
+     * in the same order, because the order is the contract: state first,
+     * then Plugin::installdb() to apply the plugin's schema migrations,
+     * and installed=1 LAST so the column only ever claims an install that
+     * actually happened.
+     *
+     * installdb() is called unconditionally rather than only for a plugin
+     * that is not yet installed. Migration steps are append-only and
+     * idempotent by contract (docs/PLUGIN_SCHEMA_MIGRATIONS.md) and
+     * Schema::applyUpdates() resumes from the stored count, so calling it
+     * on an installed plugin applies only steps it has not seen -- which
+     * is what the Upgrade action does. One route therefore installs, and
+     * brings a plugin whose code ships newer schema() steps up to date,
+     * without a drop and recreate.
+     *
+     * That also makes it the repair for a row whose installed flag was set
+     * without the tables ever being created. The web Install action cannot
+     * do it: installPost() filters on installed IN ('', 0, '0'), so it
+     * skips a plugin that already claims to be installed.
+     *
+     * @param int $id The plugin id.
+     *
+     * @return void
+     */
+    public static function pluginInstall($id)
+    {
+        try {
+            $Plugin = self::getClass('Plugin', (int)$id);
+            if (!$Plugin->isValid()) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_NOT_FOUND,
+                    _('Plugin not found')
+                );
+                return;
+            }
+            // Same gate the page applies. A blocked plugin is one the
+            // server has a reason to refuse -- a conflict with a core
+            // feature that replaced it, for instance -- and the API must
+            // not be the way around it.
+            $blockers = Plugin::activationBlockers([$Plugin->get('id')]);
+            if (count($blockers)) {
+                $reasons = [];
+                foreach ($blockers as $name => $reason) {
+                    $reasons[] = sprintf('%s %s', $name, $reason);
+                }
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_BAD_REQUEST,
+                    implode('; ', $reasons)
+                );
+                return;
+            }
+            $Plugin->set('state', 1)->save();
+            if (!$Plugin->installdb()) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                    sprintf(
+                        // translators: %s is the plugin name.
+                        _('Failed to install %s'),
+                        $Plugin->get('name')
+                    )
+                );
+                return;
+            }
+            // Written here, by the server, having done the work. The
+            // generic edit route refuses this column for exactly that
+            // reason -- see Route::$serverOwnedFields.
+            $Plugin->set('installed', 1)->save();
+            self::sendResponse(HTTPResponseCodes::HTTP_NO_CONTENT);
+        } catch (\Exception $e) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
                 $e->getMessage()

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -4156,6 +4156,38 @@ class Route extends FOGBase
                             ->addHost($hostsToAdd);
                     }
                     break;
+                case 'plugin':
+                    // installed and schema are server-owned, but state is
+                    // deliberately not: activating is a plain column write
+                    // and doing it over the API is legitimate. What is NOT
+                    // legitimate is using it to switch on a plugin the
+                    // server refuses to run -- an installed plugin left
+                    // deactivated because a FOG upgrade moved past its
+                    // fog_max is exactly the case activationBlockers()
+                    // exists for, and without this it is one PUT away from
+                    // loading on every boot (installed=1 AND state=1 is
+                    // what getActivePlugins() selects on).
+                    //
+                    // Gated on the TRANSITION to active, read from the
+                    // stored row rather than the mutated object, for the
+                    // same reason _refuseServerOwned() compares values: a
+                    // client that reads a plugin and PUTs it back
+                    // unchanged is asking for nothing, and an ordinary
+                    // description edit on an already-active plugin must
+                    // not start failing the day it becomes blocked.
+                    if (isset($vars->state)
+                        && (int)$vars->state === 1
+                        && !(int)self::getClass('Plugin', $id)->get('state')
+                    ) {
+                        $blockers = Plugin::activationBlockers([(int)$id]);
+                        if (count($blockers)) {
+                            self::setErrorMessage(
+                                self::_blockerReasons($blockers),
+                                HTTPResponseCodes::HTTP_BAD_REQUEST
+                            );
+                        }
+                    }
+                    break;
             }
             // Store the data and recreate.
             // If failed present so.
@@ -4505,6 +4537,27 @@ class Route extends FOGBase
         }
     }
     /**
+     * Flattens Plugin::activationBlockers() into one readable sentence.
+     *
+     * Shared by the two places that refuse an activation -- this route and
+     * the plugin arm of edit() -- so a caller turning a plugin on gets the
+     * same reason whichever way it asked. PluginManagementPage does the
+     * identical join in _refuseBlocked(); it stays there because it throws
+     * rather than answering, and this is the HTTP boundary.
+     *
+     * @param array $blockers name => reason, as activationBlockers returns.
+     *
+     * @return string
+     */
+    private static function _blockerReasons(array $blockers)
+    {
+        $reasons = [];
+        foreach ($blockers as $name => $reason) {
+            $reasons[] = sprintf('%s %s', $name, $reason);
+        }
+        return implode('; ', $reasons);
+    }
+    /**
      * Installs a plugin: activate, create its tables, then record it.
      *
      * POST /plugin/{id}/install.
@@ -4515,14 +4568,19 @@ class Route extends FOGBase
      * and installed=1 LAST so the column only ever claims an install that
      * actually happened.
      *
-     * installdb() is called unconditionally rather than only for a plugin
-     * that is not yet installed. Migration steps are append-only and
+     * installdb() is called without the install-state filter the web
+     * Install button applies. Migration steps are append-only and
      * idempotent by contract (docs/PLUGIN_SCHEMA_MIGRATIONS.md) and
      * Schema::applyUpdates() resumes from the stored count, so calling it
      * on an installed plugin applies only steps it has not seen -- which
      * is what the Upgrade action does. One route therefore installs, and
      * brings a plugin whose code ships newer schema() steps up to date,
      * without a drop and recreate.
+     *
+     * That contract holds only for a plugin that adopted schema(). One
+     * that did not is refused a SECOND install, because installdb() would
+     * fall back to its legacy install() and drop its tables; see the
+     * guard below.
      *
      * That also makes it the repair for a row whose installed flag was set
      * without the tables ever being created. The web Install action cannot
@@ -4538,39 +4596,70 @@ class Route extends FOGBase
         try {
             $Plugin = self::getClass('Plugin', (int)$id);
             if (!$Plugin->isValid()) {
-                self::sendResponse(
-                    HTTPResponseCodes::HTTP_NOT_FOUND,
-                    _('Plugin not found')
+                // setErrorMessage(), not sendResponse(): every error this
+                // route can answer with is documented as the Error schema,
+                // and sendResponse() writes the bare string into a body
+                // labelled application/json. A generated client parses
+                // that and gets a syntax error instead of the reason.
+                self::setErrorMessage(
+                    _('Plugin not found'),
+                    HTTPResponseCodes::HTTP_NOT_FOUND
                 );
-                return;
             }
             // Same gate the page applies. A blocked plugin is one the
             // server has a reason to refuse -- a conflict with a core
             // feature that replaced it, for instance -- and the API must
-            // not be the way around it.
+            // not be the way around it. The generic edit route carries
+            // the other half of this, on `state`; see Route::edit().
             $blockers = Plugin::activationBlockers([$Plugin->get('id')]);
             if (count($blockers)) {
-                $reasons = [];
-                foreach ($blockers as $name => $reason) {
-                    $reasons[] = sprintf('%s %s', $name, $reason);
-                }
-                self::sendResponse(
-                    HTTPResponseCodes::HTTP_BAD_REQUEST,
-                    implode('; ', $reasons)
+                self::setErrorMessage(
+                    self::_blockerReasons($blockers),
+                    HTTPResponseCodes::HTTP_BAD_REQUEST
                 );
-                return;
+            }
+            // installdb() is idempotent only for a manager that adopted
+            // the schema() contract. Without one it falls back to the
+            // legacy install(), whose 1.5 shape opens with uninstall() --
+            // a DROP -- and rebuilds; wolbroadcast destroyed its own
+            // table on every install that way until fog-plugins#24. The
+            // web Install button never met that because it filters on
+            // installed IN ('', 0, '0'), and this route deliberately does
+            // not filter, so the protection has to be restored here or
+            // "install an installed plugin" silently means "empty it".
+            //
+            // A FIRST install of such a plugin is still allowed: there is
+            // nothing to lose, and it is how a legacy plugin has always
+            // been installed. A plugin with no manager at all (hooks
+            // only) has neither method and re-installs as a no-op, which
+            // is correct and must not be refused.
+            $manager = $Plugin->getManager();
+            if ($Plugin->get('installed')
+                && !method_exists($manager, 'schema')
+                && method_exists($manager, 'install')
+            ) {
+                self::setErrorMessage(
+                    sprintf(
+                        // translators: %s is the plugin name.
+                        _('%s does not declare schema() migrations, so '
+                            . 're-installing it would drop and recreate its '
+                            . 'tables. Uninstall it first if that is what '
+                            . 'you want.'),
+                        $Plugin->get('name')
+                    ),
+                    HTTPResponseCodes::HTTP_BAD_REQUEST
+                );
             }
             $Plugin->set('state', 1)->save();
             if (!$Plugin->installdb()) {
-                self::sendResponse(
-                    HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                self::setErrorMessage(
                     sprintf(
                         // translators: %s is the plugin name.
                         _('Failed to install %s'),
                         $Plugin->get('name')
-                    )
+                    ),
+                    HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR
                 );
-                return;
             }
             // Written here, by the server, having done the work. The
             // generic edit route refuses this column for exactly that
@@ -4578,9 +4667,9 @@ class Route extends FOGBase
             $Plugin->set('installed', 1)->save();
             self::sendResponse(HTTPResponseCodes::HTTP_NO_CONTENT);
         } catch (\Exception $e) {
-            self::sendResponse(
-                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
-                $e->getMessage()
+            self::setErrorMessage(
+                $e->getMessage(),
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR
             );
         }
     }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2118,7 +2118,22 @@ class Route extends FOGBase
                     $whereItems['jobID'] = [-1];
                 }
             }
-            if (count($whereItems ?: []) < 1) {
+            // Not under $inputoverride, which the docblock defines as
+            // "override php://input to blank" -- and getsearchbody() reads
+            // php://input and turns any class field it finds there into a
+            // WHERE. The parse_str() branch above was the only thing the
+            // flag suppressed, so every internal Route::getList() call was
+            // still silently filtered by the body of whatever request it
+            // happened to run inside.
+            //
+            // That is not a tidiness point. Plugin::activationBlockers()
+            // lists `plugin` this way to decide whether a plugin may be
+            // switched on, so POST /plugin/{id}/install with an unrelated
+            // body -- {"name":"ldap"} -- listed one row, found the target
+            // was not in it, reported no blockers and installed a plugin
+            // this server refuses to run. Any gate built on a getList() is
+            // defeatable the same way.
+            if (!$inputoverride && count($whereItems ?: []) < 1) {
                 $whereItems = self::getsearchbody($class);
             }
 

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -383,6 +383,36 @@ class Route extends FOGBase
         'user' => [
             'token',
         ],
+        // Both record what the installer DID, and are written by it only
+        // after it succeeded. PluginManagementPage::installPost() sets
+        // state, then runs Plugin::installdb() to create the tables, and
+        // writes installed=1 last; Plugin::installdb() writes schema to
+        // the number of migration steps it applied.
+        //
+        // Accepting them over the generic edit route lets a client assert
+        // an install that never happened. Measured: PUT /plugin/{id}/edit
+        // with installed=1 on an uninstalled plugin registers the plugin's
+        // classes -- so its routes and schemas appear in GET
+        // system/openapi -- while no table is ever created, and every one
+        // of those routes then answers
+        //
+        //   406  SQLSTATE[42S02]: Base table or view not found
+        //
+        // A client generated from that document gets commands guaranteed
+        // to fail. It also hides from the repair path most admins would
+        // reach for: installPost() only calls installdb() for plugins
+        // filtered on installed IN ('', 0, '0'), so the Install button
+        // skips a row that already claims to be installed. upgradePost()
+        // is what fixes it, and nothing says so.
+        //
+        // state is deliberately NOT here. Activating is a column write and
+        // nothing else -- installPost() and the Activate action both just
+        // set state=1 -- so a client writing it does the whole job rather
+        // than half of it.
+        'plugin' => [
+            'installed',
+            'schema',
+        ],
     ];
     /**
      * Memoized union of the list above and what plugins declare through

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -139,6 +139,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -337,6 +341,9 @@ msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Dieser Benutzername ist bereits vorhanden!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -578,6 +585,9 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Activated"
 msgstr "Aktiv"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Aktiv"
@@ -2668,6 +2678,10 @@ msgstr "Verbindung nicht möglich"
 msgid "Failed to install "
 msgstr "Starten fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "Starten fehlgeschlagen"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "Starten fehlgeschlagen"
@@ -4065,6 +4079,10 @@ msgid "Install Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "Plugins installieren"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "Plugins installieren"
 
@@ -5412,6 +5430,10 @@ msgid "No plugin tasks to run"
 msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Keine gültigen Tasks gefunden"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Snapin geschützt"
 
@@ -6139,6 +6161,10 @@ msgstr "Plugin-Name"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Plugin-Name"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8356,6 +8382,9 @@ msgstr "Home-Verzeichnis speichern"
 msgid "The plugin directory does not exist."
 msgstr "Methode ist nicht vorhanden"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "* Anpingen der Hosts ist global deaktiviert"
@@ -8382,6 +8411,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr "läuft nicht mehr"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -144,6 +144,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -342,6 +346,9 @@ msgstr "An image already exists with this name!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "An image already exists with this name!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -582,6 +589,9 @@ msgstr "Remove selected printers"
 #, fuzzy
 msgid "Activated"
 msgstr "Active"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Active"
@@ -2669,6 +2679,10 @@ msgstr "Failed to connect"
 msgid "Failed to install "
 msgstr "Failed to destroy"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "Failed to destroy"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "Failed to destroy"
@@ -4066,6 +4080,10 @@ msgid "Install Plugins"
 msgstr "Install Plugins"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "Install Plugins"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "Install Plugins"
 
@@ -5410,6 +5428,10 @@ msgid "No plugin tasks to run"
 msgstr "No valid class sent"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "No valid class sent"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Snapin updated"
 
@@ -6137,6 +6159,10 @@ msgstr "Plugin Name"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Plugin Name"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Record not found, Error: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8352,6 +8378,9 @@ msgstr "Directory"
 msgid "The plugin directory does not exist."
 msgstr "Method does not exist"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "Donations are disabled"
@@ -8378,6 +8407,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr " no longer exists"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -142,6 +142,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -340,6 +344,9 @@ msgstr "Una imagen ya existe con este nombre!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -587,6 +594,9 @@ msgstr "Impresora"
 #, fuzzy
 msgid "Activated"
 msgstr "Activo"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Activo"
@@ -2718,6 +2728,10 @@ msgstr "No se ha podido destruir"
 msgid "Failed to install "
 msgstr "No se ha podido destruir"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "No se ha podido destruir"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "No se ha podido destruir"
@@ -4147,6 +4161,10 @@ msgid "Install Plugins"
 msgstr ""
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "Añadir fallidos SNAPin!"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "Añadir fallidos SNAPin!"
 
@@ -5536,6 +5554,10 @@ msgid "No plugin tasks to run"
 msgstr "Ninguna clase válida enviado"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Ninguna clase válida enviado"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Nombre snapin"
 
@@ -6276,6 +6298,10 @@ msgstr "Nombre de la impresora"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Nombre de la impresora"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Registro no encontrado, error: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8538,6 +8564,9 @@ msgstr "Directorio"
 msgid "The plugin directory does not exist."
 msgstr "Método no existe"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "Ancho por defecto"
@@ -8563,6 +8592,9 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 msgid "The selected site no longer exists"
+msgstr ""
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -139,6 +139,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -337,6 +341,9 @@ msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Dieser Benutzername ist bereits vorhanden!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -578,6 +585,9 @@ msgstr "ausgewählte Images hinzufügen"
 #, fuzzy
 msgid "Activated"
 msgstr "Aktiv"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Aktiv"
@@ -2668,6 +2678,10 @@ msgstr "Verbindung nicht möglich"
 msgid "Failed to install "
 msgstr "Starten fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "Starten fehlgeschlagen"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "Starten fehlgeschlagen"
@@ -4065,6 +4079,10 @@ msgid "Install Plugins"
 msgstr "Plugins installieren"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "Plugins installieren"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "Plugins installieren"
 
@@ -5413,6 +5431,10 @@ msgid "No plugin tasks to run"
 msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Keine gültigen Tasks gefunden"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Snapin geschützt"
 
@@ -6140,6 +6162,10 @@ msgstr "Plugin-Name"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Plugin-Name"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8357,6 +8383,9 @@ msgstr "Home-Verzeichnis speichern"
 msgid "The plugin directory does not exist."
 msgstr "Methode ist nicht vorhanden"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "* Anpingen der Hosts ist global deaktiviert"
@@ -8383,6 +8412,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr "läuft nicht mehr"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -145,6 +145,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -343,6 +347,9 @@ msgstr "Une image existe déjà avec ce nom!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -583,6 +590,9 @@ msgstr "Imprimante"
 #, fuzzy
 msgid "Activated"
 msgstr "actif"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "actif"
@@ -2671,6 +2681,10 @@ msgstr "Échec de connexion"
 msgid "Failed to install "
 msgstr "Impossible de détruire"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "Impossible de détruire"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "Impossible de détruire"
@@ -4068,6 +4082,10 @@ msgid "Install Plugins"
 msgstr "Installer Plugins"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "Installer Plugins"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "Installer Plugins"
 
@@ -5412,6 +5430,10 @@ msgid "No plugin tasks to run"
 msgstr "Aucune classe valide envoyé"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Aucune classe valide envoyé"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "snapin mise à jour"
 
@@ -6139,6 +6161,10 @@ msgstr "Nom Plugin"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Nom Plugin"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Enregistrement non trouvé, Erreur: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8354,6 +8380,9 @@ msgstr "Annuaire"
 msgid "The plugin directory does not exist."
 msgstr "Méthode n'existe pas"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "Les dons sont désactivés"
@@ -8380,6 +8409,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr " n'existe plus"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -144,6 +144,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -334,6 +338,9 @@ msgstr "Esiste già un snapin con questo nome!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Esiste già un utente con questo nome!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -568,6 +575,9 @@ msgstr "Aggiungi stampanti selezionate"
 #, fuzzy
 msgid "Activated"
 msgstr "Attivo"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Attivo"
@@ -2595,6 +2605,10 @@ msgstr "Connessione fallita"
 msgid "Failed to install "
 msgstr "non è riuscito a iniziare"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "non è riuscito a iniziare"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "non è riuscito a iniziare"
@@ -3940,6 +3954,10 @@ msgid "Install Plugins"
 msgstr "installare plugin"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "installare plugin"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "installare plugin"
 
@@ -5232,6 +5250,10 @@ msgid "No plugin tasks to run"
 msgstr "Non sono stati trovati compiti validi"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Non sono stati trovati compiti validi"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Snapin Protetto"
 
@@ -5939,6 +5961,10 @@ msgstr "Nome Plugin"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Nome Plugin"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Record non trovato"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8069,6 +8095,9 @@ msgstr "directory"
 msgid "The plugin directory does not exist."
 msgstr "La funzione non esiste"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "* Gli host Ping sono disattivati a livello globale"
@@ -8095,6 +8124,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr "non è più in esecuzione"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Le impostazioni tendono ad essere le impostazioni globali che influenzano tutti gli host"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -135,6 +135,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -324,6 +328,9 @@ msgstr "この名前のスナップインは既に存在します！"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "この名前のユーザーは既に存在します"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -554,6 +561,9 @@ msgstr "選択項目を削除"
 #, fuzzy
 msgid "Activated"
 msgstr "有効"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "有効"
@@ -2573,6 +2583,10 @@ msgstr "接続に失敗しました"
 msgid "Failed to install "
 msgstr "プラグインのインストールに失敗しました"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "プラグインのインストールに失敗しました"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "プラグインのインストールに失敗しました"
@@ -3902,6 +3916,10 @@ msgid "Install Plugins"
 msgstr "プラグインをインストール"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "プラグインをインストール"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "プラグインをインストール"
 
@@ -5192,6 +5210,10 @@ msgid "No plugin tasks to run"
 msgstr "有効なタスクが見つかりません"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "有効なタスクが見つかりません"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "ロールが選択されていません"
 
@@ -5904,6 +5926,10 @@ msgstr "プラグインをインストールしました！"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "プラグインをインストールしました！"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "ログアウトが見つかりません"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8006,6 +8032,9 @@ msgstr "ディレクトリ"
 msgid "The plugin directory does not exist."
 msgstr "関数が存在しません"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "このプラグインはインストールされていません"
@@ -8032,6 +8061,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr "選択したプリンターを追加"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "これらの設定は通常グローバル設定であり、すべてのホストに影響します。"
@@ -10951,9 +10983,6 @@ msgstr ""
 #~ msgid "Install Kernel"
 #~ msgstr "カーネルをインストール"
 
-#~ msgid "Install Plugin"
-#~ msgstr "プラグインをインストール"
-
 #~ msgid "Invalid Host Colors"
 #~ msgstr "無効なホストカラー"
 
@@ -11078,9 +11107,6 @@ msgstr ""
 
 #~ msgid "Login with the FOG credentials and you will see the menu"
 #~ msgstr "FOG の認証情報でログインすると、メニューが表示されます"
-
-#~ msgid "Logout not found"
-#~ msgstr "ログアウトが見つかりません"
 
 #~ msgid "MB Asset"
 #~ msgstr "MB 資産タグ"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -120,6 +120,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -297,6 +301,9 @@ msgid "A location already exists with this name!"
 msgstr ""
 
 msgid "A menu entry already exists with this name!"
+msgstr ""
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
 msgstr ""
 
 msgid "A module already exists with this name!"
@@ -497,6 +504,9 @@ msgid "Activate selected"
 msgstr ""
 
 msgid "Activated"
+msgstr ""
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
 msgstr ""
 
 msgid "Active"
@@ -2277,6 +2287,10 @@ msgstr ""
 msgid "Failed to install "
 msgstr ""
 
+#, php-format
+msgid "Failed to install %s"
+msgstr ""
+
 msgid "Failed to install logo file"
 msgstr ""
 
@@ -3445,6 +3459,9 @@ msgstr ""
 msgid "Install Plugins"
 msgstr ""
 
+msgid "Install a plugin"
+msgstr ""
+
 msgid "Install plugins failed!"
 msgstr ""
 
@@ -4592,6 +4609,9 @@ msgstr ""
 msgid "No plugin tasks to run"
 msgstr ""
 
+msgid "No plugin with that id."
+msgstr ""
+
 msgid "No plugins selected."
 msgstr ""
 
@@ -5214,6 +5234,9 @@ msgid "Plugin deactivated!"
 msgstr ""
 
 msgid "Plugin installed!"
+msgstr ""
+
+msgid "Plugin not found"
 msgstr ""
 
 msgid "Plugin runner is globally disabled"
@@ -7090,6 +7113,9 @@ msgstr ""
 msgid "The plugin directory does not exist."
 msgstr ""
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 msgid "The plugin system is disabled"
 msgstr ""
 
@@ -7113,6 +7139,9 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 msgid "The selected site no longer exists"
+msgstr ""
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -144,6 +144,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -342,6 +346,9 @@ msgstr "Uma imagem já existe com este nome!"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -582,6 +589,9 @@ msgstr "Impressora"
 #, fuzzy
 msgid "Activated"
 msgstr "Ativo"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "Ativo"
@@ -2670,6 +2680,10 @@ msgstr "Falhou ao conectar"
 msgid "Failed to install "
 msgstr "Falha ao destruir"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "Falha ao destruir"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "Falha ao destruir"
@@ -4067,6 +4081,10 @@ msgid "Install Plugins"
 msgstr "instalar Plugins"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "instalar Plugins"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "instalar Plugins"
 
@@ -5411,6 +5429,10 @@ msgid "No plugin tasks to run"
 msgstr "Nenhuma classe válida enviada"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "Nenhuma classe válida enviada"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "Snapin atualizada"
 
@@ -6138,6 +6160,10 @@ msgstr "Nome Plugin"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "Nome Plugin"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "Registro não encontrado, erro: %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8353,6 +8379,9 @@ msgstr "Diretório"
 msgid "The plugin directory does not exist."
 msgstr "O método não existe"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "As doações são deficientes"
@@ -8379,6 +8408,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr " não existe mais"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -144,6 +144,10 @@ msgid "%s could not be loaded. Check that %s declares a class of that exact name
 msgstr ""
 
 #, php-format
+msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
+msgstr ""
+
+#, php-format
 msgid "%s does not exist. Re-run the FOG installer."
 msgstr ""
 
@@ -342,6 +346,9 @@ msgstr "图像已经存在具有此名称！"
 #, fuzzy
 msgid "A menu entry already exists with this name!"
 msgstr "图像已经存在具有此名称！"
+
+msgid "A migration step failed. The plugin is left activated and not marked installed."
+msgstr ""
 
 #, fuzzy
 msgid "A module already exists with this name!"
@@ -582,6 +589,9 @@ msgstr "打印机"
 #, fuzzy
 msgid "Activated"
 msgstr "活性"
+
+msgid "Activates the plugin, applies its schema migrations, and records the result -- the same three steps, in the same order, as the Install action in the web UI. Idempotent: migration steps are append-only and are resumed from the count already applied, so calling this on an installed plugin applies only steps it has not seen, which is what the UI calls Upgrade. Setting `installed` through the generic edit route instead is refused: that column records that this operation succeeded, and asserting it without running the migrations leaves the plugin's routes in this document while its tables do not exist."
+msgstr ""
 
 msgid "Active"
 msgstr "活性"
@@ -2670,6 +2680,10 @@ msgstr "连接失败"
 msgid "Failed to install "
 msgstr "未能摧毁"
 
+#, fuzzy, php-format
+msgid "Failed to install %s"
+msgstr "未能摧毁"
+
 #, fuzzy
 msgid "Failed to install logo file"
 msgstr "未能摧毁"
@@ -4067,6 +4081,10 @@ msgid "Install Plugins"
 msgstr "安装插件"
 
 #, fuzzy
+msgid "Install a plugin"
+msgstr "安装插件"
+
+#, fuzzy
 msgid "Install plugins failed!"
 msgstr "安装插件"
 
@@ -5411,6 +5429,10 @@ msgid "No plugin tasks to run"
 msgstr "发送无有效类"
 
 #, fuzzy
+msgid "No plugin with that id."
+msgstr "发送无有效类"
+
+#, fuzzy
 msgid "No plugins selected."
 msgstr "更新管理单元"
 
@@ -6138,6 +6160,10 @@ msgstr "插件名称"
 #, fuzzy
 msgid "Plugin installed!"
 msgstr "插件名称"
+
+#, fuzzy
+msgid "Plugin not found"
+msgstr "未发现记录，错误： %s"
 
 #, fuzzy
 msgid "Plugin runner is globally disabled"
@@ -8353,6 +8379,9 @@ msgstr "目录"
 msgid "The plugin directory does not exist."
 msgstr "方法不存在"
 
+msgid "The plugin is installed and its schema is up to date."
+msgstr ""
+
 #, fuzzy
 msgid "The plugin system is disabled"
 msgstr "捐款将被禁用"
@@ -8379,6 +8408,9 @@ msgstr ""
 #, fuzzy
 msgid "The selected site no longer exists"
 msgstr "不复存在"
+
+msgid "The server refuses to activate this plugin, or the plugin declares no schema() migrations and is already installed, so re-running its installer would drop and recreate its tables. The message says which."
+msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr ""


### PR DESCRIPTION
Supersedes #1360. Carries @darksidemilk's two commits unchanged, then fixes
what a real run against a server found. The original said it had not been
exercised at runtime; it has now.

## How it was verified

A clone of a live 1.6 database in a throwaway MariaDB container, the branch's
own `packages/web` served over HTTP, driven with real `fog-api-token` /
`fog-user-token` headers. Nothing was written to a live install.

## What was wrong

**1. `Route::listem()` leaked the request body into every internal list read —
and that defeated the blocker gate this PR adds.**

`$inputoverride` is documented as "override php://input to blank" and
suppressed exactly one of the two places `listem()` reads it. The other is
`getsearchbody()`, which turns any of the class's own fields found in the body
into a `WHERE`. `Plugin::activationBlockers()` lists `plugin` through
`Route::getList()` and treats "the target id is not in the list" as "nothing
blocks it", so on a plugin whose manifest declares `fog_min 9.9.9`:

```
POST /plugin/2/install                     -> 400 capone needs FOG 9.9.9 or newer
POST /plugin/2/install  {"name":"ldap"}    -> 204, installed
```

One unrelated key in a body the route does not read was enough to walk past
the gate. Fixed in `listem()`, not in `activationBlockers()`, because any gate
built on a `getList()` was defeatable the same way. `Route::getList()` is the
only caller in the tree that passes `$inputoverride = true`, so the change
reaches internal list reads and nothing else — `/list`, `/count`, `/names` and
`/ids` still honour a JSON search body, verified.

**2. Every error arm answered with a bare string in a body labelled
`application/json`.** The document declares 400/404/500 as the `Error` schema,
so a generated client parsed `Plugin not found` and got a syntax error instead
of the reason. Now `setErrorMessage()`, i.e. `{"error": ...}`.

**3. `installdb()` is idempotent only for a manager that adopted `schema()`.**
Without one it falls back to the legacy `install()`, whose 1.5 shape opens with
`uninstall()` — a DROP — and rebuilds. `wolbroadcast` destroyed its own table
on every install that way until FOGProject/fog-plugins#24, and `taskstateedit`
and `tasktypeedit` still ship no `schema()`. The web Install button never met
this because it filters on `installed IN ('', 0, '0')`; this route deliberately
does not filter, so "install an installed plugin" silently meant "empty it". A
*second* install of such a plugin now answers 400 and says why. A first install
still works — there is nothing to lose — and a hooks-only plugin with no manager
re-installs as the no-op it should.

**4. The blocker gate was one PUT away from being irrelevant.** `state` is
deliberately left writable so activating over the API keeps working, but
nothing gated it — so an installed plugin left deactivated because a FOG upgrade
moved past its `fog_max` could be switched back on with `{"state":"1"}` and
would load on every boot (`getActivePlugins()` selects `installed=1 AND
state=1`). `edit()` now applies the same `Plugin::activationBlockers()` check,
on the *transition* to active only: an unchanged round-trip PUT, and a
description edit on an already-active plugin, both still work.

**5. The operation was tagged `system`.** `_op()` takes its tag from the class
argument, which has to stay empty for a fixed route so the operation id and the
permission lookup key off the route name — the two upload routes already
override the tag afterwards for exactly this. Now `plugin`.

## Behaviour matrix, all measured

| | |
|---|---|
| `POST /plugin/99999/install` | 404 `{"error":"Plugin not found"}` |
| blocked plugin | 400 `{"error":"capone needs FOG 9.9.9 or newer; this server is 1.6.0"}` |
| blocked plugin + filtering body | 400 (was 204 + installed) |
| `PUT /plugin/2/edit {"state":"1"}` on a blocked plugin | 400 (was 200 + activated) |
| `PUT` writing `installed` / `schema` | 400 `... is maintained by the server` |
| `PUT` unchanged round-trip | 200 |
| fresh `schema()` plugin | 204, table created, `installed` written last |
| re-install of a `schema()` plugin | 204, no-op upgrade |
| fresh legacy plugin | 204 |
| re-install of a legacy plugin | 400 `... does not declare schema() migrations` |
| holder of `plugin.edit` only | 403 |
| holder of `plugin.install` | 204 |

`tests/run-all.sh`: 149 passed, 0 failed.

## Downstream

No change to `Route::$validClasses`, so FogApi's hardcoded class list
(`Private/Get-DynmicParam.ps1`) needs no sync. `POST /plugin/{id}/install` is a
new operation FogApi has no cmdlet for.

## Still open, deliberately not in this PR

`handleWhereItems()` also picks up the dispatched route's `?filter=` when
`$whereItems` is `false`, so a nested internal `getList()` inside a filterable
route can consume the filter the handler was going to use. Not reachable here —
`captureRequestFilter()` only arms for filterable route names, and
`pluginInstall` is not one, verified — but it is the same shape as the bug
fixed above.
