### PR TITLE
Store booleans as tinyint(1), not enum('0','1')

### DIFF
--- a/docs/adr/0028-booleans-are-tinyint-not-enum.md
+++ b/docs/adr/0028-booleans-are-tinyint-not-enum.md
@@ -1,0 +1,135 @@
+# A boolean column is `TINYINT(1)`, not `enum('0','1')`
+
+## Status
+
+accepted
+
+Prompted by [forum topic 18227](https://forums.fogproject.org/topic/18227/fog-supported-os)
+and the fix in #1361, which made the cost of the old encoding visible.
+
+## Context
+
+FOG has spelled its two-state columns `enum('0','1')` since the beginning, and it
+has never spelled all of them that way. Before this change the database held
+**36** `enum('0','1')` columns and **four** genuine `tinyint(1)` booleans —
+`sites`.`siteCatchAll`, `auditLog`.`alRenderable`, `auditChange`.`acRedacted` and
+`hosts`.`hostInfoLock`. Two conventions for one idea, with no rule saying which to
+reach for.
+
+That alone would be a tidiness problem. The reason it is not is that the older of
+the two conventions has a trap in it.
+
+### An integer written to these enums is off by one
+
+An integer written to an `ENUM` is a **member index**, not a value. For
+`enum('0','1')` the indices are: 0 = the error value, 1 = the member `'0'`,
+2 = the member `'1'`. Measured on MariaDB 11.8 under `STRICT_TRANS_TABLES`:
+
+| bound value | `tinyint(1)` | `enum('0','1')` |
+|---|---|---|
+| `'0'` | `0` | `'0'` |
+| `'1'` | `1` | `'1'` |
+| int `0` | `0` | **refused — error 1265** |
+| int `1` | `1` | **stores `'0'`** — i.e. FALSE |
+| int `2` | `2` | stores `'1'` |
+| `''` | refused | refused |
+
+So `->set('isEnabled', 1)` means *disabled* the moment the value reaches the
+server as an integer rather than a string. FOG survives that only because
+`PDODB::_bind()` binds every parameter as `PDO::PARAM_STR`. That is not a design;
+it is a load-bearing accident, and it has already cost real work:
+
+- `PDODB::_bind()` cannot normalise a PHP boolean with `PDO::PARAM_BOOL`, because
+  bound as an integer `false` would be index 0 and `true` index 1 — refused and
+  inverted respectively. It has to produce the *strings* `'0'`/`'1'` (#1361).
+- `Schema::defaultLiteral()` exists because `createTable()` callers pass values
+  rather than SQL, and an unquoted `0` against an ENUM is a malformed default.
+- `groupmanagement.page.php` carries a comment explaining, at the call site, why
+  the enforce value must be passed as a string.
+
+`tinyint(1)` has none of this. `0` is false and `1` is true whether it arrives as
+a string or an integer.
+
+### What the ENUM buys, and why it is not enough
+
+An `enum('0','1')` constrains the domain to exactly two values; `tinyint(1)` will
+store `2` or `47` without complaint. That is a real property and it is the only
+argument for the status quo. It is outweighed because the constraint is enforced
+in the one direction that does not matter (a wrong *string* is refused) and
+inverted in the direction that does (a wrong *integer* is silently accepted as a
+different value). MariaDB 10.2+ `CHECK (col IN (0,1))` is available if the domain
+constraint is ever wanted back.
+
+## Decision
+
+Two-state columns are `TINYINT(1) NOT NULL DEFAULT 0` (or `DEFAULT 1` where that
+is the existing default). Core columns are converted by schema step 368; the
+bundled plugins convert their own, because each plugin owns its schema
+([ADR 0009](0009-plugins-become-installable-artifacts.md)).
+
+New two-state columns are declared `TINYINT(1)` from the start. `enum` remains
+correct for a genuine enumeration — `lsSearchScope`, `pmAction`, `ttType`,
+`alOutcome` and the rest are untouched.
+
+### The migration is three statements per column, and this is not optional
+
+🔴 A direct `ALTER TABLE t MODIFY c TINYINT(1)` converts an ENUM **by index, not
+by label**. Measured:
+
+```
+before:  '0'  '1'  '0'  '1'
+after:    1    2    1    2
+```
+
+Every false becomes `1` and every true becomes `2` — both truthy, no error,
+nothing logged. On upgrade that would silently switch on every flag in every FOG
+database: every host pending, every snapin set to shut down, every user allowed
+API access. The safe form goes through a string type, which converts by label:
+
+```sql
+ALTER TABLE t MODIFY c VARCHAR(1) NOT NULL DEFAULT '0';
+UPDATE t SET c = '0' WHERE c NOT IN ('0','1');
+ALTER TABLE t MODIFY c TINYINT(1) NOT NULL DEFAULT 0;
+```
+
+The `UPDATE` is not decoration: a row still holding the ENUM error value (the
+nine-year legacy of `SET SESSION sql_mode=''`, see GH-1245) arrives at the varchar
+stage as `''`, which `tinyint` refuses.
+
+### The REST payload changes, deliberately
+
+`PDODB` runs with `ATTR_EMULATE_PREPARES => false`, so mysqlnd returns native
+types. These columns now read back as the integer `1` where they used to read
+back as the string `'1'`, and the API payload changes accordingly:
+
+```
+{"imageEnabled":"1"}   ->   {"imageEnabled":1}
+```
+
+`OpenAPI::_columnSchema()` already maps `tinyint` to `integer`, so the published
+document follows the data with no edit.
+
+Every reader inside the tree either tests truthiness or casts with `(string)`
+first, and both spellings survive — audited, no call site needed changing. A
+downstream consumer that compares the JSON strictly against `"1"` does not, which
+is why this lands in a beta rather than a patch line. **`darksidemilk/FogApi`
+is the known downstream consumer.**
+
+## Consequences
+
+- One convention. A new boolean column has an obvious type.
+- The integer/index trap is gone, so a future `PDO::PARAM_INT` or an unquoted `0`
+  in a schema step is no longer a silent data corruption.
+- 36 columns changed type: 26 core columns in 15 tables, and 10 plugin columns
+  in 3 tables -- `LDAPServers` (4), `OIDCProviders` (5) and `location` (1),
+  which ship from `FOGProject/fog-plugins` and so change in their own release.
+- `commons/schema-expected.php` regenerated; `SchemaReconciler` brings any
+  database that missed the step into line.
+- **`dev-branch` does not take this.** 1.5.x is a patches line with the largest
+  installed base FOG has; the payload change is not worth it there, and #1362
+  already closed the bug that prompted this.
+- **Not included, deliberately:** the `char(1)`/`varchar(1)` flags
+  (`tasks`.`taskShutdown`, `snapins`.`sReboot`, `hosts`.`hostUseAD`). They look
+  like the same family and are not — `hostUseAD` is tri-state, with `''` meaning
+  "inherit" as a third value the form renders. That family needs a per-column
+  reading, not a sweep.

--- a/docs/adr/0028-booleans-are-tinyint-not-enum.md
+++ b/docs/adr/0028-booleans-are-tinyint-not-enum.md
@@ -67,6 +67,15 @@ is the existing default). Core columns are converted by schema step 368; the
 bundled plugins convert their own, because each plugin owns its schema
 ([ADR 0009](0009-plugins-become-installable-artifacts.md)).
 
+All four callers run the same code: `Schema::enumToTinyint()`. The conversion has
+one rule in it that must not be re-derived per plugin (below), so it is written
+once and the plugins call it. It reads nullability and default out of
+`information_schema` and carries them across rather than assuming `NOT NULL` —
+`LDAPServers`.`lsAllowAPI` is nullable and `lsUseGroupMatch` has no default at
+all, and rewriting either would be a behaviour change smuggled in by a type
+change. It also skips any column that is not still exactly `enum('0','1')`, so a
+re-run is a read.
+
 New two-state columns are declared `TINYINT(1)` from the start. `enum` remains
 correct for a genuine enumeration — `lsSearchScope`, `pmAction`, `ttType`,
 `alOutcome` and the rest are untouched.

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -75,6 +75,19 @@ return [
         ],
     ],
     'tables' => [
+        'apiTokens' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `apiTokens` ( `atID` int(11) NOT NULL AUTO_INCREMENT, `atUserID` int(11) NOT NULL DEFAULT 0, `atName` varchar(255) NOT NULL DEFAULT \'\', `atHash` char(64) NOT NULL DEFAULT \'\', `atEnabled` tinyint(1) NOT NULL DEFAULT 1, `atCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `atCreatedBy` varchar(255) NOT NULL DEFAULT \'\', `atLastUsed` datetime DEFAULT NULL, PRIMARY KEY (`atID`), UNIQUE KEY `atHash` (`atHash`), KEY `atUserID` (`atUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'atID' => 'int(11) NOT NULL',
+                'atUserID' => 'int(11) NOT NULL DEFAULT 0',
+                'atName' => 'varchar(255) NOT NULL DEFAULT \'\'',
+                'atHash' => 'char(64) NOT NULL DEFAULT \'\'',
+                'atEnabled' => 'tinyint(1) NOT NULL DEFAULT 1',
+                'atCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'atCreatedBy' => 'varchar(255) NOT NULL DEFAULT \'\'',
+                'atLastUsed' => 'datetime DEFAULT NULL',
+            ],
+        ],
         'auditChange' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `auditChange` ( `acID` int(11) NOT NULL AUTO_INCREMENT, `acAuditID` int(11) NOT NULL, `acSubjectType` varchar(64) NOT NULL DEFAULT \'\', `acSubjectID` int(11) NOT NULL DEFAULT 0, `acField` varchar(128) NOT NULL DEFAULT \'\', `acOldValue` longtext DEFAULT NULL, `acNewValue` longtext DEFAULT NULL, `acRedacted` tinyint(1) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`acID`), KEY `acAuditID` (`acAuditID`), KEY `acSubject` (`acSubjectType`,`acSubjectID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
@@ -86,19 +99,6 @@ return [
                 'acOldValue' => 'longtext DEFAULT NULL',
                 'acNewValue' => 'longtext DEFAULT NULL',
                 'acRedacted' => 'tinyint(1) unsigned NOT NULL DEFAULT 0',
-            ],
-        ],
-        'apiTokens' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `apiTokens` ( `atID` int(11) NOT NULL AUTO_INCREMENT, `atUserID` int(11) NOT NULL DEFAULT 0, `atName` varchar(255) NOT NULL DEFAULT \'\', `atHash` char(64) NOT NULL DEFAULT \'\', `atEnabled` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `atCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `atCreatedBy` varchar(255) NOT NULL DEFAULT \'\', `atLastUsed` datetime DEFAULT NULL, PRIMARY KEY (`atID`), UNIQUE KEY `atHash` (`atHash`), KEY `atUserID` (`atUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'atID' => 'int(11) NOT NULL',
-                'atUserID' => 'int(11) NOT NULL DEFAULT 0',
-                'atName' => 'varchar(255) NOT NULL DEFAULT \'\'',
-                'atHash' => 'char(64) NOT NULL DEFAULT \'\'',
-                'atEnabled' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
-                'atCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
-                'atCreatedBy' => 'varchar(255) NOT NULL DEFAULT \'\'',
-                'atLastUsed' => 'datetime DEFAULT NULL',
             ],
         ],
         'auditLog' => [
@@ -232,20 +232,20 @@ return [
             ],
         ],
         'hostMAC' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `hostMAC` ( `hmID` int(11) NOT NULL AUTO_INCREMENT, `hmHostID` int(11) NOT NULL, `hmMAC` varchar(59) NOT NULL, `hmDesc` longtext NOT NULL DEFAULT \'\', `hmPrimary` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `hmPending` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `hmIgnoreClient` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `hmIgnoreImaging` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`hmID`), UNIQUE KEY `hmHostID` (`hmMAC`), UNIQUE KEY `hmMAC` (`hmMAC`), UNIQUE KEY `hmMAC_2` (`hmMAC`), KEY `idxHostID` (`hmHostID`), KEY `idxMac` (`hmMAC`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `hostMAC` ( `hmID` int(11) NOT NULL AUTO_INCREMENT, `hmHostID` int(11) NOT NULL, `hmMAC` varchar(59) NOT NULL, `hmDesc` longtext NOT NULL DEFAULT \'\', `hmPrimary` tinyint(1) NOT NULL DEFAULT 0, `hmPending` tinyint(1) NOT NULL DEFAULT 0, `hmIgnoreClient` tinyint(1) NOT NULL DEFAULT 0, `hmIgnoreImaging` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`hmID`), UNIQUE KEY `hmHostID` (`hmMAC`), UNIQUE KEY `hmMAC` (`hmMAC`), UNIQUE KEY `hmMAC_2` (`hmMAC`), KEY `idxHostID` (`hmHostID`), KEY `idxMac` (`hmMAC`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'hmID' => 'int(11) NOT NULL',
                 'hmHostID' => 'int(11) NOT NULL',
                 'hmMAC' => 'varchar(59) NOT NULL',
                 'hmDesc' => 'longtext NOT NULL DEFAULT \'\'',
-                'hmPrimary' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
-                'hmPending' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
-                'hmIgnoreClient' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
-                'hmIgnoreImaging' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'hmPrimary' => 'tinyint(1) NOT NULL DEFAULT 0',
+                'hmPending' => 'tinyint(1) NOT NULL DEFAULT 0',
+                'hmIgnoreClient' => 'tinyint(1) NOT NULL DEFAULT 0',
+                'hmIgnoreImaging' => 'tinyint(1) NOT NULL DEFAULT 0',
             ],
         ],
         'hosts' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `hosts` ( `hostID` int(11) NOT NULL AUTO_INCREMENT, `hostName` varchar(16) NOT NULL, `hostDesc` longtext NOT NULL DEFAULT \'\', `hostIP` varchar(25) NOT NULL DEFAULT \'\', `hostImage` int(11) NOT NULL DEFAULT 0, `hostBuilding` int(11) NOT NULL DEFAULT 0, `hostCreateDate` timestamp NOT NULL DEFAULT current_timestamp(), `hostLastDeploy` datetime DEFAULT NULL, `hostCreateBy` varchar(50) NOT NULL DEFAULT \'\', `hostUseAD` char(1) NOT NULL DEFAULT \'\', `hostADDomain` varchar(250) NOT NULL DEFAULT \'\', `hostADOU` longtext NOT NULL DEFAULT \'\', `hostADUser` varchar(250) NOT NULL DEFAULT \'\', `hostADPass` varchar(250) NOT NULL DEFAULT \'\', `hostADPassLegacy` longtext NOT NULL DEFAULT \'\', `hostProductKey` longtext DEFAULT NULL, `hostPrinterLevel` varchar(2) NOT NULL DEFAULT \'\', `hostKernelArgs` varchar(250) NOT NULL DEFAULT \'\', `hostKernel` varchar(250) NOT NULL DEFAULT \'\', `hostDevice` varchar(250) NOT NULL DEFAULT \'\', `hostInit` longtext DEFAULT NULL, `hostPending` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `hostPubKey` longtext NOT NULL DEFAULT \'\', `hostSecToken` longtext NOT NULL DEFAULT \'\', `hostSecTime` timestamp NULL DEFAULT NULL, `hostPingCode` varchar(20) DEFAULT NULL, `hostExitBios` longtext DEFAULT NULL, `hostExitEfi` longtext DEFAULT NULL, `hostEnforce` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `hostInfoKey` varchar(255) DEFAULT NULL, `hostInfoLock` tinyint(1) DEFAULT 0, `hostSecTokenPrev` longtext NOT NULL DEFAULT \'\', `hostLastPing` datetime DEFAULT NULL, `hostLastCheckin` datetime DEFAULT NULL, `hostPingMethod` varchar(10) DEFAULT NULL, PRIMARY KEY (`hostID`), UNIQUE KEY `hostName` (`hostName`), KEY `new_index` (`hostName`), KEY `new_index1` (`hostIP`), KEY `new_index4` (`hostUseAD`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `hosts` ( `hostID` int(11) NOT NULL AUTO_INCREMENT, `hostName` varchar(16) NOT NULL, `hostDesc` longtext NOT NULL DEFAULT \'\', `hostIP` varchar(25) NOT NULL DEFAULT \'\', `hostImage` int(11) NOT NULL DEFAULT 0, `hostBuilding` int(11) NOT NULL DEFAULT 0, `hostCreateDate` timestamp NOT NULL DEFAULT current_timestamp(), `hostLastDeploy` datetime DEFAULT NULL, `hostCreateBy` varchar(50) NOT NULL DEFAULT \'\', `hostUseAD` char(1) NOT NULL DEFAULT \'\', `hostADDomain` varchar(250) NOT NULL DEFAULT \'\', `hostADOU` longtext NOT NULL DEFAULT \'\', `hostADUser` varchar(250) NOT NULL DEFAULT \'\', `hostADPass` varchar(250) NOT NULL DEFAULT \'\', `hostADPassLegacy` longtext NOT NULL DEFAULT \'\', `hostProductKey` longtext DEFAULT NULL, `hostPrinterLevel` varchar(2) NOT NULL DEFAULT \'\', `hostKernelArgs` varchar(250) NOT NULL DEFAULT \'\', `hostKernel` varchar(250) NOT NULL DEFAULT \'\', `hostDevice` varchar(250) NOT NULL DEFAULT \'\', `hostInit` longtext DEFAULT NULL, `hostPending` tinyint(1) NOT NULL DEFAULT 0, `hostPubKey` longtext NOT NULL DEFAULT \'\', `hostSecToken` longtext NOT NULL DEFAULT \'\', `hostSecTime` timestamp NULL DEFAULT NULL, `hostPingCode` varchar(20) DEFAULT NULL, `hostExitBios` longtext DEFAULT NULL, `hostExitEfi` longtext DEFAULT NULL, `hostEnforce` tinyint(1) NOT NULL DEFAULT 1, `hostInfoKey` varchar(255) DEFAULT NULL, `hostInfoLock` tinyint(1) DEFAULT 0, `hostSecTokenPrev` longtext NOT NULL DEFAULT \'\', `hostLastPing` datetime DEFAULT NULL, `hostLastCheckin` datetime DEFAULT NULL, `hostPingMethod` varchar(10) DEFAULT NULL, PRIMARY KEY (`hostID`), UNIQUE KEY `hostName` (`hostName`), KEY `new_index` (`hostName`), KEY `new_index1` (`hostIP`), KEY `new_index4` (`hostUseAD`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'hostID' => 'int(11) NOT NULL',
                 'hostName' => 'varchar(16) NOT NULL',
@@ -268,14 +268,14 @@ return [
                 'hostKernel' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'hostDevice' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'hostInit' => 'longtext DEFAULT NULL',
-                'hostPending' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'hostPending' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'hostPubKey' => 'longtext NOT NULL DEFAULT \'\'',
                 'hostSecToken' => 'longtext NOT NULL DEFAULT \'\'',
                 'hostSecTime' => 'timestamp NULL DEFAULT NULL',
                 'hostPingCode' => 'varchar(20) DEFAULT NULL',
                 'hostExitBios' => 'longtext DEFAULT NULL',
                 'hostExitEfi' => 'longtext DEFAULT NULL',
-                'hostEnforce' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
+                'hostEnforce' => 'tinyint(1) NOT NULL DEFAULT 1',
                 'hostInfoKey' => 'varchar(255) DEFAULT NULL',
                 'hostInfoLock' => 'tinyint(1) DEFAULT 0',
                 'hostSecTokenPrev' => 'longtext NOT NULL DEFAULT \'\'',
@@ -298,12 +298,12 @@ return [
             ],
         ],
         'imageGroupAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `imageGroupAssoc` ( `igaID` mediumint(9) NOT NULL AUTO_INCREMENT, `igaImageID` mediumint(9) NOT NULL, `igaStorageGroupID` mediumint(9) NOT NULL, `igaPrimary` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`igaID`), UNIQUE KEY `igaImageID` (`igaImageID`,`igaStorageGroupID`), UNIQUE KEY `igaImageID_2` (`igaImageID`,`igaStorageGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `imageGroupAssoc` ( `igaID` mediumint(9) NOT NULL AUTO_INCREMENT, `igaImageID` mediumint(9) NOT NULL, `igaStorageGroupID` mediumint(9) NOT NULL, `igaPrimary` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`igaID`), UNIQUE KEY `igaImageID` (`igaImageID`,`igaStorageGroupID`), UNIQUE KEY `igaImageID_2` (`igaImageID`,`igaStorageGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'igaID' => 'mediumint(9) NOT NULL',
                 'igaImageID' => 'mediumint(9) NOT NULL',
                 'igaStorageGroupID' => 'mediumint(9) NOT NULL',
-                'igaPrimary' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'igaPrimary' => 'tinyint(1) NOT NULL DEFAULT 0',
             ],
         ],
         'imagePartitionTypes' => [
@@ -315,7 +315,7 @@ return [
             ],
         ],
         'images' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `images` ( `imageID` int(11) NOT NULL AUTO_INCREMENT, `imageName` varchar(40) NOT NULL, `imageDesc` longtext NOT NULL DEFAULT \'\', `imagePath` longtext NOT NULL, `imageProtect` mediumint(9) NOT NULL DEFAULT 0, `imageMagnetUri` longtext NOT NULL DEFAULT \'\', `imageDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `imageCreateBy` varchar(50) NOT NULL DEFAULT \'\', `imageBuilding` int(11) NOT NULL DEFAULT 0, `imageSize` varchar(255) NOT NULL DEFAULT \'\', `imageTypeID` mediumint(9) NOT NULL, `imagePartitionTypeID` mediumint(9) NOT NULL, `imageOSID` mediumint(9) NOT NULL, `imageFormat` char(1) DEFAULT NULL, `imageLastDeploy` datetime DEFAULT NULL, `imageCompress` int(11) DEFAULT NULL, `imageEnabled` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `imageReplicate` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `imageServerSize` bigint(20) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`imageID`), UNIQUE KEY `imageName` (`imageName`), KEY `new_index` (`imageName`), KEY `new_index1` (`imageBuilding`), KEY `new_index2` (`imageTypeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `images` ( `imageID` int(11) NOT NULL AUTO_INCREMENT, `imageName` varchar(40) NOT NULL, `imageDesc` longtext NOT NULL DEFAULT \'\', `imagePath` longtext NOT NULL, `imageProtect` mediumint(9) NOT NULL DEFAULT 0, `imageMagnetUri` longtext NOT NULL DEFAULT \'\', `imageDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `imageCreateBy` varchar(50) NOT NULL DEFAULT \'\', `imageBuilding` int(11) NOT NULL DEFAULT 0, `imageSize` varchar(255) NOT NULL DEFAULT \'\', `imageTypeID` mediumint(9) NOT NULL, `imagePartitionTypeID` mediumint(9) NOT NULL, `imageOSID` mediumint(9) NOT NULL, `imageFormat` char(1) DEFAULT NULL, `imageLastDeploy` datetime DEFAULT NULL, `imageCompress` int(11) DEFAULT NULL, `imageEnabled` tinyint(1) NOT NULL DEFAULT 1, `imageReplicate` tinyint(1) NOT NULL DEFAULT 1, `imageServerSize` bigint(20) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`imageID`), UNIQUE KEY `imageName` (`imageName`), KEY `new_index` (`imageName`), KEY `new_index1` (`imageBuilding`), KEY `new_index2` (`imageTypeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'imageID' => 'int(11) NOT NULL',
                 'imageName' => 'varchar(40) NOT NULL',
@@ -333,8 +333,8 @@ return [
                 'imageFormat' => 'char(1) DEFAULT NULL',
                 'imageLastDeploy' => 'datetime DEFAULT NULL',
                 'imageCompress' => 'int(11) DEFAULT NULL',
-                'imageEnabled' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
-                'imageReplicate' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
+                'imageEnabled' => 'tinyint(1) NOT NULL DEFAULT 1',
+                'imageReplicate' => 'tinyint(1) NOT NULL DEFAULT 1',
                 'imageServerSize' => 'bigint(20) unsigned NOT NULL DEFAULT 0',
             ],
         ],
@@ -427,7 +427,7 @@ return [
             ],
         ],
         'multicastSessions' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `multicastSessions` ( `msID` int(11) NOT NULL AUTO_INCREMENT, `msName` varchar(250) NOT NULL DEFAULT \'\', `msBasePort` int(11) NOT NULL DEFAULT 0, `msLogPath` longtext NOT NULL DEFAULT \'\', `msImage` longtext NOT NULL DEFAULT \'\', `msClients` int(11) NOT NULL DEFAULT 0, `msSessClients` int(11) NOT NULL DEFAULT 0, `msInterface` varchar(250) NOT NULL DEFAULT \'\', `msStartDateTime` datetime DEFAULT NULL, `msPercent` int(11) NOT NULL DEFAULT 0, `msState` int(11) NOT NULL DEFAULT 0, `msCompleteDateTime` datetime DEFAULT NULL, `msIsDD` int(11) NOT NULL DEFAULT 0, `msNFSGroupID` int(11) NOT NULL, `msShutdown` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `msMaxwait` int(11) NOT NULL DEFAULT 0, `msAnon5` varchar(250) NOT NULL DEFAULT \'\', `msSenderPID` int(11) NOT NULL DEFAULT 0, `msSenderNode` int(11) NOT NULL DEFAULT 0, `msSenderStart` datetime DEFAULT NULL, PRIMARY KEY (`msID`), KEY `new_index` (`msNFSGroupID`), KEY `idx_msStartDateTime` (`msStartDateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `multicastSessions` ( `msID` int(11) NOT NULL AUTO_INCREMENT, `msName` varchar(250) NOT NULL DEFAULT \'\', `msBasePort` int(11) NOT NULL DEFAULT 0, `msLogPath` longtext NOT NULL DEFAULT \'\', `msImage` longtext NOT NULL DEFAULT \'\', `msClients` int(11) NOT NULL DEFAULT 0, `msSessClients` int(11) NOT NULL DEFAULT 0, `msInterface` varchar(250) NOT NULL DEFAULT \'\', `msStartDateTime` datetime DEFAULT NULL, `msPercent` int(11) NOT NULL DEFAULT 0, `msState` int(11) NOT NULL DEFAULT 0, `msCompleteDateTime` datetime DEFAULT NULL, `msIsDD` int(11) NOT NULL DEFAULT 0, `msNFSGroupID` int(11) NOT NULL, `msShutdown` tinyint(1) NOT NULL DEFAULT 0, `msMaxwait` int(11) NOT NULL DEFAULT 0, `msAnon5` varchar(250) NOT NULL DEFAULT \'\', `msSenderPID` int(11) NOT NULL DEFAULT 0, `msSenderNode` int(11) NOT NULL DEFAULT 0, `msSenderStart` datetime DEFAULT NULL, PRIMARY KEY (`msID`), KEY `new_index` (`msNFSGroupID`), KEY `idx_msStartDateTime` (`msStartDateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'msID' => 'int(11) NOT NULL',
                 'msName' => 'varchar(250) NOT NULL DEFAULT \'\'',
@@ -443,7 +443,7 @@ return [
                 'msCompleteDateTime' => 'datetime DEFAULT NULL',
                 'msIsDD' => 'int(11) NOT NULL DEFAULT 0',
                 'msNFSGroupID' => 'int(11) NOT NULL',
-                'msShutdown' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'msShutdown' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'msMaxwait' => 'int(11) NOT NULL DEFAULT 0',
                 'msAnon5' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'msSenderPID' => 'int(11) NOT NULL DEFAULT 0',
@@ -471,7 +471,7 @@ return [
             ],
         ],
         'nfsGroupMembers' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `nfsGroupMembers` ( `ngmID` int(11) NOT NULL AUTO_INCREMENT, `ngmMemberName` varchar(250) NOT NULL DEFAULT \'\', `ngmMemberDescription` longtext NOT NULL DEFAULT \'\', `ngmIsMasterNode` char(1) NOT NULL DEFAULT \'\', `ngmGroupID` int(11) NOT NULL, `ngmRootPath` longtext NOT NULL, `ngmSSLPath` longtext NOT NULL DEFAULT \'\', `ngmFTPPath` longtext NOT NULL, `ngmMaxBitrate` varchar(25) DEFAULT NULL, `ngmHelloInterval` varchar(8) DEFAULT NULL, `ngmGraphColor` varchar(6) DEFAULT NULL, `ngmSnapinPath` longtext NOT NULL DEFAULT \'\', `ngmIsEnabled` char(1) NOT NULL DEFAULT \'\', `ngmHostname` varchar(250) NOT NULL, `ngmMaxClients` int(11) NOT NULL DEFAULT 0, `ngmBandwidthLimit` int(20) NOT NULL DEFAULT 0, `ngmUser` varchar(250) NOT NULL, `ngmPass` varchar(250) NOT NULL, `ngmKey` varchar(250) NOT NULL DEFAULT \'\', `ngmInterface` varchar(25) NOT NULL DEFAULT \'\', `ngmGraphEnabled` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `ngmWebroot` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`ngmID`), UNIQUE KEY `ngmMemberName` (`ngmMemberName`), UNIQUE KEY `ngmMemberName_2` (`ngmMemberName`), KEY `new_index` (`ngmMemberName`), KEY `new_index2` (`ngmIsMasterNode`), KEY `new_index3` (`ngmGroupID`), KEY `new_index4` (`ngmIsEnabled`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `nfsGroupMembers` ( `ngmID` int(11) NOT NULL AUTO_INCREMENT, `ngmMemberName` varchar(250) NOT NULL DEFAULT \'\', `ngmMemberDescription` longtext NOT NULL DEFAULT \'\', `ngmIsMasterNode` char(1) NOT NULL DEFAULT \'\', `ngmGroupID` int(11) NOT NULL, `ngmRootPath` longtext NOT NULL, `ngmSSLPath` longtext NOT NULL DEFAULT \'\', `ngmFTPPath` longtext NOT NULL, `ngmMaxBitrate` varchar(25) DEFAULT NULL, `ngmHelloInterval` varchar(8) DEFAULT NULL, `ngmGraphColor` varchar(6) DEFAULT NULL, `ngmSnapinPath` longtext NOT NULL DEFAULT \'\', `ngmIsEnabled` char(1) NOT NULL DEFAULT \'\', `ngmHostname` varchar(250) NOT NULL, `ngmMaxClients` int(11) NOT NULL DEFAULT 0, `ngmBandwidthLimit` int(20) NOT NULL DEFAULT 0, `ngmUser` varchar(250) NOT NULL, `ngmPass` varchar(250) NOT NULL, `ngmKey` varchar(250) NOT NULL DEFAULT \'\', `ngmInterface` varchar(25) NOT NULL DEFAULT \'\', `ngmGraphEnabled` tinyint(1) NOT NULL DEFAULT 1, `ngmWebroot` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`ngmID`), UNIQUE KEY `ngmMemberName` (`ngmMemberName`), UNIQUE KEY `ngmMemberName_2` (`ngmMemberName`), KEY `new_index` (`ngmMemberName`), KEY `new_index2` (`ngmIsMasterNode`), KEY `new_index3` (`ngmGroupID`), KEY `new_index4` (`ngmIsEnabled`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'ngmID' => 'int(11) NOT NULL',
                 'ngmMemberName' => 'varchar(250) NOT NULL DEFAULT \'\'',
@@ -493,7 +493,7 @@ return [
                 'ngmPass' => 'varchar(250) NOT NULL',
                 'ngmKey' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'ngmInterface' => 'varchar(25) NOT NULL DEFAULT \'\'',
-                'ngmGraphEnabled' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
+                'ngmGraphEnabled' => 'tinyint(1) NOT NULL DEFAULT 1',
                 'ngmWebroot' => 'longtext NOT NULL DEFAULT \'\'',
             ],
         ],
@@ -546,7 +546,7 @@ return [
             ],
         ],
         'powerManagement' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `powerManagement` ( `pmID` int(11) NOT NULL AUTO_INCREMENT, `pmHostID` int(11) NOT NULL, `pmMin` varchar(50) NOT NULL DEFAULT \'\', `pmHour` varchar(50) NOT NULL DEFAULT \'\', `pmDom` varchar(50) NOT NULL DEFAULT \'\', `pmMonth` varchar(50) NOT NULL DEFAULT \'\', `pmDow` varchar(50) NOT NULL DEFAULT \'\', `pmAction` enum(\'shutdown\',\'reboot\',\'wol\') NOT NULL, `pmOndemand` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`pmID`), UNIQUE KEY `cron` (`pmHostID`,`pmMin`,`pmHour`,`pmDom`,`pmMonth`,`pmDow`,`pmAction`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `powerManagement` ( `pmID` int(11) NOT NULL AUTO_INCREMENT, `pmHostID` int(11) NOT NULL, `pmMin` varchar(50) NOT NULL DEFAULT \'\', `pmHour` varchar(50) NOT NULL DEFAULT \'\', `pmDom` varchar(50) NOT NULL DEFAULT \'\', `pmMonth` varchar(50) NOT NULL DEFAULT \'\', `pmDow` varchar(50) NOT NULL DEFAULT \'\', `pmAction` enum(\'shutdown\',\'reboot\',\'wol\') NOT NULL, `pmOndemand` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`pmID`), UNIQUE KEY `cron` (`pmHostID`,`pmMin`,`pmHour`,`pmDom`,`pmMonth`,`pmDow`,`pmAction`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'pmID' => 'int(11) NOT NULL',
                 'pmHostID' => 'int(11) NOT NULL',
@@ -556,7 +556,7 @@ return [
                 'pmMonth' => 'varchar(50) NOT NULL DEFAULT \'\'',
                 'pmDow' => 'varchar(50) NOT NULL DEFAULT \'\'',
                 'pmAction' => 'enum(\'shutdown\',\'reboot\',\'wol\') NOT NULL',
-                'pmOndemand' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'pmOndemand' => 'tinyint(1) NOT NULL DEFAULT 0',
             ],
         ],
         'printerAssoc' => [
@@ -592,7 +592,7 @@ return [
             ],
         ],
         'pxeMenu' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `pxeMenu` ( `pxeID` mediumint(9) NOT NULL AUTO_INCREMENT, `pxeName` varchar(100) NOT NULL, `pxeDesc` longtext NOT NULL DEFAULT \'\', `pxeParams` longtext NOT NULL DEFAULT \'\', `pxeRegOnly` int(11) NOT NULL DEFAULT 0, `pxeArgs` varchar(250) DEFAULT NULL, `pxeDefault` int(11) NOT NULL DEFAULT 0, `pxeHotKeyEnable` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `pxeKeySequence` varchar(255) NOT NULL DEFAULT \'\', PRIMARY KEY (`pxeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `pxeMenu` ( `pxeID` mediumint(9) NOT NULL AUTO_INCREMENT, `pxeName` varchar(100) NOT NULL, `pxeDesc` longtext NOT NULL DEFAULT \'\', `pxeParams` longtext NOT NULL DEFAULT \'\', `pxeRegOnly` int(11) NOT NULL DEFAULT 0, `pxeArgs` varchar(250) DEFAULT NULL, `pxeDefault` int(11) NOT NULL DEFAULT 0, `pxeHotKeyEnable` tinyint(1) NOT NULL DEFAULT 0, `pxeKeySequence` varchar(255) NOT NULL DEFAULT \'\', PRIMARY KEY (`pxeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'pxeID' => 'mediumint(9) NOT NULL',
                 'pxeName' => 'varchar(100) NOT NULL',
@@ -601,7 +601,7 @@ return [
                 'pxeRegOnly' => 'int(11) NOT NULL DEFAULT 0',
                 'pxeArgs' => 'varchar(250) DEFAULT NULL',
                 'pxeDefault' => 'int(11) NOT NULL DEFAULT 0',
-                'pxeHotKeyEnable' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'pxeHotKeyEnable' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'pxeKeySequence' => 'varchar(255) NOT NULL DEFAULT \'\'',
             ],
         ],
@@ -747,26 +747,26 @@ return [
             ],
         ],
         'snapinGroupAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `snapinGroupAssoc` ( `sgaID` mediumint(9) NOT NULL AUTO_INCREMENT, `sgaSnapinID` mediumint(9) NOT NULL, `sgaStorageGroupID` mediumint(9) NOT NULL, `sgaPrimary` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`sgaID`), UNIQUE KEY `sgaSnapinID` (`sgaSnapinID`,`sgaStorageGroupID`), UNIQUE KEY `sgaStorageGroupID` (`sgaStorageGroupID`,`sgaSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `snapinGroupAssoc` ( `sgaID` mediumint(9) NOT NULL AUTO_INCREMENT, `sgaSnapinID` mediumint(9) NOT NULL, `sgaStorageGroupID` mediumint(9) NOT NULL, `sgaPrimary` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`sgaID`), UNIQUE KEY `sgaSnapinID` (`sgaSnapinID`,`sgaStorageGroupID`), UNIQUE KEY `sgaStorageGroupID` (`sgaStorageGroupID`,`sgaSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'sgaID' => 'mediumint(9) NOT NULL',
                 'sgaSnapinID' => 'mediumint(9) NOT NULL',
                 'sgaStorageGroupID' => 'mediumint(9) NOT NULL',
-                'sgaPrimary' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'sgaPrimary' => 'tinyint(1) NOT NULL DEFAULT 0',
             ],
         ],
         'snapinJobs' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `snapinJobs` ( `sjID` int(11) NOT NULL AUTO_INCREMENT, `sjHostID` int(11) NOT NULL, `sjStateID` int(11) NOT NULL, `sjAbortOnFail` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `sjCreateTime` timestamp NOT NULL DEFAULT current_timestamp(), PRIMARY KEY (`sjID`), KEY `new_index` (`sjHostID`), KEY `idx_sjCreateTime` (`sjCreateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `snapinJobs` ( `sjID` int(11) NOT NULL AUTO_INCREMENT, `sjHostID` int(11) NOT NULL, `sjStateID` int(11) NOT NULL, `sjAbortOnFail` tinyint(1) NOT NULL DEFAULT 0, `sjCreateTime` timestamp NOT NULL DEFAULT current_timestamp(), PRIMARY KEY (`sjID`), KEY `new_index` (`sjHostID`), KEY `idx_sjCreateTime` (`sjCreateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'sjID' => 'int(11) NOT NULL',
                 'sjHostID' => 'int(11) NOT NULL',
                 'sjStateID' => 'int(11) NOT NULL',
-                'sjAbortOnFail' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'sjAbortOnFail' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'sjCreateTime' => 'timestamp NOT NULL DEFAULT current_timestamp()',
             ],
         ],
         'snapins' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `snapins` ( `sID` int(11) NOT NULL AUTO_INCREMENT, `sName` varchar(200) NOT NULL, `sDesc` longtext NOT NULL DEFAULT \'\', `sFilePath` longtext NOT NULL, `sArgs` longtext NOT NULL DEFAULT \'\', `sCreateDate` timestamp NOT NULL DEFAULT current_timestamp(), `sCreator` varchar(200) NOT NULL DEFAULT \'\', `sReboot` varchar(1) NOT NULL DEFAULT \'\', `sRunWith` varchar(245) NOT NULL DEFAULT \'\', `sRunWithArgs` varchar(200) NOT NULL DEFAULT \'\', `sAnon3` varchar(45) NOT NULL DEFAULT \'\', `snapinProtect` mediumint(9) NOT NULL DEFAULT 0, `sEnabled` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `sReplicate` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `sShutdown` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `sHideLog` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `sTimeout` int(11) NOT NULL DEFAULT 0, `sPackType` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `sHash` varchar(255) NOT NULL DEFAULT \'\', `sSize` bigint(20) NOT NULL DEFAULT 0, PRIMARY KEY (`sID`), UNIQUE KEY `sName` (`sName`), KEY `new_index` (`sName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `snapins` ( `sID` int(11) NOT NULL AUTO_INCREMENT, `sName` varchar(200) NOT NULL, `sDesc` longtext NOT NULL DEFAULT \'\', `sFilePath` longtext NOT NULL, `sArgs` longtext NOT NULL DEFAULT \'\', `sCreateDate` timestamp NOT NULL DEFAULT current_timestamp(), `sCreator` varchar(200) NOT NULL DEFAULT \'\', `sReboot` varchar(1) NOT NULL DEFAULT \'\', `sRunWith` varchar(245) NOT NULL DEFAULT \'\', `sRunWithArgs` varchar(200) NOT NULL DEFAULT \'\', `sAnon3` varchar(45) NOT NULL DEFAULT \'\', `snapinProtect` mediumint(9) NOT NULL DEFAULT 0, `sEnabled` tinyint(1) NOT NULL DEFAULT 1, `sReplicate` tinyint(1) NOT NULL DEFAULT 1, `sShutdown` tinyint(1) NOT NULL DEFAULT 0, `sHideLog` tinyint(1) NOT NULL DEFAULT 0, `sTimeout` int(11) NOT NULL DEFAULT 0, `sPackType` tinyint(1) NOT NULL DEFAULT 0, `sHash` varchar(255) NOT NULL DEFAULT \'\', `sSize` bigint(20) NOT NULL DEFAULT 0, PRIMARY KEY (`sID`), UNIQUE KEY `sName` (`sName`), KEY `new_index` (`sName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'sID' => 'int(11) NOT NULL',
                 'sName' => 'varchar(200) NOT NULL',
@@ -780,12 +780,12 @@ return [
                 'sRunWithArgs' => 'varchar(200) NOT NULL DEFAULT \'\'',
                 'sAnon3' => 'varchar(45) NOT NULL DEFAULT \'\'',
                 'snapinProtect' => 'mediumint(9) NOT NULL DEFAULT 0',
-                'sEnabled' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
-                'sReplicate' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
-                'sShutdown' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
-                'sHideLog' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'sEnabled' => 'tinyint(1) NOT NULL DEFAULT 1',
+                'sReplicate' => 'tinyint(1) NOT NULL DEFAULT 1',
+                'sShutdown' => 'tinyint(1) NOT NULL DEFAULT 0',
+                'sHideLog' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'sTimeout' => 'int(11) NOT NULL DEFAULT 0',
-                'sPackType' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'sPackType' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'sHash' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'sSize' => 'bigint(20) NOT NULL DEFAULT 0',
             ],
@@ -830,7 +830,7 @@ return [
             ],
         ],
         'tasks' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `tasks` ( `taskID` int(11) NOT NULL AUTO_INCREMENT, `taskName` varchar(250) NOT NULL DEFAULT \'\', `taskCreateTime` timestamp NOT NULL DEFAULT current_timestamp(), `taskCheckIn` datetime DEFAULT NULL, `taskHostID` int(11) NOT NULL, `taskImageID` int(11) NOT NULL, `taskStateID` int(11) NOT NULL, `taskIsDebug` mediumint(9) NOT NULL DEFAULT 0, `taskCreateBy` varchar(200) NOT NULL DEFAULT \'\', `taskForce` varchar(1) NOT NULL DEFAULT \'\', `taskScheduledStartTime` datetime DEFAULT NULL, `taskTypeID` mediumint(9) NOT NULL, `taskPCT` int(10) unsigned zerofill NOT NULL DEFAULT 0000000000, `taskBPM` varchar(250) NOT NULL DEFAULT \'\', `taskTimeElapsed` varchar(250) NOT NULL DEFAULT \'\', `taskTimeRemaining` varchar(250) NOT NULL DEFAULT \'\', `taskDataCopied` varchar(250) NOT NULL DEFAULT \'\', `taskPercentText` varchar(250) NOT NULL DEFAULT \'\', `taskDataTotal` varchar(250) NOT NULL DEFAULT \'\', `taskNFSGroupID` int(11) NOT NULL, `taskNFSMemberID` int(11) NOT NULL, `taskNFSFailures` char(1) NOT NULL DEFAULT \'\', `taskLastMemberID` int(11) NOT NULL, `taskWOL` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `taskPassreset` varchar(250) NOT NULL DEFAULT \'\', `taskShutdown` char(1) NOT NULL DEFAULT \'\', `taskBypassBitlocker` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `taskStateChangedTime` datetime DEFAULT NULL, PRIMARY KEY (`taskID`), KEY `new_index` (`taskHostID`), KEY `new_index1` (`taskCheckIn`), KEY `new_index2` (`taskStateID`), KEY `new_index3` (`taskForce`), KEY `new_index4` (`taskTypeID`), KEY `new_index5` (`taskNFSGroupID`), KEY `new_index6` (`taskNFSMemberID`), KEY `new_index7` (`taskNFSFailures`), KEY `new_index8` (`taskLastMemberID`), KEY `idx_taskCreateTime` (`taskCreateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `tasks` ( `taskID` int(11) NOT NULL AUTO_INCREMENT, `taskName` varchar(250) NOT NULL DEFAULT \'\', `taskCreateTime` timestamp NOT NULL DEFAULT current_timestamp(), `taskCheckIn` datetime DEFAULT NULL, `taskHostID` int(11) NOT NULL, `taskImageID` int(11) NOT NULL, `taskStateID` int(11) NOT NULL, `taskIsDebug` mediumint(9) NOT NULL DEFAULT 0, `taskCreateBy` varchar(200) NOT NULL DEFAULT \'\', `taskForce` varchar(1) NOT NULL DEFAULT \'\', `taskScheduledStartTime` datetime DEFAULT NULL, `taskTypeID` mediumint(9) NOT NULL, `taskPCT` int(10) unsigned zerofill NOT NULL DEFAULT 0000000000, `taskBPM` varchar(250) NOT NULL DEFAULT \'\', `taskTimeElapsed` varchar(250) NOT NULL DEFAULT \'\', `taskTimeRemaining` varchar(250) NOT NULL DEFAULT \'\', `taskDataCopied` varchar(250) NOT NULL DEFAULT \'\', `taskPercentText` varchar(250) NOT NULL DEFAULT \'\', `taskDataTotal` varchar(250) NOT NULL DEFAULT \'\', `taskNFSGroupID` int(11) NOT NULL, `taskNFSMemberID` int(11) NOT NULL, `taskNFSFailures` char(1) NOT NULL DEFAULT \'\', `taskLastMemberID` int(11) NOT NULL, `taskWOL` tinyint(1) NOT NULL DEFAULT 0, `taskPassreset` varchar(250) NOT NULL DEFAULT \'\', `taskShutdown` char(1) NOT NULL DEFAULT \'\', `taskBypassBitlocker` tinyint(1) NOT NULL DEFAULT 0, `taskStateChangedTime` datetime DEFAULT NULL, PRIMARY KEY (`taskID`), KEY `new_index` (`taskHostID`), KEY `new_index1` (`taskCheckIn`), KEY `new_index2` (`taskStateID`), KEY `new_index3` (`taskForce`), KEY `new_index4` (`taskTypeID`), KEY `new_index5` (`taskNFSGroupID`), KEY `new_index6` (`taskNFSMemberID`), KEY `new_index7` (`taskNFSFailures`), KEY `new_index8` (`taskLastMemberID`), KEY `idx_taskCreateTime` (`taskCreateTime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'taskID' => 'int(11) NOT NULL',
                 'taskName' => 'varchar(250) NOT NULL DEFAULT \'\'',
@@ -855,10 +855,10 @@ return [
                 'taskNFSMemberID' => 'int(11) NOT NULL',
                 'taskNFSFailures' => 'char(1) NOT NULL DEFAULT \'\'',
                 'taskLastMemberID' => 'int(11) NOT NULL',
-                'taskWOL' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'taskWOL' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'taskPassreset' => 'varchar(250) NOT NULL DEFAULT \'\'',
                 'taskShutdown' => 'char(1) NOT NULL DEFAULT \'\'',
-                'taskBypassBitlocker' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'taskBypassBitlocker' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'taskStateChangedTime' => 'datetime DEFAULT NULL',
             ],
         ],
@@ -873,7 +873,7 @@ return [
             ],
         ],
         'taskTypes' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `taskTypes` ( `ttID` mediumint(9) NOT NULL AUTO_INCREMENT, `ttName` varchar(30) NOT NULL, `ttDescription` text NOT NULL DEFAULT \'\', `ttIcon` varchar(30) NOT NULL, `ttKernel` varchar(100) NOT NULL DEFAULT \'\', `ttKernelArgs` text NOT NULL DEFAULT \'\', `ttType` enum(\'fog\',\'user\') NOT NULL DEFAULT \'user\', `ttIsAdvanced` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', `ttIsAccess` enum(\'both\',\'host\',\'group\') NOT NULL DEFAULT \'both\', `ttInitrd` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`ttID`), UNIQUE KEY `ttName` (`ttName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `taskTypes` ( `ttID` mediumint(9) NOT NULL AUTO_INCREMENT, `ttName` varchar(30) NOT NULL, `ttDescription` text NOT NULL DEFAULT \'\', `ttIcon` varchar(30) NOT NULL, `ttKernel` varchar(100) NOT NULL DEFAULT \'\', `ttKernelArgs` text NOT NULL DEFAULT \'\', `ttType` enum(\'fog\',\'user\') NOT NULL DEFAULT \'user\', `ttIsAdvanced` tinyint(1) NOT NULL DEFAULT 0, `ttIsAccess` enum(\'both\',\'host\',\'group\') NOT NULL DEFAULT \'both\', `ttInitrd` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`ttID`), UNIQUE KEY `ttName` (`ttName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'ttID' => 'mediumint(9) NOT NULL',
                 'ttName' => 'varchar(30) NOT NULL',
@@ -882,7 +882,7 @@ return [
                 'ttKernel' => 'varchar(100) NOT NULL DEFAULT \'\'',
                 'ttKernelArgs' => 'text NOT NULL DEFAULT \'\'',
                 'ttType' => 'enum(\'fog\',\'user\') NOT NULL DEFAULT \'user\'',
-                'ttIsAdvanced' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'ttIsAdvanced' => 'tinyint(1) NOT NULL DEFAULT 0',
                 'ttIsAccess' => 'enum(\'both\',\'host\',\'group\') NOT NULL DEFAULT \'both\'',
                 'ttInitrd' => 'longtext NOT NULL DEFAULT \'\'',
             ],
@@ -925,7 +925,7 @@ return [
             ],
         ],
         'users' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `users` ( `uId` int(11) NOT NULL AUTO_INCREMENT, `uName` varchar(255) DEFAULT NULL, `uPass` longtext NOT NULL, `uCreateDate` datetime NOT NULL DEFAULT current_timestamp(), `uCreateBy` varchar(255) DEFAULT NULL, `uType` int(11) NOT NULL DEFAULT 0, `uDisplay` varchar(255) NOT NULL DEFAULT \'\', `uAllowAPI` enum(\'0\',\'1\') NOT NULL DEFAULT \'1\', `uAPIToken` varchar(255) NOT NULL DEFAULT \'\', `uAuthSource` varchar(32) NOT NULL DEFAULT \'\', `uAPIOnly` enum(\'0\',\'1\') NOT NULL DEFAULT \'0\', PRIMARY KEY (`uId`), UNIQUE KEY `name` (`uName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `users` ( `uId` int(11) NOT NULL AUTO_INCREMENT, `uName` varchar(255) DEFAULT NULL, `uPass` longtext NOT NULL, `uCreateDate` datetime NOT NULL DEFAULT current_timestamp(), `uCreateBy` varchar(255) DEFAULT NULL, `uType` int(11) NOT NULL DEFAULT 0, `uDisplay` varchar(255) NOT NULL DEFAULT \'\', `uAllowAPI` tinyint(1) NOT NULL DEFAULT 1, `uAPIToken` varchar(255) NOT NULL DEFAULT \'\', `uAuthSource` varchar(32) NOT NULL DEFAULT \'\', `uAPIOnly` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`uId`), UNIQUE KEY `name` (`uName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'uId' => 'int(11) NOT NULL',
                 'uName' => 'varchar(255) DEFAULT NULL',
@@ -934,10 +934,10 @@ return [
                 'uCreateBy' => 'varchar(255) DEFAULT NULL',
                 'uType' => 'int(11) NOT NULL DEFAULT 0',
                 'uDisplay' => 'varchar(255) NOT NULL DEFAULT \'\'',
-                'uAllowAPI' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'1\'',
+                'uAllowAPI' => 'tinyint(1) NOT NULL DEFAULT 1',
                 'uAPIToken' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'uAuthSource' => 'varchar(32) NOT NULL DEFAULT \'\'',
-                'uAPIOnly' => 'enum(\'0\',\'1\') NOT NULL DEFAULT \'0\'',
+                'uAPIOnly' => 'tinyint(1) NOT NULL DEFAULT 0',
             ],
         ],
         'userTracking' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7677,26 +7677,14 @@ $this->schema[] = [
     // false and 1 is true whether it arrives as a string or an integer.
     // See fogproject#1361 and forum topic 18227.
     //
-    // 🔴 WHY THIS IS THREE STATEMENTS AND NOT ONE ALTER. A direct
-    // `ALTER TABLE t MODIFY c TINYINT(1)` converts an ENUM BY INDEX, not by
-    // label. Measured on MariaDB 11.8:
-    //
-    //     before:  '0'  '1'  '0'  '1'
-    //     after:    1    2    1    2
-    //
-    // Every false becomes 1 and every true becomes 2 -- both truthy, no
-    // error, nothing logged. That would silently switch on every flag in the
-    // database on upgrade. Going through VARCHAR(1) first converts by LABEL,
-    // and the second ALTER then converts the resulting '0'/'1' strings by
-    // VALUE, which is the wanted mapping. The UPDATE between them exists
-    // because a row still holding the ENUM error value arrives at the
-    // varchar stage as '', which tinyint would refuse.
+    // The migration itself -- and the reason it is three statements per
+    // column rather than one ALTER -- is Schema::enumToTinyint().
     //
     // WHAT CHANGES FOR CALLERS. PDODB runs with ATTR_EMULATE_PREPARES off,
     // so mysqlnd hands back native types: these columns read back as the
     // integer 1 where they used to read back as the string '1', and the REST
     // API payload changes from "imageEnabled":"1" to "imageEnabled":1.
-    // Deliberate -- see docs/adr/0023. Every reader in the tree tests
+    // Deliberate -- see docs/adr/0028. Every reader in the tree tests
     // truthiness or casts with (string) first; both spellings are unchanged
     // by this. Downstream consumers that compare the JSON strictly against
     // "1" are not, which is why it lands in a beta.
@@ -7711,92 +7699,39 @@ $this->schema[] = [
     // with '' meaning "inherit" as a third value the form renders, so that
     // family needs a per-column reading rather than a sweep.
     function () {
-        $booleans = [
-            'apiTokens' => ['atEnabled'],
-            'hostMAC' => [
-                'hmIgnoreClient', 'hmIgnoreImaging', 'hmPending', 'hmPrimary'
-            ],
-            'hosts' => ['hostEnforce', 'hostPending'],
-            'imageGroupAssoc' => ['igaPrimary'],
-            'images' => ['imageEnabled', 'imageReplicate'],
-            'multicastSessions' => ['msShutdown'],
-            'nfsGroupMembers' => ['ngmGraphEnabled'],
-            'powerManagement' => ['pmOndemand'],
-            'pxeMenu' => ['pxeHotKeyEnable'],
-            'snapinGroupAssoc' => ['sgaPrimary'],
-            'snapinJobs' => ['sjAbortOnFail'],
-            'snapins' => [
-                'sEnabled', 'sHideLog', 'sPackType', 'sReplicate', 'sShutdown'
-            ],
-            'tasks' => ['taskBypassBitlocker', 'taskWOL'],
-            'taskTypes' => ['ttIsAdvanced'],
-            'users' => ['uAllowAPI', 'uAPIOnly'],
-        ];
-
-        foreach ($booleans as $table => $columns) {
-            // Ask the catalogue rather than trusting the list: a column
-            // already converted reads back tinyint and is skipped, so a
-            // re-run is a read and nothing else, and a column someone has
-            // changed to something else entirely is left alone rather than
-            // rewritten.
-            $rows = self::$DB->query(
-                "SELECT `COLUMN_NAME` AS `c`, `COLUMN_TYPE` AS `ty`, "
-                . "`COLUMN_DEFAULT` AS `d` "
-                . "FROM `information_schema`.`COLUMNS` "
-                . "WHERE `TABLE_SCHEMA` = DATABASE() "
-                . "AND LOWER(`TABLE_NAME`) = :table",
-                [],
-                [':table' => strtolower($table)]
-            )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
-
-            $want = array_map('strtolower', $columns);
-            foreach ((array) $rows as $row) {
-                if (!isset($row['c'], $row['ty'])
-                    || !in_array(strtolower($row['c']), $want, true)
-                ) {
-                    continue;
-                }
-                if (!preg_match(
-                    "/^enum\\('0','1'\\)$/i",
-                    trim($row['ty'])
-                )) {
-                    continue;
-                }
-                // MariaDB reports a string default quoted ('1'), MySQL 8
-                // does not (1). Both spellings mean the same member.
-                $default = trim((string) $row['d'], "'");
-                $default = ('1' === $default) ? '1' : '0';
-
-                self::$DB->query(
-                    sprintf(
-                        'ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(1) '
-                        . "NOT NULL DEFAULT '%s'",
-                        $table,
-                        $row['c'],
-                        $default
-                    )
-                );
-                self::$DB->query(
-                    sprintf(
-                        'UPDATE `%s` SET `%s` = \'0\' '
-                        . "WHERE `%s` NOT IN ('0', '1')",
-                        $table,
-                        $row['c'],
-                        $row['c']
-                    )
-                );
-                self::$DB->query(
-                    sprintf(
-                        'ALTER TABLE `%s` MODIFY COLUMN `%s` TINYINT(1) '
-                        . 'NOT NULL DEFAULT %s',
-                        $table,
-                        $row['c'],
-                        $default
-                    )
-                );
-            }
-        }
-
-        return true;
+        // The conversion itself is Schema::enumToTinyint() -- shared,
+        // because the bundled LDAP, OIDC and location plugins each convert
+        // their own columns from their own schema() (ADR 0009) and the
+        // three-statement rule above must not be re-implemented per caller.
+        return Schema::enumToTinyint(
+            [
+                'apiTokens' => ['atEnabled'],
+                'hostMAC' => [
+                    'hmIgnoreClient',
+                    'hmIgnoreImaging',
+                    'hmPending',
+                    'hmPrimary'
+                ],
+                'hosts' => ['hostEnforce', 'hostPending'],
+                'imageGroupAssoc' => ['igaPrimary'],
+                'images' => ['imageEnabled', 'imageReplicate'],
+                'multicastSessions' => ['msShutdown'],
+                'nfsGroupMembers' => ['ngmGraphEnabled'],
+                'powerManagement' => ['pmOndemand'],
+                'pxeMenu' => ['pxeHotKeyEnable'],
+                'snapinGroupAssoc' => ['sgaPrimary'],
+                'snapinJobs' => ['sjAbortOnFail'],
+                'snapins' => [
+                    'sEnabled',
+                    'sHideLog',
+                    'sPackType',
+                    'sReplicate',
+                    'sShutdown'
+                ],
+                'tasks' => ['taskBypassBitlocker', 'taskWOL'],
+                'taskTypes' => ['ttIsAdvanced'],
+                'users' => ['uAllowAPI', 'uAPIOnly'],
+            ]
+        );
     },
 ];

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7651,3 +7651,152 @@ $this->schema[] = [
     "UPDATE `taskStates` SET `tsIcon`='bookmark' "
     . "WHERE `tsID`=1 AND `tsIcon`='bookmark-o'",
 ];
+// 368
+$this->schema[] = [
+    // Store a boolean as a boolean.
+    //
+    // FOG has spelled its two-state columns `enum('0','1')` since the
+    // beginning, and it has never spelled all of them that way: `sites`
+    // .`siteCatchAll`, `auditLog`.`alRenderable`, `auditChange`.`acRedacted`
+    // and `hosts`.`hostInfoLock` are already tinyint(1). Two conventions for
+    // one idea, and the older of the two is the one with a trap in it.
+    //
+    // WHY THE ENUM IS ACTIVELY DANGEROUS, not merely inconsistent. An
+    // integer written to an ENUM is a MEMBER INDEX, not a value, and these
+    // enums are therefore off by one:
+    //
+    //     0  ->  index 0, the error value: refused under STRICT_TRANS_TABLES
+    //     1  ->  index 1, which is the member '0'  -- i.e. FALSE
+    //     2  ->  index 2, which is the member '1'  -- i.e. TRUE
+    //
+    // So `->set('isEnabled', 1)` means DISABLED if the value ever reaches
+    // the server as an integer rather than a string. FOG survives that only
+    // because PDODB binds every parameter as PDO::PARAM_STR; it is the
+    // reason PDODB::_bind() may not use PDO::PARAM_BOOL, and the reason
+    // Schema::defaultLiteral() exists. tinyint(1) has no such trap: 0 is
+    // false and 1 is true whether it arrives as a string or an integer.
+    // See fogproject#1361 and forum topic 18227.
+    //
+    // 🔴 WHY THIS IS THREE STATEMENTS AND NOT ONE ALTER. A direct
+    // `ALTER TABLE t MODIFY c TINYINT(1)` converts an ENUM BY INDEX, not by
+    // label. Measured on MariaDB 11.8:
+    //
+    //     before:  '0'  '1'  '0'  '1'
+    //     after:    1    2    1    2
+    //
+    // Every false becomes 1 and every true becomes 2 -- both truthy, no
+    // error, nothing logged. That would silently switch on every flag in the
+    // database on upgrade. Going through VARCHAR(1) first converts by LABEL,
+    // and the second ALTER then converts the resulting '0'/'1' strings by
+    // VALUE, which is the wanted mapping. The UPDATE between them exists
+    // because a row still holding the ENUM error value arrives at the
+    // varchar stage as '', which tinyint would refuse.
+    //
+    // WHAT CHANGES FOR CALLERS. PDODB runs with ATTR_EMULATE_PREPARES off,
+    // so mysqlnd hands back native types: these columns read back as the
+    // integer 1 where they used to read back as the string '1', and the REST
+    // API payload changes from "imageEnabled":"1" to "imageEnabled":1.
+    // Deliberate -- see docs/adr/0023. Every reader in the tree tests
+    // truthiness or casts with (string) first; both spellings are unchanged
+    // by this. Downstream consumers that compare the JSON strictly against
+    // "1" are not, which is why it lands in a beta.
+    //
+    // CORE TABLES ONLY. Each bundled plugin owns its own schema (ADR 0009),
+    // so LDAPServers, OIDCProviders and location are converted by their own
+    // steps in FOGProject/fog-plugins rather than reached into from here.
+    //
+    // NOT INCLUDED, deliberately: the char(1)/varchar(1) flags
+    // (`tasks`.`taskShutdown`, `snapins`.`sReboot`, `hosts`.`hostUseAD`).
+    // They look like the same thing and are not -- `hostUseAD` is tri-state,
+    // with '' meaning "inherit" as a third value the form renders, so that
+    // family needs a per-column reading rather than a sweep.
+    function () {
+        $booleans = [
+            'apiTokens' => ['atEnabled'],
+            'hostMAC' => [
+                'hmIgnoreClient', 'hmIgnoreImaging', 'hmPending', 'hmPrimary'
+            ],
+            'hosts' => ['hostEnforce', 'hostPending'],
+            'imageGroupAssoc' => ['igaPrimary'],
+            'images' => ['imageEnabled', 'imageReplicate'],
+            'multicastSessions' => ['msShutdown'],
+            'nfsGroupMembers' => ['ngmGraphEnabled'],
+            'powerManagement' => ['pmOndemand'],
+            'pxeMenu' => ['pxeHotKeyEnable'],
+            'snapinGroupAssoc' => ['sgaPrimary'],
+            'snapinJobs' => ['sjAbortOnFail'],
+            'snapins' => [
+                'sEnabled', 'sHideLog', 'sPackType', 'sReplicate', 'sShutdown'
+            ],
+            'tasks' => ['taskBypassBitlocker', 'taskWOL'],
+            'taskTypes' => ['ttIsAdvanced'],
+            'users' => ['uAllowAPI', 'uAPIOnly'],
+        ];
+
+        foreach ($booleans as $table => $columns) {
+            // Ask the catalogue rather than trusting the list: a column
+            // already converted reads back tinyint and is skipped, so a
+            // re-run is a read and nothing else, and a column someone has
+            // changed to something else entirely is left alone rather than
+            // rewritten.
+            $rows = self::$DB->query(
+                "SELECT `COLUMN_NAME` AS `c`, `COLUMN_TYPE` AS `ty`, "
+                . "`COLUMN_DEFAULT` AS `d` "
+                . "FROM `information_schema`.`COLUMNS` "
+                . "WHERE `TABLE_SCHEMA` = DATABASE() "
+                . "AND LOWER(`TABLE_NAME`) = :table",
+                [],
+                [':table' => strtolower($table)]
+            )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+
+            $want = array_map('strtolower', $columns);
+            foreach ((array) $rows as $row) {
+                if (!isset($row['c'], $row['ty'])
+                    || !in_array(strtolower($row['c']), $want, true)
+                ) {
+                    continue;
+                }
+                if (!preg_match(
+                    "/^enum\\('0','1'\\)$/i",
+                    trim($row['ty'])
+                )) {
+                    continue;
+                }
+                // MariaDB reports a string default quoted ('1'), MySQL 8
+                // does not (1). Both spellings mean the same member.
+                $default = trim((string) $row['d'], "'");
+                $default = ('1' === $default) ? '1' : '0';
+
+                self::$DB->query(
+                    sprintf(
+                        'ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(1) '
+                        . "NOT NULL DEFAULT '%s'",
+                        $table,
+                        $row['c'],
+                        $default
+                    )
+                );
+                self::$DB->query(
+                    sprintf(
+                        'UPDATE `%s` SET `%s` = \'0\' '
+                        . "WHERE `%s` NOT IN ('0', '1')",
+                        $table,
+                        $row['c'],
+                        $row['c']
+                    )
+                );
+                self::$DB->query(
+                    sprintf(
+                        'ALTER TABLE `%s` MODIFY COLUMN `%s` TINYINT(1) '
+                        . 'NOT NULL DEFAULT %s',
+                        $table,
+                        $row['c'],
+                        $default
+                    )
+                );
+            }
+        }
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -550,9 +550,11 @@ class OpenAPI extends FOGBase
      * Input looks like 'varchar(250) NOT NULL', 'int(11) NOT NULL',
      * "enum('0','1') NOT NULL" or 'longtext DEFAULT NULL'.
      *
-     * tinyint(1) maps to integer rather than boolean on purpose: FOG spells
-     * its booleans enum('0','1') and uses tinyint for genuine small integers,
-     * so the usual MySQL-to-bool shortcut would mistype real data.
+     * tinyint(1) maps to integer rather than boolean on purpose. Since ADR
+     * 0028 tinyint(1) IS how FOG spells a boolean, so the shortcut is no
+     * longer a mistyping -- but the value on the wire is 0/1, not JSON
+     * true/false, because that is what mysqlnd returns for the column.
+     * Documenting it as boolean would describe a payload FOG does not send.
      *
      * @param string $sqlType The column definition.
      *

--- a/packages/web/lib/fog/schema.class.php
+++ b/packages/web/lib/fog/schema.class.php
@@ -593,6 +593,123 @@ class Schema extends FOGController
         return "''";
     }
     /**
+     * Converts enum('0','1') columns to tinyint(1), preserving every value.
+     *
+     * ADR 0028. FOG spelled its two-state columns enum('0','1') for years,
+     * which put a trap in every one of them: an integer written to an ENUM is
+     * a member INDEX, not a value, so 1 selects the member '0' -- FALSE --
+     * and 0 is the error value STRICT_TRANS_TABLES refuses. tinyint(1) has no
+     * such trap. Core converts its columns in schema step 368; each bundled
+     * plugin converts its own from its own schema() (ADR 0009), and calls
+     * this so there is one implementation of the conversion rather than four.
+     *
+     * 🔴 THREE STATEMENTS, NOT ONE, AND THAT IS NOT OPTIONAL. A direct
+     * `ALTER TABLE t MODIFY c TINYINT(1)` converts an ENUM BY INDEX. Measured
+     * on MariaDB 11.8:
+     *
+     *     before:  '0'  '1'  '0'  '1'
+     *     after:    1    2    1    2
+     *
+     * Every false becomes 1 and every true becomes 2 -- both truthy, no
+     * error, nothing logged, on every upgrading server. VARCHAR(1) first
+     * converts by LABEL; the second ALTER then converts the resulting
+     * '0'/'1' strings by VALUE, which is the wanted mapping. The UPDATE
+     * between the two is not cosmetic either: a row still holding the ENUM
+     * error value from before GH-1245 arrives at the varchar stage as '',
+     * which tinyint refuses, so without it the upgrade fails hard on exactly
+     * the databases that most need repairing.
+     *
+     * Nullability and default are read from the catalogue and carried across
+     * rather than assumed -- LDAPServers.lsAllowAPI is nullable and
+     * lsUseGroupMatch has no default at all, and rewriting either would be a
+     * behaviour change smuggled in by a type change.
+     *
+     * Re-running is a read: a column that is not still exactly
+     * enum('0','1') is skipped, so a converted column is left alone and so is
+     * one an admin has changed to something else.
+     *
+     * @param array $map table name => list of column names.
+     *
+     * @return bool
+     */
+    public static function enumToTinyint(array $map)
+    {
+        foreach ($map as $table => $columns) {
+            $rows = self::$DB->query(
+                "SELECT `COLUMN_NAME` AS `c`, `COLUMN_TYPE` AS `ty`, "
+                . "`COLUMN_DEFAULT` AS `d`, `IS_NULLABLE` AS `n` "
+                . "FROM `information_schema`.`COLUMNS` "
+                . "WHERE `TABLE_SCHEMA` = DATABASE() "
+                . "AND LOWER(`TABLE_NAME`) = :table",
+                [],
+                [':table' => strtolower($table)]
+            )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+
+            $want = array_map('strtolower', (array) $columns);
+            foreach ((array) $rows as $row) {
+                if (!isset($row['c'], $row['ty'])
+                    || !in_array(strtolower($row['c']), $want, true)
+                ) {
+                    continue;
+                }
+                if (!preg_match("/^enum\\('0','1'\\)$/i", trim($row['ty']))) {
+                    continue;
+                }
+
+                $nullable = isset($row['n'])
+                    && 0 === strcasecmp((string) $row['n'], 'YES');
+                // MariaDB reports a string default quoted ('1') and reports
+                // "no default" as SQL NULL; MySQL 8 reports the member
+                // unquoted. Trimming the quotes normalises both.
+                $raw = $row['d'];
+                $hasDefault = null !== $raw
+                    && 0 !== strcasecmp((string) $raw, 'NULL');
+                $default = ('1' === trim((string) $raw, "'")) ? '1' : '0';
+
+                $null = $nullable ? 'NULL' : 'NOT NULL';
+                if (!$hasDefault && $nullable) {
+                    $strTail = $null . ' DEFAULT NULL';
+                    $intTail = $null . ' DEFAULT NULL';
+                } elseif (!$hasDefault) {
+                    $strTail = $null;
+                    $intTail = $null;
+                } else {
+                    $strTail = $null . " DEFAULT '" . $default . "'";
+                    $intTail = $null . ' DEFAULT ' . $default;
+                }
+
+                self::$DB->query(
+                    sprintf(
+                        'ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(1) %s',
+                        $table,
+                        $row['c'],
+                        $strTail
+                    )
+                );
+                self::$DB->query(
+                    sprintf(
+                        'UPDATE `%s` SET `%s` = \'0\' '
+                        . "WHERE `%s` IS NOT NULL AND `%s` NOT IN ('0', '1')",
+                        $table,
+                        $row['c'],
+                        $row['c'],
+                        $row['c']
+                    )
+                );
+                self::$DB->query(
+                    sprintf(
+                        'ALTER TABLE `%s` MODIFY COLUMN `%s` TINYINT(1) %s',
+                        $table,
+                        $row['c'],
+                        $intTail
+                    )
+                );
+            }
+        }
+
+        return true;
+    }
+    /**
      * SQL create table syntax
      *
      * @param string $name    What are we calling the table?

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 367);
+        define('FOG_SCHEMA', 368);
         define('FOG_BCACHE_VER', 315);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -1504,8 +1504,10 @@ class GroupManagement extends FOGPage
         }
         if (isset($_POST['confirmenforcesend'])) {
             // Tri-state: '' = no change (no-clobber), '1'/'0' = force on all.
-            // hostEnforce is enum('0','1'); pass the STRING, not an int -- an
-            // int indexes the enum (1 -> '0', 0 -> truncation error).
+            // hostEnforce is tinyint(1) since ADR 0028, so a string and an
+            // int now mean the same thing. It stays a string because the
+            // POST value is one and the '' arm has to stay distinguishable
+            // from 0 -- casting would make "no change" mean "disable".
             $enforce = (string)filter_input(INPUT_POST, 'enforce');
             if ($enforce === '1' || $enforce === '0') {
                 self::getClass('HostManager')->update(

--- a/tests/booleans-are-tinyint.test.php
+++ b/tests/booleans-are-tinyint.test.php
@@ -97,54 +97,83 @@ foreach ($tables as $table => $def) {
 }
 
 // --- 2 & 3. the conversion keeps its three statements ----------------------
-$schema = (string) file_get_contents($web . '/commons/schema.php');
-$step = '';
-if (preg_match('#\n// 368\n\$this->schema\[\] = \[(.*?)\n\];#s', $schema, $m)) {
-    $step = $m[1];
+// The SQL lives in Schema::enumToTinyint(), shared so that core step 368 and
+// the three bundled plugins that convert their own columns cannot drift.
+$schemaClass = (string) file_get_contents($web . '/lib/fog/schema.class.php');
+$method = '';
+if (preg_match(
+    '#public static function enumToTinyint\(array \$map\)\s*\{(.*?)\n    \}#s',
+    $schemaClass,
+    $m
+)) {
+    $method = $m[1];
 }
-btCheck('schema step 368 was found', $step !== '', $failures, $checks);
+btCheck(
+    'Schema::enumToTinyint() exists -- core and the bundled plugins share one '
+    . 'implementation of the conversion',
+    $method !== '',
+    $failures,
+    $checks
+);
 
-// The step opens with a comment block that names all three statements in a
-// different order to the one it runs them in. Order is only meaningful for
-// the code, so read the code.
-$code = preg_replace('#^\s*//.*$#m', '', $step);
-
-$varcharAt = strpos($code, 'VARCHAR(1)');
-$updateAt = strpos($code, 'UPDATE');
-$tinyintAt = strpos($code, 'TINYINT(1)');
+$varcharAt = strpos($method, 'VARCHAR(1)');
+$updateAt = strpos($method, 'UPDATE');
+$tinyintAt = strpos($method, 'TINYINT(1)');
 
 btCheck(
-    'step 368 converts through VARCHAR(1) first -- a direct ALTER to TINYINT '
-    . "converts an ENUM by INDEX, turning every '0' into 1 and every '1' into "
-    . '2, silently, on every upgrading server',
+    'enumToTinyint() converts through VARCHAR(1) first -- a direct ALTER to '
+    . "TINYINT converts an ENUM by INDEX, turning every '0' into 1 and every "
+    . "'1' into 2, silently, on every upgrading server",
     $varcharAt !== false,
     $failures,
     $checks
 );
 btCheck(
-    'step 368 still repairs stragglers between the two ALTERs -- a row holding '
-    . "the ENUM error value arrives as '' and tinyint refuses it",
+    'enumToTinyint() still repairs stragglers between the two ALTERs -- a row '
+    . "holding the ENUM error value arrives as '' and tinyint refuses it",
     $updateAt !== false,
     $failures,
     $checks
 );
 btCheck(
-    'step 368 lands on TINYINT(1)',
+    'enumToTinyint() lands on TINYINT(1)',
     $tinyintAt !== false,
     $failures,
     $checks
 );
 btCheck(
-    'step 368 runs VARCHAR -> UPDATE -> TINYINT in that order',
+    'enumToTinyint() runs VARCHAR -> UPDATE -> TINYINT in that order',
     $varcharAt !== false && $updateAt !== false && $tinyintAt !== false
         && $varcharAt < $updateAt && $updateAt < $tinyintAt,
     $failures,
     $checks
 );
 btCheck(
-    'step 368 checks the live column type before touching it, so a re-run is '
-    . 'a read and a column already changed is left alone',
-    false !== strpos($code, "enum\\\\('0','1'\\\\)"),
+    'enumToTinyint() checks the live column type before touching it, so a '
+    . 're-run is a read and a column already changed is left alone',
+    false !== strpos($method, "enum\\\\('0','1'\\\\)"),
+    $failures,
+    $checks
+);
+btCheck(
+    'enumToTinyint() carries the column\'s nullability across rather than '
+    . 'assuming NOT NULL -- LDAPServers.lsAllowAPI is nullable, and rewriting '
+    . 'that would be a behaviour change smuggled in by a type change',
+    false !== strpos($method, 'IS_NULLABLE'),
+    $failures,
+    $checks
+);
+
+// --- 4. step 368 is what runs it for the core tables -----------------------
+$schema = (string) file_get_contents($web . '/commons/schema.php');
+$step = '';
+if (preg_match('#\n// 368\n\$this->schema\[\] = \[(.*?)\n\];#s', $schema, $m)) {
+    $step = $m[1];
+}
+btCheck('schema step 368 was found', $step !== '', $failures, $checks);
+btCheck(
+    'schema step 368 converts the core columns through the shared helper',
+    false !== strpos(preg_replace('#^\s*//.*$#m', '', $step), 'Schema::enumToTinyint'),
     $failures,
     $checks
 );

--- a/tests/booleans-are-tinyint.test.php
+++ b/tests/booleans-are-tinyint.test.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Two-state columns are tinyint(1), and the migration that made them so does
+ * not convert an ENUM by index.
+ *
+ * ADR 0028. FOG spelled its booleans enum('0','1') for years, which put a trap
+ * in every one of them: an integer written to an ENUM is a member INDEX, so
+ * `1` means the member '0' -- FALSE -- and `0` is the error value, refused
+ * under STRICT_TRANS_TABLES. The tree only survived that because PDODB binds
+ * everything as PDO::PARAM_STR.
+ *
+ * WHAT THIS PINS, and why each half matters:
+ *
+ *   1. The manifest carries no enum('0','1') column. That is the end state,
+ *      and it is what a new column added as an enum would break.
+ *
+ *   2. Step 368 converts through VARCHAR before TINYINT. This is the
+ *      load-bearing one. A direct `ALTER ... MODIFY TINYINT(1)` converts an
+ *      ENUM BY INDEX, not by label -- '0' becomes 1 and '1' becomes 2, both
+ *      truthy, silently, on every upgrading server. Anyone "simplifying"
+ *      those three statements into one turns an upgrade into a data
+ *      corruption with no error anywhere. Measured on MariaDB 11.8; the live
+ *      proof is background_scripts/prove_boolean_column_writes.php's sibling
+ *      run in the pull request.
+ *
+ *   3. The UPDATE between the two ALTERs survives. A row still holding the
+ *      ENUM error value (GH-1245's legacy) reaches the varchar stage as '',
+ *      which tinyint refuses -- so removing it turns the step into a hard
+ *      failure on exactly the servers that most need it.
+ *
+ * It does NOT pin today's column list. A boolean added later is covered by
+ * check 1 without anyone editing this file.
+ *
+ * DB-free: reads the manifest and the schema source.
+ *
+ * Usage: php tests/booleans-are-tinyint.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$failures = [];
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $what     what is being asserted
+ * @param bool   $ok       whether it holds
+ * @param array  $failures collected failures
+ * @param int    $checks   running count
+ *
+ * @return void
+ */
+function btCheck($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+// --- 1. no two-state ENUM survives in the manifest -------------------------
+$manifest = include $web . '/commons/schema-expected.php';
+$tables = isset($manifest['tables']) && is_array($manifest['tables'])
+    ? $manifest['tables']
+    : [];
+btCheck('the manifest has tables', count($tables) > 0, $failures, $checks);
+
+foreach ($tables as $table => $def) {
+    if (!isset($def['columns']) || !is_array($def['columns'])) {
+        continue;
+    }
+    foreach ($def['columns'] as $column => $type) {
+        btCheck(
+            sprintf(
+                '%s.%s is %s -- a two-state column is tinyint(1) (ADR 0028); '
+                . 'an integer written to enum(\'0\',\'1\') is a member index, '
+                . 'so 1 stores FALSE',
+                $table,
+                $column,
+                trim((string) $type)
+            ),
+            !preg_match("/^enum\('0','1'\)/i", trim((string) $type)),
+            $failures,
+            $checks
+        );
+    }
+    if (isset($def['create'])) {
+        btCheck(
+            sprintf('%s\'s CREATE carries no enum(\'0\',\'1\') column', $table),
+            !preg_match("/enum\('0','1'\)/i", (string) $def['create']),
+            $failures,
+            $checks
+        );
+    }
+}
+
+// --- 2 & 3. the conversion keeps its three statements ----------------------
+$schema = (string) file_get_contents($web . '/commons/schema.php');
+$step = '';
+if (preg_match('#\n// 368\n\$this->schema\[\] = \[(.*?)\n\];#s', $schema, $m)) {
+    $step = $m[1];
+}
+btCheck('schema step 368 was found', $step !== '', $failures, $checks);
+
+// The step opens with a comment block that names all three statements in a
+// different order to the one it runs them in. Order is only meaningful for
+// the code, so read the code.
+$code = preg_replace('#^\s*//.*$#m', '', $step);
+
+$varcharAt = strpos($code, 'VARCHAR(1)');
+$updateAt = strpos($code, 'UPDATE');
+$tinyintAt = strpos($code, 'TINYINT(1)');
+
+btCheck(
+    'step 368 converts through VARCHAR(1) first -- a direct ALTER to TINYINT '
+    . "converts an ENUM by INDEX, turning every '0' into 1 and every '1' into "
+    . '2, silently, on every upgrading server',
+    $varcharAt !== false,
+    $failures,
+    $checks
+);
+btCheck(
+    'step 368 still repairs stragglers between the two ALTERs -- a row holding '
+    . "the ENUM error value arrives as '' and tinyint refuses it",
+    $updateAt !== false,
+    $failures,
+    $checks
+);
+btCheck(
+    'step 368 lands on TINYINT(1)',
+    $tinyintAt !== false,
+    $failures,
+    $checks
+);
+btCheck(
+    'step 368 runs VARCHAR -> UPDATE -> TINYINT in that order',
+    $varcharAt !== false && $updateAt !== false && $tinyintAt !== false
+        && $varcharAt < $updateAt && $updateAt < $tinyintAt,
+    $failures,
+    $checks
+);
+btCheck(
+    'step 368 checks the live column type before touching it, so a re-run is '
+    . 'a read and a column already changed is left alone',
+    false !== strpos($code, "enum\\\\('0','1'\\\\)"),
+    $failures,
+    $checks
+);
+
+printf("%d checks\n", $checks);
+if (count($failures) > 0) {
+    foreach ($failures as $f) {
+        printf("  FAIL  %s\n", $f);
+    }
+    printf("%d failed\n", count($failures));
+    exit(1);
+}
+printf("all passed\n");
+exit(0);


### PR DESCRIPTION
## Problem

FOG spells its two-state columns `enum('0','1')`. That encoding has a trap in it:
**an integer written to an ENUM is a member index, not a value.** For
`enum('0','1')` the mapping is

| written | MariaDB stores | means |
|---|---|---|
| `'0'` (string) | `'0'` | FALSE — correct |
| `'1'` (string) | `'1'` | TRUE — correct |
| `0` (int) | error value `''` | rejected under `STRICT_TRANS_TABLES` |
| `1` (int) | `'0'` | **FALSE — silently inverted** |

The tree only survived nine years of that because `PDODB` binds every parameter
as `PDO::PARAM_STR`. #1245 (removing the nine-year-old `SET SESSION sql_mode=''`)
and #1361 (normalising bools to `'0'`/`'1'` at the bind seam) are both patches on
top of an encoding that should not be there. FOG also already has four genuine
`tinyint(1)` booleans — `sites`.`siteCatchAll`, `auditLog`.`alRenderable`,
`auditChange`.`acRedacted`, `hosts`.`hostInfoLock` — so there are two conventions
for one idea with no rule saying which to reach for.

## What this does

Converts the **26 core two-state columns in 15 tables** to
`TINYINT(1) NOT NULL DEFAULT 0` (or `1` where that was the existing default),
via schema step **368**, and regenerates `commons/schema-expected.php`.

`docs/adr/0028-booleans-are-tinyint-not-enum.md` carries the full reasoning,
including why the ENUM domain constraint does not outweigh the index trap and
what a `CHECK (col IN (0,1))` would buy if it is ever wanted back.

### The migration is three statements per column, and that is not optional

`ALTER TABLE t MODIFY c TINYINT(1)` on an ENUM converts **by index**, so every
`'0'` becomes `1` and every `'1'` becomes `2` — both truthy, silently, on every
upgrading server. Measured on MariaDB 11.8:

```
before  0 1 0 1
after   1 2 1 2      <- naive ALTER
after   0 1 0 1      <- via VARCHAR(1)
```

So the step goes `enum` → `VARCHAR(1)` (converts by *label*) → `UPDATE` any row
still holding the ENUM error value → `TINYINT(1)`. The middle `UPDATE` is not
cosmetic: a row carrying the `''` error value from before #1245 arrives at the
varchar stage as `''`, which `tinyint` refuses, so dropping it turns the upgrade
into a hard failure on exactly the servers that most need it.

The conversion lives in **`Schema::enumToTinyint()`**, not inline in the step:
the three bundled plugins that own boolean columns convert their own from their
own `schema()`, and this is exactly the rule that must not be re-derived per
caller. It reads nullability and default out of `information_schema` and carries
them across rather than assuming `NOT NULL` — `LDAPServers`.`lsAllowAPI` is
nullable and `lsUseGroupMatch` has no default at all.

`tests/booleans-are-tinyint.test.php` pins that ordering, so the conversion cannot
be "simplified" into one `ALTER` later. Mutation-verified: removing the VARCHAR hop,
removing the `UPDATE`, or reintroducing an `enum('0','1')` column to the manifest
each fail the gate.

The step reads `information_schema` per column and skips anything not still
exactly `enum('0','1')`, so a re-run is a read and a database already converted
is left alone.

## Wire format changes, deliberately

`ATTR_EMULATE_PREPARES` is off, so mysqlnd returns native types: `enum` came back
as the string `"1"`, `tinyint` comes back as the integer `1`. These fields now
serialise as `0`/`1` rather than `"0"`/`"1"` in REST responses. That is the right
representation and this is a beta line, which is why it lands here rather than on
a patches branch. Every in-tree reader was audited — all use truthiness or cast
`(string)` first — and `MIN(COALESCE(hostEnforce,''))` still yields `0`/`1`.

`OpenAPI::_columnSchema()` already mapped `tinyint` → `integer`, which is correct
for a 0/1 payload; only its docblock changed, since it claimed FOG spelled
booleans as enums.

**Downstream: `darksidemilk/FogApi`** consumes these payloads and is the known
downstream reader of the type change.

## Not included, deliberately

- **`dev-branch`.** 1.5.x is the patches line with the largest installed base FOG
  has; the payload change is not worth it there, and #1362 already closed the bug
  that prompted this.
- **The 10 bundled-plugin columns** — `LDAPServers` (4), `OIDCProviders` (5),
  `location` (1). Each plugin owns its schema ([ADR 0009]), so those convert in
  **FOGProject/fog-plugins#27**, and reach servers through a release and a pin
  bump. That PR calls `Schema::enumToTinyint()` from here, so **this one merges
  first**.
- **The `char(1)`/`varchar(1)` flags** — `tasks`.`taskShutdown`, `snapins`.`sReboot`,
  `hosts`.`hostUseAD`. They look like the same family and are not: `hostUseAD` is
  tri-state, `''` meaning "inherit". That family needs a per-column reading, not a
  sweep.

## Verification

- Converted a throwaway copy of a live 1.6 database — all 36 columns, plugin
  tables included: every value, default and nullability preserved, re-run a
  no-op. Harness: `background_scripts/prove_enum_to_tinyint_conversion.{sh,php}`.
- Re-measured the index trap on MariaDB 11.8.8: naive `ALTER` gives `1,2,1,2`
  from `0,1,0,1`; via `VARCHAR(1)` gives `0,1,0,1`.
- `bash tests/run-all.sh` — **151 passed, 0 failed**.
- Gate mutation-verified four ways (above).

[ADR 0009]: https://github.com/FOGProject/fogproject/blob/working-1.6/docs/adr/0009-plugins-become-installable-artifacts.md

