### PR TITLE
Pin fog-plugins v1.6.17

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.16');
+        define('FOG_PLUGINS_VERSION', 'v1.6.17');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Carries the plugin half of [ADR 0028][adr] — the ten two-state columns in
`LDAPServers`, `OIDCProviders` and `location` become `tinyint(1)`.

They convert through `Schema::enumToTinyint()`, which #1364 already landed on
this branch, so the ordering is right: the helper exists before anything calls
it.

Without this bump the core columns are `tinyint(1)` and the plugin ones stay
`enum('0','1')` — the two-conventions state ADR 0028 exists to end, and the
plugin columns keep the index trap.

Verified against a restore of a live 1.6 database, driving each plugin manager's
own `install()`: all ten converted, every value, default and nullability
preserved, idempotent on re-run.

FOGProject/fog-plugins#27, released as [v1.6.17][rel].

[adr]: https://github.com/FOGProject/fogproject/blob/working-1.6/docs/adr/0028-booleans-are-tinyint-not-enum.md
[rel]: https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.17
