### PR TITLE
Route: stop refusing writes the schema allows ($nonUniqueNameClasses)

### DIFF
--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -540,14 +540,61 @@ class Route extends FOGBase
         'task'
     ];
     /**
-     * Names not unique
+     * Classes whose `name` the database does not make unique.
+     *
+     * create() and edit() refuse a body whose `name` any EXISTING row of
+     * that class already holds, unless the class is listed here. The
+     * question that check is really asking is whether the name identifies
+     * a row on its own -- and the authority on that is the schema, not
+     * this list. Where the two disagree the API refuses a write the
+     * database would have accepted, with a 500 reading `Already created`.
+     *
+     * The test is "a UNIQUE index covering the name column ALONE". A name
+     * that appears only inside a COMPOSITE unique key is not unique by
+     * itself, and that is the case the original list missed:
+     * rolePermissions is keyed `(rpRoleID, rpName)`, so two roles are
+     * meant to hold `plugin.view` -- but the API answered `Already
+     * created` to the second one, which made granting a permission to a
+     * second role impossible over REST. Measured on a real server:
+     * `image.task`, `report.view` and `task.view` were each held by three
+     * roles at the time.
+     *
+     * The others earn their place the same way:
+     *
+     *   - oui           the manufacturer repeats by design; a live server
+     *                   holds 1533 rows reading `Apple, Inc.`, and the
+     *                   unique key is `(ouiMACPrefix, ouiMan)`.
+     *   - the three association classes, whose name column is '' on every
+     *     row that exists -- so a client PUTting an object back verbatim,
+     *     `"name":""` included, was refused.
+     *   - multicastsession, which has no unique key on msName and holds
+     *     '' for every session created without one.
+     *
+     * NOT added, deliberately: imagetype, keysequence, module and
+     * pxemenuoptions. Nothing indexes their names either, but nothing
+     * shows duplicates are INTENDED there, and quietly allowing them is
+     * the riskier direction to be wrong in. Refusing a duplicate the
+     * schema would accept is an inconvenience; accepting one the product
+     * meant to reject is a data problem. Those four stay strict until
+     * somebody wants them otherwise.
+     *
+     * tests/nonunique-names-match-schema.test.php holds the other end: it
+     * reads the same CREATE TABLE statements out of the schema manifest,
+     * so a table that gains or loses a unique key on its name cannot
+     * leave this list quietly stale.
      *
      * @var array
      */
     public static $nonUniqueNameClasses = [
         'filedeletequeue',
+        'multicastsession',
+        'oui',
+        'rolepermission',
+        'roleuserassociation',
+        'roleusergroupassociation',
         'scheduledtask',
-        'task'
+        'task',
+        'usergroupmember'
     ];
     /**
      * Valid active tasking classes.

--- a/tests/nonunique-names-match-schema.test.php
+++ b/tests/nonunique-names-match-schema.test.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Route::$nonUniqueNameClasses must agree with the schema.
+ *
+ * create() and edit() refuse a body whose `name` any existing row of that
+ * class already holds, unless the class is listed in
+ * Route::$nonUniqueNameClasses. Whether that refusal is correct is a
+ * question about the DATABASE: does a unique index cover the name column
+ * on its own? Where the list and the schema disagree, the API answers a
+ * 500 reading `Already created` to a write the database would have taken.
+ *
+ * The case that shipped: rolePermissions is keyed `(rpRoleID, rpName)`, a
+ * COMPOSITE unique key, so two roles are meant to hold `plugin.view`. The
+ * name appears in a unique index, which reads as "unique" to a careless
+ * check, and is not unique by itself -- so granting a permission to a
+ * second role was impossible over REST.
+ *
+ * Checks one direction only, and the asymmetry is the point:
+ *
+ *   listed here, but the schema makes the name unique  -> FAIL. The entry
+ *       is wrong or stale, and it makes the API accept a duplicate the
+ *       database will then reject with a constraint error.
+ *
+ *   NOT listed, and the schema does not make it unique -> reported, not
+ *       failed. Four classes are in that state on purpose (imagetype,
+ *       keysequence, module, pxemenuoptions): nothing indexes their names
+ *       and nothing shows duplicates are intended either, so they stay
+ *       strict. Failing on those would force the list to say something
+ *       the schema cannot answer.
+ *
+ * Source-level, no database: the manifest carries each table's whole
+ * CREATE TABLE statement, which is where the unique keys are written
+ * (docs/adr/0008-secure-boot-enrolment-task-type.md:103).
+ *
+ * The manifest is CORE tables only, so a class whose table is absent is
+ * skipped and counted -- see docs on schema-expected.php. A plugin class
+ * is never in this list anyway.
+ *
+ * Usage: php tests/nonunique-names-match-schema.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$routeFile = $web . '/lib/router/route.class.php';
+$manifestFile = $web . '/commons/schema-expected.php';
+
+foreach ([$routeFile, $manifestFile] as $file) {
+    if (!is_readable($file)) {
+        fwrite(STDERR, "FAIL: cannot read $file\n");
+        exit(1);
+    }
+}
+
+$routeSrc = (string)file_get_contents($routeFile);
+
+/**
+ * The classes the property declares.
+ *
+ * @param string $src route.class.php source
+ * @param string $prop property name
+ *
+ * @return array
+ */
+function tnListProperty($src, $prop)
+{
+    if (!preg_match(
+        '/public static \$' . preg_quote($prop, '/') . ' = \[(.*?)\];/s',
+        $src,
+        $m
+    )) {
+        fwrite(STDERR, "FAIL: could not find \$$prop\n");
+        exit(1);
+    }
+    preg_match_all("/'([a-z0-9_]+)'/i", $m[1], $names);
+
+    return array_map('strtolower', $names[1]);
+}
+
+$nonUnique = tnListProperty($routeSrc, 'nonUniqueNameClasses');
+$validClasses = tnListProperty($routeSrc, 'validClasses');
+if (count($nonUnique) < 1 || count($validClasses) < 1) {
+    fwrite(STDERR, "FAIL: parsed an empty class list; the parser is stale\n");
+    exit(1);
+}
+
+$manifest = require $manifestFile;
+$tables = (array)($manifest['tables'] ?? []);
+if (count($tables) < 1) {
+    fwrite(STDERR, "FAIL: manifest carries no tables\n");
+    exit(1);
+}
+
+/**
+ * Does a UNIQUE index cover this column and nothing else?
+ *
+ * PRIMARY KEY counts: it is a unique index, and a name column that is the
+ * primary key is unique by itself.
+ *
+ * @param string $create the CREATE TABLE statement
+ * @param string $column the column to test
+ *
+ * @return bool
+ */
+function tnUniqueAlone($create, $column)
+{
+    preg_match_all(
+        '/(?:UNIQUE\s+KEY\s+`[^`]+`|PRIMARY\s+KEY)\s*\(([^)]*)\)/i',
+        $create,
+        $m
+    );
+    foreach ($m[1] as $cols) {
+        $parts = array_map(
+            function ($c) {
+                // Drop a prefix length, `col`(191).
+                return strtolower(trim(preg_replace('/\(\d+\)/', '', trim($c)), " `\t\n"));
+            },
+            explode(',', $cols)
+        );
+        $parts = array_values(array_filter($parts, 'strlen'));
+        if (1 === count($parts) && $parts[0] === strtolower($column)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+$failures = [];
+$skipped = [];
+$strictButUnindexed = [];
+$checked = 0;
+
+foreach ($validClasses as $class) {
+    $modelFile = $web . '/lib/fog/' . $class . '.class.php';
+    if (!is_readable($modelFile)) {
+        continue;
+    }
+    $src = (string)file_get_contents($modelFile);
+    if (!preg_match("/protected \\\$databaseTable\s*=\s*'([^']+)'/", $src, $t)) {
+        continue;
+    }
+    $table = $t[1];
+    // The friendly `name` key, and the column it maps to. A class with no
+    // `name` never reaches the uniqueness check at all -- create() guards
+    // on property_exists($vars, 'name').
+    if (!preg_match("/'name'\s*=>\s*'([^']+)'/", $src, $n)) {
+        continue;
+    }
+    $column = $n[1];
+
+    if (!isset($tables[$table]['create'])) {
+        $skipped[] = $class . ' (' . $table . ' not in the manifest)';
+        continue;
+    }
+    $checked++;
+    $alone = tnUniqueAlone((string)$tables[$table]['create'], $column);
+    $listed = in_array($class, $nonUnique, true);
+
+    if ($listed && $alone) {
+        $failures[] = sprintf(
+            '%s is in $nonUniqueNameClasses, but `%s`.`%s` IS covered by a '
+            . 'unique index on its own. The API will accept a duplicate the '
+            . 'database then rejects.',
+            $class,
+            $table,
+            $column
+        );
+    }
+    if (!$listed && !$alone) {
+        $strictButUnindexed[] = $class . ' (`' . $table . '`.`' . $column . '`)';
+    }
+}
+
+if (count($skipped) > 0) {
+    fwrite(STDOUT, 'skipped (no manifest entry): ' . implode(', ', $skipped) . "\n");
+}
+if (count($strictButUnindexed) > 0) {
+    fwrite(
+        STDOUT,
+        "strict by choice -- no unique index on the name, still refusing\n"
+        . "duplicates, see the docblock on \$nonUniqueNameClasses:\n  "
+        . implode("\n  ", $strictButUnindexed) . "\n"
+    );
+}
+
+if (count($failures) > 0) {
+    fwrite(STDERR, "FAIL\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, '  ' . $f . "\n");
+    }
+    exit(1);
+}
+
+fwrite(
+    STDOUT,
+    sprintf(
+        "ok  %d class(es) checked against the schema manifest; %d declared "
+        . "non-unique, none of them uniquely indexed\n",
+        $checked,
+        count($nonUnique)
+    )
+);
+exit(0);


### PR DESCRIPTION
Closes #1366.

## What was wrong

`Route::create()`/`edit()` refuse a body whose `name` any existing row of that class already holds, unless the class is in `Route::$nonUniqueNameClasses`. That list carried three entries and did not match the schema, so the API answered `500 {"error":"Already created"}` to writes the database would have taken.

The one that bites: `rolePermissions` is keyed `(rpRoleID, rpName)` — composite, because two roles are *meant* to hold the same permission. Granting a permission any other role already had was impossible over REST. On a live server `image.task`, `report.view` and `task.view` were each held by three roles, all unreachable through the API.

## What changed

Six classes added, each where duplicates are demonstrably normal:

`multicastsession`, `oui`, `rolepermission`, `roleuserassociation`, `roleusergroupassociation`, `usergroupmember`

The three association classes store `''` as the name on every row, so a client PUTting an object back verbatim was refused. `oui` repeats the manufacturer by design — 1533 live rows read `Apple, Inc.`, and its unique key is `(ouiMACPrefix, ouiMan)`.

**Not added, deliberately:** `imagetype`, `keysequence`, `module`, `pxemenuoptions`. Nothing indexes their names either, but nothing shows duplicates are *intended* there, and the two directions are not equally safe — refusing a duplicate the schema would take is an inconvenience, accepting one the product meant to reject is a data problem. The docblock says so, and the new test reports them without failing.

## The test

`tests/nonunique-names-match-schema.test.php` — source level, no database. It parses `$nonUniqueNameClasses` and `$validClasses` out of `route.class.php`, reads each model's `$databaseTable` and its `'name' => 'col'` mapping, then parses the `CREATE TABLE` statement the schema manifest carries for that table and asks whether a UNIQUE index covers the name column **alone**.

It fails one direction only, and the asymmetry is the point: listed here but uniquely indexed is a stale entry that makes the API accept a duplicate the database then rejects — that fails. Not listed and not indexed is reported, because four classes are in that state on purpose.

Mutation-verified in both directions: adding `host` to the list makes it fail (`hosts`.`hostName` is uniquely indexed on its own); rewriting the manifest so `rpName` is solely unique makes `rolepermission` fail.

```
ok  31 class(es) checked against the schema manifest; 9 declared non-unique, none of them uniquely indexed
```

Full suite: **152 passed, 0 failed**.

## Verification

Over HTTP against a **clone** of a live 1.6 database (podman MariaDB, shadow tree, never the live server):

| request | before | after |
|---|---|---|
| `POST /rolepermission/create` with a permission name another role holds | `500 {"error":"Already created"}` | `200 {"id":66,"roleID":17,"name":"*"}` |
| `POST /host/create` with an existing host name (negative control) | `500 {"error":"Already created"}` | `500 {"error":"Already created"}` |

The negative control matters: `hosts`.`hostName` **is** uniquely indexed on its own, so it must keep refusing. The created row was deleted afterwards; the clone is throwaway either way.

## Notes

- No schema change, no route change — so nothing for `OpenAPI::document()` to describe differently. The affected operations are the generic CRUD ones it already emits.
- `working-1.6` only. `dev-branch` has neither `$nonUniqueNameClasses` nor `Route::getList()`; its uniqueness handling is a different shape and does not carry this bug.