### PR TITLE
Edit pages: bring back the 1.5 info card

### DIFF
--- a/packages/web/lib/fog/fogpagerender.class.php
+++ b/packages/web/lib/fog/fogpagerender.class.php
@@ -375,6 +375,106 @@ trait FOGPageRender
     }
 
     /**
+     * Renders a stored datetime for display, or the word "Never".
+     *
+     * NULL means the event has never happened, which is a different fact
+     * from "it happened at the zero date" -- so it gets its own word rather
+     * than an empty box the reader has to interpret. validDate() also
+     * catches the 0000-00-00 spelling, which a column added at step 353
+     * cannot hold but which a hand-edited database still can.
+     *
+     * Lived on HostManagement as _lastSeenText() until the edit info card
+     * needed the same guard for an image's capture date. Every empty-date
+     * column in the schema reaches a page this way, so the guard belongs
+     * next to the other shared renderers rather than on one page.
+     *
+     * @param string|null $value The stored datetime, or null.
+     *
+     * @return string
+     */
+    protected static function dateOrNever($value)
+    {
+        if (!$value || !self::validDate($value)) {
+            return _('Never');
+        }
+
+        return self::niceDate($value)->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Renders the edit page's info card: the record's identity and the few
+     * facts about it you cannot see from whichever tab you are on.
+     *
+     * 1.5 had this as an "Info" dropdown at the head of the tab strip
+     * (FOGSubMenu::addNotes), because that strip lived in a col-xs-3 sidebar
+     * with no room for anything else. 1.6's tab card is full width, and the
+     * whole value of this block is context that SURVIVES a tab switch -- a
+     * dropdown that closes on the next click gives you one glance per click,
+     * which is the thing it was supposed to save you. So it is a static card
+     * above the tabs instead.
+     *
+     * Full width rather than a sidebar column for the same reason the tab
+     * card is full width: a col-3 sidebar would squeeze every tab body on
+     * the page (the host page alone has six DataTables grids) for the whole
+     * page height, to keep five lines on screen. At md and below a sidebar
+     * column stacks to the top anyway, so it would only ever differ on
+     * desktop.
+     *
+     * Plain .card, not card-primary card-outline like the tab card below it:
+     * two identically accented outlined cards stacked read as one confused
+     * object, and the tabs should keep the visual weight.
+     *
+     * Values are escaped. 1.5's fixTitle() only collapsed whitespace, so
+     * host names, image names and file paths went into that panel raw; that
+     * also means these entries are text, and a page wanting markup here has
+     * to grow an explicit opt-in rather than smuggling it through a value.
+     *
+     * @return void
+     */
+    protected function renderInfoCard()
+    {
+        $notes = (array)$this->notes;
+        // Mirrors PLUGINS_INJECT_TABDATA in tabFields(): a plugin that adds
+        // a tab to a core page can add its line here too. 1.5's equivalent
+        // rode SUB_MENULINK_DATA, which 1.6 repurposed for the sidebar node
+        // menu, so there is no back-compat name to keep.
+        self::$HookManager->processEvent(
+            'EDIT_INFO_DATA',
+            [
+                'notes' => &$notes,
+                'obj' => &$this->obj
+            ]
+        );
+        if (!count($notes)) {
+            return;
+        }
+        echo '<div class="card mb-3" id="edit-info-card">';
+        echo '<div class="card-body py-2">';
+        echo '<div class="row row-cols-auto gx-5 gy-2">';
+        foreach ($notes as $label => $value) {
+            $value = (string)($value ?? '');
+            echo '<div class="col">';
+            echo '<div class="small text-secondary text-uppercase">';
+            echo \Initiator::e($label);
+            echo '</div>';
+            echo '<div class="fw-semibold">';
+            // An em dash rather than dropping the entry: a host with no
+            // deploy date is telling you something, and a card whose fields
+            // come and go is harder to read than one that always says the
+            // same things. Muted, matching how the grids already draw an
+            // empty cell (Route's imageLink, lastping, deployed).
+            echo $value === '' ?
+                '<span class="text-muted">&mdash;</span>' :
+                \Initiator::e($value);
+            echo '</div>';
+            echo '</div>';
+        }
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+    }
+
+    /**
      * Shared scaffold for the standard edit() tab pages.
      *
      * Sets the canonical "Edit: <name> ID: <id>" page title from the
@@ -404,6 +504,7 @@ trait FOGPageRender
             _('ID'),
             $this->obj->get('id')
         );
+        $this->renderInfoCard();
         echo self::tabFields($tabData, $obj);
     }
 

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -2419,6 +2419,10 @@ class GroupManagement extends FOGPage
      */
     public function edit()
     {
+        $this->notes = [
+            _('Group') => $this->obj->get('name'),
+            _('Members') => (string)$this->obj->getHostCount()
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -1070,27 +1070,6 @@ class HostManagement extends FOGPage
         );
     }
     /**
-     * Renders a "last seen" timestamp for display.
-     *
-     * NULL means the event has never happened, which is a different fact
-     * from "it happened at the zero date" -- so it gets its own word rather
-     * than an empty box the reader has to interpret. validDate() also
-     * catches the 0000-00-00 spelling, which a column added at step 353
-     * cannot hold but which a hand-edited database still can.
-     *
-     * @param string|null $value The stored datetime, or null.
-     *
-     * @return string
-     */
-    private static function _lastSeenText($value)
-    {
-        if (!$value || !self::validDate($value)) {
-            return _('Never');
-        }
-
-        return self::niceDate($value)->format('Y-m-d H:i:s');
-    }
-    /**
      * Displays the host general tab.
      *
      * @return void
@@ -1148,7 +1127,7 @@ class HostManagement extends FOGPage
         // Deliberately NOT read from INPUT_POST like every other value here:
         // these two are written by the ping service and by the client
         // check-in, so the object is the only source that can be right.
-        $lastPing = self::_lastSeenText($this->obj->get('lastping'));
+        $lastPing = self::dateOrNever($this->obj->get('lastping'));
         // Say WHICH probe reached it, when the row knows. A timestamp with
         // no method answers "was it up" and leaves "is the service on
         // PINGHOSTPORT running" unanswered, which is the next question
@@ -1163,7 +1142,7 @@ class HostManagement extends FOGPage
                 strtoupper($pingMethod)
             );
         }
-        $lastCheckin = self::_lastSeenText($this->obj->get('lastcheckin'));
+        $lastCheckin = self::dateOrNever($this->obj->get('lastcheckin'));
 
         $labelClass = 'col-sm-3 col-form-label';
 
@@ -3485,6 +3464,21 @@ class HostManagement extends FOGPage
      */
     public function edit()
     {
+        // Identity plus the facts you cannot see from the other twenty
+        // tabs: which image is assigned, when it was last imaged, and which
+        // group it belongs to.
+        $primaryGroup = new Group(self::minId($this->obj->get('groups')));
+        $this->notes = [
+            _('Host') => $this->obj->get('name'),
+            _('Primary MAC') => (string)$this->obj->get('mac'),
+            _('Assigned Image') => $this->obj->getImageName(),
+            _('Last Deployed') => self::dateOrNever($this->obj->get('deployed')),
+            _('Primary Group') => (
+                $primaryGroup->isValid() ?
+                $primaryGroup->get('name') :
+                _('None')
+            )
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -975,6 +975,14 @@ class ImageManagement extends FOGPage
      */
     public function edit()
     {
+        $this->notes = [
+            _('Image') => $this->obj->get('name'),
+            _('OS') => $this->obj->getOS()->get('name'),
+            _('Image Type') => $this->obj->getImageType()->get('name'),
+            _('Last Captured') => self::dateOrNever($this->obj->get('deployed')),
+            _('Size on Server') => self::formatByteSize($this->obj->get('srvsize')),
+            _('Primary Storage Group') => $this->obj->getStorageGroup()->get('name')
+        ];
         $tabData = [];
 
         $tabData[] = [

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -592,6 +592,14 @@ class RoleManagement extends FOGPage
      */
     public function edit()
     {
+        // What this role grants and who holds it -- the two questions the
+        // page exists to answer, and both are behind association tabs.
+        $this->notes = [
+            _('Role') => $this->obj->get('name'),
+            _('Permissions') => (string)count((array)$this->obj->get('permissions')),
+            _('Users') => (string)count((array)$this->obj->get('users')),
+            _('User Groups') => (string)count((array)$this->obj->get('usergroups'))
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -504,6 +504,15 @@ class SiteManagement extends FOGPage
      */
     public function edit()
     {
+        // The three membership counts, read through the object's own
+        // loaders rather than counting rows: every one of these lives
+        // behind an association tab you have to leave this one to see.
+        $this->notes = [
+            _('Site') => $this->obj->get('name'),
+            _('Hosts') => (string)count((array)$this->obj->get('hosts')),
+            _('Users') => (string)count((array)$this->obj->get('users')),
+            _('Groups') => (string)count((array)$this->obj->get('groups'))
+        ];
         $tabData = [];
 
         $tabData[] = [

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -1424,6 +1424,11 @@ class SnapinManagement extends FOGPage
      */
     public function edit()
     {
+        $this->notes = [
+            _('Snapin') => $this->obj->get('name'),
+            _('File') => $this->obj->get('file'),
+            _('Filesize') => self::formatByteSize($this->obj->get('size'))
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -770,6 +770,16 @@ class StorageGroupManagement extends FOGPage
      */
     public function edit()
     {
+        $master = $this->obj->getMasterStorageNode();
+        $this->notes = [
+            _('Storage Group') => $this->obj->get('name'),
+            _('Master Node') => (
+                $master instanceof StorageNode && $master->isValid() ?
+                $master->get('name') :
+                _('None')
+            ),
+            _('Storage Nodes') => (string)count((array)$this->obj->get('allnodes'))
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -1260,6 +1260,17 @@ class StorageNodeManagement extends FOGPage
      */
     public function edit()
     {
+        $this->notes = [
+            _('Storage Node') => $this->obj->get('name'),
+            _('Storage Group') => $this->obj->getStorageGroup()->get('name'),
+            _('Role') => (
+                $this->obj->get('isMaster') ?
+                _('Master') :
+                _('Member')
+            ),
+            _('Image Path') => $this->obj->get('path'),
+            _('Max Clients') => (string)$this->obj->get('maxClients')
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/usergroupmanagement.page.php
+++ b/packages/web/lib/pages/usergroupmanagement.page.php
@@ -336,6 +336,11 @@ class UserGroupManagement extends FOGPage
      */
     public function edit()
     {
+        $this->notes = [
+            _('User Group') => $this->obj->get('name'),
+            _('Members') => (string)count((array)$this->obj->get('users')),
+            _('Roles') => (string)count((array)$this->obj->get('roles'))
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -1544,6 +1544,17 @@ class UserManagement extends FOGPage
      */
     public function edit()
     {
+        // "Signs In With" is the same label the General tab uses for
+        // authsource, and it is the one fact here that changes what the
+        // rest of the page will let you do -- an external account has no
+        // Password tab at all.
+        $authSource = trim((string)$this->obj->get('authsource'));
+        $this->notes = [
+            _('User') => $this->obj->get('name'),
+            _('Friendly Name') => $this->obj->get('display'),
+            _('Signs In With') => ($authSource ?: _('FOG')),
+            _('API Enabled') => ($this->obj->get('api') ? _('Yes') : _('No'))
+        ];
         $tabData = [];
 
         // General

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -468,6 +468,10 @@ msgid "API Documentation"
 msgstr "Ort"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "ist aktiviert"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
@@ -2833,6 +2837,10 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "Dateigröße"
+
+#, fuzzy
 msgid "Filter"
 msgstr "Filter"
 
@@ -4923,6 +4931,10 @@ msgstr "Ausgewählten MAcs freigeben"
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#, fuzzy
+msgid "Master"
+msgstr "Master-Knoten"
+
 msgid "Master Node"
 msgstr "Master-Knoten"
 
@@ -4934,6 +4946,10 @@ msgstr "Maximale Clients"
 
 msgid "Max Size"
 msgstr "Max. Größe"
+
+#, fuzzy
+msgid "Member"
+msgstr "Mitglieder"
 
 msgid "Members"
 msgstr "Mitglieder"
@@ -5540,6 +5556,9 @@ msgstr "Pfad ist nicht verfügbar"
 msgid "Nodes"
 msgstr "Knoten"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "Normales Snapin"
@@ -5602,6 +5621,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O/S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O/S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6260,6 +6283,10 @@ msgstr "Primäre Gruppe"
 
 msgid "Primary MAC"
 msgstr "Primäre MAC"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Speichergruppe"
 
 msgid "Primary User"
 msgstr "Hauptbenutzer"
@@ -7300,6 +7327,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Größe"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Web-Server"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -472,6 +472,10 @@ msgid "API Documentation"
 msgstr "Location"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "Is Enabled"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
@@ -2834,6 +2838,10 @@ msgid "Files Deleted List"
 msgstr "Delete file data"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "filesize"
+
+#, fuzzy
 msgid "Filter"
 msgstr "File"
 
@@ -4921,6 +4929,10 @@ msgstr "Approve selected Hosts"
 msgid "Mass update failed"
 msgstr "User update failed"
 
+#, fuzzy
+msgid "Master"
+msgstr "Master Node"
+
 msgid "Master Node"
 msgstr "Master Node"
 
@@ -4932,6 +4944,10 @@ msgstr "Max Clients"
 
 msgid "Max Size"
 msgstr "Max Size"
+
+#, fuzzy
+msgid "Member"
+msgstr "Members"
 
 msgid "Members"
 msgstr "Members"
@@ -5538,6 +5554,9 @@ msgstr "No hash available"
 msgid "Nodes"
 msgstr "Node"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "Invalid Snapin"
@@ -5600,6 +5619,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O/S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O/S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6258,6 +6281,10 @@ msgstr "Primary Group"
 
 msgid "Primary MAC"
 msgstr "Primary MAC"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Storage Group"
 
 msgid "Primary User"
 msgstr "Primary User"
@@ -7298,6 +7325,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Max Size"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Web Server"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -470,6 +470,10 @@ msgid "API Documentation"
 msgstr "Acción"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "habilitado"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Añadir nueva cuenta de usuario"
 
@@ -2886,6 +2890,10 @@ msgid "Files Deleted List"
 msgstr "Eliminar los datos del archivo"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "tamaño del archivo"
+
+#, fuzzy
 msgid "Filter"
 msgstr "Archivo"
 
@@ -5036,6 +5044,10 @@ msgid "Mass update failed"
 msgstr "actualización Valoración falló"
 
 #, fuzzy
+msgid "Master"
+msgstr "nodo de almacenamiento"
+
+#, fuzzy
 msgid "Master Node"
 msgstr "nodo de almacenamiento"
 
@@ -5049,6 +5061,10 @@ msgstr "Clientela"
 #, fuzzy
 msgid "Max Size"
 msgstr "Tamaño máximo:"
+
+#, fuzzy
+msgid "Member"
+msgstr "miembros"
 
 msgid "Members"
 msgstr "miembros"
@@ -5666,6 +5682,9 @@ msgstr "No se dispone de hash"
 msgid "Nodes"
 msgstr "Modelo"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "snapin"
@@ -5730,6 +5749,10 @@ msgstr ""
 
 #, fuzzy
 msgid "O/S"
+msgstr "O / S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O / S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6398,6 +6421,10 @@ msgstr "Actualización de Grupo Primario"
 #, fuzzy
 msgid "Primary MAC"
 msgstr "usuario principal"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Grupo de almacenamiento"
 
 msgid "Primary User"
 msgstr "usuario principal"
@@ -7452,6 +7479,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Tamaño máximo:"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Servidor web"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -468,6 +468,10 @@ msgid "API Documentation"
 msgstr "Ort"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "ist aktiviert"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
@@ -2833,6 +2837,10 @@ msgid "Files Deleted List"
 msgstr "Datei löschen"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "Dateigröße"
+
+#, fuzzy
 msgid "Filter"
 msgstr "Filter"
 
@@ -4924,6 +4932,10 @@ msgstr "Ausgewählten MAcs freigeben"
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
+#, fuzzy
+msgid "Master"
+msgstr "Master-Knoten"
+
 msgid "Master Node"
 msgstr "Master-Knoten"
 
@@ -4935,6 +4947,10 @@ msgstr "Maximale Clients"
 
 msgid "Max Size"
 msgstr "Max. Größe"
+
+#, fuzzy
+msgid "Member"
+msgstr "Mitglieder"
 
 msgid "Members"
 msgstr "Mitglieder"
@@ -5541,6 +5557,9 @@ msgstr "Pfad ist nicht verfügbar"
 msgid "Nodes"
 msgstr "Knoten"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "Normales Snapin"
@@ -5603,6 +5622,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O/S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O/S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6261,6 +6284,10 @@ msgstr "Primäre Gruppe"
 
 msgid "Primary MAC"
 msgstr "Primäre MAC"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Speichergruppe"
 
 msgid "Primary User"
 msgstr "Hauptbenutzer"
@@ -7301,6 +7328,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Größe"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Web-Server"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -473,6 +473,10 @@ msgid "API Documentation"
 msgstr "Emplacement"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "Est autorisé"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Comptes Slack"
 
@@ -2836,6 +2840,10 @@ msgid "Files Deleted List"
 msgstr "Supprimer les données de fichiers"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "taille du fichier"
+
+#, fuzzy
 msgid "Filter"
 msgstr "Fichier"
 
@@ -4923,6 +4931,10 @@ msgstr "Approuver hôtes sélectionnés"
 msgid "Mass update failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
+#, fuzzy
+msgid "Master"
+msgstr "Node Master"
+
 msgid "Master Node"
 msgstr "Node Master"
 
@@ -4934,6 +4946,10 @@ msgstr "Les clients de Max"
 
 msgid "Max Size"
 msgstr "Max Taille"
+
+#, fuzzy
+msgid "Member"
+msgstr "Membres"
 
 msgid "Members"
 msgstr "Membres"
@@ -5540,6 +5556,9 @@ msgstr "Pas de hachage disponible"
 msgid "Nodes"
 msgstr "Nœud"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "Invalid Snapin"
@@ -5602,6 +5621,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O / S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O / S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6260,6 +6283,10 @@ msgstr "Primary Group"
 
 msgid "Primary MAC"
 msgstr "MAC primaire"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Groupe de stockage"
 
 msgid "Primary User"
 msgstr "utilisateur principal"
@@ -7300,6 +7327,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Max Taille"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Serveur Web"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -459,6 +459,10 @@ msgid "API Documentation"
 msgstr "Luogo"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "È abilitato"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Slack Accounts"
 
@@ -2755,6 +2759,10 @@ msgstr "Impossibile per distruggere il nodo di archiviazione"
 msgid "Files Deleted List"
 msgstr "Cancellare i file"
 
+#, fuzzy
+msgid "Filesize"
+msgstr "dimensione del file"
+
 msgid "Filter"
 msgstr "Filtro"
 
@@ -4754,6 +4762,10 @@ msgstr "Approvare MAC selezionati"
 msgid "Mass update failed"
 msgstr "Aggiornamento ruolo non riuscito"
 
+#, fuzzy
+msgid "Master"
+msgstr "Maestro Node"
+
 msgid "Master Node"
 msgstr "Maestro Node"
 
@@ -4765,6 +4777,10 @@ msgstr "clienti max"
 
 msgid "Max Size"
 msgstr "Dimensione massima"
+
+#, fuzzy
+msgid "Member"
+msgstr "Utenti"
 
 msgid "Members"
 msgstr "Utenti"
@@ -5354,6 +5370,9 @@ msgstr "Percorso non disponibile"
 msgid "Nodes"
 msgstr "Nodi"
 
+msgid "None"
+msgstr ""
+
 msgid "Normal Snapin"
 msgstr "Snapin normale"
 
@@ -5414,6 +5433,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O / S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O / S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6056,6 +6079,10 @@ msgstr "Gruppo primario"
 
 msgid "Primary MAC"
 msgstr "MAC primaria"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "gruppo di archiviazione"
 
 msgid "Primary User"
 msgstr "Utente primario"
@@ -7064,6 +7091,10 @@ msgstr ""
 
 msgid "Size"
 msgstr "Dimensione"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Server web"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -445,6 +445,10 @@ msgid "API Documentation"
 msgstr "詳細ドキュメント"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "有効"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Slack アカウント"
 
@@ -2729,6 +2733,9 @@ msgstr "ストレージノードの破棄に失敗しました"
 msgid "Files Deleted List"
 msgstr "ルールの削除に失敗しました"
 
+msgid "Filesize"
+msgstr "ファイルサイズ"
+
 msgid "Filter"
 msgstr "フィルター"
 
@@ -4711,6 +4718,10 @@ msgstr "選択したスナップインを追加"
 msgid "Mass update failed"
 msgstr "ホストの更新に失敗しました"
 
+#, fuzzy
+msgid "Master"
+msgstr "高速"
+
 msgid "Master Node"
 msgstr "マスターノード"
 
@@ -4722,6 +4733,10 @@ msgstr "最大クライアント数"
 
 msgid "Max Size"
 msgstr "最大サイズ"
+
+#, fuzzy
+msgid "Member"
+msgstr "メンバー"
 
 msgid "Members"
 msgstr "メンバー"
@@ -5313,6 +5328,9 @@ msgstr "ノードは利用できません"
 msgid "Nodes"
 msgstr "ノード"
 
+msgid "None"
+msgstr ""
+
 msgid "Normal Snapin"
 msgstr "通常のスナップイン"
 
@@ -5373,6 +5391,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "OS"
+
+#, fuzzy
+msgid "OS"
 msgstr "OS"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6021,6 +6043,10 @@ msgstr "プライマリグループ"
 
 msgid "Primary MAC"
 msgstr "プライマリ MAC アドレス"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "プライマリストレージグループ"
 
 msgid "Primary User"
 msgstr "プライマリユーザー"
@@ -7010,6 +7036,10 @@ msgstr ""
 
 msgid "Size"
 msgstr "サイズ"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "サーバー"
 
 #, php-format
 msgid "Skipped unknown %s: %s"
@@ -10667,9 +10697,6 @@ msgstr ""
 #~ msgid "File must be a csv"
 #~ msgstr "ファイルは CSV である必要があります"
 
-#~ msgid "Filesize"
-#~ msgstr "ファイルサイズ"
-
 #~ msgid "For example, a GPO policy to push"
 #~ msgstr "たとえば、配布するための GPO ポリシー"
 
@@ -12245,9 +12272,6 @@ msgstr ""
 
 #~ msgid "e.g."
 #~ msgstr "例:"
-
-#~ msgid "faster"
-#~ msgstr "高速"
 
 #~ msgid "for the advanced menu parameters"
 #~ msgstr "詳細メニューパラメーター用"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -402,6 +402,9 @@ msgstr ""
 msgid "API Documentation"
 msgstr ""
 
+msgid "API Enabled"
+msgstr ""
+
 msgid "API Only Account"
 msgstr ""
 
@@ -2414,6 +2417,9 @@ msgstr ""
 msgid "Files Deleted List"
 msgstr ""
 
+msgid "Filesize"
+msgstr ""
+
 msgid "Filter"
 msgstr ""
 
@@ -4169,6 +4175,9 @@ msgstr ""
 msgid "Mass update failed"
 msgstr ""
 
+msgid "Master"
+msgstr ""
+
 msgid "Master Node"
 msgstr ""
 
@@ -4179,6 +4188,9 @@ msgid "Max Clients"
 msgstr ""
 
 msgid "Max Size"
+msgstr ""
+
+msgid "Member"
 msgstr ""
 
 msgid "Members"
@@ -4702,6 +4714,9 @@ msgstr ""
 msgid "Nodes"
 msgstr ""
 
+msgid "None"
+msgstr ""
+
 msgid "Normal Snapin"
 msgstr ""
 
@@ -4757,6 +4772,9 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr ""
+
+msgid "OS"
 msgstr ""
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -5318,6 +5336,9 @@ msgid "Primary Group"
 msgstr ""
 
 msgid "Primary MAC"
+msgstr ""
+
+msgid "Primary Storage Group"
 msgstr ""
 
 msgid "Primary User"
@@ -6197,6 +6218,9 @@ msgid "Sites This Role Grants"
 msgstr ""
 
 msgid "Size"
+msgstr ""
+
+msgid "Size on Server"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -472,6 +472,10 @@ msgid "API Documentation"
 msgstr "Localização"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "Está ativado"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "Contas Slack"
 
@@ -2835,6 +2839,10 @@ msgid "Files Deleted List"
 msgstr "Apagar dados de arquivo"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "tamanho do arquivo"
+
+#, fuzzy
 msgid "Filter"
 msgstr "Arquivo"
 
@@ -4922,6 +4930,10 @@ msgstr "Aprovar Hosts selecionados"
 msgid "Mass update failed"
 msgstr "atualização do utilizador falhou"
 
+#, fuzzy
+msgid "Master"
+msgstr "Nó mestre"
+
 msgid "Master Node"
 msgstr "Nó mestre"
 
@@ -4933,6 +4945,10 @@ msgstr "Clientes Max"
 
 msgid "Max Size"
 msgstr "Max Size"
+
+#, fuzzy
+msgid "Member"
+msgstr "Membros"
 
 msgid "Members"
 msgstr "Membros"
@@ -5539,6 +5555,9 @@ msgstr "Nenhum de hash disponíveis"
 msgid "Nodes"
 msgstr "Nó"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "Snapin inválido"
@@ -5601,6 +5620,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O / S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O / S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6259,6 +6282,10 @@ msgstr "Grupo primário"
 
 msgid "Primary MAC"
 msgstr "MAC primária"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "Grupo de armazenamento"
 
 msgid "Primary User"
 msgstr "Usuário principal"
@@ -7299,6 +7326,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "Max Size"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "Servidor web"
 
 #, php-format
 msgid "Skipped unknown %s: %s"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -472,6 +472,10 @@ msgid "API Documentation"
 msgstr "位置"
 
 #, fuzzy
+msgid "API Enabled"
+msgstr "已启用"
+
+#, fuzzy
 msgid "API Only Account"
 msgstr "斯莱克账户"
 
@@ -2835,6 +2839,10 @@ msgid "Files Deleted List"
 msgstr "删除的文件数据"
 
 #, fuzzy
+msgid "Filesize"
+msgstr "文件大小"
+
+#, fuzzy
 msgid "Filter"
 msgstr "文件"
 
@@ -4922,6 +4930,10 @@ msgstr "批准选定主机"
 msgid "Mass update failed"
 msgstr "用户更新失败"
 
+#, fuzzy
+msgid "Master"
+msgstr "主节点"
+
 msgid "Master Node"
 msgstr "主节点"
 
@@ -4933,6 +4945,10 @@ msgstr "最大客户"
 
 msgid "Max Size"
 msgstr "最大尺寸"
+
+#, fuzzy
+msgid "Member"
+msgstr "会员"
 
 msgid "Members"
 msgstr "会员"
@@ -5539,6 +5555,9 @@ msgstr "没有可用的散列"
 msgid "Nodes"
 msgstr "节点"
 
+msgid "None"
+msgstr ""
+
 #, fuzzy
 msgid "Normal Snapin"
 msgstr "无效的管理单元"
@@ -5601,6 +5620,10 @@ msgid "Numeric OS family id the installer recorded. A second encoding of FOG_os_
 msgstr ""
 
 msgid "O/S"
+msgstr "O / S"
+
+#, fuzzy
+msgid "OS"
 msgstr "O / S"
 
 msgid "OS family name the installer recorded. The stable identifier of the two."
@@ -6259,6 +6282,10 @@ msgstr "主要组"
 
 msgid "Primary MAC"
 msgstr "主MAC"
+
+#, fuzzy
+msgid "Primary Storage Group"
+msgstr "存储组"
 
 msgid "Primary User"
 msgstr "主要用户"
@@ -7299,6 +7326,10 @@ msgstr ""
 #, fuzzy
 msgid "Size"
 msgstr "最大尺寸"
+
+#, fuzzy
+msgid "Size on Server"
+msgstr "网络服务器"
 
 #, php-format
 msgid "Skipped unknown %s: %s"


### PR DESCRIPTION
`FOGPage::$notes` is declared in 1.6 (`fogpage.class.php:72`) and nothing populates or renders it. In 1.5 it was the **"Info" dropdown** at the head of the tab strip — `FOGSubMenu::addNotes()` turned a `label => value` array into a list, `FOGSubMenu::get()` drew it, and every management page filled it in its constructor. The 1.6 rewrite kept the property and dropped both ends, so the feature has been amputated rather than removed.

This renders it again, as a **static card above the tabs**.

## Why not a dropdown, and why not a sidebar

The value of this block is context that *survives a tab switch* — what host am I looking at, which image is assigned — while you are three tabs deep in a snapin association grid. A dropdown that closes on the next click gives you one glance per click, which is the thing it was meant to save. 1.5 had no choice: that strip lived in a `col-xs-3` sidebar with no room for anything else.

Full width rather than a sidebar column, for the same reason the tab card is full width. A `col-3` sidebar costs 25% of the page width for the whole page height — the host page alone has six DataTables grids inside its tabs — to keep five lines on screen, and at `md` and below it stacks to the top anyway, so it would only ever differ on desktop. No 1.6 edit page uses a column split today. If "stays on screen while scrolling a long tab" turns out to matter, `position: sticky` gets it later for one CSS rule and no layout change.

## Shape

One insertion point: `FOGPageRender::renderEditTabs()`, which all 22 edit pages already funnel through, core and plugin alike. A page that sets no `$notes` renders no card, so the four object-less pages calling `tabFields()` directly are unaffected.

Plugins inject through a new **`EDIT_INFO_DATA`** hook, mirroring `PLUGINS_INJECT_TABDATA` in `tabFields()`. 1.5's equivalent rode `SUB_MENULINK_DATA`, which 1.6 repurposed for the sidebar node menu, so there is no back-compat name to keep.

Values are escaped — 1.5's `fixTitle()` only collapsed whitespace, so host names, image names and file paths went into that panel raw. An empty value draws a muted em dash rather than dropping the row, matching how the grids already render an empty cell.

`HostManagement::_lastSeenText()` moves to `FOGPageRender::dateOrNever()`; the image card needs the same empty-date guard for a capture date and duplicating it was the worse option.

## Which pages

Ten, the ones with three or more tabs — below that everything the card would say is already on the one tab you are looking at:

| Page | Fields |
|---|---|
| Host (21 tabs) | Host, Primary MAC, Assigned Image, Last Deployed, Primary Group |
| Group (15) | Group, Members |
| Site (7) | Site, Hosts, Users, Groups |
| User (6) | User, Friendly Name, Signs In With, API Enabled |
| User Group (5) | User Group, Members, Roles |
| Role (5) | Role, Permissions, Users, User Groups |
| Image (4) | Image, OS, Image Type, Last Captured, Size on Server, Primary Storage Group |
| Storage Group (4) | Storage Group, Master Node, Storage Nodes |
| Snapin (3) | Snapin, File, Filesize |
| Storage Node (3) | Storage Node, Storage Group, Role, Image Path, Max Clients |

Printer (2 tabs), Module (2) and iPXE (1) deliberately get none. Printer had notes in 1.5; its two facts are both on its only real tab.

## Verified

Against a copy of the live database, over HTTP, all ten pages plus printer/module/iPXE for the no-card path. Every card renders with real data, no PHP error in any body, light and dark both clean.

```
host/105      Host=telliottwin11 | Primary MAC=00:ff:41:24:a3:6f | Assigned Image=test | Last Deployed=Never | Primary Group=testing 123
image/1       Image=test | OS=Windows 11 | Image Type=Single Disk - Resizable | Last Captured=2026-08-24 14:37:12 | Size on Server=6.00 GiB | Primary Storage Group=default
role/1        Role=Administrator | Permissions=1 | Users=4 | User Groups=0
storagenode/1 Storage Node=DefaultMember | Storage Group=default | Role=Master | Image Path=/images | Max Clients=1
host/48       ... Assigned Image=— ... Last Deployed=Never      (no image, no deploy date)
printer/1     NO CARD                                            (200, no empty card)
```

A host with no group draws "None" rather than raising `ValueError` out of `min([])` — `minId()` covers the empty list.

## Notes

- No route change, so `OpenAPI::document()` is untouched.
- No JS or CSS change, so no `FOG_BCACHE_VER` bump.
- The pre-commit language regen was skipped in this worktree (`packages/web/lib/plugins` is unpopulated and the hook correctly refuses rather than dropping every plugin string), so the new `_()` strings will land in `messages.pot` on the next commit made from a clone that has plugins fetched.

## Known, left as-is

Edit saves are AJAX with no page reload, so renaming a host on the General tab leaves the card showing the old name until you navigate. Fixing it means adding JS to a change that currently needs none.
