### PR TITLE
Answer a signed-out XHR with 401 JSON, not the login page at 200

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 368);
-        define('FOG_BCACHE_VER', 315);
+        define('FOG_BCACHE_VER', 316);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -134,6 +134,49 @@ if (!isset($node) || (!in_array($node, $nodes) && !$currentUser->isValid())) {
             exit;
         }
     }
+    /*
+     * A caller that cannot follow a browser sign-in must not be handed the
+     * sign-in FORM either.
+     *
+     * $browserNavigation above already tells browsers and machines apart, and
+     * already declines to bounce a machine to the identity provider. But
+     * execution then fell through to the login page for both, so a signed-out
+     * XHR got the form at HTTP 200 with Content-type: text/html. jQuery treats
+     * 200 as success, so $.apiCall ran its SUCCESS handler with a string body;
+     * $.notifyFromAPI found none of error/info/warning/msg in it and -- until
+     * the matching change in fog.common.js -- fell back to a GREEN toast
+     * reading "Bad Response". The write had been discarded and the UI said it
+     * worked. Reported against the plugin Update button, but this branch is
+     * reached by every ?node= endpoint, so it was every Save on every page.
+     *
+     * 401 with a readable reason instead. That is what the XHR error handler
+     * is for, and it is also the right answer for curl, FogApi and any other
+     * client library, none of which can do anything with a login form.
+     *
+     * The install/schema paths cannot reach this: `schema` and `client` are in
+     * $nodes above and take the other branch. Nor can the login POST itself --
+     * processMainLogin() answers it through jsonSend(), which exits.
+     *
+     * FOG_LOCAL_LOGIN is exempt, for the same reason the redirect above exempts
+     * it and not a weaker one. management/login.php defines it and then
+     * requires this file; that page exists so a human can always reach a form
+     * when the provider is down, and answering it with JSON would take the
+     * break-glass page away on exactly the request shape it is there to serve.
+     * A browser sends an Accept naming text/html and would have rendered
+     * anyway -- this makes it true regardless of what the client asks for,
+     * which is what a break-glass path has to be.
+     */
+    if (!defined('FOG_LOCAL_LOGIN') && !$browserNavigation) {
+        header('Content-type: application/json');
+        echo json_encode(
+            [
+                'error' => _('Your session has ended. Sign in again.'),
+                'title' => _('Session Expired')
+            ]
+        );
+        http_response_code(HTTPResponseCodes::HTTP_UNAUTHORIZED);
+        exit;
+    }
     $Page
         ->setTitle($foglang['Login'])
         ->setSecTitle($foglang['ManagementLogin'])

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -1824,29 +1824,45 @@ $.notify = function(title, body, type) {
   return toast;
 };
 $.notifyFromAPI = function(res, isError) {
-  if (res === undefined) {
-    typemsg = "msg";
+  // A body that is not an object cannot carry a message, and the guard used
+  // to be `res === undefined` -- which a STRING body walks straight past. A
+  // string is exactly what arrives when an endpoint answers with HTML, the
+  // shape management/index.php returned for a signed-out XHR: the sign-in
+  // page at 200. Every lookup below was then undefined, `type` kept its old
+  // 'success' default, and the user got a GREEN toast reading 'Bad Response'
+  // while the write was silently discarded.
+  //
+  // statusText is not used for the reason: it is empty over HTTP/2, which has
+  // no reason phrase, so it produced an empty message on exactly the servers
+  // most likely to hit this.
+  if (!res || typeof res !== 'object') {
     res = {
-      title: 'Generic ' + (isError ? 'Error' : 'Message'),
+      title: 'Bad Response',
+      error: (isError && isError.status)
+        ? 'The server answered ' + isError.status
+          + ' with no readable message.'
+        : 'The server returned no readable message.'
     };
-    if (isError) {
-      res.error = isError ? isError.statusText : 'Unknown issue';
-    } else {
-      res.msg = 'No message';
-    }
   }
   var title = res.title,
-    type = 'success',
+    // NOT 'success'. A response carrying none of error/info/warning/msg is
+    // one that nothing could be read out of, and that is a failure whatever
+    // the status line says -- the fallback at the bottom of this function
+    // exists precisely for it. Each branch below overrides this, so a
+    // response that does carry a message is unaffected.
+    type = 'error',
     // Declared. It never was: every branch below ASSIGNED it as an implicit
     // global, and `if (!msg)` READS it -- so any response carrying none of
     // error/info/warning/msg threw ReferenceError out of the success
     // handler and took the caller's callback with it. The fallback two
     // lines down existed precisely for that case and could never run.
     //
-    // The usual way in is a body jQuery did not parse as JSON (an endpoint
-    // missing its Content-type header): res is then a string, every lookup
-    // is undefined, and the user sees a silent failure rather than
-    // 'Bad Response'.
+    // The usual way in was a body jQuery did not parse as JSON (an endpoint
+    // missing its Content-type header, or answering with HTML): res was then
+    // a string and every lookup below undefined. The guard at the top of this
+    // function now turns any non-object into a real error object, so a string
+    // no longer reaches here -- but `msg` can still end up unset if an object
+    // carries none of the four keys, which is what the fallback below is for.
     msg;
   if (res.error) {
     type = 'error';

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9600,6 +9600,9 @@ msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -9596,6 +9596,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9782,6 +9782,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9601,6 +9601,9 @@ msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9598,6 +9598,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -9275,6 +9275,9 @@ msgstr "Il tuo schema di database FOG non è aggiornato"
 msgid "Your database connection appears to be invalid"
 msgstr "La connessione al database sembra non valida"
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -9213,6 +9213,9 @@ msgstr "FOG データベースのスキーマが最新ではありません"
 msgid "Your database connection appears to be invalid"
 msgstr "データベース接続が無効のようです"
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8181,6 +8181,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9597,6 +9597,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -9597,6 +9597,9 @@ msgstr ""
 msgid "Your database connection appears to be invalid"
 msgstr ""
 
+msgid "Your session has ended. Sign in again."
+msgstr ""
+
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
 msgstr ""
 

--- a/tests/signed-out-xhr-gets-401-json.test.php
+++ b/tests/signed-out-xhr-gets-401-json.test.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * A signed-out non-browser caller must be answered, not handed the form.
+ *
+ * management/index.php is shared by browsers and machines. When a session
+ * has expired it used to render the sign-in FORM to both, at HTTP 200 with
+ * Content-type: text/html. jQuery treats 200 as success, so $.apiCall ran
+ * its SUCCESS handler with a string body, and $.notifyFromAPI -- finding
+ * none of error/info/warning/msg in a string -- kept its 'success' default
+ * and drew a GREEN toast reading "Bad Response". The write had been thrown
+ * away and the UI said it worked.
+ *
+ * Reported against the plugin Update button, but nothing about that button
+ * was involved: this branch is reached by every ?node= endpoint, so it was
+ * every Save on every page, on every install, whenever a session lapsed.
+ *
+ * Two independent halves, and each one alone still leaves a lie on screen,
+ * so both are pinned here:
+ *
+ * 1. index.php answers a non-browser caller with 401 and a JSON reason.
+ * 2. fog.common.js treats a body it cannot read as a failure.
+ *
+ * Three mutations this exists to catch, all of which review clean:
+ *
+ * - Folding the two FOG_LOCAL_LOGIN guards together, or dropping the
+ *   defined() test from the 401 arm. management/login.php defines that
+ *   constant and then requires this file; it is the break-glass page that
+ *   exists for when the identity provider is down, and answering it with
+ *   JSON removes it on exactly the request shape it is there to serve.
+ * - Moving the arm above the $browserNavigation assignment. The variable
+ *   then reads null, !null is true, and EVERY signed-out caller -- browsers
+ *   included -- gets 401 JSON instead of a login page. That is the whole UI
+ *   gone, and it is one cut-and-paste away.
+ * - Restoring `type = 'success'` as the declaration default in
+ *   notifyFromAPI, or dropping the non-object guard back to `=== undefined`.
+ *   Either one puts the green toast back with the server side still correct.
+ *
+ * This is inspection, not execution: reaching the branch for real needs a
+ * bootstrapped session, a database and a rendered Page. The property being
+ * pinned is where the arm SITS relative to the value it reads and the form
+ * it replaces, which is a fact about the source.
+ *
+ * Usage: php tests/signed-out-xhr-gets-401-json.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+chdir($root);
+
+$fails = [];
+$indexFile = 'packages/web/management/index.php';
+$jsFile = 'packages/web/management/js/fog/fog.common.js';
+
+/**
+ * PHP source with comments stripped and whitespace collapsed.
+ *
+ * Comments go first, and it matters: index.php carries a long block naming
+ * 401, application/json and $browserNavigation, so a test reading raw text
+ * would be satisfied by its own documentation with the code deleted.
+ *
+ * @param string $file path to read
+ *
+ * @return string stripped source
+ */
+function strippedPhp($file)
+{
+    $out = '';
+    foreach (token_get_all(file_get_contents($file)) as $c) {
+        if (is_array($c)
+            && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $out .= is_array($c) ? $c[1] : $c;
+    }
+    return preg_replace('#\s+#', '', $out);
+}
+
+/**
+ * Condition and body of the first `if` whose condition contains a needle.
+ *
+ * Brace counting is done on tokens rather than on the stripped string so a
+ * brace inside a string literal cannot close the block early -- the
+ * containment claims below are the whole test, and a containment claim
+ * computed from a substring search is not one.
+ *
+ * @param string $file      path to read
+ * @param string $condition text the condition must contain, stripped form
+ *
+ * @return array|null ['cond' => string, 'body' => string], or null
+ */
+function phpGuard($file, $condition)
+{
+    $pieces = [];
+    foreach (token_get_all(file_get_contents($file)) as $c) {
+        if (is_array($c)
+            && in_array(
+                $c[0],
+                [T_COMMENT, T_DOC_COMMENT, T_WHITESPACE],
+                true
+            )
+        ) {
+            continue;
+        }
+        $pieces[] = is_array($c) ? [$c[0], $c[1]] : [null, $c];
+    }
+    $n = count($pieces);
+    for ($i = 0; $i < $n; $i++) {
+        if (T_IF !== $pieces[$i][0]
+            || $i + 1 >= $n
+            || '(' !== $pieces[$i + 1][1]
+        ) {
+            continue;
+        }
+        $depth = 0;
+        $cond = '';
+        for ($j = $i + 1; $j < $n; $j++) {
+            $tok = $pieces[$j][1];
+            if (null === $pieces[$j][0] && '(' === $tok) {
+                $depth++;
+            } elseif (null === $pieces[$j][0] && ')' === $tok) {
+                if (0 === --$depth) {
+                    break;
+                }
+            }
+            $cond .= $tok;
+        }
+        if (false === strpos($cond . ')', $condition)) {
+            continue;
+        }
+        // A guard written without braces cannot contain anything, so a
+        // single-statement rewrite reads as "not found" rather than
+        // quietly passing with an empty body.
+        if ($j + 1 >= $n || '{' !== $pieces[$j + 1][1]) {
+            return null;
+        }
+        $depth = 0;
+        $body = '';
+        for ($k = $j + 1; $k < $n; $k++) {
+            $type = $pieces[$k][0];
+            $tok = $pieces[$k][1];
+            if ((null === $type && '{' === $tok)
+                || T_CURLY_OPEN === $type
+                || T_DOLLAR_OPEN_CURLY_BRACES === $type
+            ) {
+                $depth++;
+            } elseif (null === $type && '}' === $tok) {
+                if (0 === --$depth) {
+                    return ['cond' => $cond . ')', 'body' => $body];
+                }
+            }
+            if ($depth > 0 && $k > $j + 1) {
+                $body .= $tok;
+            }
+        }
+        return null;
+    }
+    return null;
+}
+
+/*
+ * 1. index.php answers a non-browser caller instead of rendering the form.
+ *
+ * `!$browserNavigation` is what makes this the 401 arm and not the redirect
+ * guard above it, whose condition holds the same constant test but the
+ * variable unnegated.
+ */
+$index = strippedPhp($indexFile);
+$arm = phpGuard($indexFile, '!$browserNavigation');
+if (null === $arm) {
+    $fails[] = $indexFile . ' no longer has a guard on !$browserNavigation,'
+        . ' so a signed-out XHR is handed the sign-in form at HTTP 200 and'
+        . ' every failed Save in the UI reports success';
+} else {
+    if (false === strpos($arm['cond'], "!defined('FOG_LOCAL_LOGIN')")) {
+        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+            . ' longer exempts FOG_LOCAL_LOGIN, so management/login.php --'
+            . ' the break-glass form for when the identity provider is'
+            . ' down -- answers JSON to any client not asking for text/html';
+    }
+    if (false === strpos($arm['body'], 'HTTP_UNAUTHORIZED')
+        && false === strpos($arm['body'], '401')
+    ) {
+        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+            . ' longer sets 401, and a status jQuery reads as success is'
+            . ' the whole bug however good the body is';
+    }
+    if (false === strpos($arm['body'], 'application/json')) {
+        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+            . ' longer declares application/json, so jQuery hands the'
+            . ' caller a string and notifyFromAPI has nothing to read';
+    }
+    if (false === strpos($arm['body'], 'exit;')) {
+        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' does'
+            . ' not stop, so the login form is appended to the JSON body';
+    }
+    /*
+     * Ordering. Above the assignment the variable is null, !null is true,
+     * and every signed-out caller including a browser gets 401 instead of
+     * a page to sign in on.
+     */
+    $at = strpos($index, '$browserNavigation=');
+    $armAt = strpos($index, $arm['cond']);
+    if (false === $at) {
+        $fails[] = $indexFile . ' no longer computes $browserNavigation';
+    } elseif (false !== $armAt && $at > $armAt) {
+        $fails[] = $indexFile . ' computes $browserNavigation after the 401'
+            . ' arm that reads it, so the arm reads null and answers 401 to'
+            . ' browsers as well -- the sign-in page becomes unreachable';
+    }
+    /*
+     * And it has to come before the thing it is replacing. After the form
+     * is echoed the headers are already committed.
+     */
+    $formAt = strpos($index, 'echo$login;');
+    if (false !== $formAt && false !== $armAt && $armAt > $formAt) {
+        $fails[] = $indexFile . ' renders the login form before the 401'
+            . ' arm runs, so the XHR still receives the form';
+    }
+}
+
+/*
+ * 2. notifyFromAPI treats a body it cannot read as a failure.
+ */
+$js = file_get_contents($jsFile);
+$fnAt = strpos($js, '$.notifyFromAPI = function');
+if (false === $fnAt) {
+    $fails[] = $jsFile . ' no longer defines $.notifyFromAPI; if it moved,'
+        . ' this half of the test is looking at the wrong code';
+} else {
+    /*
+     * Slice the function out, tracking quotes so a brace inside a string
+     * cannot close it early, and dropping comments so the prose in this
+     * function -- which names both 'success' and === undefined -- cannot
+     * satisfy or fail a claim about the code.
+     */
+    $body = '';
+    $depth = 0;
+    $started = false;
+    $len = strlen($js);
+    for ($i = $fnAt; $i < $len; $i++) {
+        $ch = $js[$i];
+        $two = substr($js, $i, 2);
+        if ('//' === $two) {
+            $i = strpos($js, "\n", $i);
+            if (false === $i) {
+                break;
+            }
+            continue;
+        }
+        if ('/*' === $two) {
+            $end = strpos($js, '*/', $i + 2);
+            if (false === $end) {
+                break;
+            }
+            $i = $end + 1;
+            continue;
+        }
+        if ("'" === $ch || '"' === $ch || '`' === $ch) {
+            $quote = $ch;
+            $body .= $ch;
+            for ($i++; $i < $len; $i++) {
+                $body .= $js[$i];
+                if ('\\' === $js[$i]) {
+                    $body .= $js[++$i];
+                    continue;
+                }
+                if ($quote === $js[$i]) {
+                    break;
+                }
+            }
+            continue;
+        }
+        $body .= $ch;
+        if ('{' === $ch) {
+            $depth++;
+            $started = true;
+        } elseif ('}' === $ch) {
+            if ($started && 0 === --$depth) {
+                break;
+            }
+        }
+    }
+    $body = str_replace('"', "'", preg_replace('#\s+#', '', $body));
+    /*
+     * The guard has to reject any non-object. `=== undefined` is the
+     * version that shipped the bug: a STRING body -- which is what an HTML
+     * answer arrives as -- walks straight past it.
+     */
+    if (false === strpos($body, "typeofres!=='object'")) {
+        $fails[] = 'notifyFromAPI in ' . $jsFile . ' no longer tests that'
+            . ' the body is an object, so a string body (an endpoint'
+            . ' answering with HTML) reaches the lookups below it and'
+            . ' every one of them is undefined';
+    }
+    /*
+     * The declaration default. Each branch overrides it, so this only
+     * decides what a response carrying none of the four keys renders as --
+     * which is precisely the case that has nothing to say and must not be
+     * green.
+     */
+    $declAt = strpos($body, 'vartitle=');
+    if (false === $declAt) {
+        $fails[] = 'notifyFromAPI in ' . $jsFile . ' no longer declares its'
+            . ' locals in one var statement; this test cannot see the'
+            . ' default for `type` any more';
+    } else {
+        $end = strpos($body, ';', $declAt);
+        $decl = false === $end
+            ? substr($body, $declAt)
+            : substr($body, $declAt, $end - $declAt);
+        if (false === strpos($decl, "type='error'")) {
+            $fails[] = 'notifyFromAPI in ' . $jsFile . ' no longer defaults'
+                . ' `type` to error, so a response nothing could be read'
+                . ' out of draws a green toast saying it worked';
+        }
+        /*
+         * `msg` was assigned by every branch as an implicit global and read
+         * by `if (!msg)`, so the fallback that exists for a message-less
+         * body threw ReferenceError instead of running.
+         */
+        if (false === strpos($decl, ',msg')) {
+            $fails[] = 'notifyFromAPI in ' . $jsFile . ' no longer declares'
+                . ' `msg`, so the fallback that reads it throws'
+                . ' ReferenceError out of the success handler and takes the'
+                . ' caller\'s callback with it';
+        }
+    }
+}
+
+if (count($fails) > 0) {
+    echo 'FAIL: ' . count($fails) . " problem(s):\n";
+    foreach ($fails as $f) {
+        echo '  - ' . $f . "\n";
+    }
+    exit(1);
+}
+echo "ok: a signed-out XHR is answered 401 JSON and rendered as an error\n";
+exit(0);


### PR DESCRIPTION
Reported as a **green** toast reading "Bad Response" — twice, because it is both the title and the body — when pressing Update on the plugin page.

Two defects in series. The plugin page is only where it was noticed: this branch of `management/index.php` is reached by every `?node=` endpoint, so it was **every Save on every page**. You think you saved; you didn't; the UI says you did.

## Server half

`management/index.php` already tells browsers and machines apart — `$browserNavigation` (index.php:114), a `GET` whose `Accept` names `text/html` — and already declines to bounce a machine to the identity provider. The installer is why that exists: `installfog.sh` reported "Updating Database...Failed!" on a healthy server when its schema POST got redirected to a provider.

But execution then fell through to the login **form** for both, so a signed-out XHR got that form at **HTTP 200** with `Content-type: text/html`. The docblock there says a caller failing the test "gets the login form, which is the safe direction to fail in" — true for the *redirect* decision, and the reason nobody noticed the XHR caller ends up parsing a login page as a successful response.

A caller that cannot follow a sign-in redirect cannot use a sign-in page either. It now gets 401 and a reason it can read, which is also the right answer for curl, FogApi and any other client library.

`FOG_LOCAL_LOGIN` is exempt from the new arm, for the same reason the redirect above exempts it. `management/login.php` defines it and then requires `index.php`; that page exists so a human can always reach a form when the provider is down, and answering it with JSON took the break-glass page away on exactly the request shape it is there to serve. Caught in testing — `login.php` answered 401 to any client not asking for `text/html`.

## Client half

`$.notifyFromAPI` guarded only on `res === undefined`, and a **string** body walks straight past that. Every lookup was then undefined, `type` kept its declared default of `'success'`, and `title || 'Bad Response'` supplied the title — so an unreadable response rendered as a green success.

The guard now rejects anything that is not an object, and the default type is `'error'`: a response carrying none of `error`/`info`/`warning`/`msg` is one nothing could be read out of, whatever the status line says. Each branch below still overrides it, so a response that does carry a message is unaffected.

`statusText` is deliberately not used for the fallback message — HTTP/2 has no reason phrase, so it is empty on exactly the servers most likely to hit this. The status code is reported instead.

Both halves are needed. The server fix alone leaves the whole class open for any other endpoint that answers unreadably; the client fix alone would just recolor this bug.

## Verified

Against a copy of the live database.

| | Before | After |
|---|---|---|
| Signed-out AJAX POST to `?node=plugin&sub=upgrade` | `200` `text/html`, login page | `401` `application/json`, `{"error":"Your session has ended. Sign in again.","title":"Session Expired"}` |
| Login POST | 202, "Login successful!" | unchanged — `processMainLogin()` answers through `jsonSend()`, which exits before this branch; the session it mints renders a host edit page |
| Browser navigation, signed out | sign-in flow | unchanged |
| `node=schema` / `node=client` | other branch | unchanged — the installer cannot reach the new arm |
| `login.php`, any `Accept` | login form | unchanged — form renders, and a POST through it signs in (202) |
| Signed-in AJAX POST | 202 | unchanged |

In the browser, driving `notifyFromAPI` directly:

| Input | Before | After |
|---|---|---|
| HTML body at 200 | 🟢 "Bad Response \| Bad Response" | 🔴 "Bad Response \| The server answered 200 with no readable message." |
| `undefined` at 401, empty `statusText` (HTTP/2) | 🟢 "Bad Response" | 🔴 "Bad Response \| The server answered 401 with no readable message." |
| The new 401 payload | — | 🔴 "Session Expired \| Your session has ended. Sign in again." |
| `{msg, title}` | 🟢 success | 🟢 unchanged |
| `{warning, title}` | 🟡 warning | 🟡 unchanged |

Ruled out on the way in, so the search does not get repeated: the upgrade endpoint itself (with the six real installed plugin ids it returns `202` + `{"msg":"Plugins updated!"}`), both client paths (drove the bulk button and an injected per-row badge in a browser — both send POST), stray output at plugin-manager autoload, BOM or content after `?>` in any installed plugin, PHP warnings in the logs.

`FOG_BCACHE_VER` 315 → 316 for the `fog.common.js` change.

## Not ported to dev-branch

The server half exists there, but 1.5 has no `notifyFromAPI` at all, so the reported symptom cannot occur. `$browserNavigation` does not exist on that branch either, so the fix would mean introducing the whole browsers-vs-machines seam on the patches line in order to change the response shape for every non-browser caller — a larger change than the bug it would fix there. Happy to do it if you'd rather.

