### PR TITLE
Make the architecture columns actually reach an upgraded server

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7734,7 +7734,10 @@ $this->schema[] = [
             ]
         );
     },
-    // 369: hosts.hostArch -- the architecture last observed for this host.
+];
+// 369
+$this->schema[] = [
+    // hosts.hostArch -- the architecture last observed for this host.
     //
     // FOG has always known this and never kept it. iPXE posts `arch` on every
     // boot (default.ipxe sends ${buildarch} with the cpuid promotion that
@@ -7786,7 +7789,10 @@ $this->schema[] = [
 
         return true;
     },
-    // 370: images.imageArch -- the architecture of the machine this image was
+];
+// 370
+$this->schema[] = [
+    // images.imageArch -- the architecture of the machine this image was
     // captured from.
     //
     // The half that makes the host column worth having. With both sides

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 368);
+        define('FOG_SCHEMA', 370);
         define('FOG_BCACHE_VER', 316);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -48,12 +48,19 @@ class ImageManagement extends FOGPage
             _('Enabled'),
             _('Captured')
         ];
+        // Each <th> carries its DataTables data key, the same contract the
+        // host grid uses. fog.image.list.js builds both its column list and
+        // its columnDefs targets from these rather than from hardcoded
+        // indexes: the renders here used to be pinned to targets 1 and 2, so
+        // inserting Architecture at position 1 slid the lock render onto the
+        // new column and the enabled render onto Protected, silently. Names
+        // cannot slide.
         $this->attributes = [
-            [],
-            [],
-            [],
-            [],
-            []
+            ['data-col' => 'mainlink'],
+            ['data-col' => 'arch'],
+            ['data-col' => 'protected'],
+            ['data-col' => 'isEnabled'],
+            ['data-col' => 'deployed']
         ];
     }
     /**
@@ -1289,6 +1296,30 @@ class ImageManagement extends FOGPage
     {
         $this->title = _('Architectures');
 
+        // Refuse to render against a database that has not been migrated.
+        //
+        // Not hypothetical: this page was reachable on a live 1.6 server
+        // sitting at schema version 368 while FOG_SCHEMA still said 368, so
+        // the updater never offered steps 369/370. The queries below then
+        // failed with 1054 Unknown column, PDODB swallowed the exception and
+        // returned false, and the tables rendered one blank row each -- which
+        // looks like "no data" rather than "broken", and is the worst of both.
+        //
+        // tableColumns() returns [] when it cannot read the table at all, and
+        // its contract is that empty means "don't know", so only a populated
+        // list missing the column counts as proof of an unmigrated database.
+        $hostCols = DatabaseManager::tableColumns('hosts');
+        $imageCols = DatabaseManager::tableColumns('images');
+        if ((count($hostCols) && !in_array('hostarch', $hostCols))
+            || (count($imageCols) && !in_array('imagearch', $imageCols))
+        ) {
+            echo '<div class="alert alert-warning">';
+            echo '<strong>' . _('Database update required.') . '</strong> ';
+            echo _('The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page.');
+            echo '</div>';
+            return;
+        }
+
         $rows = self::$DB->query(
             "SELECT `hosts`.`hostID` AS `id`, `hosts`.`hostName` AS `host`, "
             . "`hosts`.`hostArch` AS `hostArch`, "
@@ -1299,7 +1330,7 @@ class ImageManagement extends FOGPage
             . "ON `hosts`.`hostImage` = `images`.`imageID` "
             . "ORDER BY `hosts`.`hostName`"
         )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
-        $rows = (array)$rows;
+        $rows = is_array($rows) ? $rows : [];
 
         $images = self::$DB->query(
             "SELECT `images`.`imageID` AS `id`, "
@@ -1314,7 +1345,7 @@ class ImageManagement extends FOGPage
             . "`images`.`imageArch`, `images`.`imageDateTime` "
             . "ORDER BY `images`.`imageName`"
         )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
-        $images = (array)$images;
+        $images = is_array($images) ? $images : [];
 
         // Counted in PHP off the same rows the table renders, so the summary
         // and the detail cannot disagree.

--- a/packages/web/management/js/fog/image/fog.image.list.js
+++ b/packages/web/management/js/fog/image/fog.image.list.js
@@ -13,64 +13,92 @@
         disableButtons(disabled);
     }
     disableButtons(true);
+    // Columns and their render targets are both derived from the header
+    // row's data-col attributes, never from literal indexes.
+    //
+    // They used to be literals, and it broke the moment a column was added:
+    // Architecture went in at position 1 and every columnDefs target below it
+    // still pointed at its old number, so the lock render landed on the new
+    // column and the enabled render landed on Protected. Nothing errored --
+    // the grid just showed the wrong icon in the wrong place. Same failure the
+    // host grid documents, same fix.
+    var columns = [],
+        colIndex = {};
+    $('#dataTable thead th').each(function() {
+        var key = $(this).attr('data-col');
+        if (!key) {
+            // Keep the counts equal: DataTables raises "Incorrect column
+            // count" and draws nothing at all if the header row and this
+            // list disagree.
+            if (window.console && console.warn) {
+                console.warn('FOG: image list header with no data-col', this);
+            }
+            columns.push({data: null, defaultContent: ''});
+            return;
+        }
+        colIndex[key] = columns.length;
+        columns.push({data: key});
+    });
+
+    var columnDefs = [];
+    if ('mainlink' in colIndex) {
+        columnDefs.push({
+            responsivePriority: -1,
+            targets: colIndex.mainlink
+        });
+    }
+    if ('arch' in colIndex) {
+        columnDefs.push({
+            render: function(data, type, row) {
+                if (type !== 'display') {
+                    return data;
+                }
+                // Spelled out rather than blank: an empty cell reads as x86
+                // to anyone scanning. Images captured before schema step 370
+                // have no architecture recorded and never will.
+                if (!data) {
+                    return '<span class="text-muted">Not recorded</span>';
+                }
+                return '<code>' + data + '</code>';
+            },
+            targets: colIndex.arch
+        });
+    }
+    if ('protected' in colIndex) {
+        columnDefs.push({
+            responsivePriority: 0,
+            render: function(data, type, row) {
+                var lock = '<span class="badge bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
+                var unlock = '<span class="badge bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
+                if (row.protected > 0) {
+                    return lock;
+                }
+                return unlock;
+            },
+            targets: colIndex.protected
+        });
+    }
+    if ('isEnabled' in colIndex) {
+        columnDefs.push({
+            render: function(data, type, row) {
+                var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
+                var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                if (row.isEnabled > 0) {
+                    return enabled;
+                }
+                return disabled;
+            },
+            targets: colIndex.isEnabled
+        });
+    }
+
     var table = $('#dataTable').registerTable(onSelect, {
         order: [
             [0, 'asc']
         ],
-        columns: [
-            {data: 'mainlink'},
-            // Unlike the host grid this column list is not derived from the
-            // table headers, so it has to be kept in step with headerData in
-            // imagemanagement.page.php by hand -- a mismatch makes DataTables
-            // refuse to draw the grid at all.
-            {
-                data: 'arch',
-                render: function(data, type, row) {
-                    // Spelled out rather than blank: an empty cell reads as
-                    // x86 to anyone scanning. Images captured before schema
-                    // step 370 have no architecture recorded.
-                    if (!data) {
-                        return '<span class="text-muted">' +
-                            'Not recorded' +
-                            '</span>';
-                    }
-                    return '<code>' + data + '</code>';
-                }
-            },
-            {data: 'protected'},
-            {data: 'isEnabled'},
-            {data: 'deployed'}
-        ],
+        columns: columns,
         rowId: 'id',
-        columnDefs: [
-            {
-                responsivePriority: -1,
-                targets: 0,
-            },
-            {
-                responsivePriority: 0,
-                render: function(data, type, row) {
-                    var lock = '<span class="badge bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
-                    var unlock = '<span class="badge bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
-                    if (row.protected > 0) {
-                        return lock;
-                    }
-                    return unlock;
-                },
-                targets: 1
-            },
-            {
-                render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
-                    if (row.isEnabled > 0) {
-                        return enabled;
-                    }
-                    return disabled;
-                },
-                targets: 2
-            }
-        ],
+        columnDefs: columnDefs,
         processing: true,
         serverSide: true,
         ajax: {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2033,6 +2033,10 @@ msgstr "Datenbankspeicherung fehlgeschlagen"
 msgid "Database schema is already up to date."
 msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Datenbankupdate fehlgeschlagen"
+
 msgid "Date"
 msgstr "Datum"
 
@@ -8323,6 +8327,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2035,6 +2035,10 @@ msgstr "Database update failed"
 msgid "Database schema is already up to date."
 msgstr "Database Schema Installer / Updater"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Database Update Failed"
+
 msgid "Date"
 msgstr "Date"
 
@@ -8318,6 +8322,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2057,6 +2057,10 @@ msgstr "actualización de la base no"
 msgid "Database schema is already up to date."
 msgstr "Esquema de base de datos del instalador / actualizador"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "actualización de la base no"
+
 msgid "Date"
 msgstr "Fecha"
 
@@ -8503,6 +8507,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2033,6 +2033,10 @@ msgstr "Datenbankspeicherung fehlgeschlagen"
 msgid "Database schema is already up to date."
 msgstr "Ihr FOG-Datenbankschema ist nicht aktuell"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Datenbankupdate fehlgeschlagen"
+
 msgid "Date"
 msgstr "Datum"
 
@@ -8324,6 +8328,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2037,6 +2037,10 @@ msgstr "mise à jour de base de données a échoué"
 msgid "Database schema is already up to date."
 msgstr "Base de données de schéma d'installation / Updater"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Mise à jour de base de données a échoué"
+
 msgid "Date"
 msgstr "date"
 
@@ -8320,6 +8324,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1975,6 +1975,10 @@ msgstr "Salvataggio del database non riuscito"
 msgid "Database schema is already up to date."
 msgstr "Il tuo schema di database FOG non è aggiornato"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Aggiornamento del database non riuscito"
+
 msgid "Date"
 msgstr "Data"
 
@@ -8037,6 +8041,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1958,6 +1958,10 @@ msgstr "データベースの保存に失敗しました"
 msgid "Database schema is already up to date."
 msgstr "FOG データベースのスキーマが最新ではありません"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "データベースの更新に失敗しました"
+
 msgid "Date"
 msgstr "日付"
 
@@ -7974,6 +7978,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1729,6 +1729,9 @@ msgstr ""
 msgid "Database schema is already up to date."
 msgstr ""
 
+msgid "Database update required."
+msgstr ""
+
 msgid "Date"
 msgstr ""
 
@@ -7052,6 +7055,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2036,6 +2036,10 @@ msgstr "atualização de banco de dados falhou"
 msgid "Database schema is already up to date."
 msgstr "Banco de dados de esquema Instalador / Updater"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "Atualização de banco de dados falhou"
+
 msgid "Date"
 msgstr "Encontro"
 
@@ -8319,6 +8323,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2036,6 +2036,10 @@ msgstr "数据库更新失败"
 msgid "Database schema is already up to date."
 msgstr "数据库模式安装/更新"
 
+#, fuzzy
+msgid "Database update required."
+msgstr "数据库更新失败"
+
 msgid "Date"
 msgstr "日期"
 
@@ -8319,6 +8323,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
 msgstr ""
 
 msgid "The architecture of the machine this image was captured from."

--- a/tests/arch-compatibility.test.php
+++ b/tests/arch-compatibility.test.php
@@ -166,4 +166,41 @@ $t->check(
     (bool)preg_match('/hostArch|set\(\s*\'arch\'/', $menuSrc)
 );
 
+// --- the three regressions found on a live server 2026-08-25 -------------
+// All three were invisible to CI: a fresh install creates the columns, so
+// only an UPGRADE showed them.
+$paneSrc = (string)file_get_contents($web . '/lib/pages/imagemanagement.page.php');
+$listJs = (string)file_get_contents(
+    $web . '/management/js/fog/image/fog.image.list.js'
+);
+$systemSrc = (string)file_get_contents($web . '/lib/fog/system.class.php');
+
+$t->check(
+    'steps 369/370 are their own column-zero appends, not nested in step 368',
+    (bool)preg_match('/^\/\/ 369$\s*^\$this->schema\[\] = \[/m', $schemaSrc)
+    && (bool)preg_match('/^\/\/ 370$\s*^\$this->schema\[\] = \[/m', $schemaSrc)
+);
+$t->check(
+    'FOG_SCHEMA reaches 370, so the updater actually offers the new steps',
+    (bool)preg_match("/define\('FOG_SCHEMA',\s*(\d+)\)/", $systemSrc, $fs)
+    && (int)$fs[1] >= 370
+);
+$t->check(
+    'the Architectures page refuses to render against an unmigrated database',
+    false !== strpos($paneSrc, "DatabaseManager::tableColumns('hosts')")
+    && false !== strpos($paneSrc, 'hostarch')
+);
+$t->check(
+    'no (array) cast on a query result -- (array)false is [false], one blank row',
+    false === strpos($paneSrc, '(array)$rows')
+    && false === strpos($paneSrc, '(array)$images')
+);
+$t->check(
+    'the image grid targets render columns by name, never by index',
+    false === strpos($listJs, 'targets: 0')
+    && false === strpos($listJs, 'targets: 1')
+    && false === strpos($listJs, 'targets: 2')
+    && false !== strpos($listJs, 'colIndex')
+);
+
 $t->finish();

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -251,6 +251,54 @@ $schema = (int)$const[1];
  * though it means a deliberate skip in the numbering is now a failure. There
  * has never been one.
  */
+/*
+ * A step label that is INDENTED is a step nested inside another step.
+ *
+ * The label scan above is anchored to column zero, which is what stops a
+ * number inside a step's own prose being read as a label. The cost is a blind
+ * spot with no symptom: append your closures inside the previous step's array
+ * and label them `    // 369`, and every check here still passes. The highest
+ * column-zero label has not moved, so FOG_SCHEMA already matches it; there is
+ * no unlabelled append, because there is no append at all.
+ *
+ * What you get is a migration that runs on a FRESH install -- the containing
+ * step still executes, so CI is green on every engine -- and never runs on an
+ * UPGRADE, because that step's number is already stored and it is never
+ * replayed. The columns exist everywhere the tests look and on no real server.
+ *
+ * That is exactly what happened to steps 369/370 (hostArch/imageArch): both
+ * closures went inside step 368, CI passed on MariaDB 10.5, 11.8 and MySQL
+ * 8.0, and the live upgrade silently did nothing.
+ *
+ * Only numbers ABOVE the highest real label are flagged. Steps routinely cite
+ * earlier ones in prose ("same as 336/338/341"), and those are legitimate.
+ */
+$nested = [];
+preg_match_all(
+    '/^[ \t]+\/\/ (\d+)\s*[:.]/m',
+    $schemaSrc,
+    $nestedMatches,
+    PREG_SET_ORDER
+);
+foreach ($nestedMatches as $m) {
+    if ((int)$m[1] > $highest) {
+        $nested[] = (int)$m[1];
+    }
+}
+if (count($nested)) {
+    fwrite(
+        STDERR,
+        "FAIL: indented step label(s) above the highest real step ("
+        . $highest . "): " . implode(', ', $nested) . "\n"
+        . "  An indented `// N` is a step appended INSIDE another step's\n"
+        . "  array. It runs on a fresh install and never on an upgrade, and\n"
+        . "  nothing else in this file's checks can see it.\n"
+        . "  Move it to a column-zero `// N` label followed by its own\n"
+        . "  `\$this->schema[] = [...]`, and bump FOG_SCHEMA to match.\n"
+    );
+    exit(1);
+}
+
 if ($schema !== $highest) {
     $why = $schema < $highest
         ? "  Every step after $schema applies to nobody: the coarse gate\n"


### PR DESCRIPTION
Three defects from #1369, all found by opening the page on a live 1.6 server sitting at schema version 368 — and all invisible to CI for the same reason: **a fresh install creates the columns, so only an upgrade showed any of them.**

## 1. Steps 369/370 were never steps

Both closures were appended *inside* step 368's array rather than as their own `$this->schema[] = [...]` entries. A server that has already stored 368 never replays it, so the two `ALTER`s ran on new installs and on nobody else. CI passed on MariaDB 10.5, MariaDB 11.8 and MySQL 8.0 because every one of those starts from an empty database.

## 2. `FOG_SCHEMA` was left at 368

The coarse gate is `mySchema < FOG_SCHEMA`. With both at 368 the server reported itself up to date, so the updater was never offered and the precise gate inside `SchemaUpdaterPage` never got to speak.

`tests/schema-gate.test.php` exists precisely to catch this, and could not see it: its label scan is anchored to column zero, and a nested step's label is indented. It now fails on an indented `// N` above the highest real step — the only trace this mistake leaves in the file. Mutation-tested both ways.

## 3. The image grid's renders were pinned to numeric `columnDefs` targets

Inserting Architecture at position 1 slid the lock render onto the new column and the enabled render onto Protected, so **Protected displayed the Enabled icon and Enabled displayed a raw `1`**. Nothing errored.

The grid now derives its columns *and* its render targets from the header row's `data-col` attributes — the same contract the host grid adopted after this exact failure, which its own comment documents.

## Also: one blank row instead of a failure

The Architectures page rendered a single empty row per table when the columns were absent. PDODB swallows the 1054 and returns `false`, and `(array)false` is `[false]` — one phantom element. That reads as "no data" rather than "broken", which is the worst of both. The casts are gone, and the page now checks `DatabaseManager::tableColumns()` first and tells the admin to run the updater.

## Verification

- `tests/run-all.sh` — 154 passed, 0 failed
- `tests/arch-compatibility.test.php` — 38 checks, including one per defect above
- The schema array really collects **370** elements, with the new steps at indexes 368 and 369
- `tests/schema-upgrade-replay.test.php` — every server from version 0 to 369 reaches 370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
