### PR TITLE
Gate the signed-out 401 on X-Requested-With, not on "not a browser"

### DIFF
--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -138,10 +138,28 @@ if (!isset($node) || (!in_array($node, $nodes) && !$currentUser->isValid())) {
      * A caller that cannot follow a browser sign-in must not be handed the
      * sign-in FORM either.
      *
-     * $browserNavigation above already tells browsers and machines apart, and
-     * already declines to bounce a machine to the identity provider. But
-     * execution then fell through to the login page for both, so a signed-out
-     * XHR got the form at HTTP 200 with Content-type: text/html. jQuery treats
+     * Gated on X-Requested-With, NOT on !$browserNavigation. Getting that
+     * wrong broke installs: the first shape of this arm answered 401 to
+     * everything that was not a document navigation, and checkWebTier() in
+     * lib/common/functions.sh probes this very URL with a plain tokenless GET
+     * and curl -fL, so it took the 401, saw zero bytes and aborted the install
+     * with "Checking web server serves FOG...Failed!". Its comment says in so
+     * many words that it expects a page to render regardless -- and it is only
+     * one such caller. Monitoring, a hand-rolled curl and the recovery command
+     * this installer prints on failure all want the same thing, and none of
+     * them can be enumerated from here.
+     *
+     * Only an XHR can commit the actual error, which is reading a login form
+     * as a successful save. Everything else either renders the form (exactly
+     * as it did before any of this) or, for a real API client, uses /api/,
+     * which has answered 401 properly all along -- see
+     * tests/api-unauthenticated-401.test.php. So the narrow gate loses nothing
+     * and the wide one silently changed the contract for every machine that
+     * has ever fetched a FOG page.
+     *
+     * The bug itself: execution used to fall through to the login page for
+     * signed-out callers of every kind, so an XHR got the form at HTTP 200
+     * with Content-type: text/html. jQuery treats
      * 200 as success, so $.apiCall ran its SUCCESS handler with a string body;
      * $.notifyFromAPI found none of error/info/warning/msg in it and -- until
      * the matching change in fog.common.js -- fell back to a GREEN toast
@@ -150,12 +168,11 @@ if (!isset($node) || (!in_array($node, $nodes) && !$currentUser->isValid())) {
      * reached by every ?node= endpoint, so it was every Save on every page.
      *
      * 401 with a readable reason instead. That is what the XHR error handler
-     * is for, and it is also the right answer for curl, FogApi and any other
-     * client library, none of which can do anything with a login form.
+     * is for, and $.notifyFromAPI renders it as the red toast the user should
+     * have seen all along.
      *
-     * The install/schema paths cannot reach this: `schema` and `client` are in
-     * $nodes above and take the other branch. Nor can the login POST itself --
-     * processMainLogin() answers it through jsonSend(), which exits.
+     * The login POST cannot reach this: processMainLogin() answers it through
+     * jsonSend(), which exits.
      *
      * FOG_LOCAL_LOGIN is exempt, for the same reason the redirect above exempts
      * it and not a weaker one. management/login.php defines it and then
@@ -166,7 +183,7 @@ if (!isset($node) || (!in_array($node, $nodes) && !$currentUser->isValid())) {
      * anyway -- this makes it true regardless of what the client asks for,
      * which is what a break-glass path has to be.
      */
-    if (!defined('FOG_LOCAL_LOGIN') && !$browserNavigation) {
+    if (!defined('FOG_LOCAL_LOGIN') && FOGCore::$ajax) {
         header('Content-type: application/json');
         echo json_encode(
             [

--- a/tests/signed-out-xhr-gets-401-json.test.php
+++ b/tests/signed-out-xhr-gets-401-json.test.php
@@ -166,14 +166,14 @@ function phpGuard($file, $condition)
  * variable unnegated.
  */
 $index = strippedPhp($indexFile);
-$arm = phpGuard($indexFile, '!$browserNavigation');
+$arm = phpGuard($indexFile, 'FOGCore::$ajax');
 if (null === $arm) {
-    $fails[] = $indexFile . ' no longer has a guard on !$browserNavigation,'
-        . ' so a signed-out XHR is handed the sign-in form at HTTP 200 and'
-        . ' every failed Save in the UI reports success';
+    $fails[] = $indexFile . ' no longer has a guard on FOGCore::$ajax, so'
+        . ' a signed-out XHR is handed the sign-in form at HTTP 200 and every'
+        . ' failed Save in the UI reports success';
 } else {
     if (false === strpos($arm['cond'], "!defined('FOG_LOCAL_LOGIN')")) {
-        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+        $fails[] = 'the XHR 401 arm in ' . $indexFile . ' no'
             . ' longer exempts FOG_LOCAL_LOGIN, so management/login.php --'
             . ' the break-glass form for when the identity provider is'
             . ' down -- answers JSON to any client not asking for text/html';
@@ -181,33 +181,38 @@ if (null === $arm) {
     if (false === strpos($arm['body'], 'HTTP_UNAUTHORIZED')
         && false === strpos($arm['body'], '401')
     ) {
-        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+        $fails[] = 'the XHR 401 arm in ' . $indexFile . ' no'
             . ' longer sets 401, and a status jQuery reads as success is'
             . ' the whole bug however good the body is';
     }
     if (false === strpos($arm['body'], 'application/json')) {
-        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' no'
+        $fails[] = 'the XHR 401 arm in ' . $indexFile . ' no'
             . ' longer declares application/json, so jQuery hands the'
             . ' caller a string and notifyFromAPI has nothing to read';
     }
     if (false === strpos($arm['body'], 'exit;')) {
-        $fails[] = 'the !$browserNavigation arm in ' . $indexFile . ' does'
+        $fails[] = 'the XHR 401 arm in ' . $indexFile . ' does'
             . ' not stop, so the login form is appended to the JSON body';
     }
     /*
-     * Ordering. Above the assignment the variable is null, !null is true,
-     * and every signed-out caller including a browser gets 401 instead of
-     * a page to sign in on.
+     * And it must stay NARROW. Widening it to !$browserNavigation -- which
+     * looks like the more thorough answer, and which is what shipped first --
+     * answers 401 to every caller that is not a document navigation. That
+     * includes checkWebTier() in lib/common/functions.sh, which probes
+     * ?node=schema with a tokenless GET and curl -fL purely to prove the web
+     * tier renders. It took the 401, saw zero bytes and aborted the install
+     * with "Checking web server serves FOG...Failed!" on three healthy
+     * servers. Monitoring and the recovery curl this installer prints on
+     * failure are the same shape and equally unenumerable from here.
      */
-    $at = strpos($index, '$browserNavigation=');
-    $armAt = strpos($index, $arm['cond']);
-    if (false === $at) {
-        $fails[] = $indexFile . ' no longer computes $browserNavigation';
-    } elseif (false !== $armAt && $at > $armAt) {
-        $fails[] = $indexFile . ' computes $browserNavigation after the 401'
-            . ' arm that reads it, so the arm reads null and answers 401 to'
-            . ' browsers as well -- the sign-in page becomes unreachable';
+    if (false !== strpos($arm['cond'], 'browserNavigation')) {
+        $fails[] = 'the XHR 401 arm in ' . $indexFile . ' is gated on'
+            . ' $browserNavigation, so every non-browser caller gets 401 --'
+            . ' including the installer\'s own liveness probe, which then'
+            . ' aborts the install with "Checking web server serves'
+            . ' FOG...Failed!" on a server that is working perfectly';
     }
+    $armAt = strpos($index, $arm['cond']);
     /*
      * And it has to come before the thing it is replacing. After the form
      * is echoed the headers are already committed.


### PR DESCRIPTION
Fixes an install-breaking regression from #1370, reported by Tom against
`fogdebian` and reproduced on all three 1.6 lab servers.

## What broke

`checkWebTier()` (`lib/common/functions.sh:812`) probes
`index.php?node=schema` with a **tokenless GET** and `curl -fL`, purely to prove
the web tier renders. An already-current schema 308s that to `index.php` with the
query string gone — straight onto #1370's new arm:

```
Checking web server serves FOG..............................Failed!
  (curl exit 22, 0 bytes of body)
  Reason: the server answered HTTP 401.
```

Reproduced verbatim: `curl exit=22 code=401 bytes=0`.

#1370 gated on `!$browserNavigation`, i.e. "anything that is not a document
navigation". That swept in every machine caller that legitimately wants a page —
this probe, monitoring, and the recovery `curl` the installer itself prints on
failure. None of them are enumerable from `index.php`, which is the argument
against the wide gate rather than against this particular caller.

## The fix

Gate on `X-Requested-With` instead. Only an XHR can commit the error #1370 was
about — reading a login form as a successful save.

| Caller | Before #1370 | #1370 | Now |
|---|---|---|---|
| jQuery `$.apiCall`, lapsed session | 200 form → **green** toast | 401 → red toast | 401 → red toast |
| installer `checkWebTier()` | 200 form (passes) | **401 → install aborts** | 200 form (passes) |
| installer `updateDB()` (token) | 200 | 200 | 200 |
| `AjaxPageLink` (asks for HTML) | 200 form | 401 | 200 form |
| `/api/` client | 401 | 401 | 401 |

## Verification

- The failing probe reproduces against the current deploy on all three servers.
- `tests/signed-out-xhr-gets-401-json.test.php` retargeted, and now **fails if
  the gate is widened back to `$browserNavigation`** — the assertion that would
  have caught this. Four mutations, all caught.
- `installer-schema-deploy`, `local-login-entrypoint`, `break-glass-auth-sources`,
  `api-unauthenticated-401`, `no-session-for-browserless` all still pass.

End-to-end confirmation of the probe returning 200 needs a deploy — Tom's box.