### PR TITLE
Record the sector size an image was captured on

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -316,7 +316,7 @@ return [
             ],
         ],
         'images' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `images` ( `imageID` int(11) NOT NULL AUTO_INCREMENT, `imageName` varchar(40) NOT NULL, `imageDesc` longtext NOT NULL DEFAULT \'\', `imagePath` longtext NOT NULL, `imageProtect` mediumint(9) NOT NULL DEFAULT 0, `imageMagnetUri` longtext NOT NULL DEFAULT \'\', `imageDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `imageCreateBy` varchar(50) NOT NULL DEFAULT \'\', `imageBuilding` int(11) NOT NULL DEFAULT 0, `imageSize` varchar(255) NOT NULL DEFAULT \'\', `imageTypeID` mediumint(9) NOT NULL, `imagePartitionTypeID` mediumint(9) NOT NULL, `imageOSID` mediumint(9) NOT NULL, `imageFormat` char(1) DEFAULT NULL, `imageLastDeploy` datetime DEFAULT NULL, `imageCompress` int(11) DEFAULT NULL, `imageEnabled` tinyint(1) NOT NULL DEFAULT 1, `imageReplicate` tinyint(1) NOT NULL DEFAULT 1, `imageServerSize` bigint(20) unsigned NOT NULL DEFAULT 0, `imageArch` varchar(16) DEFAULT NULL, PRIMARY KEY (`imageID`), UNIQUE KEY `imageName` (`imageName`), KEY `new_index` (`imageName`), KEY `new_index1` (`imageBuilding`), KEY `new_index2` (`imageTypeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `images` ( `imageID` int(11) NOT NULL AUTO_INCREMENT, `imageName` varchar(40) NOT NULL, `imageDesc` longtext NOT NULL DEFAULT \'\', `imagePath` longtext NOT NULL, `imageProtect` mediumint(9) NOT NULL DEFAULT 0, `imageMagnetUri` longtext NOT NULL DEFAULT \'\', `imageDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `imageCreateBy` varchar(50) NOT NULL DEFAULT \'\', `imageBuilding` int(11) NOT NULL DEFAULT 0, `imageSize` varchar(255) NOT NULL DEFAULT \'\', `imageTypeID` mediumint(9) NOT NULL, `imagePartitionTypeID` mediumint(9) NOT NULL, `imageOSID` mediumint(9) NOT NULL, `imageFormat` char(1) DEFAULT NULL, `imageLastDeploy` datetime DEFAULT NULL, `imageCompress` int(11) DEFAULT NULL, `imageEnabled` tinyint(1) NOT NULL DEFAULT 1, `imageReplicate` tinyint(1) NOT NULL DEFAULT 1, `imageServerSize` bigint(20) unsigned NOT NULL DEFAULT 0, `imageArch` varchar(16) DEFAULT NULL, `imageSectorSize` int(11) DEFAULT NULL, PRIMARY KEY (`imageID`), UNIQUE KEY `imageName` (`imageName`), KEY `new_index` (`imageName`), KEY `new_index1` (`imageBuilding`), KEY `new_index2` (`imageTypeID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'imageID' => 'int(11) NOT NULL',
                 'imageName' => 'varchar(40) NOT NULL',
@@ -338,6 +338,7 @@ return [
                 'imageReplicate' => 'tinyint(1) NOT NULL DEFAULT 1',
                 'imageServerSize' => 'bigint(20) unsigned NOT NULL DEFAULT 0',
                 'imageArch' => 'varchar(16) DEFAULT NULL',
+                'imageSectorSize' => 'int(11) DEFAULT NULL',
             ],
         ],
         'imageTypes' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -7837,3 +7837,53 @@ $this->schema[] = [
         return true;
     },
 ];
+// 371
+$this->schema[] = [
+    // images.imageSectorSize -- the LOGICAL sector size, in bytes, of the disk
+    // this image was captured from. 512 or 4096; NULL when unknown.
+    //
+    // FOS has refused a cross-sector-size deploy since ADR-0005
+    // (validateImageSectorSize in funcs.sh): partition-table and filesystem
+    // geometry bake in the source disk's logical sector size and cannot be
+    // translated, so deploying a 4Kn image onto a 512-byte disk produces an
+    // unbootable machine. The server has never known any of this, so the
+    // refusal only ever arrives at the client, minutes into a task, as a
+    // failure rather than as something anyone could see beforehand.
+    //
+    // LOGICAL, not physical, and that is the whole distinction that matters.
+    // 512n and 512e both present 512-byte logical sectors and are freely
+    // interchangeable as deploy targets; only 4Kn differs. FOS reads the
+    // source size with `blockdev --getss` (logical) and records it on the
+    // `sector-size:` line of the sfdisk dump, and physical block size is
+    // never persisted at capture -- so 512n and 512e are indistinguishable
+    // here by construction, and separating them would buy nothing.
+    //
+    // NULL for every image captured before this, and for any image whose
+    // sfdisk dump predates util-linux 2.35 and so carries no `sector-size:`
+    // line at all. FOS treats that same absence as "allow the deploy rather
+    // than guess"; nothing here may be stricter than the thing doing the
+    // actual refusing.
+    //
+    // Guarded closure, same as 336/338/341/349/350/351/353/354/369/370.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'images' "
+            . "AND `COLUMN_NAME` IN ('imageSectorSize')"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        if (!in_array('imageSectorSize', $cols)) {
+            self::$DB->query(
+                "ALTER TABLE `images` "
+                . "ADD `imageSectorSize` INT(11) NULL DEFAULT NULL"
+            );
+        }
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -331,6 +331,42 @@ class FOGSSH
      *
      * @return array
      */
+    /**
+     * Reads a small remote file over the open sftp session.
+     *
+     * Same ssh2.sftp:// stream wrapper scanFilesystem() below uses. Bounded on
+     * purpose: every caller so far wants a metadata sidecar of a few hundred
+     * bytes, and an unbounded read here would happily pull a 40GB image into
+     * memory if a path were ever wrong.
+     *
+     * Returns '' for absent or unreadable rather than false, so callers can
+     * treat "not there" and "could not read it" the same way -- which is what
+     * they want, because both mean "we do not know".
+     *
+     * @param string $remote_file the path on the node
+     * @param int    $maxBytes    hard cap on what is read
+     *
+     * @return string
+     */
+    public function readFile($remote_file, $maxBytes = 65536)
+    {
+        if (!$this->exists($remote_file)) {
+            return '';
+        }
+        if (!$this->_sftp) {
+            $this->sftp();
+        }
+        $sftp = $this->_sftp;
+        $data = @file_get_contents(
+            "ssh2.sftp://$sftp$remote_file",
+            false,
+            null,
+            0,
+            $maxBytes
+        );
+
+        return false === $data ? '' : (string)$data;
+    }
     public function scanFilesystem($remote_file)
     {
         if (!$this->exists($remote_file)) {

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -61,7 +61,11 @@ class Image extends FOGController
         // TaskQueue::_moveUpload() when the captured bytes land; NULL for
         // every image captured before schema step 370, which is why
         // archCanRun() treats unknown as allowed.
-        'arch' => 'imageArch'
+        'arch' => 'imageArch',
+        // The LOGICAL sector size, in bytes, of the disk this image was
+        // captured from -- 512 or 4096, NULL when unknown. Read out of the
+        // image's own sfdisk dump; see parseSectorSize(). Schema step 371.
+        'sectorsize' => 'imageSectorSize'
     ];
     /**
      * The required fields
@@ -108,6 +112,68 @@ class Image extends FOGController
             'imagetype'
         ]
     ];
+    /**
+     * The logical sector size recorded in an sfdisk dump.
+     *
+     * FOS writes the source disk's geometry into the dump at capture, and
+     * util-linux 2.35+ puts the logical sector size on its own line:
+     *
+     *     label: gpt
+     *     device: /dev/sda
+     *     unit: sectors
+     *     sector-size: 4096
+     *
+     * This is the same line, read the same way, that
+     * validateImageSectorSize() in FOS's funcs.sh keys its refusal off. Two
+     * readers of one fact is one too many, but the alternative is asking FOS
+     * to report something it has been writing to disk for years -- which
+     * would need an init release to reach anybody.
+     *
+     * Returns 0 when the dump has no such line. That is not a failure: dumps
+     * written before util-linux 2.35 do not carry it, and FOS treats the same
+     * absence as "allow the deploy rather than guess". Nothing here may be
+     * stricter than the code doing the actual refusing.
+     *
+     * @param string $dump the contents of a d<N>.*partitions file
+     *
+     * @return int bytes, or 0 when the dump does not say
+     */
+    public static function parseSectorSize($dump)
+    {
+        if (!preg_match('/^sector-size:\\s*(\\d+)\\s*$/mi', (string)$dump, $m)) {
+            return 0;
+        }
+
+        return (int)$m[1];
+    }
+    /**
+     * How a sector size should be described to a person.
+     *
+     * 4096 is 4Kn. 512 is deliberately NOT called "512n" or "512e": those
+     * differ only in PHYSICAL block size, which no capture records, and they
+     * are interchangeable as deploy targets anyway because only the logical
+     * size governs whether an image's geometry fits. Claiming one or the
+     * other would be inventing a fact.
+     *
+     * @param int $bytes the logical sector size
+     *
+     * @return string '' when unknown
+     */
+    public static function sectorSizeLabel($bytes)
+    {
+        $bytes = (int)$bytes;
+        if ($bytes < 1) {
+            return '';
+        }
+        if (4096 === $bytes) {
+            return '4Kn (4096-byte logical sectors)';
+        }
+        if (512 === $bytes) {
+            return '512n/512e (512-byte logical sectors)';
+        }
+
+        return sprintf('%d-byte logical sectors', $bytes);
+    }
     /**
      * Normalises an architecture string to iPXE's vocabulary.
      *

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 370);
+        define('FOG_SCHEMA', 371);
         define('FOG_BCACHE_VER', 316);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -44,6 +44,7 @@ class ImageManagement extends FOGPage
         $this->headerData = [
             _('Image Name'),
             _('Architecture'),
+            _('Sector Size'),
             _('Protected'),
             _('Enabled'),
             _('Captured')
@@ -58,6 +59,7 @@ class ImageManagement extends FOGPage
         $this->attributes = [
             ['data-col' => 'mainlink'],
             ['data-col' => 'arch'],
+            ['data-col' => 'sectorsize'],
             ['data-col' => 'protected'],
             ['data-col' => 'isEnabled'],
             ['data-col' => 'deployed']
@@ -1076,6 +1078,36 @@ class ImageManagement extends FOGPage
         }
         echo '</div>';
         echo '</div>';
+        // Sector size. The other half of "can this image go on that disk",
+        // and the half FOS has been refusing on since ADR-0005 without the
+        // server ever being able to show it.
+        $sectorLabel = Image::sectorSizeLabel($this->obj->get('sectorsize'));
+        echo '<div class="card card-primary card-outline">';
+        echo '<div class="card-header">';
+        echo '<h4 class="card-title">';
+        echo _('Sector Size');
+        echo '</h4>';
+        echo '<br/>';
+        echo _('The logical sector size of the disk this image was captured from.');
+        echo ' ';
+        echo _('An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them.');
+        echo '<div class="card-tools float-end">';
+        echo self::$FOGCollapseBox;
+        echo self::$FOGCloseBox;
+        echo '</div>';
+        echo '</div>';
+        echo '<div class="card-body">';
+        if ('' === $sectorLabel) {
+            echo '<span class="text-muted">';
+            echo _('Not recorded');
+            echo ' &mdash; ';
+            echo _('captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured.');
+            echo '</span>';
+        } else {
+            echo '<code>' . htmlentities($sectorLabel, ENT_QUOTES, 'utf-8') . '</code>';
+        }
+        echo '</div>';
+        echo '</div>';
         // Size on server
         echo '<div class="card card-primary card-outline">';
         echo '<div class="card-header">';
@@ -1336,13 +1368,15 @@ class ImageManagement extends FOGPage
             "SELECT `images`.`imageID` AS `id`, "
             . "`images`.`imageName` AS `image`, "
             . "`images`.`imageArch` AS `imageArch`, "
+            . "`images`.`imageSectorSize` AS `sectorsize`, "
             . "`images`.`imageDateTime` AS `captured`, "
             . "COUNT(`hosts`.`hostID`) AS `assigned` "
             . "FROM `images` "
             . "LEFT OUTER JOIN `hosts` "
             . "ON `hosts`.`hostImage` = `images`.`imageID` "
             . "GROUP BY `images`.`imageID`, `images`.`imageName`, "
-            . "`images`.`imageArch`, `images`.`imageDateTime` "
+            . "`images`.`imageArch`, `images`.`imageSectorSize`, "
+            . "`images`.`imageDateTime` "
             . "ORDER BY `images`.`imageName`"
         )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $images = is_array($images) ? $images : [];
@@ -1398,6 +1432,7 @@ class ImageManagement extends FOGPage
         echo '<table class="table table-hover"><thead><tr>';
         echo '<th>' . _('Image') . '</th>';
         echo '<th>' . _('Architecture') . '</th>';
+        echo '<th>' . _('Sector Size') . '</th>';
         echo '<th>' . _('Captured') . '</th>';
         echo '<th>' . _('Hosts assigned') . '</th>';
         echo '</tr></thead><tbody>';
@@ -1406,6 +1441,15 @@ class ImageManagement extends FOGPage
             echo '<tr>';
             echo '<td>' . htmlentities($img['image'], ENT_QUOTES, 'utf-8') . '</td>';
             echo '<td>' . $this->_archCell($arch, _('Not recorded')) . '</td>';
+            // Sector size is not compared against anything here: the server
+            // never learns a host disk's sector size, so unlike architecture
+            // there is no mismatch to flag. FOS does that check at deploy.
+            echo '<td>'
+                . $this->_archCell(
+                    Image::sectorSizeLabel($img['sectorsize'] ?? 0),
+                    _('Not recorded')
+                )
+                . '</td>';
             echo '<td>' . htmlentities((string)$img['captured'], ENT_QUOTES, 'utf-8') . '</td>';
             echo '<td>' . (int)$img['assigned'] . '</td>';
             echo '</tr>';

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -504,6 +504,45 @@ class TaskQueue extends TaskingElement
             self::$FOGSSH->delete($backup);
         }
         self::$FOGSSH->sftp_chmod($dest, 0775);
+        // Sector size, read out of the image's own sfdisk dump while the
+        // session to the node is still open.
+        //
+        // FOS wrote it there at capture and has refused a cross-sector-size
+        // deploy off the same line since ADR-0005 -- the server simply never
+        // looked. Reading it here rather than having FOS post it means no init
+        // release is needed for the server to know something already on disk.
+        //
+        // Candidate order matches validateImageSectorSize() in funcs.sh
+        // exactly: minimum, then partitions, then the legacy original name.
+        // Two readers of one fact have to agree on WHICH file, or they can
+        // disagree about one image.
+        //
+        // Disk 1 only. A multi-disk capture could in principle mix sector
+        // sizes across disks and one column cannot say so; FOS still checks
+        // every disk at deploy, which is where the refusal actually lives.
+        // This is for showing an operator what they have, not for deciding.
+        $sectorSize = 0;
+        foreach (
+            [
+                'minimum.partitions',
+                'partitions',
+                'original.partitions'
+            ] as $suffix
+        ) {
+            $dump = self::$FOGSSH->readFile(
+                sprintf('%s/d1.%s', $dest, $suffix)
+            );
+            if ('' === $dump) {
+                continue;
+            }
+            $sectorSize = Image::parseSectorSize($dump);
+            if ($sectorSize > 0) {
+                break;
+            }
+        }
+        if ($sectorSize > 0) {
+            $this->Image->set('sectorsize', $sectorSize);
+        }
         self::$FOGSSH->disconnect();
         if ($this->Image->get('format') == 1) {
             $this->Image

--- a/packages/web/management/js/fog/image/fog.image.list.js
+++ b/packages/web/management/js/fog/image/fog.image.list.js
@@ -64,6 +64,30 @@
             targets: colIndex.arch
         });
     }
+    if ('sectorsize' in colIndex) {
+        columnDefs.push({
+            render: function(data, type, row) {
+                if (type !== 'display') {
+                    return data;
+                }
+                // 512n and 512e are not separated: they differ only in
+                // PHYSICAL block size, which no capture records, and they are
+                // interchangeable as deploy targets because only the logical
+                // size governs whether the geometry fits.
+                if (!data) {
+                    return '<span class="text-muted">Not recorded</span>';
+                }
+                if (parseInt(data, 10) === 4096) {
+                    return '<code>4Kn</code>';
+                }
+                if (parseInt(data, 10) === 512) {
+                    return '<code>512n/512e</code>';
+                }
+                return '<code>' + data + '</code>';
+            },
+            targets: colIndex.sectorsize
+        });
+    }
     if ('protected' in colIndex) {
         columnDefs.push({
             responsivePriority: 0,

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -935,6 +935,9 @@ msgstr "Dieser Benutzername ist bereits vorhanden!"
 msgid "An image already exists with this name!"
 msgstr "Ein Image mit diesem Namen ist bereits vorhanden!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
@@ -7025,6 +7028,10 @@ msgstr "Service-Status"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "Server-Shell"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8438,6 +8445,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9750,6 +9760,9 @@ msgstr "ist offen, aber ist vor kurzem für diesen Host fehlgeschlagen"
 #, fuzzy
 msgid "but there are"
 msgstr "Es gibt"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -939,6 +939,9 @@ msgstr "An image already exists with this name!"
 msgid "An image already exists with this name!"
 msgstr "An image already exists with this name!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "A hostname with that name already exists."
@@ -7022,6 +7025,10 @@ msgstr "Service Status"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "Server Shell"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8433,6 +8440,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9743,6 +9753,9 @@ msgstr "is open, but has recently failed for this Host"
 #, fuzzy
 msgid "but there are"
 msgstr "There are"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -953,6 +953,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "An image already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Sesión con ese nombre ya existe"
@@ -7173,6 +7176,10 @@ msgstr "Estado del servicio"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "servidor TFTP"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8619,6 +8626,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9928,6 +9938,9 @@ msgstr "No se ha definido de este alojamiento imagen"
 #, fuzzy
 msgid "but there are"
 msgstr "Existen"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -935,6 +935,9 @@ msgstr "Dieser Benutzername ist bereits vorhanden!"
 msgid "An image already exists with this name!"
 msgstr "Ein Image mit diesem Namen ist bereits vorhanden!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
@@ -7026,6 +7029,10 @@ msgstr "Service-Status"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "Server-Shell"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8439,6 +8446,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr "Der Schlüssel wird registrierten Hosts zugewiesen, wenn"
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9751,6 +9761,9 @@ msgstr "ist offen, aber ist vor kurzem für diesen Host fehlgeschlagen"
 #, fuzzy
 msgid "but there are"
 msgstr "Es gibt"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -940,6 +940,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "An image already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Un nom d'hôte avec ce nom existe déjà."
@@ -7024,6 +7027,10 @@ msgstr "État du service"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "serveur Shell"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8435,6 +8442,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9745,6 +9755,9 @@ msgstr "est ouvert, mais a récemment échoué à cet hôte"
 #, fuzzy
 msgid "but there are"
 msgstr "Il y a"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -911,6 +911,9 @@ msgstr "Esiste già un utente con questo nome!"
 msgid "An image already exists with this name!"
 msgstr "Un'immagine esiste già con questo nome!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Un nome host con questo nome esiste già"
@@ -6798,6 +6801,10 @@ msgstr "Stato servizio"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "Server Shell"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8151,6 +8158,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr "La chiave verrà assegnata agli host registrati quando una"
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9419,6 +9429,9 @@ msgstr "ma è fallito di recente per questo host"
 #, fuzzy
 msgid "but there are"
 msgstr "Ci sono"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -896,6 +896,9 @@ msgstr "この名前のプリンターは既に存在します！"
 msgid "An image already exists with this name!"
 msgstr "この名前のイメージは既に存在します！"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "その名前のホストは既に存在します"
@@ -6753,6 +6756,10 @@ msgstr "設定"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "サーバーシェル"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8087,6 +8094,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr "キーは、登録済みホストに次の場合割り当てられます"
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9358,6 +9368,9 @@ msgstr "ただし、このホストでは最近失敗しています"
 
 msgid "but there are"
 msgstr "ただし、次があります"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -799,6 +799,9 @@ msgstr ""
 msgid "An image already exists with this name!"
 msgstr ""
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 msgid "An image with this name already exists!"
 msgstr ""
 
@@ -5972,6 +5975,9 @@ msgstr ""
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+msgid "Sector Size"
+msgstr ""
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -7159,6 +7165,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -8313,6 +8322,9 @@ msgid "but has recently failed for this host"
 msgstr ""
 
 msgid "but there are"
+msgstr ""
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
 msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -939,6 +939,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "An image already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "Um nome de host com esse nome já existe."
@@ -7023,6 +7026,10 @@ msgstr "status do serviço"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "Shell servidor"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8434,6 +8441,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9744,6 +9754,9 @@ msgstr "está aberto, mas recentemente falhou para este alojamento"
 #, fuzzy
 msgid "but there are"
 msgstr "tem"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -939,6 +939,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "An image already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
+msgid "An image cannot be deployed to a disk with a different logical sector size -- partition and filesystem geometry cannot be translated between them."
+msgstr ""
+
 #, fuzzy
 msgid "An image with this name already exists!"
 msgstr "使用此名称的主机名已经存在。"
@@ -7023,6 +7026,10 @@ msgstr "服务状态"
 msgid "Seconds before the client gives up. 0 is no timeout."
 msgstr ""
 
+#, fuzzy
+msgid "Sector Size"
+msgstr "服务器外壳"
+
 msgid "Secure Boot"
 msgstr ""
 
@@ -8434,6 +8441,9 @@ msgstr ""
 msgid "The key will be assigned to registered hosts when a"
 msgstr ""
 
+msgid "The logical sector size of the disk this image was captured from."
+msgstr ""
+
 #, php-format
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
@@ -9744,6 +9754,9 @@ msgstr "是开放的，但最近没有这个主机"
 #, fuzzy
 msgid "but there are"
 msgstr "有"
+
+msgid "captured before FOG tracked this, or by a FOS build whose partition dump predates the sector-size field. It will be set the next time this image is captured."
+msgstr ""
 
 msgid "captured before FOG tracked this. It will be set the next time this image is captured."
 msgstr ""

--- a/tests/arch-compatibility.test.php
+++ b/tests/arch-compatibility.test.php
@@ -203,4 +203,69 @@ $t->check(
     && false !== strpos($listJs, 'colIndex')
 );
 
+// --- sector size (schema step 371) ---------------------------------------
+// The value FOS already refuses on, finally visible to the server. The parse
+// target is the `sector-size:` line util-linux 2.35+ writes into the sfdisk
+// dump -- the exact line validateImageSectorSize() in funcs.sh reads.
+$dump4k = "label: gpt\n"
+    . "label-id: 3C1B8A0E-1111-4222-8333-444455556666\n"
+    . "device: /dev/nvme0n1\n"
+    . "unit: sectors\n"
+    . "first-lba: 6\n"
+    . "sector-size: 4096\n"
+    . "\n"
+    . "/dev/nvme0n1p1 : start=6, size=32768, type=EF00\n";
+$dump512 = str_replace('sector-size: 4096', 'sector-size: 512', $dump4k);
+// Pre-2.35 dumps have no such line at all. FOS treats that as "allow the
+// deploy rather than guess", so this must read as unknown, never as 512.
+$dumpOld = str_replace("sector-size: 4096\n", '', $dump4k);
+
+$t->check(
+    'a 4Kn dump parses to 4096',
+    \FOG\Image::parseSectorSize($dump4k) === 4096
+);
+$t->check(
+    'a 512-byte dump parses to 512',
+    \FOG\Image::parseSectorSize($dump512) === 512
+);
+$t->check(
+    'a dump with no sector-size line is unknown (0), not assumed 512',
+    \FOG\Image::parseSectorSize($dumpOld) === 0
+);
+$t->check(
+    'an empty dump is unknown rather than an error',
+    \FOG\Image::parseSectorSize('') === 0
+);
+$t->check(
+    'a sector-size mentioned mid-line is not mistaken for the field',
+    \FOG\Image::parseSectorSize("# note: sector-size: 4096 was seen\n") === 0
+);
+$t->check(
+    '4096 is labelled 4Kn',
+    false !== strpos(\FOG\Image::sectorSizeLabel(4096), '4Kn')
+);
+$t->check(
+    '512 is labelled 512n/512e -- the two are not separable from a capture',
+    false !== strpos(\FOG\Image::sectorSizeLabel(512), '512n/512e')
+);
+$t->check(
+    'unknown has no label at all, rather than a misleading default',
+    \FOG\Image::sectorSizeLabel(0) === ''
+);
+$t->check(
+    "Image maps 'sectorsize' to imageSectorSize",
+    (bool)preg_match("/'sectorsize'\s*=>\s*'imageSectorSize'/", $imageSrc)
+);
+$t->check(
+    'schema adds images.imageSectorSize',
+    false !== strpos($schemaSrc, 'ADD `imageSectorSize` INT(11) NULL DEFAULT NULL')
+);
+$t->check(
+    'the capture path reads the dump in the same candidate order as FOS',
+    (bool)preg_match(
+        "/'minimum\.partitions',\s*'partitions',\s*'original\.partitions'/s",
+        $queueSrc
+    )
+);
+
 $t->finish();

--- a/tests/fixtures/route-column-contract.txt
+++ b/tests/fixtures/route-column-contract.txt
@@ -115,6 +115,7 @@ image	18	imageEnabled	isEnabled	-	-
 image	19	imageReplicate	toReplicate	-	-
 image	20	imageServerSize	srvsize	-	-
 image	21	imageArch	arch	-	-
+image	22	imageSectorSize	sectorsize	-	-
 imageassociation	0	igaID	id	-	-
 imageassociation	1	igaID	DT_RowId	f	-
 imageassociation	2	igaImageID	imageID	-	-


### PR DESCRIPTION
FOS has refused a cross-sector-size deploy since **ADR-0005** — partition-table and filesystem geometry bake in the source disk's logical sector size and cannot be translated, so a 4Kn image on a 512-byte disk produces an unbootable machine. `validateImageSectorSize()` in `funcs.sh` does that check, and the server has never known any of it. The refusal therefore only ever arrives at the client, minutes into a task, as a failure nobody could have seen coming.

`images.imageSectorSize` (schema step 371) records the logical sector size of the disk an image was captured from.

## Why "512n/512e" and not one or the other

**Logical**, and that is the whole distinction:

| | Logical | Physical | Deployable onto |
|---|---|---|---|
| 512n | 512 | 512 | any 512 disk |
| 512e | 512 | 4096 | any 512 disk |
| 4Kn | 4096 | 4096 | only 4Kn disks |

512n and 512e are freely interchangeable as targets; only 4Kn differs. They are also **not separable from a capture even in principle** — FOS reads the source size with `blockdev --getss` (logical) and writes it to the `sector-size:` line of the sfdisk dump, while physical block size is read once for alignment (`funcs.sh:472`) and never persisted.

So the column answers *4Kn or 512-family*, which is the question that governs deployability, and the UI says `512n/512e` rather than claiming a distinction it cannot support.

## No FOS change, no init release

The value has been in the image's own sfdisk dump for years; the server simply never looked. `TaskQueue::_moveUpload()` now reads it over the sftp session it already has open, in the **same candidate order** `validateImageSectorSize()` uses — `minimum.partitions`, `partitions`, `original.partitions`. Two readers of one fact have to agree on which file or they can disagree about a single image.

## Unknown stays unknown

A dump written before util-linux 2.35 carries no `sector-size:` line, and FOS treats that absence as *allow the deploy rather than guess*. Nothing here may be stricter than the code doing the refusing, so:

- every image captured before this reads **Not recorded**
- **no server-side refusal is added** — the server never learns a target disk's sector size, so there is nothing to compare against. FOS keeps that job.

Disk 1 only: a multi-disk capture could in principle mix sector sizes and one column cannot say so. FOS still checks every disk at deploy. This is for showing an operator what they have, not for deciding.

## Verification

- `tests/run-all.sh` — 154 passed, 0 failed
- `tests/arch-compatibility.test.php` — 49 checks, including 4Kn, 512, a pre-2.35 dump with no line, an empty dump, and a `sector-size:` mentioned mid-line (must not parse)
- `schema-upgrade-replay` — every version from 0 to 370 reaches 371
- `route-column-contract` fixture updated: one new column, no index shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
