### PR TITLE
Make the Architectures page readable in dark mode and its tables DataTables

### DIFF
--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1511,6 +1511,11 @@ class ImageManagement extends FOGPage
         echo _('Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose.');
         echo '</div>';
         echo '<div class="card-body table-responsive">';
+        // NOT a DataTable, unlike the two report tables below, and it must not
+        // become one: every row here is a pair of form inputs, and DataTables
+        // removes the rows it has paged away from the DOM -- so anything past
+        // page one would silently stop being submitted. Three rows need no
+        // paging anyway.
         echo '<table class="table table-hover"><thead><tr>';
         echo '<th>' . _('Architecture') . '</th>';
         echo '<th>' . _('Description') . '</th>';
@@ -1558,7 +1563,8 @@ class ImageManagement extends FOGPage
         echo _('Images');
         echo '</h4></div>';
         echo '<div class="card-body table-responsive">';
-        echo '<table class="table table-hover"><thead><tr>';
+        echo '<table id="architectures-images" class="table table-hover">';
+        echo '<thead><tr>';
         echo '<th>' . _('Image') . '</th>';
         echo '<th>' . _('Architecture') . '</th>';
         echo '<th>' . _('Sector Size') . '</th>';
@@ -1591,7 +1597,8 @@ class ImageManagement extends FOGPage
         echo _('Hosts');
         echo '</h4></div>';
         echo '<div class="card-body table-responsive">';
-        echo '<table class="table table-hover"><thead><tr>';
+        echo '<table id="architectures-hosts" class="table table-hover">';
+        echo '<thead><tr>';
         echo '<th>' . _('Host') . '</th>';
         echo '<th>' . _('Architecture') . '</th>';
         echo '<th>' . _('Assigned image') . '</th>';
@@ -1690,10 +1697,27 @@ class ImageManagement extends FOGPage
      */
     private function _archStat($value, $label, $warn)
     {
+        // A card, not AdminLTE's `small-box`. small-box is built for a
+        // saturated background with white text forced on top of it, so
+        // `bg-light` -- the only neutral in that family -- paints a near-white
+        // box that the dark theme then writes its light text onto, and the
+        // number is invisible. Nothing else in FOG used small-box, so there
+        // was no house tile to inherit a fix from.
+        //
+        // The card idiom below is the one the Images and Hosts cards on this
+        // same page already use. The theme styles cards in both modes, so this
+        // needs no colour of its own and cannot drift from the rest of the
+        // page. Only the warning tile takes a colour, and it takes it from
+        // card-danger, which forces its own contrast.
         echo '<div class="col-sm-6 col-md-3">';
-        echo '<div class="small-box ' . ($warn ? 'bg-danger' : 'bg-light') . '">';
-        echo '<div class="inner"><h3>' . (int)$value . '</h3>';
-        echo '<p>' . htmlentities($label, ENT_QUOTES, 'utf-8') . '</p>';
+        echo '<div class="card '
+            . ($warn && $value > 0 ? 'card-danger' : 'card-primary')
+            . ' card-outline">';
+        echo '<div class="card-body text-center">';
+        echo '<h3 class="mb-0">' . (int)$value . '</h3>';
+        echo '<p class="mb-0 text-muted">'
+            . htmlentities($label, ENT_QUOTES, 'utf-8')
+            . '</p>';
         echo '</div></div></div>';
     }
     /**

--- a/packages/web/management/js/fog/image/fog.image.architectures.js
+++ b/packages/web/management/js/fog/image/fog.image.architectures.js
@@ -1,0 +1,50 @@
+(function($) {
+    // The two report tables on Image Management -> Architectures.
+    //
+    // WHY THIS FILE EXISTS AT ALL: Page::_setJavascripts() resolves a page's
+    // script purely by name -- ?node=image&sub=architectures loads
+    // js/fog/image/fog.image.architectures.js if it is there, and falls back
+    // to fog.image.list.js if it is not. Until this file existed the fallback
+    // ran, and it looks for #dataTable, which this page does not have. So the
+    // page loaded a script, that script found nothing, and the tables stayed
+    // plain HTML with no error anywhere.
+    //
+    // Enhancing the SERVER-RENDERED DOM rather than fetching JSON is
+    // deliberate. These tables are a join across hosts and images that no
+    // Route class models -- there is no 'host and its image's architecture'
+    // entity to list -- so a server-side grid would need a bespoke endpoint
+    // for one page. Reading the rows PHP already wrote costs nothing, keeps
+    // the mismatch row highlighting (tr.table-danger) that the report is
+    // largely for, and cannot disagree with the summary tiles above, which
+    // are counted off those same rows.
+    //
+    // registerTable() rather than a bare .DataTable(): it is what applies the
+    // admin's own FOG_VIEW_DEFAULT_SCREEN row count and FOG_TABLE_SCROLL_MODE
+    // paging style, plus column resizing, exactly as every other grid in FOG
+    // does. That consistency is the point of using it here.
+    var opts = {
+        // Read-only reports. registerTable() defaults to multi-select with
+        // Select All / Deselect All buttons, which offer an action that does
+        // not exist on this page.
+        select: false,
+        buttons: [],
+        paging: true,
+        searching: true,
+        ordering: true,
+        info: true,
+        // Classic paging, not the virtual scroller. Scroller sizes its
+        // viewport from a UNIFORM row height, and these tables deliberately
+        // carry taller rows (the muted "Not yet seen" spans) alongside short
+        // ones; it also renders into a fixed-height viewport, which is wrong
+        // for a report whose whole job is to be read top to bottom.
+        scroller: false
+    };
+    // Ordered by the first column, which is the name in both tables -- the
+    // order the PHP already emitted, so the first paint does not reshuffle.
+    $('#architectures-images').registerTable(null, $.extend({}, opts, {
+        order: [[0, 'asc']]
+    }));
+    $('#architectures-hosts').registerTable(null, $.extend({}, opts, {
+        order: [[0, 'asc']]
+    }));
+})(jQuery);


### PR DESCRIPTION
Both reported off one screenshot of the live page.

## The summary tiles were invisible in dark mode

They used AdminLTE's `small-box` with `bg-light`. `small-box` is built for a
saturated background with white text forced on top of it, and `bg-light` is the
only neutral in that family -- so it paints a near-white box, the dark theme
writes its own light foreground onto it, and both the number and the label
disappear.

`small-box` appeared **exactly once in the whole codebase**: here. Nothing else
in FOG uses it or `info-box`, so there was no house stat-tile to inherit a
working dark mode from -- which is how it shipped broken in the first place.

The tiles are now built from the same `card card-*-outline` idiom the Images
and Hosts cards directly below them already use. The theme styles cards in both
modes, so they need no colour of their own and cannot drift from the rest of
the page. The mismatch tile takes `card-danger`, and now only when the count is
actually above zero -- a red tile reading `0` is a false alarm.

## The tables were plain HTML, not DataTables

`Page::_setJavascripts()` resolves a page's script purely by name:
`?node=image&sub=architectures` loads `js/fog/image/fog.image.architectures.js`
if it exists, and **falls back to `fog.image.list.js`** if it does not. That
file did not exist, so the fallback ran -- and `fog.image.list.js` binds to
`#dataTable`, which this page has never had. The page loaded a script, the
script found nothing to do, and the tables stayed static with nothing logged.

The new file enhances the **server-rendered DOM** rather than fetching JSON,
which is the deliberate part. These tables are a join across hosts and images
that no Route class models -- there is no "host and its image's architecture"
entity to list -- so a server-side grid would mean a bespoke endpoint serving
one page. Reading the rows PHP already wrote costs nothing, keeps the
`tr.table-danger` mismatch highlighting the report largely exists for, and
cannot disagree with the summary tiles above, which are counted off those same
rows.

`registerTable()` rather than a bare `.DataTable()`, because that is what
applies the admin's own `FOG_VIEW_DEFAULT_SCREEN` row count and
`FOG_TABLE_SCROLL_MODE` paging style, plus column resizing -- the same as every
other grid in FOG. Switched off for these two:

- **selection and the Select All / Deselect All buttons** -- read-only reports,
  and those buttons offer an action that does not exist here
- **the virtual scroller** -- it sizes its viewport from a uniform row height
  these tables do not have, and a report meant to be read top to bottom does
  not want a fixed-height window

The **Architectures editing table** above them stays plain HTML and now carries
a comment saying why: every row is a pair of form inputs, and DataTables
removes paged-away rows from the DOM, so anything past page one would silently
stop being submitted.

Full suite green: 123 PHP harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)