### PR TITLE
Let the Architectures tables follow FOG_TABLE_SCROLL_MODE like every other grid

### DIFF
--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1606,7 +1606,14 @@ class ImageManagement extends FOGPage
         echo '</tr></thead><tbody>';
         foreach ($rows as $row) {
             $bad = !Architecture::canRun($row['imageArch'] ?? '', $row['hostArch'] ?? '');
-            echo $bad ? '<tr class="table-danger">' : '<tr>';
+            // data-mismatch as well as the class: this table is a DataTable
+            // and redraws its rows when paged, so fog.image.architectures.js
+            // re-applies the highlight from the attribute on every draw. The
+            // class stays for the first paint and for anyone reading the page
+            // with JavaScript off.
+            echo $bad
+                ? '<tr class="table-danger" data-mismatch="1">'
+                : '<tr>';
             echo '<td>' . htmlentities($row['host'], ENT_QUOTES, 'utf-8') . '</td>';
             echo '<td>'
                 . $this->_archCell(

--- a/packages/web/management/js/fog/image/fog.image.architectures.js
+++ b/packages/web/management/js/fog/image/fog.image.architectures.js
@@ -28,23 +28,32 @@
         // not exist on this page.
         select: false,
         buttons: [],
-        paging: true,
-        searching: true,
-        ordering: true,
-        info: true,
-        // Classic paging, not the virtual scroller. Scroller sizes its
-        // viewport from a UNIFORM row height, and these tables deliberately
-        // carry taller rows (the muted "Not yet seen" spans) alongside short
-        // ones; it also renders into a fixed-height viewport, which is wrong
-        // for a report whose whole job is to be read top to bottom.
-        scroller: false
+        // Ordered by the first column, which is the name in both tables --
+        // the order the PHP already emitted, so the first paint does not
+        // reshuffle.
+        order: [[0, 'asc']],
+        // Paging style is NOT set here. registerTable() derives it from the
+        // admin's FOG_TABLE_SCROLL_MODE, and these two tables follow that
+        // setting like every other grid in FOG. An earlier version passed
+        // scroller:false to force classic paging, on the theory that Scroller
+        // needs a uniform row height these tables do not have -- they do: the
+        // muted "Not yet seen" spans are ordinary inline text at the same line
+        // height as every other cell. Opting a table out of a global display
+        // preference needs a real reason, and that was not one.
+        rowCallback: function(row, data) {
+            // Re-apply the mismatch highlight on every draw.
+            //
+            // The class is written by PHP onto the <tr>, but a table that
+            // pages -- virtually or classically -- redraws its rows, and the
+            // red row is the single thing this report exists to show. Keying
+            // off a data attribute rather than trusting the class to survive
+            // means it cannot quietly stop appearing on page two, which is a
+            // failure nobody would notice until it mattered.
+            if ($(row).attr('data-mismatch') === '1') {
+                $(row).addClass('table-danger');
+            }
+        }
     };
-    // Ordered by the first column, which is the name in both tables -- the
-    // order the PHP already emitted, so the first paint does not reshuffle.
-    $('#architectures-images').registerTable(null, $.extend({}, opts, {
-        order: [[0, 'asc']]
-    }));
-    $('#architectures-hosts').registerTable(null, $.extend({}, opts, {
-        order: [[0, 'asc']]
-    }));
+    $('#architectures-images').registerTable(null, $.extend({}, opts));
+    $('#architectures-hosts').registerTable(null, $.extend({}, opts));
 })(jQuery);


### PR DESCRIPTION
The two report tables on Image Management -> Architectures were passing
`scroller: false`, which opts a table out of the admin's
`FOG_TABLE_SCROLL_MODE` preference entirely -- `registerTable()` reads that
setting only when `scroller` is not explicitly false:

```js
var infiniteScroll =
  (opts.scroller !== false) &&
  !opts.rowGroup &&
  (($('#scrollMode').val() || 'infinite').toLowerCase() !== 'paged');
```

So these two were the only grids in FOG ignoring it.

**The reason given for that was wrong.** It claimed Scroller needs a uniform
row height these tables do not have. They do -- the muted "Not yet seen" and
"Not recorded" spans are ordinary inline text at the same line height as every
other cell, so no row here is taller than any other. Opting a table out of a
global display preference needs a real constraint, and that was not one.

## The highlight is now redraw-proof

The mismatch row is re-applied on every draw from a `data-mismatch` attribute
rather than relying on the class surviving. A table that pages -- virtually or
classically -- rebuilds its rows, and the red row is the single thing this
report exists to show; having it quietly stop appearing on page two is a
failure nobody would notice until the one time it mattered. The class stays on
the `<tr>` too, for the first paint and for anyone reading with JavaScript off.

Also dropped `paging` / `searching` / `ordering` / `info` from the options: all
four are already `registerTable()` defaults, and restating a default is a line
that looks like a decision.

Full suite green: 123 PHP harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)