### PR TITLE
Stop FOGSSH::delete() recursing forever on a path it cannot remove

### DIFF
--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -384,29 +384,74 @@ class FOGSSH
         return @unlink("ssh2.sftp://{$this->_sftp}{$path}");
     }
     /**
-     * Deletes the item passed
-     * This is the method called for the delete.
+     * Deletes the item passed.
+     *
+     * Bounded, and it answers with a bool.
+     *
+     * THE RECURSION USED TO BE UNBOUNDED. The old shape ended with a bare
+     * `$this->delete($path)` after emptying the directory -- an unconditional
+     * self-call with identical arguments and no test for whether anything had
+     * changed. For a path that exists but CANNOT be removed, every pass
+     * repeated itself exactly: sftp_rmdir failed, sftp_unlink failed,
+     * scanFilesystem() returned [] (it lists files, and a plain file is not a
+     * directory), and delete() called itself again. That recursion had no
+     * termination condition at all; it ran until PHP exhausted memory_limit.
+     *
+     * A PHP memory-exhaustion fatal is NOT catchable, so no catch block
+     * anywhere upstream could see it. TaskQueue::checkout() caught nothing, the
+     * response body was empty, and FOS -- which reads the body and waits for
+     * '##' -- printed "Error returned:" with nothing after it and retried until
+     * it gave up. A capture that had already been renamed into place therefore
+     * never reached Complete.
+     *
+     * How it was reached in the field: `_moveUpload()` renames the previous
+     * image aside to `<image>.movetmp` and deletes it after the new one lands.
+     * That directory keeps the OWNERSHIP of whatever it was renamed from, and a
+     * root-owned 0755 directory cannot be emptied by the storage node's SSH
+     * user -- unlinking a file needs write permission on its parent. So both
+     * primitives failed forever.
+     *
+     * The fix is the missing progress condition, not a depth cap: after
+     * emptying a directory the primitives are retried EXACTLY ONCE, and if the
+     * path is still there we say so instead of asking again.
+     *
+     * Known limitation, unchanged from before and now honest about itself:
+     * scanFilesystem() returns files only, so a tree with nested directories
+     * cannot be emptied by this method and returns false. The old code
+     * responded to that case by recursing forever.
      *
      * @param string $path the item to delete
      *
-     * @return object
+     * @return bool true when the path is gone, false when it is still there
      */
     public function delete($path)
     {
         if (!$this->exists($path)) {
-            return $this;
+            return true;
         }
-        $rmdir = $this->sftp_rmdir($path);
-        $unlink = $this->sftp_unlink($path);
-        if (!$rmdir && !$unlink) {
-            $filelist = $this->scanFilesystem($path);
-            foreach ((array)$filelist as $file) {
-                $this->delete($file);
+        // A directory that is not empty fails both of these, which is the
+        // signal to empty it and try again -- and so does a path that simply
+        // cannot be removed, which is why the retry below happens once.
+        if ($this->sftp_rmdir($path) || $this->sftp_unlink($path)) {
+            return true;
+        }
+        $emptied = true;
+        foreach ((array)$this->scanFilesystem($path) as $file) {
+            if (!$this->delete($file)) {
+                $emptied = false;
             }
-            $this->delete($path);
+        }
+        if (!$emptied) {
+            return false;
+        }
+        if ($this->sftp_rmdir($path) || $this->sftp_unlink($path)) {
+            return true;
         }
 
-        return $this;
+        // Re-checked rather than assumed: another writer may have removed it
+        // while we were working, and reporting a failure for a path that is
+        // gone would send a caller looking for something that is not there.
+        return !$this->exists($path);
     }
 }
 

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -500,8 +500,27 @@ class TaskQueue extends TaskingElement
                 )
             );
         }
-        if ($moved) {
-            self::$FOGSSH->delete($backup);
+        if ($moved && !self::$FOGSSH->delete($backup)) {
+            // Deliberately NOT fatal. By this line the rename above has
+            // already put the captured image at its final path -- the capture
+            // succeeded, and all that is left is removing the previous copy.
+            // Failing the task for that trades a stale directory (disk, which
+            // an admin can reclaim) for a task stuck short of Complete after a
+            // good capture (an hour of imaging, which nobody can reclaim).
+            //
+            // It is not silent either: the run is marked PARTIAL, so the audit
+            // trail names the leftover and says the capture itself was fine.
+            // The likeliest cause is ownership -- .movetmp inherits the
+            // permissions of whatever it was renamed from, and a root-owned
+            // directory cannot be emptied by the storage node's user.
+            Audit::markOutcome(
+                Audit::PARTIAL,
+                sprintf(
+                    '%s: %s',
+                    _('Image captured; previous copy needs manual removal'),
+                    $backup
+                )
+            );
         }
         self::$FOGSSH->sftp_chmod($dest, 0775);
         self::$FOGSSH->disconnect();
@@ -615,7 +634,14 @@ class TaskQueue extends TaskingElement
                 ->set('percent', 100)
                 ->set('stateID', self::getCompleteState());
             if (!self::$Host->isValid()) {
-                throw new \Exception('##');
+                // NOT '##'. That string is what FOS reads as success, and it
+                // was thrown here -- so the catch below echoed it verbatim and
+                // FOS moved on satisfied, while the task was never saved and
+                // the host was never updated. A completion that did not happen
+                // must not be reported as one.
+                throw new \Exception(
+                    _('Host is not valid; the task cannot be completed')
+                );
             }
             $updatedHost = self::getClass('HostManager')->update(
                 ['id' => self::$Host->get('id')],

--- a/packages/web/lib/service/filedeleter.class.php
+++ b/packages/web/lib/service/filedeleter.class.php
@@ -284,6 +284,11 @@ class FileDeleter extends FOGService
                             )
                         );
                     } elseif (!self::$FOGSSH->delete($deleteFile)) {
+                        // This branch was unreachable until FOGSSH::delete()
+                        // started answering with a bool: it returned $this,
+                        // which is always truthy, so every failed removal was
+                        // reported below as a successful one and the path was
+                        // dequeued regardless.
                         self::outall(
                             sprintf(
                                 "%s: %s.\n\t -  %s: %s.\n\t - %s.",

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3585,6 +3585,10 @@ msgstr "Host ist nicht gültig"
 msgid "Host is not valid!"
 msgstr "Host ist nicht gültig"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "Image ist geschützt und kann nicht gelöscht werden"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3888,6 +3892,9 @@ msgstr "Image hinzugefügt"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Geschützt"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3586,6 +3586,10 @@ msgstr "Host is not valid"
 msgid "Host is not valid!"
 msgstr "Host is not valid"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "Image is protected and cannot be deleted"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3889,6 +3893,9 @@ msgstr "Image Name"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Protected"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3655,6 +3655,10 @@ msgstr "tipo de tarea no es válida"
 msgid "Host is not valid!"
 msgstr "tipo de tarea no es válida"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "está protegido, no se permite la eliminación"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3964,6 +3968,9 @@ msgstr "Nombre de la imagen"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Protegido"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3585,6 +3585,10 @@ msgstr "Host ist nicht gültig"
 msgid "Host is not valid!"
 msgstr "Host ist nicht gültig"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "Image ist geschützt und kann nicht gelöscht werden"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3888,6 +3892,9 @@ msgstr "Image hinzugefügt"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Geschützt"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3588,6 +3588,10 @@ msgstr "Host est pas valide"
 msgid "Host is not valid!"
 msgstr "Host est pas valide"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "L'image est protégée et ne peut être supprimé"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3891,6 +3895,9 @@ msgstr "Nom de l'image"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Protégé"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3484,6 +3484,10 @@ msgstr "Host non è valido"
 msgid "Host is not valid!"
 msgstr "Host non è valido"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "L'immagine è protetta e non può essere cancellato"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3776,6 +3780,9 @@ msgstr "Immagine aggiunta!"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Protetta"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3452,6 +3452,10 @@ msgstr "ホストが無効です"
 msgid "Host is not valid!"
 msgstr "ホストが無効です"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "イメージは保護されているため削除できません"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3744,6 +3748,9 @@ msgstr "イメージを追加しました！"
 #, fuzzy
 msgid "Image architecture"
 msgstr "保護済み"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3046,6 +3046,9 @@ msgstr ""
 msgid "Host is not valid!"
 msgstr ""
 
+msgid "Host is not valid; the task cannot be completed"
+msgstr ""
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3307,6 +3310,9 @@ msgid "Image added!"
 msgstr ""
 
 msgid "Image architecture"
+msgstr ""
+
+msgid "Image captured; previous copy needs manual removal"
 msgstr ""
 
 msgid "Image is invalid"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3587,6 +3587,10 @@ msgstr "Host não é válido"
 msgid "Host is not valid!"
 msgstr "Host não é válido"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "A imagem está protegida e não pode ser excluído"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3890,6 +3894,9 @@ msgstr "Nome da imagem"
 #, fuzzy
 msgid "Image architecture"
 msgstr "Protegido"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3587,6 +3587,10 @@ msgstr "主机是无效的"
 msgid "Host is not valid!"
 msgstr "主机是无效的"
 
+#, fuzzy
+msgid "Host is not valid; the task cannot be completed"
+msgstr "图像被保护，不能被删除"
+
 msgid "Host login records are kept forever"
 msgstr ""
 
@@ -3890,6 +3894,9 @@ msgstr "图片名称"
 #, fuzzy
 msgid "Image architecture"
 msgstr "受保护"
+
+msgid "Image captured; previous copy needs manual removal"
+msgstr ""
 
 #, fuzzy
 msgid "Image is invalid"

--- a/tests/fogssh-delete-terminates.test.php
+++ b/tests/fogssh-delete-terminates.test.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * FOGSSH::delete() always terminates, and says whether it worked.
+ *
+ * The old shape ended with a bare `$this->delete($path)` after emptying the
+ * directory -- an unconditional self-call with identical arguments and no test
+ * for whether anything had changed. For a path that exists but CANNOT be
+ * removed, every pass repeated itself exactly: sftp_rmdir failed, sftp_unlink
+ * failed, scanFilesystem() returned [] (it lists files, and a plain file is not
+ * a directory), and delete() called itself again. No termination condition at
+ * all -- it ran until PHP exhausted memory_limit.
+ *
+ * Observed in the field as:
+ *
+ *   PHP Fatal error: Allowed memory size of 268435456 bytes exhausted
+ *   in lib/fog/fogssh.class.php on line 336
+ *
+ * once per FOS retry. A memory-exhaustion fatal is not catchable, so
+ * TaskQueue::checkout()'s catch never ran, the response body was empty, and FOS
+ * -- which waits for '##' -- printed "Error returned:" with nothing after it
+ * until it gave up. The capture had already been renamed into place; the task
+ * never reached Complete. Reached because `<image>.movetmp` keeps the ownership
+ * of whatever it was renamed from, and a root-owned 0755 directory cannot be
+ * emptied by the storage node's SSH user.
+ *
+ * The runaway is what this file pins, so the stub COUNTS the passes and throws
+ * once they exceed a small bound. A regression therefore fails this test in
+ * milliseconds instead of reproducing the out-of-memory kill inside CI.
+ *
+ * No ssh2 extension needed: FOGSSH has no constructor, sftp_rmdir/sftp_unlink
+ * reach the real class only through __call, and exists()/scanFilesystem() are
+ * ordinary methods -- so a subclass can stand in for the filesystem entirely.
+ *
+ * Usage: php tests/fogssh-delete-terminates.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('fogssh-delete');
+
+$t = new FogChecks();
+
+/**
+ * A fake remote filesystem with per-path removal permission.
+ */
+class FakeSshFs extends \FOG\FOGSSH
+{
+    /** @var array path => 'file'|'dir' */
+    public $tree = [];
+
+    /** @var array paths whose removal always fails, whatever they are */
+    public $refuse = [];
+
+    /** @var int how many times delete() has looked at anything */
+    public $passes = 0;
+
+    /** @var int the bound; past this the stub assumes a runaway */
+    public $bound = 40;
+
+    public function exists($path)
+    {
+        // delete() calls this first on every pass, so it is the natural place
+        // to notice that we are going around in circles.
+        if (++$this->passes > $this->bound) {
+            throw new \RuntimeException(
+                'runaway: delete() made more than ' . $this->bound . ' passes'
+            );
+        }
+
+        return isset($this->tree[$path]);
+    }
+
+    public function scanFilesystem($remote_file)
+    {
+        if ('dir' !== ($this->tree[$remote_file] ?? '')) {
+            return [];
+        }
+        // Files only, matching the real method -- which is why a tree with
+        // nested directories cannot be emptied by delete() at all.
+        $prefix = rtrim($remote_file, '/') . '/';
+        $found = [];
+        foreach ($this->tree as $path => $type) {
+            if ($path === $remote_file || 'file' !== $type) {
+                continue;
+            }
+            if (0 === strpos($path, $prefix)) {
+                $found[] = $path;
+            }
+        }
+
+        return $found;
+    }
+
+    public function sftp_rmdir($path)
+    {
+        if (in_array($path, $this->refuse, true)
+            || 'dir' !== ($this->tree[$path] ?? '')
+            || count($this->scanFilesystem($path))
+        ) {
+            return false;
+        }
+        unset($this->tree[$path]);
+
+        return true;
+    }
+
+    public function sftp_unlink($path)
+    {
+        if (in_array($path, $this->refuse, true)
+            || 'file' !== ($this->tree[$path] ?? '')
+        ) {
+            return false;
+        }
+        unset($this->tree[$path]);
+
+        return true;
+    }
+}
+
+/**
+ * Runs one case, turning a runaway into a failure rather than a hang.
+ *
+ * @param object $fs   the fake filesystem
+ * @param string $path what to delete
+ *
+ * @return array [bool|null $answer, string $error]
+ */
+function tryDelete($fs, $path)
+{
+    try {
+        return [$fs->delete($path), ''];
+    } catch (\RuntimeException $e) {
+        return [null, $e->getMessage()];
+    }
+}
+
+/*
+ * 1. THE REPORTED CASE. A root-owned directory the SSH user cannot empty:
+ *    neither the directory nor anything in it can be removed.
+ */
+$fs = new FakeSshFs();
+$fs->tree = [
+    '/images/Base-Dev.movetmp' => 'dir',
+    '/images/Base-Dev.movetmp/d1.partitions' => 'file',
+    '/images/Base-Dev.movetmp/d1.original.fstypes' => 'file',
+];
+$fs->refuse = array_keys($fs->tree);
+
+list($answer, $error) = tryDelete($fs, '/images/Base-Dev.movetmp');
+$t->check(
+    'an unremovable directory terminates instead of recursing',
+    '' === $error
+);
+$t->check(
+    'and it answers false rather than claiming success',
+    false === $answer
+);
+
+/*
+ * 2. A single unremovable FILE. This is the tighter version of the same
+ *    runaway: scanFilesystem() returns [] for a file, so the old code had
+ *    nothing at all to make progress with and simply called itself.
+ */
+$fs = new FakeSshFs();
+$fs->tree = ['/images/locked' => 'file'];
+$fs->refuse = ['/images/locked'];
+
+list($answer, $error) = tryDelete($fs, '/images/locked');
+$t->check(
+    'an unremovable file terminates',
+    '' === $error
+);
+$t->check(
+    'an unremovable file answers false',
+    false === $answer
+);
+
+/*
+ * 3. The case that has to keep working: a populated directory the user CAN
+ *    empty. rmdir fails first (not empty), the contents go, and the retry
+ *    succeeds.
+ */
+$fs = new FakeSshFs();
+$fs->tree = [
+    '/images/Base-Dev.movetmp' => 'dir',
+    '/images/Base-Dev.movetmp/d1.partitions' => 'file',
+    '/images/Base-Dev.movetmp/d1.img' => 'file',
+];
+
+list($answer, $error) = tryDelete($fs, '/images/Base-Dev.movetmp');
+$t->check(
+    'a removable directory still terminates',
+    '' === $error
+);
+$t->check(
+    'a removable directory is removed and answers true',
+    true === $answer
+);
+$t->check(
+    'and nothing is left behind',
+    [] === $fs->tree
+);
+
+/*
+ * 4. One unremovable file inside an otherwise removable directory. The
+ *    directory must not be reported as deleted, and the pass count must stay
+ *    bounded even though part of the work succeeded.
+ */
+$fs = new FakeSshFs();
+$fs->tree = [
+    '/images/part' => 'dir',
+    '/images/part/ok.img' => 'file',
+    '/images/part/locked.img' => 'file',
+];
+$fs->refuse = ['/images/part/locked.img'];
+
+list($answer, $error) = tryDelete($fs, '/images/part');
+$t->check(
+    'a partially removable directory terminates',
+    '' === $error
+);
+$t->check(
+    'a partially removable directory answers false',
+    false === $answer
+);
+$t->check(
+    'the file that could be removed still was',
+    !isset($fs->tree['/images/part/ok.img'])
+);
+
+/*
+ * 5. Nothing to do. A path that is not there is not a failure -- the caller
+ *    wanted it gone and it is gone.
+ */
+$fs = new FakeSshFs();
+list($answer, $error) = tryDelete($fs, '/images/never-existed');
+$t->check(
+    'a missing path answers true without touching anything',
+    '' === $error && true === $answer
+);
+
+/*
+ * 6. The return type itself. filedeleter.class.php tests
+ *    `!self::$FOGSSH->delete($deleteFile)` to decide whether to report a failed
+ *    removal; while delete() returned $this that branch could never run, so
+ *    every failure was reported as a success. Pinned here because it is a
+ *    contract between two files.
+ */
+$fs = new FakeSshFs();
+$fs->tree = ['/images/locked' => 'file'];
+$fs->refuse = ['/images/locked'];
+list($answer, $error) = tryDelete($fs, '/images/locked');
+$t->check(
+    'delete() returns a bool, not a fluent $this',
+    '' === $error && is_bool($answer)
+);
+
+$t->finish();


### PR DESCRIPTION
Fixes #1380.

A capture finished, was renamed into place correctly, and then never reached
Complete — FOS printing `Updating Database... Failed` with an **empty**
`Error returned:` every three minutes until it gave up. The server log named the
line:

```
PHP Fatal error: Allowed memory size of 268435456 bytes exhausted
in lib/fog/fogssh.class.php on line 336
```

`FOGSSH::delete()` ended with a bare `$this->delete($path)` after emptying the
directory: an unconditional self-call with identical arguments and no test for
whether anything had changed. For a path that exists but **cannot** be removed,
every pass repeated itself exactly — `sftp_rmdir` failed, `sftp_unlink` failed,
`scanFilesystem()` returned `[]` because it lists files and a plain file is not a
directory — so it recursed until memory ran out. A memory-exhaustion fatal is not
catchable, which is why `checkout()`'s catch never ran and the body was empty.

Reached because `_moveUpload()` renames the previous image aside to
`<image>.movetmp`, and a renamed directory keeps the ownership of whatever it
came from — a root-owned 0755 directory cannot be emptied by the storage node's
SSH user, so both primitives failed on every pass.

The fix is the missing progress condition, not a depth cap: retry the primitives
exactly once after emptying, and return a real bool.

Two consequences, both intended:

- **Cleanup can no longer fail the task.** By that line the capture is already at
  its final path, so the run is marked `PARTIAL` with the leftover named in the
  audit trail, rather than trading a successful capture for a stale directory.
- **filedeleter's failure branch starts working.** It could never run while
  `delete()` returned `$this` (always truthy), so every failed removal was
  reported as a success and the path was dequeued regardless.

Also removes an unrelated landmine in `checkout()`: it threw
`new \Exception('##')` when the host was invalid, and the catch echoes the
message — so FOS read that failure as *success* while the task was never saved.

## Testing

New `tests/fogssh-delete-terminates.test.php`, 12 checks covering the reported
case (a root-owned directory nothing can remove), a single unremovable file, a
directory that still deletes correctly, a partially-removable directory, a
missing path, and the bool return contract.

The stub **counts the passes and throws past a small bound**, so a regression
fails the suite in under a second instead of reproducing the out-of-memory kill
inside CI. Verified against the unfixed method: 9 of 12 checks fail in 0.47s
with `delete()` visibly recursing in the stack trace.

Full suite: 124 gates, same 16 pre-existing environment failures as the base
branch, no new ones.

Independent of #1379 — no overlapping files.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S67FaXehexRLqnbsa5Jwmk
