### PR TITLE
Say which class a foreign-key column points at

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -802,6 +802,7 @@ class OpenAPI extends FOGBase
                 );
             }
             $schema = self::_applyModelConstraint($class, $property, $schema);
+            $schema = self::_applyReference($vars, $property, $schema);
             $properties[$property] = $schema;
         }
         // additionalProperties is stated rather than left to the default.
@@ -897,6 +898,86 @@ class OpenAPI extends FOGBase
         }
         return $out;
     }
+    /**
+     * Marks a column that holds another class's id as pointing at it.
+     *
+     * `Image.osID` is emitted as a plain integer with a column name. Nothing
+     * in the document says it holds an `os` id, so a client generated from
+     * it cannot offer completion for the parameter, cannot validate one, and
+     * cannot follow the relationship. Every consumer that wants any of that
+     * has to hand-maintain a list of which column points where -- which is a
+     * copy of something the server already knows, kept somewhere it will go
+     * stale.
+     *
+     * The model declares it. Each one carries
+     * $databaseFieldClassRelationships, e.g. image.class.php:
+     *
+     *     'OS' => ['id', 'osID', 'os']
+     *              ^^^^  ^^^^^^  ^^^^
+     *              their  my      the joined property the route exposes
+     *              key    column
+     *
+     * so the second element is the column to mark and the key is the class
+     * it points at. Derived, like everything else here.
+     *
+     * Emitted as an object rather than a bare class name because the target
+     * key is part of the fact: it is `id` everywhere today, and the map is
+     * where that is stated, so reading it beats assuming it.
+     *
+     * A relationship whose class is not in this document is SKIPPED. Not
+     * every model relation is an exposed route -- and a reference pointing
+     * at a schema the reader cannot resolve is worse than no reference,
+     * exactly as a dangling $ref is.
+     *
+     * @param array  $vars     The reflected class metadata.
+     * @param string $property The property being described.
+     * @param array  $schema   The schema built so far.
+     *
+     * @return array
+     */
+    private static function _applyReference($vars, $property, array $schema)
+    {
+        if (!isset($vars['databaseFieldClassRelationships'])) {
+            return $schema;
+        }
+        $rels = (array)$vars['databaseFieldClassRelationships'];
+        foreach ($rels as $target => $spec) {
+            $spec = (array)$spec;
+            if (count($spec) < 2) {
+                continue;
+            }
+            $mine = strtolower((string)$spec[1]);
+            if ($mine !== strtolower((string)$property)) {
+                continue;
+            }
+            // The map holds both directions, and only one of them is a
+            // foreign key on THIS row:
+            //
+            //   'OS' => ['id', 'osID', 'os']
+            //       their id  <- my osID          outbound, a real FK
+            //   'MACAddressAssociation' => ['hostID', 'id', 'primac']
+            //       their hostID <- my id         inbound, one-to-many
+            //
+            // Without this the inbound half marks `id` -- the primary key,
+            // readOnly in every schema here -- as referencing whichever
+            // class happens to point back at it, which is both wrong and
+            // useless: nothing completes a primary key from its children.
+            if ('id' === strtolower((string)$property)) {
+                continue;
+            }
+            $targetClass = strtolower((string)$target);
+            if (!in_array($targetClass, self::_documentedClasses(), true)) {
+                continue;
+            }
+            $schema['x-fog-references'] = [
+                'class' => $targetClass,
+                'field' => (string)$spec[0]
+            ];
+            break;
+        }
+        return $schema;
+    }
+
     /**
      * What the generic additionalFields sentence above cannot know.
      *


### PR DESCRIPTION
Follow-on to #1373. That change made the document's *names* readable by a generator; this one makes a relationship readable.

## The gap

`Image.osID` is emitted as a plain integer with a column name:

```json
"osID": { "type": "integer", "x-fog-column": "imageOSID" }
```

Nothing says it holds an `os` id. So a client generated from this document cannot offer completion for the parameter, cannot validate one, and cannot follow the relationship. Every consumer that wants any of that has to hand-maintain a table of which column points where — a copy of something the server already knows, kept somewhere it will go stale.

## The model already declares it

Every model carries `$databaseFieldClassRelationships`. From `image.class.php`:

```php
'OS' => ['id', 'osID', 'os']
//        ^^^^  ^^^^^^  ^^^^
//        their  my      the joined property the route exposes
//        key    column
```

The second element names the column to mark, the key names the class it points at. Read through the same reflection pass this file already uses for `$databaseFields` — nothing new is hand-kept.

```json
"osID": {
    "type": "integer",
    "x-fog-column": "imageOSID",
    "x-fog-references": { "class": "os", "field": "id" }
}
```

An object rather than a bare class name because the target key is part of the fact. It is `id` in all 29 cases today, and the map is where that is stated, so reading it beats assuming it.

## Two things deliberately skipped

**A relationship whose class is not in the document.** Not every model relation is an exposed route, and a reference the reader cannot resolve is worse than no reference — the same failure mode as a dangling `$ref`.

**The inbound half of the map.** It holds both directions and only one is a foreign key on this row:

```php
'OS' => ['id', 'osID', 'os']                    // their id     <- my osID
'MACAddressAssociation' => ['hostID', 'id', …]  // their hostID <- my id
```

Without the guard the second form marks `id` — the primary key, `readOnly` in every schema here — as referencing whichever class points back at it. I caught this by inspecting the output rather than by reasoning: the first run emitted `Host.id -> macaddressassociation.hostID`, which is both wrong and useless, since nothing completes a primary key from its children.

## What it unblocks

Dynamic argument completion written **once** rather than per parameter. A client reads the reference and completes `-osID` from `GET /os`, `-stateID` from `GET /taskstate`, and so on for all 29, without knowing any of them in advance.

Neither AutoRest nor openapi-generator produces server-driven completion from a spec, and FogApi has none today either — so this is what makes it writable generically instead of hand-maintained.

## Verified

On a regenerated document (`spec/tools/dump-openapi.php`, no server needed):

```
29 columns marked
 0 pointing at a class not in the document
 0 on a primary key
 0 whose target field is anything but id
```

```
Host.imageID  -> image.id            Task.stateID   -> taskstate.id
Image.osID    -> os.id               Task.typeID    -> tasktype.id
Image.archID  -> architecture.id     Task.imageID   -> image.id
```

`MulticastSession.image` is in the set and its column is not named `*ID` — which is the argument for deriving this rather than pattern-matching column names.

`php -l` clean; added lines within the file's 80-column style.
