### PR TITLE
Use MAC of first link-up interface instead of forcing net0 for setmacto

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -395,6 +395,16 @@ class BootMenu extends FOGBase
          */
         $webroot = $bootroot;
         $this->_web = sprintf('%s://%s%s', self::$httpproto, $webserver, $curroot);
+        /**
+         * setmacto is the MAC FOS forces onto whichever interface it manages
+         * to reach us on, so it has to be the MAC iPXE actually booted with.
+         * ${net0/mac} was wrong on any machine whose first enumerated NIC has
+         * no link: iPXE gets its lease over the NIC that does, FOS then
+         * rewrites that NIC to the unplugged one's MAC and the re-DHCP fails.
+         * ${netX} is iPXE's alias for the last opened network device, so it
+         * follows the interface that got us here and still resolves to net0
+         * on a single-NIC machine.
+         */
         $Send['booturl'] = array(
             '#!ipxe',
             "set fog-ip $webserver",
@@ -402,7 +412,7 @@ class BootMenu extends FOGBase
             'set boot-url '
             . self::$httpproto
             . '://${fog-ip}/${fog-webroot}',
-            'set setmacto ${${ifname}/mac}',
+            'set setmacto ${netX/mac}',
         );
         if (self::$Host->isValid()) {
             $sysuuid = filter_input(INPUT_POST, 'sysuuid')

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -402,7 +402,7 @@ class BootMenu extends FOGBase
             'set boot-url '
             . self::$httpproto
             . '://${fog-ip}/${fog-webroot}',
-            'set setmacto ${net0/mac}',
+            'set setmacto ${${ifname}/mac}',
         );
         if (self::$Host->isValid()) {
             $sysuuid = filter_input(INPUT_POST, 'sysuuid')

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -3,7 +3,7 @@
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -76,7 +76,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -156,7 +156,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -242,7 +242,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -322,7 +322,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -400,7 +400,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -479,7 +479,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -581,7 +581,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -696,7 +696,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -772,7 +772,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -874,7 +874,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 echo Ignoring host kernel custom-bzImage -- this machine is 64-bit ARM. Using arm_Image.
@@ -982,7 +982,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1089,7 +1089,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 echo Ignoring host init arm_init.cpio.gz -- this machine is x86. Using init.xz.
@@ -1199,7 +1199,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 echo Ignoring host kernel evilechopwnedchainhttpxid -- this machine is 64-bit ARM. Using arm_Image.
@@ -1307,7 +1307,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1414,7 +1414,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1477,7 +1477,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1553,7 +1553,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1639,7 +1639,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1668,7 +1668,7 @@ chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1697,7 +1697,7 @@ chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1770,7 +1770,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1843,7 +1843,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1916,7 +1916,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -1989,7 +1989,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2062,7 +2062,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2135,7 +2135,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2208,7 +2208,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2281,7 +2281,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2361,7 +2361,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2441,7 +2441,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2519,7 +2519,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2592,7 +2592,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2694,7 +2694,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
@@ -2704,7 +2704,7 @@ console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap uk
 set arch ${buildarch}
@@ -2777,7 +2777,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap no-latin1
 set arch ${buildarch}
@@ -2850,7 +2850,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap sr-latin
 set arch ${buildarch}
@@ -2923,7 +2923,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -2996,7 +2996,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot apps/fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}
@@ -3069,7 +3069,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set keymap us
 set arch ${buildarch}


### PR DESCRIPTION
## What
The iPXE scripts always set the `setmacto` kernel parameter to the MAC
address of `net0`, regardless of which interface actually has a link.
This patch changes that so `setmacto` uses the MAC address of the first
NIC that has an active link during iPXE's network autoconfiguration,
falling back to the same behavior as before (`net0`) when only one NIC
is present or when `net0` itself is the one with a valid link.

## Why
On multi-NIC machines where the interface labeled `net0` by iPXE has no
link (unplugged) and a different interface (e.g. `net1`) does, iPXE still
autoconfigures and gets a DHCP lease over the interface that has a link.
However, the kernel is told via `setmacto` to apply `net0`'s MAC address
to all interfaces. If only the actually-connected NIC's MAC is
provisioned for DHCP on the network, FOS then fails to get an IP,
because every interface presents the MAC of the unplugged one.

## Reproduction steps
1. Take a machine with 2+ NICs.
2. Leave the interface iPXE enumerates as `net0` unplugged, and plug in
   another (e.g. `net1`).
3. Configure DHCP/network access to only recognize the MAC of the
   plugged-in interface.
4. PXE boot into FOS.
5. Expected: FOS gets an IP over the interface with link.
   Actual: FOS fails to obtain an IP, because `setmacto` forces every
   interface (including the one with link) to use `net0`'s MAC.

## Testing
Tested on 60+ physical machines:
- Multi-NIC machines with `net0` unplugged: FOS now gets an IP over the
  linked interface.
- Single-NIC machines: behavior unchanged.

## Environment
- FOG version: 1.5.10.2254