### PR TITLE
Point setmacto at the NIC iPXE booted from, not net0

### DIFF
--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -569,6 +569,16 @@ class BootMenu extends FOGBase
          */
         $webroot = $bootroot;
         $this->_web = sprintf('%s://%s%s', self::$httpproto, $webserver, $curroot);
+        /**
+         * setmacto is the MAC FOS forces onto whichever interface it manages
+         * to reach us on, so it has to be the MAC iPXE actually booted with.
+         * ${net0/mac} was wrong on any machine whose first enumerated NIC has
+         * no link: iPXE gets its lease over the NIC that does, FOS then
+         * rewrites that NIC to the unplugged one's MAC and the re-DHCP fails.
+         * ${netX} is iPXE's alias for the last opened network device, so it
+         * follows the interface that got us here and still resolves to net0
+         * on a single-NIC machine.
+         */
         $Send['booturl'] = [
             '#!ipxe',
             "set fog-ip $webserver",
@@ -576,7 +586,7 @@ class BootMenu extends FOGBase
             'set boot-url '
             . self::$httpproto
             . '://${fog-ip}/${fog-webroot}',
-            'set setmacto ${net0/mac}',
+            'set setmacto ${netX/mac}',
         ];
         $sysuuid = filter_input(INPUT_POST, 'sysuuid') ?: filter_input(INPUT_GET, 'sysuuid') ?: '';
         if (self::$Host->isValid()) {

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -3,7 +3,7 @@
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -62,7 +62,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -128,7 +128,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -200,7 +200,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -277,7 +277,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -348,7 +348,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -414,7 +414,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -474,7 +474,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -539,7 +539,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -637,7 +637,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -753,7 +753,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -815,7 +815,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -913,7 +913,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 echo Ignoring host kernel custom-bzImage -- this machine is 64-bit ARM. Using arm_Image.
@@ -1013,7 +1013,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -1112,7 +1112,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 echo Ignoring host init arm_init.cpio.gz -- this machine is 64-bit x86. Using init.xz.
@@ -1218,7 +1218,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 echo Ignoring host kernel evilechopwnedchainhttpxid -- this machine is 64-bit ARM. Using arm_Image.
@@ -1318,7 +1318,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -1421,7 +1421,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1470,7 +1470,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1532,7 +1532,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1603,7 +1603,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1632,7 +1632,7 @@ chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1661,7 +1661,7 @@ chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1720,7 +1720,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1779,7 +1779,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1838,7 +1838,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1897,7 +1897,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -1956,7 +1956,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2015,7 +2015,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2074,7 +2074,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2140,7 +2140,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2206,7 +2206,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2266,7 +2266,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2325,7 +2325,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 set arch ${buildarch}
@@ -2423,7 +2423,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set hostname testhost
 set storage-ip 10.0.0.1
 console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80 || sanboot --no-describe --drive 0x81 || sanboot --no-describe --drive 0x82
@@ -2433,7 +2433,7 @@ console && sanboot --drive 0 --no-describe || sanboot --no-describe --drive 0x80
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2492,7 +2492,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2551,7 +2551,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot apps/fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||
@@ -2610,7 +2610,7 @@ autoboot
 set fog-ip 10.0.0.1
 set fog-webroot fog
 set boot-url http://${fog-ip}/${fog-webroot}
-set setmacto ${net0/mac}
+set setmacto ${netX/mac}
 set storage-ip 10.0.0.1
 set arch ${buildarch}
 iseq ${arch} i386 && cpuid --ext 29 && set arch x86_64 ||


### PR DESCRIPTION
Port of #1383 (dev-branch) to working-1.6, with the same one-line effect written as `${netX/mac}`.

## The bug

`setmacto` does not do what its name suggests. FOS's `S40network` walks the interfaces, and on the first one that both gets a DHCP lease **and** can reach the web root, it compares that NIC's MAC to `$setmacto`; if they differ it takes the NIC down, rewrites its MAC, brings it up and re-DHCPs. There is no restore path.

So on a machine whose first enumerated NIC has no link:

1. iPXE gets its lease over the NIC that does have link (say net1).
2. FOS reaches us over net1.
3. FOS rewrites net1's MAC to net0's, because `set setmacto ${net0/mac}`.
4. The re-DHCP fails, because the server has never seen that address on that port.
5. Both `exit 0` guards miss and the retry loop spins on a NIC it just broke.

Reported by @MrLego8-9 in #1383 and reproduced there on 60+ physical machines.

## The fix

`${netX}` is iPXE's alias for the last opened network device, so `setmacto` now follows the interface that actually got us here. Single-NIC machines are unaffected: `netX` is `net0`, the MACs match, and FOS skips the rewrite entirely.

#1383 used `${${ifname}/mac}`, which produces the same value. It works because an unscoped iPXE setting lookup resolves through the `netX` redirect block, which is registered before any network device and points at the last opened one, so the nesting is a long way round to say `netX`. `${netX/mac}` is one expansion and is the documented spelling.

## Verification

Built iPXE 2.0.0 (the version `FOG_IPXE_VERSION` pins) with an embedded probe script and ran it under qemu with net0 on a dead socket netdev and net1 on a working one:

```
=== before dhcp ===   ifname=[net0]  netXmac=[]        nested=[52:54:00:00:00:10]
Configuring (net0 52:54:00:00:00:10)... No configuration methods succeeded
Configuring (net1 52:54:00:00:00:11)... ok
=== after dhcp ===    ifname=[net1]  netXmac=[...:11]  nested=[52:54:00:00:00:11]
```

With both NICs live, iPXE stops at the first success and `netX` is `net0`, so nothing changes for the ordinary case. The `setmacto` line is only ever emitted inside a boot.php response, which by definition is fetched after a lease exists.

## Tests

`tests/bootmenu-ipxe-output.golden` regenerated. The only bytes that move are the 39 `setmacto` lines:

```
$ php tests/bootmenu-ipxe-output.test.php
bootmenu-ipxe-output: 39 scenarios, 99683 bytes rendered
bootmenu-ipxe-output: 6 behaviour checks passed
PASS
```

## Not addressed here

FOS never restores the original MAC when the forced re-DHCP fails, which is what turns this into a hard failure rather than a degraded boot. That is a FOS change, not a fogproject one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)