### PR TITLE
Record the real manufacturer, stop blanking the boot log, and look past three NICs

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2246,7 +2246,23 @@ configureDefaultiPXEfile() {
         _resolveNetbootHost || return 1
         nbhost="$netboothost"
     fi
-    echo -e "#!ipxe\nset arch \${buildarch}\niseq \${arch} i386 && cpuid --ext 29 && set arch x86_64 ||\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${product}\nparam ipxever \${version}\nparam filename \${filename}\nparam sysuuid \${uuid}\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\n:bootme\nchain ${BOOT_url_proto}://${nbhost}${WEB_root}service/ipxe/boot.php##params" > "$tftpdirdst/default.ipxe"
+    # param manufacturer took ${product} for years, so every ipxeTable row
+    # recorded the model twice and the vendor never once. iPXE exposes the two
+    # as separate SMBIOS settings.
+    #
+    # macboot is ${netX/mac}, iPXE's alias for the device it booted from. It is
+    # NOT a replacement for mac0: netX is a pointer at one of net0..netN, so
+    # swapping it in would drop net0 from the set on a machine that booted off
+    # net1. boot.php unions every mac* field and array_unique()s the result, so
+    # sending both costs nothing when they are the same NIC and guarantees the
+    # booting NIC is present however many NICs the box has. It sits above the
+    # net1..net7 chain because that chain short-circuits to :bootme on the first
+    # absent interface, which on a single-NIC machine is net1.
+    #
+    # The enumeration used to stop at net2. Anything past three NICs was
+    # invisible to the host lookup, so a machine registered under only its
+    # fourth NIC could not be found at all.
+    echo -e "#!ipxe\nset arch \${buildarch}\niseq \${arch} i386 && cpuid --ext 29 && set arch x86_64 ||\nparams\nparam mac0 \${net0/mac}\nparam arch \${arch}\nparam platform \${platform}\nparam product \${product}\nparam manufacturer \${manufacturer}\nparam ipxever \${version}\nparam filename \${filename}\nparam sysuuid \${uuid}\nisset \${netX/mac} && param macboot \${netX/mac} ||\nisset \${net1/mac} && param mac1 \${net1/mac} || goto bootme\nisset \${net2/mac} && param mac2 \${net2/mac} || goto bootme\nisset \${net3/mac} && param mac3 \${net3/mac} || goto bootme\nisset \${net4/mac} && param mac4 \${net4/mac} || goto bootme\nisset \${net5/mac} && param mac5 \${net5/mac} || goto bootme\nisset \${net6/mac} && param mac6 \${net6/mac} || goto bootme\nisset \${net7/mac} && param mac7 \${net7/mac} || goto bootme\n:bootme\nchain ${BOOT_url_proto}://${nbhost}${WEB_root}service/ipxe/boot.php##params" > "$tftpdirdst/default.ipxe"
     errorStat $?
 }
 prepareiPXEsource() {

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -8062,3 +8062,80 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 374
+$this->schema[] = [
+    // Widen the stored pxeMenu param blocks past three NICs.
+    //
+    // The mac0/mac1/mac2 enumeration is not only in code -- six of these
+    // blocks ship as `pxeMenu`.`pxeParams` DATA (step 182, and 129 before it),
+    // and _menuOpt() emits whatever the row says verbatim. So fixing
+    // _chainParams() and the installer's default.ipxe leaves every existing
+    // site's menu items still posting at most three MACs, which is what made
+    // a host registered under only its fourth NIC unfindable.
+    //
+    // Two additions per row, matching _chainParams():
+    //   - macboot, ${netX/mac}, the NIC iPXE actually booted from. An
+    //     ADDITION to mac0, not a replacement: netX is a pointer at one of
+    //     net0..netN, so substituting it would drop net0 on a machine that
+    //     booted off net1. boot.php unions every mac* field and array_unique()s
+    //     the result, so the overlap costs nothing. It goes ABOVE the chain
+    //     because the chain short-circuits to :bootme on the first absent
+    //     interface, which on a single-NIC machine is net1.
+    //   - net3..net7, so the enumeration reaches eight interfaces.
+    //
+    // Guarded on the row still matching what we shipped, byte for byte. These
+    // rows are user-writable from iPXE Menu Customization, and a site that has
+    // edited one has made a deliberate choice; an untouched row provably has
+    // not. A customized row keeps its three NICs rather than losing the edit,
+    // and re-running is a no-op because the old value no longer matches.
+    //
+    // A closure rather than seven literal statements: the old and the new
+    // value differ by one line in the middle of a nine-line blob, and writing
+    // both out per menu entry is fourteen near-identical paragraphs in which a
+    // single wrong character silently means "match nothing, change nothing".
+    function () {
+        // pxeName => the boolean flag that row's params block carries.
+        $menus = [
+            'fog.deployimage' => 'qihost',
+            'fog.quickdel' => 'delhost',
+            'fog.keyreg' => 'keyreg',
+            'fog.debug' => 'debugAccess',
+            'fog.multijoin' => 'sessionJoin',
+            'fog.advancedlogin' => 'advLog',
+            'fog.approvehost' => 'approveHost',
+        ];
+        $head = "login\n"
+            . "params\n"
+            . 'param mac0 ${net0/mac}' . "\n"
+            . 'param arch ${arch}' . "\n"
+            . 'param username ${username}' . "\n"
+            . 'param password ${password}' . "\n";
+        $oldTail = 'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme'
+            . "\n"
+            . 'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme';
+        $newTail = 'isset ${netX/mac} && param macboot ${netX/mac} ||';
+        for ($nic = 1; $nic <= 7; $nic++) {
+            $newTail .= "\n" . sprintf(
+                'isset ${net%1$d/mac} && param mac%1$d ${net%1$d/mac}'
+                . ' || goto bootme',
+                $nic
+            );
+        }
+        foreach ($menus as $pxeName => $flag) {
+            $body = $head . sprintf('param %s 1', $flag) . "\n";
+            self::$DB->query(
+                'UPDATE `pxeMenu` SET `pxeParams` = :new '
+                . 'WHERE `pxeName` = :name AND `pxeParams` = :old',
+                [],
+                [
+                    ':new' => $body . $newTail,
+                    ':name' => $pxeName,
+                    ':old' => $body . $oldTail,
+                ]
+            );
+        }
+
+        return true;
+    },
+];

--- a/packages/web/lib/fog/bootmenu.class.php
+++ b/packages/web/lib/fog/bootmenu.class.php
@@ -985,9 +985,25 @@ class BootMenu extends FOGBase
      * not tell UEFI from BIOS. Order is not significant to iPXE (these all
      * become POST fields), so one canonical order serves every caller.
      *
-     * The mac1/mac2 lines are conditional because iPXE errors on an unset
+     * The mac1..mac7 lines are conditional because iPXE errors on an unset
      * variable; jumping to :bootme on the first absent NIC is how the
-     * original avoided that, and it is preserved exactly.
+     * original avoided that, and it is preserved exactly. The enumeration
+     * used to stop at net2, which made a host registered under only its
+     * fourth NIC invisible to the lookup in boot.php.
+     *
+     * macboot is ${netX/mac}, iPXE's alias for the device it booted from,
+     * and is an ADDITION to mac0 rather than a replacement -- netX is a
+     * pointer at one of net0..netN, so substituting it would drop net0 from
+     * the set on a machine that booted off net1. boot.php unions every mac*
+     * field and array_unique()s the result, so the overlap is free. It is
+     * emitted above the net1..net7 chain because that chain short-circuits
+     * to :bootme on the first absent interface, which on a single-NIC
+     * machine is net1.
+     *
+     * product/manufacturer/ipxever/filename ride along because _ipxeLog()
+     * keys its lookup on file+product+manufacturer+mac. default.ipxe posts
+     * them; this block did not, so every re-chain failed to match the row
+     * the first request had written and inserted a fresh blank one instead.
      *
      * @param array $params call-specific 'param ...' lines
      * @param bool  $tail   emit the :bootme label and the chain itself.
@@ -1004,12 +1020,22 @@ class BootMenu extends FOGBase
                 'param mac0 ${net0/mac}',
                 'param arch ${arch}',
                 'param platform ${platform}',
+                'param product ${product}',
+                'param manufacturer ${manufacturer}',
+                'param ipxever ${version}',
+                'param filename ${filename}',
             ],
             $params,
             [
                 'param sysuuid ${uuid}',
+                'isset ${netX/mac} && param macboot ${netX/mac} ||',
                 'isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme',
                 'isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme',
+                'isset ${net3/mac} && param mac3 ${net3/mac} || goto bootme',
+                'isset ${net4/mac} && param mac4 ${net4/mac} || goto bootme',
+                'isset ${net5/mac} && param mac5 ${net5/mac} || goto bootme',
+                'isset ${net6/mac} && param mac6 ${net6/mac} || goto bootme',
+                'isset ${net7/mac} && param mac7 ${net7/mac} || goto bootme',
             ]
         );
         if (!$tail) {

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 373);
+        define('FOG_SCHEMA', 374);
         define('FOG_BCACHE_VER', 316);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/service/ipxe/boot.php
+++ b/packages/web/service/ipxe/boot.php
@@ -30,18 +30,39 @@ define('FOG_MACHINE_REQUEST', true);
 
 require '../../commons/base.inc.php';
 header("Content-type: text/plain");
-$items = [
-    'mac' => filter_input(INPUT_POST, 'mac'),
-    'mac0' => filter_input(INPUT_POST, 'mac0'),
-    'mac1' => filter_input(INPUT_POST, 'mac1'),
-    'mac2' => filter_input(INPUT_POST, 'mac2')
+/*
+ * Every mac* field the iPXE scripts can post, unioned into one candidate list
+ * for the host lookup. The field NAMES carry no meaning -- getHostItem()
+ * matches a host on any MAC associated with it -- so this is purely "collect
+ * every address this machine can be identified by".
+ *
+ * 'macboot' is ${netX/mac}, the NIC iPXE actually booted from. It is an
+ * ADDITION to mac0 rather than a replacement: netX is a pointer at one of
+ * net0..netN, so a machine booting off net1 would post net1's MAC twice and
+ * net0's not at all. array_unique() below makes the overlap free.
+ *
+ * mac3..mac7 widen an enumeration that stopped at net2, which made a host
+ * registered under only its fourth NIC unfindable. Absent fields come back
+ * null from filter_input() and array_filter() drops them, so a one-NIC
+ * machine posting only mac0 behaves exactly as before.
+ */
+$macFields = [
+    'mac',
+    'mac0',
+    'macboot',
+    'mac1',
+    'mac2',
+    'mac3',
+    'mac4',
+    'mac5',
+    'mac6',
+    'mac7',
 ];
-$mac = FOGCore::fastmerge(
-    explode('|', $items['mac']),
-    explode('|', $items['mac0']),
-    explode('|', $items['mac1']),
-    explode('|', $items['mac2'])
-);
+$macLists = [];
+foreach ($macFields as $macField) {
+    $macLists[] = explode('|', (string)filter_input(INPUT_POST, $macField));
+}
+$mac = FOGCore::fastmerge(...$macLists);
 $mac = implode(
     '|',
     array_values(

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -1616,13 +1616,23 @@ params
 param mac0 ${net0/mac}
 param arch ${arch}
 param platform ${platform}
+param product ${product}
+param manufacturer ${manufacturer}
+param ipxever ${version}
+param filename ${filename}
 param username ${username}
 param password ${password}
 param menuaccess 1
 param debug 1
 param sysuuid ${uuid}
+isset ${netX/mac} && param macboot ${netX/mac} ||
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+isset ${net3/mac} && param mac3 ${net3/mac} || goto bootme
+isset ${net4/mac} && param mac4 ${net4/mac} || goto bootme
+isset ${net5/mac} && param mac5 ${net5/mac} || goto bootme
+isset ${net6/mac} && param mac6 ${net6/mac} || goto bootme
+isset ${net7/mac} && param mac7 ${net7/mac} || goto bootme
 goto bootme
 :bootme
 chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params
@@ -1645,13 +1655,23 @@ params
 param mac0 ${net0/mac}
 param arch ${arch}
 param platform ${platform}
+param product ${product}
+param manufacturer ${manufacturer}
+param ipxever ${version}
+param filename ${filename}
 param username ${username}
 param password ${password}
 param menuaccess 1
 param debug 1
 param sysuuid ${uuid}
+isset ${netX/mac} && param macboot ${netX/mac} ||
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
+isset ${net3/mac} && param mac3 ${net3/mac} || goto bootme
+isset ${net4/mac} && param mac4 ${net4/mac} || goto bootme
+isset ${net5/mac} && param mac5 ${net5/mac} || goto bootme
+isset ${net6/mac} && param mac6 ${net6/mac} || goto bootme
+isset ${net7/mac} && param mac7 ${net7/mac} || goto bootme
 goto bootme
 :bootme
 chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params


### PR DESCRIPTION
Follow-on from #1384. Same audit, three more places where an iPXE value was pinned narrower than the thing it stands for.

## 1. `param manufacturer ${product}`

`lib/common/functions.sh`, the generated `default.ipxe`. iPXE exposes `manufacturer` and `product` as separate SMBIOS settings (`smbios_settings.c:221` and `:232`); FOG asked for the model twice.

On the reference 1.6 install, **23 of 23 `ipxeTable` rows have `ipxeManufacturer` identical to `ipxeProduct`**. The vendor has never been recorded, and the PXE Boot Log has been showing a duplicated column since it was written.

## 2. Re-chains inserted a blank boot-log row

`default.ipxe` posts `product`, `manufacturer`, `ipxever`, `filename`. `_chainParams()` posted none of them. `_ipxeLog()` runs on every `boot.php` request and keys its lookup on file+product+manufacturer+mac, so a re-chain matched nothing and inserted a fresh row with everything blank but the MAC.

Same install: **14 of 23 rows are that empty shape**, with one host appearing twice — once populated from `default.ipxe`, once blank from the re-chain.

## 3. The MAC enumeration stopped at net2

Four places, and the last is the awkward one:

| Where | |
|---|---|
| `functions.sh` (`default.ipxe`) | code |
| `bootmenu.class.php::_chainParams()` | code |
| `commons/schema.php` | **six `pxeMenu.pxeParams` rows shipped as DATA**, emitted verbatim by `_menuOpt()` |

A machine with four or more NICs never sent its fourth address, so a host registered under only that NIC could not be found at all. Now `net0..net7`.

## `macboot` is an addition, not a swap

The obvious-looking fix is `param mac0 ${netX/mac}`, and it is wrong. `netX` is iPXE's pointer at *one of* `net0..netN` — on a box booting off net1 it **is** `${net1/mac}`. Substituting it would send net1's MAC twice and drop net0 entirely, trading one blind spot for another.

`boot.php` unions every `mac*` field and `array_unique()`s the result, so sending both costs nothing when they are the same NIC. What it buys is the guarantee that the booting NIC's MAC is always in the candidate set, however many interfaces the machine has. It is emitted **above** the `net1..net7` chain, because that chain short-circuits to `:bootme` on the first absent interface — which on a single-NIC machine is net1.

## Schema step 374

Widens the stored `pxeMenu` rows, guarded on the row still matching what we shipped byte for byte. Those rows are user-writable from iPXE Menu Customization: a site that has edited one has made a deliberate choice and keeps it; an untouched row provably has not.

Verified against the reference install by loading the real closure through the replay collector — not a retyped copy — and running it inside a transaction:

```
rows in pxeMenu: 13
rows changed by step 374: 5
re-run changed anything further: no (idempotent)
rollback restored the live table: yes
```

## Tests

```
161 passed, 0 failed
```

Golden fixture regenerated; every moved byte is an addition, nothing removed:

```
+isset ${netX/mac} && param macboot ${netX/mac} ||
+isset ${net3/mac} && param mac3 ${net3/mac} || goto bootme
 ... net4..net7
+param product ${product}
+param manufacturer ${manufacturer}
+param ipxever ${version}
+param filename ${filename}
```

## Not changed

`fog-ipxe`'s `autoexec.ipxe` and `src/ipxe/src/ipxescript` also enumerate `net0..net2`, but they fall through to a bare `dhcp` that tries every interface, so a 4+ NIC machine already boots. Widening them buys three fewer failed attempts on a box with unplugged low-numbered NICs, at the cost of a binary rebuild and release. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)