### PR TITLE
Stop a task ever pointing at nothing, and free the ones that do

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -77,6 +77,17 @@ abstract class FOGManagerController extends FOGBase
      */
     protected $databaseFieldsRequired = [];
     /**
+     * Required keys whose name ends in ID but which are NOT foreign keys.
+     *
+     * Mirrored from the model for the same reason isValid() carries its own
+     * copy of the rule save() uses: both write paths infer "ends in id, so it
+     * is a foreign key", so both need the model's opt-out or one of them
+     * refuses a string identifier the other accepts.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = [];
+    /**
      * The Class relationships.
      *
      * @var array
@@ -179,6 +190,7 @@ abstract class FOGManagerController extends FOGBase
             'sqlQueryStr',
             'sqlFilterStr',
             'sqlTotalStr',
+            'databaseFieldsNotInt',
         ];
         $this->databaseTable = &$classVars[$classGet[0]];
         $this->databaseFields = &$classVars[$classGet[1]];
@@ -189,6 +201,7 @@ abstract class FOGManagerController extends FOGBase
         $this->sqlQueryStr = &$classVars[$classGet[5]];
         $this->sqlFilterStr = &$classVars[$classGet[6]];
         $this->sqlTotalStr = &$classVars[$classGet[7]];
+        $this->databaseFieldsNotInt = &$classVars[$classGet[8]];
         unset($classGet);
     }
     /**
@@ -924,6 +937,102 @@ abstract class FOGManagerController extends FOGBase
         return is_string($value) ? trim($value) : $value;
     }
     /**
+     * Refuses a batch row whose required foreign key points at nothing.
+     *
+     * FOGController::save() will not write a row whose required *ID field is
+     * not an integer >= 1 -- see its "Required *id must be integer >= 1"
+     * branch. insertBatch() enforced nothing, so the same model validated
+     * itself when written one row at a time and did not when written a
+     * hundred at a time.
+     *
+     * What gets through is a 0. Since GH-1245 the server's own sql_mode
+     * rejects a null or an '' bound into a NOT NULL int, but 0 is a perfectly
+     * legal integer and no layer has an opinion about it -- and a caller
+     * indexing a positional list past its end, or reading an id off an object
+     * that did not load, produces exactly that.
+     *
+     * In `tasks` such a row is permanent and invisible at the same time.
+     * taskStateID still resolves, so the task counts as active for every
+     * "is this live" test in the tree; taskHostID/taskImageID/taskTypeID
+     * match nothing, and because the Active Tasks list renders from
+     * buildQuery()'s LEFT OUTER JOINs those columns come back NULL. The row
+     * shows as "() -" for host and image with no type icon, cannot be
+     * completed by any host, and nothing ever reaps it. Reported as "null
+     * tasks" in forum topics 18228 and 18230.
+     *
+     * Deliberately narrow, because this is a write path with 26 call sites:
+     *
+     *  - Only columns the caller NAMED. A required column the batch is silent
+     *    about is left to columnsRequiringValue() below, which is the
+     *    behaviour every one of those call sites already relies on; turning
+     *    silence into an error is a different change with a different blast
+     *    radius.
+     *  - Only *ID columns. They are the ones whose zero is indistinguishable
+     *    from a value; a required string is caught by the server or by the
+     *    reader either way.
+     *  - Never the model's own primary key. No batch caller supplies it, and
+     *    save() skips it for the same reason.
+     *  - Never a key the model has declared is a string via
+     *    $databaseFieldsNotInt.
+     *
+     * @param array $fields the friendly field names the caller named
+     * @param array $values the rows, positional against $fields
+     *
+     * @throws \Exception
+     *
+     * @return void
+     */
+    private function _assertBatchForeignKeys($fields, $values)
+    {
+        $notInt = array_map(
+            'strtolower',
+            (array)$this->databaseFieldsNotInt
+        );
+        $positions = [];
+        foreach ((array)$this->databaseFieldsRequired as $friendly) {
+            $lower = strtolower($friendly);
+            if ('id' === $lower
+                || 'id' !== substr($lower, -2)
+                || in_array($lower, $notInt, true)
+            ) {
+                continue;
+            }
+            foreach ((array)$fields as $i => $named) {
+                if (strtolower($named) === $lower) {
+                    $positions[$i] = $friendly;
+                }
+            }
+        }
+        if (count($positions ?: []) < 1) {
+            return;
+        }
+        foreach ((array)$values as $rowIndex => $row) {
+            foreach ($positions as $i => $friendly) {
+                $val = isset($row[$i]) ? $row[$i] : null;
+                $valid = filter_var(
+                    $val,
+                    FILTER_VALIDATE_INT,
+                    ['options' => ['min_range' => 1]]
+                );
+                if (false !== $valid) {
+                    continue;
+                }
+                throw new \Exception(
+                    sprintf(
+                        '%s: `%s`.%s %s %d, %s: %s',
+                        self::$foglang['RequiredDB'],
+                        $this->databaseTable,
+                        $friendly,
+                        _('in batch row'),
+                        $rowIndex,
+                        _('got'),
+                        var_export($val, true)
+                    )
+                );
+            }
+        }
+    }
+    /**
      * Inserts data in mass to the database.
      *
      * @param array  $fields the fields to insert into
@@ -944,6 +1053,9 @@ abstract class FOGManagerController extends FOGBase
         if ($valuelength < 1) {
             throw new \Exception(_('No values passed'));
         }
+        // Before the loop below, which rewrites $fields from friendly names
+        // to column names in place.
+        $this->_assertBatchForeignKeys($fields, $values);
         $keys = [];
         foreach ((array) $fields as &$key) {
             $key = $this->databaseFields[$key];
@@ -977,29 +1089,39 @@ abstract class FOGManagerController extends FOGBase
          * on a row that already exists the stored value must stand. Filling
          * settingDesc into the update list would blank the description of
          * every setting on the page the moment anyone pressed save.
+         *
+         * The filled columns and their values are worked out ONCE here; the
+         * placeholders that carry them are named PER ROW, down in the loop.
+         * They were named once too, and the single `:_fill_0` was then
+         * repeated in every VALUES tuple -- which one row survives and two do
+         * not: PDODB sets PDO::ATTR_EMULATE_PREPARES => false, and a real
+         * server-side prepare answers SQLSTATE[HY093] "Invalid parameter
+         * number" to a named parameter used twice. So every batch of two or
+         * more rows into a table with an unnamed NOT NULL column failed
+         * outright, silently to the user: tasking a GROUP of two hosts with
+         * anything that is not a deploy or a multicast (wipe, virus scan,
+         * hardware inventory, password reset, snapins) names none of
+         * `tasks`' four NFS/image columns and so hit this every time.
+         * See background_scripts/prove_batch_fill_duplicate_bind.php.
          */
-        $fillKeys = [];
-        $fillVals = [];
+        $fillCols = [];
         foreach ((array) self::columnsRequiringValue(
             $table ?: $this->databaseTable
         ) as $column => $type) {
             if (in_array(strtolower($column), array_map('strtolower', $keys), true)) {
                 continue;
             }
-            $bind = sprintf('_fill_%d', count($fillKeys));
             $keys[] = $column;
-            $fillKeys[] = sprintf(':%s', $bind);
-            $fillVals[$bind] = self::emptyValueFor(
+            $fillCols[] = self::emptyValueFor(
                 $table ?: $this->databaseTable,
                 $column
             );
         }
         $affectedRows = 0;
         $vals = [];
-        $insertVals = $fillVals;
         $values = array_chunk($values, 500);
         foreach ((array) $values as $ind => &$v) {
-            $insertVals = $fillVals;
+            $insertVals = [];
             foreach ((array) $v as $index => &$value) {
                 $insertKeys = [];
                 foreach ((array) $value as $i => &$val) {
@@ -1016,9 +1138,21 @@ abstract class FOGManagerController extends FOGBase
                     $insertVals[$key] = $val;
                     unset($val);
                 }
+                foreach ($fillCols as $fillIndex => $fillVal) {
+                    $key = sprintf(
+                        '_fill_%d_%d',
+                        $fillIndex,
+                        $index
+                    );
+                    $insertKeys[] = sprintf(
+                        ':%s',
+                        $key
+                    );
+                    $insertVals[$key] = $fillVal;
+                }
                 $vals[] = sprintf(
                     '(%s)',
-                    implode(',', array_merge((array) $insertKeys, $fillKeys))
+                    implode(',', (array) $insertKeys)
                 );
                 unset($value);
             }

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -7103,6 +7103,43 @@ class Route extends FOGBase
                         '',
                         ['imageID' => 0]
                     );
+                    // Cancel the tasks that were still going to use it.
+                    //
+                    // A queued or in-progress task pointing at an image that
+                    // no longer exists can never finish: TaskingElement
+                    // cannot build the Image, so the host is turned away at
+                    // check-in and the task sits in Active Tasks forever.
+                    // Worse, it is unreadable while it sits there -- the
+                    // list renders from buildQuery()'s LEFT OUTER JOINs, so
+                    // the dead imageID yields NULL for every image column
+                    // and the row shows "() -" with no name to act on.
+                    // Reported as "null tasks" in forum topics 18228/18230.
+                    //
+                    // Cancelled rather than added to $removeItems, which is
+                    // where the host case puts its tasks. Deleting a host
+                    // takes its history with it because the subject of that
+                    // history is gone; deleting an image does not -- the
+                    // HOSTS survive, and their finished tasks are still
+                    // their imaging record. Only the live ones are stuck.
+                    //
+                    // TaskManager::cancel() rather than a state update: it
+                    // is what already reissues the host token, unwinds any
+                    // multicast session behind the task and records the
+                    // state change in the task log.
+                    $activeImageTaskIDs = self::getIds(
+                        'task',
+                        [
+                            'imageID' => $itemIDs,
+                            'stateID' => self::fastmerge(
+                                (array)self::getQueuedStates(),
+                                (array)self::getProgressState()
+                            )
+                        ]
+                    );
+                    if (count($activeImageTaskIDs ?: [])) {
+                        self::getClass('TaskManager')
+                            ->cancel($activeImageTaskIDs);
+                    }
                     $removeItems = [
                         'imageassociation' => $findWhere
                     ];

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9928,6 +9928,10 @@ msgstr "wie Dienste auf Clientcomputer funktionieren."
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr "vor"
+
 msgid "group"
 msgstr "Gruppe"
 
@@ -10067,6 +10071,9 @@ msgid "in"
 msgstr "Minuten"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -9921,6 +9921,10 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr " ago"
+
 msgid "group"
 msgstr "group"
 
@@ -10060,6 +10064,9 @@ msgid "in"
 msgstr "minutes"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10107,6 +10107,10 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr " hace"
+
 msgid "group"
 msgstr "grupo"
 
@@ -10248,6 +10252,9 @@ msgid "in"
 msgstr "minutos"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9929,6 +9929,10 @@ msgstr "wie Dienste auf Clientcomputer funktionieren."
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr "vor"
+
 msgid "group"
 msgstr "Gruppe"
 
@@ -10068,6 +10072,9 @@ msgid "in"
 msgstr "Minuten"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9923,6 +9923,10 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr " depuis"
+
 msgid "group"
 msgstr "groupe"
 
@@ -10062,6 +10066,9 @@ msgid "in"
 msgstr "minutes"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -9591,6 +9591,10 @@ msgstr "funziona sui computer client."
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr "fa"
+
 msgid "group"
 msgstr "gruppo"
 
@@ -9719,6 +9723,9 @@ msgid "in"
 msgstr "minuti"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -9528,6 +9528,10 @@ msgstr "クライアントコンピューター上の機能。"
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr "前"
+
 msgid "group"
 msgstr "グループ"
 
@@ -9657,6 +9661,9 @@ msgid "in"
 msgstr "分"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8467,6 +8467,9 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+msgid "got"
+msgstr ""
+
 msgid "group"
 msgstr ""
 
@@ -8579,6 +8582,9 @@ msgid "in"
 msgstr ""
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 msgid "in minutes"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9922,6 +9922,10 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr " atrás"
+
 msgid "group"
 msgstr "grupo"
 
@@ -10061,6 +10065,9 @@ msgid "in"
 msgstr "minutos"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -9922,6 +9922,10 @@ msgstr ""
 msgid "further cycles"
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr "前"
+
 msgid "group"
 msgstr "组"
 
@@ -10061,6 +10065,9 @@ msgid "in"
 msgstr "分钟"
 
 msgid "in Hz"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 #, fuzzy

--- a/tests/insertbatch-required-columns.test.php
+++ b/tests/insertbatch-required-columns.test.php
@@ -158,20 +158,32 @@ check(
  * the placeholders, or emitting placeholders without binding, both produce a
  * broken statement rather than a wrong one -- but neither is visible from the
  * column list alone.
+ *
+ * And every ROW needs its own placeholder. The fill bind was named once,
+ * outside the row loop, and the single `:_fill_0` was then repeated in each
+ * VALUES tuple -- which one row survives and two do not: PDODB sets
+ * PDO::ATTR_EMULATE_PREPARES => false, so a real server-side prepare answers
+ * SQLSTATE[HY093] "Invalid parameter number" to a named parameter used twice.
+ * Every batch of two or more rows into a table with an unnamed NOT NULL
+ * column failed outright, which is most of group tasking: the snapin and
+ * generic branches of Group::createImagePackage() name none of `tasks`' four
+ * NFS/image columns. Proved both ways by
+ * background_scripts/prove_batch_fill_duplicate_bind.php.
  */
 check(
     'their placeholders are emitted into every row tuple',
-    false !== strpos($batch, '$fillKeys')
-    && 1 === preg_match(
-        '/array_merge\(\s*\(array\)\s*\$insertKeys,\s*\$fillKeys\s*\)/',
+    1 === preg_match(
+        '/foreach \(\$fillCols as \$fillIndex => \$fillVal\)/',
         $batch
-    ),
+    )
+    && 1 === preg_match('/\$insertVals\[\$key\]\s*=\s*\$fillVal;/', $batch),
     $failures,
     $checks
 );
 check(
-    'and their values are bound for every chunk, not just the first',
-    2 === preg_match_all('/\$insertVals\s*=\s*\$fillVals;/', $batch),
+    'each row binds its own copy, never one shared placeholder',
+    1 === preg_match("/'_fill_%d_%d'/", $batch)
+    && false === strpos($batch, '$fillKeys'),
     $failures,
     $checks
 );

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * A task must never end up pointing at nothing, and deleting an image must
+ * not strand the tasks that were going to use it.
+ *
+ * THE FAILURE. A `tasks` row whose taskHostID / taskImageID / taskTypeID
+ * match no row is permanent and unreadable at the same time. taskStateID
+ * still resolves, so every "is this task live" test in the tree -- all of
+ * which ask for getQueuedStates() plus getProgressState() -- counts it as
+ * active. The Active Tasks list renders each cell from buildQuery()'s LEFT
+ * OUTER JOINs and guards it with isset(), which is false for the NULL a
+ * non-matching join returns, so the row draws as "() -" for host and image
+ * with no type icon and no MAC. It can never complete: TaskingElement cannot
+ * build the Image or the Host, so the machine is turned away at check-in.
+ * Nothing reaps it. Reported as "null tasks" in forum topics 18228 and 18230.
+ *
+ * TWO WAYS IN, both closed here:
+ *
+ *   1. Written that way. FOGController::save() refuses a required *ID that is
+ *      not an integer >= 1; FOGManagerController::insertBatch() enforced
+ *      nothing, so the same model was validated one row at a time and not a
+ *      hundred at a time. A 0 is legal to the server under any sql_mode.
+ *   2. Stranded afterwards. Deleting an image reset hosts.imageID and removed
+ *      the imageassociation rows and said nothing about `tasks`.
+ *
+ * WHAT THIS PINS is the mechanism, not a call site -- a test that walked
+ * today's group-tasking branches would go green the moment someone added a
+ * branch it did not know about, which is exactly how this arrived.
+ *
+ * DB-free: this reads the source, like insertbatch-required-columns. The
+ * behaviour is proved against the live database by
+ * background_scripts/prove_batch_fk_guard.php and
+ * background_scripts/prove_image_delete_cancels_tasks.php -- the second of
+ * which fails on an unpatched tree, which is what makes it a gate.
+ *
+ * Usage: php tests/null-tasks-cannot-be-created-or-stranded.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+function check($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+$man = (string) file_get_contents(
+    "$root/packages/web/lib/fog/fogmanagercontroller.class.php"
+);
+$route = (string) file_get_contents(
+    "$root/packages/web/lib/router/route.class.php"
+);
+
+/* ---------------------------------------------------------------- 1. guard */
+
+$guard = '';
+if (preg_match(
+    '/private function _assertBatchForeignKeys\(.*?\n    \}/s',
+    $man,
+    $m
+)) {
+    $guard = $m[0];
+}
+check(
+    'insertBatch has a required-foreign-key guard',
+    '' !== $guard,
+    $failures,
+    $checks
+);
+
+$batch = '';
+if (preg_match('/public function insertBatch\(.*?\n    \}/s', $man, $m)) {
+    $batch = $m[0];
+}
+check(
+    'insertBatch calls it',
+    false !== strpos($batch, '_assertBatchForeignKeys('),
+    $failures,
+    $checks
+);
+
+/*
+ * Order matters and is invisible at the call. The loop that builds $keys
+ * rewrites $fields IN PLACE from friendly names to column names, so a guard
+ * running after it would be comparing 'taskHostID' against 'hostID' and
+ * matching nothing -- passing everything, silently, forever.
+ */
+$callPos = strpos($batch, '_assertBatchForeignKeys(');
+$rewritePos = strpos($batch, '$key = $this->databaseFields[$key];');
+check(
+    'and calls it BEFORE $fields is rewritten to column names',
+    false !== $callPos
+    && false !== $rewritePos
+    && $callPos < $rewritePos,
+    $failures,
+    $checks
+);
+
+/*
+ * The rule has to be the same one save() applies, or an object validates
+ * itself on one write path and not the other -- the split that produced this.
+ */
+check(
+    'the guard demands an integer >= 1, as save() does',
+    1 === preg_match(
+        "/FILTER_VALIDATE_INT.*?'min_range'\s*=>\s*1/s",
+        $guard
+    ),
+    $failures,
+    $checks
+);
+check(
+    'it reads the model\'s own required list',
+    false !== strpos($guard, '$this->databaseFieldsRequired'),
+    $failures,
+    $checks
+);
+
+/*
+ * Three exemptions, each of which turns the guard from a fix into a new
+ * outage if it is missing.
+ */
+check(
+    'it never demands the model\'s own auto-increment id',
+    1 === preg_match("/'id'\s*===\s*\\\$lower/", $guard),
+    $failures,
+    $checks
+);
+check(
+    'it only polices keys whose name ends in ID',
+    1 === preg_match("/'id'\s*!==\s*substr\(\\\$lower,\s*-2\)/", $guard),
+    $failures,
+    $checks
+);
+check(
+    'it honours the model\'s $databaseFieldsNotInt opt-out',
+    false !== strpos($guard, '$this->databaseFieldsNotInt'),
+    $failures,
+    $checks
+);
+
+/*
+ * That opt-out only reaches the manager if the constructor pulls it off the
+ * model. It is the one property in the list that was not being pulled, and
+ * without it a string identifier declared required would be refused here
+ * while save() accepted it.
+ */
+check(
+    'the manager pulls $databaseFieldsNotInt from its model',
+    1 === preg_match(
+        "/'databaseFieldsNotInt',\s*\n\s*\];/",
+        $man
+    )
+    && 1 === preg_match(
+        '/\$this->databaseFieldsNotInt\s*=\s*&\$classVars\[/',
+        $man
+    ),
+    $failures,
+    $checks
+);
+
+/*
+ * Only columns the caller NAMED. Twenty-six call sites rely on being able to
+ * stay silent about a column and let columnsRequiringValue() fill it;
+ * demanding they name it is a different change with a different blast radius.
+ */
+check(
+    'it only checks columns the caller actually named',
+    1 === preg_match(
+        '/foreach \(\(array\)\$fields as \$i => \$named\)/',
+        $guard
+    ),
+    $failures,
+    $checks
+);
+
+/* -------------------------------------------------- 2. image delete cascade */
+
+$imageCase = '';
+if (preg_match(
+    "/case 'image':\s*\n\s*\\\$findWhere = \['imageID' => \\\$itemIDs\];.*?break;/s",
+    $route,
+    $m
+)) {
+    $imageCase = $m[0];
+}
+check(
+    "deletemass's image arm was found",
+    '' !== $imageCase,
+    $failures,
+    $checks
+);
+check(
+    'deleting an image cancels the tasks still queued against it',
+    false !== strpos($imageCase, "->cancel(")
+    && false !== strpos($imageCase, "'task'"),
+    $failures,
+    $checks
+);
+check(
+    'and only the ones that are still live',
+    false !== strpos($imageCase, 'getQueuedStates()')
+    && false !== strpos($imageCase, 'getProgressState()'),
+    $failures,
+    $checks
+);
+
+/*
+ * The half that is easy to lose. A host delete takes its tasks with it
+ * because the subject of that history is gone; an image delete must NOT,
+ * because the hosts survive and their finished tasks are still their imaging
+ * record. Putting 'task' into $removeItems here would silently delete it.
+ */
+check(
+    'it does not delete task rows outright, as the host arm does',
+    false === strpos($imageCase, "'task' => \$findWhere"),
+    $failures,
+    $checks
+);
+
+/*
+ * TaskManager::cancel() rather than a bare state update: cancelling a task
+ * also has to reissue the host's token, unwind any multicast session behind
+ * it and record the transition in the task log. A state UPDATE does none of
+ * those and looks identical in the list.
+ */
+check(
+    'it goes through TaskManager::cancel, not a bare state update',
+    false !== strpos($imageCase, "getClass('TaskManager')"),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Forum topics [18228](https://forums.fogproject.org/topic/18228/failed-to-update-database-and-host) and [18230](https://forums.fogproject.org/topic/18230/1-5-10-2402-additional-null-tasks-created-but-this-time-manages-to-start-a-transfer) both report the same thing: rows in Active Tasks with nothing in them — `() -` for hostname, `() -` for image, no MAC, no task-type icon — that never go away.

## What a "null task" actually is

A `tasks` row whose `taskHostID` / `taskImageID` / `taskTypeID` match no row, while `taskStateID` still does.

* `taskStateID` resolving is what makes it **permanent**: every "is this task live" test in the tree is an allowlist of `getQueuedStates()` plus `getProgressState()`, so the row counts as active forever. Nothing reaps it, and no host can finish it — `TaskingElement` cannot build the Image or the Host, so the machine is turned away at check-in.
* The other three not resolving is what makes it **unreadable**. `FOGController::buildQuery()` joins the related tables with `LEFT OUTER JOIN`, so the row comes back with `NULL` in every host/image/type column; the Active Tasks template guards each cell with `isset()`, which is false for `NULL`. Hence `() -`, and hence no name to act on.

Both halves are needed for the reported symptom, which is why the screenshots show the Queued bookmark (state 1 exists) and no type icon (the type does not).

## Three fixes

**1. `insertBatch()` enforces the required-foreign-key contract `save()` already enforces.**

`FOGController::save()` refuses a required `*ID` that is not an integer >= 1. `FOGManagerController::insertBatch()` enforced nothing, so the same model was validated one row at a time and unvalidated a hundred rows at a time. What gets through is a `0` — legal to the server under any `sql_mode`, and exactly what a caller indexing a positional list past its end produces.

Deliberately narrow, because this write path has 26 call sites:

* only columns the caller **named** (a required column the batch is silent about is still left to `columnsRequiringValue()`);
* only `*ID` columns — the ones whose zero is indistinguishable from a value;
* never the model's own auto-increment `id`;
* never a key the model has opted out of via `$databaseFieldsNotInt`, which needed the manager to start pulling that property off its model — it was the one entry missing from the constructor's list.

**2. Deleting an image cancels the tasks still queued against it.**

`deletemass`'s `image` arm reset `hosts.imageID` and removed the `imageassociation` rows and said nothing about `tasks`. Cancelled, **not** deleted, unlike the `host` arm: a host delete takes its history with it because the subject of that history is gone, but the hosts survive an image delete and their finished tasks are still their imaging record. Through `TaskManager::cancel()`, which is what already reissues the host token, unwinds any multicast session behind the task and records the transition in the task log.

Reporter maxcarpone deleted an image record by hand in the first post of 18228.

**3. `insertBatch()` can write more than one row again.**

Found while proving (1), and the largest live impact here. GH-1245's backfill names its fill placeholder once, outside the row loop, then repeats that same `:_fill_0` in every `VALUES` tuple. PDODB sets `ATTR_EMULATE_PREPARES => false`, so a real server-side prepare answers `SQLSTATE[HY093] Invalid parameter number` to a named parameter used twice — **one row works, two do not**.

Every batch of two or more rows into a table with an unnamed `NOT NULL` column has been failing outright since GH-1245 landed. That is most of group tasking: the snapin and generic branches of `Group::createImagePackage()` name none of `tasks`' four NFS/image columns, so tasking a group of two hosts with a wipe, virus scan, hardware inventory, password reset or snapin task fails every time. The fill columns are still worked out once; only their placeholders are now per row.

## Proof

Three scripts, each run against the live 1.6 database from a shadow web root, and each shown failing first on an unpatched tree:

* `prove_batch_fk_guard.php` — 13/13. `hostID` 0, `typeID` 0 and a short row are each refused; a mixed batch is refused whole; a valid two-row batch still inserts and lands both rows; a model with no required FK is untouched.
* `prove_batch_fill_duplicate_bind.php` — deployed tree: `1 row -> 1 landed, 2 rows -> 0 landed (HY093)`. Patched tree: `2 rows -> 2 landed`.
* `prove_image_delete_cancels_tasks.php` — 6/6 patched, **5/6 on the deployed tree**, the failure being `the queued task is Cancelled, not left Queued -- state is 1`. Creates and removes its own throwaway host, image and tasks; touches nothing that was already there.

`tests/null-tasks-cannot-be-created-or-stranded.test.php` (15 checks) pins the mechanism; all ten of its gates are mutation-verified. `tests/insertbatch-required-columns.test.php` is updated for the per-row placeholder and still passes. Whole PHP suite: 0 failing files.

## Not in this PR

A reaper for tasks that are *already* stranded on an existing install. Whether it should match on `0` or on a deleted id depends on what the reporters' rows actually contain, and I have asked for that.

`TaskState::getQueuedStates()` returning `range(0, 2)` looks wrong for tasks — state `0` has no `taskStates` row — but it is load-bearing for `MulticastSession`, whose initial state *is* 0. Left alone deliberately; the reaper is the right place to deal with a `taskStateID` of 0.

## Downstream

None. No route class added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
