### PR TITLE
Give Host and Image a getArch(), and make the host's arch actually be the host's

### DIFF
--- a/packages/web/lib/fog/host.class.php
+++ b/packages/web/lib/fog/host.class.php
@@ -158,12 +158,8 @@ class Host extends FOGController
             'hostID',
             'id',
             'inventory'
-        ],
-        'Architecture' => [
-            'id',
-            'archID',
-            'arch'
         ]
+        // No 'Architecture' entry, deliberately -- see loadArch() below.
     ];
 
     protected $sqlQueryStr = "SELECT `%s`
@@ -564,6 +560,37 @@ class Host extends FOGController
     {
         $mac = new MACAddress($this->get('primac'));
         $this->set('mac', $mac);
+    }
+    /**
+     * Loads the arch additional field
+     *
+     * A lazy load rather than a databaseFieldClassRelationships entry, which
+     * is what it was and what did not work. buildQuery() keys its JOIN map by
+     * lowercase class name, one slot per class. Host relates to Image, Image
+     * relates to Architecture, and Image is declared first -- so Image's
+     * nested join claimed the single 'architecture' slot and Host's own join
+     * off hosts.hostArchID was skipped by the array_key_exists() guard:
+     *
+     *   LEFT OUTER JOIN `architectures`
+     *     ON `architectures`.`archID` = `images`.`imageArchID`
+     *
+     * Reordering the map only moves the problem, because SELECT
+     * `architectures`.* returns ONE row per result row either way -- the join
+     * shape cannot carry a host's architecture and its image's at the same
+     * time without an alias, which the builder has no way to express.
+     *
+     * The visible cost was not the undefined-method fatal that led here. It
+     * was that $this->get('arch') silently answered with the IMAGE's
+     * architecture, so the image/host compatibility guard in getImageMemberFromHostID()
+     * compared the image against itself and could never fire: a host recorded
+     * as arm64 running an i386 image read as i386 on both sides.
+     *
+     * @return void
+     */
+    protected function loadArch()
+    {
+        $arch = new Architecture($this->get('archID'));
+        $this->set('arch', $arch);
     }
     /**
      * Loads any groups this host is in
@@ -2056,6 +2083,21 @@ class Host extends FOGController
     public function getOS()
     {
         return $this->getImage()->getOS()->get('name');
+    }
+    /**
+     * Returns the hosts architecture object
+     *
+     * Named accessor for the same reason getImage() and getOS() are ones:
+     * Route::getter() calls it alongside getImageType()/getOS()/
+     * getStorageGroup() on its neighbouring lines. It was written there
+     * before it existed here, which is the fatal that led to this. The value
+     * comes from loadArch(), not from a join.
+     *
+     * @return Architecture
+     */
+    public function getArch()
+    {
+        return $this->get('arch');
     }
     /**
      * Returns the snapinjob

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -452,6 +452,15 @@ class Image extends FOGController
         return $this->get('imagepartitiontype');
     }
     /**
+     * Returns the Architecture object
+     *
+     * @return Architecture
+     */
+    public function getArch()
+    {
+        return $this->get('arch');
+    }
+    /**
      * Returns the partition type
      *
      * @return string


### PR DESCRIPTION
Fixes the fatal that takes out every PXE boot of a registered host on working-1.6.

```
PHP Fatal error:  Uncaught Error: Call to undefined method FOG\Host::getArch()
 in /var/www/html/fog-1.6/lib/router/route.class.php:5399
#0 route.class.php(3971): FOG\Route::getter()
#1 route.class.php(6927): FOG\Route::indiv()
#2 bootmenu.class.php(624): FOG\Route::getItem()
#3 service/ipxe/boot.php(61): FOG\BootMenu->__construct()
```

## Blast radius

`Route::getter()` calls `$class->getArch()->get('name')` for **both** the host case (`:5399`) and the image case (`:5445`). Neither class has the method, so `GET /host/{id}` and `GET /image/{id}` are both uncaught Errors — and because `BootMenu`'s constructor goes through `Route::getItem()`, so is every PXE boot of a registered host. Reproduced against the live tree:

```
host  id=1  FATAL  Call to undefined method FOG\Host::getArch()   at route.class.php:5399
image id=1  FATAL  Call to undefined method FOG\Image::getArch()  at route.class.php:5445
```

The accessor was written against a convention that already existed for its neighbours on the same lines — `getImageType()`, `getOS()`, `getStorageGroup()` are all one-line wrappers — and never added.

## Why adding the accessor alone would be worse

It would turn a loud fatal into a silent wrong answer, because Host's architecture relationship does not resolve to the host's architecture.

`buildQuery()` keys its JOIN map by lowercase class name, one slot per class. Host relates to Image, Image relates to Architecture, and **Image is declared first** — so Image's nested join claims the single `architecture` slot and Host's own join off `hosts.hostArchID` is skipped by the `array_key_exists()` guard. The query FOG actually runs for a host is:

```sql
LEFT OUTER JOIN `architectures` ON `architectures`.`archID` = `images`.`imageArchID`
```

Reordering the map only moves the problem: `SELECT architectures.*` returns one row per result row either way, so the join shape cannot carry a host's architecture and its image's at the same time without an alias the builder has no way to express.

## The part that actually matters

The image/host compatibility guard compares `$Image->get('arch')->get('name')` against `$this->get('arch')->get('name')` — and the second was reading the *image's* architecture. **It compared the image against itself and could never fire.**

Verified against a live database, host 49 running image 1:

```
set host archID=3 (arm64), image archID=1 (i386)

  host archID column      : 3
  host get('arch')->name  : 'i386'    <-- what the guard reads for the HOST
  image get('arch')->name : 'i386'    <-- what the guard reads for the IMAGE
```

That guard exists to refuse a deploy that *succeeds* and leaves a machine holding a bootloader and binaries it cannot execute — a failure that surfaces at next power-on looking like dead hardware.

After:

```
  host archID column      : 3
  host get('arch')->name  : 'arm64'
  image get('arch')->name : 'i386'
```

## The fix

Host loads `arch` lazily, the way it already loads `mac`, `task` and `snapinjob`: `loadArch()` does `new Architecture($this->get('archID'))`. Image keeps its relationship, which was always correct and is what every other reader of an image's architecture uses.

**Nothing in `route.class.php` changes** — both call sites now resolve, and both resolve to the right object.

Everything that writes or reads the scalar (`hostmanagement.page.php`, `imagemanagement.page.php`, `bootmenu.class.php`, `Architecture::pickable()`) uses `archID` and was never affected.

## Tests

```
161 passed, 0 failed
```

Not present on `dev-branch` — the `architectures` lookup table is working-1.6 only (schema steps 369/370/372), so there is nothing to port.

Verification scripts: `/images/claude-lab/archfix/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)