### PR TITLE
Stop a task ever pointing at nothing, and free the ones that do (1.5)

### DIFF
--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -206,7 +206,27 @@ abstract class FOGManagerController extends FOGBase
             $count = 0;
             foreach ($findWhere as $field => &$value) {
                 $key = trim($field);
-                if (!$value) {
+                /*
+                 * GH-1245 gave find() the `null === $value` branch below, but
+                 * left this expansion above it -- and `!null` is true, so an
+                 * explicit null was turned into the array first and that
+                 * branch could never run. The emitted term was
+                 * `col IN ('0',0,NULL,'')`, which is never TRUE for a column
+                 * holding NULL: SQL evaluates `NULL IN (...)` to unknown. So
+                 * every `find()` filtering on null silently matched nothing.
+                 *
+                 * TaskingElement::imageLog() is where it showed: it looks up
+                 * the open imaging log by `finish => null`, missed it on every
+                 * single deployment, and the caller reported "Failed to update
+                 * imaging log" for a machine that had imaged perfectly (forums
+                 * topic 18228).
+                 *
+                 * Only the null case is taken out of the expansion. A filter
+                 * holding 0, '' or false keeps matching the falsey stored
+                 * representations exactly as before -- that list has hundreds
+                 * of callers and this is not the change to alter them in.
+                 */
+                if (null !== $value && !$value) {
                     $value = array(
                         '0',
                         0,

--- a/packages/web/lib/fog/fogmanagercontroller.class.php
+++ b/packages/web/lib/fog/fogmanagercontroller.class.php
@@ -58,6 +58,17 @@ abstract class FOGManagerController extends FOGBase
      */
     protected $databaseFieldClassRelationships = array();
     /**
+     * Fields whose name ends in "id" but which are not foreign keys.
+     *
+     * Mirrored from the model for the same reason isValid() carries its own
+     * copy of the rule save() uses: both write paths infer "ends in id, so it
+     * is a foreign key", so both need the model's opt-out or one of them
+     * refuses a string identifier the other accepts.
+     *
+     * @var array
+     */
+    protected $databaseFieldsNotInt = array();
+    /**
      * The additional fields.
      *
      * @var array
@@ -129,12 +140,14 @@ abstract class FOGManagerController extends FOGBase
             'additionalFields',
             'databaseFieldsRequired',
             'databaseFieldClassRelationships',
+            'databaseFieldsNotInt',
         );
         $this->databaseTable = &$classVars[$classGet[0]];
         $this->databaseFields = &$classVars[$classGet[1]];
         $this->additionalFields = &$classVars[$classGet[2]];
         $this->databaseFieldsRequired = &$classVars[$classGet[3]];
         $this->databaseFieldClassRelationships = &$classVars[$classGet[4]];
+        $this->databaseFieldsNotInt = &$classVars[$classGet[5]];
         $this->databaseFieldsFlipped = array_flip($this->databaseFields);
         unset($classGet);
     }
@@ -667,6 +680,102 @@ abstract class FOGManagerController extends FOGBase
         return is_string($value) ? trim($value) : $value;
     }
     /**
+     * Refuses a batch row whose required foreign key points at nothing.
+     *
+     * FOGController::save() will not write a row whose required *ID field is
+     * not an integer >= 1 -- see its "Required *id must be integer >= 1"
+     * branch. insertBatch() enforced nothing, so the same model validated
+     * itself when written one row at a time and did not when written a
+     * hundred at a time.
+     *
+     * What gets through is a 0. Since GH-1245 the server's own sql_mode
+     * rejects a null or an '' bound into a NOT NULL int, but 0 is a perfectly
+     * legal integer and no layer has an opinion about it -- and a caller
+     * indexing a positional list past its end, or reading an id off an object
+     * that did not load, produces exactly that.
+     *
+     * In `tasks` such a row is permanent and invisible at the same time.
+     * taskStateID still resolves, so the task counts as active for every
+     * "is this live" test in the tree; taskHostID/taskImageID/taskTypeID
+     * match nothing, and because the Active Tasks list renders from
+     * buildQuery()'s LEFT OUTER JOINs those columns come back NULL. The row
+     * shows as "() -" for host and image with no type icon, cannot be
+     * completed by any host, and nothing ever reaps it. Reported as "null
+     * tasks" in forum topics 18228 and 18230.
+     *
+     * Deliberately narrow, because this is a write path with many call sites:
+     *
+     *  - Only columns the caller NAMED. A required column the batch is silent
+     *    about is left to columnsRequiringValue() below, which is the
+     *    behaviour every one of those call sites already relies on; turning
+     *    silence into an error is a different change with a different blast
+     *    radius.
+     *  - Only *ID columns. They are the ones whose zero is indistinguishable
+     *    from a value; a required string is caught by the server or by the
+     *    reader either way.
+     *  - Never the model's own primary key. No batch caller supplies it, and
+     *    save() skips it for the same reason.
+     *  - Never a key the model has declared is a string via
+     *    $databaseFieldsNotInt.
+     *
+     * @param array $fields the friendly field names the caller named
+     * @param array $values the rows, positional against $fields
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    private function _assertBatchForeignKeys($fields, $values)
+    {
+        $notInt = array_map(
+            'strtolower',
+            (array)$this->databaseFieldsNotInt
+        );
+        $positions = array();
+        foreach ((array)$this->databaseFieldsRequired as $friendly) {
+            $lower = strtolower($friendly);
+            if ('id' === $lower
+                || 'id' !== substr($lower, -2)
+                || in_array($lower, $notInt, true)
+            ) {
+                continue;
+            }
+            foreach ((array)$fields as $i => $named) {
+                if (strtolower($named) === $lower) {
+                    $positions[$i] = $friendly;
+                }
+            }
+        }
+        if (count($positions) < 1) {
+            return;
+        }
+        foreach ((array)$values as $rowIndex => $row) {
+            foreach ($positions as $i => $friendly) {
+                $val = isset($row[$i]) ? $row[$i] : null;
+                $valid = filter_var(
+                    $val,
+                    FILTER_VALIDATE_INT,
+                    array('options' => array('min_range' => 1))
+                );
+                if (false !== $valid) {
+                    continue;
+                }
+                throw new Exception(
+                    sprintf(
+                        '%s: `%s`.%s %s %d, %s: %s',
+                        self::$foglang['RequiredDB'],
+                        $this->databaseTable,
+                        $friendly,
+                        _('in batch row'),
+                        $rowIndex,
+                        _('got'),
+                        var_export($val, true)
+                    )
+                );
+            }
+        }
+    }
+    /**
      * Inserts data in mass to the database.
      *
      * @param array $fields the fields to insert into
@@ -684,6 +793,9 @@ abstract class FOGManagerController extends FOGBase
         if ($valuelength < 1) {
             throw new Exception(_('No values passed'));
         }
+        // Before the loop below, which rewrites $fields from friendly names
+        // to column names in place.
+        $this->_assertBatchForeignKeys($fields, $values);
         $keys = array();
         foreach ((array) $fields as &$key) {
             $key = $this->databaseFields[$key];
@@ -717,9 +829,22 @@ abstract class FOGManagerController extends FOGBase
          * on a row that already exists the stored value must stand. Filling
          * settingDesc into the update list would blank the description of
          * every setting on the page the moment anyone pressed save.
+         *
+         * The filled columns and their values are worked out ONCE here; the
+         * placeholders that carry them are named PER ROW, down in the loop.
+         * They were named once too, and the single `:_fill_0` was then
+         * repeated in every VALUES tuple -- which one row survives and two do
+         * not: PDODB sets PDO::ATTR_EMULATE_PREPARES => false, and a real
+         * server-side prepare answers SQLSTATE[HY093] "Invalid parameter
+         * number" to a named parameter used twice. So every batch of two or
+         * more rows into a table with an unnamed NOT NULL column failed
+         * outright, silently to the user: tasking a GROUP of two hosts with
+         * anything that is not a deploy or a multicast (wipe, virus scan,
+         * hardware inventory, password reset, snapins) names none of
+         * `tasks`' NFS/image columns and so hit this every time.
+         * See background_scripts/prove_batch_fill_duplicate_bind.php.
          */
-        $fillKeys = array();
-        $fillVals = array();
+        $fillCols = array();
         $named = array_map('strtolower', $keys);
         foreach ((array) self::columnsRequiringValue(
             $this->databaseTable
@@ -727,20 +852,17 @@ abstract class FOGManagerController extends FOGBase
             if (in_array(strtolower($column), $named, true)) {
                 continue;
             }
-            $bind = sprintf('_fill_%d', count($fillKeys));
             $keys[] = $column;
-            $fillKeys[] = sprintf(':%s', $bind);
-            $fillVals[$bind] = self::emptyValueFor(
+            $fillCols[] = self::emptyValueFor(
                 $this->databaseTable,
                 $column
             );
         }
         $affectedRows = 0;
         $vals = array();
-        $insertVals = $fillVals;
         $values = array_chunk($values, 500);
         foreach ((array) $values as $ind => &$v) {
-            $insertVals = $fillVals;
+            $insertVals = array();
             foreach ((array) $v as $index => &$value) {
                 $insertKeys = array();
                 foreach ((array) $value as $i => &$val) {
@@ -757,9 +879,21 @@ abstract class FOGManagerController extends FOGBase
                     $insertVals[$key] = $val;
                     unset($val);
                 }
+                foreach ($fillCols as $fillIndex => $fillVal) {
+                    $key = sprintf(
+                        '_fill_%d_%d',
+                        $fillIndex,
+                        $index
+                    );
+                    $insertKeys[] = sprintf(
+                        ':%s',
+                        $key
+                    );
+                    $insertVals[$key] = $fillVal;
+                }
                 $vals[] = sprintf(
                     '(%s)',
-                    implode(',', array_merge((array) $insertKeys, $fillKeys))
+                    implode(',', (array) $insertKeys)
                 );
                 unset($value);
             }

--- a/packages/web/lib/fog/group.class.php
+++ b/packages/web/lib/fog/group.class.php
@@ -593,20 +593,25 @@ class Group extends FOGController
             } elseif ($TaskType->isDeploy()) {
                 $hostIDs = array_values($hostids);
                 $hostCount = count($hostIDs);
-                $imageIDs = self::getSubObjectIDs(
-                    'Host',
-                    array(
-                        'id' => $hostIDs,
-                    ),
-                    'imageID',
-                    false,
-                    'AND',
-                    'name',
-                    false,
-                    ''
-                );
-                if (!is_array($imageIDs)) {
-                    $imageIDs = array($imageIDs);
+                /**
+                 * Map each host to ITS OWN image.
+                 *
+                 * $hostIDs is the group's membership in id order; the image
+                 * list was a separate lookup ordered by host NAME, and the
+                 * two were then zipped positionally. So unless the group's
+                 * hosts happened to sort the same way both times, every task
+                 * got somebody else's image -- and a host without an image
+                 * shortened the list, which made $imageIDs[$i] undefined for
+                 * the tail of the group and wrote a 0 into tasks.taskImageID.
+                 * A task pointing at image 0 shows as "() -" in Active Tasks
+                 * and can never complete. Forum topics 18228 and 18230.
+                 */
+                $imageMap = array();
+                foreach ((array)self::getClass('HostManager')->find(
+                    array('id' => $hostIDs)
+                ) as &$Host) {
+                    $imageMap[$Host->get('id')] = $Host->get('imageID');
+                    unset($Host);
                 }
                 $batchFields = array(
                     'name',
@@ -633,7 +638,9 @@ class Group extends FOGController
                         $TaskType->get('id'),
                         $StorageNode->get('id'),
                         $wol,
-                        $imageIDs[$i],
+                        isset($imageMap[$hostIDs[$i]])
+                            ? $imageMap[$hostIDs[$i]]
+                            : 0,
                         $shutdown,
                         $debug,
                         $passreset,

--- a/packages/web/lib/fog/image.class.php
+++ b/packages/web/lib/fog/image.class.php
@@ -120,6 +120,41 @@ class Image extends FOGController
             );
         self::getClass('ImageAssociationManager')
             ->destroy($find);
+        /**
+         * Cancel the tasks that were still going to use it.
+         *
+         * Resetting hosts.imageID and dropping the associations said nothing
+         * about `tasks`, so a queued or in-progress task kept pointing at an
+         * image row that no longer exists. taskStateID still resolves, so
+         * every "is this task live" test in the tree counts it as active, but
+         * the LEFT OUTER JOIN behind the Active Tasks list returns NULL for
+         * every image column and the row draws as "() -" with no type icon.
+         * No host can finish it either -- TaskingElement cannot build the
+         * Image -- and nothing reaps it, so it stays forever. Reported as
+         * "null tasks" in forum topics 18228 and 18230.
+         *
+         * Cancelled rather than deleted, unlike the host case: a host delete
+         * takes its task history with it because the subject of that history
+         * is gone, but the hosts survive an image delete and their finished
+         * tasks are still their imaging record. Only the live ones are stuck.
+         *
+         * Through TaskManager::cancel() rather than a bare state update: it
+         * also reissues the host's token, unwinds any multicast session
+         * behind the task and cancels the snapin jobs riding on it.
+         */
+        $activeImageTaskIDs = self::getSubObjectIDs(
+            'Task',
+            array(
+                'imageID' => $this->get('id'),
+                'stateID' => self::fastmerge(
+                    (array)self::getQueuedStates(),
+                    (array)self::getProgressState()
+                )
+            )
+        );
+        if (count($activeImageTaskIDs) > 0) {
+            self::getClass('TaskManager')->cancel($activeImageTaskIDs);
+        }
         self::$HookManager
             ->processEvent(
                 'DESTROY_IMAGE',

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -293,8 +293,31 @@ abstract class TaskingElement extends FOGBase
         // uncaught ValueError on that (@ cannot suppress an Error). maxId()
         // yields 0, which makes the ImagingLog below a new row as intended.
         $ilID = self::maxId($ilID);
-        return self::getClass('ImagingLog', $ilID)
-            ->set('finish', self::formatTime('now', 'Y-m-d H:i:s'))
-            ->save();
+        $ImagingLog = self::getClass('ImagingLog', $ilID)
+            ->set('finish', self::formatTime('now', 'Y-m-d H:i:s'));
+        // A new row needs the three fields ImagingLog declares required --
+        // hostID, start and image -- or save() refuses it and the caller
+        // reports "Failed to update imaging log" for a machine that imaged
+        // fine. Setting only `finish`, as this did, could therefore only ever
+        // fail on the no-open-log path the maxId() note above describes.
+        // The start time is the task's own check-in, not now: the imaging
+        // began then, and a start equal to the finish would read as a
+        // zero-length deployment in the imaging report.
+        if (!$ImagingLog->isValid()) {
+            $checkInTime = $this->Task->get('checkInTime');
+            if (!self::validDate($checkInTime)) {
+                $checkInTime = self::formatTime('now', 'Y-m-d H:i:s');
+            }
+            $ImagingLog
+                ->set('hostID', self::$Host->get('id'))
+                ->set('start', $checkInTime)
+                ->set('image', $this->Image->get('name'))
+                // 'up'/'down' are the two values the imaging report maps to
+                // Capture and Deploy; check-in reads them off the request,
+                // which is not available here.
+                ->set('type', $this->Task->isCapture() ? 'up' : 'down')
+                ->set('createdBy', $this->Task->get('createdBy'));
+        }
+        return $ImagingLog->save();
     }
 }

--- a/packages/web/lib/reg-task/taskqueue.class.php
+++ b/packages/web/lib/reg-task/taskqueue.class.php
@@ -519,6 +519,26 @@ class TaskQueue extends TaskingElement
             if (!$updatedHost) {
                 throw new Exception(_('Failed to update Host'));
             }
+            /**
+             * Close the imaging log BEFORE the task is marked Complete.
+             *
+             * It used to be the last thing done, after the save below had
+             * already written the Complete state. So a failure here threw
+             * with the task already finished: FOS never saw '##', retried,
+             * and every retry from then on was answered "No Active Task found
+             * for Host" -- on a machine that had in fact imaged perfectly.
+             * The operator sees a host that will not stop rebooting into an
+             * error and a task that is nowhere to be found.
+             *
+             * Written first, a failure leaves the task in progress, which is
+             * the truth: the imaging happened but FOG could not record it,
+             * FOS can retry, and the task is still visible and cancellable.
+             */
+            if ($this->imagingTask) {
+                if (!$this->imageLog(false)) {
+                    throw new Exception(_('Failed to update imaging log'));
+                }
+            }
             if (!$this->Task->save()) {
                 throw new Exception(_('Failed to update Task'));
             }
@@ -532,11 +552,6 @@ class TaskQueue extends TaskingElement
                 );
             if (!$this->taskLog()) {
                 throw new Exception(_('Failed to update task log'));
-            }
-            if ($this->imagingTask) {
-                if (!$this->imageLog(false)) {
-                    throw new Exception(_('Failed to update imaging log'));
-                }
             }
             self::$EventManager->notify(
                 'HOST_IMAGE_COMPLETE',

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7640,6 +7640,10 @@ msgstr "Von"
 msgid "function on client computers."
 msgstr "wie Dienste auf Clientcomputer funktionieren."
 
+#, fuzzy
+msgid "got"
+msgstr "vor"
+
 msgid "group"
 msgstr "Gruppe"
 
@@ -7782,6 +7786,9 @@ msgstr "Images"
 #, fuzzy
 msgid "images to a storage group"
 msgstr "bildet ab zu einer Speichergruppe"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "in Sekunden"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7637,6 +7637,10 @@ msgstr "From"
 msgid "function on client computers."
 msgstr ""
 
+#, fuzzy
+msgid "got"
+msgstr " ago"
+
 msgid "group"
 msgstr "group"
 
@@ -7779,6 +7783,9 @@ msgstr "Images"
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Primary Storage Group"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7593,6 +7593,10 @@ msgid "function on client computers."
 msgstr "Configuración del cliente"
 
 #, fuzzy
+msgid "got"
+msgstr "Cerrar sesión"
+
+#, fuzzy
 msgid "group"
 msgstr "Grupo"
 
@@ -7729,6 +7733,9 @@ msgstr "Imágenes"
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Añadir grupo de almacenamiento"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6761,6 +6761,10 @@ msgstr "de"
 msgid "function on client computers."
 msgstr "fonctionnent sur les ordinateurs clients."
 
+#, fuzzy
+msgid "got"
+msgstr "depuis"
+
 msgid "group"
 msgstr "groupe"
 
@@ -6877,6 +6881,9 @@ msgstr "images"
 
 msgid "images to a storage group"
 msgstr "images vers un groupe de stockage"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "en secondes"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6902,6 +6902,10 @@ msgstr "da"
 msgid "function on client computers."
 msgstr "funziona sui computer client."
 
+#, fuzzy
+msgid "got"
+msgstr "fa"
+
 msgid "group"
 msgstr "gruppo"
 
@@ -7019,6 +7023,9 @@ msgstr "immagini"
 
 msgid "images to a storage group"
 msgstr "Immagini in un gruppo di archiviazione"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "in secondi"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6695,6 +6695,10 @@ msgstr "送信元"
 msgid "function on client computers."
 msgstr "クライアントコンピューター上の機能。"
 
+#, fuzzy
+msgid "got"
+msgstr "前"
+
 msgid "group"
 msgstr "グループ"
 
@@ -6811,6 +6815,9 @@ msgstr "イメージ"
 
 msgid "images to a storage group"
 msgstr "イメージをストレージグループへ"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "秒単位"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6652,6 +6652,9 @@ msgstr ""
 msgid "function on client computers."
 msgstr ""
 
+msgid "got"
+msgstr ""
+
 msgid "group"
 msgstr ""
 
@@ -6767,6 +6770,9 @@ msgid "images"
 msgstr ""
 
 msgid "images to a storage group"
+msgstr ""
+
+msgid "in batch row"
 msgstr ""
 
 msgid "in seconds"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6723,6 +6723,10 @@ msgstr "de"
 msgid "function on client computers."
 msgstr "funcionar em computadores clientes."
 
+#, fuzzy
+msgid "got"
+msgstr "atrás"
+
 msgid "group"
 msgstr "grupo"
 
@@ -6840,6 +6844,9 @@ msgstr "imagens"
 
 msgid "images to a storage group"
 msgstr "imagens para um grupo de armazenamento"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "em segundos"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6723,6 +6723,10 @@ msgstr "从"
 msgid "function on client computers."
 msgstr "在客户端计算机上运行的功能."
 
+#, fuzzy
+msgid "got"
+msgstr "前"
+
 msgid "group"
 msgstr "群组"
 
@@ -6839,6 +6843,9 @@ msgstr "镜像"
 
 msgid "images to a storage group"
 msgstr "存储组镜像"
+
+msgid "in batch row"
+msgstr ""
 
 msgid "in seconds"
 msgstr "几秒钟内"

--- a/tests/insertbatch-required-columns.test.php
+++ b/tests/insertbatch-required-columns.test.php
@@ -159,19 +159,32 @@ ibCheck(
     'the filled columns are no longer added to the column list'
 );
 ibCheck(
-    strpos($batch, '$fillKeys') !== false
-    && preg_match(
-        '#array_merge\(\s*\(array\)\s*\$insertKeys,\s*\$fillKeys\s*\)#',
+    preg_match(
+        '#foreach \(\$fillCols as \$fillIndex => \$fillVal\)#',
         $batch
-    ) === 1,
+    ) === 1
+    && preg_match('#\$insertVals\[\$key\]\s*=\s*\$fillVal;#', $batch) === 1,
     'the fill placeholders are no longer emitted into every row tuple, so '
     . 'the column list and the value list would disagree'
 );
+/*
+ * Every ROW needs its own placeholder name. The fill bind used to be named
+ * once, outside the row loop, and the single `:_fill_0` was then repeated in
+ * each VALUES tuple -- which one row survives and two do not: PDODB sets
+ * PDO::ATTR_EMULATE_PREPARES => false, so a real server-side prepare answers
+ * SQLSTATE[HY093] "Invalid parameter number" to a named parameter used twice.
+ * Every batch of two or more rows into a table with an unnamed NOT NULL
+ * column failed outright, which is most of group tasking: the snapin and
+ * generic branches of Group::createImagePackage() name none of `tasks`'
+ * NFS/image columns. Proved both ways by
+ * background_scripts/prove_batch_fill_duplicate_bind.php.
+ */
 ibCheck(
-    preg_match_all('#\$insertVals\s*=\s*\$fillVals;#', $batch) === 2,
-    'the fill values are not re-bound for every chunk. $insertVals is unset '
-    . 'at the end of each chunk, so binding them once covers only the first '
-    . '500 rows and a bigger batch fails on the second'
+    strpos($batch, "'_fill_%d_%d'") !== false
+    && strpos($batch, '$fillKeys') === false,
+    'the fill placeholders are shared between rows again. One name reused '
+    . 'across VALUES tuples is SQLSTATE[HY093] on a real server-side '
+    . 'prepare, so a batch of two or more rows fails outright'
 );
 
 // ---------------------------------------------------------------

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -25,10 +25,14 @@
  *   3. Stranded afterwards. Deleting an image reset hosts.imageID and removed
  *      the imageassociation rows and said nothing about `tasks`.
  *
- * And one that makes a GOOD task look like a lost one: checkout() marked the
- * task Complete before it wrote the imaging log, so a failure writing that
- * log left FOS retrying against a task that was already finished, answered
- * "No Active Task found for Host" forever.
+ * And one that makes a GOOD task look like a lost one, in three layers:
+ * FOGManagerController::find() expanded an explicit null filter into
+ * `col IN ('0',0,NULL,'')`, which is never TRUE for a NULL column, so the
+ * lookup for the open imaging log missed it on EVERY imaging run;
+ * imageLog() then tried to close a row it had had to create by setting only
+ * `finish`, which ImagingLog refuses; and checkout() had already marked the
+ * task Complete, so FOS's retries were answered "No Active Task found for
+ * Host" forever, on a machine that had imaged perfectly.
  *
  * WHAT THIS PINS is the mechanism, not a call site -- a test that walked
  * today's group-tasking branches would go green the moment someone added a
@@ -285,6 +289,64 @@ ntCheck(
     'imageLog()\'s checkout branch no longer completes a row it had to '
     . 'create. ImagingLog requires hostID, start and image, so setting only '
     . 'finish is a guaranteed "Failed to update imaging log"'
+);
+
+// ---------------------------------------------------------------
+// 5. find() honours an explicit null filter.
+// ---------------------------------------------------------------
+/*
+ * This is what actually made the imaging log unfindable, and it is a defect
+ * in the query builder rather than in any caller.
+ *
+ * find() opens by expanding a falsey filter into every stored representation
+ * of "nothing":
+ *
+ *     if (!$value) { $value = array('0', 0, null, ''); }
+ *
+ * GH-1245 added a `null === $value` branch further down that emits IS NULL --
+ * but !null is TRUE, so the expansion above always ran first and that branch
+ * was unreachable. The term emitted for a null filter was
+ * `col IN ('0',0,NULL,'')`, and `NULL IN (...)` evaluates to UNKNOWN in SQL,
+ * never TRUE. So find() could not match a null column at all, and
+ * imageLog()'s `finish => null` lookup missed the open row on every run.
+ *
+ * Pinned by isolating find() and reading the condition on the expansion,
+ * because a check for the IS NULL branch's mere presence passes while the
+ * branch is dead -- which is exactly the state this was in.
+ */
+preg_match('#public function find\(.*?\n    \}\n#s', $man, $m);
+$find = isset($m[0]) ? $m[0] : '';
+ntCheck($find !== '', 'FOGManagerController::find() could not be isolated');
+
+preg_match('#if \(([^)]*!\$value)\) \{\s*\$value = array\(#s', $find, $m);
+$expansion = isset($m[1]) ? $m[1] : '';
+ntCheck(
+    $expansion !== '',
+    'find()\'s falsey-value expansion could not be found, so the guard on it '
+    . 'cannot be read'
+);
+ntCheck(
+    strpos($expansion, 'null !== $value') !== false,
+    'find() expands an explicit null into array(\'0\', 0, null, \'\') and '
+    . 'emits `col IN (...)`, which is never TRUE for a NULL column. Every '
+    . 'find() filtering on null silently matches nothing, and the IS NULL '
+    . 'branch below it is dead code'
+);
+ntCheck(
+    strpos($find, 'null === $value') !== false
+    && strpos($find, 'IS%sNULL') !== false,
+    'find() no longer emits IS NULL for a null filter'
+);
+/*
+ * The expansion itself stays. A filter holding 0, \'\' or false has hundreds
+ * of callers relying on it matching the falsey stored representations, and
+ * narrowing that is a separate change with a far wider blast radius.
+ */
+ntCheck(
+    strpos($find, "\$value = array(\n                        '0',") !== false
+    || preg_match('#\$value = array\(\s*\'0\',\s*0,\s*null,\s*\'\',\s*\);#s', $find),
+    'find() no longer expands a falsey (non-null) filter, which silently '
+    . 'changes what every 0/\'\'/false filter in the tree matches'
 );
 
 ntCheck(

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * A task must never end up pointing at nothing, and deleting an image must
+ * not strand the tasks that were going to use it.
+ *
+ * THE FAILURE. A `tasks` row whose taskHostID / taskImageID / taskTypeID
+ * match no row is permanent and unreadable at the same time. taskStateID
+ * still resolves, so every "is this task live" test in the tree -- all of
+ * which ask for getQueuedStates() plus getProgressState() -- counts it as
+ * active. The Active Tasks list renders each cell from buildQuery()'s LEFT
+ * OUTER JOINs and guards it with isset(), which is false for the NULL a
+ * non-matching join returns, so the row draws as "() -" for host and image
+ * with no type icon and no MAC. It can never complete: TaskingElement cannot
+ * build the Image or the Host, so the machine is turned away at check-in.
+ * Nothing reaps it. Reported as "null tasks" in forum topics 18228 and 18230.
+ *
+ * THREE WAYS IN, all closed here:
+ *
+ *   1. Written that way. FOGController::save() refuses a required *ID that is
+ *      not an integer >= 1; FOGManagerController::insertBatch() enforced
+ *      nothing, so the same model was validated one row at a time and not a
+ *      hundred at a time. A 0 is legal to the server under any sql_mode.
+ *   2. Written that way by the group deploy branch specifically, which zipped
+ *      a host list ordered by id against an image list ordered by host name.
+ *   3. Stranded afterwards. Deleting an image reset hosts.imageID and removed
+ *      the imageassociation rows and said nothing about `tasks`.
+ *
+ * And one that makes a GOOD task look like a lost one: checkout() marked the
+ * task Complete before it wrote the imaging log, so a failure writing that
+ * log left FOS retrying against a task that was already finished, answered
+ * "No Active Task found for Host" forever.
+ *
+ * WHAT THIS PINS is the mechanism, not a call site -- a test that walked
+ * today's group-tasking branches would go green the moment someone added a
+ * branch it did not know about, which is exactly how this arrived.
+ *
+ * DB-free: this reads the source, like its sibling
+ * insertbatch-required-columns.test.php.
+ *
+ * Usage: php tests/null-tasks-cannot-be-created-or-stranded.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+$failures = array();
+$checks = 0;
+
+/**
+ * Source with comments removed, so a commented-out line can neither satisfy
+ * a check nor fail one.
+ *
+ * @param string $file the file to read
+ *
+ * @return string
+ */
+function ntStrip($file)
+{
+    $clean = '';
+    foreach (token_get_all(file_get_contents($file)) as $token) {
+        if (is_array($token)
+            && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    return $clean;
+}
+
+/**
+ * Records a check.
+ *
+ * @param bool   $ok      whether it passed
+ * @param string $message what failed, stated as the defect
+ *
+ * @return void
+ */
+function ntCheck($ok, $message)
+{
+    global $checks, $failures;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $message;
+    }
+}
+
+$man = ntStrip($web . '/lib/fog/fogmanagercontroller.class.php');
+$image = ntStrip($web . '/lib/fog/image.class.php');
+$group = ntStrip($web . '/lib/fog/group.class.php');
+$queue = ntStrip($web . '/lib/reg-task/taskqueue.class.php');
+$element = ntStrip($web . '/lib/reg-task/taskingelement.class.php');
+
+// ---------------------------------------------------------------
+// 1. insertBatch() applies the rule save() applies.
+// ---------------------------------------------------------------
+preg_match(
+    '#private function _assertBatchForeignKeys\(.*?\n    \}#s',
+    $man,
+    $m
+);
+$guard = isset($m[0]) ? $m[0] : '';
+ntCheck(
+    $guard !== '',
+    'insertBatch() has no required-foreign-key guard, so a 0 in a required '
+    . '*ID column is written without complaint'
+);
+
+preg_match('#public function insertBatch\(.*?\n    \}#s', $man, $m);
+$batch = isset($m[0]) ? $m[0] : '';
+ntCheck($batch !== '', 'insertBatch() could not be isolated');
+ntCheck(
+    strpos($batch, '_assertBatchForeignKeys(') !== false,
+    'insertBatch() no longer calls the guard'
+);
+
+/*
+ * Order matters and is invisible at the call. The loop that builds $keys
+ * rewrites $fields IN PLACE from friendly names to column names, so a guard
+ * running after it would be comparing 'taskHostID' against 'hostID' and
+ * matching nothing -- passing everything, silently, forever.
+ */
+$callPos = strpos($batch, '_assertBatchForeignKeys(');
+$rewritePos = strpos($batch, '$key = $this->databaseFields[$key];');
+ntCheck(
+    $callPos !== false && $rewritePos !== false && $callPos < $rewritePos,
+    'the guard runs after $fields has been rewritten to column names, so it '
+    . 'matches nothing and passes everything'
+);
+
+/*
+ * The rule has to be the same one save() and isValid() apply, or an object
+ * validates itself on one write path and not the other -- the split that
+ * produced this.
+ */
+ntCheck(
+    preg_match("#FILTER_VALIDATE_INT.*?'min_range'\s*=>\s*1#s", $guard) === 1,
+    'the guard no longer demands an integer >= 1, which is the rule save() '
+    . 'and isValid() apply to the same field'
+);
+ntCheck(
+    strpos($guard, '$this->databaseFieldsRequired') !== false,
+    'the guard no longer reads the model\'s own required list'
+);
+
+/*
+ * Three exemptions, each of which turns the guard from a fix into a new
+ * outage if it goes missing.
+ */
+ntCheck(
+    preg_match("#'id'\s*===\s*\\\$lower#", $guard) === 1,
+    'the guard demands the model\'s own auto-increment id, which no batch '
+    . 'caller supplies -- every insertBatch would throw'
+);
+ntCheck(
+    preg_match("#'id'\s*!==\s*substr\(\\\$lower,\s*-2\)#", $guard) === 1,
+    'the guard no longer restricts itself to keys ending in ID, so a '
+    . 'required string column is refused for not being an integer'
+);
+ntCheck(
+    strpos($guard, '$this->databaseFieldsNotInt') !== false,
+    'the guard no longer honours the model\'s $databaseFieldsNotInt '
+    . 'opt-out, so a string identifier declared required is refused here '
+    . 'while save() accepts it'
+);
+
+/*
+ * That opt-out only reaches the manager if the constructor pulls it off the
+ * model. It is the one property in the list that was not being pulled.
+ */
+ntCheck(
+    preg_match("#'databaseFieldsNotInt',#", $man) === 1
+    && preg_match(
+        '#\$this->databaseFieldsNotInt\s*=\s*&\$classVars\[#',
+        $man
+    ) === 1,
+    'FOGManagerController no longer pulls $databaseFieldsNotInt from its '
+    . 'model, so the opt-out above is always empty'
+);
+
+/*
+ * Only columns the caller NAMED. Every batch call site relies on being able
+ * to stay silent about a column and let columnsRequiringValue() fill it;
+ * demanding they name it is a different change with a different blast radius.
+ */
+ntCheck(
+    preg_match('#foreach \(\(array\)\$fields as \$i => \$named\)#', $guard)
+    === 1,
+    'the guard no longer restricts itself to the columns the caller named, '
+    . 'so a column the batch is silent about is now an error'
+);
+
+// ---------------------------------------------------------------
+// 2. Deleting an image cancels the tasks queued against it.
+// ---------------------------------------------------------------
+preg_match('#public function destroy\(.*?\n    \}#s', $image, $m);
+$destroy = isset($m[0]) ? $m[0] : '';
+ntCheck($destroy !== '', 'Image::destroy() could not be isolated');
+ntCheck(
+    strpos($destroy, "getClass('TaskManager')") !== false
+    && strpos($destroy, '->cancel(') !== false,
+    'deleting an image no longer cancels the tasks still queued against it, '
+    . 'so each one is left pointing at an image row that does not exist'
+);
+ntCheck(
+    strpos($destroy, 'getQueuedStates()') !== false
+    && strpos($destroy, 'getProgressState()') !== false,
+    'the image delete no longer restricts itself to live tasks'
+);
+/*
+ * The half that is easy to lose. A host delete takes its tasks with it
+ * because the subject of that history is gone; an image delete must NOT,
+ * because the hosts survive and their finished tasks are still their imaging
+ * record.
+ */
+ntCheck(
+    strpos($destroy, "getClass('TaskManager')->destroy") === false
+    && strpos($destroy, "getClass('TaskManager')\n            ->destroy")
+    === false,
+    'the image delete removes task rows outright rather than cancelling '
+    . 'them, which throws away the imaging history of hosts that survive'
+);
+/*
+ * And it has to find them by the image being deleted, not by anything wider.
+ */
+ntCheck(
+    preg_match(
+        "#getSubObjectIDs\(\s*'Task',.*?'imageID' => \\\$this->get\('id'\)#s",
+        $destroy
+    ) === 1,
+    'the image delete no longer scopes the cancellation to the tasks '
+    . 'pointing at THIS image'
+);
+
+// ---------------------------------------------------------------
+// 3. Group deploy gives each host ITS OWN image.
+// ---------------------------------------------------------------
+preg_match(
+    '#public function createImagePackage\(.*?\n    \}#s',
+    $group,
+    $m
+);
+$package = isset($m[0]) ? $m[0] : '';
+ntCheck($package !== '', 'createImagePackage() could not be isolated');
+ntCheck(
+    strpos($package, '$imageMap[$Host->get(\'id\')]') !== false,
+    'the group deploy no longer maps each host id to its own image, so the '
+    . 'image list is zipped positionally against the host list again'
+);
+ntCheck(
+    preg_match('#\$imageIDs\[\$i\]#', $package) === 0,
+    'the group deploy indexes a flat image list by host position. The two '
+    . 'lists are ordered differently and a host with no image shortens one '
+    . 'of them, so the tail of the group is tasked with image 0'
+);
+
+// ---------------------------------------------------------------
+// 4. The imaging log is written BEFORE the task is marked Complete.
+// ---------------------------------------------------------------
+preg_match('#public function checkout\(\).*?\n    \}#s', $queue, $m);
+$checkout = isset($m[0]) ? $m[0] : '';
+ntCheck($checkout !== '', 'TaskQueue::checkout() could not be isolated');
+$logPos = strpos($checkout, '$this->imageLog(false)');
+$savePos = strpos($checkout, '$this->Task->save()');
+ntCheck(
+    $logPos !== false && $savePos !== false && $logPos < $savePos,
+    'checkout() marks the task Complete before writing the imaging log. A '
+    . 'failure writing the log then throws with the task already finished, '
+    . 'so FOS retries forever against a task that no longer exists and the '
+    . 'host is told "No Active Task found for Host" after imaging perfectly'
+);
+
+/*
+ * And the no-open-log branch has to be able to succeed. ImagingLog declares
+ * hostID, start and image required, so setting only `finish` on a row that
+ * had to be created could ONLY ever fail.
+ */
+preg_match('#protected function imageLog\(.*?\n    \}#s', $element, $m);
+$imageLog = isset($m[0]) ? $m[0] : '';
+ntCheck($imageLog !== '', 'imageLog() could not be isolated');
+ntCheck(
+    strpos($imageLog, '->isValid()') !== false
+    && strpos($imageLog, "->set('hostID'") !== false
+    && strpos($imageLog, "->set('start'") !== false
+    && strpos($imageLog, "->set('image'") !== false,
+    'imageLog()\'s checkout branch no longer completes a row it had to '
+    . 'create. ImagingLog requires hostID, start and image, so setting only '
+    . 'finish is a guaranteed "Failed to update imaging log"'
+);
+
+ntCheck(
+    strlen($man) > 10000
+    && strlen($image) > 5000
+    && strlen($group) > 10000
+    && strlen($queue) > 5000
+    && strlen($element) > 5000,
+    'the scan did not reach the sources and would pass vacuously'
+);
+
+if (count($failures) > 0) {
+    echo 'FAIL null-tasks-cannot-be-created-or-stranded ('
+        . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS null-tasks-cannot-be-created-or-stranded ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
dev-branch port of #1389, plus two defects that exist only on this branch.

Forum topics [18228](https://forums.fogproject.org/topic/18228/failed-to-update-database-and-host) and [18230](https://forums.fogproject.org/topic/18230/1-5-10-2402-additional-null-tasks-created-but-this-time-manages-to-start-a-transfer) both report the same thing: rows in Active Tasks with nothing in them — `() -` for hostname, `() -` for image, no MAC, no task-type icon — that never go away. Both reporters are on 1.5.10, so this branch is where they actually live.

## What a "null task" actually is

A `tasks` row whose `taskHostID` / `taskImageID` / `taskTypeID` match no row, while `taskStateID` still does.

* `taskStateID` resolving is what makes it **permanent**: every "is this task live" test in the tree is an allowlist of `getQueuedStates()` plus `getProgressState()`, so the row counts as active forever. Nothing reaps it, and no host can finish it — `TaskingElement` cannot build the Image or the Host, so the machine is turned away at check-in.
* The other three not resolving is what makes it **unreadable**. `FOGController::buildQuery()` joins the related tables with `LEFT OUTER JOIN`, so the row comes back with `NULL` in every host/image/type column; the Active Tasks template guards each cell with `isset()`, which is false for `NULL`. Hence `() -`, and hence no name to act on.

## Ported from #1389

**1. `insertBatch()` enforces the required-foreign-key contract `save()` already enforces.**

`FOGController::save()` refuses a required `*ID` that is not an integer >= 1. `FOGManagerController::insertBatch()` enforced nothing, so the same model was validated one row at a time and unvalidated a hundred rows at a time. What gets through is a `0` — legal to the server under any `sql_mode`, and exactly what a caller indexing a positional list past its end produces.

Deliberately narrow: only columns the caller **named**, only `*ID` columns, never the model's own auto-increment `id`, never a key the model has opted out of via `$databaseFieldsNotInt`. That last one needed `FOGManagerController`'s constructor to start pulling `$databaseFieldsNotInt` off its model — it was the one entry missing from `$classGet`.

**2. `insertBatch()` can write more than one row again.**

GH-1245's backfill names its fill placeholder once, outside the row loop, then repeats that same `:_fill_0` in every `VALUES` tuple. PDODB sets `ATTR_EMULATE_PREPARES => false`, so a real server-side prepare answers `SQLSTATE[HY093] Invalid parameter number` to a named parameter used twice — **one row works, two do not**.

Every batch of two or more rows into a table with an unnamed `NOT NULL` column has been failing outright since GH-1245 landed. On this branch that includes **any group deploy of two or more hosts**, which the proof below reproduces against a real group. The fill columns are still worked out once; only their placeholders are now per row.

**3. Deleting an image cancels the tasks still queued against it.**

`Image::destroy()` reset `hosts.imageID` and removed the `imageassociation` rows and said nothing about `tasks`. That is the seam on this branch: `Route::deletemass()` here is a raw `DELETE` used only for association rows, so the UI's `FOGPage::deletePost()` and the API's `Route::delete()` both land on `destroy()`.

Cancelled, **not** deleted, unlike a host delete: the hosts survive an image delete and their finished tasks are still their imaging record. Through `TaskManager::cancel()`, which is what already reissues the host token, unwinds any multicast session behind the task and cancels the snapin jobs riding on it.

Reporter maxcarpone deleted an image record by hand in the first post of 18228.

## Only on this branch

**4. Group deploy tasked each host with somebody else's image.**

`Group::createImagePackage()`'s deploy branch built two lists and zipped them positionally:

```php
$hostIDs  = array_values($hostids);                     // membership order
$imageIDs = self::getSubObjectIDs('Host', ['id' => $hostIDs], 'imageID',
                                  false, 'AND', 'name', false, '');  // NAME order
...
$imageIDs[$i],
```

The two orders agree only by coincidence. Worse, a host with no image assigned shortens the image list, so `$imageIDs[$i]` is undefined for the tail of the group and writes a `0` into `taskImageID` — a null task, made by the product's own group tasking. Now mapped host id → image id, the way 1.6 does it.

**5. `TaskQueue::checkout()` marked the task Complete before it wrote the imaging log.**

So a failure writing that log threw *after* the task was already finished: FOS never saw `##`, retried, and from then on was answered "No Active Task found for Host" — on a machine that had imaged perfectly. Writing the log first means a failure leaves the task in progress, which is the truth, and FOS can retry.

That failure was also **guaranteed** on the no-open-log path. `imageLog(false)` falls back to `maxId([])` → `0` → a fresh `ImagingLog` with only `finish` set, while `ImagingLog` declares `hostID`, `start` and `image` required. `save()` could only ever refuse it. It now completes the row, taking the start time from the task's own `checkInTime` rather than `now` — a start equal to the finish would read as a zero-length deployment in the imaging report.

## Proof

Three scripts, each run against the live local 1.5 database from a shadow web root, and each shown failing first on an unpatched tree:

| Script | Patched | Unpatched |
|---|---|---|
| `prove_batch_fk_guard_15.php` | 13/13 | **6/13** — `hostID` 0 lands (0 → 1 rows), and the two-row batch dies `SQLSTATE[HY093]` |
| `prove_image_delete_cancels_tasks_15.php` | 6/6 | **5/6** — `the queued task is Cancelled, not left Queued -- state is 1` |
| `prove_group_deploy_image_map_15.php` | 8/8 | **4/8** — group deploy of two hosts dies `HY093`; with only the manager fixed, **6/8** and the two hosts get each other's images |

The group script builds its fixture so id order and name order deliberately disagree (`zz-nt-b` gets the lower id, `zz-nt-a` sorts first), which is what makes the positional zip visible. All three create and remove their own throwaway rows and touch nothing that was already there; hosts carry locally-administered MACs.

`tests/null-tasks-cannot-be-created-or-stranded.test.php` (24 checks) pins the mechanism; all 17 of its gates are mutation-verified. `tests/insertbatch-required-columns.test.php` is updated for the per-row placeholder and still passes. Whole suite: **38 passed, 0 failed**.

## Not in this PR

A reaper for tasks that are *already* stranded on an existing install. Whether it should match on `0` or on a deleted id depends on what the reporters' rows actually contain, and I have asked for that.

## Downstream

None. No route class added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
