### PR TITLE
Reap the tasks that can never run, and say why

### DIFF
--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -321,7 +321,14 @@ class TaskLog extends FOGController
             $values[] = [
                 (int)$row['taskID'],
                 (int)$row['stateID'],
-                self::$remoteaddr,
+                // Cast, because there is no remote address in a daemon.
+                // filter_input(INPUT_SERVER, 'REMOTE_ADDR') is null under CLI,
+                // `ip` is varchar(15) NOT NULL, and a null bound into a NOT
+                // NULL column is error 1048 on a strict server -- which is
+                // every server since GH-1245 stopped PDODB clearing sql_mode.
+                // TaskManager::cancel() is reached from the multicast manager
+                // and from TaskManager::reapUnrunnable(), both daemons.
+                (string)self::$remoteaddr,
                 $now,
                 (string)$row['createdBy'],
                 self::TYPE_STATE,

--- a/packages/web/lib/fog/taskmanager.class.php
+++ b/packages/web/lib/fog/taskmanager.class.php
@@ -139,6 +139,237 @@ class TaskManager extends FOGManagerController
             self::getClass('MulticastSessionManager')->cancel($MulticastSessionIDs);
         }
     }
+    /**
+     * Moves active tasks that can never run to Failed, and says why.
+     *
+     * THE ROWS THIS IS FOR. A task whose taskHostID, taskTypeID or -- for an
+     * imaging type -- taskImageID matches no row is permanent and unreadable
+     * at the same time. taskStateID still resolves, so every "is this task
+     * live" test in the tree is an allowlist of getQueuedStates() plus
+     * getProgressState() and counts it as active forever. The Active Tasks
+     * list renders each cell from buildQuery()'s LEFT OUTER JOINs and guards
+     * it with isset(), which is false for the NULL a non-matching join
+     * returns, so the row draws as "() -" with no type icon and no MAC. No
+     * host can complete it -- TaskingElement cannot build the Image or the
+     * Host, so the machine is turned away at check-in -- and until now
+     * nothing reaped it. Reported as "null tasks" in forum topics 18228 and
+     * 18230.
+     *
+     * The write paths that produced them are closed separately; this is for
+     * the rows an install is already carrying, which no code change can
+     * reach. It runs from the task scheduler, so an install fixes itself
+     * without anyone being told to run SQL.
+     *
+     * RESOLUTION, NOT ZERO. A dangling reference is found by asking whether
+     * it joins, which is true of a 0 and of the id of something deleted
+     * alike -- there is no need to know which, and matching on 0 would be
+     * wrong twice over. It would miss every task pointing at a deleted row,
+     * and it would sweep up perfectly good tasking: a wipe, snapin, hardware
+     * inventory, password reset or Secure Boot task has no image by design
+     * and stores taskImageID 0. Confirmed on a live install carrying three
+     * such rows -- two All Snapins, one Enroll Secure Boot -- every one of
+     * them correct. So the image is only asked about for an imaging type.
+     *
+     * FAILED, NOT CANCELLED. Cancelled means an administrator stopped it.
+     * Losing the difference between "somebody stopped this" and "this broke"
+     * is exactly the distinction an operator needs at the moment they are
+     * looking at the task list. Same reasoning as TaskState::getFailedState()
+     * and TaskError::_markFailed(), and the Recent Tasks pane already has a
+     * Failed filter to show them in.
+     *
+     * NOTHING IS UNWOUND, unlike cancel(). A task that cannot resolve its
+     * host or its task type cannot have got past check-in -- TaskingElement
+     * builds both before anything else -- so there is no token to reissue, no
+     * multicast session behind it and no snapin job riding on it. Reaping is
+     * a state change plus its record, deliberately.
+     *
+     * @return array taskID => the reason it was reaped, empty if none were.
+     */
+    public function reapUnrunnable()
+    {
+        /*
+         * Guarded on the row actually existing rather than assuming schema
+         * 339 has run, exactly as TaskError::_markFailed() is. A web tree can
+         * be updated ahead of its database -- the ordinary state of an
+         * install between the files landing and the admin loading a page --
+         * and this runs from a daemon, which reaches that window before any
+         * person does. Pointing a task at a taskStates row that is not there
+         * renders blank and cannot be filtered for, which is worse than
+         * leaving it where it was for a few minutes.
+         */
+        $failed = (int)self::getFailedState();
+        if (!self::getClass('TaskState', $failed)->isValid()) {
+            return [];
+        }
+        $active = self::fastmerge(
+            (array)self::getQueuedStates(),
+            (array)self::getProgressState()
+        );
+        $active = array_map('intval', $active);
+        // Which type ids count as imaging, from the same constants
+        // TaskManagement's Recent Tasks pane groups on, so the two cannot
+        // drift into disagreeing about what has an image.
+        $imaging = array_unique(
+            array_merge(
+                TaskType::DEPLOYTASKS,
+                TaskType::CAPTURETASKS
+            )
+        );
+        $imaging = array_map('intval', $imaging);
+        /*
+         * Interpolated rather than bound, as TaskLog::recordStates() does
+         * with its task ids and sitescope.class.php with its site ids: every
+         * element has been through (int) above, and a bound IN list needs a
+         * placeholder per element.
+         *
+         * The three joins are the same three the Active Tasks list builds,
+         * which is what makes "does this row draw as () -" and "does this
+         * row get reaped" the same question rather than two that can drift.
+         */
+        $rows = self::$DB->query(
+            "SELECT `tasks`.`taskID` AS `taskID`, "
+            . "`tasks`.`taskHostID` AS `hostID`, "
+            . "`tasks`.`taskTypeID` AS `typeID`, "
+            . "`tasks`.`taskImageID` AS `imageID`, "
+            . "`tasks`.`taskCreateBy` AS `createdBy`, "
+            . "`tasks`.`taskStateID` AS `stateID`, "
+            . "`hosts`.`hostID` AS `hostFound`, "
+            . "COALESCE(`hosts`.`hostName`, '') AS `hostName`, "
+            . "`taskTypes`.`ttID` AS `typeFound`, "
+            . "COALESCE(`taskTypes`.`ttName`, '') AS `taskTypeName`, "
+            . "`images`.`imageID` AS `imageFound` "
+            . "FROM `tasks` "
+            . "LEFT OUTER JOIN `hosts` "
+            . "ON `hosts`.`hostID` = `tasks`.`taskHostID` "
+            . "LEFT OUTER JOIN `taskTypes` "
+            . "ON `taskTypes`.`ttID` = `tasks`.`taskTypeID` "
+            . "LEFT OUTER JOIN `images` "
+            . "ON `images`.`imageID` = `tasks`.`taskImageID` "
+            . "WHERE `tasks`.`taskStateID` IN (" . implode(',', $active) . ") "
+            . "AND ("
+            . "`hosts`.`hostID` IS NULL "
+            . "OR `taskTypes`.`ttID` IS NULL "
+            . "OR ("
+            . "`images`.`imageID` IS NULL "
+            . "AND `tasks`.`taskTypeID` IN (" . implode(',', $imaging) . ")"
+            . ")"
+            . ")"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        if (!count((array)$rows ?: [])) {
+            return [];
+        }
+
+        $reasons = [];
+        $logRows = [];
+        $now = self::niceDate()->format('Y-m-d H:i:s');
+        foreach ((array)$rows as $row) {
+            $why = [];
+            if (null === $row['hostFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('host no longer exists'),
+                    (int)$row['hostID']
+                );
+            }
+            if (null === $row['typeFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('task type no longer exists'),
+                    (int)$row['typeID']
+                );
+            }
+            if (null === $row['imageFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('image no longer exists'),
+                    (int)$row['imageID']
+                );
+            }
+            $text = sprintf(
+                '%s: %s',
+                _('Task can never run and was marked failed'),
+                implode(', ', $why)
+            );
+            $reasons[(int)$row['taskID']] = $text;
+            /*
+             * `ip` and `type` are set here because a batched INSERT never
+             * runs TaskLog's constructor, which is where a singly-written row
+             * gets both -- the same note recordStates() carries.
+             *
+             * TYPE_ERROR, not TYPE_STATE: the reason is the whole value of
+             * this row, and the log pane's DEFAULT filter is error plus
+             * warning. A state row saying only "Failed" against a task whose
+             * host is gone tells an operator nothing they can act on. The
+             * state transition itself is recorded separately, below, so the
+             * state pane is not missing it either.
+             *
+             * stateID is the state the task is being moved TO, so the row
+             * reads as the transition it accompanies.
+             */
+            $logRows[] = [
+                (int)$row['taskID'],
+                $failed,
+                (string)self::$remoteaddr,
+                $now,
+                (string)$row['createdBy'],
+                TaskLog::TYPE_ERROR,
+                $text,
+                (int)($row['hostFound'] ?: 0),
+                (string)$row['hostName'],
+                (string)$row['taskTypeName']
+            ];
+        }
+
+        $updated = $this->update(
+            ['id' => array_keys($reasons)],
+            '',
+            [
+                'stateID' => $failed,
+                'stateChangedTime' => $now
+            ]
+        );
+        if (!$updated) {
+            return [];
+        }
+        // The state row, so Task Management's state pane shows the transition
+        // like every other one. Read back from `tasks` after the update, as
+        // cancel() does, so what is recorded is what the row says now.
+        TaskLog::recordStates(array_keys($reasons));
+        /*
+         * Caught, because the reap has already happened. insertBatch() THROWS
+         * where save() returns false, and losing the reason is not worth
+         * turning a daemon pass into an exception once the tasks are already
+         * moved -- the same call recordStates() makes for the same reason.
+         */
+        try {
+            self::getClass('TaskLogManager')->insertBatch(
+                [
+                    'taskID',
+                    'stateID',
+                    'ip',
+                    'createdTime',
+                    'createdBy',
+                    'type',
+                    'text',
+                    'hostID',
+                    'hostName',
+                    'taskTypeName'
+                ],
+                $logRows
+            );
+        } catch (\Exception $e) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s',
+                    _('Failed to record why tasks were reaped'),
+                    _('Error'),
+                    $e->getMessage()
+                )
+            );
+        }
+
+        return $reasons;
+    }
 }
 
 /*

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -130,6 +130,58 @@ class TaskScheduler extends FOGService
                     self::wakeUp($hostMACs);
                 }
             }
+            /*
+             * The two housekeeping sweeps run BEFORE the "no tasks found"
+             * exit below, and that ordering is the point of moving them.
+             *
+             * That exit counts SCHEDULED and power-management tasks -- the
+             * two things the rest of this method acts on -- and throws when
+             * there are none, which ends the pass. The expired-check-in sweep
+             * sat after it, so on any install with no scheduled task and no
+             * power-management task it never ran at all. That is most small
+             * installs, and it is exactly the population reporting tasks
+             * stuck active forever. Neither sweep has anything to do with
+             * whether a schedule exists.
+             */
+            self::outall(
+                ' * '
+                . _('Checking for tasks that can never run...')
+            );
+            $reaped = self::getClass('TaskManager')->reapUnrunnable();
+            foreach ($reaped as $taskID => $why) {
+                self::outall(
+                    sprintf(
+                        ' * %s %d: %s',
+                        _('Marked failed, task'),
+                        $taskID,
+                        $why
+                    )
+                );
+            }
+            if (count($reaped ?: []) < 1) {
+                self::outall(' * ' . _('No unrunnable tasks found.'));
+            }
+            //check for expired check-ins on active Tasks
+            self::outall(
+                ' * '
+                . _('Checking for expired checked-in tasks...')
+            );
+            $used = explode(',', (string)self::getSetting('FOG_USED_TASKS'));
+            $find = [
+                'stateID' => self::getCheckedInState(),
+                'typeID' => $used
+            ];
+            $Tasks = Route::getList('task', $find);
+            foreach ($Tasks as $Task) {
+                if(self::getClass('Task', $Task->id)->expireTaskCheckin()) {
+                    self::outall(
+                        ' * '
+                        . _('Found an expired task, resetting to queued for task of id')
+                        . ': '
+                        . $Task->id
+                    );
+                }
+            }
             // asValue(), not getList(): both counts below come off the
             // envelope, so the envelope has to survive. What this buys is the
             // other half -- a failure raises instead of ending the daemon.
@@ -164,27 +216,6 @@ class TaskScheduler extends FOGService
                 )
             );
             unset($taskCount);
-            //check for expired check-ins on active Tasks
-            self::outall(
-                ' * '
-                . _('Checking for expired checked-in tasks...')
-            );
-            $used = explode(',', (string)self::getSetting('FOG_USED_TASKS'));
-            $find = [
-                'stateID' => self::getCheckedInState(),
-                'typeID' => $used
-            ];
-            $Tasks = Route::getList('task', $find);
-            foreach ($Tasks as $Task) {
-                if(self::getClass('Task', $Task->id)->expireTaskCheckin()) {
-                    self::outall(
-                        ' * '
-                        . _('Found an expired task, resetting to queued for task of id')
-                        . ': '
-                        . $Task->id
-                    );
-                }
-            }
             // Scheduled Tasks
             foreach ($ScheduledTasks->data as $Task) {
                 $Task = self::getClass('ScheduledTask', $Task->id);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1517,6 +1517,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
 
@@ -2728,6 +2731,10 @@ msgstr "Löschen der Datei fehlgeschlagen"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Fehler beim Erstellen eines Tasks"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Fehler beim Erstellen eines Tasks"
 
 #, fuzzy
@@ -4995,6 +5002,10 @@ msgid "Mark selected pending"
 msgstr "Ausgewählten MAcs freigeben"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Laden fehlgeschlagen: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -5583,6 +5594,10 @@ msgstr "Kein valides Image für diesen Host definiert"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8213,6 +8228,9 @@ msgstr "Task-Typen"
 msgid "Task activity"
 msgstr "Aktiv"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Laden fehlgeschlagen: %s"
@@ -9977,6 +9995,10 @@ msgid "host is"
 msgstr "Hosts"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "läuft nicht mehr"
+
+#, fuzzy
 msgid "hosts"
 msgstr "Hosts"
 
@@ -10046,6 +10068,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "Images"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "läuft nicht mehr"
 
 #, fuzzy
 msgid "image replication"
@@ -10416,6 +10442,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "Task gefunden"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr "läuft nicht mehr"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1520,6 +1520,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2729,6 +2732,10 @@ msgstr "Failed to delete file"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Failed to create task"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Failed to create task"
 
 #, fuzzy
@@ -4993,6 +5000,10 @@ msgid "Mark selected pending"
 msgstr "Approve selected Hosts"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Load failed: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "User update failed"
 
@@ -5581,6 +5592,10 @@ msgstr "No Image defined for this host"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "No valid class sent"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8208,6 +8223,9 @@ msgstr "Task Types"
 msgid "Task activity"
 msgstr "Active"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Load failed: %s"
@@ -9970,6 +9988,10 @@ msgid "host is"
 msgstr "host"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr " no longer exists"
+
+#, fuzzy
 msgid "hosts"
 msgstr "host"
 
@@ -10039,6 +10061,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "Images"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr " no longer exists"
 
 #, fuzzy
 msgid "image replication"
@@ -10407,6 +10433,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "task found"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr " no longer exists"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1536,6 +1536,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2778,6 +2781,10 @@ msgstr "No se pudo crear el usuario"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "No se pudo crear la tarea"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "No se pudo crear la tarea"
 
 #, fuzzy
@@ -5107,6 +5114,10 @@ msgid "Mark selected pending"
 msgstr "retirar"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Carga ha fallado: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "actualización Valoración falló"
 
@@ -5708,6 +5719,10 @@ msgstr "No se ha definido de este alojamiento imagen"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Ninguna clase válida enviado"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8395,6 +8410,9 @@ msgstr "Tipo de tarea"
 msgid "Task activity"
 msgstr "Activo"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Carga ha fallado: %s"
@@ -10156,6 +10174,10 @@ msgid "host is"
 msgstr "anfitrión"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "Impresora ya existe"
+
+#, fuzzy
 msgid "hosts"
 msgstr "anfitrión"
 
@@ -10227,6 +10249,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "Imagen"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "nombre de usuario ya existe"
 
 #, fuzzy
 msgid "image replication"
@@ -10592,6 +10618,9 @@ msgstr ""
 #, fuzzy
 msgid "task found"
 msgstr "tarea para"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1517,6 +1517,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
 
@@ -2728,6 +2731,10 @@ msgstr "Löschen der Datei fehlgeschlagen"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Fehler beim Erstellen eines Tasks"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Fehler beim Erstellen eines Tasks"
 
 #, fuzzy
@@ -4996,6 +5003,10 @@ msgid "Mark selected pending"
 msgstr "Ausgewählten MAcs freigeben"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Laden fehlgeschlagen: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -5584,6 +5595,10 @@ msgstr "Kein valides Image für diesen Host definiert"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8214,6 +8229,9 @@ msgstr "Task-Typen"
 msgid "Task activity"
 msgstr "Aktiv"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Laden fehlgeschlagen: %s"
@@ -9978,6 +9996,10 @@ msgid "host is"
 msgstr "Hosts"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "läuft nicht mehr"
+
+#, fuzzy
 msgid "hosts"
 msgstr "Hosts"
 
@@ -10047,6 +10069,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "Images"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "läuft nicht mehr"
 
 #, fuzzy
 msgid "image replication"
@@ -10417,6 +10443,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "Task gefunden"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr "läuft nicht mehr"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1521,6 +1521,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2731,6 +2734,10 @@ msgstr "Impossible de supprimer le fichier"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Impossible de créer la tâche"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Impossible de créer la tâche"
 
 #, fuzzy
@@ -4995,6 +5002,10 @@ msgid "Mark selected pending"
 msgstr "Approuver hôtes sélectionnés"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Échec du chargement: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
@@ -5583,6 +5594,10 @@ msgstr "Pas d'image définie pour cet hôte"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Aucune classe valide envoyé"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8210,6 +8225,9 @@ msgstr "Types de tâches"
 msgid "Task activity"
 msgstr "actif"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Échec du chargement: %s"
@@ -9972,6 +9990,10 @@ msgid "host is"
 msgstr "hôte"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr " n'existe plus"
+
+#, fuzzy
 msgid "hosts"
 msgstr "hôte"
 
@@ -10041,6 +10063,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "Images"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr " n'existe plus"
 
 #, fuzzy
 msgid "image replication"
@@ -10409,6 +10435,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "tâche trouvée"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr " n'existe plus"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1477,6 +1477,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Controllare se sono il responsabile del gruppo"
 
@@ -2655,6 +2658,10 @@ msgstr "Impossibile eliminare il file"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Impossibile creare un'attività"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Impossibile creare un'attività"
 
 #, fuzzy
@@ -4826,6 +4833,10 @@ msgid "Mark selected pending"
 msgstr "Approvare MAC selezionati"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Caricamento non riuscito"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aggiornamento ruolo non riuscito"
 
@@ -5401,6 +5412,10 @@ msgstr "Nessuna Imagine valida definita per questo host"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Non sono stati trovati compiti validi"
 
 msgid "No valid storage nodes found"
 msgstr "Nessun nodo di archiviazione valido trovato"
@@ -7931,6 +7946,9 @@ msgstr "Tipi di attività"
 msgid "Task activity"
 msgstr "Attivo"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Caricamento non riuscito"
@@ -9636,6 +9654,10 @@ msgstr "host"
 msgid "host is"
 msgstr "hosts"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "non è più in esecuzione"
+
 msgid "hosts"
 msgstr "hosts"
 
@@ -9701,6 +9723,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "immagini"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "non è più in esecuzione"
 
 msgid "image replication"
 msgstr "replica dell'immagine"
@@ -10050,6 +10076,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "compito trovato"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr "non è più in esecuzione"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1460,6 +1460,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "自身がグループマネージャーか確認しています"
 
@@ -2633,6 +2636,10 @@ msgstr "ファイルの削除に失敗しました"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "タスクの作成に失敗しました"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "タスクの作成に失敗しました"
 
 #, fuzzy
@@ -4782,6 +4789,10 @@ msgid "Mark selected pending"
 msgstr "選択したスナップインを追加"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "読み込みに失敗しました"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "ホストの更新に失敗しました"
 
@@ -5360,6 +5371,10 @@ msgstr "このホストを認証するためのトークンが渡されていま
 #, fuzzy
 msgid "No type information available for this column."
 msgstr "このグループで利用可能なアクティビティ情報はありません"
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "新しいタスクは見つかりません"
 
 msgid "No valid storage nodes found"
 msgstr "有効なストレージノードが見つかりません"
@@ -7868,6 +7883,9 @@ msgstr "タスクタイプ"
 msgid "Task activity"
 msgstr "有効"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "タスク実行に失敗しました"
@@ -9573,6 +9591,10 @@ msgstr "ホスト"
 msgid "host is"
 msgstr "ホスト"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "選択したプリンターを追加"
+
 msgid "hosts"
 msgstr "ホスト"
 
@@ -9639,6 +9661,10 @@ msgstr "イメージファイルが見つかりました。ファイル: "
 #, fuzzy
 msgid "image is"
 msgstr "イメージ"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "選択したプリンターを追加"
 
 msgid "image replication"
 msgstr "イメージレプリケーション"
@@ -9989,6 +10015,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "タスクが見つかりました"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr "選択したプリンターを追加"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"
@@ -12469,10 +12499,6 @@ msgstr ""
 
 #~ msgid "no login will appear"
 #~ msgstr "ログイン画面は表示されません"
-
-#, fuzzy
-#~ msgid "no longer exists"
-#~ msgstr "選択したプリンターを追加"
 
 #~ msgid "of"
 #~ msgstr "の"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1300,6 +1300,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2331,6 +2334,9 @@ msgid "Failed to move uploaded file."
 msgstr ""
 
 msgid "Failed to record task state changes"
+msgstr ""
+
+msgid "Failed to record why tasks were reaped"
 msgstr ""
 
 msgid "Failed to remove"
@@ -4229,6 +4235,9 @@ msgstr ""
 msgid "Mark selected pending"
 msgstr ""
 
+msgid "Marked failed, task"
+msgstr ""
+
 msgid "Mass update failed"
 msgstr ""
 
@@ -4736,6 +4745,9 @@ msgid "No token passed to authenticate this host"
 msgstr ""
 
 msgid "No type information available for this column."
+msgstr ""
+
+msgid "No unrunnable tasks found."
 msgstr ""
 
 msgid "No valid storage nodes found"
@@ -6958,6 +6970,9 @@ msgstr ""
 msgid "Task activity"
 msgstr ""
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task failed"
 msgstr ""
 
@@ -8506,6 +8521,9 @@ msgstr ""
 msgid "host is"
 msgstr ""
 
+msgid "host no longer exists"
+msgstr ""
+
 msgid "hosts"
 msgstr ""
 
@@ -8561,6 +8579,9 @@ msgid "image file found, file"
 msgstr ""
 
 msgid "image is"
+msgstr ""
+
+msgid "image no longer exists"
 msgstr ""
 
 msgid "image replication"
@@ -8894,6 +8915,9 @@ msgid "supports FOG up to %s; this server is %s"
 msgstr ""
 
 msgid "task found"
+msgstr ""
+
+msgid "task type no longer exists"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1520,6 +1520,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2730,6 +2733,10 @@ msgstr "Falha ao excluir arquivo"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "Falha ao criar tarefa"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "Falha ao criar tarefa"
 
 #, fuzzy
@@ -4994,6 +5001,10 @@ msgid "Mark selected pending"
 msgstr "Aprovar Hosts selecionados"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Carga falhou: %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "atualização do utilizador falhou"
 
@@ -5582,6 +5593,10 @@ msgstr "Sem Imagem definida para este alojamento"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Nenhuma classe válida enviada"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8209,6 +8224,9 @@ msgstr "Tipos de tarefa"
 msgid "Task activity"
 msgstr "Ativo"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "Carga falhou: %s"
@@ -9971,6 +9989,10 @@ msgid "host is"
 msgstr "anfitrião"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr " não existe mais"
+
+#, fuzzy
 msgid "hosts"
 msgstr "anfitrião"
 
@@ -10040,6 +10062,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "imagens"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr " não existe mais"
 
 #, fuzzy
 msgid "image replication"
@@ -10408,6 +10434,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "tarefa encontrados"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr " não existe mais"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1520,6 +1520,9 @@ msgstr ""
 msgid "Checking for expired checked-in tasks..."
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2730,6 +2733,10 @@ msgstr "无法删除文件"
 
 #, fuzzy
 msgid "Failed to record task state changes"
+msgstr "无法创建任务"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
 msgstr "无法创建任务"
 
 #, fuzzy
@@ -4994,6 +5001,10 @@ msgid "Mark selected pending"
 msgstr "批准选定主机"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "加载失败： %s"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "用户更新失败"
 
@@ -5582,6 +5593,10 @@ msgstr "没有找到主机定义图片"
 
 msgid "No type information available for this column."
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "发送无有效类"
 
 #, fuzzy
 msgid "No valid storage nodes found"
@@ -8209,6 +8224,9 @@ msgstr "任务类型"
 msgid "Task activity"
 msgstr "活性"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task failed"
 msgstr "加载失败： %s"
@@ -9971,6 +9989,10 @@ msgid "host is"
 msgstr "主办"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "不复存在"
+
+#, fuzzy
 msgid "hosts"
 msgstr "主办"
 
@@ -10040,6 +10062,10 @@ msgstr ""
 #, fuzzy
 msgid "image is"
 msgstr "图片"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "不复存在"
 
 #, fuzzy
 msgid "image replication"
@@ -10408,6 +10434,10 @@ msgstr ""
 
 msgid "task found"
 msgstr "发现任务"
+
+#, fuzzy
+msgid "task type no longer exists"
+msgstr "不复存在"
 
 #, fuzzy, php-format
 msgid "terminating so it can be restarted"

--- a/tests/unrunnable-tasks-are-reaped.test.php
+++ b/tests/unrunnable-tasks-are-reaped.test.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * A task that can never run must not sit in Active Tasks forever.
+ *
+ * THE ROWS. A `tasks` row whose taskHostID, taskTypeID or -- for an imaging
+ * type -- taskImageID matches no row is permanent and unreadable at the same
+ * time. taskStateID still resolves, so every "is this task live" test in the
+ * tree is an allowlist of getQueuedStates() plus getProgressState() and counts
+ * it as active. The Active Tasks list renders each cell from buildQuery()'s
+ * LEFT OUTER JOINs and guards it with isset(), which is false for the NULL a
+ * non-matching join returns, so the row draws as "() -" with no type icon and
+ * no MAC. No host can complete it, and nothing reaped it. Reported as "null
+ * tasks" in forum topics 18228 and 18230.
+ *
+ * The write paths that create such a row are closed elsewhere. What this pins
+ * is the sweep for the rows an install is ALREADY carrying, which no code
+ * change can reach.
+ *
+ * THE TWO CHECKS THAT MATTER MOST, because getting either wrong is worse than
+ * not having the sweep at all:
+ *
+ *   - It must find rows by whether they JOIN, not by whether a column is 0. A
+ *     0 and the id of something deleted are both dangling and both have to go;
+ *     matching on 0 would miss every deleted-id case AND destroy good tasking,
+ *     because a wipe, snapin, inventory, password-reset or Secure Boot task
+ *     legitimately stores taskImageID 0.
+ *   - The image is therefore only asked about for an IMAGING task type.
+ *
+ * DB-free: this reads the source. The behaviour is proved against a live
+ * database by background_scripts/prove_unrunnable_task_reaper.php, which fails
+ * on an unpatched tree.
+ *
+ * Usage: php tests/unrunnable-tasks-are-reaped.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+/**
+ * Source with comments removed, so a commented-out line can neither satisfy
+ * a check nor fail one -- these files carry long docblocks that name the very
+ * things being grepped for.
+ *
+ * @param string $file the file to read
+ *
+ * @return string
+ */
+function reapStrip($file)
+{
+    $clean = '';
+    foreach (token_get_all((string)file_get_contents($file)) as $token) {
+        if (is_array($token)
+            && (T_COMMENT === $token[0] || T_DOC_COMMENT === $token[0])
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    return $clean;
+}
+
+function check($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+$man = reapStrip("$root/packages/web/lib/fog/taskmanager.class.php");
+$log = reapStrip("$root/packages/web/lib/fog/tasklog.class.php");
+$sched = reapStrip("$root/packages/web/lib/service/taskscheduler.class.php");
+
+/* ------------------------------------------------------------- 1. the sweep */
+
+$reap = '';
+if (preg_match('/public function reapUnrunnable\(\).*?\n    \}/s', $man, $m)) {
+    $reap = $m[0];
+}
+check(
+    'TaskManager has a sweep for unrunnable tasks',
+    '' !== $reap,
+    $failures,
+    $checks
+);
+
+/*
+ * The schema guard. This runs from a daemon, which reaches the window between
+ * the files landing and the database being upgraded before any person does.
+ * Pointing a task at a taskStates row that is not there renders blank and
+ * cannot be filtered for -- worse than leaving it where it was.
+ */
+check(
+    'it refuses to run until the Failed state row exists',
+    1 === preg_match(
+        "/getClass\('TaskState',\s*\\\$failed\)->isValid\(\)/",
+        $reap
+    ),
+    $failures,
+    $checks
+);
+
+check(
+    'it only considers tasks FOG still counts as active',
+    false !== strpos($reap, 'getQueuedStates()')
+    && false !== strpos($reap, 'getProgressState()'),
+    $failures,
+    $checks
+);
+
+/* ------------------------------------------ 2. resolution, not zero */
+
+/*
+ * The load-bearing one. Three LEFT OUTER JOINs and three IS NULL tests: that
+ * is the same question the Active Tasks list asks when it draws "() -", so
+ * "is this row unreadable" and "is this row reaped" cannot drift apart.
+ */
+foreach (['hosts', 'taskTypes', 'images'] as $table) {
+    check(
+        "it LEFT OUTER JOINs `$table` to ask whether the reference resolves",
+        1 === preg_match(
+            '/LEFT OUTER JOIN `' . $table . '`/',
+            $reap
+        ),
+        $failures,
+        $checks
+    );
+}
+check(
+    'and selects on the join failing, not on the column being 0',
+    3 === preg_match_all('/IS NULL/', $reap)
+    && 0 === preg_match('/`task(Host|Type|Image)ID`\s*=\s*0/', $reap),
+    $failures,
+    $checks
+);
+
+/*
+ * The one that protects good data. taskImageID 0 is CORRECT for every task
+ * type that has no image -- proven on a live install carrying three such rows,
+ * two All Snapins and one Enroll Secure Boot. Asking about the image without
+ * gating on the type would fail all of them.
+ */
+check(
+    'the image is only asked about for an imaging task type',
+    1 === preg_match(
+        '/`images`\.`imageID` IS NULL.*?AND.*?`tasks`\.`taskTypeID` IN/s',
+        $reap
+    ),
+    $failures,
+    $checks
+);
+check(
+    'and "imaging" comes from TaskType, not a list written down here',
+    false !== strpos($reap, 'TaskType::DEPLOYTASKS')
+    && false !== strpos($reap, 'TaskType::CAPTURETASKS'),
+    $failures,
+    $checks
+);
+
+/* ---------------------------------------------------- 3. what it writes */
+
+/*
+ * Failed, not Cancelled. Cancelled means an administrator stopped it; losing
+ * the difference between "somebody stopped this" and "this broke" is the
+ * distinction an operator needs at the moment they are reading the task list.
+ */
+check(
+    'it moves the task to Failed',
+    false !== strpos($reap, 'getFailedState()'),
+    $failures,
+    $checks
+);
+check(
+    'and never to Cancelled',
+    false === strpos($reap, 'getCancelledState()'),
+    $failures,
+    $checks
+);
+
+check(
+    'it records the state transition like every other one',
+    false !== strpos($reap, 'TaskLog::recordStates('),
+    $failures,
+    $checks
+);
+
+/*
+ * And the reason, as a separate row. A state row saying only "Failed" against
+ * a task whose host is gone tells an operator nothing they can act on, and the
+ * log pane's DEFAULT filter is error plus warning -- so an error row is the
+ * one that is actually seen.
+ */
+check(
+    'it writes the reason into the log',
+    false !== strpos($reap, 'TaskLog::TYPE_ERROR')
+    && false !== strpos($reap, "'text',"),
+    $failures,
+    $checks
+);
+check(
+    'the reason names which reference did not resolve',
+    false !== strpos($reap, "_('host no longer exists')")
+    && false !== strpos($reap, "_('task type no longer exists')")
+    && false !== strpos($reap, "_('image no longer exists')"),
+    $failures,
+    $checks
+);
+
+/*
+ * A batched INSERT never runs TaskLog's constructor, which is where a singly
+ * written row gets its ip and its type -- so a reaped row must set both or it
+ * is distinguishable from every other row for no reason.
+ */
+check(
+    'the batched rows carry the ip and type the constructor would have set',
+    false !== strpos($reap, "'ip',")
+    && false !== strpos($reap, "'type',"),
+    $failures,
+    $checks
+);
+
+/*
+ * There is no REMOTE_ADDR in a daemon: filter_input(INPUT_SERVER,
+ * 'REMOTE_ADDR') is null under CLI, `ip` is varchar(15) NOT NULL, and a null
+ * bound into a NOT NULL column is error 1048 on a strict server -- which is
+ * every server since GH-1245. save() coerces this for a single row;
+ * insertBatch() does not, so both batched writers have to cast.
+ */
+foreach (['reap' => $reap, 'recordStates' => $log] as $where => $src) {
+    check(
+        "the batched write in $where casts the remote address to a string",
+        0 === preg_match('/[^)]self::\$remoteaddr,/', $src),
+        $failures,
+        $checks
+    );
+}
+
+/* ------------------------------------------------- 4. it actually runs */
+
+check(
+    'the task scheduler runs the sweep',
+    false !== strpos($sched, 'reapUnrunnable()'),
+    $failures,
+    $checks
+);
+
+/*
+ * ORDER IS THE POINT. The "No tasks found!" exit counts SCHEDULED and
+ * power-management tasks and throws when there are none, ending the pass. Both
+ * housekeeping sweeps used to sit after it, so on any install with no schedule
+ * they never ran -- which is most small installs, and exactly the population
+ * reporting tasks stuck active forever.
+ */
+$reapPos = strpos($sched, 'reapUnrunnable()');
+$expirePos = strpos($sched, 'expireTaskCheckin()');
+$throwPos = strpos($sched, 'No tasks found!');
+check(
+    'the "no scheduled tasks" exit was found',
+    false !== $throwPos,
+    $failures,
+    $checks
+);
+check(
+    'the sweep runs BEFORE the "no scheduled tasks" exit',
+    false !== $reapPos && false !== $throwPos && $reapPos < $throwPos,
+    $failures,
+    $checks
+);
+check(
+    'and so does the expired-check-in sweep, which used to be skipped with it',
+    false !== $expirePos && false !== $throwPos && $expirePos < $throwPos,
+    $failures,
+    $checks
+);
+
+check(
+    'the scan reached the sources and did not pass vacuously',
+    strlen($man) > 4000 && strlen($log) > 4000 && strlen($sched) > 4000,
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
#1389 closes the write paths that create a task pointing at nothing. This is the other half: the rows an install is **already** carrying, which no code change can reach.

Independent of #1389 — different files, no shared lines, either can merge first.

## The rows

A `tasks` row whose `taskHostID`, `taskTypeID` or — for an imaging type — `taskImageID` matches no row is permanent and unreadable at the same time.

* `taskStateID` still resolves, so every "is this task live" test in the tree is an allowlist of `getQueuedStates()` plus `getProgressState()` and counts it as active **forever**.
* The other three do not, so the Active Tasks list's `LEFT OUTER JOIN`s return `NULL`, its `isset()` guards draw the row as `() -` with no type icon and no MAC, and there is not even a name to act on.
* No host can complete it either — `TaskingElement` cannot build the Image or the Host, so the machine is turned away at check-in.

Forum topics [18228](https://forums.fogproject.org/topic/18228/failed-to-update-database-and-host) and [18230](https://forums.fogproject.org/topic/18230/1-5-10-2402-additional-null-tasks-created-but-this-time-manages-to-start-a-transfer).

## `TaskManager::reapUnrunnable()`

Moves those to Failed and records why. It runs from the task scheduler, so an install fixes itself rather than an admin being told to run SQL.

**Resolution, not zero.** A dangling reference is found by asking whether it **JOINs**, which is true of a `0` and of the id of something deleted alike. Matching on `0` would be wrong twice over:

* it would miss every task pointing at a *deleted* row, and
* it would destroy good tasking — a wipe, snapin, hardware inventory, password reset or Secure Boot task has no image **by design** and stores `taskImageID` 0.

Confirmed against a live install carrying three such rows — two `All Snapins`, one `Enroll Secure Boot` — every one of them correct. So the image is only asked about for an imaging task type, and "imaging" is `TaskType::DEPLOYTASKS` plus `CAPTURETASKS`, the same constants TaskManagement's Recent Tasks pane groups on, rather than a second list that can drift.

The three joins are the same three the Active Tasks list builds, which is what makes "does this row draw as `() -`" and "does this row get reaped" one question instead of two.

**Failed, not Cancelled.** Cancelled means an administrator stopped it. Losing the difference between "somebody stopped this" and "this broke" is exactly the distinction an operator needs at the moment they are looking at the task list. Guarded on the `taskStates` row for Failed actually existing, as `TaskError::_markFailed()` is — this runs from a daemon, which reaches the window between the files landing and the database being upgraded before any person does.

**Two log rows per reaped task.** The state transition through `TaskLog::recordStates()`, so the state pane shows it like every other one; and a `TYPE_ERROR` row naming which reference did not resolve, because that is the whole value here and the log pane's *default* filter is error plus warning. A state row saying only "Failed" against a task whose host is gone tells an operator nothing they can act on.

**Nothing is unwound**, unlike `cancel()`. A task that cannot resolve its host or its task type cannot have got past check-in, so there is no token to reissue, no multicast session behind it and no snapin job riding on it.

## Two things this pass had to fix to work at all

**1. The scheduler's housekeeping sweeps never ran on most installs.**

`TaskScheduler::_commonOutput()` counts **scheduled** and power-management tasks and throws `' * No tasks found!'` when there are none, which ends the pass:

```php
$taskCount = $staskcount + $ptaskcount;
if ($taskCount <= 0) {
    throw new \Exception(' * No tasks found!');
}
...
//check for expired check-ins on active Tasks     <-- never reached
```

So the expired-check-in sweep has never run on an install with no scheduled task and no power-management task. That is most small installs, and it is exactly the population reporting tasks stuck active forever. Both sweeps now run before that exit; the change is a reordering, not a logic change, and neither sweep has anything to do with whether a schedule exists.

**2. `TaskLog::recordStates()` now casts the remote address.**

There is none in a daemon: `filter_input(INPUT_SERVER, 'REMOTE_ADDR')` is `null` under CLI, `ip` is `varchar(15) NOT NULL`, and a null bound into a NOT NULL column is error 1048 on any strict server — which is every server since GH-1245 stopped PDODB clearing `sql_mode`. `save()` coerces this for a single row; `insertBatch()` does not. `TaskManager::cancel()` already reaches that line from the multicast manager, so this is a live crash, not only a new one.

## Proof

`background_scripts/prove_unrunnable_task_reaper.php`, against the live 1.6 database from a shadow web root: **17/17**. Built around what must **not** be reaped, because that is the expensive way to get this wrong:

| fixture | expected | result |
|---|---|---|
| A — active, host deleted | reaped → Failed | ✅ |
| B — active, task type deleted | reaped → Failed | ✅ |
| C — active Deploy, image deleted | reaped → Failed | ✅ |
| **D — active All Snapins, `imageID` 0** | **left alone** | ✅ |
| **E — active, everything resolves** | **left alone** | ✅ |
| **F — Complete, host since deleted** | **left alone** | ✅ |

Plus: the reasons name the right reference for each, both log rows land with the Failed state, the error rows carry the host name where there is one to carry, and a second pass finds nothing to do — the sweep is idempotent. On the unpatched tree the method does not exist, and the fixture tasks stay Queued.

`tests/unrunnable-tasks-are-reaped.test.php` (22 checks) pins the mechanism; all 16 of its gates are mutation-verified, including the two that matter most — matching on `imageID = 0` instead of the join, and asking about the image for every task type. Whole suite: **162 passed, 0 failed**.

## Related issues

* **#1378** — task-log truthfulness. Its causes 1 and 2 are already fixed on this branch (`TaskLog::recordState()`/`recordStates()`, wired into `Task::cancel()` and `TaskManager::cancel()`, stamping the transition time). What remains open here is its cause 3, the pre-373 state rows whose task is already gone. It is still fully unfixed on `dev-branch`.
* **#895** — closed, but its own tail says "pre-existing rows are data and need a sweep" for the `snapintask` orphans left behind before that fix. Same shape as this sweep, different table; not in this PR.
* **#1380** — also a task that never reaches Complete, but its references all resolve, so this sweep does not and should not touch it. Different mechanism, same reported symptom.

## Downstream

None. No route class added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
