### PR TITLE
Allow elliptic curve root CAs

### DIFF
--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -166,6 +166,20 @@ The installer (working-1.6 and later) can sign FOG's server certificate with a C
 | `--ca-key`  | Intermediate CA **private key** (PEM) | Must match `--ca-cert` |
 | `--ca-root` | **Root** CA certificate (PEM) | `--ca-cert` must verify against this |
 
+**Key algorithms.** Any key OpenSSL can load is accepted -- RSA, RSA-PSS, EC on
+any curve, Ed25519, Ed448 -- because the installer pairs `--ca-key` to
+`--ca-cert` by comparing public keys rather than RSA moduli. The one refusal is
+**DSA**, which TLS 1.3 removed and no current browser trusts.
+
+Accepted is not the same as usable everywhere, though, and the narrow verifier
+is iPXE's. The imported CA is compiled into the iPXE binary, and iPXE verifies
+**RSA and ECDSA P-256/P-384 signatures only** -- no P-521, no Ed25519/Ed448, no
+RSA-PSS. A CA outside that set serves the web UI and satisfies fog-client
+normally, then fails HTTPS netboot at `boot.php`; the installer prints a note
+saying so at import time. See [How iPXE validates
+HTTPS](#how-ipxe-validates-https). **If you netboot over HTTPS, use RSA or EC
+P-256/P-384.**
+
 Enable it with `--external-ca`, or answer the interactive prompt during install:
 
 ```bash
@@ -452,8 +466,13 @@ fog-client installer and reboot PXE clients after the switch.
 
 - **`The supplied CA private key does not match the supplied CA certificate`** —
   `--ca-key` and `--ca-cert` are not a pair. Confirm with:
-  `openssl x509 -noout -modulus -in cert | openssl md5` vs
-  `openssl rsa -noout -modulus -in key | openssl md5`.
+  `openssl x509 -pubkey -noout -in cert` vs `openssl pkey -pubout -in key`;
+  they print identical PEM for a real pair. (Do **not** use `openssl rsa -noout
+  -modulus` — it only reads RSA keys, so it reports a mismatch on an EC or
+  Ed25519 CA that is perfectly well paired.)
+- **`The supplied CA certificate uses DSA`** — DSA is refused deliberately.
+  TLS 1.3 removed DSA signatures entirely and no current browser trusts a DSA
+  chain. Re-issue the CA with an RSA or elliptic curve key.
 - **`The supplied certificate is not a CA certificate`** — `--ca-cert` lacks
   `basicConstraints CA:TRUE`. You passed a leaf, not an intermediate CA.
 - **`The intermediate CA does not verify against the supplied root`** — `--ca-cert`

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6610,30 +6610,48 @@ validateExternalCA() {
     fi
     dots "Validating external CA files (${zone})"
     # The supplied private key must match the supplied intermediate certificate
-    local certmod keymod
-    # Raw modulus, no `openssl md5`: md5 of the empty output an unreadable file
+    local certpub keypub certalgorithm certcurve
+    # Compare the SUBJECT PUBLIC KEY, not an RSA modulus. `openssl rsa -modulus`
+    # only understands RSA, so an EC -- or Ed25519, or RSA-PSS -- CA could never
+    # pair with its own key and the install aborted on a "does not match" that
+    # was not true (GH-1393). `openssl x509 -pubkey` and `openssl pkey -pubout`
+    # emit byte-identical SPKI PEM for every algorithm openssl can load, so ONE
+    # comparison covers all of them.
+    #
+    # Deliberately NOT an algorithm allow-list feeding two per-algorithm
+    # comparisons. A list here has to be edited every time openssl names
+    # something new, and anything it has not heard of hard-fails an install that
+    # would otherwise have worked -- which is how RSA-PSS, supported before this
+    # check existed, briefly stopped working. Nothing downstream cares which
+    # algorithm the CA uses; it only has to sign, and openssl decides that.
+    #
+    # Raw PEM, no `openssl md5`: md5 of the empty output an unreadable file
     # produces is a non-empty hash, so with it two unreadable files "pair".
-    certalgorithm=$(openssl x509 -in $certsrc -noout -text | grep "Public Key Algorithm" | awk -F ': ' '{print $2}')
-    case $certalgorithm in
-        "rsaEncryption")
-            certmod=$(openssl x509 -noout -modulus -in "$certsrc" 2>>$error_log)
-            keymod=$(openssl rsa -noout -modulus -in "$keysrc" 2>>$error_log)
-            ;;
-        "id-ecPublicKey")
-            certmod=$(openssl x509 -noout -pubkey -in "$certsrc" 2>>$error_log)
-            keymod=$(openssl ec -pubout -in "$keysrc" 2>>$error_log)
-            ;;
-        *)
-            echo "Failed to determine certificate algorithm"
-            echo "  The supplied CA certificate does not use a supported algorithm."
-            echo "  Currently supporte are rsaEncryption and id-ecPublicKey"
-            exit 1
-            ;;
-    esac
-    if [[ -z $certmod || -z $keymod || $certmod != "$keymod" ]]; then
+    certpub=$(openssl x509 -pubkey -noout -in "$certsrc" 2>>$error_log)
+    keypub=$(openssl pkey -pubout -in "$keysrc" 2>>$error_log)
+    if [[ -z $certpub || -z $keypub || $certpub != "$keypub" ]]; then
         echo "Failed"
         echo "  The supplied CA private key ($keysrc) does not match the"
         echo "  supplied CA certificate ($certsrc)."
+        exit 1
+    fi
+    # DSA is the one algorithm openssl will happily pair and nothing downstream
+    # will accept: TLS 1.3 removed DSA signatures outright, no current browser
+    # trusts a DSA chain, and iPXE has no DSA at all. It was already refused
+    # before the comparison above became algorithm-agnostic -- as a bogus "key
+    # does not match", because `openssl rsa -modulus` cannot read a DSA key --
+    # so this keeps the outcome and drops the lie about the cause.
+    #
+    # An exact match, not a default-reject arm: a garbage or unreadable
+    # certificate leaves this empty, and that case belongs to the pairing check
+    # above, which names the two files.
+    certalgorithm=$(openssl x509 -noout -text -in "$certsrc" 2>>$error_log         | awk -F': ' '/Public Key Algorithm/ {print $2; exit}')
+    if [[ $certalgorithm == "dsaEncryption" ]]; then
+        echo "Failed"
+        echo "  The supplied CA certificate ($certsrc) uses DSA, which no"
+        echo "  current TLS client accepts -- TLS 1.3 removed DSA signatures"
+        echo "  entirely, and iPXE cannot verify them at all."
+        echo "  Re-issue the CA with an RSA or elliptic curve key."
         exit 1
     fi
     # The supplied intermediate must actually be a CA certificate
@@ -6669,6 +6687,38 @@ validateExternalCA() {
     # exists to prevent.
     PKI_web_external_root_cert="$rootsrc"
     errorStat $?
+    # iPXE's verifier is narrower than openssl's, and THIS certificate is the
+    # one it gets: _resolveIpxeTrust() sets ${ipxetrust} to ${PKI_web_ca_cert},
+    # and buildipxe.sh compiles it in as CERT=/TRUST=. The pinned tag (fog-ipxe
+    # IPXEVER, v2.0.0 at time of writing) carries crypto/rsa.c plus ecdsa.c with
+    # p256.c and p384.c, and nothing else -- no P-521, no EdDSA, no RSASSA-PSS.
+    #
+    # So a CA outside that set is not broken, it is narrower than it looks: the
+    # web UI serves fine and fog-client is satisfied, then HTTPS netboot dies at
+    # boot.php with iPXE's "Permission denied" out of x509.c, with nothing
+    # server-side connecting the two. Say so here, at the moment the CA is
+    # chosen, rather than leaving it to be discovered at a PXE client.
+    #
+    # Advisory and not a rejection: a site that netboots over HTTP, or serves
+    # netboot from a publicly-trusted certificate, is unaffected -- and the
+    # limit is a pinned iPXE version, not a property of the CA.
+    certcurve=$(openssl x509 -pubkey -noout -in "$certsrc" 2>>$error_log         | openssl pkey -pubin -noout -text 2>>$error_log         | awk -F': ' '/NIST CURVE|ASN1 OID/ {print $2; exit}')
+    # openssl >= 1.1.0 prints "NIST CURVE: P-256"; 1.0.2 prints only
+    # "ASN1 OID: prime256v1". Both spellings are accepted so the advisory does
+    # not fire spuriously on an older host.
+    case "${certalgorithm}${certcurve:+/$certcurve}" in
+        rsaEncryption|id-ecPublicKey/P-256|id-ecPublicKey/prime256v1|id-ecPublicKey/P-384|id-ecPublicKey/secp384r1)
+            ;;
+        *)
+            echo
+            echo "  Note: the imported CA uses ${certalgorithm:-an unrecognised algorithm}${certcurve:+ (${certcurve})}."
+            echo "  iPXE can only verify RSA and ECDSA P-256/P-384 signatures, so HTTPS"
+            echo "  netboot will fail against this CA. The web UI and fog-client are"
+            echo "  unaffected. Use HTTP netboot, serve netboot from a publicly-trusted"
+            echo "  certificate, or re-issue the CA with an RSA or EC P-256/P-384 key."
+            echo
+            ;;
+    esac
     # If we are replacing the CA on a server that already issued a server cert, warn
     if [[ -n ${PKI_web_vhost_cert} && -e ${PKI_web_vhost_cert} ]] && \
         ! openssl verify -CAfile "${PKI_web_trust_chain}" "${PKI_web_vhost_cert}" >>$error_log 2>&1; then

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6613,8 +6613,23 @@ validateExternalCA() {
     local certmod keymod
     # Raw modulus, no `openssl md5`: md5 of the empty output an unreadable file
     # produces is a non-empty hash, so with it two unreadable files "pair".
-    certmod=$(openssl x509 -noout -modulus -in "$certsrc" 2>>$error_log)
-    keymod=$(openssl rsa -noout -modulus -in "$keysrc" 2>>$error_log)
+    certalgorithm=$(openssl x509 -in $certsrc -noout -text | grep "Public Key Algorithm" | awk -F ': ' '{print $2}')
+    case $certalgorithm in
+        "rsaEncryption")
+            certmod=$(openssl x509 -noout -modulus -in "$certsrc" 2>>$error_log)
+            keymod=$(openssl rsa -noout -modulus -in "$keysrc" 2>>$error_log)
+            ;;
+        "id-ecPublicKey")
+            certmod=$(openssl x509 -noout -pubkey -in "$certsrc" 2>>$error_log)
+            keymod=$(openssl ec -pubout -in "$keysrc" 2>>$error_log)
+            ;;
+        *)
+            echo "Failed to determine certificate algorithm"
+            echo "  The supplied CA certificate does not use a supported algorithm."
+            echo "  Currently supporte are rsaEncryption and id-ecPublicKey"
+            exit 1
+            ;;
+    esac
     if [[ -z $certmod || -z $keymod || $certmod != "$keymod" ]]; then
         echo "Failed"
         echo "  The supplied CA private key ($keysrc) does not match the"

--- a/tests/external-ca-key-algorithms.test.sh
+++ b/tests/external-ca-key-algorithms.test.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+#
+# Pins which CA key algorithms validateExternalCA() accepts.
+#
+#   tests/external-ca-key-algorithms.test.sh
+#
+# The function has to answer one question about the admin's --ca-cert/--ca-key
+# pair: are they each other's halves? That was `openssl x509 -modulus` against
+# `openssl rsa -modulus`, which only understands RSA -- so an elliptic curve CA
+# could never pair with its own key and the install aborted claiming a mismatch
+# that was not there (GH-1393).
+#
+# The obvious repair -- detect the algorithm, branch to a per-algorithm
+# comparison, reject anything not on the list -- traded that bug for a worse
+# one: RSA-PSS worked BEFORE the check existed (`openssl rsa -modulus` reads an
+# RSA-PSS key fine) and a two-entry allow-list turned it into a hard install
+# failure. So did Ed25519 and Ed448, which are elliptic curve CAs and the whole
+# point of the change.
+#
+# What is here instead compares the SUBJECT PUBLIC KEY: `openssl x509 -pubkey`
+# and `openssl pkey -pubout` emit byte-identical SPKI PEM for every algorithm
+# openssl can load, so one comparison covers all of them and there is no list to
+# fall behind openssl again. This test is that claim, per algorithm.
+#
+# Two things the comparison must NOT wave through, also pinned here:
+#
+#   DSA      openssl pairs it happily and nothing downstream accepts it -- TLS
+#            1.3 removed DSA signatures, browsers reject the chain, iPXE has no
+#            DSA. Already refused before this change, as a bogus "key does not
+#            match"; still refused, now for the stated reason.
+#
+#   a real   the pairing check has to still FAIL on a genuine mismatch. A
+#   mismatch comparison that is accidentally always-true would pass every case
+#            above and be worse than the bug it replaced.
+#
+# And the iPXE advisory: the imported CA is compiled into the iPXE binary as
+# CERT=/TRUST=, and the pinned tag verifies RSA and ECDSA P-256/P-384 only. An
+# Ed25519 or P-521 CA installs fine and then fails HTTPS netboot, so the
+# installer says so at import time.
+#
+# Needs openssl. Runs on generated fixtures -- no install, no network, no root.
+# An algorithm the local openssl cannot generate is skipped, not failed.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+SKIPPED=0
+ok()   { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+skip() { SKIPPED=$((SKIPPED + 1)); printf '  skip  %s\n' "$1"; }
+
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+# dots/errorStat draw the installer's progress line; the assertions here are
+# about exit status and the text of a failure, not about the cosmetics.
+dots() { :; }
+errorStat() { :; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+fogprogramdir="$WORK/opt/fog"
+PKI_client_cert_dir="$WORK/opt/fog/snapins/ssl"
+# Unset so the function's closing "you are switching CA" warning -- which is
+# about an already-issued vhost cert, not about algorithms -- stays quiet.
+PKI_web_vhost_cert=""
+
+# Generate a private key for $1 into $2. Returns non-zero when this openssl
+# cannot produce that algorithm, which is a skip and not a failure: Ed448 and
+# RSA-PSS need 1.1.1+, and a FIPS build may refuse others.
+genkey() {
+    case "$1" in
+        rsa)      openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$2" 2>>"$error_log" ;;
+        ec-p256)  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$2" 2>>"$error_log" ;;
+        ec-p384)  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-384 -out "$2" 2>>"$error_log" ;;
+        ec-p521)  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-521 -out "$2" 2>>"$error_log" ;;
+        # `ecparam -genkey` without -noout prefixes the file with an EC
+        # PARAMETERS block. That is what most EC how-tos produce, and it must
+        # not change the SPKI openssl derives from it.
+        ec-params) openssl ecparam -name prime256v1 -genkey -out "$2" 2>>"$error_log" ;;
+        rsa-pss)  openssl genpkey -algorithm RSA-PSS -pkeyopt rsa_keygen_bits:2048 -out "$2" 2>>"$error_log" ;;
+        ed25519)  openssl genpkey -algorithm ED25519 -out "$2" 2>>"$error_log" ;;
+        ed448)    openssl genpkey -algorithm ED448 -out "$2" 2>>"$error_log" ;;
+        dsa)      openssl genpkey -genparam -algorithm DSA -pkeyopt dsa_paramgen_bits:2048 \
+                      -out "$2.params" 2>>"$error_log" \
+                      && openssl genpkey -paramfile "$2.params" -out "$2" 2>>"$error_log" ;;
+        *)        return 1 ;;
+    esac
+}
+
+# root CA -> intermediate CA, both on algorithm $1, into directory $2. The
+# intermediate is what an admin passes as --ca-cert/--ca-key; the root is
+# --ca-root. Deliberately the same algorithm on both, which is the realistic
+# case and the one the function has to verify a chain across.
+makeca() {
+    local alg="$1" d="$2"
+    mkdir -p "$d" || return 1
+    genkey "$alg" "$d/root.key" || return 1
+    genkey "$alg" "$d/int.key" || return 1
+    openssl req -x509 -new -nodes -key "$d/root.key" -days 2 \
+        -subj "/CN=${alg} root" -addext "basicConstraints=critical,CA:TRUE" \
+        -out "$d/root.pem" 2>>"$error_log" || return 1
+    openssl req -new -nodes -key "$d/int.key" -subj "/CN=${alg} intermediate" \
+        -out "$d/int.csr" 2>>"$error_log" || return 1
+    printf 'basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n' \
+        > "$d/int.ext"
+    openssl x509 -req -in "$d/int.csr" -CA "$d/root.pem" -CAkey "$d/root.key" \
+        -CAcreateserial -days 2 -extfile "$d/int.ext" -out "$d/int.pem" \
+        2>>"$error_log" || return 1
+    [[ -s $d/int.pem ]]
+}
+
+# Run the function over a prepared fixture directory and capture BOTH its exit
+# status and its output. A subshell is not optional: every failure path in
+# validateExternalCA is `exit 1`, which would take this test process with it.
+runvalidate() {
+    local d="$1"
+    OUT=$(
+        importWebCACert="$d/int.pem"
+        importWebCAKey="$d/int.key"
+        importWebCARoot="$d/root.pem"
+        validateExternalCA web 2>&1
+    )
+    STATUS=$?
+}
+
+echo "external CA key algorithms:"
+
+# --- every algorithm openssl can load pairs with its own certificate ---------
+#
+# ec-p521, rsa-pss, ed25519 and ed448 are the cases a two-entry allow-list
+# rejected; rsa and ec-p256 are the two it allowed. All of them have to pass,
+# and for the same reason rather than through one branch each.
+for alg in rsa ec-p256 ec-p384 ec-p521 ec-params rsa-pss ed25519 ed448; do
+    d="$WORK/$alg"
+    if ! makeca "$alg" "$d"; then
+        skip "$alg (this openssl cannot generate it)"
+        continue
+    fi
+    runvalidate "$d"
+    if [[ $STATUS -ne 0 ]]; then
+        bad "$alg is accepted (exit $STATUS: $(printf '%s' "$OUT" | tr '\n' ' '))"
+    else
+        ok "$alg is accepted"
+    fi
+done
+
+# --- DSA is refused, and says why -------------------------------------------
+d="$WORK/dsa"
+if ! makeca dsa "$d"; then
+    skip "dsa (this openssl cannot generate it)"
+else
+    runvalidate "$d"
+    if [[ $STATUS -eq 0 ]]; then
+        bad "dsa is refused"
+    else
+        ok "dsa is refused"
+    fi
+    if printf '%s' "$OUT" | grep -qi 'DSA'; then
+        ok "the DSA refusal names DSA rather than claiming a key mismatch"
+    else
+        bad "the DSA refusal names DSA (got: $(printf '%s' "$OUT" | tr '\n' ' '))"
+    fi
+fi
+
+# --- a genuine mismatch still fails -----------------------------------------
+#
+# The guard against an accidentally always-true comparison. Same algorithm, same
+# curve, different key -- so nothing but the public key itself distinguishes
+# them.
+d="$WORK/mismatch"
+if ! makeca ec-p256 "$d"; then
+    skip "mismatch (this openssl cannot generate EC P-256)"
+else
+    genkey ec-p256 "$d/other.key"
+    cp "$d/other.key" "$d/int.key"
+    runvalidate "$d"
+    if [[ $STATUS -eq 0 ]]; then
+        bad "an EC key that is not the certificate's key is refused"
+    else
+        ok "an EC key that is not the certificate's key is refused"
+    fi
+fi
+
+# --- the iPXE advisory fires on exactly what iPXE cannot verify -------------
+for alg in rsa ec-p256 ec-p384; do
+    d="$WORK/$alg"
+    [[ -s $d/int.pem ]] || continue
+    runvalidate "$d"
+    if printf '%s' "$OUT" | grep -qi 'netboot will fail'; then
+        bad "$alg draws no iPXE advisory"
+    else
+        ok "$alg draws no iPXE advisory"
+    fi
+done
+for alg in ec-p521 ed25519 ed448 rsa-pss; do
+    d="$WORK/$alg"
+    [[ -s $d/int.pem ]] || continue
+    runvalidate "$d"
+    if printf '%s' "$OUT" | grep -qi 'netboot will fail'; then
+        ok "$alg is advised about HTTPS netboot"
+    else
+        bad "$alg is advised about HTTPS netboot"
+    fi
+done
+
+echo
+echo "  passed: $PASS  failed: $FAIL  skipped: $SKIPPED"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
this patch allows the usage of root CAs using elliptic curves over RSA. 

I have at least one installation with a root CA using elliptic curves which failed with the current installer.