### PR TITLE
Reap the tasks that can never run, and say why (1.5)

### DIFF
--- a/packages/web/lib/fog/task.class.php
+++ b/packages/web/lib/fog/task.class.php
@@ -279,7 +279,14 @@ class Task extends TaskType
                     )
                 );
         }
-        $this->set('stateID', self::getCancelledState())->save();
+        // Recorded only if the save actually happened, so the log cannot
+        // claim a transition the database never took. Before this, cancelling
+        // wrote nothing to taskLog at all: the row for the In-Progress
+        // transition stayed the last word on the task, so every reader of the
+        // log -- the REST API included -- showed a cancelled task as running.
+        if ($this->set('stateID', self::getCancelledState())->save()) {
+            TaskLog::recordState($this);
+        }
 
         return $this;
     }

--- a/packages/web/lib/fog/tasklog.class.php
+++ b/packages/web/lib/fog/tasklog.class.php
@@ -127,6 +127,153 @@ class TaskLog extends FOGController
         }
     }
     /**
+     * Records one task state transition.
+     *
+     * The single definition of what a state row looks like. It used to live
+     * inline in TaskingElement::taskLog(), which meant only the two callers
+     * that go through a TaskingElement -- checkIn() and checkout() -- could
+     * write one. Cancellation does not go through either, so a cancelled task
+     * left no row at all and the last thing the log said about it was
+     * In-Progress, forever.
+     *
+     * The timestamp is the moment of the TRANSITION. taskLog() passed the
+     * task's own createdTime, and `createdTime` maps to this row's
+     * `createTime` -- one column, not two -- so every row a task ever wrote
+     * carried the instant the task was created. In-Progress and Complete came
+     * out sharing a timestamp to the second, which is what made the log
+     * unreadable: nothing could be ordered and repeated transitions looked
+     * like duplicates.
+     *
+     * hostID/hostName/taskTypeName are deliberately left empty, which is this
+     * branch's existing convention for a state row and the reason the
+     * databaseFields note above gives: a state row is an annotation on its
+     * task and says nothing without it, and this runs on every transition.
+     * The reaper's error rows do fill them, because those outlive the host
+     * they name -- that is the case the columns were added for.
+     *
+     * @param object $Task the task whose state just changed.
+     *
+     * @return bool|object false if there is no task to record.
+     */
+    public static function recordState($Task)
+    {
+        if (!$Task instanceof Task || !$Task->isValid()) {
+            return false;
+        }
+
+        return self::getClass('TaskLog')
+            ->set('taskID', $Task->get('id'))
+            ->set('stateID', $Task->get('stateID'))
+            ->set('createdTime', self::niceDate()->format('Y-m-d H:i:s'))
+            ->set('createdBy', $Task->get('createdBy'))
+            ->save();
+    }
+    /**
+     * Records a state transition for many tasks at once.
+     *
+     * recordState()'s bulk sibling, and it exists because the per-object
+     * shape does not survive TaskManager::cancel(). That method cancels every
+     * active task in a group in ONE statement; recording the result by
+     * rebuilding each Task cost a reload and an INSERT apiece, so a 300-host
+     * group turned a two-statement cancel into hundreds of queries inside one
+     * request. Same row, same columns, one SELECT and one batched INSERT.
+     *
+     * Reading `tasks` rather than trusting the ids is what makes this safe to
+     * call after the update: the state written is whatever the row says NOW,
+     * so a task whose state moved concurrently logs the truth rather than
+     * what the caller assumed, and an id that no longer resolves returns no
+     * row at all instead of one claiming a transition. That is the same
+     * guarantee recordState()'s isValid() gate gives, expressed as a query.
+     *
+     * @param array $taskIDs ids of the tasks whose state just changed.
+     *
+     * @return int how many rows were written.
+     */
+    public static function recordStates($taskIDs)
+    {
+        $ids = array();
+        foreach ((array)$taskIDs as $taskID) {
+            $taskID = (int)$taskID;
+            if ($taskID > 0) {
+                $ids[$taskID] = $taskID;
+            }
+        }
+        if (count($ids) < 1) {
+            return 0;
+        }
+        // Interpolated rather than bound: every element has been through
+        // (int) above, and a bound IN list needs a placeholder per element.
+        $rows = self::$DB->query(
+            "SELECT `taskID`, `taskStateID`, `taskCreateBy` "
+            . "FROM `tasks` "
+            . "WHERE `taskID` IN (" . implode(',', $ids) . ")"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        if (count((array)$rows) < 1) {
+            return 0;
+        }
+        // `ip` and `type` as well: recordState() gets both from TaskLog's
+        // constructor, which a batched INSERT never runs, and a bulk-cancelled
+        // row must not be distinguishable from a singly-cancelled one.
+        $fields = array(
+            'taskID',
+            'stateID',
+            'ip',
+            'createdTime',
+            'createdBy',
+            'type',
+        );
+        $now = self::niceDate()->format('Y-m-d H:i:s');
+        $values = array();
+        foreach ((array)$rows as $row) {
+            $values[] = array(
+                (int)$row['taskID'],
+                (int)$row['taskStateID'],
+                // Cast, because there is no remote address in a daemon.
+                // filter_input(INPUT_SERVER, 'REMOTE_ADDR') is null under CLI,
+                // `ip` is varchar(15) NOT NULL, and a null bound into a NOT
+                // NULL column is error 1048 on a strict server -- which is
+                // every server since GH-1245 stopped PDODB clearing sql_mode.
+                // TaskManager::cancel() is reached from the multicast manager
+                // and from TaskManager::reapUnrunnable(), both daemons.
+                (string)self::$remoteaddr,
+                $now,
+                (string)$row['taskCreateBy'],
+                self::TYPE_STATE,
+            );
+        }
+        /*
+         * Caught, because the cancel has already happened.
+         *
+         * insertBatch() THROWS where FOGController::save() returns false, and
+         * its callers sit inside a try that answers a request -- so an
+         * unhandled failure here would tell a caller whose tasks really were
+         * cancelled that the cancel failed, which is the same class of lie
+         * this change exists to remove. recordState() cannot do that to its
+         * caller and neither should this.
+         *
+         * Not silent: logFault() is where a failure on a path with nobody
+         * signed in gets written, exactly as save()'s own catch does with it.
+         */
+        try {
+            list($insertID, $affected) = self::getClass('TaskLogManager')
+                ->insertBatch($fields, $values);
+            unset($insertID);
+        } catch (Exception $e) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s',
+                    _('Failed to record task state changes'),
+                    _('Error'),
+                    $e->getMessage()
+                )
+            );
+
+            return 0;
+        }
+
+        return (int)$affected;
+    }
+    /**
      * Gets the task object.
      *
      * @return object

--- a/packages/web/lib/fog/taskmanager.class.php
+++ b/packages/web/lib/fog/taskmanager.class.php
@@ -101,13 +101,30 @@ class TaskManager extends FOGManagerController
             '',
             $updateFields
         );
-        $this->update(
+        // Enumerated BEFORE the update, because $findWhere selects on the
+        // states being cancelled out of and matches nothing once they are
+        // gone. Every bulk cancel comes through here, so without this a group
+        // cancel left every one of its tasks reading In-Progress in the log --
+        // the same hole Task::cancel() had.
+        $cancelledIDs = self::getSubObjectIDs(
+            'Task',
+            $findWhere
+        );
+        $updated = $this->update(
             $findWhere,
             '',
             array(
                 'stateID' => $cancelled
             )
         );
+        if ($updated) {
+            // Read back from `tasks` after the update, so each row records the
+            // state the task is now in rather than the one it was cancelled
+            // out of -- and in one SELECT plus one batched INSERT, because
+            // this arm cancels a whole group and rebuilding a Task per id to
+            // write its row cost a reload and an INSERT apiece.
+            TaskLog::recordStates($cancelledIDs);
+        }
         $findWhere = array(
             'hostID' => $hostIDs,
             'stateID' => $notComplete
@@ -158,5 +175,233 @@ class TaskManager extends FOGManagerController
         if ($StillLeft < 1 && count($MulticastSessionIDs) > 0) {
             self::getClass('MulticastSessionManager')->cancel($MulticastSessionIDs);
         }
+    }
+    /**
+     * Moves active tasks that can never run to Failed, and says why.
+     *
+     * THE ROWS THIS IS FOR. A task whose taskHostID, taskTypeID or -- for an
+     * imaging type -- taskImageID matches no row is permanent and unreadable
+     * at the same time. taskStateID still resolves, so every "is this task
+     * live" test in the tree is an allowlist of getQueuedStates() plus
+     * getProgressState() and counts it as active forever. The Active Tasks
+     * list renders each cell from a LEFT OUTER JOIN and guards it with
+     * isset(), which is false for the NULL a non-matching join returns, so
+     * the row draws with no host, no image and no type. No host can complete
+     * it either -- TaskingElement cannot build the Image or the Host, so the
+     * machine is turned away at check-in -- and until now nothing reaped it.
+     * Reported as "null tasks" in forum topics 18228 and 18230.
+     *
+     * The write paths that produce them are closed separately (GH-1391); this
+     * is for the rows an install is already carrying, which no code change can
+     * reach. It runs from the task scheduler, so an install fixes itself
+     * without anyone being told to run SQL.
+     *
+     * RESOLUTION, NOT ZERO. A dangling reference is found by asking whether it
+     * joins, which is true of a 0 and of the id of something deleted alike --
+     * there is no need to know which, and matching on 0 would be wrong twice
+     * over. It would miss every task pointing at a deleted row, and it would
+     * sweep up perfectly good tasking: a wipe, snapin, hardware inventory,
+     * password reset or Secure Boot task has no image by design and stores
+     * taskImageID 0. Confirmed on a live install carrying three such rows --
+     * two All Snapins, one Enroll Secure Boot -- every one of them correct. So
+     * the image is only asked about for an imaging task type.
+     *
+     * FAILED, NOT CANCELLED. Cancelled means an administrator stopped it.
+     * Losing the difference between "somebody stopped this" and "this broke"
+     * is exactly the distinction an operator needs at the moment they are
+     * looking at the task list. Same reasoning as TaskState::getFailedState()
+     * and TaskError::_markFailed().
+     *
+     * NOTHING IS UNWOUND, unlike cancel(). A task that cannot resolve its host
+     * or its task type cannot have got past check-in -- TaskingElement builds
+     * both before anything else -- so there is no token to reissue, no
+     * multicast session behind it and no snapin job riding on it. Reaping is a
+     * state change plus its record, deliberately.
+     *
+     * @return array taskID => the reason it was reaped, empty if none were.
+     */
+    public function reapUnrunnable()
+    {
+        /*
+         * Guarded on the row actually existing rather than assuming schema
+         * 281 has run, exactly as TaskError::_markFailed() is. A web tree can
+         * be updated ahead of its database -- the ordinary state of an install
+         * between the files landing and the admin loading a page -- and this
+         * runs from a daemon, which reaches that window before any person
+         * does. Pointing a task at a taskStates row that is not there renders
+         * blank and cannot be filtered for, which is worse than leaving it
+         * where it was for a few minutes.
+         */
+        $failed = (int)self::getFailedState();
+        if (!self::getClass('TaskState', $failed)->isValid()) {
+            return array();
+        }
+        $active = self::fastmerge(
+            (array)self::getQueuedStates(),
+            (array)self::getProgressState()
+        );
+        $active = array_map('intval', $active);
+        // Which type ids count as imaging, asked of TaskType rather than
+        // written down here, so this and every other reader of "is this an
+        // imaging task" cannot drift apart. isDeploy(true) already covers
+        // multicast (type 8).
+        $TaskType = self::getClass('TaskType');
+        $imaging = self::fastmerge(
+            (array)$TaskType->isDeploy(true),
+            (array)$TaskType->isCapture(true)
+        );
+        $imaging = array_map('intval', array_unique($imaging));
+        /*
+         * Interpolated rather than bound, as TaskLog::recordStates() does with
+         * its task ids: every element has been through (int) above, and a
+         * bound IN list needs a placeholder per element.
+         *
+         * The three joins are the same three the Active Tasks list builds,
+         * which is what makes "does this row draw empty" and "does this row
+         * get reaped" the same question rather than two that can drift.
+         */
+        $rows = self::$DB->query(
+            "SELECT `tasks`.`taskID` AS `taskID`, "
+            . "`tasks`.`taskHostID` AS `hostID`, "
+            . "`tasks`.`taskTypeID` AS `typeID`, "
+            . "`tasks`.`taskImageID` AS `imageID`, "
+            . "`tasks`.`taskCreateBy` AS `createdBy`, "
+            . "`hosts`.`hostID` AS `hostFound`, "
+            . "COALESCE(`hosts`.`hostName`, '') AS `hostName`, "
+            . "`taskTypes`.`ttID` AS `typeFound`, "
+            . "COALESCE(`taskTypes`.`ttName`, '') AS `taskTypeName`, "
+            . "`images`.`imageID` AS `imageFound` "
+            . "FROM `tasks` "
+            . "LEFT OUTER JOIN `hosts` "
+            . "ON `hosts`.`hostID` = `tasks`.`taskHostID` "
+            . "LEFT OUTER JOIN `taskTypes` "
+            . "ON `taskTypes`.`ttID` = `tasks`.`taskTypeID` "
+            . "LEFT OUTER JOIN `images` "
+            . "ON `images`.`imageID` = `tasks`.`taskImageID` "
+            . "WHERE `tasks`.`taskStateID` IN (" . implode(',', $active) . ") "
+            . "AND ("
+            . "`hosts`.`hostID` IS NULL "
+            . "OR `taskTypes`.`ttID` IS NULL "
+            . "OR ("
+            . "`images`.`imageID` IS NULL "
+            . "AND `tasks`.`taskTypeID` IN (" . implode(',', $imaging) . ")"
+            . ")"
+            . ")"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        if (count((array)$rows) < 1) {
+            return array();
+        }
+
+        $reasons = array();
+        $logRows = array();
+        $now = self::niceDate()->format('Y-m-d H:i:s');
+        foreach ((array)$rows as $row) {
+            $why = array();
+            if (null === $row['hostFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('host no longer exists'),
+                    (int)$row['hostID']
+                );
+            }
+            if (null === $row['typeFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('task type no longer exists'),
+                    (int)$row['typeID']
+                );
+            }
+            if (null === $row['imageFound']) {
+                $why[] = sprintf(
+                    '%s (%d)',
+                    _('image no longer exists'),
+                    (int)$row['imageID']
+                );
+            }
+            $text = sprintf(
+                '%s: %s',
+                _('Task can never run and was marked failed'),
+                implode(', ', $why)
+            );
+            $reasons[(int)$row['taskID']] = $text;
+            /*
+             * `ip` and `type` are set here because a batched INSERT never runs
+             * TaskLog's constructor, which is where a singly-written row gets
+             * both -- the same note recordStates() carries.
+             *
+             * TYPE_ERROR, not TYPE_STATE: the reason is the whole value of
+             * this row. A state row saying only "Failed" against a task whose
+             * host is gone tells an operator nothing they can act on. The
+             * state transition itself is recorded separately, below.
+             *
+             * hostName and taskTypeName ARE filled here, where a state row
+             * leaves them empty. This is the case those columns were added
+             * for: the host is already gone, so the name cannot be recovered
+             * by joining, and it is the only thing that makes the row mean
+             * anything to whoever reads it later.
+             *
+             * stateID is the state the task is being moved TO, so the row
+             * reads as the transition it accompanies.
+             */
+            $logRows[] = array(
+                (int)$row['taskID'],
+                $failed,
+                (string)self::$remoteaddr,
+                $now,
+                (string)$row['createdBy'],
+                TaskLog::TYPE_ERROR,
+                $text,
+                (int)($row['hostFound'] ?: 0),
+                (string)$row['hostName'],
+                (string)$row['taskTypeName']
+            );
+        }
+
+        $updated = $this->update(
+            array('id' => array_keys($reasons)),
+            '',
+            array('stateID' => $failed)
+        );
+        if (!$updated) {
+            return array();
+        }
+        // The state row, so every reader of the log sees the transition like
+        // any other one. Read back from `tasks` after the update, as cancel()
+        // does, so what is recorded is what the row says now.
+        TaskLog::recordStates(array_keys($reasons));
+        /*
+         * Caught, because the reap has already happened. insertBatch() THROWS
+         * where save() returns false, and losing the reason is not worth
+         * turning a daemon pass into an exception once the tasks are already
+         * moved -- the same call recordStates() makes for the same reason.
+         */
+        try {
+            self::getClass('TaskLogManager')->insertBatch(
+                array(
+                    'taskID',
+                    'stateID',
+                    'ip',
+                    'createdTime',
+                    'createdBy',
+                    'type',
+                    'text',
+                    'hostID',
+                    'hostName',
+                    'taskTypeName'
+                ),
+                $logRows
+            );
+        } catch (Exception $e) {
+            self::logFault(
+                sprintf(
+                    '%s: %s: %s',
+                    _('Failed to record why tasks were reaped'),
+                    _('Error'),
+                    $e->getMessage()
+                )
+            );
+        }
+
+        return $reasons;
     }
 }

--- a/packages/web/lib/reg-task/taskingelement.class.php
+++ b/packages/web/lib/reg-task/taskingelement.class.php
@@ -243,12 +243,17 @@ abstract class TaskingElement extends FOGBase
      */
     protected function taskLog()
     {
-        return self::getClass('TaskLog', $this->Task)
-            ->set('taskID', $this->Task->get('id'))
-            ->set('taskStateID', $this->Task->get('stateID'))
-            ->set('createdTime', $this->Task->get('createdTime'))
-            ->set('createdBy', $this->Task->get('createdBy'))
-            ->save();
+        // The row is built by TaskLog::recordState() rather than here, because
+        // a state transition is not something only a TaskingElement can cause.
+        // Cancellation reaches the tasks table through Task::cancel() and
+        // TaskManager::cancel(), neither of which has a TaskingElement, and so
+        // wrote no row at all -- leaving In-Progress as the last thing the log
+        // ever said about a cancelled task.
+        //
+        // It also stamps the row with the moment of the transition rather than
+        // the task's createdTime, which is what this line used to pass. See
+        // recordState() for why that made the log unorderable.
+        return TaskLog::recordState($this->Task);
     }
     /**
      * Creates the image log record for the task/host.

--- a/packages/web/lib/service/taskscheduler.class.php
+++ b/packages/web/lib/service/taskscheduler.class.php
@@ -123,6 +123,36 @@ class TaskScheduler extends FOGService
                     self::wakeUp($hostMACs);
                 }
             }
+            /*
+             * The housekeeping sweep runs BEFORE the "no tasks found" exit
+             * below, and that ordering is the point of putting it here.
+             *
+             * That exit counts SCHEDULED and power-management tasks -- the two
+             * things the rest of this method acts on -- and throws when there
+             * are none, which ends the pass. Anything placed after it never
+             * runs on an install with no scheduled task and no power-
+             * management task. That is most small installs, and it is exactly
+             * the population reporting tasks stuck active forever. Reaping has
+             * nothing to do with whether a schedule exists.
+             */
+            self::outall(
+                ' * '
+                . _('Checking for tasks that can never run...')
+            );
+            $reaped = self::getClass('TaskManager')->reapUnrunnable();
+            foreach ($reaped as $taskID => $why) {
+                self::outall(
+                    sprintf(
+                        ' * %s %d: %s',
+                        _('Marked failed, task'),
+                        $taskID,
+                        $why
+                    )
+                );
+            }
+            if (count($reaped) < 1) {
+                self::outall(' * ' . _('No unrunnable tasks found.'));
+            }
             $findWhere = array(
                 'isActive' => 1
             );

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1007,6 +1007,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Check-in-Zeit"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
 
@@ -2114,6 +2117,14 @@ msgstr "Zerstören des Speicherknotens fehlgeschlagen"
 
 msgid "Failed to install plugin"
 msgstr "Fehler beim Installieren des Plugins"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Fehler beim Erstellen der Aufgabe (Task)"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Fehler beim Entschlüsseln der Daten"
 
 msgid "Failed to save assignment"
 msgstr "Speichern der Zuweisung fehlgeschlagen"
@@ -3982,6 +3993,10 @@ msgid "Management Username"
 msgstr "Management-Benutzernamen"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Stornierter Task"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Zerstörung fehlgeschlagen: %s"
 
@@ -4475,6 +4490,10 @@ msgstr "Keine Snapins mit dieser Gruppe als Master verbunden"
 
 msgid "No token passed to authenticate this host"
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Keine neuen Tasks gefunden"
 
 #, fuzzy
 msgid "No valid Image defined for this host"
@@ -6458,6 +6477,9 @@ msgstr "Task-Typ ist nicht gültig"
 msgid "Task Types"
 msgstr "Task-Typen"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "Task Start erzwungen"
 
@@ -7686,6 +7708,10 @@ msgid "host"
 msgstr "Host"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "läuft nicht mehr"
+
+#, fuzzy
 msgid "hosts"
 msgstr "Hosts"
 
@@ -7770,6 +7796,10 @@ msgstr "Image"
 
 msgid "image file found, file: "
 msgstr ""
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "läuft nicht mehr"
 
 #, fuzzy
 msgid "image replication"
@@ -8066,6 +8096,9 @@ msgstr "erfolgreich entfernt!"
 
 msgid "task found"
 msgstr "Task gefunden"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1012,6 +1012,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Task Checkin Time"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2118,6 +2121,14 @@ msgstr "Failed to destroy Storage Node"
 
 msgid "Failed to install plugin"
 msgstr "Failed to install plugin"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Failed to create task"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Failed to decrypt data"
 
 msgid "Failed to save assignment"
 msgstr "Failed to save assignment"
@@ -3982,6 +3993,10 @@ msgid "Management Username"
 msgstr "Management Username"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Cancelled task"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Destroy failed: %s"
 
@@ -4475,6 +4490,10 @@ msgstr "There are no snapins associated with this host"
 
 msgid "No token passed to authenticate this host"
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "No valid class sent"
 
 #, fuzzy
 msgid "No valid Image defined for this host"
@@ -6456,6 +6475,9 @@ msgstr "Task Type is not valid"
 msgid "Task Types"
 msgstr "Task Types"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "Task forced to start"
 
@@ -7683,6 +7705,10 @@ msgid "host"
 msgstr "host"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr " no longer exists"
+
+#, fuzzy
 msgid "hosts"
 msgstr "host"
 
@@ -7767,6 +7793,10 @@ msgstr "Image"
 
 msgid "image file found, file: "
 msgstr ""
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr " no longer exists"
 
 #, fuzzy
 msgid "image replication"
@@ -8062,6 +8092,9 @@ msgstr "successfully removed"
 
 msgid "task found"
 msgstr "task found"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1000,6 +1000,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Fecha ya existe"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -2100,6 +2103,14 @@ msgstr "Error al eliminar el nodo de almacenamiento"
 #, fuzzy
 msgid "Failed to install plugin"
 msgstr "Gestión de plugins"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Error al crear la tarea"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Error al desencriptar los datos"
 
 #, fuzzy
 msgid "Failed to save assignment"
@@ -3984,6 +3995,10 @@ msgid "Management Username"
 msgstr "Usuario"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Tarea"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Error al eliminar"
 
@@ -4491,6 +4506,10 @@ msgstr ""
 
 msgid "No token passed to authenticate this host"
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "No se han encontrado tareas"
 
 msgid "No valid Image defined for this host"
 msgstr ""
@@ -6449,6 +6468,9 @@ msgstr "Tipo de tarea no válida"
 msgid "Task Types"
 msgstr "Tarea"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 #, fuzzy
 msgid "Task forced to start"
 msgstr "Gestión de tareas"
@@ -7636,6 +7658,10 @@ msgid "host"
 msgstr "Equipo"
 
 #, fuzzy
+msgid "host no longer exists"
+msgstr "Ya existe este equipo"
+
+#, fuzzy
 msgid "hosts"
 msgstr "Equipos"
 
@@ -7717,6 +7743,10 @@ msgstr "Imagen"
 #, fuzzy
 msgid "image file found, file: "
 msgstr "Archivo"
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "El grupo de almacenamiento ya existe"
 
 #, fuzzy
 msgid "image replication"
@@ -8008,6 +8038,9 @@ msgstr "Eliminado"
 #, fuzzy
 msgid "task found"
 msgstr "No hay tareas activas para este equipo"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -884,6 +884,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Heure d'enregistrement"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Vérifier si je suis le gestionnaire du groupe"
 
@@ -1873,6 +1876,14 @@ msgstr "Impossible de détruire le nœud de stockage"
 
 msgid "Failed to install plugin"
 msgstr "Impossible d'installer le greffon"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Échec de la création d'une tâche"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Échec du déchiffrement des données sur le serveur"
 
 msgid "Failed to save assignment"
 msgstr "Échec de l'enregistrement de l'affectation"
@@ -3522,6 +3533,10 @@ msgid "Management Username"
 msgstr "Gestion des identifiants"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Tâche annulée"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Échec de la destruction"
 
@@ -3972,6 +3987,10 @@ msgstr "Aucun Snapin associé à ce groupe en tant que maître"
 
 msgid "No token passed to authenticate this host"
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Aucune nouvelle tâche trouvée"
 
 msgid "No valid Image defined for this host"
 msgstr "Pas d'image définie pour cette machine"
@@ -5708,6 +5727,9 @@ msgstr "Type de tâche n'est pas valide"
 msgid "Task Types"
 msgstr "Types de tâches"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "Tâche forcée de commencer"
 
@@ -6800,6 +6822,10 @@ msgstr "ici"
 msgid "host"
 msgstr "machine"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "ne fonctionne plus"
+
 msgid "hosts"
 msgstr "machines"
 
@@ -6868,6 +6894,10 @@ msgstr "image"
 
 msgid "image file found, file: "
 msgstr "fichier image trouvé, fichier : "
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "ne fonctionne plus"
 
 msgid "image replication"
 msgstr "réplication des images"
@@ -7126,6 +7156,9 @@ msgstr "supprimé avec succès !"
 
 msgid "task found"
 msgstr "tâche trouvée"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -912,6 +912,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Orario Checkin"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Controllare se sono il responsabile del gruppo"
 
@@ -1922,6 +1925,14 @@ msgstr "Impossibile per distruggere il nodo di archiviazione"
 
 msgid "Failed to install plugin"
 msgstr "Impossibile installare plug-in"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Impossibile creare un'attività"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Impossibile decifrare i dati"
 
 msgid "Failed to save assignment"
 msgstr "Impossibile salvare l'assegnazione"
@@ -3591,6 +3602,10 @@ msgid "Management Username"
 msgstr "Gestione utente"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "compito Annullato"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Deistruzione fallita"
 
@@ -4046,6 +4061,10 @@ msgstr "Nessun snapins associato a questo gruppo come master"
 
 msgid "No token passed to authenticate this host"
 msgstr ""
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Non sono stati trovati compiti validi"
 
 msgid "No valid Image defined for this host"
 msgstr "Nessuna Imagine valida definita per questo host"
@@ -5829,6 +5848,9 @@ msgstr "Task Type non è valido"
 msgid "Task Types"
 msgstr "Tipi di attività"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "Task forzato a partire"
 
@@ -6942,6 +6964,10 @@ msgstr "qui"
 msgid "host"
 msgstr "host"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "non è più in esecuzione"
+
 msgid "hosts"
 msgstr "hosts"
 
@@ -7010,6 +7036,10 @@ msgstr "Immagine"
 
 msgid "image file found, file: "
 msgstr ""
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "non è più in esecuzione"
 
 msgid "image replication"
 msgstr "replica dell'immagine"
@@ -7274,6 +7304,9 @@ msgstr "rimosso con successo"
 
 msgid "task found"
 msgstr "compito trovato"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -873,6 +873,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "チェックイン時刻"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "自身がグループマネージャーか確認しています"
 
@@ -1855,6 +1858,14 @@ msgstr "ストレージノードの破棄に失敗しました"
 
 msgid "Failed to install plugin"
 msgstr "プラグインのインストールに失敗しました"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "タスクの作成に失敗しました"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "サーバー上のデータ復号に失敗しました"
 
 msgid "Failed to save assignment"
 msgstr "割り当ての保存に失敗しました"
@@ -3484,6 +3495,10 @@ msgid "Management Username"
 msgstr "管理ユーザー名"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "キャンセルされたタスク"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "解除に失敗しました"
 
@@ -3933,6 +3948,10 @@ msgstr "このグループにマスターとして関連付けられたスナッ
 
 msgid "No token passed to authenticate this host"
 msgstr "このホストを認証するためのトークンが渡されていません"
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "新しいタスクは見つかりません"
 
 msgid "No valid Image defined for this host"
 msgstr "このホストに有効なイメージが定義されていません"
@@ -5652,6 +5671,9 @@ msgstr "タスクタイプが無効です"
 msgid "Task Types"
 msgstr "タスクタイプ"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "タスクを強制開始しました"
 
@@ -6734,6 +6756,10 @@ msgstr "ここ"
 msgid "host"
 msgstr "ホスト"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "現在は実行されていません"
+
 msgid "hosts"
 msgstr "ホスト"
 
@@ -6802,6 +6828,10 @@ msgstr "イメージ"
 
 msgid "image file found, file: "
 msgstr "イメージファイルが見つかりました。ファイル: "
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "現在は実行されていません"
 
 msgid "image replication"
 msgstr "イメージレプリケーション"
@@ -7059,6 +7089,9 @@ msgstr "正常に削除しました！"
 
 msgid "task found"
 msgstr "タスクが見つかりました"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -858,6 +858,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr ""
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr ""
 
@@ -1833,6 +1836,12 @@ msgid "Failed to destroy Storage Node"
 msgstr ""
 
 msgid "Failed to install plugin"
+msgstr ""
+
+msgid "Failed to record task state changes"
+msgstr ""
+
+msgid "Failed to record why tasks were reaped"
 msgstr ""
 
 msgid "Failed to save assignment"
@@ -3453,6 +3462,9 @@ msgstr ""
 msgid "Management Username"
 msgstr ""
 
+msgid "Marked failed, task"
+msgstr ""
+
 msgid "Mass destroy failed"
 msgstr ""
 
@@ -3898,6 +3910,9 @@ msgid "No snapins associated with this group as master"
 msgstr ""
 
 msgid "No token passed to authenticate this host"
+msgstr ""
+
+msgid "No unrunnable tasks found."
 msgstr ""
 
 msgid "No valid Image defined for this host"
@@ -5614,6 +5629,9 @@ msgstr ""
 msgid "Task Types"
 msgstr ""
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr ""
 
@@ -6691,6 +6709,9 @@ msgstr ""
 msgid "host"
 msgstr ""
 
+msgid "host no longer exists"
+msgstr ""
+
 msgid "hosts"
 msgstr ""
 
@@ -6758,6 +6779,9 @@ msgid "image"
 msgstr ""
 
 msgid "image file found, file: "
+msgstr ""
+
+msgid "image no longer exists"
 msgstr ""
 
 msgid "image replication"
@@ -7015,6 +7039,9 @@ msgid "successfully removed!"
 msgstr ""
 
 msgid "task found"
+msgstr ""
+
+msgid "task type no longer exists"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -883,6 +883,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "Tempo de Checkin"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "Verificando se eu sou o gerente do grupo"
 
@@ -1866,6 +1869,14 @@ msgstr "Falha ao destruir Nó de Armazenamento"
 
 msgid "Failed to install plugin"
 msgstr "Falha ao instalar plugin"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "Falha ao criar tarefa"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "Falha ao descriptografar dados no servidor"
 
 msgid "Failed to save assignment"
 msgstr "Falha ao salvar atribuição"
@@ -3504,6 +3515,10 @@ msgid "Management Username"
 msgstr "Usuário de Gerenciamento"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "Tarefa cancelada"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "Falha ao Destruir"
 
@@ -3954,6 +3969,10 @@ msgstr "Nenhum snapin associado a este grupo como mestre"
 
 msgid "No token passed to authenticate this host"
 msgstr "Nenhum token passado para autenticar este host"
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "Nenhuma tarefa nova encontrada"
 
 msgid "No valid Image defined for this host"
 msgstr "Nenhuma Imagem válida definida para este host"
@@ -5679,6 +5698,9 @@ msgstr "Tipo de Tarefa não é válido"
 msgid "Task Types"
 msgstr "Tipos de Tarefa"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "Tarefa forçada a iniciar"
 
@@ -6763,6 +6785,10 @@ msgstr "aqui"
 msgid "host"
 msgstr "host"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "não está mais rodando"
+
 msgid "hosts"
 msgstr "hosts"
 
@@ -6831,6 +6857,10 @@ msgstr "imagem"
 
 msgid "image file found, file: "
 msgstr "arquivo de imagem encontrado, arquivo: "
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "não está mais rodando"
 
 msgid "image replication"
 msgstr "replicação de imagem"
@@ -7088,6 +7118,9 @@ msgstr "removido com sucesso!"
 
 msgid "task found"
 msgstr "tarefa encontrada"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -883,6 +883,9 @@ msgstr ""
 msgid "Checkin Time"
 msgstr "登录时间"
 
+msgid "Checking for tasks that can never run..."
+msgstr ""
+
 msgid "Checking if I am the group manager"
 msgstr "请组管理员检查"
 
@@ -1866,6 +1869,14 @@ msgstr "未能摧毁存储节点"
 
 msgid "Failed to install plugin"
 msgstr "无法安装插件"
+
+#, fuzzy
+msgid "Failed to record task state changes"
+msgstr "无法创建任务"
+
+#, fuzzy
+msgid "Failed to record why tasks were reaped"
+msgstr "数据解密失败"
 
 msgid "Failed to save assignment"
 msgstr "无法保存分配"
@@ -3504,6 +3515,10 @@ msgid "Management Username"
 msgstr "管理用户名"
 
 #, fuzzy
+msgid "Marked failed, task"
+msgstr "取消任务"
+
+#, fuzzy
 msgid "Mass destroy failed"
 msgstr "销毁失败"
 
@@ -3954,6 +3969,10 @@ msgstr "无主Snapin与此群组关联"
 
 msgid "No token passed to authenticate this host"
 msgstr "未传递令牌以验证此主机"
+
+#, fuzzy
+msgid "No unrunnable tasks found."
+msgstr "无新任务"
 
 msgid "No valid Image defined for this host"
 msgstr "此主机未定义有效镜像"
@@ -5679,6 +5698,9 @@ msgstr "任务状态无效"
 msgid "Task Types"
 msgstr "任务类型"
 
+msgid "Task can never run and was marked failed"
+msgstr ""
+
 msgid "Task forced to start"
 msgstr "任务强行启动"
 
@@ -6762,6 +6784,10 @@ msgstr "这里"
 msgid "host"
 msgstr "主机"
 
+#, fuzzy
+msgid "host no longer exists"
+msgstr "不再运行"
+
 msgid "hosts"
 msgstr "主机"
 
@@ -6830,6 +6856,10 @@ msgstr "镜像"
 
 msgid "image file found, file: "
 msgstr "镜像文件检索结果："
+
+#, fuzzy
+msgid "image no longer exists"
+msgstr "不再运行"
 
 msgid "image replication"
 msgstr "镜像复制"
@@ -7087,6 +7117,9 @@ msgstr "成功移除!"
 
 msgid "task found"
 msgstr "发现任务"
+
+msgid "task type no longer exists"
+msgstr ""
 
 #, php-format
 msgid "terminating so it can be restarted"

--- a/tests/unrunnable-tasks-are-reaped.test.php
+++ b/tests/unrunnable-tasks-are-reaped.test.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * A task that can never run must not sit in Active Tasks forever, and every
+ * state a task moves through must reach the log.
+ *
+ * THE ROWS. A `tasks` row whose taskHostID, taskTypeID or -- for an imaging
+ * type -- taskImageID matches no row is permanent and unreadable at the same
+ * time. taskStateID still resolves, so every "is this task live" test in the
+ * tree is an allowlist of getQueuedStates() plus getProgressState() and counts
+ * it as active. The Active Tasks list renders each cell from a LEFT OUTER JOIN
+ * and guards it with isset(), which is false for the NULL a non-matching join
+ * returns, so the row draws with no host, no image and no type. No host can
+ * complete it, and nothing reaped it. Reported as "null tasks" in forum topics
+ * 18228 and 18230.
+ *
+ * The write paths that create such a row are closed elsewhere (GH-1391). What
+ * this pins is the sweep for the rows an install is ALREADY carrying, which no
+ * code change can reach.
+ *
+ * THE TWO CHECKS THAT MATTER MOST, because getting either wrong is worse than
+ * not having the sweep at all:
+ *
+ *   - It must find rows by whether they JOIN, not by whether a column is 0. A
+ *     0 and the id of something deleted are both dangling and both have to go;
+ *     matching on 0 would miss every deleted-id case AND destroy good tasking,
+ *     because a wipe, snapin, inventory, password-reset or Secure Boot task
+ *     legitimately stores taskImageID 0.
+ *   - The image is therefore only asked about for an IMAGING task type.
+ *
+ * AND THE LOG IT WRITES INTO. The sweep needs somewhere truthful to record
+ * itself, and on this branch there was nowhere: a state row could only be
+ * written by TaskingElement, so cancellation -- which reaches `tasks` through
+ * Task::cancel() and TaskManager::cancel(), neither of which has one -- wrote
+ * nothing at all, and In-Progress stayed the last word on a cancelled task
+ * forever (GH-1378 causes 1 and 2). Both are wired here, so the same checks
+ * cover them.
+ *
+ * DB-free: this reads the source. The behaviour is proved against a live
+ * database by background_scripts/prove_unrunnable_task_reaper_15.php, which
+ * fails on an unpatched tree.
+ *
+ * Usage: php tests/unrunnable-tasks-are-reaped.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = array();
+$checks = 0;
+
+/**
+ * Source with comments removed, so a commented-out line can neither satisfy
+ * a check nor fail one -- these files carry long docblocks that name the very
+ * things being grepped for.
+ *
+ * @param string $file the file to read
+ *
+ * @return string
+ */
+function reapStrip($file)
+{
+    $clean = '';
+    foreach (token_get_all((string)file_get_contents($file)) as $token) {
+        if (is_array($token)
+            && (T_COMMENT === $token[0] || T_DOC_COMMENT === $token[0])
+        ) {
+            continue;
+        }
+        $clean .= is_array($token) ? $token[1] : $token;
+    }
+    return $clean;
+}
+
+/**
+ * Records a check.
+ *
+ * @param string $what the defect, stated as what would be wrong
+ * @param bool   $ok   whether it passed
+ *
+ * @return void
+ */
+function reapCheck($what, $ok)
+{
+    global $checks, $failures;
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+$man = reapStrip("$root/packages/web/lib/fog/taskmanager.class.php");
+$log = reapStrip("$root/packages/web/lib/fog/tasklog.class.php");
+$sched = reapStrip("$root/packages/web/lib/service/taskscheduler.class.php");
+$task = reapStrip("$root/packages/web/lib/fog/task.class.php");
+$element = reapStrip("$root/packages/web/lib/reg-task/taskingelement.class.php");
+
+/* ------------------------------------------------------------- 1. the sweep */
+
+$reap = '';
+if (preg_match('/public function reapUnrunnable\(\).*?\n    \}/s', $man, $m)) {
+    $reap = $m[0];
+}
+reapCheck(
+    'TaskManager has no reapUnrunnable(), so an install carrying tasks that '
+    . 'can never run keeps carrying them',
+    '' !== $reap
+);
+
+reapCheck(
+    'the sweep does not wait for the Failed taskStates row to exist. It runs '
+    . 'from a daemon, which reaches the window between the files landing and '
+    . 'the database being upgraded before any person does, and a task '
+    . 'pointing at a missing state renders blank and cannot be filtered for',
+    false !== strpos($reap, "getClass('TaskState', \$failed)->isValid()")
+);
+
+reapCheck(
+    'the sweep is no longer restricted to active tasks, so it would rewrite '
+    . 'finished history',
+    false !== strpos($reap, 'getQueuedStates()')
+    && false !== strpos($reap, 'getProgressState()')
+);
+
+/* ------------------------------------- 2. resolution, not zero (the big one) */
+
+reapCheck(
+    'the sweep no longer joins all three of hosts, taskTypes and images, so '
+    . 'it cannot see the same danglings the Active Tasks list draws blank',
+    3 === substr_count($reap, 'LEFT OUTER JOIN')
+);
+
+reapCheck(
+    'the sweep matches on a column being 0 instead of on the join failing. A '
+    . '0 and the id of something deleted are both dangling; matching on 0 '
+    . 'misses every deleted-id case, and for taskImageID it would destroy '
+    . 'good tasking -- a wipe, snapin, inventory, password-reset or Secure '
+    . 'Boot task stores 0 there by design',
+    3 === substr_count($reap, 'IS NULL')
+    && false === strpos($reap, '`taskImageID` = 0')
+    && false === strpos($reap, '`taskHostID` = 0')
+    && false === strpos($reap, '`taskTypeID` = 0')
+);
+
+reapCheck(
+    'the image is asked about for every task type, not only imaging ones, so '
+    . 'every snapin, wipe, inventory and password-reset task would be reaped',
+    false !== strpos($reap, '`images`.`imageID` IS NULL ')
+    && false !== strpos($reap, "AND `tasks`.`taskTypeID` IN (")
+);
+
+reapCheck(
+    'which types count as imaging is written down here rather than asked of '
+    . 'TaskType, so this and every other reader of "is this an imaging task" '
+    . 'can drift apart',
+    false !== strpos($reap, 'isDeploy(true)')
+    && false !== strpos($reap, 'isCapture(true)')
+);
+
+/* --------------------------------------------------- 3. failed, not cancelled */
+
+reapCheck(
+    'the sweep reaps to a state other than Failed. Cancelled means an '
+    . 'administrator stopped it, and losing the difference between "somebody '
+    . 'stopped this" and "this broke" is the distinction an operator needs',
+    false !== strpos($reap, 'getFailedState()')
+    && false === strpos($reap, 'getCancelledState()')
+);
+
+/* ------------------------------------------------------------ 4. it says why */
+
+reapCheck(
+    'the state transition is not recorded, so no reader of the log sees the '
+    . 'task move to Failed',
+    false !== strpos($reap, 'TaskLog::recordStates(')
+);
+
+reapCheck(
+    'the reason row is no longer an error row. The reason is the whole value '
+    . 'of this row -- a state row saying only "Failed" against a task whose '
+    . 'host is gone tells an operator nothing they can act on',
+    false !== strpos($reap, 'TaskLog::TYPE_ERROR')
+);
+
+reapCheck(
+    'the reason no longer names which reference failed to resolve',
+    false !== strpos($reap, "_('host no longer exists')")
+    && false !== strpos($reap, "_('task type no longer exists')")
+    && false !== strpos($reap, "_('image no longer exists')")
+);
+
+reapCheck(
+    'the batched reason rows dropped ip or type. A batched INSERT never runs '
+    . "TaskLog's constructor, which is where a singly-written row gets both, "
+    . 'and `ip` is varchar(15) NOT NULL',
+    false !== strpos($reap, "'ip',")
+    && false !== strpos($reap, "'type',")
+);
+
+reapCheck(
+    'the reaper stopped casting the remote address. There is none in a '
+    . 'daemon: filter_input(INPUT_SERVER, REMOTE_ADDR) is null under CLI and a '
+    . 'null bound into a NOT NULL column is error 1048 on a strict server',
+    false !== strpos($reap, '(string)self::$remoteaddr')
+);
+
+/* -------------------------------- 5. the log it writes into (GH-1378 1 and 2) */
+
+$recordState = '';
+if (preg_match('/public static function recordState\(.*?\n    \}/s', $log, $m)) {
+    $recordState = $m[0];
+}
+reapCheck(
+    'TaskLog::recordState() is gone, so a state row can once again only be '
+    . 'written by a TaskingElement -- and cancellation has none',
+    '' !== $recordState
+);
+
+reapCheck(
+    'recordState() stamps the row with something other than the moment of '
+    . 'the transition. Passing the task\'s createdTime made In-Progress and '
+    . 'Complete share a timestamp to the second, so nothing could be ordered '
+    . 'and repeated transitions read as duplicates',
+    false !== strpos($recordState, "->set('createdTime', self::niceDate()")
+);
+
+reapCheck(
+    'recordState() no longer refuses a task that does not resolve, so the '
+    . 'log can claim a transition for a task that is not there',
+    false !== strpos($recordState, '$Task->isValid()')
+);
+
+$recordStates = '';
+if (preg_match('/public static function recordStates\(.*?\n    \}/s', $log, $m)) {
+    $recordStates = $m[0];
+}
+reapCheck(
+    'TaskLog::recordStates() is gone, so a bulk cancel has to rebuild a Task '
+    . 'per id to record itself',
+    '' !== $recordStates
+);
+
+reapCheck(
+    'recordStates() no longer reads the state back from `tasks`. Trusting the '
+    . 'caller\'s ids records what the caller assumed rather than what the row '
+    . 'says, and logs a transition for an id that no longer resolves',
+    false !== strpos($recordStates, 'FROM `tasks` ')
+    && false !== strpos($recordStates, '`taskStateID`')
+);
+
+reapCheck(
+    'recordStates() stopped casting the remote address -- same 1048 as the '
+    . 'reaper, and this one is reached from the multicast manager too',
+    false !== strpos($recordStates, '(string)self::$remoteaddr')
+);
+
+reapCheck(
+    'recordStates() no longer sets ip or type, which a batched INSERT cannot '
+    . "get from TaskLog's constructor",
+    false !== strpos($recordStates, "'ip',")
+    && false !== strpos($recordStates, "'type',")
+);
+
+$taskCancel = '';
+if (preg_match('/public function cancel\(\).*?\n        return \$this;/s', $task, $m)) {
+    $taskCancel = $m[0];
+}
+reapCheck(
+    'Task::cancel() could not be isolated',
+    '' !== $taskCancel
+);
+reapCheck(
+    'Task::cancel() records nothing, so In-Progress stays the last word the '
+    . 'log ever says about a cancelled task',
+    false !== strpos($taskCancel, 'TaskLog::recordState($this)')
+);
+reapCheck(
+    'Task::cancel() records the transition without checking the save '
+    . 'happened, so the log can claim a state change the database refused',
+    (bool)preg_match(
+        '/if \(\$this->set\(\'stateID\', self::getCancelledState\(\)\)->save\(\)\) \{\s*TaskLog::recordState\(\$this\);/s',
+        $taskCancel
+    )
+);
+
+$manCancel = '';
+if (preg_match('/public function cancel\(\$taskids\).*?\n    \}/s', $man, $m)) {
+    $manCancel = $m[0];
+}
+reapCheck(
+    'TaskManager::cancel() could not be isolated',
+    '' !== $manCancel
+);
+reapCheck(
+    'TaskManager::cancel() records nothing, so a group cancel leaves every '
+    . 'one of its tasks reading In-Progress in the log',
+    false !== strpos($manCancel, 'TaskLog::recordStates($cancelledIDs)')
+);
+/*
+ * Order, not presence. $findWhere selects on the states being cancelled OUT
+ * of, so enumerating after the update matches nothing and the recording is
+ * silently a no-op -- which passes a presence check perfectly.
+ */
+$idsPos = strpos($manCancel, '$cancelledIDs = self::getSubObjectIDs(');
+$updPos = strpos($manCancel, '$updated = $this->update(');
+reapCheck(
+    'TaskManager::cancel() enumerates the ids after the update. $findWhere '
+    . 'selects on the states being cancelled out of and matches nothing once '
+    . 'they are gone, so nothing would be recorded and nothing would say so',
+    false !== $idsPos && false !== $updPos && $idsPos < $updPos
+);
+
+reapCheck(
+    'TaskingElement::taskLog() builds the row itself again instead of going '
+    . 'through recordState(), which is how the two callers that have no '
+    . 'TaskingElement came to write nothing',
+    false !== strpos($element, 'return TaskLog::recordState($this->Task);')
+);
+
+/* ------------------------------------------------ 6. the scheduler runs it */
+
+reapCheck(
+    'the task scheduler no longer runs the sweep, so nothing does',
+    false !== strpos($sched, "getClass('TaskManager')->reapUnrunnable()")
+);
+
+/*
+ * THE ORDERING ONE. _commonOutput() counts SCHEDULED and power-management
+ * tasks and throws ' * No tasks found!' when there are none, which ends the
+ * pass. A sweep placed after that never runs on an install with no scheduled
+ * task and no power-management task -- most small installs, and exactly the
+ * population reporting tasks stuck active forever.
+ */
+$reapPos = strpos($sched, "getClass('TaskManager')->reapUnrunnable()");
+$throwPos = strpos($sched, "' * No tasks found!'");
+reapCheck(
+    'the sweep runs after the scheduler\'s "No tasks found!" exit, so it '
+    . 'never runs at all on an install with no scheduled tasks',
+    false !== $reapPos && false !== $throwPos && $reapPos < $throwPos
+);
+
+reapCheck(
+    'the scan did not reach the sources and would pass vacuously',
+    strlen($man) > 5000
+    && strlen($log) > 2500
+    && strlen($sched) > 5000
+    && strlen($task) > 5000
+    && strlen($element) > 4000
+);
+
+if (count($failures) > 0) {
+    echo 'FAIL unrunnable-tasks-are-reaped (' . count($failures) . " problem(s))\n";
+    foreach ($failures as $failure) {
+        echo "  - $failure\n";
+    }
+    exit(1);
+}
+
+echo "PASS unrunnable-tasks-are-reaped ($checks checks)\n";
+exit(0);


### PR DESCRIPTION
Port of #1392 to the patches line, with the log it records into built first — this branch did not have one.

#1391 closes the write paths that create a task pointing at nothing. This is the other half: the rows an install is **already** carrying, which no code change can reach. Independent of #1391 — different files, no shared lines, either can merge first.

## The rows

A `tasks` row whose `taskHostID`, `taskTypeID` or — for an imaging type — `taskImageID` matches no row is permanent and unreadable at the same time.

* `taskStateID` still resolves, so every "is this task live" test in the tree is an allowlist of `getQueuedStates()` plus `getProgressState()` and counts it as active **forever**.
* The other three do not, so the Active Tasks list's `LEFT OUTER JOIN`s return `NULL`, its `isset()` guards draw the row with no host, no image and no type, and there is not even a name to act on.
* No host can complete it either — `TaskingElement` cannot build the Image or the Host, so the machine is turned away at check-in.

Forum topics [18228](https://forums.fogproject.org/topic/18228/failed-to-update-database-and-host) and [18230](https://forums.fogproject.org/topic/18230/1-5-10-2402-additional-null-tasks-created-but-this-time-manages-to-start-a-transfer).

## `TaskManager::reapUnrunnable()`

Moves those to Failed and records why, from the task scheduler, so an install fixes itself rather than an admin being told to run SQL.

**Resolution, not zero.** A dangling reference is found by asking whether it **JOINs**, which is true of a `0` and of the id of something deleted alike. Matching on `0` would be wrong twice over: it would miss every task pointing at a *deleted* row, and it would destroy good tasking — a wipe, snapin, hardware inventory, password reset or Secure Boot task has no image **by design** and stores `taskImageID` 0. Confirmed against a live install carrying three such rows (two `All Snapins`, one `Enroll Secure Boot`), every one correct.

So the image is only asked about for an imaging task type, and which types those are is asked of `TaskType::isDeploy(true)`/`isCapture(true)` rather than written down where it can drift. `isDeploy` already covers multicast.

The three joins are the same three the Active Tasks list builds, which is what makes "does this row draw blank" and "does this row get reaped" one question instead of two.

**Failed, not Cancelled.** Cancelled means an administrator stopped it. Guarded on the `taskStates` row for Failed (schema 281) actually existing, as `TaskError::_markFailed()` is — this runs from a daemon, which reaches the window between the files landing and the database being upgraded before any person does.

**Nothing is unwound**, unlike `cancel()`. A task that cannot resolve its host or its task type cannot have got past check-in, so there is no token to reissue, no multicast session behind it and no snapin job riding on it.

## What had to be built first — #1378 causes 1 and 2

The sweep needs somewhere truthful to record itself, and there was nowhere. A state row could only be written by `TaskingElement::taskLog()`, so the two callers that reach `tasks` without one — `Task::cancel()` and `TaskManager::cancel()` — wrote **nothing at all**. In-Progress stayed the last word the log ever said about a cancelled task, and the REST API is the only reader of that log on this branch, so there was no other way to find out.

| Added | Why |
|---|---|
| `TaskLog::recordState()` | the single definition of a state row, callable without a `TaskingElement` |
| `TaskLog::recordStates()` | its bulk sibling: `TaskManager::cancel()` cancels a whole group in one statement, so recording it costs one SELECT and one batched INSERT rather than a reload and an INSERT per task |

Four details that are the difference between a log and a plausible-looking log:

* **The timestamp is the transition, not the task's `createdTime`.** `createdTime` maps to this row's `createTime` — one column, not two — so every row a task ever wrote carried the instant the *task* was created. In-Progress and Complete came out sharing a timestamp to the second, so nothing could be ordered and repeated transitions read as duplicates.
* **Both read the state back from `tasks`** rather than trusting the caller, so a task whose state moved concurrently logs the truth and an id that no longer resolves logs nothing.
* **`TaskManager::cancel()` enumerates its ids BEFORE the update.** `$findWhere` selects on the states being cancelled *out of* and matches nothing once they are gone — enumerating afterwards records nothing and says nothing. Mutation-verified as its own gate, because a presence check passes that defect perfectly.
* **`Task::cancel()` records only if the save happened**, so the log cannot claim a transition the database refused.

Both batched writers cast the remote address. There is none in a daemon: `filter_input(INPUT_SERVER, 'REMOTE_ADDR')` is `null` under CLI, `ip` is `varchar(15) NOT NULL`, and a null bound into a NOT NULL column is error 1048 on any strict server — which is every server since GH-1245 stopped PDODB clearing `sql_mode`. `save()` coerces this for a single row; `insertBatch()` does not.

## The scheduler ordering

The sweep runs **before** `_commonOutput()`'s `' * No tasks found!'` exit. That exit counts **scheduled** and power-management tasks and throws when there are none, ending the pass — so anything placed after it never runs on an install with no scheduled task and no power-management task. That is most small installs, and it is exactly the population reporting tasks stuck active forever.

## How this differs from #1392

| 1.6 | here |
|---|---|
| writes `imageName` onto the row | `taskLog` has no such column — `imagingLog` is still the imaging record on this branch |
| writes `stateChangedTime` | `Task` has no such field here |
| `TaskType::DEPLOYTASKS`/`CAPTURETASKS` | `isDeploy(true)`/`isCapture(true)`, which is what this branch has |
| also moves a pre-existing expired-check-in sweep above the exit | this branch has no such sweep |

The reaper's error rows **do** fill `hostName` and `taskTypeName` where a state row leaves them empty. That is the case those columns were added for: the host is already gone, so the name cannot be recovered by joining, and it is the only thing that makes the row mean anything later.

## Proof

`background_scripts/prove_unrunnable_task_reaper_15.php` against a real replay of this branch's own `commons/schema.php`: **23/23**. Built around what must **not** be reaped, because that is the expensive way to get this wrong:

| fixture | expected | result |
|---|---|---|
| A — active, host deleted | reaped → Failed | ✅ |
| B — active, task type deleted | reaped → Failed | ✅ |
| C — active Deploy, image deleted | reaped → Failed | ✅ |
| **D — active All Snapins, `imageID` 0** | **left alone** | ✅ |
| **E — active, everything resolves** | **left alone** | ✅ |
| **F — Complete, host since deleted** | **left alone** | ✅ |

Plus: the reasons name the right reference for each, both log rows land with the Failed state, the error rows carry the host name where there is one, a second pass finds nothing to do, and cancelling through **both** paths now writes exactly one state row carrying the state it moved *to* — where before it wrote none. `negctl_15_reaper.sh` runs the same script against the unpatched tree and it fails.

`tests/unrunnable-tasks-are-reaped.test.php` (30 checks) pins the mechanism; all **27** mutations of its gates are caught, including the four that matter most — matching on `imageID = 0` instead of the join, asking about the image for every task type, enumerating the cancel ids after the update, and moving the sweep back below the scheduler's exit. Whole suite: **38 passed, 0 failed**.

## Related

* **#1378** — its causes 1 and 2 are closed here, which is the work above. What remains is its cause 3, the pre-existing state rows whose task is already gone.
* **#895** — closed, but its own tail says "pre-existing rows are data and need a sweep" for the `snapintask` orphans left behind. Same shape, different table; not in this PR.

## Downstream

None. No route class added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
