### PR TITLE
Name the page a list route returns

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -656,6 +656,13 @@ class OpenAPI extends FOGBase
                 continue;
             }
             $schemas[self::schemaName($class)] = $entity;
+            // Every class with an entity also answers list, search and
+            // active, and all three return the same page shape. Registered
+            // beside the entity so the pair cannot drift apart.
+            $ref = '#/components/schemas/' . self::schemaName($class);
+            $pageRef = self::pageRef($ref);
+            $page = substr($pageRef, strrpos($pageRef, '/') + 1);
+            $schemas[$page] = self::_pageSchema($ref);
         }
         return $schemas;
     }
@@ -1815,24 +1822,81 @@ class OpenAPI extends FOGBase
                 'description' => _('A page of results.'),
                 'content' => [
                     'application/json' => [
-                        'schema' => [
-                            'allOf' => [
-                                ['$ref' => '#/components/schemas/ListEnvelope'],
-                                [
-                                    'type' => 'object',
-                                    'properties' => [
-                                        'data' => [
-                                            'type' => 'array',
-                                            'items' => ['$ref' => $ref]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
+                        'schema' => ['$ref' => self::pageRef($ref)]
                     ]
                 ]
             ]
         ];
+    }
+
+    /**
+     * The component ref for the page wrapper around a row type.
+     *
+     * `#/components/schemas/Host` -> `#/components/schemas/HostPage`.
+     *
+     * The wrapper used to be written inline at each of the three places a
+     * page is returned, which is legal and unusable: an anonymous schema has
+     * no name, so every code generator invents one. AutoRest called this one
+     * `IPaths8Cd1AsHostGetResponses200ContentApplicationJsonSchema` and put
+     * it in Get-Host's OutputType, where a user reads it.
+     *
+     * @param string $ref The row type's own ref.
+     *
+     * @return string
+     */
+    public static function pageRef($ref)
+    {
+        $name = substr((string)$ref, strrpos((string)$ref, '/') + 1);
+        return '#/components/schemas/' . $name . 'Page';
+    }
+
+    /**
+     * The page wrapper schema for one row type: the shared envelope, plus a
+     * data array of that type.
+     *
+     * Named rather than inline so it is addressable -- by a generator
+     * deciding what to call the model, and by x-ms-pageable, which names the
+     * item property it has to walk.
+     *
+     * @param string $ref The row type's own ref.
+     *
+     * @return array
+     */
+    private static function _pageSchema($ref)
+    {
+        // Flat, not an allOf over ListEnvelope, and the reason is
+        // mechanical rather than stylistic.
+        //
+        // x-ms-pageable names the property holding the rows and the property
+        // holding the link, and a generator then looks both up on the
+        // schema: AutoRest does
+        //
+        //   schema.properties.find(p => p.serializedName === itemName)
+        //
+        // An allOf composition has no properties of its own -- data and
+        // nextUrl each live in a branch -- so that lookup finds nothing and
+        // the generator fails outright. Composing was tried first and
+        // reproduced exactly that.
+        //
+        // Inlining the envelope is also the better shape to read: a page IS
+        // its counts, its link and its rows, and a named type saying so
+        // beats one that says "see the other schema".
+        $envelope = self::_listEnvelopeSchema();
+        $properties = isset($envelope['properties'])
+            ? $envelope['properties']
+            : [];
+        $properties['data'] = [
+            'type' => 'array',
+            'items' => ['$ref' => $ref]
+        ];
+        $out = [
+            'type' => 'object',
+            'properties' => $properties
+        ];
+        if (isset($envelope['description'])) {
+            $out['description'] = $envelope['description'];
+        }
+        return $out;
     }
 
     /**


### PR DESCRIPTION
Follow-on to #1373 and #1382. Those made the document's names and relationships readable by a generator; this one makes the *response type* readable.

## The problem

Every list, search and active route returned an anonymous `allOf`, written inline at the response:

```json
"schema": { "allOf": [
    { "$ref": "#/components/schemas/ListEnvelope" },
    { "properties": { "data": { "type": "array", "items": { "$ref": ".../Host" } } } }
]}
```

Legal, and unusable. An anonymous schema has no name, so every generator invents one — and the invented name is what a user reads. AutoRest called this one:

```
IPaths8Cd1AsHostGetResponses200ContentApplicationJsonSchema
```

and put it in `Get-Host`'s `OutputType`, where it appears in `Get-Help`, in IntelliSense, and in `.GetType()`.

## The change

Named as `{Class}Page` and `$ref`'d. Derived from the row type's own ref, so **no call site changes**: `_listResponse()` computes `HostPage` from `Host`, and `_schemas()` registers the pair together so they cannot drift apart.

The page schema is **flat** rather than an `allOf` over `ListEnvelope` — the envelope's properties are inlined beside `data`. A page *is* its counts, its link and its rows, and a named type that says so beats one that says "see the other schema". `ListEnvelope` stays registered; the task route still references it.

## Measured

Same generator, same config, only the document changed:

| | before | after |
|---|---|---|
| generated models | 2,167 | **1,457** |
| synthesized `Paths*`/`Components*` names | 1,866 | **973** |
| `Get-Host` OutputType | `IPaths8Cd1As…` | **`IHostPage`** |

The 973 that remain are inline **request** bodies — create, update and join payloads. Same defect, same fix, deliberately left out so the response half is reviewable on its own.

## What is not here, and why

`x-ms-pageable` was meant to ship with this. FOG caps an unpaged list at `MAX_ROWS`, so a client that does not follow `nextUrl` silently stops at 10,000 rows, and the extension is how a generator is told to follow it. AutoRest's PowerShell generator reads both of its keys, so the shape looked right:

```json
"x-ms-pageable": { "itemName": "data", "nextLinkName": "nextUrl" }
```

**It crashes the generator.**

```
fatal | TypeError: Cannot read properties of undefined (reading 'properties')
error | Plugin powershell-v2 reported failure.
```

Bisected rather than guessed. Named schemas alone generate 2,569 files clean; adding the extension fails. It fails with the page schema composed **and** flattened, on all 91 operations **and** on a single one, and with `itemName` alone as well as with both keys. Every arm failed, so the extension is not usable against this document at 4.0.758 whatever shape the page takes.

Emitting something that breaks the primary consumer is worse than emitting nothing, so it is not emitted. Paging stays a client-side concern, with the row cap documented on the envelope as it is today.

## Verification

On a regenerated document (`spec/tools/dump-openapi.php`, no server needed):

```
106 schemas, 106 distinct $refs, 0 dangling, 0 unreferenced
52 page schemas
0 inline allOf remaining in any 200 response
```

Through AutoRest.PowerShell 4.0.758: completes, 2,569 files, **zero** `inferred without finding action` warnings.

`php -l` clean; added lines within the file's 80-column style.
