### PR TITLE
Say what was actually checked in the Secure Boot enrolment path

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -11331,8 +11331,32 @@ _publishSecureBootAuthVars() {
     # install rather than leaving stale ones a client would happily enrol: an
     # .auth signed by a key this server no longer holds enrols a platform the
     # server can never update again.
+    #
+    # This used to return in silence, which made it the ONE cause of "automatic
+    # enrolment is unavailable" that produced no diagnostic anywhere -- and it
+    # is the likeliest cause on a server that has efitools installed. An admin
+    # re-running the installer to fix it therefore saw nothing at all, then read
+    # a web page confidently naming a different cause (GH-1266). It says which
+    # of its three reasons applied now, so re-running the installer surfaces it.
     if [[ -z $secureBootPKKey || -z $secureBootKEKKey ]]; then
         rm -f "$helper" "${kitdir}"/{PK,KEK,db}.auth >>$error_log 2>&1
+        dots "Publishing Secure Boot variable updates"
+        echo "Skipped"
+        if [[ ${PKI_sb_enabled:-yes} != yes ]]; then
+            echo " * Secure Boot enrolment material is switched off for this"
+            echo "   install (PKI_sb_enabled is not \"yes\"), so no platform keys"
+            echo "   were minted and the automatic enrolment blobs were not"
+            echo "   built. FOS kernels are still signed."
+        elif [[ -z ${PKI_sb_codesign_key} || -z ${PKI_sb_codesign_cert} ]]; then
+            echo " * No Secure Boot signing key is configured, so there is"
+            echo "   nothing for a platform key to authorise and the automatic"
+            echo "   enrolment blobs were not built."
+        else
+            echo " * The Secure Boot platform keys (PK/KEK) are missing, so the"
+            echo "   automatic enrolment blobs were not built. Generating them"
+            echo "   failed earlier in this run -- see $error_log."
+        fi
+        echo "   The MOK enrolment paths are unaffected."
         return 0
     fi
 
@@ -11364,6 +11388,11 @@ _publishSecureBootAuthVars() {
     install -o root -g root -m 0700 ../packages/secureboot/fog-build-sb-authvars \
         "$helper" >>$error_log 2>&1 || {
         echo "Failed"
+        # The only arm here that used to print a bare "Failed" with no cause,
+        # which is the same complaint as GH-1266 one line down.
+        echo " * Could not install the Secure Boot variable builder to $helper,"
+        echo "   so automatic enrolment will be unavailable. The MOK enrolment"
+        echo "   paths are unaffected. See $error_log."
         return 0
     }
     sed -i "s|^CONF=.*|CONF=\"${conf}\"|" "$helper" >>$error_log 2>&1

--- a/packages/secureboot/fog-enroll-mok.sh
+++ b/packages/secureboot/fog-enroll-mok.sh
@@ -69,9 +69,24 @@ case "$answer" in
     *) echo; echo " Aborted -- nothing was changed."; pause; exit 1 ;;
 esac
 
+# --test-key interrogates MokList -- shim's trust store -- and nothing else. The
+# check is right for what this script does: it IS the MOK enroller, and
+# re-enrolling a MOK genuinely is a no-op. The MESSAGE used to be wrong, drawing
+# a machine-wide "nothing to do" from a store-specific test (GH-1266). It is not
+# the same question: a MOK only helps where shim is in the boot chain -- firmware
+# never reads MokList -- so booting a FOG-signed binary DIRECTLY needs the
+# certificate in db, which this script neither reads nor writes. An admin setting
+# up the shim-less route was being told to stop.
 if mokutil --test-key "$cert" 2>/dev/null | grep -qi "already enrolled"; then
     echo
-    echo " This key is already enrolled on this machine. Nothing to do."
+    echo " This key is already enrolled in MokList, so this script has nothing"
+    echo " left to do. MokList is shim's own trust store: it covers anything"
+    echo " booted through shim, which is the normal FOG PXE path."
+    echo
+    echo " It does NOT cover the firmware's db. This script does not look at db"
+    echo " and does not write to it. If you are setting up a shim-less boot --"
+    echo " firmware loading a FOG-signed binary directly -- MOK.der still has to"
+    echo " go into db, which is a separate step in the Secure Boot guide."
     pause
     exit 0
 fi

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -558,13 +558,42 @@ class FOGConfigurationPage extends FOGPage
             }
         }
         if (!$haveAuth) {
-            // The installer builds these whenever efitools is present, so a
-            // missing set almost always means that package is not installed.
-            $auto = '<p>' . sprintf(
-                '%s. %s <code>efitools</code> %s.',
-                _('Automatic Secure Boot enrolment is not available on this server'),
-                _('Install'),
-                _('and re-run the installer to enable it')
+            // Reports the CONDITION, not a cause. This used to assert that
+            // efitools was missing, which is only one of three ways the blobs
+            // can be absent -- and the least likely on a server that has the
+            // package installed. A server with efitools present and PK/KEK on
+            // disk still got told to install efitools (GH-1266). The page
+            // cannot see which cause applied; the installer can, and now says
+            // so on every run, so this points there instead of guessing.
+            $auto = '<p>' . _(
+                'This server has not published the automatic Secure Boot '
+                . 'enrolment blobs (PK.auth, KEK.auth and db.auth), so '
+                . 'automatic enrolment is unavailable. There are three '
+                . 'reasons that happens:'
+            ) . '</p>';
+            $auto .= '<ul>';
+            $auto .= '<li>' . _(
+                'Secure Boot enrolment material is switched off for this '
+                . 'install, or no signing key is configured -- so no platform '
+                . 'keys were minted.'
+            ) . '</li>';
+            // One msgid with a placeholder rather than sentence fragments
+            // glued together: a translator needs the whole sentence to word it.
+            $auto .= '<li>' . sprintf(
+                _(
+                    'The %s package is not installed and could not be built '
+                    . 'from source.'
+                ),
+                '<code>efitools</code>'
+            ) . '</li>';
+            $auto .= '<li>' . _(
+                'Building the blobs failed.'
+            ) . '</li>';
+            $auto .= '</ul>';
+            $auto .= '<p>' . _(
+                'Re-run the installer and read what it prints under '
+                . '"Publishing Secure Boot variable updates" -- it names '
+                . 'which of the three applied here.'
             ) . '</p>';
             $auto .= '<p>' . _(
                 'The manual enrolment steps below are unaffected.'

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1113,10 +1113,6 @@ msgstr "Integritätseinstellungen"
 msgid "Auto Logout Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "Es gibt keine Images auf diesem Server."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1216,6 +1212,10 @@ msgstr "Broadcast aktualisiert"
 
 msgid "Browse"
 msgstr "browse"
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4153,10 +4153,6 @@ msgstr "Update"
 msgid "Initrd Update Fail"
 msgstr "Drucker-Update fehlgeschlagen!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Installierte Plugins"
-
 msgid "Install Plugins"
 msgstr "Plugins installieren"
 
@@ -6598,6 +6594,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7081,6 +7080,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8330,6 +8332,10 @@ msgstr "Es gibt keine Images auf diesem Server."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Die Einstellung 'ist Masterknoten' definiert,"
@@ -8763,6 +8769,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9751,9 +9760,6 @@ msgstr "und die Datenbank läuft,"
 
 msgid "and node A only has a 5Mbps and you want the speed"
 msgstr "und Knoten A hat nur 5MBit/s, und Sie wollen die Geschwindigkeit"
-
-msgid "and re-run the installer to enable it"
-msgstr ""
 
 msgid "and set it to master"
 msgstr "und diesen als Master einstellen,"
@@ -10776,6 +10782,10 @@ msgstr ""
 #~ msgstr "Versuche, anzupingen"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "Es gibt keine Images auf diesem Server."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
@@ -11025,6 +11035,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Installierte Plugins"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1117,10 +1117,6 @@ msgstr "Settings"
 msgid "Auto Logout Time"
 msgstr "Default log out time (in minutes)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "There are no images on this server."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1220,6 +1216,10 @@ msgstr "Broadcast Updated"
 
 msgid "Browse"
 msgstr ""
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Load failed: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4154,10 +4154,6 @@ msgstr "Update"
 msgid "Initrd Update Fail"
 msgstr "Printer update failed!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Installed Plugins"
-
 msgid "Install Plugins"
 msgstr "Install Plugins"
 
@@ -6595,6 +6591,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7078,6 +7077,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8325,6 +8327,10 @@ msgstr "There are no images on this server."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "This setting defines "
@@ -8757,6 +8763,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9744,9 +9753,6 @@ msgid "and if the Database service is running"
 msgstr "Check that database is running"
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"
@@ -10764,6 +10770,10 @@ msgstr ""
 #~ msgstr "Attempting to ping"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "There are no images on this server."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
 
@@ -11003,6 +11013,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "Import Users"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Installed Plugins"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1131,10 +1131,6 @@ msgstr "Configuración Tecla"
 msgid "Auto Logout Time"
 msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "No hay grupos en este servidor."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1237,6 +1233,10 @@ msgstr "Servicio de Actualización!"
 
 msgid "Browse"
 msgstr ""
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Carga ha fallado: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4235,10 +4235,6 @@ msgstr "Actualizar"
 msgid "Initrd Update Fail"
 msgstr "actualización de la impresora ha fallado!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Instalador inteligente (recomendado)"
-
 msgid "Install Plugins"
 msgstr ""
 
@@ -6739,6 +6735,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7229,6 +7228,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8512,6 +8514,10 @@ msgstr "No hay grupos en este servidor."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 msgid "The 'Is Master Node' setting defines which"
 msgstr ""
 
@@ -8943,6 +8949,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9929,9 +9938,6 @@ msgid "and if the Database service is running"
 msgstr "Compruebe que la base de datos se está ejecutando"
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"
@@ -10942,6 +10948,10 @@ msgstr ""
 #~ msgstr "Sesión con ese nombre ya existe"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "No hay grupos en este servidor."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Guardar cambios"
 
@@ -11195,6 +11205,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Users"
 #~ msgstr "Importar"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Instalador inteligente (recomendado)"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1113,10 +1113,6 @@ msgstr "Integritätseinstellungen"
 msgid "Auto Logout Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "Es gibt keine Images auf diesem Server."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1216,6 +1212,10 @@ msgstr "Broadcast aktualisiert"
 
 msgid "Browse"
 msgstr "browse"
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4153,10 +4153,6 @@ msgstr "Update"
 msgid "Initrd Update Fail"
 msgstr "Drucker-Update fehlgeschlagen!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Installierte Plugins"
-
 msgid "Install Plugins"
 msgstr "Plugins installieren"
 
@@ -6599,6 +6595,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7082,6 +7081,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8331,6 +8333,10 @@ msgstr "Es gibt keine Images auf diesem Server."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Die Einstellung 'ist Masterknoten' definiert,"
@@ -8764,6 +8770,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9752,9 +9761,6 @@ msgstr "und die Datenbank läuft,"
 
 msgid "and node A only has a 5Mbps and you want the speed"
 msgstr "und Knoten A hat nur 5MBit/s, und Sie wollen die Geschwindigkeit"
-
-msgid "and re-run the installer to enable it"
-msgstr ""
 
 msgid "and set it to master"
 msgstr "und diesen als Master einstellen,"
@@ -10777,6 +10783,10 @@ msgstr ""
 #~ msgstr "Versuche, anzupingen"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "Es gibt keine Images auf diesem Server."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
@@ -11026,6 +11036,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "Benutzer importieren"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Installierte Plugins"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1118,10 +1118,6 @@ msgstr "Paramètres"
 msgid "Auto Logout Time"
 msgstr "Par défaut déconnecter le temps (en minutes)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "Il n'y a pas d'images sur ce serveur."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1221,6 +1217,10 @@ msgstr "Diffusion Mise à jour"
 
 msgid "Browse"
 msgstr ""
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Échec du chargement: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4156,10 +4156,6 @@ msgstr "Mettre à jour"
 msgid "Initrd Update Fail"
 msgstr "mise à jour de l'imprimante a échoué!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Plugins installés"
-
 msgid "Install Plugins"
 msgstr "Installer Plugins"
 
@@ -6597,6 +6593,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7080,6 +7079,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8327,6 +8329,10 @@ msgstr "Il n'y a pas d'images sur ce serveur."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Ce paramètre définit "
@@ -8759,6 +8765,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9746,9 +9755,6 @@ msgid "and if the Database service is running"
 msgstr "Vérifiez que la base de données est en cours d'exécution"
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"
@@ -10766,6 +10772,10 @@ msgstr ""
 #~ msgstr "Tenter de faire un ping"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "Il n'y a pas d'images sur ce serveur."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
 
@@ -11009,6 +11019,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "Importer des utilisateurs"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Plugins installés"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1086,10 +1086,6 @@ msgstr "Impostazioni di integrità"
 msgid "Auto Logout Time"
 msgstr "Predefinito disconnettersi tempo (in minuti)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "Non ci sono immagini su questo server"
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1181,6 +1177,10 @@ msgstr "Broadcast aggiornato!"
 
 msgid "Browse"
 msgstr "Sfoglia"
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Caricamento non riuscito"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4028,10 +4028,6 @@ msgstr "Aggiornare"
 msgid "Initrd Update Fail"
 msgstr "Aggiornamento della stampante non riuscito"
 
-#, fuzzy
-msgid "Install"
-msgstr "plugin installati"
-
 msgid "Install Plugins"
 msgstr "installare plugin"
 
@@ -6388,6 +6384,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -6854,6 +6853,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8045,6 +8047,10 @@ msgstr "Non ci sono immagini su questo server"
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 msgid "The 'Is Master Node' setting defines which"
 msgstr "L'impostazione \"nodo master\" definisce quale"
 
@@ -8470,6 +8476,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9422,9 +9431,6 @@ msgstr "e se il servizio Database è in esecuzione"
 
 msgid "and node A only has a 5Mbps and you want the speed"
 msgstr "E il nodo A ha solo 5Mbps e si desidera la velocità"
-
-msgid "and re-run the installer to enable it"
-msgstr ""
 
 msgid "and set it to master"
 msgstr "ed imposta a master"
@@ -10397,6 +10403,10 @@ msgstr ""
 #~ msgstr "Il tentativo di ping"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "Non ci sono immagini su questo server"
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
 
@@ -10641,6 +10651,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "Importa utenti"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "plugin installati"
 
 #~ msgid "Invalid Type"
 #~ msgstr "Tipo non valido"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1071,9 +1071,6 @@ msgstr "整合性設定"
 msgid "Auto Logout Time"
 msgstr "ホスト自動ログアウト"
 
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr ""
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1164,6 +1161,10 @@ msgstr "ブロードキャストを更新しました！"
 
 msgid "Browse"
 msgstr "参照"
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "読み込みに失敗しました"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -3989,10 +3990,6 @@ msgstr "Initrd 更新"
 msgid "Initrd Update Fail"
 msgstr "Initrd 更新"
 
-#, fuzzy
-msgid "Install"
-msgstr "インストール"
-
 msgid "Install Plugins"
 msgstr "プラグインをインストール"
 
@@ -6351,6 +6348,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr "Hello 送信間隔"
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -6809,6 +6809,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 msgid "Secure Boot kernel signing is not configured on this server"
@@ -7982,6 +7985,10 @@ msgstr "このサーバーにはイメージがありません"
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 msgid "The 'Is Master Node' setting defines which"
 msgstr "「マスターノード」設定は、どのノードを"
 
@@ -8407,6 +8414,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9361,9 +9371,6 @@ msgstr "また、データベースサービスが実行中かどうか"
 
 msgid "and node A only has a 5Mbps and you want the speed"
 msgstr "ノード A の帯域が 5 Mbps のみで、その速度に制限したい場合"
-
-msgid "and re-run the installer to enable it"
-msgstr ""
 
 msgid "and set it to master"
 msgstr "そしてマスターに設定します"
@@ -11149,6 +11156,10 @@ msgstr ""
 
 #~ msgid "Initrd Name"
 #~ msgstr "Initrd 名"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "インストール"
 
 #~ msgid "Install / Update Failed!"
 #~ msgstr "インストール/更新に失敗しました！"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -953,9 +953,6 @@ msgstr ""
 msgid "Auto Logout Time"
 msgstr ""
 
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr ""
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1041,6 +1038,9 @@ msgid "Broadcast updated!"
 msgstr ""
 
 msgid "Browse"
+msgstr ""
+
+msgid "Building the blobs failed."
 msgstr ""
 
 msgid "Buildroot Version"
@@ -3522,9 +3522,6 @@ msgstr ""
 msgid "Initrd Update Fail"
 msgstr ""
 
-msgid "Install"
-msgstr ""
-
 msgid "Install Plugins"
 msgstr ""
 
@@ -5603,6 +5600,9 @@ msgstr ""
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -6019,6 +6019,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 msgid "Secure Boot kernel signing is not configured on this server"
@@ -7055,6 +7058,10 @@ msgstr ""
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 msgid "The 'Is Master Node' setting defines which"
 msgstr ""
 
@@ -7454,6 +7461,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -8308,9 +8318,6 @@ msgid "and if the Database service is running"
 msgstr ""
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1117,10 +1117,6 @@ msgstr "Configurações"
 msgid "Auto Logout Time"
 msgstr "Padrão log out tempo (em minutos)"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "Não há imagens neste servidor."
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1220,6 +1216,10 @@ msgstr "transmitido Atualizado"
 
 msgid "Browse"
 msgstr ""
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "Carga falhou: %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4155,10 +4155,6 @@ msgstr "Atualizar"
 msgid "Initrd Update Fail"
 msgstr "atualização da impressora falhou!"
 
-#, fuzzy
-msgid "Install"
-msgstr "Plugins instalados"
-
 msgid "Install Plugins"
 msgstr "instalar Plugins"
 
@@ -6596,6 +6592,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7079,6 +7078,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8326,6 +8328,10 @@ msgstr "Não há imagens neste servidor."
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "Esta configuração define "
@@ -8758,6 +8764,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9745,9 +9754,6 @@ msgid "and if the Database service is running"
 msgstr "Verifique o banco de dados está em execução"
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"
@@ -10765,6 +10771,10 @@ msgstr ""
 #~ msgstr "A tentativa de executar ping"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "Não há imagens neste servidor."
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
 
@@ -11008,6 +11018,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "importar usuários"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "Plugins instalados"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1117,10 +1117,6 @@ msgstr "设置"
 msgid "Auto Logout Time"
 msgstr "默认注销时间（分钟）"
 
-#, fuzzy
-msgid "Automatic Secure Boot enrolment is not available on this server"
-msgstr "有此服务器上没有图像。"
-
 msgid "Automatic enrolment (Setup/Custom Mode)"
 msgstr ""
 
@@ -1220,6 +1216,10 @@ msgstr "广播更新"
 
 msgid "Browse"
 msgstr ""
+
+#, fuzzy
+msgid "Building the blobs failed."
+msgstr "加载失败： %s"
 
 #, fuzzy
 msgid "Buildroot Version"
@@ -4155,10 +4155,6 @@ msgstr "更新"
 msgid "Initrd Update Fail"
 msgstr "打印机更新失败！"
 
-#, fuzzy
-msgid "Install"
-msgstr "已安装的插件"
-
 msgid "Install Plugins"
 msgstr "安装插件"
 
@@ -6596,6 +6592,9 @@ msgstr "RX"
 msgid "Re-Transmit Hello Interval"
 msgstr ""
 
+msgid "Re-run the installer and read what it prints under \"Publishing Secure Boot variable updates\" -- it names which of the three applied here."
+msgstr ""
+
 msgid "Re-run the installer, which restricts them to root. If this persists, check that nothing else is widening permissions on the snapins directory afterwards."
 msgstr ""
 
@@ -7079,6 +7078,9 @@ msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the
 msgstr ""
 
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgstr ""
+
+msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -8326,6 +8328,10 @@ msgstr "有此服务器上没有图像。"
 msgid "The \"CSV (All)\" button exports every item that matches the current search to a CSV file (the whole list, not just what is on screen). The Copy, Excel and Print buttons act only on the rows currently loaded in the table."
 msgstr ""
 
+#, php-format
+msgid "The %s package is not installed and could not be built from source."
+msgstr ""
+
 #, fuzzy
 msgid "The 'Is Master Node' setting defines which"
 msgstr "此设置定义"
@@ -8758,6 +8764,9 @@ msgid "This section allows you to upload user defined reports that may not be a 
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
+msgstr ""
+
+msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9745,9 +9754,6 @@ msgid "and if the Database service is running"
 msgstr "检查数据库运行"
 
 msgid "and node A only has a 5Mbps and you want the speed"
-msgstr ""
-
-msgid "and re-run the installer to enable it"
 msgstr ""
 
 msgid "and set it to master"
@@ -10765,6 +10771,10 @@ msgstr ""
 #~ msgstr "尝试ping"
 
 #, fuzzy
+#~ msgid "Automatic Secure Boot enrolment is not available on this server"
+#~ msgstr "有此服务器上没有图像。"
+
+#, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
 
@@ -11008,6 +11018,10 @@ msgstr ""
 
 #~ msgid "Import Users"
 #~ msgstr "导入用户"
+
+#, fuzzy
+#~ msgid "Install"
+#~ msgstr "已安装的插件"
 
 #, fuzzy
 #~ msgid "Invalid Type"

--- a/tests/secureboot-enrolment-diagnostics.test.sh
+++ b/tests/secureboot-enrolment-diagnostics.test.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# Guards the "narrow check reported as a broad conclusion" bug class in the
+# Secure Boot enrolment path (#1266).
+#
+#   tests/secureboot-enrolment-diagnostics.test.sh
+#
+# Two faults, filed and fixed together because they share a shape. Between them
+# they made db/Setup-Mode enrolment look unavailable on a server that was fully
+# configured for it.
+#
+#   1. _publishSecureBootAuthVars()'s "no platform keys" branch RETURNED IN
+#      SILENCE. That is one of three ways the PK/KEK/db .auth blobs can be
+#      absent, and the only one that produced no diagnostic anywhere -- so an
+#      admin re-running the installer to fix it saw nothing at all. The web page
+#      then named a different cause outright ("install efitools"), which is the
+#      LEAST likely explanation on a server that has efitools installed. That is
+#      what was observed in the field.
+#
+#   2. fog-enroll-mok.sh tested MokList with `mokutil --test-key` and reported
+#      "already enrolled on this machine. Nothing to do." MokList is shim's
+#      trust store; firmware never reads it. Booting a FOG-signed binary
+#      directly, with no shim, needs the certificate in **db** -- a store this
+#      script neither reads nor writes. So an admin setting up the shim-less
+#      route was told to stop, by a script that had not looked at the thing they
+#      were asking about.
+#
+# The properties pinned here:
+#
+#   A  _publishSecureBootAuthVars' no-platform-keys branch emits a diagnostic
+#      rather than returning silently -- executed, not grepped, once per arm.
+#   B  Each of the three arms says something DIFFERENT, so the message actually
+#      distinguishes the causes rather than being one generic line.
+#   C  Every other "Failed" arm in that function carries a reason too.
+#   D  fog-enroll-mok.sh's already-enrolled path names MokList as what it
+#      checked and db as what it did not -- executed against a stubbed mokutil.
+#   E  It no longer makes the machine-wide "nothing to do" claim.
+#   F  The web page reports the condition and points at the installer, instead
+#      of asserting efitools as the cause.
+#
+# A, B, C and D/E execute the code. F is a content assertion scoped to the one
+# block that renders the message: the page method needs a booted FOG to render,
+# and the message text IS the deliverable here, so the text is what is pinned.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+MOKSH="$REPO/packages/secureboot/fog-enroll-mok.sh"
+PAGE="$REPO/packages/web/lib/pages/fogconfigurationpage.page.php"
+
+for f in "$FUNCS" "$MOKSH" "$PAGE"; do
+    [[ -f $f ]] || { echo "ERROR: $f not found" >&2; exit 1; }
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# A/B -- the installer's no-platform-keys branch, run for real.
+#
+# The function is pulled out on its own with stubs for everything it touches
+# before the branch. Running the installer is not an option in a test, and
+# sourcing all of functions.sh drags in the whole world.
+# ---------------------------------------------------------------------------
+run_publish() {
+    # $1 PKI_sb_enabled  $2 codesign key  $3 codesign cert
+    bash -c '
+        error_log=/dev/null
+        webdirdest="$4"; fogprogramdir="$4"
+        dots() { printf "  * %-60s" "$1"; }
+        _pkiZoneDir() { echo "${fogprogramdir}/pki/$1"; }
+        _ensureEfitools() { :; }
+        eval "$(awk "/^_publishSecureBootAuthVars\(\) \{/,/^\}\$/" "$5")"
+        secureBootPKKey="" secureBootKEKKey=""
+        PKI_sb_enabled="$1" PKI_sb_codesign_key="$2" PKI_sb_codesign_cert="$3"
+        _publishSecureBootAuthVars
+    ' _ "$1" "$2" "$3" "$WORK" "$FUNCS" 2>&1
+}
+
+optout=$(run_publish no  /k /c)
+nokey=$(run_publish  yes ""  "")
+genfail=$(run_publish yes /k /c)
+
+# Something beyond the dots line. The old code printed literally nothing, so an
+# empty capture is exactly the regression this exists to catch.
+for arm in optout nokey genfail; do
+    body=$(printf '%s\n' "${!arm}" | grep -v 'Publishing Secure Boot variable updates')
+    if [[ -n ${body//[[:space:]]/} ]]; then
+        ok "A: the $arm arm explains itself instead of returning silently"
+    else
+        bad "A: the $arm arm printed no diagnostic -- silent skip is back"
+    fi
+done
+
+# Distinct messages, or the branch is not actually distinguishing anything.
+if [[ $optout != "$nokey" && $nokey != "$genfail" && $optout != "$genfail" ]]; then
+    ok "B: the three causes produce three different messages"
+else
+    bad "B: two or more arms print the same message"
+fi
+
+# ---------------------------------------------------------------------------
+# C -- no bare "Failed" anywhere in that function. A status with no reason is
+# the same complaint as the silent return, one line down.
+# ---------------------------------------------------------------------------
+# Looks ahead for a reason line rather than at the very next line: a comment
+# between the status and its explanation is normal in this file.
+bare=$(awk '
+    /^_publishSecureBootAuthVars\(\) \{/ { inf = 1 }
+    inf && /echo "Failed"/ {
+        line = NR; found = 0
+        for (i = 0; i < 6; i++) {
+            if ((getline) <= 0) break
+            if ($0 ~ /echo " \*/) { found = 1; break }
+            if ($0 ~ /return|^\}$/) break
+        }
+        if (!found) print line
+    }
+    inf && /^\}$/ { inf = 0 }
+' "$FUNCS")
+if [[ -z $bare ]]; then
+    ok "C: every Failed arm in _publishSecureBootAuthVars states a cause"
+else
+    bad "C: bare Failed with no reason at line(s): $(echo "$bare" | tr '\n' ' ')"
+fi
+
+# ---------------------------------------------------------------------------
+# D/E -- fog-enroll-mok.sh, executed against a stubbed mokutil that reports the
+# key as already enrolled. sudo is stubbed to a passthrough because the script
+# re-execs itself through it, and openssl is real -- the certificate has to
+# parse or the script fails before reaching the branch under test.
+# ---------------------------------------------------------------------------
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not installed"; exit 0; }
+
+mkdir -p "$WORK/kit" "$WORK/bin"
+openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 1 \
+    -subj "/CN=FOG enrol-mok test/" -keyout "$WORK/mok.key" \
+    -out "$WORK/mok.pem" 2>/dev/null
+openssl x509 -in "$WORK/mok.pem" -outform der -out "$WORK/kit/MOK.der" 2>/dev/null
+# The script re-execs itself through sudo when not root. A passthrough stub
+# cannot satisfy that -- EUID stays non-zero, so it re-execs forever -- so the
+# re-exec is dropped from the COPY under test. Asserted rather than assumed: if
+# that line ever changes shape this fails loudly instead of quietly testing
+# nothing. The re-exec itself is not what is under test here; the message is.
+if ! grep -qF 'exec sudo -- "$0" "$@"' "$MOKSH"; then
+    echo "FAIL: the sudo re-exec in fog-enroll-mok.sh changed shape -- this"
+    echo "      test strips it and can no longer do so reliably."
+    exit 1
+fi
+# Neutered, not deleted: the line sits inside an `if`, so removing it outright
+# leaves a dangling `fi` and the script dies before the branch under test.
+sed 's|exec sudo -- "\$0" "\$@"|:|' "$MOKSH" > "$WORK/kit/fog-enroll-mok.sh"
+chmod +x "$WORK/kit/fog-enroll-mok.sh"
+bash -n "$WORK/kit/fog-enroll-mok.sh" || {
+    echo "FAIL: the de-sudo'd copy does not parse"
+    exit 1
+}
+
+cat > "$WORK/bin/mokutil" <<'EOS'
+#!/bin/bash
+case "$1" in
+    --sb-state) echo "SecureBoot enabled" ;;
+    --test-key) echo "$2 is already enrolled" ;;
+    --import)   echo "IMPORT SHOULD NOT HAPPEN" ; exit 1 ;;
+esac
+exit 0
+EOS
+chmod +x "$WORK/bin/mokutil"
+
+# "y" answers the fingerprint prompt; the trailing newline feeds pause's read.
+out=$(printf 'y\n\n' | PATH="$WORK/bin:$PATH" bash "$WORK/kit/fog-enroll-mok.sh" 2>&1)
+rc=$?
+
+# Proves the run reached the branch under test. Without this the two negative
+# assertions below pass whenever the script dies early -- which is a check that
+# can pass for the wrong reason, the thing this file exists to complain about.
+if [[ $rc -eq 0 ]] && grep -q 'Certificate:' <<<"$out"; then
+    ok "D: the run reached the already-enrolled branch"
+else
+    bad "D: the run never reached the branch (exit $rc)"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+fi
+
+if grep -qi 'MokList' <<<"$out" && grep -qi '\bdb\b' <<<"$out"; then
+    ok "D: the already-enrolled path names MokList and db as different stores"
+else
+    bad "D: already-enrolled output does not distinguish MokList from db"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+fi
+
+if grep -qi 'enrolled on this machine' <<<"$out"; then
+    bad "E: the machine-wide 'enrolled on this machine' claim is back"
+else
+    ok "E: no machine-wide claim drawn from a MokList-only test"
+fi
+
+if grep -qi 'IMPORT SHOULD NOT HAPPEN' <<<"$out"; then
+    bad "D: the script re-imported a key it had just reported as enrolled"
+else
+    ok "D: an already-enrolled key is still a no-op, as intended"
+fi
+
+# ---------------------------------------------------------------------------
+# F -- the web page's unavailable message. Scoped to the block that builds it,
+# so an unrelated mention of efitools elsewhere on the page cannot mask this.
+# ---------------------------------------------------------------------------
+block=$(awk '
+    /if \(!\$haveAuth\) \{/ { inb = 1 }
+    inb { print }
+    inb && /echo \$this->_box\(/ { exit }
+' "$PAGE")
+
+if [[ -z $block ]]; then
+    bad "F: could not find the !\$haveAuth block -- the anchor moved"
+elif grep -qi "and re-run the installer to enable it" <<<"$block"; then
+    bad "F: the page still asserts efitools as the cause"
+elif grep -qi "Publishing Secure Boot variable updates" <<<"$block"; then
+    ok "F: the page reports the condition and points at the installer output"
+else
+    bad "F: the page names no way for an admin to find the actual cause"
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #1266.

Two faults, filed together because they share a shape — **a narrow check reported as a broad conclusion** — and because between them they made `db`/Setup-Mode enrolment look unavailable on a server that was fully configured for it.

## 1. The installer's silent skip, and the page that guessed at it

`_publishSecureBootAuthVars()`'s "no platform keys" branch **returned in silence**. That is one of three ways the `PK`/`KEK`/`db` `.auth` blobs can be absent, and the only one that produced no diagnostic anywhere — so an admin re-running the installer to fix it saw nothing at all.

It now prints a `Skipped` line naming which of its three reasons applied:

| Condition | What it says now |
|---|---|
| `PKI_sb_enabled` not `yes` | enrolment material is switched off for this install; FOS kernels are still signed |
| no `PKI_sb_codesign_key`/`cert` | no signing key, so nothing for a platform key to authorise |
| keys absent anyway | generation failed earlier this run — see the error log |

The one bare `Failed` left in that function — the builder-install arm — states its cause too. Same complaint, one line down.

The web page then **asserted** the cause: *"Install `efitools` and re-run the installer."* Missing `efitools` is the least likely of the three on a server that has the package installed, and a server with `efitools` present **and** PK/KEK on disk was observed getting exactly that message. The page cannot see which cause applied; the installer can. So the page now reports the **condition** — this server has not published the blobs — lists the three causes, and points at what the installer prints under *"Publishing Secure Boot variable updates"*.

## 2. `fog-enroll-mok.sh` answering a question it did not ask

`mokutil --test-key` interrogates **MokList**, shim's trust store. The *check* is right for what this script does: it **is** the MOK enroller, and re-enrolling a MOK genuinely is a no-op. The **message** was wrong.

Firmware never reads MokList, so booting a FOG-signed binary **directly**, with no shim, needs the certificate in **db** — a store this script neither reads nor writes. `"This key is already enrolled on this machine. Nothing to do."` told an admin setting up the shim-less route to stop, on the strength of a test that had not looked at the thing they were asking about.

It now names MokList as what it checked and `db` as what it did not, and points at the guide for the `db` step.

## Behaviour

Unchanged on all three. Same paths taken, the already-enrolled key is still not re-imported, manual enrolment steps untouched. These are diagnostics.

## Test

`tests/secureboot-enrolment-diagnostics.test.sh` — 10 assertions.

The installer arms and the mok script are **executed**, not grepped: the installer function is pulled out with stubs for what it touches before the branch, and the mok script runs against a stubbed `mokutil` that reports the key as already enrolled. Two of its assertions are negative (no machine-wide claim; no re-import), which would pass whenever the script died early, so there is a guard asserting the run actually reached the branch under test — that guard caught a real bug in the harness during development.

Only the page's message is a content assertion, scoped to the `!$haveAuth` block so an unrelated `efitools` mention elsewhere on the page cannot mask it. The page method needs a booted FOG to render, and the message text is the deliverable here.

**Verified by mutation**, not by being green: reverting all three files to their pre-fix content turns **8 of the 10 red**. The two that stay green are the invariants that held before and after.

```
FAIL: A: the optout arm printed no diagnostic -- silent skip is back
FAIL: A: the nokey arm printed no diagnostic -- silent skip is back
FAIL: A: the genfail arm printed no diagnostic -- silent skip is back
FAIL: B: two or more arms print the same message
FAIL: C: bare Failed with no reason at line(s): 11366
FAIL: D: already-enrolled output does not distinguish MokList from db
FAIL: E: the machine-wide 'enrolled on this machine' claim is back
FAIL: F: the page still asserts efitools as the cause
passed: 2   failed: 8
```

`tests/secureboot-authvars.test.sh` still passes 7/7.

## Downstream

None. No routes, no schema, no class list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)