### PR TITLE
Say which store fog-enroll-mok.sh actually checked

### DIFF
--- a/packages/secureboot/fog-enroll-mok.sh
+++ b/packages/secureboot/fog-enroll-mok.sh
@@ -69,9 +69,24 @@ case "$answer" in
     *) echo; echo " Aborted -- nothing was changed."; pause; exit 1 ;;
 esac
 
+# --test-key interrogates MokList -- shim's trust store -- and nothing else. The
+# check is right for what this script does: it IS the MOK enroller, and
+# re-enrolling a MOK genuinely is a no-op. The MESSAGE used to be wrong, drawing
+# a machine-wide "nothing to do" from a store-specific test (GH-1266). It is not
+# the same question: a MOK only helps where shim is in the boot chain -- firmware
+# never reads MokList -- so booting a FOG-signed binary DIRECTLY needs the
+# certificate in db, which this script neither reads nor writes. An admin setting
+# up the shim-less route was being told to stop.
 if mokutil --test-key "$cert" 2>/dev/null | grep -qi "already enrolled"; then
     echo
-    echo " This key is already enrolled on this machine. Nothing to do."
+    echo " This key is already enrolled in MokList, so this script has nothing"
+    echo " left to do. MokList is shim's own trust store: it covers anything"
+    echo " booted through shim, which is the normal FOG PXE path."
+    echo
+    echo " It does NOT cover the firmware's db. This script does not look at db"
+    echo " and does not write to it. If you are setting up a shim-less boot --"
+    echo " firmware loading a FOG-signed binary directly -- MOK.der still has to"
+    echo " go into db, which is a separate step in the Secure Boot guide."
     pause
     exit 0
 fi

--- a/tests/secureboot-mok-enrolment-message.test.sh
+++ b/tests/secureboot-mok-enrolment-message.test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Guards the "narrow check reported as a broad conclusion" bug in
+# fog-enroll-mok.sh (#1266).
+#
+#   tests/secureboot-mok-enrolment-message.test.sh
+#
+# `mokutil --test-key` interrogates MokList -- shim's trust store -- and nothing
+# else. The check is right for what this script does: it IS the MOK enroller,
+# and re-enrolling a MOK genuinely is a no-op. The MESSAGE was wrong. It said
+# "This key is already enrolled on this machine. Nothing to do." -- a
+# machine-wide claim drawn from a store-specific test.
+#
+# The two stores are not interchangeable. A MOK only helps where shim is in the
+# boot chain; firmware never reads MokList. Booting a FOG-signed binary
+# DIRECTLY, with no shim, needs the certificate in **db**, which this script
+# neither reads nor writes. So an admin setting up the shim-less route was told
+# to stop, by a script that had not looked at the thing they were asking about.
+#
+# This is the dev-branch half of the #1266 fix. The other half -- the installer's
+# silent skip and the web page that named the wrong cause -- does not exist on
+# this branch: there is no _publishSecureBootAuthVars() and no automatic
+# enrolment card. working-1.6 carries the full test as
+# tests/secureboot-enrolment-diagnostics.test.sh.
+#
+# The script is EXECUTED, against a stubbed mokutil that reports the key as
+# already enrolled. Two of the assertions below are negative and would pass
+# whenever the script died early, so a guard asserts the run actually reached
+# the branch under test.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+MOKSH="$REPO/packages/secureboot/fog-enroll-mok.sh"
+
+[[ -f $MOKSH ]] || { echo "ERROR: $MOKSH not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+mkdir -p "$WORK/kit" "$WORK/bin"
+openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 1 \
+    -subj "/CN=FOG enrol-mok test/" -keyout "$WORK/mok.key" \
+    -out "$WORK/mok.pem" 2>/dev/null
+openssl x509 -in "$WORK/mok.pem" -outform der -out "$WORK/kit/MOK.der" 2>/dev/null
+
+# The script re-execs itself through sudo when not root. A passthrough stub
+# cannot satisfy that -- EUID stays non-zero, so it re-execs forever -- so the
+# re-exec is neutered in the COPY under test. Neutered, not deleted: the line
+# sits inside an `if`, and removing it outright leaves a dangling `fi`.
+# Asserted rather than assumed, so a change of shape fails loudly instead of
+# quietly testing nothing. The re-exec is not what is under test; the message is.
+if ! grep -qF 'exec sudo -- "$0" "$@"' "$MOKSH"; then
+    echo "FAIL: the sudo re-exec changed shape -- this test can no longer strip it"
+    exit 1
+fi
+sed 's|exec sudo -- "\$0" "\$@"|:|' "$MOKSH" > "$WORK/kit/fog-enroll-mok.sh"
+chmod +x "$WORK/kit/fog-enroll-mok.sh"
+bash -n "$WORK/kit/fog-enroll-mok.sh" || { echo "FAIL: the de-sudo'd copy does not parse"; exit 1; }
+
+cat > "$WORK/bin/mokutil" <<'EOS'
+#!/bin/bash
+case "$1" in
+    --sb-state) echo "SecureBoot enabled" ;;
+    --test-key) echo "$2 is already enrolled" ;;
+    --import)   echo "IMPORT SHOULD NOT HAPPEN" ; exit 1 ;;
+esac
+exit 0
+EOS
+chmod +x "$WORK/bin/mokutil"
+
+# "y" answers the fingerprint prompt; the trailing newline feeds pause's read.
+out=$(printf 'y\n\n' | PATH="$WORK/bin:$PATH" bash "$WORK/kit/fog-enroll-mok.sh" 2>&1)
+rc=$?
+
+if [[ $rc -eq 0 ]] && grep -q 'Certificate:' <<<"$out"; then
+    ok "the run reached the already-enrolled branch"
+else
+    bad "the run never reached the branch (exit $rc)"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+fi
+
+if grep -qi 'MokList' <<<"$out" && grep -qi '\bdb\b' <<<"$out"; then
+    ok "the already-enrolled path names MokList and db as different stores"
+else
+    bad "already-enrolled output does not distinguish MokList from db"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+fi
+
+if grep -qi 'enrolled on this machine' <<<"$out"; then
+    bad "the machine-wide 'enrolled on this machine' claim is back"
+else
+    ok "no machine-wide claim drawn from a MokList-only test"
+fi
+
+if grep -qi 'IMPORT SHOULD NOT HAPPEN' <<<"$out"; then
+    bad "the script re-imported a key it had just reported as enrolled"
+else
+    ok "an already-enrolled key is still a no-op, as intended"
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Port of the `fog-enroll-mok.sh` half of #1266 from `working-1.6` (#1400). The script here was **byte-identical** to the 1.6 version before the fix, so this is the same change.

## The bug

`mokutil --test-key` interrogates **MokList** — shim's trust store — and nothing else. The *check* is right for what this script does: it **is** the MOK enroller, and re-enrolling a MOK genuinely is a no-op. The **message** was wrong:

> This key is already enrolled on this machine. Nothing to do.

That is a machine-wide claim drawn from a store-specific test, and the two stores are not interchangeable:

- a MOK only helps where **shim** is in the boot chain — firmware never reads MokList
- booting a FOG-signed binary **directly**, with no shim, requires the certificate in **db**, which this script neither reads nor writes

So an admin setting up the shim-less route was told to stop, by a script that had not looked at the thing they were asking about.

It now names MokList as what it checked and `db` as what it did not, and points at the guide for the `db` step.

## Behaviour

Unchanged. Same branch taken, key still not re-imported. This is a diagnostic.

## Not ported

The other half of #1266 — `_publishSecureBootAuthVars()`'s silent skip and the web page that named the wrong cause — **does not exist on this branch**. Neither the function nor the automatic enrolment card is here, so there is nothing to fix. `working-1.6` carries the full change and the full test.

## Test

`tests/secureboot-mok-enrolment-message.test.sh` — 4 assertions, and the script is **executed** against a stubbed `mokutil` rather than grepped.

Two of the four are negative (no machine-wide claim; no re-import), which would pass whenever the script died early, so there is a guard asserting the run actually reached the branch under test. The script re-execs through `sudo`; a passthrough stub cannot satisfy that (EUID stays non-zero, so it re-execs forever), so the re-exec is neutered in the copy under test — asserted first, so a change of shape fails loudly instead of quietly testing nothing.

**Verified by mutation:** reverting the script to its pre-fix content turns 2 of the 4 red. The 2 that stay green are the invariants that held before and after.

```
FAIL: already-enrolled output does not distinguish MokList from db
FAIL: the machine-wide 'enrolled on this machine' claim is back
passed: 2   failed: 2
```

## Downstream

None. No routes, no schema, no class list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)