### PR TITLE
One channel vocabulary, shared by the update track and the version label

### DIFF
--- a/.githooks/lib/fog-version.sh
+++ b/.githooks/lib/fog-version.sh
@@ -50,6 +50,14 @@ compute_version() {
     channel="$current_channel"
     trunkversion="$current_version"
 
+    # The channel labels below are the title-case form of the SAME vocabulary
+    # lib/common/functions.sh uses for fog_update_channel (GH-1279):
+    #
+    #   stable -> Stable   patches -> Patches   beta -> Beta
+    #
+    # rc and feature have no update channel -- nobody tracks a release candidate
+    # as a standing preference -- so those two labels are this file's alone.
+    # tests/update-channel-vocabulary.test.sh fails if the two halves drift.
     case "$branchon" in
         dev)
             tagversion=$(git describe --tags "$gitcom")
@@ -62,7 +70,14 @@ compute_version() {
             baseversion=${tagversion%.*}
             count=$(git rev-list master..dev-branch --count) # Get the gitcount from dev-branch instead
             trunkversion="${baseversion}.${count}"
-            channel="Patches"
+            # "Stable", not "Patches" -- one channel vocabulary now, shared with
+            # fog_update_channel (GH-1279). stable and dev-branch used to
+            # compute the SAME label while their update channels differed, so
+            # the label could not have distinguished them. Nothing released
+            # changes: stable carries no FOG_CHANNEL line, so the sed in
+            # apply-fog-version.sh matches nothing and writes nothing there.
+            # This is what the commit message and the job summary say.
+            channel="Stable"
             ;;
         working)
             verbegin="${branchend}.0-beta"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,21 @@ FOG uses a versioning schema that follows the general principles of semantic ver
 
 This gives us a Production, Staging, and Dev branches to follow standard devops practices.
 
-| Dev Cycle Stage  | Branches                                                                                                              | Version Property Associated |
-|------------------|-----------------------------------------------------------------------------------------------------------------------| ----------------------------|
-| Production       | stable, master                                                                                                        | Minor and Patch
-| Staging          | dev-branch                                                                                                            | Patch
-| Dev              | working-*, {feature-name}                                                                                             | Major, Minor
+| Dev Cycle Stage  | Channel   | Branches                    | Version Property Associated |
+|------------------|-----------|-----------------------------|-----------------------------|
+| Production       | `stable`  | stable, master              | Minor and Patch |
+| Staging          | `patches` | dev-branch                  | Patch |
+| Dev              | `beta`    | working-*, {feature-name}   | Major, Minor |
+
+The **Channel** column is the value to put in `FOG_update_channel` in
+`.fogsettings`, or to pass to `bin/updatefog.sh --channel`. It is the same word
+as the `FOG_CHANNEL` your server reports, in lowercase — one vocabulary for
+both, so the value you configure and the value you read back agree.
+
+> The earlier spellings `staging` and `dev` mean `patches` and `beta`
+> respectively, and are still accepted so existing servers keep updating. They
+> are no longer the documented names: `dev` in particular pointed at
+> `working-1.6`, not at `dev-branch`, which read as a typo and was not one.
 
 See also: [Version Sync Automation](https://docs.fogproject.org/en/latest/version-sync-automation) for how `FOG_VERSION`/`FOG_CHANNEL` are kept in sync with git state on each branch.
 
@@ -36,8 +46,8 @@ Current version on each of the main branches (updated automatically - see the do
 | Channel | Version |
 |---|---|
 | [`Stable`](https://github.com/FOGProject/fogproject/tree/stable) | [![stable version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/stable.json)](https://github.com/FOGProject/fogproject/tree/stable) |
-| [`Staging`](https://github.com/FOGProject/fogproject/tree/dev-branch) | [![dev-branch version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/dev-branch.json)](https://github.com/FOGProject/fogproject/tree/dev-branch) |
-| [`Dev`](https://github.com/FOGProject/fogproject/tree/working-1.6) | [![working-1.6 version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/working-1.6.json)](https://github.com/FOGProject/fogproject/tree/working-1.6) |
+| [`Patches`](https://github.com/FOGProject/fogproject/tree/dev-branch) | [![dev-branch version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/dev-branch.json)](https://github.com/FOGProject/fogproject/tree/dev-branch) |
+| [`Beta`](https://github.com/FOGProject/fogproject/tree/working-1.6) | [![working-1.6 version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FOGProject/fog-workflows/main/badges/working-1.6.json)](https://github.com/FOGProject/fogproject/tree/working-1.6) |
 
 ### Version Format
 

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -39,10 +39,10 @@ done
 export PATH
 
 usage() {
-    echo -e "Usage: $0 [-h?y] [--channel stable|staging|dev] [--branch <name>] [--git-path </path>]"
+    echo -e "Usage: $0 [-h?y] [--channel stable|patches|beta] [--branch <name>] [--git-path </path>]"
     echo -e "\t                 \t\t[--no-revert] [--no-vhost]"
     echo -e "\t-h -? --help\t\tDisplay this info"
-    echo -e "\t      --channel\tUpdate channel to track: stable, staging, or dev"
+    echo -e "\t      --channel\tUpdate channel to track: stable, patches, or beta"
     echo -e "\t               \t\tdefaults to whatever this server already tracks"
     echo -e "\t      --branch\tCheck out an arbitrary branch instead of a channel"
     echo -e "\t               \t\t(e.g. to test a PR/feature branch). One-off: does"
@@ -238,12 +238,16 @@ else
 
     if [[ -z ${FOG_update_channel} ]]; then
         echo " * No update channel configured for this server, and none given via --channel."
-        echo " * Pass --channel stable|staging|dev, or --branch for a one-off checkout."
+        echo " * Pass --channel stable|patches|beta, or --branch for a one-off checkout."
         exit 1
     fi
 
     branch=$(channelToBranch "${FOG_update_channel}") || {
-        echo " * Unknown update channel: ${FOG_update_channel} (expected stable, staging, or dev)"
+        # Names the retired spellings too. They still WORK -- normalizeChannel
+        # folds them -- so anyone who reaches this line has a genuine typo, and
+        # the two vocabularies were confusable enough to be worth a sentence.
+        echo " * Unknown update channel: ${FOG_update_channel} (expected stable, patches, or beta)"
+        echo " * The retired names staging and dev are still accepted, and mean patches and beta."
         exit 1
     }
 

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -190,3 +190,15 @@ serviceList="$initdMCfullname $initdIRfullname $initdSRfullname $initdSDfullname
 # the three known channel branches (e.g. a feature/PR branch, or no git repo
 # at all for a tarball install) rather than guessing.
 [[ -z ${FOG_update_channel} ]] && FOG_update_channel="$(branchToChannel "$(git -C "${FOG_git_path}" rev-parse --abbrev-ref HEAD 2>/dev/null)" 2>/dev/null)"
+# Fold a value stored under the retired stable/staging/dev vocabulary to its
+# canonical spelling (GH-1279), so writeUpdateFile persists the new one and the
+# admin's file stops disagreeing with the docs. Only ever rewrites a value that
+# normalizeChannel RECOGNISES -- anything else is left exactly as found, because
+# an unknown value is either a typo the admin should see or a channel a newer
+# installer knows about, and silently blanking either would be worse than
+# leaving it to fail loudly in channelToBranch.
+if [[ -n ${FOG_update_channel} ]]; then
+    _canonicalChannel="$(normalizeChannel "${FOG_update_channel}" 2>/dev/null)" \
+        && FOG_update_channel="${_canonicalChannel}"
+    unset _canonicalChannel
+fi

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -44,28 +44,82 @@ linkIfAbsent() {
     [[ -e $link || -L $link ]] && return 0
     ln -s "$target" "$link" >>$error_log 2>&1
 }
-# Maps a FOG update channel name to the git branch it tracks. Channel names
-# match README.md's "Channel" table (Stable/Staging/Dev), not the informal
-# "dev"/"beta" prose fog-docs used before that table existed -- see
-# FOGProject/fogproject#1012. Codified here so bin/updatefog.sh and
-# lib/common/config.sh share one mapping instead of each guessing at it.
+# ONE channel vocabulary, shared by the update track and the version label.
+#
+# FOG used to have two things called a channel that shared the word and shared
+# nothing else (GH-1279). `fog_update_channel` said stable/staging/dev; the
+# FOG_CHANNEL stamped into system.class.php said Patches/Beta/Release
+# Candidate/Feature. So working-1.6 was simultaneously channel "dev" and channel
+# "Beta", and dev-branch was channel "staging" and channel "Patches". Nothing
+# reconciled them and neither name said which one it was, so the docs
+# contradicted themselves and an admin reading one while configuring the other
+# got it wrong, silently.
+#
+# They are now the same word: the stored value is lowercase, the FOG_CHANNEL
+# label is its title-case form. .githooks/lib/fog-version.sh owns the label end
+# and must be kept in step with the table below; tests/update-channel-vocabulary
+# .test.sh fails if the two drift.
+#
+#   branch        channel   FOG_CHANNEL
+#   stable        stable    Stable
+#   dev-branch    patches   Patches
+#   working-1.6   beta      Beta
+#   rc-*          --        Release Candidate
+#   feature-*     --        Feature
+#
+# The last two have no update channel: nobody tracks a release candidate or a
+# feature branch as a standing preference, so FOG_CHANNEL is a superset rather
+# than a mismatch.
+#
+# WHY THIS DIRECTION, given GH-1012 deliberately chose stable/staging/dev to
+# match README.md's table. That decision was "match README", not "these three
+# words are fixed", so changing README honours it rather than reversing it. And
+# FOG_CHANNEL was already the more accurate half: dev-branch really is the
+# 1.5.x PATCHES line rather than anything staged for stable, and working-1.6
+# really is the 1.6 BETA. Worse, `dev` pointed at working-1.6 while a branch
+# literally named `dev-branch` existed -- an admin who read
+# fog_update_channel='dev' and assumed it tracked dev-branch was wrong, and
+# nothing told them. Aligning the other way would have preserved that.
+#
+# Maps a channel name to the git branch it tracks. Accepts the retired
+# stable/staging/dev spellings so an existing .fogsettings keeps updating; see
+# normalizeChannel().
 channelToBranch() {
-    case "$1" in
+    case "$(normalizeChannel "$1")" in
         stable) echo "stable" ;;
-        staging) echo "dev-branch" ;;
-        dev) echo "working-1.6" ;;
+        patches) echo "dev-branch" ;;
+        beta) echo "working-1.6" ;;
         *) return 1 ;;
     esac
 }
-# The inverse of channelToBranch(), used to derive a sensible fog_update_channel
+# Folds a channel name to its canonical spelling, so exactly one place knows the
+# retired names. Returns 1 for anything unrecognised rather than echoing it
+# back: a caller asking "is this a channel" needs a no, and a typo silently
+# passed through would be resolved as a branch name later and fail further from
+# the cause.
+#
+# The retired spellings are accepted FOREVER, not for a deprecation window.
+# Every server installed before this change carries one in .fogsettings, that
+# file is the admin's own record, and an update that refuses to run because a
+# value was renamed under it would be a far worse outcome than two extra case
+# arms.
+normalizeChannel() {
+    case "$1" in
+        stable) echo "stable" ;;
+        patches|staging) echo "patches" ;;
+        beta|dev) echo "beta" ;;
+        *) return 1 ;;
+    esac
+}
+# The inverse of channelToBranch(), used to derive a sensible FOG_update_channel
 # default from whatever branch happens to be checked out. Echoes nothing for a
 # branch that is not one of the three channels -- a feature/PR branch has no
 # channel, and guessing one would be worse than leaving it for the admin to set.
 branchToChannel() {
     case "$1" in
         stable) echo "stable" ;;
-        dev-branch) echo "staging" ;;
-        working-1.6) echo "dev" ;;
+        dev-branch) echo "patches" ;;
+        working-1.6) echo "beta" ;;
         *) return 1 ;;
     esac
 }
@@ -747,7 +801,13 @@ applyNewInstallDefaults() {
 recordGitUpdateSettings() {
     dots "Recording fog_git_path/update channel/extra server names"
     mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_GIT_PATH', 'Filesystem path of the FOG git checkout on this server. Recorded automatically by installfog.sh/updatefog.sh -- editing it here has no effect on the next update.', \"${FOG_git_path}\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"${FOG_git_path}\"" ${DB_name} >>$error_log 2>&1
-    mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_UPDATE_CHANNEL', 'Update channel this server tracks: stable, staging, or dev.', \"${FOG_update_channel}\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"${FOG_update_channel}\"" ${DB_name} >>$error_log 2>&1
+    # settingDesc is refreshed too, unlike its two neighbours. The channel
+    # vocabulary changed (GH-1279), and ON DUPLICATE KEY UPDATE touching only
+    # settingValue would leave every server installed before that change showing
+    # "stable, staging, or dev" in the FOG Settings UI forever -- which is the
+    # documentation contradiction the rename exists to end, preserved in the one
+    # place an admin is most likely to read it.
+    mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_UPDATE_CHANNEL', 'Update channel this server tracks: stable, patches, or beta.', \"${FOG_update_channel}\", 'FOG Update') ON DUPLICATE KEY UPDATE settingDesc=VALUES(settingDesc), settingValue=\"${FOG_update_channel}\"" ${DB_name} >>$error_log 2>&1
     mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_EXTRA_SERVER_NAMES', 'Extra vhost/certificate name(s) this server answers to, beyond the primary hostname and detected IPs. Set via --extra-server-name -- editing it here has no effect on the next update.', \"${PKI_san_dns_names}\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"${PKI_san_dns_names}\"" ${DB_name} >>$error_log 2>&1
     # SERVICE_LOG_PATH used to be an independent control, and nothing kept it
     # in step with where the install actually put its logs. Relocating

--- a/tests/update-channel-vocabulary.test.sh
+++ b/tests/update-channel-vocabulary.test.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+#
+# Guards the ONE channel vocabulary (#1279).
+#
+#   tests/update-channel-vocabulary.test.sh
+#
+# FOG had two things called a channel. They shared the word and shared nothing
+# else:
+#
+#   fog_update_channel  which branch this server tracks   stable/staging/dev
+#   FOG_CHANNEL         the label stamped into            Patches/Beta/
+#                       system.class.php                  Release Candidate/Feature
+#
+# So working-1.6 was simultaneously channel "dev" and channel "Beta", and
+# dev-branch was channel "staging" and channel "Patches". Nothing reconciled
+# them and neither name said which one it was, so fog-docs described
+# fog_update_channel as "stable, staging or dev" while fog-workflows described
+# the same branch as being on the "Beta channel" -- both correct about different
+# variables, and anyone reading one while configuring the other got it wrong
+# with no error.
+#
+# Worse than untidy: `dev` pointed at working-1.6 while a branch literally named
+# `dev-branch` existed. An admin who set fog_update_channel='dev' expecting to
+# track dev-branch tracked the 1.6 beta instead, and nothing told them.
+#
+# There is now one vocabulary. The stored value is lowercase, the FOG_CHANNEL
+# label is its title-case form:
+#
+#   branch        channel   FOG_CHANNEL
+#   stable        stable    Stable
+#   dev-branch    patches   Patches
+#   working-1.6   beta      Beta
+#   rc-*          --        Release Candidate
+#   feature-*     --        Feature
+#
+# The two halves live in different files that nothing else connects --
+# lib/common/functions.sh owns the update track, .githooks/lib/fog-version.sh
+# owns the label -- which is exactly how they drifted in the first place. Case F
+# is the reason this file exists: it EXECUTES both and compares them, so the two
+# cannot silently disagree again.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+CONFIG="$REPO/lib/common/config.sh"
+VERSIONSH="$REPO/.githooks/lib/fog-version.sh"
+
+for f in "$FUNCS" "$CONFIG" "$VERSIONSH"; do
+    [[ -f $f ]] || { echo "ERROR: $f not found" >&2; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1 ($2)"; FAIL=$((FAIL + 1)); }
+
+# The three mapping functions are self-contained -- no globals, no external
+# tools -- so they are pulled out and run for real rather than pattern-matched.
+eval "$(awk '/^channelToBranch\(\) \{/,/^\}$/' "$FUNCS")"
+eval "$(awk '/^normalizeChannel\(\) \{/,/^\}$/' "$FUNCS")"
+eval "$(awk '/^branchToChannel\(\) \{/,/^\}$/' "$FUNCS")"
+
+for fn in channelToBranch normalizeChannel branchToChannel; do
+    declare -F "$fn" >/dev/null || { echo "ERROR: could not extract $fn from functions.sh" >&2; exit 1; }
+done
+
+# --- A. canonical channel -> branch ---------------------------------------
+while read -r ch want; do
+    got=$(channelToBranch "$ch" 2>/dev/null)
+    [[ $got == "$want" ]] && ok "A. channel '$ch' tracks $want" \
+        || bad "A. channel '$ch' tracks $want" "got '$got'"
+done <<'EOF'
+stable stable
+patches dev-branch
+beta working-1.6
+EOF
+
+# --- B. branch -> channel is the true inverse ------------------------------
+for br in stable dev-branch working-1.6; do
+    ch=$(branchToChannel "$br" 2>/dev/null)
+    back=$(channelToBranch "$ch" 2>/dev/null)
+    [[ $back == "$br" ]] && ok "B. $br -> '$ch' -> $br round-trips" \
+        || bad "B. $br round-trip" "got '$ch' -> '$back'"
+done
+
+# --- C. the retired spellings still resolve -------------------------------
+# Every server installed before #1279 carries one of these in .fogsettings.
+# If this goes red, an update stops working on a server that did nothing wrong.
+while read -r ch want; do
+    got=$(channelToBranch "$ch" 2>/dev/null)
+    [[ $got == "$want" ]] && ok "C. retired name '$ch' still tracks $want" \
+        || bad "C. retired name '$ch' still tracks $want" "got '$got'"
+done <<'EOF'
+staging dev-branch
+dev working-1.6
+EOF
+
+# --- D. normalizeChannel folds, and refuses the unknown -------------------
+while read -r inp want; do
+    got=$(normalizeChannel "$inp" 2>/dev/null)
+    [[ $got == "$want" ]] && ok "D. '$inp' normalizes to '$want'" \
+        || bad "D. '$inp' normalizes to '$want'" "got '$got'"
+done <<'EOF'
+staging patches
+dev beta
+patches patches
+beta beta
+stable stable
+EOF
+
+# --- E. an unknown channel is refused, not echoed back ---------------------
+# Echoing it back would have it resolved as a branch name later, failing a long
+# way from the typo that caused it.
+for bad_in in devel Beta "" nightly working-1.6; do
+    if out=$(normalizeChannel "$bad_in" 2>/dev/null); then
+        bad "E. '$bad_in' is refused" "returned 0 with '$out'"
+    elif [[ -n $out ]]; then
+        bad "E. '$bad_in' is refused" "echoed '$out'"
+    else
+        ok "E. '$bad_in' is refused rather than passed through"
+    fi
+done
+for bad_in in devel nightly; do
+    channelToBranch "$bad_in" >/dev/null 2>&1 \
+        && bad "E. channelToBranch refuses '$bad_in'" "returned 0" \
+        || ok "E. channelToBranch refuses '$bad_in'"
+done
+
+# --- F. THE ALIGNMENT: both halves compared ------------------------------
+# The two definitions are PARSED out of their own files and compared. Not a
+# grep for a symbol: this reads the authoritative `case` arms in each file, so
+# gutting either one -- renaming a value, dropping an arm, wrapping it in a
+# condition that never fires -- changes what is parsed and shows up here.
+#
+# Why parsed rather than executed. fog-version.sh needs tags, master and
+# dev-branch present locally (`git describe --tags`, `git rev-list
+# master..dev-branch`), and CI checks out with actions/checkout at its default
+# fetch-depth: 1 -- one commit, no tags, no other branches. Executing it would
+# fail in CI for every branch, for reasons that have nothing to do with the
+# vocabulary. F2 below runs it anyway WHERE IT CAN, and skips otherwise.
+#
+# And the `stable` arm is never executed even then. stable is the release
+# branch, promoted from dev-branch by stable-releases.yml; a test has no
+# business exercising it, and its arm is the one that reaches for dev-branch's
+# commit count.
+titlecase() { printf '%s' "$(tr '[:lower:]' '[:upper:]' <<<"${1:0:1}")${1:1}"; }
+
+# branchon is what fog-version.sh keys on: the branch name up to the first '-'.
+branchon_of() { printf '%s' "${1%%-*}"; }
+
+# Pull `arm) ... channel="X" ...` out of fog-version.sh's compute_version case.
+labelForArm() {
+    awk -v want="$1" '
+        /case "\$branchon" in/ { inc = 1; next }
+        inc && /^        [a-z]+\)/ {
+            arm = $0; sub(/\).*/, "", arm); gsub(/[ \t]/, "", arm)
+        }
+        inc && arm == want && /channel="/ {
+            line = $0
+            sub(/.*channel="/, "", line); sub(/".*/, "", line)
+            print line; exit
+        }
+        inc && /^    esac$/ { exit }
+    ' "$VERSIONSH"
+}
+
+for br in stable dev-branch working-1.6; do
+    ch=$(branchToChannel "$br" 2>/dev/null)
+    want=$(titlecase "$ch")
+    got=$(labelForArm "$(branchon_of "$br")")
+    if [[ -z $got ]]; then
+        bad "F. $br: FOG_CHANNEL matches the update channel" "no channel arm parsed from fog-version.sh"
+    elif [[ $got == "$want" ]]; then
+        ok "F. $br: update channel '$ch' and FOG_CHANNEL '$got' are one word"
+    else
+        bad "F. $br: update channel '$ch' implies FOG_CHANNEL '$want'" "fog-version.sh says '$got'"
+    fi
+done
+
+# The two labels with no update channel. Pinned so that a later attempt to give
+# them one has to come here and think about it, rather than silently inventing a
+# fourth spelling of an existing channel.
+for pair in "rc:Release Candidate" "feature:Feature"; do
+    arm="${pair%%:*}"; want="${pair#*:}"
+    got=$(labelForArm "$arm")
+    [[ $got == "$want" ]] && ok "F. $arm labels '$want'" \
+        || bad "F. $arm labels '$want'" "got '$got'"
+    branchToChannel "${arm}-1.6" >/dev/null 2>&1 \
+        && bad "F. $arm has no update channel" "branchToChannel returned one" \
+        || ok "F. $arm correctly has no update channel"
+done
+
+# --- F2. the same thing EXECUTED, where the checkout allows it ------------
+# Belt and braces for a full local clone: proves the parse above describes what
+# the script really computes. Skipped rather than failed on a shallow checkout,
+# and stable is deliberately absent from the loop.
+if git rev-parse --verify --quiet master >/dev/null 2>&1 \
+   && [[ -n $(git tag 2>/dev/null | head -1) ]]; then
+    for br in dev-branch working-1.6; do
+        want=$(titlecase "$(branchToChannel "$br" 2>/dev/null)")
+        got=$(sh "$VERSIONSH" "$br" head 2>/dev/null | sed -n '2p')
+        if [[ -z $got ]]; then
+            bad "F2. $br: fog-version.sh runs" "produced nothing"
+        elif [[ $got == "$want" ]]; then
+            ok "F2. $br: fog-version.sh really computes '$got'"
+        else
+            bad "F2. $br: fog-version.sh really computes '$want'" "got '$got'"
+        fi
+    done
+else
+    echo "SKIP: F2 needs master and tags locally (shallow checkout) -- F still ran"
+fi
+
+# --- G. config.sh migrates a stored legacy value --------------------------
+# Anchored on the whole migration block, not on the function name: a grep for
+# normalizeChannel passes when the assignment back to FOG_update_channel has
+# been dropped, which is the failure that would leave the old value persisted.
+if grep -q 'normalizeChannel "${FOG_update_channel}"' "$CONFIG" \
+   && grep -q 'FOG_update_channel="${_canonicalChannel}"' "$CONFIG"; then
+    ok "G. config.sh folds a stored legacy channel to its canonical spelling"
+else
+    bad "G. config.sh folds a stored legacy channel" "migration block missing or changed shape"
+fi
+
+# --- H. no stale vocabulary left in user-facing text ----------------------
+# updatefog.sh's help and errors are where an admin learns the names.
+if grep -q 'stable|staging|dev' "$REPO/bin/updatefog.sh"; then
+    bad "H. updatefog.sh documents the current names" "still offers stable|staging|dev"
+elif ! grep -q 'stable|patches|beta' "$REPO/bin/updatefog.sh"; then
+    bad "H. updatefog.sh documents the current names" "does not offer stable|patches|beta"
+else
+    ok "H. updatefog.sh documents stable|patches|beta"
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #1279. Option 2 from the issue — align the values, rather than rename one side or just document the trap.

## The collision

Two things called a channel, sharing the word and nothing else:

| | Meaning | Values |
|---|---|---|
| `fog_update_channel` | which branch this server tracks | `stable` / `staging` / `dev` |
| `FOG_CHANNEL` | the label in `system.class.php` | `Patches` / `Beta` / `Release Candidate` / `Feature` |

So `working-1.6` was simultaneously channel `dev` **and** channel `Beta`, and `dev-branch` was channel `staging` **and** channel `Patches`. fog-docs described `fog_update_channel` as "stable, staging or dev" while fog-workflows described the same branch as being on the "Beta channel" — both correct about different variables, and anyone reading one while configuring the other got it wrong with no error.

Worse than untidy: **`dev` pointed at `working-1.6` while a branch literally named `dev-branch` existed.** An admin who set `fog_update_channel='dev'` expecting to track `dev-branch` tracked the 1.6 beta instead, and nothing told them.

## One vocabulary

Stored value is lowercase; the `FOG_CHANNEL` label is its title-case form.

| branch | channel | `FOG_CHANNEL` |
|---|---|---|
| `stable` | `stable` | `Stable` |
| `dev-branch` | `patches` | `Patches` |
| `working-1.6` | `beta` | `Beta` |
| `rc-*` | — | `Release Candidate` |
| `feature-*` | — | `Feature` |

`rc` and `feature` have no update channel — nobody tracks a release candidate as a standing preference — so `FOG_CHANNEL` is a superset, not a mismatch.

## Why this direction

#1012 deliberately chose `stable`/`staging`/`dev` **to match README's table**. This reverses nothing: that decision was "match README", and README changes here too.

`FOG_CHANNEL` was already the more accurate half — `dev-branch` really is the 1.5.x **patches** line rather than anything staged for stable, and `working-1.6` really is the 1.6 **beta** — and it was already 2/3 aligned. Only the `stable` arm moved, `Patches` → `Stable`, a value it previously **shared with `dev-branch`** and so could never have told them apart.

Aligning the other way would have kept the `dev`/`dev-branch` collision *and* rewritten the `FOG_CHANNEL` every user sees.

## Nothing released changes

- `stable` and `dev-branch` carry no `FOG_CHANNEL` line at all, so `apply-fog-version.sh`'s `sed` matches nothing on either.
- `working-1.6` keeps `Beta`; the version string `1.6.0-beta.NNNN` is untouched.
- **fog-workflows needs no change** — it passes the computed strings through and hardcodes none of them, and the version badge carries only branch and version.

## Existing servers

The retired spellings `staging` and `dev` are accepted **forever**, not for a deprecation window. Every server installed before this carries one in `.fogsettings`; that file is the admin's own record, and an update refusing to run because a value was renamed under it would be far worse than two case arms.

- `normalizeChannel()` is the single place that knows them.
- `config.sh` folds a stored legacy value so `writeUpdateFile` persists the canonical spelling.
- `FOG_UPDATE_CHANNEL`'s `settingDesc` is now refreshed on update — otherwise every existing server would keep showing the old vocabulary in the FOG Settings UI, which is the contradiction this change exists to end, preserved exactly where an admin is most likely to read it.

## Test

`tests/update-channel-vocabulary.test.sh` — 31 assertions.

Case F is why the file exists. The two halves live in files nothing else connects (`lib/common/functions.sh` and `.githooks/lib/fog-version.sh`), which is how they drifted, so it **parses the authoritative `case` arms out of both and compares them** — not a symbol grep.

Parsed rather than executed because `fog-version.sh` needs tags, `master` and `dev-branch` present locally, and CI checks out at `actions/checkout`'s default `fetch-depth: 1`. Executing it would fail in CI **for every branch**, for reasons unrelated to the vocabulary. F2 executes it anyway where the checkout allows and skips cleanly otherwise — and **`stable` is deliberately absent from that loop**, because it is the release branch promoted by `stable-releases.yml` and a test has no business exercising it.

**Verified by mutation:**

| Mutation | Goes red |
|---|---|
| working arm → `Dev` | F, F2 |
| stable arm back to `Patches` | F |
| rc arm gutted to `RC` | F |
| retired names removed | C ×2, D ×2 |
| `config.sh` fold dropped | G |
| unknown channel echoed instead of refused | E ×7, F ×2 |

Full suite **166 passed, 0 failed**. The new test also passes in a simulated `fetch-depth: 1` checkout (29 passed, F2 skipped).

## Follow-up

fog-docs `docs/management/server/install-fogsettings.md` names the old values in two places; a PR follows there. No fog-workflows change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)