### PR TITLE
Serve the signed shim chain to every UEFI client by default

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1203,7 +1203,26 @@ case ${FOG_install_type} in
                 echo " * On a Windows DHCP server you must set options 066 and 067"
                 echo
                 echo " * Option 066/next-server is the IP of the FOG Server: (e.g. ${NET_fog_server_ip})"
-                echo " * Option 067/filename is the bootfile: (e.g. undionly.kkpxe or snponly.efi)"
+                echo " * Option 067/filename is the bootfile, per client architecture:"
+                echo " |   BIOS / legacy   $(_biosBootFile)"
+                echo " |   32-bit UEFI     i386-efi/snponly.efi"
+                echo " |   64-bit UEFI     secureboot/snponly-shimx64.efi"
+                echo " |   ARM64 UEFI      secureboot/arm64-efi/snponly-shimaa64.efi"
+                echo
+                # The BIOS row goes through _biosBootFile because --boot-delay
+                # really does change it (10secdelay/) and that flag is parsed
+                # well before here. The UEFI rows are literal rather than
+                # $(_uefiBootFile) for the opposite reason: this summary prints
+                # before downloadipxesecureboot has run, so the guard would be
+                # answering about the PREVIOUS install's staging tree. These are
+                # what this run is about to stage; if the fetch fails, that
+                # function says so itself.
+                echo " * The secureboot/ files are the signed chain. They boot the same"
+                echo " | whether Secure Boot is enabled or not, so they are the right"
+                echo " | answer for every 64-bit UEFI client, not just the ones enforcing"
+                echo " | it. There is no signed 32-bit chain -- those clients must have"
+                echo " | Secure Boot disabled to netboot at all."
+                echo " | See https://docs.fogproject.org/en/latest/secure-boot-netboot"
                 ;;
         esac
         ;;
@@ -1306,6 +1325,14 @@ while [[ -z $blGo ]]; do
                     backupReports
                     configureMinHttpd
                     configureStorage
+                    # Before configureDHCP, not with the rest of the TFTP
+                    # staging in configureTFTPandPXE. The generated DHCP config
+                    # names the signed shim for UEFI clients, and _sbChainStaged
+                    # decides that by looking for the staged binary -- so the
+                    # fetch has to have happened, or every install would fall
+                    # back to the unsigned names. Non-fatal on its own; the
+                    # fallback is exactly what a failure here selects.
+                    downloadipxesecureboot
                     configureDHCP
                     configureTFTPandPXE
                     configureFTP
@@ -1406,6 +1433,14 @@ while [[ -z $blGo ]]; do
                     backupDB
                     updateDB
                     configureStorage
+                    # Before configureDHCP, not with the rest of the TFTP
+                    # staging in configureTFTPandPXE. The generated DHCP config
+                    # names the signed shim for UEFI clients, and _sbChainStaged
+                    # decides that by looking for the staged binary -- so the
+                    # fetch has to have happened, or every install would fall
+                    # back to the unsigned names. Non-fatal on its own; the
+                    # fallback is exactly what a failure here selects.
+                    downloadipxesecureboot
                     configureDHCP
                     configureTFTPandPXE
                     # After configureTFTPandPXE -> downloadfiles() has re-laid

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2505,6 +2505,82 @@ _biosBootFile() {
         echo "undionly.kkpxe"
     fi
 }
+# Is the signed Secure Boot chain actually staged?
+#
+# downloadipxesecureboot is deliberately non-fatal, so an install whose fetch
+# failed has no $tftpdirsrc/secureboot at all. The generated DHCP config names
+# the shim by default, and naming a file TFTP cannot serve breaks every UEFI
+# client on the network -- so that default has to be conditional on the file
+# being there.
+#
+# Reads the STAGING tree, not $tftpdirdst: configureDHCP runs before
+# configureTFTPandPXE's copy loop, so the destination is still empty on a first
+# install (or still holds the previous install's files) at the point this is
+# asked. installfog.sh calls downloadipxesecureboot ahead of configureDHCP
+# precisely so this has an answer -- see the comment at that call site.
+#
+# readlink -f for the same reason downloadipxesecureboot does it: $tftpdirsrc is
+# the relative ../packages/tftp.
+_sbChainStaged() {
+    local src="$(readlink -f "$tftpdirsrc" 2>/dev/null)"
+    [[ -n $src && -f "${src}/secureboot/snponly-shimx64.efi" ]]
+}
+# Which UEFI boot file DHCP should hand out, per architecture.
+#
+# The signed chain is the default for every x86-64 and arm64 UEFI client, not an
+# opt-in for the Secure Boot ones. This used to be emitted commented out, on the
+# reasoning that option 93 carries the client architecture and nothing else, so
+# a DHCP request cannot say whether Secure Boot is on and a site therefore has
+# to opt specific machines in.
+#
+# The premise is true and the conclusion does not follow. shim is an ordinary
+# UEFI application that happens to carry a Microsoft signature: with Secure Boot
+# on the firmware verifies it and it verifies what it loads next; with Secure
+# Boot off the firmware verifies nothing and shim enforces nothing. It simply
+# boots. So the signed chain is a SUPERSET -- it covers the machines that need it
+# and costs the others nothing -- and there is nothing to detect.
+#
+# Why the boot file names the shim and not the loader: ipxe/shim carries a
+# fork-only patch (automatic_next_path(), ipxe/shim 1b02ba2c) that strips a
+# "-shim[arch]" infix from the path it was ITSELF fetched from and loads that,
+# out of the same directory. So snponly-shimx64.efi fetches snponly.efi and
+# ipxe-shimx64.efi fetches ipxe.efi -- from one signed binary staged under both
+# names. Do not conclude from `strings` that the loader is hardcoded to
+# ipxe.efi; that is only the DEFAULT_LOADER the patch hooks. Over TFTP the
+# device path carries the filename, so the rename resolves correctly (observed);
+# off an ESP it does not, which is a separate problem handled elsewhere.
+#
+# If this chain loads but the network never comes up, the firmware's own UEFI
+# SNP is at fault -- switch the name to secureboot/ipxe-shimx64.efi for iPXE's
+# built-in drivers. That is a DHCP-only change with nothing renamed
+# server-side, and it is what the commented fallback in the generated config
+# points at.
+#
+# No 32-bit case on purpose: there is no Microsoft-signed ia32 shim and no
+# signed 32-bit iPXE, so i386-efi clients stay on the unsigned binary and must
+# have Secure Boot disabled to netboot at all.
+#
+# --boot-delay needs no handling here either. EFI takes its delay from
+# autoexec.ipxe (_applyBootDelay), so unlike _biosBootFile there is no second
+# binary to point at.
+_uefiBootFile() {
+    case "$1" in
+        arm64)
+            if _sbChainStaged; then
+                echo "secureboot/arm64-efi/snponly-shimaa64.efi"
+            else
+                echo "arm64-efi/snponly.efi"
+            fi
+            ;;
+        *)
+            if _sbChainStaged; then
+                echo "secureboot/snponly-shimx64.efi"
+            else
+                echo "snponly.efi"
+            fi
+            ;;
+    esac
+}
 # Write the pre-DHCP sleep into autoexec.ipxe, per --boot-delay.
 #
 # Some switches take several seconds to bring a port out of STP listening or
@@ -2857,6 +2933,14 @@ downloadipxesecureboot() {
         echo " * Could not download $tarball from ${ipxeurl}/${ipxeVer}/"
         echo " * Secure Boot clients will not have a signed chain to boot; every"
         echo " *   other client is unaffected. Re-run the installer to retry."
+        # Said out loud because it changes what the DHCP config written a moment
+        # later contains. UEFI clients normally get the signed shim; with nothing
+        # staged, _uefiBootFile falls back to the unsigned names so the config
+        # cannot name a file TFTP has no copy of. That is the safe outcome, but
+        # it is silent otherwise -- an admin who expected Secure Boot to work
+        # would find the old boot file in a config they did not edit.
+        echo " * Any DHCP configuration written by this run therefore names the"
+        echo " *   unsigned UEFI boot files, not secureboot/snponly-shimx64.efi."
         return 0
     fi
     errorStat 0
@@ -2864,8 +2948,15 @@ downloadipxesecureboot() {
 configureTFTPandPXE() {
     # Fills $tftpdirsrc, which is now a staging directory rather than tracked
     # build output, so this has to happen before anything reads from it.
+    #
+    # downloadipxesecureboot is NOT called here. It runs earlier, from
+    # installfog.sh, because configureDHCP has to know whether the signed chain
+    # is staged before it writes a boot filename -- see _sbChainStaged. Both
+    # assets untar additively into the same staging tree (fetchipxeasset only
+    # does mkdir -p + tar -xzf -C, it never clears the destination), so their
+    # relative order does not matter and nothing reads the tree until the copy
+    # loop below.
     downloadipxe || return 1
-    downloadipxesecureboot
     [[ -d ${tftpdirdst}.prev ]] && rm -rf ${tftpdirdst}.prev >>$error_log 2>&1
     [[ ! -d ${tftpdirdst} ]] && mkdir -p $tftpdirdst >>$error_log 2>&1
     [[ -e ${tftpdirdst}.fogbackup ]] && rm -rf ${tftpdirdst}.fogbackup >>$error_log 2>&1
@@ -13100,8 +13191,21 @@ _resignCustomKernels() {
 _keaBaseClasses() {
     # Piped through sed rather than unquoting the heredoc: the block is JSON and
     # keeping it literal is what stops a stray $ or backtick in a future edit
-    # being expanded by the shell. Only the BIOS name varies -- see _biosBootFile.
-    cat <<'EOFCLS' | sed "s|\"boot-file-name\": \"undionly.kkpxe\"|\"boot-file-name\": \"$(_biosBootFile)\"|"
+    # being expanded by the shell. The BIOS name varies with --boot-delay
+    # (_biosBootFile) and the 64-bit UEFI names with whether the signed chain is
+    # staged (_uefiBootFile).
+    #
+    # The arm64 expression comes first, but the order is not load-bearing: each
+    # pattern matches a whole quote-delimited value, so "snponly.efi" cannot also
+    # match inside "arm64-efi/snponly.efi".
+    #
+    # i386-efi is deliberately absent -- no signed 32-bit shim exists -- and so
+    # is the Apple BSDP class, which lives in _keaAppleClass and serves Intel
+    # Macs over a protocol Secure Boot never enters.
+    cat <<'EOFCLS' | sed \
+        -e "s|\"boot-file-name\": \"undionly.kkpxe\"|\"boot-file-name\": \"$(_biosBootFile)\"|" \
+        -e "s|\"boot-file-name\": \"arm64-efi/snponly.efi\"|\"boot-file-name\": \"$(_uefiBootFile arm64)\"|" \
+        -e "s|\"boot-file-name\": \"snponly.efi\"|\"boot-file-name\": \"$(_uefiBootFile x64)\"|"
         {
             "name": "FOG-Legacy-BIOS",
             "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00000'",
@@ -13144,43 +13248,39 @@ _keaBaseClasses() {
         }
 EOFCLS
 }
-# A Secure Boot class, emitted commented out.
+# The two ways off the default boot file, emitted commented out.
 #
-# Still commented out, but for one reason now rather than two: DHCP option 93
-# carries the client architecture and nothing else, so a request cannot tell us
-# whether Secure Boot is on. A site has to opt specific machines in.
+# This used to be the other way round: the base classes served the unsigned
+# snponly.efi and this block was the Secure Boot opt-in. The signed chain is now
+# the default for every 64-bit UEFI and arm64 client (see _uefiBootFile for why
+# that is a superset rather than a conditional), so what is left to document is
+# how to move away from it.
 #
-# The second reason is gone. This used to point at ipxe-shimx64.efi because
-# upstream published only an all-drivers signed iPXE -- the build that takes the
-# NIC over from the firmware and hangs on some hardware -- and there was no
-# signed snponly equivalent. ipxe/ipxe#1776 closed 2026-08-02 and iPXE 2.0.0
-# ships a signed x86_64-sb/snponly.efi, staged by fog-ipxe since v2.0.0-fog.3.
-# So this now matches what FOG serves every other UEFI client: snponly.
-#
-# Why the boot file names the shim and not the loader: ipxe/shim carries a
-# fork-only patch (automatic_next_path(), ipxe/shim 1b02ba2c) that strips a
-# "-shim[arch]" infix from the path it was ITSELF fetched from and loads that,
-# out of the same directory. So snponly-shimx64.efi fetches snponly.efi and
-# ipxe-shimx64.efi fetches ipxe.efi -- from one signed binary staged under both
-# names. Do not conclude from `strings` that the loader is hardcoded to
-# ipxe.efi; that is only the DEFAULT_LOADER the patch hooks.
-#
-# If this chain loads but the network never comes up, the firmware's own UEFI
-# SNP is at fault -- switch the name to secureboot/ipxe-shimx64.efi for iPXE's
-# built-in drivers. That is the fallback the Secure Boot config page documents,
-# and it is purely a DHCP change with nothing to rename server-side.
-#
-# The binaries are staged at $tftpdir/secureboot by downloadipxesecureboot()
-# on every install, so the path below always exists.
-_keaSecureBootClassCommented() {
+# Both are DHCP-only changes. Nothing is renamed server-side: the shim picks its
+# second stage out of its own filename, so both chains sit side by side in one
+# directory and the boot file name alone decides which runs.
+_keaBootFileFallbackComment() {
     cat <<'EOFSBC'
-#        Secure Boot clients. Uncomment, add a leading comma to the entry
-#        above, and narrow the test to the machines whose firmware trusts this
-#        server's certificate -- by subnet, MAC or a client class of your own.
+#        Two alternatives to the boot file above, if you need them. Uncomment
+#        one, add a leading comma to the entry above, and narrow the test to the
+#        affected machines -- by subnet, MAC or a client class of your own.
+#
+#        1. The chain loads but the network never comes up. That is the
+#           firmware's own UEFI SNP driver, not anything signed. Use iPXE's
+#           built-in NIC drivers instead (arm64: secureboot/arm64-efi/ipxe-shimaa64.efi):
 #        {
-#            "name": "FOG-UEFI-64-SecureBoot",
+#            "name": "FOG-UEFI-64-IpxeDrivers",
 #            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
-#            "boot-file-name": "secureboot/snponly-shimx64.efi"
+#            "boot-file-name": "secureboot/ipxe-shimx64.efi"
+#        }
+#
+#        2. You do not want the signed chain at all. The unsigned binaries are
+#           still in the TFTP root (arm64: arm64-efi/snponly.efi). Clients with
+#           Secure Boot enforcing will refuse these:
+#        {
+#            "name": "FOG-UEFI-64-Unsigned",
+#            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
+#            "boot-file-name": "snponly.efi"
 #        }
 EOFSBC
 }
@@ -13354,11 +13454,11 @@ writeKeaSample() {
                 { \"name\": \"routers\", \"data\": \"${DHCP_router}\" }"
     [[ $(validip ${DHCP_dns_server_ip}) -eq 0 ]] && optdata="${optdata},
                 { \"name\": \"domain-name-servers\", \"data\": \"${DHCP_dns_server_ip}\" }"
-    # Full reference: base classes + Apple BSDP, plus a commented-out Secure
-    # Boot class. The admin can trim as needed.
+    # Full reference: base classes + Apple BSDP, plus the commented-out
+    # boot-file fallbacks. The admin can trim as needed.
     _writeKeaConfig "$target" "$(_keaBaseClasses),
 $(_keaAppleClass)
-$(_keaSecureBootClassCommented)"
+$(_keaBootFileFallbackComment)"
     if [[ -s $target ]]; then
         echo
         echo " * A sample Kea DHCP config for a dedicated/external DHCP server was"
@@ -13472,23 +13572,23 @@ configureDHCP() {
             echo "}" >> "$dhcptouse"
             echo "class \"UEFI-64-1\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
-            echo "    filename \"snponly.efi\";" >> "$dhcptouse"
+            echo "    filename \"$(_uefiBootFile x64)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"UEFI-64-2\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00008\";" >> "$dhcptouse"
-            echo "    filename \"snponly.efi\";" >> "$dhcptouse"
+            echo "    filename \"$(_uefiBootFile x64)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"UEFI-64-3\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00009\";" >> "$dhcptouse"
-            echo "    filename \"snponly.efi\";" >> "$dhcptouse"
+            echo "    filename \"$(_uefiBootFile x64)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"UEFI-ARM64\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00011\";" >> "$dhcptouse"
-            echo "    filename \"arm64-efi/snponly.efi\";" >> "$dhcptouse"
+            echo "    filename \"$(_uefiBootFile arm64)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"SURFACE-PRO-4\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 32) = \"PXEClient:Arch:00007:UNDI:003016\";" >> "$dhcptouse"
-            echo "    filename \"snponly.efi\";" >> "$dhcptouse"
+            echo "    filename \"$(_uefiBootFile x64)\";" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
             echo "class \"Apple-Intel-Netboot\" {" >> "$dhcptouse"
             echo "    match if substring(option vendor-class-identifier, 0, 14) = \"AAPLBSDPC/i386\";" >> "$dhcptouse"
@@ -13502,17 +13602,29 @@ configureDHCP() {
             echo "        }" >> "$dhcptouse"
             echo "    }" >> "$dhcptouse"
             echo "}" >> "$dhcptouse"
-            # Secure Boot clients, commented out on purpose -- see the note on
-            # _keaSecureBootClassCommented() for the full reasoning, including
-            # why the boot file names the shim rather than the loader. Option 93
-            # cannot tell us whether Secure Boot is on, so this has to be opted
-            # into per machine rather than applied to every UEFI client.
-            echo "# Secure Boot clients. Uncomment and narrow the match to the machines" >> "$dhcptouse"
-            echo "# whose firmware trusts this server's certificate. Swap snponly- for" >> "$dhcptouse"
-            echo "# ipxe- if the chain loads but the network never comes up." >> "$dhcptouse"
-            echo "#class \"FOG-UEFI-64-SecureBoot\" {" >> "$dhcptouse"
+            # The two ways off the default boot file, commented out. Mirrors
+            # _keaBootFileFallbackComment() -- see the note on _uefiBootFile()
+            # for why the signed chain is the default for every 64-bit UEFI
+            # client rather than a per-machine opt-in, and why the boot file
+            # names the shim rather than the loader.
+            echo "# Two alternatives to the UEFI boot file above, if you need them." >> "$dhcptouse"
+            echo "# Uncomment one and narrow the match to the affected machines. Both are" >> "$dhcptouse"
+            echo "# DHCP-only changes -- nothing is renamed on this server." >> "$dhcptouse"
+            echo "#" >> "$dhcptouse"
+            echo "# 1. The chain loads but the network never comes up: that is the firmware's" >> "$dhcptouse"
+            echo "#    own UEFI SNP driver, so use iPXE's built-in drivers instead." >> "$dhcptouse"
+            echo "#    On arm64, secureboot/arm64-efi/ipxe-shimaa64.efi." >> "$dhcptouse"
+            echo "#class \"FOG-UEFI-64-IpxeDrivers\" {" >> "$dhcptouse"
             echo "#    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
-            echo "#    filename \"secureboot/snponly-shimx64.efi\";" >> "$dhcptouse"
+            echo "#    filename \"secureboot/ipxe-shimx64.efi\";" >> "$dhcptouse"
+            echo "#}" >> "$dhcptouse"
+            echo "#" >> "$dhcptouse"
+            echo "# 2. You do not want the signed chain at all. The unsigned binaries are" >> "$dhcptouse"
+            echo "#    still in the TFTP root; on arm64, arm64-efi/snponly.efi. A client" >> "$dhcptouse"
+            echo "#    with Secure Boot enforcing will refuse these." >> "$dhcptouse"
+            echo "#class \"FOG-UEFI-64-Unsigned\" {" >> "$dhcptouse"
+            echo "#    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
+            echo "#    filename \"snponly.efi\";" >> "$dhcptouse"
             echo "#}" >> "$dhcptouse"
             diffconfig "${dhcptouse}"
             # Non-fatal syntax check; ISC has historically started without one.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2556,8 +2556,16 @@ _sbChainStaged() {
 # server-side, and it is what the commented fallback in the generated config
 # points at.
 #
-# No 32-bit case on purpose: there is no Microsoft-signed ia32 shim and no
-# signed 32-bit iPXE, so i386-efi clients stay on the unsigned binary and must
+# The fallback names are not "unsigned" binaries -- _signLocalIpxe() signs every
+# *.efi in the TFTP root with this server's own leaf. The difference is which
+# trust root the client must already hold: the secureboot/ pair starts from
+# Microsoft's signature and loads on a machine that has never met this server,
+# while snponly.efi needs THIS server's certificate enrolled first. That is the
+# real reason the shim chain is the better default, and it is stronger than
+# "signed vs not".
+#
+# No 32-bit case on purpose: there is no Microsoft-signed ia32 shim to start a
+# chain from and no 32-bit MokManager to enrol one with, so i386-efi clients must
 # have Secure Boot disabled to netboot at all.
 #
 # --boot-delay needs no handling here either. EFI takes its delay from
@@ -2940,7 +2948,9 @@ downloadipxesecureboot() {
         # it is silent otherwise -- an admin who expected Secure Boot to work
         # would find the old boot file in a config they did not edit.
         echo " * Any DHCP configuration written by this run therefore names the"
-        echo " *   unsigned UEFI boot files, not secureboot/snponly-shimx64.efi."
+        echo " *   TFTP-root UEFI boot files, not secureboot/snponly-shimx64.efi."
+        echo " *   Those are signed with this server's own key, so a Secure Boot"
+        echo " *   client needs that certificate enrolled before it will load one."
         return 0
     fi
     errorStat 0
@@ -13274,11 +13284,12 @@ _keaBootFileFallbackComment() {
 #            "boot-file-name": "secureboot/ipxe-shimx64.efi"
 #        }
 #
-#        2. You do not want the signed chain at all. The unsigned binaries are
-#           still in the TFTP root (arm64: arm64-efi/snponly.efi). Clients with
-#           Secure Boot enforcing will refuse these:
+#        2. You want FOG's own builds rather than upstream's signed pair. They
+#           are in the TFTP root (arm64: arm64-efi/snponly.efi), signed with this
+#           server's key -- so a Secure Boot client will refuse them until that
+#           certificate is enrolled on it:
 #        {
-#            "name": "FOG-UEFI-64-Unsigned",
+#            "name": "FOG-UEFI-64-FogBuild",
 #            "test": "substring(option[60].hex,0,20) == 'PXEClient:Arch:00007'",
 #            "boot-file-name": "snponly.efi"
 #        }
@@ -13619,10 +13630,11 @@ configureDHCP() {
             echo "#    filename \"secureboot/ipxe-shimx64.efi\";" >> "$dhcptouse"
             echo "#}" >> "$dhcptouse"
             echo "#" >> "$dhcptouse"
-            echo "# 2. You do not want the signed chain at all. The unsigned binaries are" >> "$dhcptouse"
-            echo "#    still in the TFTP root; on arm64, arm64-efi/snponly.efi. A client" >> "$dhcptouse"
-            echo "#    with Secure Boot enforcing will refuse these." >> "$dhcptouse"
-            echo "#class \"FOG-UEFI-64-Unsigned\" {" >> "$dhcptouse"
+            echo "# 2. You want FOG's own builds rather than upstream's signed pair. They" >> "$dhcptouse"
+            echo "#    are in the TFTP root; on arm64, arm64-efi/snponly.efi. They carry" >> "$dhcptouse"
+            echo "#    this server's own signature, so a Secure Boot client refuses them" >> "$dhcptouse"
+            echo "#    until that certificate is enrolled on it." >> "$dhcptouse"
+            echo "#class \"FOG-UEFI-64-FogBuild\" {" >> "$dhcptouse"
             echo "#    match if substring(option vendor-class-identifier, 0, 20) = \"PXEClient:Arch:00007\";" >> "$dhcptouse"
             echo "#    filename \"snponly.efi\";" >> "$dhcptouse"
             echo "#}" >> "$dhcptouse"

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -696,17 +696,24 @@ class FOGConfigurationPage extends FOGPage
                 . 'secureboot/arm64-efi/'
             )
         ) . '</p>';
-        // Stated rather than detected: the web request's own scheme says
-        // nothing about the install's $httpproto, so guessing here would be
-        // worse than telling the admin what to check. See
-        // downloadipxesecureboot() -- an HTTPS install skips the staging
-        // entirely, because a signed binary cannot be rebuilt to carry this
-        // server's CA without invalidating the signature.
+        // This used to say Secure Boot PXE and HTTPS were mutually exclusive,
+        // because downloadipxesecureboot() skipped the staging entirely on an
+        // HTTPS install. It no longer does, and the claim was wrong even then:
+        // upstream iPXE defines CROSSCERT unconditionally, so its signed
+        // binaries validate a publicly-issued certificate with no rebuild and
+        // no embedded CA. Only a private CA forces a choice, and the answer
+        // there is to leave netboot on HTTP -- which has nothing to do with
+        // whether a signed chain is available. See downloadipxesecureboot().
+        //
+        // Stated rather than detected: the web request's own scheme says nothing
+        // about the install's $httpproto or its netboot protocol, so guessing
+        // here would be worse than telling the admin what to check.
         $steps .= '<p>' . _(
-            'Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS '
-            . 'install the installer skips these binaries, because rebuilding '
-            . 'them to trust this server\'s CA would invalidate the signature '
-            . 'that makes them bootable.'
+            'These binaries are staged on every install, HTTPS included. An '
+            . 'HTTPS web interface has no bearing on netboot, which has its own '
+            . 'protocol setting. HTTPS netboot only needs a rebuilt iPXE when '
+            . 'the certificate comes from a private CA -- a publicly-issued one '
+            . 'on an FQDN needs no rebuild and keeps the signed shim.'
         ) . '</p>';
         echo $this->_box(_('What to do next'), $steps);
     }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7062,9 +7062,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8622,6 +8619,9 @@ msgstr "Es gibt nichts zu replizieren"
 
 msgid "There you can download utilities such as FOG Prep"
 msgstr "Dort können Sie Tools wie FOG Prep, "
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
+msgstr ""
 
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7059,9 +7059,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8616,6 +8613,9 @@ msgid "There is nothing to replicate"
 msgstr "There is nothing to replicate"
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7210,9 +7210,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8804,6 +8801,9 @@ msgid "There is nothing to replicate"
 msgstr ""
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7063,9 +7063,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8623,6 +8620,9 @@ msgstr "Es gibt nichts zu replizieren"
 
 msgid "There you can download utilities such as FOG Prep"
 msgstr "Dort können Sie Tools wie FOG Prep, "
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
+msgstr ""
 
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7061,9 +7061,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8618,6 +8615,9 @@ msgid "There is nothing to replicate"
 msgstr "Il n'y a rien à répliquer"
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6835,9 +6835,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8331,6 +8328,9 @@ msgstr "Non c'è nulla da replicare"
 
 msgid "There you can download utilities such as FOG Prep"
 msgstr "Qui è possibile scaricare programmi di utilità come FOG Prep"
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
+msgstr ""
 
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6790,9 +6790,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8269,6 +8266,9 @@ msgstr "レプリケーションする項目はありません"
 
 msgid "There you can download utilities such as FOG Prep"
 msgstr "そこから FOG Prep などのユーティリティをダウンロードできます"
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
+msgstr ""
 
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6003,9 +6003,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -7321,6 +7318,9 @@ msgid "There is nothing to replicate"
 msgstr ""
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7060,9 +7060,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8617,6 +8614,9 @@ msgid "There is nothing to replicate"
 msgstr "Não há nada para replicar"
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7060,9 +7060,6 @@ msgstr ""
 msgid "Secure Boot CA private key"
 msgstr ""
 
-msgid "Secure Boot PXE and HTTPS are mutually exclusive: on an HTTPS install the installer skips these binaries, because rebuilding them to trust this server's CA would invalidate the signature that makes them bootable."
-msgstr ""
-
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
@@ -8617,6 +8614,9 @@ msgid "There is nothing to replicate"
 msgstr "没有什么可以复制"
 
 msgid "There you can download utilities such as FOG Prep"
+msgstr ""
+
+msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
 #, php-format

--- a/tests/dhcp-bootfile-mapping.test.sh
+++ b/tests/dhcp-bootfile-mapping.test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# Guards the architecture -> DHCP boot file mapping, and that ISC and Kea agree.
+#
+#   tests/dhcp-bootfile-mapping.test.sh
+#
+# FOG hands each client architecture a different PXE boot file, and 64-bit UEFI
+# and arm64 now get the signed shim chain by default -- secureboot/*-shim*.efi --
+# rather than the unsigned binaries. That is deliberate and not a Secure Boot
+# opt-in: shim is an ordinary UEFI application carrying a Microsoft signature, so
+# it boots the same whether the firmware is enforcing or not. The signed chain is
+# a superset, so every 64-bit UEFI client gets it. See _uefiBootFile().
+#
+# Two things are easy to break here and neither shows up until a client fails to
+# boot, long after the install that caused it:
+#
+#   1. The fallback. downloadipxesecureboot() is deliberately non-fatal, so an
+#      install whose fetch failed has no secureboot/ tree at all. If the config
+#      still named the shim, TFTP would answer "file not found" and EVERY UEFI
+#      client on the network would stop booting -- over a feature the site may
+#      not even use. _sbChainStaged() is what prevents that, and it reads the
+#      STAGING tree because configureDHCP runs before the copy loop fills the
+#      TFTP root.
+#
+#   2. The ISC/Kea agreement. The two generators are separate bodies of code --
+#      a heredoc piped through sed for Kea, a run of echo lines for ISC -- and
+#      the only thing keeping them in step was a comment asking future editors
+#      to keep them in sync. A site switching DHCP engines would otherwise get
+#      silently different boot files.
+#
+# Also pinned: what must NOT move. There is no Microsoft-signed 32-bit shim and
+# no signed 32-bit iPXE, so i386-efi clients cannot use this chain at all; BIOS
+# has no Secure Boot to speak of; and Apple BSDP serves Intel Macs over a
+# protocol none of this enters.
+#
+# No install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+BOOT_dhcp_delay_seconds=0
+
+# Two staging trees: one with the signed chain present, one without. Only the
+# x86-64 shim is created -- that is exactly the file _sbChainStaged() looks for,
+# so this also pins that it is not testing for something else.
+mkdir -p "$WORK/staged/secureboot"
+: > "$WORK/staged/secureboot/snponly-shimx64.efi"
+mkdir -p "$WORK/bare"
+
+# Replay the ISC class block from configureDHCP() rather than copying the
+# expected filenames into this test. Sourcing functions.sh does not run it -- it
+# is inline in a case branch -- so the lines are extracted and evaluated with
+# $dhcptouse pointed at a file. Reading the real lines is the point: a test that
+# restated them would pass while the generator drifted.
+isc_classes() {
+    local out="$WORK/dhcpd.conf"
+    : > "$out"
+    local block
+    block=$(sed -n '/echo "class \\"Legacy\\" {"/,/^            diffconfig/p' "$FUNCS" \
+        | sed '/^            diffconfig/d')
+    [[ -n $block ]] || { echo "ERROR: could not extract the ISC class block" >&2; exit 1; }
+    local dhcptouse="$out"
+    eval "$block"
+    cat "$out"
+}
+
+# The filename ISC gives one class, by class name.
+isc_file_for() {
+    isc_classes | awk -v want="class \"$1\" {" '
+        $0 == want { found = 1; next }
+        found && /filename/ { gsub(/^ *filename "|"; *$/, ""); print; exit }
+    '
+}
+
+# The boot-file-name Kea gives one client-class, by class name.
+kea_file_for() {
+    _keaBaseClasses | awk -v want="\"name\": \"$1\"" '
+        index($0, want) { found = 1; next }
+        found && /boot-file-name/ {
+            sub(/^.*"boot-file-name": "/, ""); sub(/".*$/, ""); print; exit
+        }
+    '
+}
+
+echo "With the signed chain staged"
+tftpdirsrc="$WORK/staged"
+
+is "$(_sbChainStaged && echo yes || echo no)" "yes" "_sbChainStaged sees the staged shim"
+is "$(_uefiBootFile x64)"   "secureboot/snponly-shimx64.efi"            "x86-64 UEFI gets the shim"
+is "$(_uefiBootFile arm64)" "secureboot/arm64-efi/snponly-shimaa64.efi" "arm64 UEFI gets the arm64 shim"
+
+# Arch 7, 8 and 9 all mean "64-bit UEFI" to some firmware vendor, so all three
+# have to land on the same file or the disagreement becomes a boot failure.
+for c in UEFI-64-1 UEFI-64-2 UEFI-64-3; do
+    is "$(isc_file_for $c)" "secureboot/snponly-shimx64.efi" "ISC $c -> shim"
+done
+is "$(isc_file_for UEFI-ARM64)" "secureboot/arm64-efi/snponly-shimaa64.efi" "ISC UEFI-ARM64 -> arm64 shim"
+# Arch 00007 with a UNDI suffix -- a 64-bit UEFI client like any other, and it
+# used to be matched separately and left behind by changes like this one.
+is "$(isc_file_for SURFACE-PRO-4)" "secureboot/snponly-shimx64.efi" "ISC SURFACE-PRO-4 -> shim"
+
+echo
+echo "With the signed chain missing (a failed or skipped download)"
+tftpdirsrc="$WORK/bare"
+
+is "$(_sbChainStaged && echo yes || echo no)" "no" "_sbChainStaged reports it missing"
+is "$(_uefiBootFile x64)"   "snponly.efi"           "x86-64 UEFI falls back to the unsigned binary"
+is "$(_uefiBootFile arm64)" "arm64-efi/snponly.efi" "arm64 UEFI falls back to the unsigned binary"
+
+for c in UEFI-64-1 UEFI-64-2 UEFI-64-3; do
+    is "$(isc_file_for $c)" "snponly.efi" "ISC $c falls back"
+done
+is "$(isc_file_for UEFI-ARM64)"    "arm64-efi/snponly.efi" "ISC UEFI-ARM64 falls back"
+is "$(isc_file_for SURFACE-PRO-4)" "snponly.efi"           "ISC SURFACE-PRO-4 falls back"
+
+echo
+echo "What must not move"
+for tree in staged bare; do
+    tftpdirsrc="$WORK/$tree"
+    is "$(isc_file_for UEFI-32-1)" "i386-efi/snponly.efi" "ISC UEFI-32-1 stays unsigned ($tree)"
+    is "$(isc_file_for UEFI-32-2)" "i386-efi/snponly.efi" "ISC UEFI-32-2 stays unsigned ($tree)"
+    is "$(kea_file_for FOG-UEFI-32-1)" "i386-efi/snponly.efi" "Kea FOG-UEFI-32-1 stays unsigned ($tree)"
+    is "$(kea_file_for FOG-Apple-Intel-Netboot)" "" "Kea Apple BSDP is not in the base classes ($tree)"
+    is "$(_biosBootFile)" "undionly.kkpxe" "BIOS is untouched ($tree)"
+done
+
+# --boot-delay drives a second BIOS binary through _biosBootFile, and both
+# indirections now run through the same sed pipeline in _keaBaseClasses. Pin
+# that adding the UEFI one did not break the BIOS one.
+tftpdirsrc="$WORK/staged"
+BOOT_dhcp_delay_seconds=10
+is "$(kea_file_for FOG-Legacy-BIOS)" "10secdelay/undionly.kkpxe" "Kea BIOS still follows --boot-delay"
+is "$(kea_file_for FOG-UEFI-64-1)" "secureboot/snponly-shimx64.efi" "Kea 64-bit UEFI unaffected by --boot-delay"
+BOOT_dhcp_delay_seconds=0
+
+echo
+echo "ISC and Kea agree"
+# The invariant _keaBaseClasses' own comment asks for, checked rather than asked.
+for tree in staged bare; do
+    tftpdirsrc="$WORK/$tree"
+    while read -r isc kea; do
+        is "$(kea_file_for "$kea")" "$(isc_file_for "$isc")" "$isc == $kea ($tree)"
+    done <<'PAIRS'
+Legacy FOG-Legacy-BIOS
+UEFI-32-2 FOG-UEFI-32-2
+UEFI-32-1 FOG-UEFI-32-1
+UEFI-64-1 FOG-UEFI-64-1
+UEFI-64-2 FOG-UEFI-64-2
+UEFI-64-3 FOG-UEFI-64-3
+UEFI-ARM64 FOG-UEFI-ARM64
+SURFACE-PRO-4 FOG-Surface-Pro-4
+PAIRS
+done
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
FOG stages upstream's Microsoft-signed shim and signed iPXE under `secureboot/` on every install — but every DHCP config this installer writes handed out the TFTP-root `snponly.efi` and emitted the Secure Boot stanza **commented out**. So the feature shipped, and no generated config used it.

## The reasoning it replaces

The old comments argued: DHCP option 93 carries the client architecture and nothing else, so a request cannot say whether Secure Boot is on, therefore a site has to opt specific machines in.

The premise is true and the conclusion does not follow. `shim` is an ordinary UEFI application that happens to carry a Microsoft signature — with Secure Boot on the firmware verifies it and it verifies what it loads next; with Secure Boot off the firmware verifies nothing and shim enforces nothing. It boots either way. That makes the signed chain a **superset** rather than a conditional: it covers the machines that need it and costs the others nothing, and there is nothing to detect.

## What changed

Arch `00007`/`00008`/`00009` and the Surface Pro 4 class now get `secureboot/snponly-shimx64.efi`, and `00011` gets `secureboot/arm64-efi/snponly-shimaa64.efi` — in the ISC generator, the live Kea config, and the copy-ready `kea-dhcp4.conf.fog-sample` alike. What used to be the commented Secure Boot *opt-in* is now the commented way back *out*: the `ipxe-` chain for firmware whose own SNP is broken, and FOG's own TFTP-root builds for a site that wants neither.

**Unchanged on purpose:** BIOS (no Secure Boot in CSM mode), both `i386-efi` classes (no Microsoft-signed 32-bit shim exists, so those clients cannot use this chain at all), and Apple BSDP.

## A correction to an earlier revision of this branch

An earlier version of these comments called the TFTP-root names "unsigned". They are not: `_signLocalIpxe()` signs every `*.efi` in the TFTP root with this server's own Secure Boot leaf, pruning `secureboot/` because that is upstream's Microsoft- and iPXE-signed pair. The distinction is which trust root the client must already hold:

| Boot file | Signed by | Loads on a machine that has never met this server |
| --- | --- | --- |
| `secureboot/snponly-shimx64.efi` | Microsoft (shim) → iPXE (loader) | **yes** |
| `snponly.efi` | this server's Secure Boot leaf | no — needs that certificate enrolled first |

Which is a *stronger* argument for the new default than the one the comments originally gave: the shim chain is the only one that boots before enrolment has happened anywhere. Fixed in a follow-up commit, along with renaming the commented fallback class from `FOG-UEFI-64-Unsigned` to `FOG-UEFI-64-FogBuild` — the old name put the same mistake somewhere an admin would paste into their own config.

## Guarded, and why the call had to move

`downloadipxesecureboot` is deliberately non-fatal. If its fetch failed there is no `secureboot/` tree, and a config naming a file TFTP cannot serve would stop **every UEFI client on the network** booting — over a feature the site may not even use. `_sbChainStaged()` falls the config back to the TFTP-root names, and the download's own failure message now says so, since otherwise an admin would find the old boot file in a config they did not edit.

That guard needs the fetch to have happened, and **`configureDHCP` runs before `configureTFTPandPXE`** — so a filesystem check as-is would fall back to the TFTP-root names on every first install, silently. `downloadipxesecureboot` is therefore hoisted out of `configureTFTPandPXE` to just before `configureDHCP` at both call sites.

I did **not** swap those two functions, which would have been the smaller diff. `fetchipxeasset` only does `mkdir -p` + `tar -xzf -C` and never clears the destination, so the two assets untar additively and their relative order does not matter — while that install sequence is heavily order-dependent and extensively commented, and a hidden dependency there would break every install.

## Also here

- **`tests/dhcp-bootfile-mapping.test.sh`** (44 assertions). Nothing covered this mapping, and the ISC and Kea generators are separate bodies of code — a heredoc piped through `sed` for Kea, a run of `echo` lines for ISC — kept in step only by a comment asking future editors to remember. The test pins both states of the guard, what must not move, the `--boot-delay` interaction, and that ISC and Kea agree class for class. It reads the real generator lines rather than restating filenames, so it cannot pass while they drift; verified by injecting a regression.
- **The Secure Boot config page claimed Secure Boot PXE and HTTPS are mutually exclusive.** `downloadipxesecureboot` no longer skips on HTTPS, and the claim was wrong even when it did: upstream iPXE defines `CROSSCERT` unconditionally, so its signed binaries validate a publicly-issued certificate with no rebuild and no embedded CA.
- **The installer's option 067 hint** was a single "e.g." naming `snponly.efi`; it is now the per-architecture table with a docs link.

## Verification

- Both guard states exercised across both generators — output identical between ISC and Kea in each state.
- The generated Kea JSON parses; 9 client-classes with the expected boot files.
- `--boot-delay` still reaches the BIOS name through the same `sed` pipeline it now shares with the UEFI substitution.
- `bash -n` on both shell files, `php -l` on the page.
- The 14 pre-existing shell-test failures on `origin/working-1.6` are unchanged in number and identity — this adds none, plus one new passing test. (`ipxe-tree-preservation.test.sh`'s "changed CA rebuilds at the same tag" failure was confirmed pre-existing by stashing.)

**Not done, needs a VM and hardware:** a real install asserting the generated `dhcpd.conf`/`kea-dhcp4.conf`, `dhcpd -t` / `kea-dhcp4 -t` validation, the guard test against a blocked release asset, and the end-to-end boot with Secure Boot both **on** (CA enrolled) and **off** (nothing enrolled). That last one is the superset claim itself, and the one result that would invalidate this PR.

Docs: FOGProject/fog-docs#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVRiHn5P4C15Lu3LxGtN8g

