### PR TITLE
Name the server, not just its address, when the install finishes

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1504,9 +1504,7 @@ while [[ -z $blGo ]]; do
                     echo "   the information listed below.  The login information"
                     echo "   is only if this is the first install."
                     echo
-                    echo "   This can be done by opening a web browser and going to:"
-                    echo
-                    echo "   ${WEB_url_proto}://${NET_fog_server_ip}${WEB_root}management"
+                    _managementUrls
                     echo
                     echo "   Default User Information"
                     echo "   Username: fog"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5282,6 +5282,59 @@ _servedCertName() {
     [[ -n ${NET_hostname} ]] && { echo "${NET_hostname}"; return 0; }
     echo "${NET_fog_server_ip}"
 }
+# The management-portal URLs to print when the install finishes.
+#
+# This used to be one line naming ${NET_fog_server_ip}, which on an HTTPS
+# install is the one address guaranteed to make the browser complain: the
+# certificate is issued for a NAME (see _certLeafName), so reaching the portal
+# by address is a name mismatch every time. The admin's first contact with their
+# new server was a security warning, with nothing on screen to say the name that
+# would have worked.
+#
+# So print both, name first. The address still has to be here -- DNS may not
+# have caught up yet, and it is the only thing that works on a server with no
+# usable name at all -- but as the fallback it is, not as the headline.
+#
+# The name comes from _servedCertName, i.e. the commonName of the certificate
+# actually on disk, rather than from ${NET_hostname}. Those differ on exactly
+# the installs where it matters: an externally-issued or publicly-trusted leaf
+# carries only the names its issuer was asked for, and --public-web-cert is a
+# supported path. Printing a name the certificate does not carry would send the
+# admin to a URL that warns just as loudly as the address, while implying it
+# would not.
+_managementUrls() {
+    local name="" ip="${NET_fog_server_ip}"
+    name=$(_servedCertName)
+    # _servedCertName's own last resort IS the address, so it can hand back the
+    # very thing the fallback line prints. Suppress the name line rather than
+    # printing the same URL twice with different captions.
+    [[ -z $name || $name == "$ip" || $(validip "$name") -eq 0 ]] && name=""
+
+    echo "   This can be done by opening a web browser and going to:"
+    echo
+    [[ -n $name ]] && echo "   ${WEB_url_proto}://${name}${WEB_root}management"
+    echo "   ${WEB_url_proto}://${ip}${WEB_root}management"
+    # The blank line belongs to the explanation, so it is emitted per branch
+    # rather than up front -- an HTTP install with no name has nothing to
+    # explain, and an unconditional echo there just orphans a blank line.
+    if [[ ${WEB_url_proto} == https ]]; then
+        echo
+        if [[ -n $name ]]; then
+            echo "   Use the first one. It is the name this server's certificate is"
+            echo "   issued for, so it is the only one that will not warn. The address"
+            echo "   works too -- useful before DNS catches up -- but the browser will"
+            echo "   object that the certificate names ${name} instead."
+        else
+            echo "   This server has no name in its certificate, only the address, so"
+            echo "   the browser will warn about the certificate every time. Give it a"
+            echo "   resolvable name with --hostname and re-run to fix that."
+        fi
+    elif [[ -n $name ]]; then
+        echo
+        echo "   Either works. The name is ${name}; the address is there for"
+        echo "   before DNS catches up."
+    fi
+}
 # The DNS names a certificate carries as subjectAltName entries.
 #
 # Echoes one per line, nothing at all when the certificate has no

--- a/tests/management-url-report.test.sh
+++ b/tests/management-url-report.test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Guards the management-portal URLs the installer prints when it finishes.
+#
+#   tests/management-url-report.test.sh
+#
+# This used to be a single line naming ${NET_fog_server_ip}. On an HTTPS install
+# that is the one address guaranteed to make the browser complain -- the
+# certificate is issued for a NAME, so reaching the portal by address is a name
+# mismatch every time -- so an admin's first contact with their new server was a
+# security warning, with nothing on screen naming the URL that would have
+# worked.
+#
+# _managementUrls() now prints the certificate's name first and the address as a
+# fallback. Three things about that are easy to regress and none of them would
+# fail an install, so nothing would catch them:
+#
+#   1. The name has to come from the CERTIFICATE (_servedCertName), not from
+#      ${NET_hostname}. Those differ on an externally-issued or publicly-trusted
+#      leaf, which carries only the names its issuer was asked for -- and
+#      --public-web-cert is a supported path. Printing a name the certificate
+#      does not carry sends the admin to a URL that warns exactly as loudly as
+#      the address, while implying it will not.
+#
+#   2. _servedCertName's own last resort IS the address. So on a server with no
+#      usable name it hands back the very thing the fallback line prints, and an
+#      unguarded implementation emits the same URL twice under two different
+#      captions -- one of which claims it is a certificate name.
+#
+#   3. The address must still be printed. DNS may not have caught up when the
+#      install finishes, and on a server with no name it is the only thing that
+#      works at all.
+#
+# No install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+has() { grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3 (output did not contain '$2')"; }
+hasnt() { grep -qF -- "$2" <<<"$1" && bad "$3 (output unexpectedly contained '$2')" || ok "$3"; }
+
+# Read the real function rather than reimplementing it -- a test that restated
+# the format would pass while the installer drifted.
+eval "$(sed -n '/^_managementUrls() {/,/^}/p' "$FUNCS")"
+declare -F _managementUrls >/dev/null || { echo "ERROR: could not extract _managementUrls" >&2; exit 1; }
+
+# validip echoes 0 for a valid IPv4 literal, 1 otherwise -- same contract as the
+# installer's own, which lives in lib/common/config.sh and needs no sourcing for
+# this.
+validip() { [[ $1 =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] && echo 0 || echo 1; }
+
+WEB_root="/fog/"
+NET_fog_server_ip="10.0.0.10"
+CERT_CN=""
+_servedCertName() { echo "$CERT_CN"; }
+
+emit() { WEB_url_proto="$1"; CERT_CN="$2"; _managementUrls; }
+
+echo "HTTPS with a name in the certificate"
+out=$(emit https "fogserver.example.com")
+has "$out" "https://fogserver.example.com/fog/management" "prints the certificate name URL"
+has "$out" "https://10.0.0.10/fog/management"             "prints the address URL too"
+# Order is the point: the name is the recommendation, the address is the
+# fallback. A reader takes the first URL offered.
+nameline=$(grep -n "fogserver.example.com/fog/management" <<<"$out" | head -1 | cut -d: -f1)
+ipline=$(grep -n "10.0.0.10/fog/management" <<<"$out" | head -1 | cut -d: -f1)
+[[ -n $nameline && -n $ipline && $nameline -lt $ipline ]] \
+    && ok "the name comes before the address" \
+    || bad "the name comes before the address (name@${nameline:-?}, ip@${ipline:-?})"
+has "$out" "certificate names fogserver.example.com instead" "says why the address warns"
+
+echo
+echo "HTTPS with no usable name (_servedCertName falls back to the address)"
+out=$(emit https "10.0.0.10")
+is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "the address URL is printed exactly once"
+hasnt "$out" "certificate is" "does not caption the address as a certificate name"
+has "$out" "--hostname" "points at --hostname as the fix"
+
+echo
+echo "HTTPS with an empty name (defensive -- _servedCertName should not, but)"
+out=$(emit https "")
+is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "still exactly one address URL"
+hasnt "$out" "https:///" "no empty-host URL is emitted"
+
+echo
+echo "HTTP"
+out=$(emit http "fogserver.example.com")
+has "$out" "http://fogserver.example.com/fog/management" "prints the name URL over http"
+hasnt "$out" "https://" "does not switch scheme"
+# The certificate wording is HTTPS-only: on a plain-HTTP install there may be no
+# served certificate at all, so claiming one would be an invention.
+hasnt "$out" "certificate" "no certificate wording on an http install"
+
+out=$(emit http "10.0.0.10")
+is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "http, no name: one address URL"
+hasnt "$out" "certificate" "http, no name: no certificate wording"
+
+echo
+echo "A non-default webroot is honoured"
+WEB_root="/"
+out=$(emit https "fog.example.com")
+has "$out" "https://fog.example.com/management" "webroot / gives a single slash"
+hasnt "$out" "//management" "no doubled slash"
+WEB_root="/fog/"
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
The last thing a successful install printed was:

```
   This can be done by opening a web browser and going to:

   https://10.0.0.10/fog/management
```

On an HTTPS install that is the **one URL guaranteed to make the browser complain**. The certificate is issued for a *name* (`_certLeafName`), so reaching the portal by address is a name mismatch every time. An admin's first contact with their new server was a security warning, with nothing on screen naming the URL that would have worked.

Now:

```
   This can be done by opening a web browser and going to:

   https://fogserver.example.com/fog/management
   https://10.0.0.10/fog/management

   Use the first one. It is the name this server's certificate is
   issued for, so it is the only one that will not warn. The address
   works too -- useful before DNS catches up -- but the browser will
   object that the certificate names fogserver.example.com instead.
```

The address stays, as the fallback it actually is: DNS may not have caught up when the install finishes, and on a server with no usable name it is the only thing that works at all.

## Where the name comes from, and why not `$NET_hostname`

`_servedCertName` — the `commonName` of the certificate actually on disk — not `${NET_hostname}`. Those differ on exactly the installs where it matters: an externally-issued or publicly-trusted leaf carries only the names its issuer was asked for, and `--public-web-cert` is a supported path. Printing a name the certificate does not carry would send the admin to a URL that warns *just as loudly* as the address, while implying it would not.

This is the same reasoning `_resolveNetbootHost` already documents for netboot, so the two now agree on how this server is named.

## Two cases the wording handles rather than assumes

- **`_servedCertName`'s own last resort is the address.** On a nameless server it hands back the very thing the fallback line prints. Unguarded, the output is the same URL twice under two captions — one of them claiming it is a certificate name. That case instead says what is wrong and names `--hostname` as the fix.
- **On plain HTTP there may be no served certificate at all**, so the certificate wording is HTTPS-only. Claiming one would be an invention.

## Verification

`tests/management-url-report.test.sh` (16 assertions) covers: name-before-address ordering, the duplicate-address guard, no certificate wording over HTTP, no scheme switching, and a non-default `--webroot`. It reads the real function via `sed` rather than restating the output format, so it cannot pass while the installer drifts.

Both regressions it exists to catch were injected and confirmed to fail it:

- reverting to address-only → 4 failures
- dropping the duplicate-address guard → 4 failures, including `the address URL is printed exactly once (expected '1', got '2')`

Rendered by hand across all seven combinations of scheme × name-state × webroot. `bash -n` on both files. The 14 pre-existing shell-test failures on `origin/working-1.6` are unchanged in number and identity.

## Scope

**Left alone:** the storage-node branch's "Management Server URL", which names the *master* via `${DB_host}` and is a different question.

Separate from #1403 (Secure Boot DHCP defaults) on purpose — unrelated concern, and that one is already up for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVRiHn5P4C15Lu3LxGtN8g
