### PR TITLE
Point the iPXE build failure at its own log

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -3082,7 +3082,31 @@ configureTFTPandPXE() {
         # binary lands exactly where a downloaded one would.
         "${buildipxesrc}/buildipxe.sh" "${ipxetrust}" "$(readlink -f $tftpdirsrc)" >>$workingdir/error_logs/fog_ipxe-build_${version}.log 2>&1
         local buildstat=$?
-        errorStat $buildstat
+        local ipxebuildlog="$workingdir/error_logs/fog_ipxe-build_${version}.log"
+        # errorStat tails $error_log, and this build does not write there -- its
+        # output goes to the file above. Tailing the wrong log printed five lines
+        # of unrelated noise from earlier steps (a DB backup line, the HTML body
+        # of the schema POST) and threw away the exit status, which is the one
+        # value that identifies the failure: buildipxe.sh returns a distinct
+        # status per stage -- 39/41 upstream checkout and patching, 40/48 BIOS,
+        # 79/80/91/95 x86 EFI, 82/93/97 the arm64 cross-compile. Report both, so
+        # a failed build can be diagnosed from what the installer prints instead
+        # of from a file nobody is told to look at.
+        if [[ $buildstat -ne 0 ]]; then
+            echo "Failed! (buildipxe.sh exit $buildstat)"
+            if [[ -z $exitFail ]]; then
+                echo
+                echo " * The iPXE build writes its own log, separate from $error_log."
+                echo " * Full build output: $ipxebuildlog"
+                echo " * Please include that file, and the exit status above, when"
+                echo "   reporting this."
+                echo
+                tail -n 20 "$ipxebuildlog"
+                exit $buildstat
+            fi
+        else
+            errorStat 0
+        fi
         # Recorded only on success, and only after the copy loop below has
         # actually put the result in place -- a stamp written for a build that
         # failed would suppress every retry.


### PR DESCRIPTION
Forum: https://forums.fogproject.org/topic/18231/ipxe-build-failing

An HTTPS install builds iPXE locally so the FOG CA can be baked in. When that build fails, `configureTFTPandPXE` calls `errorStat`, which tails `$error_log` — but the build's output went to `error_logs/fog_ipxe-build_<version>.log`. Different file.

So the failure banner printed five lines of unrelated noise from earlier steps (a DB backup line, the HTML body of the schema POST, the fog-ipxe git fetch) and threw away the exit status, which is the one value that identifies the failure: `buildipxe.sh` returns a distinct status per stage — 39/41 upstream checkout and patching, 40/48 BIOS, 79/80/91/95 x86 EFI, 82/93/97 the arm64 cross-compile.

Now: print the exit status, name the build log, and tail that log.

**Verified** by driving the extracted lines with a stub `buildipxe.sh`:

```
Compiling iPXE binaries trusting your SSL certificate.......Failed! (buildipxe.sh exit 82)

 * The iPXE build writes its own log, separate from .../fog_error_1.5.10.2424.log.
 * Full build output: .../fog_ipxe-build_1.5.10.2424.log
 * Please include that file, and the exit status above, when
   reporting this.

aarch64-linux-gnu-gcc: command not found
[installer exit: 82]
```

Mutation: with the stub exiting 0 the step still prints `OK` and the installer continues. `$exitFail` (continue-on-error) still suppresses the banner and the exit, as before.

Ported to `dev-branch` in #1406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)