### PR TITLE
Point the iPXE build failure at its own log (dev-branch port)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -1263,7 +1263,32 @@ configureTFTPandPXE() {
         # staging tree the copy loop below already reads, so a locally built
         # binary lands exactly where a downloaded one would.
         "${buildipxesrc}/buildipxe.sh" "${sslpath}CA/.fogCA.pem" "$(readlink -f $tftpdirsrc)" >>$workingdir/error_logs/fog_ipxe-build_${version}.log 2>&1
-        errorStat $?
+        local buildstat=$?
+        local ipxebuildlog="$workingdir/error_logs/fog_ipxe-build_${version}.log"
+        # errorStat tails $error_log, and this build does not write there -- its
+        # output goes to the file above. Tailing the wrong log printed five lines
+        # of unrelated noise from earlier steps (a DB backup line, the HTML body
+        # of the schema POST) and threw away the exit status, which is the one
+        # value that identifies the failure: buildipxe.sh returns a distinct
+        # status per stage -- 39/41 upstream checkout and patching, 40/48 BIOS,
+        # 79/80/91/95 x86 EFI, 82/93/97 the arm64 cross-compile. Report both, so
+        # a failed build can be diagnosed from what the installer prints instead
+        # of from a file nobody is told to look at.
+        if [[ $buildstat -ne 0 ]]; then
+            echo "Failed! (buildipxe.sh exit $buildstat)"
+            if [[ -z $exitFail ]]; then
+                echo
+                echo " * The iPXE build writes its own log, separate from $error_log."
+                echo " * Full build output: $ipxebuildlog"
+                echo " * Please include that file, and the exit status above, when"
+                echo "   reporting this."
+                echo
+                tail -n 20 "$ipxebuildlog"
+                exit $buildstat
+            fi
+        else
+            errorStat 0
+        fi
         cd $workingdir
     fi
     cd $tftpdirsrc


### PR DESCRIPTION
Port of #1405 to `dev-branch`. Same defect, same fix, verified the same way on this branch's copy of the block.

Forum: https://forums.fogproject.org/topic/18231/ipxe-build-failing — the reporter's failure banner is five lines of unrelated noise because `errorStat` tails `$error_log` while the build wrote to `error_logs/fog_ipxe-build_<version>.log`.

**Verified** by driving the extracted lines with a stub `buildipxe.sh`:

```
Compiling iPXE binaries trusting your SSL certificate.......Failed! (buildipxe.sh exit 40)

 * The iPXE build writes its own log, separate from .../fog_error_1.5.10.2424.log.
 * Full build output: .../fog_ipxe-build_1.5.10.2424.log
 * Please include that file, and the exit status above, when
   reporting this.

w89c840.c:1: error: unused variable
[exit: 40]
```

Mutation: with the stub exiting 0 the step still prints `OK` and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)