### PR TITLE
Stop double-escaping list columns: API returns text, renderer escapes

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4161');
+        define('FOG_VERSION', '1.6.0-beta.4164');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 374);
-        define('FOG_BCACHE_VER', 316);
+        define('FOG_BCACHE_VER', 317);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -2645,12 +2645,20 @@ class Route extends FOGBase
                             // ADR 0020 phase 4: the stored name answers when
                             // the host is gone, so a deleted host's rows do
                             // not all render "(41) - " forever.
+                            //
+                            // Escaped HERE, unlike the plain-text columns
+                            // around it, because this column IS markup: the
+                            // reader has to write it as HTML, so it cannot
+                            // escape the name itself. Same shape as the
+                            // hostLink built for the login-history grids.
                             return '<a href="../management/index.php?node=host&'
                                 . 'sub=edit&id='
                                 . $d
                                 . '">'
                                 . '(' . $d . ') - '
-                                . self::_hostLabel($d, $row, $classname)
+                                . \Initiator::e(
+                                    self::_hostLabel($d, $row, $classname)
+                                )
                                 . '</a>';
                         },
                         self::_hostNameOrder($classname)
@@ -3200,7 +3208,7 @@ class Route extends FOGBase
                         // Only a state row has to be assembled.
                         $text = isset($row['logText']) ? (string)$row['logText'] : '';
                         if ('' !== $text) {
-                            return \Initiator::e($text);
+                            return $text;
                         }
                         $host = self::_hostLabel(
                             isset($row['logHostID']) ? $row['logHostID'] : 0,
@@ -3237,30 +3245,29 @@ class Route extends FOGBase
                             // Nothing to say beyond the state. Rows written
                             // before schema 341 backfilled the type name are
                             // the case, and there is no way to recover it.
-                            return \Initiator::e($state);
+                            return $state;
                         }
                         // Spelled out per shape rather than assembled from
                         // fragments: a format string built from a variable
                         // never reaches the catalogue.
                         if ('' !== $image && '' !== $host) {
-                            return \Initiator::e(
-                                sprintf(
-                                    _('%1$s of %2$s on %3$s: %4$s'),
-                                    $what,
-                                    $image,
-                                    $host,
-                                    $state
-                                )
+                            return sprintf(
+                                _('%1$s of %2$s on %3$s: %4$s'),
+                                $what,
+                                $image,
+                                $host,
+                                $state
                             );
                         }
                         if ('' !== $host) {
-                            return \Initiator::e(
-                                sprintf(_('%1$s on %2$s: %3$s'), $what, $host, $state)
+                            return sprintf(
+                                _('%1$s on %2$s: %3$s'),
+                                $what,
+                                $host,
+                                $state
                             );
                         }
-                        return \Initiator::e(
-                            sprintf(_('%1$s: %2$s'), $what, $state)
-                        );
+                        return sprintf(_('%1$s: %2$s'), $what, $state);
                     }
                 ];
                 break;
@@ -3389,10 +3396,22 @@ class Route extends FOGBase
                 // LIKE against. `info` and `subjectLabel` are both still
                 // real columns and both still searchable, which is where a
                 // search for a message or an object name lands.
+                //
+                // PLAIN TEXT, not HTML. It shipped htmlspecialchars()'d and
+                // every reader escapes again, so a host called `- fos-nfs`
+                // read as `Task &quot;- fos-nfs&quot; (ID 140) was saved` in
+                // the grid and in the detail modal. `info`, `createdBy` and
+                // `ip` beside it were never escaped here, so the escape was
+                // also the odd one out. The contract for every data column
+                // in this list is: the API returns text, the renderer
+                // escapes -- which is what registerExportTable(), the audit
+                // grid and the activity grid all already do. A column that
+                // deliberately emits markup (hostLink above) escapes its own
+                // interpolations instead.
                 $columns[] = [
                     'dt' => 'summary',
                     'formatter' => function ($d, $row) {
-                        return \Initiator::e(self::_historySummary($row));
+                        return self::_historySummary($row);
                     }
                 ];
                 break;
@@ -3401,7 +3420,7 @@ class Route extends FOGBase
                     'db' => 'utUserName',
                     'dt' => 'username',
                     'formatter' => function ($d, $row) {
-                        return \Initiator::e($d);
+                        return (string)$d;
                     }
                 ];
                 $columns[] = self::relColumn(
@@ -3409,19 +3428,18 @@ class Route extends FOGBase
                     'hostname',
                     'Host',
                     function ($d, $row) use ($classname) {
-                        return \Initiator::e(
-                            self::_hostLabel($d, $row, $classname)
-                        );
+                        return self::_hostLabel($d, $row, $classname);
                     }
                 );
                 $columns[] = [
                     'db' => 'utAction',
                     'dt' => 'action',
                     'formatter' => function ($d, $row) {
-                        // Escaped here rather than in the helper: an
-                        // unrecognised code renders as itself, and the
-                        // summary below escapes the whole sentence once.
-                        return \Initiator::e(self::_userTrackingAction($d));
+                        // An unrecognised code renders as itself, so this can
+                        // carry a value written by an endpoint. Plain text
+                        // like every other data column -- see the note on
+                        // `summary` below.
+                        return self::_userTrackingAction($d);
                     }
                 ];
                 // ADR 0023 item 5: the one-line "what happened" the activity
@@ -3447,21 +3465,20 @@ class Route extends FOGBase
                         // string built from a variable never reaches the
                         // catalogue.
                         if ('' !== $who && '' !== $host) {
-                            return \Initiator::e(
-                                sprintf(_('%1$s: %2$s on %3$s'), $action, $who, $host)
+                            return sprintf(
+                                _('%1$s: %2$s on %3$s'),
+                                $action,
+                                $who,
+                                $host
                             );
                         }
                         if ('' !== $host) {
-                            return \Initiator::e(
-                                sprintf(_('%1$s on %2$s'), $action, $host)
-                            );
+                            return sprintf(_('%1$s on %2$s'), $action, $host);
                         }
                         if ('' !== $who) {
-                            return \Initiator::e(
-                                sprintf(_('%1$s: %2$s'), $action, $who)
-                            );
+                            return sprintf(_('%1$s: %2$s'), $action, $who);
                         }
-                        return \Initiator::e($action);
+                        return $action;
                     }
                 ];
                 break;

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -175,6 +175,27 @@ $.escapeHtml = function(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 }
+// A DataTables column definition for a field that is PLAIN TEXT.
+//
+// Route's list formatters return text, not markup, and DataTables writes cell
+// data as HTML unless a column supplies its own render -- so the escape lives
+// here, at the renderer, for every grid alike. Escaping server side instead
+// double-escapes wherever the reader also escapes, which is how the activity
+// viewer came to show `Task &quot;host&quot; (ID 140) was saved`.
+//
+// The t === 'display' guard is load-bearing: the Buttons CSV/copy exports ask
+// for other types, and escaping those would put &amp;/&lt; into the exported
+// file. A column that intentionally emits markup (hostLink, mainlink) is not
+// one of these -- it keeps `{data: field}` and escapes its own interpolations
+// server side.
+$.escapedColumn = function(field) {
+  return {
+    data: field,
+    render: function(d, t) {
+      return t === 'display' ? $.escapeHtml(d === null ? '' : String(d)) : d;
+    }
+  };
+}
 // Windows product-key display mask (mirror of FOGBase::productKeyMask).
 // Empty -> ''. Already-masked (contains a bullet) -> returned unchanged so
 // re-masking a redisplayed value is idempotent. A well-formed Base24 key

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -915,12 +915,17 @@
     var $groupLoginHist = $('#group-login-history-table');
     var groupHistoryLoginTable = !$groupLoginHist.length ? null :
       $groupLoginHist.registerTable(null, {
+        // hostLink stays raw -- it is a server-built <a>, and escaping it
+        // would print the markup literally. Everything beside it is plain
+        // text from Route and escapes here; `username` and `description`
+        // are written by the client check-in. Same split as the inventory
+        // report and the host page's copy of this tab.
         columns: [
             {data: 'hostLink'},
-            {data: 'createdTime'},
-            {data: 'action'},
-            {data: 'username'},
-            {data: 'description'}
+            $.escapedColumn('createdTime'),
+            $.escapedColumn('action'),
+            $.escapedColumn('username'),
+            $.escapedColumn('description')
         ],
         // Host first, because RowGroup only groups correctly when the
         // grouped column is the primary sort -- otherwise a host's rows

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -1211,11 +1211,16 @@
     var $hostLoginHist = $('#host-login-history-table');
     var hostHistoryLoginTable = !$hostLoginHist.length ? null :
       $hostLoginHist.registerTable(null, {
+        // Every column escapes. `username` and `description` are written by
+        // the client check-in, so they are attacker-writable, and DataTables
+        // writes cell data as HTML unless a column supplies its own render.
+        // Route returns these as plain text -- the escape is the reader's
+        // job, the same way the inventory report below does it.
         columns: [
-            {data: 'createdTime'},
-            {data: 'action'},
-            {data: 'username'},
-            {data: 'description'}
+            $.escapedColumn('createdTime'),
+            $.escapedColumn('action'),
+            $.escapedColumn('username'),
+            $.escapedColumn('description')
         ],
         order: [
             [0, 'desc']

--- a/packages/web/management/js/fog/report/fog.report.file.js
+++ b/packages/web/management/js/fog/report/fog.report.file.js
@@ -52,14 +52,20 @@
             }
           },
           buttons: reportButtons,
+          // Every column escapes. A history row records subject labels that
+          // came from a machine on the network, and DataTables writes cell
+          // data as HTML unless a column supplies its own render. The
+          // display-only guard is load-bearing: the Buttons CSV/copy exports
+          // ask for other types and escaping those would put &amp; into the
+          // exported file. Same shape as registerExportTable().
           columns: [
-            {data: 'createdBy'},
-            {data: 'createdTime'},
+            $.escapedColumn('createdBy'),
+            $.escapedColumn('createdTime'),
             // ADR 0020 phase 4: the server-built sentence, in the reader's
             // language, falling back to the stored prose (`info`) for rows
             // written before phase 3.
-            {data: 'summary'},
-            {data: 'ip'}
+            $.escapedColumn('summary'),
+            $.escapedColumn('ip')
           ],
           rowId: 'id',
           processing: true,


### PR DESCRIPTION
## The bug

The activity viewer's detail modal rendered its **What** line as

```
Task &quot;- fos-nfs-test 2026-08-26 11:32:39&quot; (ID 140) was saved
```

with the entities visible as literal text, in the grid column and in the modal
alike.

`Route`'s `summary` output column ran the sentence through `Initiator::e()`
before putting it in the JSON, and every reader escapes again on the way into
the DOM — so the `&` of `&quot;` was itself escaped and the browser drew the
entity instead of a quote.

## Why it was wrong, not just doubled

The escape was in the wrong layer *and* it was the odd one out. `info`,
`createdBy`, `ip` and `subjectLabel` sit in the same payload and were never
escaped server side. This file's own inventory-report comment already states
the rule:

> the server side must stay raw because `Route::listem` also feeds the
> CSV/exportAll path, where HTML entities would leak into exported files

Only `summary` — and usertracking's `username`, `hostname` and `action` —
broke it.

The contract across the list API is now uniform: **the API returns text, the
renderer escapes.** A column that deliberately emits markup escapes its own
interpolations server side instead, which is what the two `hostLink` builders
do.

## Changes

| File | Change |
|---|---|
| `route.class.php` | dropped `Initiator::e()` from the `summary` formatters (history, usertracking, tasklog) and from usertracking's `username`/`hostname`/`action`. **Added** it to the `hostLink` `<a>` builder, which was interpolating an unescaped host name straight into markup — its sibling below already escaped, this one did not. |
| `fog.common.js` | new `$.escapedColumn(field)`, the house display-only escape as a column definition. The `t === 'display'` guard is load-bearing: the Buttons CSV/copy exports ask for other types, and escaping those puts `&amp;` into the exported file. |
| `fog.report.file.js` | the History Report's four columns now escape. `createdBy` and `ip` had no escape on **either** side, so that grid wrote raw DB text as HTML. |
| `fog.host.edit.js` / `fog.group.edit.js` | the Login History tabs escape `action`/`username`/`description`. `username` and `description` are written by the client check-in, so they were raw-HTML sinks. `hostLink` stays raw — it is a server-built `<a>`. |
| `system.class.php` | `FOG_BCACHE_VER` 316 → 317, since JS changed. |

Two things fall out of the same change:

- the **Hosts And Users** report was double-escaping usernames the same way
  (`render.text()` on top of the server escape), so `O'Brien` read as
  `O&#039;Brien`;
- the activity modal's `row.info !== row.summary` test could never be true for
  a legacy row, so **Logged** was repeating the line directly above it.

## Verification

Against the lab database, not by reading. A shadow tree booted on the live
`config.class.php` calls `Route::listem('history')` exactly the way
`?node=activity&sub=getList` does, and asserts that `"<label>"` appears
verbatim in every framed row — an assertion the pre-fix formatter cannot
satisfy, because it turns the delimiters into `&quot;` too.

```
pre-fix   framed rows: 74   mismatched: 74   FAIL
post-fix  framed rows: 74   mismatched:  0   PASS
```

The gate was made to go red before being trusted: dropping the pre-fix
`route.class.php` into the shadow tree fails 74 of 74. Probe:
`~/scripts/background_scripts/probe_history_summary_escape.php` (header carries
the rebuild steps). Nothing was written to `/var/www` — the live tree was
confirmed byte-identical to `HEAD` afterwards.

The assertion deliberately ignores unframed rows: a legacy row has no type, so
`History::summary()` returns the stored prose untouched, and some of that prose
was written pre-escaped years ago. A bare grep for `&quot;` reports that as a
failure, and it is a property of the data rather than of this code.

## Notes

No route was added, renamed or removed, so `OpenAPI::document()` still
describes this API exactly as it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
