### PR TITLE
Name the bodies a write route takes

### DIFF
--- a/packages/web/lib/fog/openapi.class.php
+++ b/packages/web/lib/fog/openapi.class.php
@@ -643,6 +643,9 @@ class OpenAPI extends FOGBase
     {
         $schemas = [
             'ListEnvelope' => self::_listEnvelopeSchema(),
+            'BulkEditIds' => self::_bulkEditIdsSchema(),
+            'TaskRequest' => self::_taskRequestSchema(),
+            'NamesRequest' => self::_namesRequestSchema(),
             'Error' => [
                 'type' => 'object',
                 'properties' => [
@@ -663,6 +666,11 @@ class OpenAPI extends FOGBase
             $pageRef = self::pageRef($ref);
             $page = substr($pageRef, strrpos($pageRef, '/') + 1);
             $schemas[$page] = self::_pageSchema($ref);
+            // Likewise the join body: same field set as the entity, plus the
+            // ids to apply it to. Registered here for the same reason.
+            $joinRef = self::joinRef($ref);
+            $join = substr($joinRef, strrpos($joinRef, '/') + 1);
+            $schemas[$join] = self::_joinSchema($ref);
         }
         return $schemas;
     }
@@ -1454,17 +1462,8 @@ class OpenAPI extends FOGBase
                         'content' => [
                             'application/json' => [
                                 'schema' => [
-                                    'type' => 'object',
-                                    'properties' => [
-                                        'taskTypeID' => self::_oneOfTypes(['string', 'integer']),
-                                        'taskName' => ['type' => 'string'],
-                                        'shutdown' => self::_oneOfTypes(['string', 'boolean']),
-                                        'debug' => self::_oneOfTypes(['string', 'boolean']),
-                                        'deploySnapins' => self::_oneOfTypes(['string', 'integer', 'boolean']),
-                                        'passreset' => ['type' => 'string'],
-                                        'sessionjoin' => self::_oneOfTypes(['string', 'boolean']),
-                                        'wol' => self::_oneOfTypes(['string', 'boolean'])
-                                    ]
+                                    '$ref' => '#/components/schemas/'
+                                        . 'TaskRequest'
                                 ]
                             ]
                         ]
@@ -1949,25 +1948,108 @@ class OpenAPI extends FOGBase
             'required' => true,
             'content' => [
                 'application/json' => [
-                    'schema' => [
-                        'allOf' => [
-                            ['$ref' => $ref],
-                            [
-                                'type' => 'object',
-                                'required' => ['ids'],
-                                'properties' => [
-                                    'ids' => [
-                                        'type' => 'array',
-                                        'items' => ['type' => 'integer'],
-                                        'description' => _('The objects to '
-                                            . 'apply these values to. An '
-                                            . 'empty or absent list matches '
-                                            . 'nothing and edits nothing.')
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
+                    'schema' => ['$ref' => self::joinRef($ref)]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The component ref for the join body of a class.
+     *
+     * `#/components/schemas/Host` -> `#/components/schemas/HostJoin`.
+     *
+     * Same defect and same fix as pageRef(): the body was written inline at
+     * every join route, so it had no name and every generator invented one.
+     *
+     * @param string $ref The entity schema reference.
+     *
+     * @return string
+     */
+    public static function joinRef($ref)
+    {
+        $name = substr((string)$ref, strrpos((string)$ref, '/') + 1);
+        return '#/components/schemas/' . $name . 'Join';
+    }
+
+    /**
+     * The join body for one class: the entity's own fields, plus the ids to
+     * apply them to.
+     *
+     * Still an allOf, unlike the page schema, and deliberately so. A page was
+     * flattened because x-ms-pageable has to find `data` in the schema's own
+     * properties; nothing looks the join body up that way, and allOf is what
+     * keeps this field set from drifting away from the class's own schema.
+     *
+     * What changed is that BOTH branches are now named refs. An allOf whose
+     * second branch is written inline still leaves that branch anonymous, and
+     * a generator names it -- which is how `...JoinPutRequestbodyContent
+     * ApplicationJsonSchemaAllof1` came about. Pointing at BulkEditIds costs
+     * one shared schema and leaves nothing unnamed.
+     *
+     * @param string $ref The entity schema reference.
+     *
+     * @return array
+     */
+    private static function _joinSchema($ref)
+    {
+        return [
+            'allOf' => [
+                ['$ref' => $ref],
+                ['$ref' => '#/components/schemas/BulkEditIds']
+            ]
+        ];
+    }
+
+    /**
+     * The body POST /{class}/{id}/task takes.
+     *
+     * Written inline at the route, which meant one anonymous copy per
+     * tasking class even though every copy was identical. Shared and named,
+     * because the body genuinely is the same body -- queueing a task against
+     * a host and against a group take the same fields.
+     *
+     * @return array
+     */
+    private static function _taskRequestSchema()
+    {
+        return [
+            'type' => 'object',
+            'description' => _('The fields a queued task accepts. '
+                . 'Wake-on-lan is this body with wol set, not a route of '
+                . 'its own.'),
+            'properties' => [
+                'taskTypeID' => self::_oneOfTypes(['string', 'integer']),
+                'taskName' => ['type' => 'string'],
+                'shutdown' => self::_oneOfTypes(['string', 'boolean']),
+                'debug' => self::_oneOfTypes(['string', 'boolean']),
+                'deploySnapins' => self::_oneOfTypes(
+                    ['string', 'integer', 'boolean']
+                ),
+                'passreset' => ['type' => 'string'],
+                'sessionjoin' => self::_oneOfTypes(['string', 'boolean']),
+                'wol' => self::_oneOfTypes(['string', 'boolean'])
+            ]
+        ];
+    }
+
+    /**
+     * The ids half of every join body, shared rather than repeated.
+     *
+     * @return array
+     */
+    private static function _bulkEditIdsSchema()
+    {
+        return [
+            'type' => 'object',
+            'required' => ['ids'],
+            'properties' => [
+                'ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'integer'],
+                    'description' => _('The objects to apply these values '
+                        . 'to. An empty or absent list matches nothing and '
+                        . 'edits nothing.')
                 ]
             ]
         ];
@@ -1985,17 +2067,30 @@ class OpenAPI extends FOGBase
             'content' => [
                 'application/json' => [
                     'schema' => [
-                        'type' => 'object',
-                        'required' => ['names'],
-                        'properties' => [
-                            'names' => [
-                                'type' => 'array',
-                                'items' => ['type' => 'string'],
-                                'description' => _('Names to resolve. Each is '
-                                    . 'created if no object already has it.')
-                            ]
-                        ]
+                        '$ref' => '#/components/schemas/NamesRequest'
                     ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The names half of POST /group/join, named for the same reason as the
+     * rest: written inline it has no name, so a generator invents one.
+     *
+     * @return array
+     */
+    private static function _namesRequestSchema()
+    {
+        return [
+            'type' => 'object',
+            'required' => ['names'],
+            'properties' => [
+                'names' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => _('Names to resolve. Each is created '
+                        . 'if no object already has it.')
                 ]
             ]
         ];

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4164');
+        define('FOG_VERSION', '1.6.0-beta.4167');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -8437,6 +8437,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -8432,6 +8432,9 @@ msgstr "Failed to create task"
 msgid "The current user is invalid."
 msgstr "Task type is not valid"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8617,6 +8617,9 @@ msgstr "No se pudo crear la tarea"
 msgid "The current user is invalid."
 msgstr "tipo de tarea no es válida"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8438,6 +8438,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -8434,6 +8434,9 @@ msgstr "Impossible de créer la tâche"
 msgid "The current user is invalid."
 msgstr "Type de tâche n'est pas valide"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -8151,6 +8151,9 @@ msgstr "Impossibile creare un'attività"
 msgid "The current user is invalid."
 msgstr "Tipo di attività non è valido"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -8088,6 +8088,9 @@ msgstr "タスクの作成に失敗しました"
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -7152,6 +7152,9 @@ msgstr ""
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -8433,6 +8433,9 @@ msgstr "Falha ao criar tarefa"
 msgid "The current user is invalid."
 msgstr "tipo de tarefa não é válido"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -8433,6 +8433,9 @@ msgstr "无法创建任务"
 msgid "The current user is invalid."
 msgstr "任务类型无效"
 
+msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
+msgstr ""
+
 msgid "The file itself."
 msgstr ""
 


### PR DESCRIPTION
#1399 named the page a list route returns. This is the other half: the request bodies, which were written inline at the route and so had no name either.

An anonymous schema has no name, so every code generator invents one:

```
Paths10Ae5DlStoragegroupJoinPutRequestbodyContentApplicationJsonSchemaAllof1
```

Three bodies, named and `$ref`'d instead:

| schema | what it is |
|---|---|
| `{Class}Join` | the join body — the entity's fields plus the ids to apply them to, previously inline at all 49 join routes |
| `TaskRequest` | `POST /{class}/{id}/task` — written inline once but instantiated per tasking class, so every copy was a separate anonymous schema despite being identical |
| `NamesRequest` | `POST /group/join` |

`{Class}Join` is registered beside `{Class}Page` in `_schemas()`, for the same reason: the pair cannot then drift apart.

## Why join stays an allOf

`_pageSchema()` was flattened in #1399 because `x-ms-pageable` has to find `data` in the schema's own properties, and an `allOf` has none of its own. Nothing looks a request body up that way, and `_bulkEditBody()`'s original comment gives the reason to keep composing: *allOf rather than a copied property list, so the field set cannot drift from the class's own schema.* That reasoning still holds and is preserved.

What changed is that **both** branches are now named. An `allOf` whose second branch is inline still leaves that branch anonymous — which is where the `...Allof1` names came from. Pointing at a shared `BulkEditIds` costs one schema and leaves nothing unnamed.

## Measured

Same generator and config (autorest core 3.10.9, `@autorest/powershell@4.0.758`), only the document changed:

| | before | after |
|---|---|---|
| synthesized request-body names | 158 | **2** |
| synthesized names, all kinds | 280 | 124 |
| generated model files | 1,457 | 1,252 |

The 2 that remain are the `multipart/form-data` uploads, `Snapin_CreateWithFile` and `StorageGroup_UploadSnapinFiles`. Left alone deliberately: AutoRest models multipart differently from JSON, so naming those carries its own risk for 2 of an original 158.

## No surface change

The generated client is identical where a user touches it: **473 cmdlets, same parameters, same output types, 0 inference warnings.** A recorded surface snapshot was diffed before and after — **0 lines changed**. This moves nothing but the names of models nobody chose.

The 122 remaining synthesized names are non-list responses, a separate change.