### PR TITLE
Stop requiring the storage node API signing key

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4167');
+        define('FOG_VERSION', '1.6.0-beta.4171');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -1031,7 +1031,7 @@ class StorageNodeManagement extends FOGPage
                 'text',
                 'apikey',
                 $apikey,
-                true
+                false
             )
             . '<div class="form-text">'
             . _(


### PR DESCRIPTION
## Problem

Editing a storage node failed HTML5 validation on **Node API Signing Key**
with *Field is required*, while the field's own placeholder reads "Leave
empty unless this node is its own FOG server" and the help text under it
says it is "Only for a peer running its own FOG database". A true storage
node reads the master's `globalSettings` and already shares
`FOG_NODE_API_KEY`, so empty is the normal case — the field was
unfillable-but-mandatory.

## Fix

`makeInput()`'s `$required` argument for `apikey` is now `false`
(`storagenodemanagement.page.php:1034`).

Nothing else demanded a value: the post handler writes
`trim(filter_input(INPUT_POST, 'apikey'))` unconditionally, and `key`
is not in `StorageNode::$databaseFieldsRequired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)