### PR TITLE
Say which stage of the storage node SSH check failed

### DIFF
--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -73,6 +73,27 @@ class FOGSSH
      */
     private $_currentLoginHash;
     /**
+     * Which stage of connect() failed, if one did.
+     *
+     * Either 'connect' (the handshake never completed) or 'login' (the server
+     * answered and refused the credentials). connect() returns a bare false
+     * for both, so without this the caller cannot tell a transport problem
+     * from a wrong password. FOGFTP already carries the same pair for the
+     * same reason; this mirrors it.
+     *
+     * @var string
+     */
+    private $_lastFailure = '';
+    /**
+     * Which stage of the last connect() failed.
+     *
+     * @return string 'connect', 'login', or '' when it succeeded.
+     */
+    public function lastFailure()
+    {
+        return $this->_lastFailure;
+    }
+    /**
      * Sets the variable for us to use later.
      *
      * @param string $key   The key to set.
@@ -170,6 +191,7 @@ class FOGSSH
         $autologin = true,
         $connectmethod = 'ssh2_connect'
     ) {
+        $this->_lastFailure = '';
         try {
             $this->_currentConnectionHash = password_hash(
                 print_r($this->data, 1),
@@ -192,14 +214,17 @@ class FOGSSH
                     $port = $this->port;
                 }
             }
+            $this->_lastFailure = 'connect';
             $this->_link = ssh2_connect($host, $port);
             if ($this->_link === false) {
                 trigger_error(_('SSH Connection Failed'), E_USER_NOTICE);
                 $this->ssherror($this->data);
             }
             if ($autologin) {
+                $this->_lastFailure = 'login';
                 $this->login();
             }
+            $this->_lastFailure = '';
             $this->_lastConnectionHash = $this->_currentConnectionHash;
         } catch (\Exception $e) {
             FOGCore::error($e->getMessage());

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4171');
+        define('FOG_VERSION', '1.6.0-beta.4174');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -1093,20 +1093,50 @@ class StorageNodeManagement extends FOGPage
         $pass = trim(
             filter_input(INPUT_POST, 'pass')
         );
+        // Three unrelated things can fail here -- the node can be off the
+        // network, its SSH service can refuse the handshake, or the account
+        // can be rejected -- and this used to report all three as
+        // "Unable to connect using ip, user, and/or password provided!".
+        // That names the password for a failure the password was never
+        // involved in: a handshake that never completed presented no
+        // credentials at all. Reported by Tom after an ssh2_connect -43
+        // ("failed getting banner") on a node whose password was correct
+        // and merely contained a '>', which made it look like an escaping
+        // bug. Say which stage actually failed instead.
+        $warning = '';
         $testavail = self::$FOGURLRequests->isAvailable($ip);
-        $warning = !array_shift($testavail);
-        if (!$warning) {
+        if (!array_shift($testavail)) {
+            $warning = sprintf(
+                '%s: %s',
+                _('The node did not answer on the network'),
+                $ip
+            );
+        } else {
             self::$FOGSSH->username = $user;
             self::$FOGSSH->password = $pass;
             self::$FOGSSH->host = $ip;
-            $warning = !self::$FOGSSH->connect();
-        }
-        if ($warning) {
-            $warning = _(
-                'Unable to connect using ip, user, and/or password provided!'
-            );
-        } else {
-            self::$FOGSSH->disconnect();
+            if (!self::$FOGSSH->connect()) {
+                if (self::$FOGSSH->lastFailure() === 'login') {
+                    $warning = sprintf(
+                        '%s: %s@%s',
+                        _('The node refused the SSH login for'),
+                        $user,
+                        $ip
+                    );
+                } else {
+                    $warning = sprintf(
+                        '%s: %s. %s',
+                        _('Could not open an SSH connection to'),
+                        $ip,
+                        _(
+                            'This is a transport failure -- no credentials '
+                            . 'were sent -- so check sshd on the node.'
+                        )
+                    );
+                }
+            } else {
+                self::$FOGSSH->disconnect();
+            }
         }
         $bandwidth = trim(
             filter_input(INPUT_POST, 'bandwidth')

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1716,6 +1716,10 @@ msgid "Could not notify"
 msgstr "Konnte nicht benachrichtigen"
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
@@ -8507,6 +8511,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr "Der zu verwendende Knoten ist derzeit"
 
@@ -8712,6 +8722,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1718,6 +1718,10 @@ msgid "Could not notify"
 msgstr "Could not read tmp file."
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Could not read temp file"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Could not read temp file"
 
@@ -8502,6 +8506,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -8706,6 +8716,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1738,6 +1738,10 @@ msgid "Could not notify"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "No se pudo leer el archivo temporal"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "No se pudo leer el archivo temporal"
 
@@ -8688,6 +8692,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -8894,6 +8904,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1716,6 +1716,10 @@ msgid "Could not notify"
 msgstr "Konnte nicht benachrichtigen"
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
@@ -8508,6 +8512,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr "Der zu verwendende Knoten ist derzeit"
 
@@ -8713,6 +8723,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1720,6 +1720,10 @@ msgid "Could not notify"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Impossible de lire le fichier temporaire"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Impossible de lire le fichier temporaire"
 
@@ -8504,6 +8508,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -8708,6 +8718,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1662,6 +1662,10 @@ msgid "Could not notify"
 msgstr "Non posso notificare"
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Impossibile leggere il file temporaneo"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Impossibile leggere il file temporaneo"
 
@@ -8220,6 +8224,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr "Il nodo che si sta cercando di essere utilizzato è attualmente"
 
@@ -8420,6 +8430,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1646,6 +1646,10 @@ msgid "Could not notify"
 msgstr "通知できませんでした"
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "スナップインファイルを読み取れませんでした"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "スナップインファイルを読み取れませんでした"
 
@@ -8157,6 +8161,13 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+#, fuzzy
+msgid "The node did not answer on the network"
+msgstr "このノードはオンラインではないようです"
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr "使用しようとしているノードは現在"
 
@@ -8360,6 +8371,9 @@ msgstr "これは一度だけ実行されるタスクであり、現在は実行
 
 msgid "This is a single run task that should run now."
 msgstr "これは一度だけ実行されるタスクであり、現在実行される予定です。"
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
+msgstr ""
 
 #, php-format
 msgid "This is currently in %d sites (%s). Saving here replaces them all with the single site selected below. Use the site's own page to keep more than one."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1470,6 +1470,9 @@ msgstr ""
 msgid "Could not notify"
 msgstr ""
 
+msgid "Could not open an SSH connection to"
+msgstr ""
+
 msgid "Could not open file"
 msgstr ""
 
@@ -7219,6 +7222,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -7408,6 +7417,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1719,6 +1719,10 @@ msgid "Could not notify"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "Não foi possível ler arquivo temporário"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "Não foi possível ler arquivo temporário"
 
@@ -8503,6 +8507,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -8707,6 +8717,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1719,6 +1719,10 @@ msgid "Could not notify"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
+msgid "Could not open an SSH connection to"
+msgstr "无法读取临时文件"
+
+#, fuzzy
 msgid "Could not open file"
 msgstr "无法读取临时文件"
 
@@ -8503,6 +8507,12 @@ msgstr ""
 msgid "The manual enrolment steps below are unaffected."
 msgstr ""
 
+msgid "The node did not answer on the network"
+msgstr ""
+
+msgid "The node refused the SSH login for"
+msgstr ""
+
 msgid "The node trying to be used is currently"
 msgstr ""
 
@@ -8707,6 +8717,9 @@ msgid "This is a single run task that should not run now."
 msgstr ""
 
 msgid "This is a single run task that should run now."
+msgstr ""
+
+msgid "This is a transport failure -- no credentials were sent -- so check sshd on the node."
 msgstr ""
 
 #, php-format


### PR DESCRIPTION
## Problem

Saving a storage node runs a live SSH login against the node using the **FTP**
user and password (`storagenodemanagement.page.php`). Three unrelated things can
fail there:

1. the node does not answer the HTTP availability probe;
2. `ssh2_connect()` cannot complete the SSH handshake;
3. `ssh2_auth_password()` rejects the account.

All three reported `Unable to connect using ip, user, and/or password provided!`
— which names the password for a failure the password was never part of. Case 2
sends no credentials at all.

Found chasing an `ssh2_connect(): Error starting up SSH connection(-43): Failed
getting banner` on a node whose stored password was byte-correct and happened to
contain a `>`. That made it look like an HTML-escaping bug; it is not. Nothing
in the save path escapes the value — `filter_input()` with no filter is
`FILTER_UNSAFE_RAW`, `sanitizeItems()` only trims and strips NULs, and the
render side single-escapes through `Initiator::e()`.

## Fix

`FOGSSH` gains the `$_lastFailure` / `lastFailure()` pair `FOGFTP` already
carries for exactly this reason (`fogftp.class.php:81`, used at
`fogservice.class.php:558`), so `connect()`'s bare `false` can be told apart.
The page then reports the stage that actually failed.

## Verification

Three arms run against live sshd on the lab box:

| arm | `connect()` | `lastFailure()` |
|---|---|---|
| unroutable address (192.0.2.1) | `false` | `connect` |
| real host, wrong password | `false` | `login` |
| real host, stored password | object | `''` |

The middle arm is the one that used to be indistinguishable from the first.

Not ported: `dev-branch` has no SSH check on this page at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)