### PR TITLE
Name the storage node account for what it is, not for FTP

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4178');
+        define('FOG_VERSION', '1.6.0-beta.4181');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -357,11 +357,16 @@ class StorageNodeManagement extends FOGPage
                 $sslpath,
                 true
             ),
-            // Node FTP User/Password
+            // The system account FOG signs in as ON the node. Named
+            // "FTP User"/"FTP Password" until now, which described only half
+            // of what it does: the replicators use it for FTP transfers, and
+            // this page's own save-time reachability check uses it for an SSH
+            // login. It is a service account on the node, not a FOG web user,
+            // so it is named for what it is rather than for one protocol.
             self::makeLabel(
                 $labelClass,
                 'user',
-                _('Storage Node FTP User')
+                _('Node Service Account')
             ) => self::makeInput(
                 'form-control storagenodeuser-input',
                 'user',
@@ -374,7 +379,7 @@ class StorageNodeManagement extends FOGPage
             self::makeLabel(
                 $labelClass,
                 'pass',
-                _('Storage Node FTP Password')
+                _('Node Service Account Password')
             ) => '<div class="input-group">'
             . self::makeInput(
                 'form-control storagenodepass-input',
@@ -980,11 +985,16 @@ class StorageNodeManagement extends FOGPage
                 $sslpath,
                 true
             ),
-            // Node FTP User/Password
+            // The system account FOG signs in as ON the node. Named
+            // "FTP User"/"FTP Password" until now, which described only half
+            // of what it does: the replicators use it for FTP transfers, and
+            // this page's own save-time reachability check uses it for an SSH
+            // login. It is a service account on the node, not a FOG web user,
+            // so it is named for what it is rather than for one protocol.
             self::makeLabel(
                 $labelClass,
                 'user',
-                _('Storage Node FTP User')
+                _('Node Service Account')
             ) => self::makeInput(
                 'form-control storagenodeuser-input',
                 'user',
@@ -997,7 +1007,7 @@ class StorageNodeManagement extends FOGPage
             self::makeLabel(
                 $labelClass,
                 'pass',
-                _('Storage Node FTP Password')
+                _('Node Service Account Password')
             ) => '<div class="input-group">'
             . self::makeInput(
                 'form-control storagenodepass-input',
@@ -1007,6 +1017,14 @@ class StorageNodeManagement extends FOGPage
                 'pass',
                 $pass,
                 true
+            )
+            . '</div>'
+            . '<div class="form-text">'
+            . _(
+                'The account on the node itself that FOG signs in as, over '
+                . 'SSH to check the node is reachable and over FTP to move '
+                . 'images and snapins. Created by the installer, normally '
+                . '"fogproject". This is not a FOG web user.'
             )
             . '</div>',
             // Only needed when the peer is a full FOG server with its own

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5627,6 +5627,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Version"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Version"
 
@@ -7840,16 +7847,8 @@ msgid "Storage Node Enabled"
 msgstr "Speicherknoten hinzugefügt"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Speicherknoten Passwort"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "Speicherknoten-IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Speicherknoten Benutzername"
 
 msgid "Storage Node IP"
 msgstr "Speicherknoten-IP"
@@ -8387,6 +8386,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11226,6 +11228,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Speicherknoten Passwort"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Speicherknoten Benutzername"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5625,6 +5625,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Version"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Version"
 
@@ -7837,16 +7844,8 @@ msgid "Storage Node Enabled"
 msgstr "Storage Node Name"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Storage Node Password"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "Storage Node IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Storage Node Username"
 
 msgid "Storage Node IP"
 msgstr "Storage Node IP"
@@ -8382,6 +8381,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11191,6 +11193,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Created"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Storage Node Password"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Storage Node Username"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5753,6 +5753,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Versión"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Versión"
 
@@ -8009,16 +8016,8 @@ msgid "Storage Node Enabled"
 msgstr "nodo de almacenamiento"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "nodo de almacenamiento"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "nodo de almacenamiento"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Uso del disco nodo de almacenamiento"
 
 #, fuzzy
 msgid "Storage Node IP"
@@ -8567,6 +8566,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11366,6 +11368,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Uso del disco nodo de almacenamiento"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5628,6 +5628,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Version"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Version"
 
@@ -7841,16 +7848,8 @@ msgid "Storage Node Enabled"
 msgstr "Speicherknoten hinzugefügt"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Speicherknoten Passwort"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "Speicherknoten-IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Speicherknoten Benutzername"
 
 msgid "Storage Node IP"
 msgstr "Speicherknoten-IP"
@@ -8388,6 +8387,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11227,6 +11229,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Speicherknoten erstellt"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Speicherknoten Passwort"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Speicherknoten Benutzername"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5627,6 +5627,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Version"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Version"
 
@@ -7839,16 +7846,8 @@ msgid "Storage Node Enabled"
 msgstr "Nom du nœud de stockage"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Nœud de stockage Mot de passe"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "Noeud de stockage IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Nœud de stockage Nom d'utilisateur"
 
 msgid "Storage Node IP"
 msgstr "Noeud de stockage IP"
@@ -8384,6 +8383,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11197,6 +11199,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nœud de stockage Créé"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Nœud de stockage Mot de passe"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Nœud de stockage Nom d'utilisateur"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5442,6 +5442,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Versione"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Versione"
 
@@ -7577,16 +7584,8 @@ msgid "Storage Node Enabled"
 msgstr "Nodo di archiviazione aggiunto!"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Storage Node password"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "Storage Node IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Storage Node Nome utente"
 
 msgid "Storage Node IP"
 msgstr "Storage Node IP"
@@ -8101,6 +8100,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -10832,6 +10834,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Storage Node Creato"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Storage Node password"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Storage Node Nome utente"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5402,6 +5402,13 @@ msgid "Node Offline"
 msgstr "ノードはオフラインです"
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Slack アカウントを追加"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "バージョン"
 
@@ -7523,16 +7530,8 @@ msgid "Storage Node Enabled"
 msgstr "ストレージノードを追加しました！"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "ストレージノードパスワード"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "ストレージノード IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "ストレージノードユーザー名"
 
 msgid "Storage Node IP"
 msgstr "ストレージノード IP"
@@ -8039,6 +8038,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -10341,9 +10343,6 @@ msgstr ""
 #~ msgid "Add Rules"
 #~ msgstr "ルールを追加"
 
-#~ msgid "Add Slack Account"
-#~ msgstr "Slack アカウントを追加"
-
 #~ msgid "Add Snapins"
 #~ msgstr "スナップインを追加"
 
@@ -12002,6 +12001,14 @@ msgstr ""
 
 #~ msgid "Storage Group update failed!"
 #~ msgstr "ストレージグループの更新に失敗しました！"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "ストレージノードパスワード"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "ストレージノードユーザー名"
 
 #~ msgid "Storage Node General"
 #~ msgstr "ストレージノード全般"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4774,6 +4774,12 @@ msgstr ""
 msgid "Node Offline"
 msgstr ""
 
+msgid "Node Service Account"
+msgstr ""
+
+msgid "Node Service Account Password"
+msgstr ""
+
 msgid "Node Version"
 msgstr ""
 
@@ -6654,13 +6660,7 @@ msgstr ""
 msgid "Storage Node Enabled"
 msgstr ""
 
-msgid "Storage Node FTP Password"
-msgstr ""
-
 msgid "Storage Node FTP Path"
-msgstr ""
-
-msgid "Storage Node FTP User"
 msgstr ""
 
 msgid "Storage Node IP"
@@ -7105,6 +7105,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5626,6 +5626,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "Versão"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "Versão"
 
@@ -7838,16 +7845,8 @@ msgid "Storage Node Enabled"
 msgstr "Nome Storage Node"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "Nó de Armazenamento senha"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "IP nó de armazenamento"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "Nó de armazenamento do usuário"
 
 msgid "Storage Node IP"
 msgstr "IP nó de armazenamento"
@@ -8383,6 +8382,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11196,6 +11198,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "Nó de Armazenamento Criado"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "Nó de Armazenamento senha"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "Nó de armazenamento do usuário"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5626,6 +5626,13 @@ msgid "Node Offline"
 msgstr ""
 
 #, fuzzy
+msgid "Node Service Account"
+msgstr "版"
+
+msgid "Node Service Account Password"
+msgstr ""
+
+#, fuzzy
 msgid "Node Version"
 msgstr "版"
 
@@ -7838,16 +7845,8 @@ msgid "Storage Node Enabled"
 msgstr "存储节点名称"
 
 #, fuzzy
-msgid "Storage Node FTP Password"
-msgstr "存储节点密码"
-
-#, fuzzy
 msgid "Storage Node FTP Path"
 msgstr "存储节点的IP"
-
-#, fuzzy
-msgid "Storage Node FTP User"
-msgstr "存储节点的用户名"
 
 msgid "Storage Node IP"
 msgstr "存储节点的IP"
@@ -8383,6 +8382,9 @@ msgid "The ID token was issued to someone else"
 msgstr ""
 
 msgid "The PHP sockets extension is required to ping hosts"
+msgstr ""
+
+msgid "The account on the node itself that FOG signs in as, over SSH to check the node is reachable and over FTP to move images and snapins. Created by the installer, normally \"fogproject\". This is not a FOG web user."
 msgstr ""
 
 msgid "The architecture columns do not exist yet. Run the Database Schema Installer / Updater, then reload this page."
@@ -11196,6 +11198,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node Associated"
 #~ msgstr "存储节点创建"
+
+#, fuzzy
+#~ msgid "Storage Node FTP Password"
+#~ msgstr "存储节点密码"
+
+#, fuzzy
+#~ msgid "Storage Node FTP User"
+#~ msgstr "存储节点的用户名"
 
 #, fuzzy
 #~ msgid "Task run time"


### PR DESCRIPTION
## Problem

`Storage Node FTP User` / `Storage Node FTP Password` named one of the two jobs
those credentials do. The replicators use them for FTP transfers, and the
storage node edit page's own save-time reachability check signs in over **SSH**
with them — which is why a failed SSH login reads as an FTP problem and vice
versa. #1412 fixed the message; this fixes the label it was contradicting.

## Fix

**`Node Service Account`** / **`Node Service Account Password`**, on both the add
and edit forms, plus help text on the edit form:

> The account on the node itself that FOG signs in as, over SSH to check the node
> is reachable and over FTP to move images and snapins. Created by the installer,
> normally "fogproject". This is not a FOG web user.

Field names, ORM keys and columns are untouched — this is labels only.

`Storage Node FTP Path` keeps its name: that one really is the FTP path.

## Why this is a separate PR

It was committed on #1412's branch *after* that PR had already been merged, so it
never reached `working-1.6`. Same commit, rebased onto the current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)