### PR TITLE
Re-adjust table columns when the sidebar changes the content width

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 374);
-        define('FOG_BCACHE_VER', 319);
+        define('FOG_BCACHE_VER', 320);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4189');
+        define('FOG_VERSION', '1.6.0-beta.4195');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4186');
+        define('FOG_VERSION', '1.6.0-beta.4190');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -2508,7 +2508,43 @@ function fogSizeScroller(dt) {
   // until the columns are adjusted once it becomes visible.
   dt.columns.adjust();
 }
-function fogSizeAllScrollers() {
+/**
+ * Re-sync every initialized table to the width (and, for Scroller tables, the
+ * height) it now has.
+ *
+ * A scrolling table is TWO tables: DataTables puts the header in its own
+ * .dt-scroll-head table and pins that table's width in a style attribute, while
+ * the body table is width:100%. Nothing keeps the two in step by itself, so any
+ * change to the container's width leaves the header at its old pixel width and
+ * the body at the new one -- and because makeColumnsResizable() has switched
+ * both to table-layout:fixed over a shared set of colgroup widths, the body's
+ * surplus is shared out across its columns while the header's is not. The
+ * result is a header whose column boundaries no longer line up with the rows
+ * beneath them. columns.adjust() re-measures and rewrites both.
+ */
+/**
+ * Hand a table's columns back to the browser, so the next columns.adjust() is a
+ * real re-measure rather than a re-run of the numbers it already had.
+ *
+ * makeColumnsResizable() writes explicit px widths into every colgroup and puts
+ * table-layout:fixed over the top. Those widths are a floor: a table whose cols
+ * add up to 1796px cannot be measured at 1546px, so adjusting into a NARROWER
+ * container leaves the table its old width and it simply overflows. (Widening
+ * appears to work only because the body table is width:100% and grows anyway --
+ * which is the very mismatch this whole path exists to fix.)
+ *
+ * Nothing is lost by clearing them. The hand-set layout is remembered as
+ * per-column SHARES, and the column-sizing event that columns.adjust() fires
+ * runs makeColumnsResizable() again, which re-seeds against the new width and
+ * re-applies those shares -- so a dragged column keeps its proportion of the
+ * table across the resize.
+ */
+function fogReleaseColWidths(node) {
+  fogTableParts(node).tables
+    .removeClass('fog-table-fixed')
+    .find('colgroup > col').css('width', '');
+}
+function fogAdjustAllTables() {
   if (!$.fn.dataTable || !$.fn.dataTable.isDataTable) {
     return;
   }
@@ -2517,28 +2553,67 @@ function fogSizeAllScrollers() {
   // bundled 2.x/3.x build ("tables(...).every is not a function") and silently
   // aborted the entire post-show resize path on every shown.bs.tab.
   $('table.dataTable').each(function() {
-    if ($.fn.dataTable.isDataTable(this)) {
-      fogSizeScroller($(this).DataTable());
+    if (!$.fn.dataTable.isDataTable(this)) {
+      return;
     }
+    var dt = $(this).DataTable(),
+      init = (dt && typeof dt.init === 'function') ? dt.init() : null;
+    // Null init: a node the table.dataTable selector matches but that isn't a
+    // table of its own (the scrollY cloned header). Nothing to size.
+    if (!init) {
+      return;
+    }
+    if (init.scroller) {
+      // Height as well as width, and it does its own visibility check -- so
+      // only release the widths once we know it will act on them.
+      if ($(this).is(':visible')) {
+        fogReleaseColWidths(this);
+      }
+      fogSizeScroller(dt);
+      return;
+    }
+    // A paged table has no scroll body to measure, but it still needs its
+    // columns re-adjusted -- and one sitting in a hidden tab measures zero, so
+    // adjusting it there would write the zero widths in as fact.
+    if (!$(this).is(':visible')) {
+      return;
+    }
+    fogReleaseColWidths(this);
+    dt.columns.adjust();
   });
 }
-function fogBindScrollerAutosize() {
+function fogBindTableAutosize() {
   if ($.fn.dataTable.__fogScrollerBound) {
-    return; // window/tab handlers only need binding once per page
+    return; // window/tab/observer handlers only need binding once per page
   }
   $.fn.dataTable.__fogScrollerBound = true;
   var debounce;
-  $(window).on('resize.fogScroller', function() {
+  function adjustSoon() {
     clearTimeout(debounce);
-    debounce = setTimeout(fogSizeAllScrollers, 150);
-  });
+    debounce = setTimeout(fogAdjustAllTables, 150);
+  }
+  $(window).on('resize.fogScroller', adjustSoon);
+  // The sidebar is the other thing that changes a table's width, and it does it
+  // without a window resize: AdminLTE's push-menu toggle only adds/removes
+  // body.sidebar-collapse, and the content area follows via a CSS transition.
+  // So watch the content box itself rather than the window -- that covers the
+  // toggle, AL4's own responsive collapse at the sidebar breakpoint, and any
+  // other layout change that moves the edge, without this code having to know
+  // about any of them. Observing the container (whose width comes from the
+  // layout, not from what we write inside it) plus the debounce above means an
+  // adjust cannot feed itself: the transition's intermediate widths coalesce
+  // into one pass at the settled width.
+  var main = document.querySelector('.app-main');
+  if (main && typeof ResizeObserver === 'function') {
+    new ResizeObserver(adjustSoon).observe(main);
+  }
   // In-tab tables (edit pages) measure as zero-height while hidden; size them
   // once their tab is shown. Defer a tick: inside shown.bs.tab the revealed
   // tab's layout isn't final, so a synchronous columns.adjust() sizes against
   // a stale (~zero) width and leaves the header/body split misaligned until
   // the next redraw. One macrotask later the layout is settled.
   $(document).on('shown.bs.tab.fogScroller', function () {
-    setTimeout(fogSizeAllScrollers, 0);
+    setTimeout(fogAdjustAllTables, 0);
   });
 }
 // DataTables' default errMode alerts "DataTables warning: table id=X - Ajax
@@ -2604,7 +2679,7 @@ $.fn.registerTable = function(onSelect, opts) {
   // init, where Scroller's scrollY measures a display:none table as zero width
   // and the split header/body columns start misaligned. They still use infinite
   // scroll for UI consistency with the top-level lists: the shown.bs.tab handler
-  // in fogBindScrollerAutosize() re-measures (scroller.measure) and re-syncs the
+  // in fogBindTableAutosize() re-measures (scroller.measure) and re-syncs the
   // columns (columns.adjust) once the tab is visible, which is the first moment
   // the real widths exist. Selection/association is unaffected by deferRender —
   // checkbox toggles POST per-row immediately ($.checkItemUpdate) and bulk
@@ -2719,10 +2794,15 @@ $.fn.registerTable = function(onSelect, opts) {
     }, 0);
   }
 
+  // Keep every table sized to its container on resize, sidebar toggle and tab
+  // show. Bound for paged tables too, not just Scroller ones: the header/body
+  // split that goes out of alignment is created by scrollX/scrollY, but a paged
+  // table still carries the fixed colgroup widths makeColumnsResizable() wrote
+  // at the old container width and needs the same re-adjust.
+  fogBindTableAutosize();
   if (infiniteScroll) {
-    // Size the scroll body to fill the available height now (deferred so the
-    // table is laid out in the DOM first) and keep it sized on resize/tab show.
-    fogBindScrollerAutosize();
+    // Size the scroll body to fill the available height now, deferred so the
+    // table is laid out in the DOM first.
     setTimeout(function() { fogSizeScroller(table); }, 0);
   }
 

--- a/packages/web/management/js/fog/user/fog.user.edit.js
+++ b/packages/web/management/js/fog/user/fog.user.edit.js
@@ -137,7 +137,7 @@
             ]
         });
 
-        // No shown.bs.tab handler of its own: fogBindScrollerAutosize() in
+        // No shown.bs.tab handler of its own: fogBindTableAutosize() in
         // fog.common.js already re-measures every Scroller table one macrotask
         // after a tab is shown, which is what every other in-tab grid here
         // relies on. This card originally passed scroller:false and adjusted

--- a/tests/apitoken-grid-and-scope.test.php
+++ b/tests/apitoken-grid-and-scope.test.php
@@ -452,16 +452,19 @@ foreach ([
 }
 // It inits inside a hidden tab, where DataTables measures zero column widths,
 // so something has to re-measure once the tab is shown. That something is
-// fogBindScrollerAutosize() in fog.common.js, which every other in-tab grid
-// relies on -- and it only handles SCROLLER tables: fogSizeScroller() returns
-// early on !init.scroller. So opting out of Scroller here silently opts out
-// of the resize path too, and the header renders sized against a zero-width
-// table (one column squeezed to a single character, its title stacked
-// vertically). A hand-rolled shown.bs.tab handler is not the fix either: run
-// synchronously it measures before the revealed tab's layout is final, which
-// is exactly why the shared one defers a macrotask.
+// fogBindTableAutosize() in fog.common.js, which every other in-tab grid relies
+// on. It once covered SCROLLER tables only -- fogSizeScroller() returns early
+// on !init.scroller -- so opting out of Scroller here silently opted out of the
+// resize path too, and the header rendered sized against a zero-width table
+// (one column squeezed to a single character, its title stacked vertically).
+// fogAdjustAllTables() now handles the paged case as well, so that particular
+// trap is closed; the assertion below stays because this grid should still look
+// like every other one, not because breaking it would be silent again. A
+// hand-rolled shown.bs.tab handler is still not the fix: run synchronously it
+// measures before the revealed tab's layout is final, which is exactly why the
+// shared one defers a macrotask.
 $t->check(
-    'the tab grid stays a Scroller table, so the shared resize path covers it',
+    'the tab grid stays a Scroller table, like every other grid here',
     false === strpos($usrJsStripped, 'scroller: false')
 );
 $t->check(
@@ -474,7 +477,7 @@ $t->check(
 $t->check(
     'the shared handler it depends on is still there and still deferred',
     (bool)preg_match(
-        "/shown\.bs\.tab\.fogScroller[^}]*setTimeout\(fogSizeAllScrollers, 0\)/s",
+        "/shown\.bs\.tab\.fogScroller[^}]*setTimeout\(fogAdjustAllTables, 0\)/s",
         $common
     )
 );


### PR DESCRIPTION
## Problem

Collapsing the sidebar leaves every list's header out of alignment with its rows. The headers shift; the row columns don't follow.

A scrolling table is **two** tables: DataTables puts the header in its own `.dt-scroll-head` table and pins that table's width in a `style` attribute, while the body table is `width:100%`. Nothing keeps the two in step by itself. AdminLTE 4's push-menu toggle only adds `body.sidebar-collapse` and lets a CSS transition move the content edge — **no window resize fires**, so neither DataTables nor FOG's own `fogSizeAllScrollers` resize path ever heard about it.

Measured on the storage group list (1870px viewport, `working-1.6` as it stands):

| | header table | body table | header cells | row cells |
|---|---|---|---|---|
| sidebar open | 1546px | 1546px | 951 / 595 | 951 / 595 |
| sidebar collapsed | **1546px** | **1796px** | **951 / 595** | **1105 / 691** |

The body's surplus is shared out across its columns (both tables are `table-layout:fixed` over a shared colgroup, courtesy of `makeColumnsResizable()`); the header's is not. That is the misalignment.

## Fix

Watch the content box with a `ResizeObserver` rather than the sidebar, so the toggle, AL4's own responsive collapse at the sidebar breakpoint, and any other layout change that moves the edge are all covered without this code having to know about any of them. The observed element's width comes from the layout rather than from anything we write inside it, and the existing 150ms debounce coalesces the transition's intermediate widths into one pass at the settled width — so an adjust cannot feed itself.

Two things came with it:

- **The hand-set column widths have to be released before re-adjusting.** `makeColumnsResizable()` writes explicit px widths plus `table-layout:fixed`, and those widths are a *floor*: a table whose cols total 1796px cannot be measured at 1546px, so adjusting into a **narrower** container did nothing and the table simply overflowed. Widening only appeared to work because the body table is `width:100%` and grows regardless — which is the very mismatch above. Clearing them costs nothing: the hand-set layout is remembered as per-column *shares*, and the `column-sizing` event `columns.adjust()` fires re-runs `makeColumnsResizable()`, which re-seeds against the new width and re-applies those shares.
- **Paged tables get the handlers too.** `fogBindScrollerAutosize()` was only called for Scroller tables, so a paged table never re-adjusted on a plain window resize either. Renamed to `fogBindTableAutosize()` / `fogAdjustAllTables()` to match what it now covers.

## Verification

A harness page carrying the real AL4 layout markup and the real `fog.common.js`, driven through Playwright at 1870x560:

| | header table | body table | header cells | row cells |
|---|---|---|---|---|
| open | 1546 | 1546 | 951 / 595 | 951 / 595 |
| collapsed | 1796 | 1796 | 1105 / 691 | 1105 / 691 |
| expanded again | 1546 | 1546 | 951 / 595 | 951 / 595 |

- Same three states pass in **paged** mode (`scroller:false`): 751/795 → 873/923 → 751/795.
- **A dragged column keeps its proportion**: dragging the split to 751/795 (0.486/0.514) and collapsing gives 873/923 at 1796px — the same 0.486/0.514.
- **No feedback loop**: one toggle costs exactly **1** `fogAdjustAllTables()` call, and **0** while idle over 3s.

The failing numbers in the first table were measured on the unmodified file in the same harness before the change, so this is the same probe going from red to green.

`FOG_BCACHE_VER` bumped 319 → 320 for the JS change.