### PR TITLE
Stream FOGSSH::put() instead of reading the whole file into memory

### DIFF
--- a/packages/web/lib/fog/fogssh.class.php
+++ b/packages/web/lib/fog/fogssh.class.php
@@ -25,6 +25,18 @@ namespace FOG;
 class FOGSSH
 {
     /**
+     * How much of a file put() holds in memory at once.
+     *
+     * 256KB is a compromise, not a magic number: the ssh2 layer wraps each
+     * write in its own packet, so a tiny chunk turns a large upload into a very
+     * large number of round trips, while a huge one gives back the memory
+     * ceiling this exists to stay under. Whatever is chosen here, the memory
+     * cost of an upload stops depending on the size of the file.
+     *
+     * @var int
+     */
+    const CHUNK_SIZE = 262144;
+    /**
      * The default data layout
      *
      * @var array
@@ -326,6 +338,23 @@ class FOGSSH
     /**
      * Puts the files from one place to another remotely/Uploads the file
      *
+     * Copied in fixed-size chunks rather than read whole. This used to be a
+     * file_get_contents() of the local file followed by one fwrite(), which
+     * charges the entire file to PHP's memory_limit -- so uploading a snapin
+     * larger than that limit was a fatal error rather than a slow upload, and
+     * the only thing the admin saw was "Allowed memory size of 268435456 bytes
+     * exhausted (tried to allocate 623026208 bytes)" in the web server log. The
+     * file size that breaks it is whatever memory_limit happens to be, which is
+     * why this reads as a distro-specific fault and is not one.
+     *
+     * The loop is written out rather than handed to stream_copy_to_stream()
+     * because a write to an ssh2.sftp:// stream is not guaranteed to consume
+     * everything offered: a short write has to be resumed at the right offset,
+     * and a silently truncated upload is worse than a failed one -- the snapin
+     * would be stored with the hash and size of the file that was MEANT to
+     * arrive, so the client would fetch it, fail its checksum, and never say
+     * why.
+     *
      * @param string $localfile  The local file to put on the remote
      * @param string $remotefile The place/name the file is being placed.
      *
@@ -335,19 +364,49 @@ class FOGSSH
     public function put($localfile, $remotefile)
     {
         $sftp = $this->_sftp;
-        $stream = @fopen("ssh2.sftp://$sftp$remotefile", 'w');
-        if (!$stream) {
-            throw new \Exception(_("Could not open file"). ": $remotefile");
-        }
-        $data_to_send = @file_get_contents($localfile);
-        if (false === $data_to_send) {
+        $in = @fopen($localfile, 'rb');
+        if (!$in) {
             throw new \Exception(_("Could not open local file"). ": $localfile");
         }
-        if (false === @fwrite($stream, $data_to_send)) {
-            throw new \Exception(_("Could not send data from file"). ": $localfile");
+        $stream = @fopen("ssh2.sftp://$sftp$remotefile", 'w');
+        if (!$stream) {
+            @fclose($in);
+            throw new \Exception(_("Could not open file"). ": $remotefile");
         }
-
-        @fclose($stream);
+        try {
+            while (!feof($in)) {
+                $chunk = @fread($in, self::CHUNK_SIZE);
+                if (false === $chunk) {
+                    throw new \Exception(
+                        _("Could not read local file"). ": $localfile"
+                    );
+                }
+                // A zero-length read at a point feof() has not yet flagged is
+                // the end of the file for every stream this is used with; only
+                // treat it as one when feof() agrees, so a genuine read error
+                // reported as '' cannot masquerade as a complete upload.
+                if ('' === $chunk) {
+                    if (feof($in)) {
+                        break;
+                    }
+                    throw new \Exception(
+                        _("Could not read local file"). ": $localfile"
+                    );
+                }
+                for ($sent = 0, $len = strlen($chunk); $sent < $len;) {
+                    $wrote = @fwrite($stream, substr($chunk, $sent));
+                    if (false === $wrote || $wrote === 0) {
+                        throw new \Exception(
+                            _("Could not send data from file"). ": $localfile"
+                        );
+                    }
+                    $sent += $wrote;
+                }
+            }
+        } finally {
+            @fclose($in);
+            @fclose($stream);
+        }
     }
     /**
      * Scan all files as it's likely a directory.

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4186');
+        define('FOG_VERSION', '1.6.0-beta.4189');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1735,6 +1735,10 @@ msgid "Could not read file from tmp folder."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1737,6 +1737,10 @@ msgid "Could not read file from tmp folder."
 msgstr "Could not read tmp file."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "Could not read temp file"
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "Could not read tmp file."
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1757,6 +1757,10 @@ msgid "Could not read file from tmp folder."
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "No se pudo leer el archivo temporal"
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "No se pudo leer el archivo tmp."
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1735,6 +1735,10 @@ msgid "Could not read file from tmp folder."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "Snapin-Datei konnte nicht gelesen werden."
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1739,6 +1739,10 @@ msgid "Could not read file from tmp folder."
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "Impossible de lire le fichier temporaire"
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "Impossible de lire le fichier tmp."
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1680,6 +1680,10 @@ msgstr "Impossibile leggere il file temporaneo"
 msgid "Could not read file from tmp folder."
 msgstr "Impossibile leggere il file tmp."
 
+#, fuzzy
+msgid "Could not read local file"
+msgstr "Impossibile leggere il file temporaneo"
+
 msgid "Could not read snapin file"
 msgstr "Impossibile leggere il file snapin"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1664,6 +1664,10 @@ msgstr "スナップインファイルを読み取れませんでした"
 msgid "Could not read file from tmp folder."
 msgstr "一時ファイルを読み取れませんでした。"
 
+#, fuzzy
+msgid "Could not read local file"
+msgstr "スナップインファイルを読み取れませんでした"
+
 msgid "Could not read snapin file"
 msgstr "スナップインファイルを読み取れませんでした"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1485,6 +1485,9 @@ msgstr ""
 msgid "Could not read file from tmp folder."
 msgstr ""
 
+msgid "Could not read local file"
+msgstr ""
+
 msgid "Could not read snapin file"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1738,6 +1738,10 @@ msgid "Could not read file from tmp folder."
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "Não foi possível ler arquivo temporário"
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "Não foi possível ler o arquivo tmp."
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1738,6 +1738,10 @@ msgid "Could not read file from tmp folder."
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
+msgid "Could not read local file"
+msgstr "无法读取临时文件"
+
+#, fuzzy
 msgid "Could not read snapin file"
 msgstr "无法读取tmp文件。"
 


### PR DESCRIPTION
## Problem

Uploading a snapin larger than `memory_limit` is a **fatal error**, not a slow upload. Reported from the field on Debian 13:

```
PHP Fatal error: Allowed memory size of 268435456 bytes exhausted
(tried to allocate 623026208 bytes) in .../lib/fog/fogssh.class.php on line 342
referer: .../index.php?node=snapin&sub=edit&id=1
```

Line 342 was `$data_to_send = @file_get_contents($localfile);` inside `FOGSSH::put()` — the whole file read into a PHP string before a single byte is written to the sftp stream. `Snapin::addSnapin()` (`snapin.class.php:529`) ships the uploaded file to the master storage node through that method, so **the size at which snapin upload stops working is whatever `memory_limit` happens to be**: 256M here, against a ~594MB snapin.

It is not Debian-specific and it has nothing to do with the `fogproject:www-data` ownership the reporter mentioned — those are just what that install happened to have. Any distro at any limit breaks at its own file size.

## Fix

Copy in fixed-size chunks (256KB). The loop is written out rather than handed to `stream_copy_to_stream()` because a write to an `ssh2.sftp://` stream is not guaranteed to consume everything offered, and a short write has to be resumed at the right offset. A silently truncated upload would be *worse* than a failed one: the snapin row is saved with the hash and size of the file that was meant to arrive, so the client would fetch it, fail its checksum, and never say why. For the same reason the proof below asserts the far-side size rather than just "no exception".

## Verification

The real path — `FOGSSH::put()` over sftp to storage node 1 on the 1.6 lab server, using the node's own decrypted credentials, with a 400MB payload. `stock` boots the deployed tree at `/var/www/html/fog-1.6`; `patched` is the identical boot with this one class required first, so the autoloader is never asked for the deployed copy.

| run | memory_limit | result |
|---|---|---|
| stock | 256M | `PHP Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 419438624 bytes) ... on line 342` |
| patched | 256M | `OK peak_memory=4.0MB (4.0MB before put) elapsed=1.9s remote_size=419430400 expected=419430400 SIZES MATCH` |
| patched | 128M | `OK peak_memory=4.0MB ... SIZES MATCH` |

The same 400MB payload uploads with 4.0MB peak at a 128M limit, so the memory cost no longer depends on the size of the file at all.

Harness: `scripts/background_scripts/prove_fogssh_put_memory.php` (not in this repo).

## Workaround for anyone hitting this before the fix ships

Raise **FOG Configuration → FOG Settings → `FOG_MEMORY_LIMIT`** above the snapin's size. `FOGCore` (`fogcore.class.php:228`) raises PHP's limit to that value when it is higher, which is why the reporter's limit read 256M rather than the distro default.

## Scope

1.6 only. 1.5 has no `fogssh.class.php` and sends snapins with `FOGFTP::put()`, which streams from a file handle already.
