### PR TITLE
Defer the post-data column re-adjust so the header drops its scrollbar padding

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 374);
-        define('FOG_BCACHE_VER', 320);
+        define('FOG_BCACHE_VER', 321);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4195');
+        define('FOG_VERSION', '1.6.0-beta.4198');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -2490,11 +2490,33 @@ function fogSizeScroller(dt) {
   // becomes visible, when the real row widths exist. One-shot per table (flagged
   // on the settings object); the resize path runs on already-aligned rows so it
   // never needs this. Bound before measure() so it catches measure()'s redraw.
+  //
+  // Deferred a macrotask rather than run inside the draw, for the same reason
+  // the shown.bs.tab handler is: during the draw the layout is not final yet.
+  // Scroller sizes its viewport for a whole page of rows before the ajax has
+  // said how many there really are, so the scroll body is still overflowing at
+  // that moment. DataTables reserves the scrollbar's width on the header when it
+  // sees that -- a padding-right on .dt-scroll-headInner -- and it never takes
+  // the reservation back on its own. One tick later the row count is settled,
+  // the body no longer overflows, and the same call computes a padding of zero.
+  //
+  // Measured on a one-row snapin list: padding-right stuck at 15px with the body
+  // not overflowing, leaving the header 15px narrower than its rows (1540 against
+  // 1555) and the column boundaries walking out -5, -8, -12, -15 across four
+  // columns. Invisible wherever scrollbars are the overlay kind that occupy no
+  // width, which is why it shows on a desktop browser and not in headless.
   var settings = dt.settings()[0];
   if (settings && !settings._fogPostShowAdjusted) {
     settings._fogPostShowAdjusted = true;
     dt.one('draw.dt.fogScroller', function() {
-      dt.columns.adjust();
+      setTimeout(function() {
+        // The whole sizing pass, not just columns.adjust(): the height this
+        // function sets is itself an input to whether the body overflows, so
+        // re-deciding the height and the columns together is what makes the
+        // reservation and the actual scrollbar agree. Re-entry is safe --
+        // _fogPostShowAdjusted is already set, so this does not rebind.
+        fogSizeScroller(dt);
+      }, 0);
     });
   }
   // Recompute Scroller's virtual viewport for the new height (measure() also


### PR DESCRIPTION
Follow-up to #1416, which fixed the sidebar-collapse misalignment. This is the *other* symptom seen alongside it: on first load a list's header sits a few pixels narrower than its rows, and clicking **Refresh** — or collapsing the sidebar — puts it right.

## Cause

DataTables reserves the scrollbar's width on the header whenever it sees the scroll body overflowing: a `padding-right` on `.dt-scroll-headInner`. **It never takes that reservation back on its own.**

`fogSizeScroller()`'s one-shot post-draw `columns.adjust()` ran *synchronously inside the draw*. At that instant Scroller has sized its viewport for a whole page of rows, because the AJAX has not yet said there is only one — so the body **is** overflowing, 15px gets reserved, the row count then settles, the overflow goes away, and the reservation stays behind.

Measured on a one-row snapin list:

| | |
|---|---|
| `paddingRight` | **15** |
| `shouldBe` | 0 |
| `bodyOverflows` | false |
| header table width | 1540 |
| body table width | 1555 |
| per-column drift | `-5, -8, -12, -15` |

Everything that cures it is simply a later re-adjust.

## Fix

Defer that one-shot by a macrotask — the same deferral the `shown.bs.tab` handler already uses, for the same "the layout is not final yet" reason — and run the whole sizing pass rather than `columns.adjust()` alone. The height `fogSizeScroller()` sets is itself an input to whether the body overflows, so re-deciding the height and the columns *together* is what makes the reservation and the actual scrollbar agree. Re-entry is safe: `_fogPostShowAdjusted` is already set, so the deferred call does not rebind.

## Why the verification is split in two

This is only visible where scrollbars occupy layout width. Headless Chromium uses 0px overlay scrollbars, so the body never overflows during load there and the padding is never earned — the bug cannot be triggered in an automated browser at all. Seven list pages were checked at the reporting viewport, with DataTables' cached bar width forced to 15, and none went stale.

So each half was verified where it can be:

**The repair** — headless, against the live 1.6 lab box, with this file served in place of the deployed one:

- the stale state manufactured by hand (`padding-right: 15px`, body not overflowing) is cleared to `0px` by the deferred sizing pass;
- load / collapse / expand all hold head and body at identical widths with zero drift:

| | header | body | drift |
|---|---|---|---|
| load | 1546 | 1546 | `0,0,0,0` |
| collapsed | 1796 | 1796 | `0,0,0,0` |
| expanded | 1546 | 1546 | `0,0,0,0` |

- 3 sizing passes during load, 0 more over the following 3s — the re-entry does not loop.

**The trigger** — on a desktop browser where the reservation is real: the affected page read `stale: true` with `paddingRight 15` against a body that was not overflowing, and the same deferred pass cleared it to `stale: false` with drift all zeros.

## Also considered

Rendering the table empty and then forcing a data refresh would work — that is exactly why the Refresh button cures it — but it buys the fix with a second HTTP round trip on every list view and a visible empty-then-populate flash, and it leaves the underlying "sized before the layout settled" ordering in place for every other path (tab-show grids, plugin-injected tabs, column-visibility toggles). The deferral costs nothing and covers all of them.

`FOG_BCACHE_VER` 320 → 321.
