### PR TITLE
Import the flat lib/ classes that src/ references unqualified

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -20,6 +20,7 @@ use FOG\Items\Host;
 use FOG\Items\Image;
 use FOG\Items\Site;
 use FOG\Items\Snapin;
+use FOG\ReportManagement;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 

--- a/packages/web/src/Base/LoadGlobals.php
+++ b/packages/web/src/Base/LoadGlobals.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Base;
 
+use FOG\DashboardPage;
 use FOG\Db\DatabaseManager;
 use FOG\Items\User;
 use FOG\Net\FOGFTP;

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4229');
+        define('FOG_VERSION', '1.6.0-beta.4233');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/namespaced-class-refs-resolve.test.php
+++ b/tests/namespaced-class-refs-resolve.test.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Every unqualified class reference inside packages/web/src/ must resolve.
+ *
+ * PSR-4 moved ~202 classes under `packages/web/src/<Bucket>/` with a
+ * `namespace FOG\<Bucket>;`. The 46 discovery-named files -- the `.page.php`,
+ * `.hook.php`, `.report.php` and `.event.php` classes whose FILENAME is a
+ * contract with FOGPageManager::loadPageClasses() and EventManager::load() --
+ * stayed in `packages/web/lib/` under the flat `namespace FOG;`.
+ *
+ * That split is fine in one direction and a landmine in the other. PHP falls
+ * back to the global namespace for FUNCTIONS and CONSTANTS, but NEVER for
+ * class names. So an unqualified `new DashboardPage()` sitting in a file that
+ * declares `namespace FOG\Base;` resolves to `FOG\Base\DashboardPage`, which
+ * does not exist, and the request dies with a fatal -- a white screen.
+ *
+ * all-classes-load.test.php does not cover this: it proves every class
+ * DECLARES, and a bad reference inside a method body declares perfectly well
+ * and only explodes when that line runs. This shipped exactly that way and
+ * white-screened the UI on the report menu.
+ *
+ * The fix is always a `use FOG\<Name>;` import, never a rename -- the two
+ * HARD constraints stand: discovery-named files keep their names, and the
+ * reverse class_alias ABI stays.
+ *
+ * Usage: php tests/namespaced-class-refs-resolve.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+
+/**
+ * Short names declared under lib/ in the flat FOG namespace. Plugins are
+ * excluded: they carry their own runtime loader (ADR 0009) and are not part
+ * of the PSR-4 tree.
+ */
+$flat = [];
+$walk = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($web . '/lib'));
+foreach ($walk as $file) {
+    if (!$file->isFile()
+        || !preg_match('/\.(class|page|hook|report|event)\.php$/', $file->getFilename())
+        || false !== strpos($file->getPathname(), '/lib/plugins/')
+    ) {
+        continue;
+    }
+    $src = file_get_contents($file->getPathname());
+    if (preg_match_all('/^\s*(?:final\s+|abstract\s+)*(?:class|interface|trait)\s+(\w+)/mi', $src, $m)) {
+        foreach ($m[1] as $name) {
+            $flat[$name] = str_replace($web . '/', '', $file->getPathname());
+        }
+    }
+}
+
+/** Short names declared under src/, i.e. resolvable from a sibling bucket. */
+$bucketed = [];
+$walk = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($web . '/src'));
+foreach ($walk as $file) {
+    if ($file->isFile() && 'php' === $file->getExtension()) {
+        $bucketed[$file->getBasename('.php')] = $file->getPathname();
+    }
+}
+
+$fails = [];
+foreach ($bucketed as $path) {
+    $src = file_get_contents($path);
+    $rel = str_replace($web . '/', '', $path);
+
+    // Imports, by the short name they bind. `use A\B as C` binds C.
+    $imports = [];
+    if (preg_match_all('/^use\s+([^;]+);$/m', $src, $m)) {
+        foreach ($m[1] as $use) {
+            $use = trim($use);
+            if (false !== stripos($use, ' as ')) {
+                $parts = preg_split('/\s+as\s+/i', $use);
+                $imports[trim($parts[1])] = true;
+            } else {
+                $imports[substr(strrchr('\\' . $use, '\\'), 1)] = true;
+            }
+        }
+    }
+
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+    $skip = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
+    for ($i = 0; $i < $count; $i++) {
+        $token = $tokens[$i];
+        if (!is_array($token) || T_STRING !== $token[0]) {
+            continue;
+        }
+        $name = $token[1];
+        if (!isset($flat[$name]) || isset($imports[$name]) || isset($bucketed[$name])) {
+            continue;
+        }
+        // Neighbours with whitespace and comments skipped -- `new Foo` has a
+        // T_WHITESPACE between the two, so a naive $tokens[$i - 1] never sees
+        // the T_NEW and the reference reads as harmless.
+        $prev = null;
+        for ($j = $i - 1; $j >= 0; $j--) {
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $skip, true)) {
+                continue;
+            }
+            $prev = $tokens[$j];
+            break;
+        }
+        $next = null;
+        for ($j = $i + 1; $j < $count; $j++) {
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], $skip, true)) {
+                continue;
+            }
+            $next = $tokens[$j];
+            break;
+        }
+        // Already qualified, or a method/property/function/const name rather
+        // than a class reference.
+        if (is_array($prev)
+            && in_array($prev[0], [T_NS_SEPARATOR, T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_CONST], true)
+        ) {
+            continue;
+        }
+        if (is_array($next) && T_NS_SEPARATOR === $next[0]) {
+            continue;
+        }
+        $fails[] = sprintf(
+            '%s:%d references %s unqualified, which resolves inside this '
+            . "file's own namespace and does not exist. %s declares it in the "
+            . 'flat FOG namespace -- add "use FOG\%s;"',
+            $rel,
+            $token[2],
+            $name,
+            $flat[$name],
+            $name
+        );
+    }
+}
+
+$fails = array_values(array_unique($fails));
+if (count($fails)) {
+    fwrite(STDERR, 'FAIL:' . PHP_EOL);
+    foreach ($fails as $fail) {
+        fwrite(STDERR, "  - $fail\n");
+    }
+    exit(1);
+}
+
+printf(
+    "ok: every reference from src/ (%d classes) to the %d flat lib/ classes is imported\n",
+    count($bucketed),
+    count($flat)
+);
+exit(0);

--- a/tests/namespaced-class-refs-resolve.test.php
+++ b/tests/namespaced-class-refs-resolve.test.php
@@ -35,7 +35,7 @@ $web = dirname(__DIR__) . '/packages/web';
  * of the PSR-4 tree.
  */
 $flat = [];
-$walk = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($web . '/lib'));
+$walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/lib'));
 foreach ($walk as $file) {
     if (!$file->isFile()
         || !preg_match('/\.(class|page|hook|report|event)\.php$/', $file->getFilename())
@@ -53,7 +53,7 @@ foreach ($walk as $file) {
 
 /** Short names declared under src/, i.e. resolvable from a sibling bucket. */
 $bucketed = [];
-$walk = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($web . '/src'));
+$walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/src'));
 foreach ($walk as $file) {
     if ($file->isFile() && 'php' === $file->getExtension()) {
         $bucketed[$file->getBasename('.php')] = $file->getPathname();


### PR DESCRIPTION
## Problem

The UI white-screens on `working-1.6` at `1.6.0-beta.4229`. From `/var/log/php-fpm/www-error.log`:

```
PHP Fatal error:  Uncaught Error: Class "FOG\Base\ReportManagement" not found
  in /var/www/html/fog-1.6/src/Base/FOGPage.php:972
#0 FOG\Base\FOGPage::_buildSubMenuItems()
#1 FOG\Base\FOGPage::_renderMenuNode()
#2 FOG\Base\FOGPage::_buildMenuStructure()
#3 FOG\Base\Page->render()
```

The report node is built into the main menu, so this is every page, not just the report page.

## Cause

The PSR-4 move (#1421) left the 46 discovery-named classes in `packages/web/lib/` under the flat `namespace FOG;` — their filenames are a contract with `FOGPageManager::loadPageClasses()` and `EventManager::load()`, and PSR-4 does not do discovery. Everything else moved to `packages/web/src/<Bucket>/` under `namespace FOG\<Bucket>;`.

PHP falls back to the global namespace for **functions and constants** but **never for class names**. So an unqualified reference to one of those 46 from a bucketed file resolves into the referencing file's own bucket, and does not exist.

The `use`-computation in the move only scanned `src/`, so references pointing back into `lib/` were never given an import.

## Fix

Two sites, both an import — renaming the discovery-named files is not an option and the reverse `class_alias` ABI is untouched:

| Site | Import |
|---|---|
| `src/Base/FOGPage.php:972` — `ReportManagement::loadCustomReports()` | `use FOG\ReportManagement;` |
| `src/Base/LoadGlobals.php:73` — `new DashboardPage()` | `use FOG\DashboardPage;` |

## Why nothing caught it

`all-classes-load.test.php` proves every class **declares**. A bad reference inside a method body declares perfectly well and only explodes when that line runs.

`tests/namespaced-class-refs-resolve.test.php` closes that. It tokenises every file under `src/` and fails on any unqualified reference to a name declared flat under `lib/` that the file has not imported — skipping whitespace and comments when reading neighbouring tokens, which is what a first cut got wrong (`new Foo` has a `T_WHITESPACE` between the two, so a naive `$tokens[$i-1]` never sees the `T_NEW` and the `DashboardPage` site read as harmless).

## Verification

- **Live-database shadow tree**, driving the exact failing frame `FOGPage::_buildSubMenuItems('report')` by reflection: fatal with the identical message without the `use` line, clean with it.
- **All 46 discovery classes resolve** — the reverse direction (`lib/` → `src/`, handled by `Initiator::_bridgeNamespaced()`) is unaffected: 46 resolved, 0 failed.
- **The new test was mutation-tested**: removing either `use` line turns it red naming that exact file and line; restoring both turns it green.
- Whole-tree scan with the positional filter removed finds no further `src/` → `lib/` breaks.

## Not the cause

`lib/fog/config.class.php` was suspected. It is fine and the installer needs no change: the generated file declares `class Config` in the global namespace, `commons/init.php` has no `namespace` line so `new Config()` resolves globally, and `Initiator::_scanRoots()` still walks all of `BASEPATH` so the file is still found.