### PR TITLE
Resolve bare core class names through a src/ FQCN map

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -390,6 +390,16 @@ class Initiator
     private static ?array $srcMap = null;
 
     /**
+     * In-process map of lowercased class name => fully qualified name.
+     *
+     * Derived from $srcMap's paths rather than scanned separately: under
+     * PSR-4 the FQCN IS the path, so src/Items/Host.php is FOG\Items\Host
+     * and nothing else. Deriving it means one walk, one cache and one
+     * collision rule serving both maps.
+     */
+    private static ?array $srcClassMap = null;
+
+    /**
      * Every autoloadable source file under BASEPATH (*.class.php, *.page.php,
      * *.event.php, *.hook.php, *.report.php, *.task.php).
      *
@@ -445,6 +455,7 @@ class Initiator
         self::$fileList = null;
         self::$classMap = null;
         self::$srcMap = null;
+        self::$srcClassMap = null;
         @unlink(
             FOG_CACHE_DIR . DS . 'filelist.'
             . md5(implode('|', self::_scanRoots())) . '.json'
@@ -534,6 +545,49 @@ class Initiator
         $map = array_filter($map);
         self::_writeFileListCache($cacheFile, $map);
         return self::$srcMap = $map;
+    }
+
+    /**
+     * Every class under src/, by lowercased short name => fully qualified name.
+     *
+     * The bare name is what the tree actually says. 520 `getClass('X')`
+     * literals, `FOGController::getManager()`'s `new $short.'Manager'` and
+     * all 52 lowercase entries in Route::$validClasses name a class without
+     * a namespace, and every one of them resolves today only because each
+     * file under src/ ends in a class_alias() re-exporting itself globally
+     * (ADR 0013 §2). Retiring those aliases means the bare name has to
+     * become a qualified one somewhere, and this map is that somewhere --
+     * one lookup, rather than editing 520 call sites.
+     *
+     * Derived from srcFileList(), so it inherits that scan, its cache, its
+     * TTL and its refusal to serve a name two files both claim. Under PSR-4
+     * the path IS the name: src/<Bucket>/<Class>.php is FOG\<Bucket>\<Class>.
+     *
+     * Only src/ is covered, and deliberately. The 46 discovery-named classes
+     * under lib/ carry their own class_alias and are not part of the alias
+     * set being retired; plugins are global-namespace by design (ADR 0009)
+     * and must keep resolving as bare names. Both fall through untouched --
+     * see FOGBase::qualify().
+     *
+     * A useful side effect: because this is built from FOG's own tree rather
+     * than from Composer's classmap, a vendored package sharing a short name
+     * with a core class cannot win. `Mysqldump` is the live example --
+     * FOG\Db\Mysqldump and Ifsnop\Mysqldump\Mysqldump collide in the
+     * classmap and do not collide here.
+     *
+     * @return array<string, string> lowercased short name => FQCN.
+     */
+    public static function srcClassMap(): array
+    {
+        if (self::$srcClassMap !== null) {
+            return self::$srcClassMap;
+        }
+        $map = [];
+        foreach (self::srcFileList() as $short => $path) {
+            $map[$short] = 'FOG\\' . basename(dirname($path)) . '\\'
+                . basename($path, '.php');
+        }
+        return self::$srcClassMap = $map;
     }
 
     /**

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -568,6 +568,46 @@ abstract class FOGBase
         return self::shortName($this);
     }
     /**
+     * Resolves a bare core class name to its fully qualified name.
+     *
+     * Every FOG class under src/ is namespaced, but almost nothing that
+     * NAMES one is: `getClass('Host')`, `new $short.'Manager'` and the 52
+     * lowercase strings in Route::$validClasses all spell the bare name.
+     * They resolve today only because each file under src/ ends in a
+     * class_alias() re-exporting itself into the global namespace
+     * (ADR 0013 §2). This is the one place that translation happens, so
+     * retiring those aliases does not mean editing every caller.
+     *
+     * Three things pass through untouched, each on purpose:
+     *
+     *  - a plugin class, which is global-namespace by design (ADR 0009) and
+     *    is resolved by Initiator::autoload() from a directory that did not
+     *    exist at build time;
+     *  - a name src/ does not declare at all -- \DateTimeZone reaches here
+     *    from a real caller, and the 46 discovery-named classes under lib/
+     *    carry their own aliases;
+     *  - a name that is already qualified. That needs no guard of its own:
+     *    the map is keyed on lowercased SHORT names, so 'fog\items\host'
+     *    matches nothing and falls through. An explicit early return for it
+     *    was written first and removed -- mutation testing showed deleting
+     *    it changed no behaviour, which is the definition of a branch
+     *    describing a case that cannot happen.
+     *
+     * Passing an unknown name through rather than failing is what keeps this
+     * a widening of resolution rather than a narrowing: no name that
+     * resolved before stops resolving.
+     *
+     * @param string $class the class name, bare or qualified
+     *
+     * @return string the FQCN where src/ declares one, else $class unchanged
+     */
+    public static function qualify(string $class): string
+    {
+        $map = \Initiator::srcClassMap();
+        return $map[strtolower($class)] ?? $class;
+    }
+
+    /**
      * Returns the class after verifying reflection of the class.
      *
      * @param string $class the name of the class to load
@@ -595,6 +635,11 @@ abstract class FOGBase
         if ($lClass === 'reflectionclass') {
             return new \ReflectionClass(count($args ?: []) === 1 ? $args[0] : $args);
         }
+
+        // Bare core name -> FQCN, so the ~520 literal callers stop depending
+        // on the compatibility alias. A plugin name, a built-in and an
+        // already-qualified name all pass through unchanged.
+        $class = self::qualify($class);
 
         // Initiate Reflection item.
         $obj = new \ReflectionClass($class);

--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -1785,10 +1785,12 @@ abstract class FOGController extends FOGBase
      */
     public function getManager()
     {
-        // Short name: a partially namespaced tree can have FOG\Host while
-        // HostManager is still global, so derive the bare name and let the
-        // autoloader (and, after Phase 3, the compatibility alias) resolve it.
-        $man = self::shortName($this).'Manager';
+        // shortName() is deliberate: FOG\Items\Host's manager is
+        // FOG\Managers\HostManager, a different bucket, so the name has to
+        // be rebuilt from the bare one rather than derived from __NAMESPACE__.
+        // qualify() then puts it back in its own namespace, which is what
+        // stops this depending on the compatibility alias.
+        $man = self::qualify(self::shortName($this).'Manager');
         return new $man;
     }
     /**

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4236');
+        define('FOG_VERSION', '1.6.0-beta.4239');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/getclass-resolves-without-aliases.test.php
+++ b/tests/getclass-resolves-without-aliases.test.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * The bare names FOG uses to instantiate its own classes must resolve from
+ * the src/ class map, not from the compatibility aliases.
+ *
+ * Every file under packages/web/src/ ends in a class_alias() re-exporting
+ * itself into the global namespace (ADR 0013 §2). That alias is what makes
+ * `getClass('Host')` work: the tree names its classes bare in ~520 literals,
+ * in FOGController::getManager()'s `new $short.'Manager'`, and in all 52
+ * lowercase entries of Route::$validClasses.
+ *
+ * Retiring those aliases is queued work (docs/composer-psr4-plan.md). The
+ * step that makes it tractable is a single translation point --
+ * Initiator::srcClassMap() supplying the names and FOGBase::qualify()
+ * applying them -- so the 520 callers never need editing. This test covers
+ * that point, and the list in part 3 is the work still outstanding before
+ * the aliases can actually go.
+ *
+ * Usage: php tests/getclass-resolves-without-aliases.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web  = $root . '/packages/web';
+$fails = [];
+
+/*
+ * ------------------------------------------------------------------
+ * 1. qualify() itself, executed against a map we control.
+ *
+ * FOGBase only reaches \Initiator::srcClassMap(), so a stub is enough to
+ * load it standalone. Executing beats grepping here: a grep for "qualify"
+ * passes just as happily when the method has been gutted to `return
+ * $class;`.
+ * ------------------------------------------------------------------
+ */
+class Initiator
+{
+    public static function srcClassMap(): array
+    {
+        return [
+            'host'        => 'FOG\Items\Host',
+            'hostmanager' => 'FOG\Managers\HostManager',
+        ];
+    }
+}
+require $web . '/src/Base/FOGBase.php';
+
+$expect = [
+    // A bare core name becomes qualified. This is the whole point.
+    'Host'           => 'FOG\Items\Host',
+    // Case-insensitively, because Route::$validClasses spells them lowercase
+    // and the tree is inconsistent (both 'location' and 'Location' appear).
+    'host'           => 'FOG\Items\Host',
+    'HOST'           => 'FOG\Items\Host',
+    // A manager lives in a different bucket from its model, so the name has
+    // to survive being rebuilt from the bare one.
+    'HostManager'    => 'FOG\Managers\HostManager',
+    // Already qualified: untouched, never double-prefixed.
+    'FOG\Items\Host' => 'FOG\Items\Host',
+    // Unknown names pass through, so this widens resolution and never
+    // narrows it: a plugin class, a lib/ discovery class and a PHP built-in
+    // all still reach the autoloader as themselves.
+    'DateTimeZone'   => 'DateTimeZone',
+    'CaponeTasking'  => 'CaponeTasking',
+    'ServerInfo'     => 'ServerInfo',
+];
+foreach ($expect as $in => $want) {
+    $got = FOG\Base\FOGBase::qualify($in);
+    if ($got !== $want) {
+        $fails[] = "qualify('$in') returned '$got', expected '$want'";
+    }
+}
+
+/*
+ * ------------------------------------------------------------------
+ * 2. The map derivation matches what the files actually declare.
+ *
+ * srcClassMap() derives the FQCN from the path -- src/<Bucket>/<Class>.php
+ * is FOG\<Bucket>\<Class> -- which is true only while every file's own
+ * namespace agrees with the directory holding it. Move a file between
+ * buckets without editing its namespace line and the map starts handing out
+ * a name nothing declares.
+ * ------------------------------------------------------------------
+ */
+$srcMap = [];
+$walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/src'));
+foreach ($walk as $file) {
+    if (!$file->isFile() || 'php' !== $file->getExtension()) {
+        continue;
+    }
+    $short  = $file->getBasename('.php');
+    $bucket = basename(dirname($file->getPathname()));
+    $fqcn   = 'FOG\\' . $bucket . '\\' . $short;
+    $srcMap[strtolower($short)] = $fqcn;
+
+    $src = file_get_contents($file->getPathname());
+    $rel = str_replace($web . '/', '', $file->getPathname());
+    if (!preg_match('/^namespace\s+([^;]+);/m', $src, $ns)) {
+        $fails[] = "$rel declares no namespace, so srcClassMap() would name it $fqcn";
+        continue;
+    }
+    if (trim($ns[1]) !== 'FOG\\' . $bucket) {
+        $fails[] = sprintf(
+            '%s declares namespace %s but sits in %s/, so srcClassMap() '
+            . 'would name it %s -- which nothing declares',
+            $rel,
+            trim($ns[1]),
+            $bucket,
+            $fqcn
+        );
+    }
+}
+
+/*
+ * ------------------------------------------------------------------
+ * 3. Every bare name the tree instantiates resolves somewhere real.
+ *
+ * A name that is in none of these four buckets resolves today ONLY through
+ * a compatibility alias, and would become a fatal the day those are
+ * deleted. Finding one now is the point of this section.
+ * ------------------------------------------------------------------
+ */
+$literals = [];
+$dirs = ['src', 'lib', 'commons', 'service', 'api'];
+foreach ($dirs as $dir) {
+    if (!is_dir($web . '/' . $dir)) {
+        continue;
+    }
+    $walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/' . $dir));
+    foreach ($walk as $file) {
+        if (!$file->isFile() || 'php' !== $file->getExtension()) {
+            continue;
+        }
+        // Tokenised, not pattern-matched: a docblock in init.php explains
+        // this very mechanism using getClass('X') as its example, and a
+        // regex over raw source dutifully reports X as an unresolvable
+        // class name.
+        $tokens = token_get_all(file_get_contents($file->getPathname()));
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            if (!is_array($tokens[$i])
+                || T_STRING !== $tokens[$i][0]
+                || 'getClass' !== $tokens[$i][1]
+            ) {
+                continue;
+            }
+            $rest = [];
+            for ($j = $i + 1; $j < $count && count($rest) < 2; $j++) {
+                if (is_array($tokens[$j])
+                    && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+                ) {
+                    continue;
+                }
+                $rest[] = $tokens[$j];
+            }
+            if ('(' !== ($rest[0] ?? null)
+                || !is_array($rest[1] ?? null)
+                || T_CONSTANT_ENCAPSED_STRING !== $rest[1][0]
+            ) {
+                continue;
+            }
+            $name = trim($rest[1][1], "'\"");
+            if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+                $literals[$name] = true;
+            }
+        }
+    }
+}
+
+/** The 46 discovery-named classes under lib/, which carry their own aliases. */
+$libClasses = [];
+foreach (['pages', 'hooks', 'reports', 'events'] as $dir) {
+    foreach (glob($web . '/lib/' . $dir . '/*.php') as $file) {
+        $libClasses[strtolower(preg_replace('/\.(page|hook|report|event)\.php$/', '', basename($file)))] = true;
+    }
+}
+
+/** Plugin classes: global-namespace by design (ADR 0009), never aliased. */
+$pluginClasses = [];
+if (is_dir($web . '/lib/plugins')) {
+    $walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/lib/plugins'));
+    foreach ($walk as $file) {
+        if ($file->isFile() && preg_match('/\.(class|page|hook|report|event|task)\.php$/', $file->getFilename())) {
+            $pluginClasses[strtolower(preg_replace('/\.(class|page|hook|report|event|task)\.php$/', '', $file->getFilename()))] = true;
+        }
+    }
+}
+
+$unresolved = [];
+foreach (array_keys($literals) as $name) {
+    $key = strtolower($name);
+    if (isset($srcMap[$key]) || isset($libClasses[$key]) || isset($pluginClasses[$key])) {
+        continue;
+    }
+    // A PHP built-in or a vendored class, reached by its real global name.
+    if (class_exists($name) || interface_exists($name)) {
+        continue;
+    }
+    $unresolved[] = $name;
+}
+sort($unresolved);
+if ($unresolved) {
+    $fails[] = sprintf(
+        "getClass() is called with %d name(s) that resolve through nothing "
+        . "this tree declares -- they work only via a compatibility alias "
+        . "and will fatal when those are retired: %s",
+        count($unresolved),
+        implode(', ', $unresolved)
+    );
+}
+
+if (count($fails)) {
+    fwrite(STDERR, 'FAIL:' . PHP_EOL);
+    foreach ($fails as $fail) {
+        fwrite(STDERR, "  - $fail\n");
+    }
+    exit(1);
+}
+
+printf(
+    "ok: qualify() resolves %d cases, %d src/ classes map to the namespace "
+    . "they declare, and all %d getClass() literals resolve without an alias\n",
+    count($expect),
+    count($srcMap),
+    count($literals)
+);
+exit(0);


### PR DESCRIPTION
Step 1 of the alias retirement queued at `docs/composer-psr4-plan.md:815`. It adds the chokepoint `docs/refactor-brief.md`'s Phase 3 asked for and the migration never needed while the aliases were still in place.

## The problem it solves

Every file under `packages/web/src/` ends in a `class_alias()` re-exporting itself globally (ADR 0013 §2). That alias is what makes the tree's own references work — nothing in FOG names its classes with a namespace:

| Caller | Shape | Count |
|---|---|---|
| `FOGBase::getClass()` | `getClass('Host')` | 144 distinct names, ~520 call sites |
| `FOGController::getManager()` | `new $short . 'Manager'` | 1 site, every model |
| `Route::$validClasses` | lowercase strings | 52 |

The plan's stated blocker for deleting the aliases is that a bare name has to become a qualified one in ~520 places. One translation point means none of those callers change.

```
Initiator::srcClassMap()   lowercased short name => FQCN
FOGBase::qualify()         applies it; unknown names pass through
```

## Design notes

**Derived from `srcFileList()`, not scanned again.** Under PSR-4 the path *is* the name — `src/Items/Host.php` is `FOG\Items\Host` — so the map falls out of the existing walk and inherits its cache, TTL and its refusal to serve a name two files both claim.

**Built from FOG's tree, not Composer's classmap** — which settles a real collision for free. `FOG\Db\Mysqldump` and `Ifsnop\Mysqldump\Mysqldump` share a short name in the classmap; they do not collide here, so core wins by construction rather than by ordering.

**Nothing narrows.** An unknown name passes through untouched, so plugin classes (global-namespace by design, ADR 0009), the 46 discovery-named classes under `lib/` that carry their own aliases, and built-ins like `\DateTimeZone` — which a real caller does pass — all still reach the autoloader as themselves.

**`getManager()` is in, Route is not.** `getManager()` is the same chokepoint: `shortName()` is deliberate there because `FOG\Items\Host`'s manager is `FOG\Managers\HostManager` in a *different* bucket, so the name must be rebuilt bare and requalified. Route's ~10 `new $class` sites take their name from `$validClasses` at ten separate points with no shared resolution step — that is its own change.

## Verification

Shadow tree against the live database. With the `class_alias` lines stripped from `Items/Host.php` and `Managers/HostManager.php`:

```
global \Host declared: no
bare 'Host' FAILED as expected: ReflectionException
getClass('Host', 1) => FOG\Items\Host  name=test
getManager()        => FOG\Managers\HostManager
```

That is the property this PR exists to establish: the old resolution path is genuinely dead and the new one carries the load.

`tests/getclass-resolves-without-aliases.test.php` covers three things, each confirmed by mutation:

1. **`qualify()` executed** against a controlled map — a stub `\Initiator` is enough to load `FOGBase` standalone, so this is not a grep that would pass on a gutted method. Mutations: returning the argument unchanged, and making the lookup case-sensitive. Both go red.
2. **Every `src/` file declares the namespace its bucket implies**, since the map derives the FQCN from the path. Mutation: a namespace/bucket mismatch. Goes red.
3. **Every `getClass()` literal resolves** through the map, `lib/`, plugins or a built-in rather than through an alias. This list is the outstanding work before the aliases can go, and it is currently **empty**.

One mutation earned its keep immediately. An early return for already-qualified names changed **no** behaviour when deleted — the map is keyed on lowercased *short* names, so `fog\items\host` matches nothing and falls through anyway. The branch was removed rather than left describing a case that cannot happen; the reasoning is in the docblock so it does not get re-added.

Extraction in part 3 is tokenised rather than regex'd, because a docblock in `init.php` explains this mechanism using `getClass('X')` as its example and a regex over raw source dutifully reported `X` as an unresolvable class.

Full suite: **176 passed, 0 failed**.

## Not in this PR

Deleting the 202 `class_alias` lines. That is step 4 and it changes the published 1.6 plugin ABI — it needs ADR 0013 §2 amended and `fog-plugins` swept for its 178 bare-name `extends` first, released ahead of core per ADR 0009.