### PR TITLE
Remove Green FOG's configuration surface

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -8139,3 +8139,54 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 375
+$this->schema[] = [
+    // Green FOG's configuration outlives Green FOG itself.
+    //
+    // The module's server endpoint went with 565caa40c "Remove legacy client
+    // stuff", which deleted the GF class and left service/greenfog.php calling
+    // it -- a guaranteed fatal on every request until that file was deleted
+    // too.
+    //
+    // Most of the surface was already inert, in two independent ways that
+    // both predate this step: FOGBase::getGlobalModuleStatus() builds the
+    // module list from a HARDCODED $services array that has never listed
+    // greenfog, and the host, group and service-configuration pages each
+    // carried it in a $notWhere exclusion list on top of that. So there has
+    // been no per-host or per-group Green FOG toggle to tick for some time.
+    //
+    // One thing was not inert. FOG_CLIENT_GREENFOG_ENABLED still had a
+    // globalSettings row, under its own "FOG Client - Green Fog" category,
+    // so FOG Configuration rendered a real checkbox that saved a real value
+    // that nothing has read since the module was removed. That is the same
+    // failure FOG_PLUGINSYS_DIR was removed for in step 326: a setting that
+    // lies is worse than no setting.
+    //
+    // The `modules` row and its moduleStatusByHost answers go with it. They
+    // are what the exclusion lists existed to hide, and those lists are
+    // removed in the same commit -- keeping the row would put Green FOG back
+    // in the group and host module lists, which build their keys from this
+    // table rather than from $services.
+    //
+    // Deleted rather than left as dead rows because the module cannot come
+    // back: there is no GF class to restore. Ordered with the per-host
+    // answers first, so no window exists where a row references a module id
+    // nothing declares. Both are keyed on an exact value, so neither can take
+    // anything else with it.
+    //
+    // msModuleID is a VARCHAR. Step 34 seeded these rows with the short name
+    // and a later step rewrote them to the numeric id, so a server upgraded
+    // across that boundary can hold either spelling; both are matched.
+    //
+    // The seed steps that created all three are deliberately NOT edited.
+    // schema.php is a replay log, and step 326 set the precedent -- it
+    // deletes FOG_PLUGINSYS_DIR while leaving the INSERT that creates it at
+    // line 749 intact. A fresh install creates these and then removes them
+    // one step later, which costs nothing and keeps the history readable.
+    "DELETE FROM `moduleStatusByHost` "
+    . "WHERE `msModuleID` IN ('5', 'greenfog')",
+    "DELETE FROM `modules` WHERE `short_name` = 'greenfog'",
+    "DELETE FROM `globalSettings` "
+    . "WHERE `settingKey` = 'FOG_CLIENT_GREENFOG_ENABLED'",
+];

--- a/packages/web/commons/text.php
+++ b/packages/web/commons/text.php
@@ -144,7 +144,6 @@ $foglang['TaskReboot'] = _('Task Reboot');
 $foglang['UserCleanup'] = _('User Cleanup');
 $foglang['UserTracker'] = _('User Tracker');
 $foglang['SelManager'] = _('%s Manager');
-$foglang['GreenFOG'] = _('Green FOG');
 $foglang['DirectoryCleaner'] = _('Directory Cleaner');
 $foglang['MACAddrList'] = _('MAC Address List');
 $foglang['FOGSettings'] = _('FOG Settings');

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -2073,7 +2073,6 @@ class FOGConfigurationPage extends FOGPage
             'FOG_CLIENT_CLIENTUPDATER_ENABLED' => true,
             'FOG_CLIENT_DIRECTORYCLEANER_ENABLED' => true,
             'FOG_CLIENT_DISPLAYMANAGER_ENABLED' => true,
-            'FOG_CLIENT_GREENFOG_ENABLED' => true,
             'FOG_CLIENT_HOSTREGISTER_ENABLED' => true,
             'FOG_CLIENT_HOSTNAMECHANGER_ENABLED' => true,
             'FOG_CLIENT_POWERMANAGEMENT_ENABLED' => true,

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -3066,7 +3066,6 @@ class GroupManagement extends FOGPage
         $notWhere = [
             'clientupdater',
             'dircleanup',
-            'greenfog',
             'usercleanup'
         ];
         $keys = array_diff($keys, $notWhere);

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -3913,7 +3913,6 @@ class HostManagement extends FOGPage
         $notWhere = [
             'clientupdater',
             'dircleanup',
-            'greenfog',
             'usercleanup'
         ];
 

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -67,7 +67,6 @@ class ServiceConfigurationPage extends FOGPage
         $notWhere = [
             'clientupdater',
             'dircleanup',
-            'greenfog',
             'usercleanup'
         ];
         $modkeys = array_keys(self::getGlobalModuleStatus());

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3111,9 +3111,6 @@ msgstr "Diagramm aktiviert"
 msgid "Graphical"
 msgstr "Grafisch"
 
-msgid "Green FOG"
-msgstr "Green FOG"
-
 msgid "Group"
 msgstr "Gruppe"
 
@@ -10917,6 +10914,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#~ msgid "Green FOG"
+#~ msgstr "Green FOG"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3112,9 +3112,6 @@ msgstr "Graph Enabled"
 msgid "Graphical"
 msgstr "Graphical"
 
-msgid "Green FOG"
-msgstr "Green FOG"
-
 msgid "Group"
 msgstr "Group"
 
@@ -10902,6 +10899,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reboot"
+
+#~ msgid "Green FOG"
+#~ msgstr "Green FOG"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3164,10 +3164,6 @@ msgstr "habilitado"
 msgid "Graphical"
 msgstr ""
 
-#, fuzzy
-msgid "Green FOG"
-msgstr "En "
-
 msgid "Group"
 msgstr "Grupo"
 
@@ -11086,6 +11082,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reiniciar"
+
+#, fuzzy
+#~ msgid "Green FOG"
+#~ msgstr "En "
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3111,9 +3111,6 @@ msgstr "Diagramm aktiviert"
 msgid "Graphical"
 msgstr "Grafisch"
 
-msgid "Green FOG"
-msgstr "Green FOG"
-
 msgid "Group"
 msgstr "Gruppe"
 
@@ -10918,6 +10915,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Neustarten"
+
+#~ msgid "Green FOG"
+#~ msgstr "Green FOG"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3114,9 +3114,6 @@ msgstr "Graphique Enabled"
 msgid "Graphical"
 msgstr "Graphique"
 
-msgid "Green FOG"
-msgstr "FOG vert"
-
 msgid "Group"
 msgstr "Groupe"
 
@@ -10904,6 +10901,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Réinitialiser"
+
+#~ msgid "Green FOG"
+#~ msgstr "FOG vert"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3027,9 +3027,6 @@ msgstr "Grafico Abilitato"
 msgid "Graphical"
 msgstr "grafico"
 
-msgid "Green FOG"
-msgstr "FOG verde"
-
 msgid "Group"
 msgstr "Gruppo"
 
@@ -10536,6 +10533,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Riavvio"
+
+#~ msgid "Green FOG"
+#~ msgstr "FOG verde"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3000,9 +3000,6 @@ msgstr "グラフ有効"
 msgid "Graphical"
 msgstr "グラフィカル"
 
-msgid "Green FOG"
-msgstr "Green FOG"
-
 msgid "Group"
 msgstr "グループ"
 
@@ -10900,6 +10897,9 @@ msgstr ""
 
 #~ msgid "Goto task list"
 #~ msgstr "タスク一覧へ移動"
+
+#~ msgid "Green FOG"
+#~ msgstr "Green FOG"
 
 #~ msgid "Group Bios Exit Type"
 #~ msgstr "グループ BIOS 終了方法"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2662,9 +2662,6 @@ msgstr ""
 msgid "Graphical"
 msgstr ""
 
-msgid "Green FOG"
-msgstr ""
-
 msgid "Group"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3113,9 +3113,6 @@ msgstr "gráfico Ativado"
 msgid "Graphical"
 msgstr "Gráfico"
 
-msgid "Green FOG"
-msgstr "FOG verde"
-
 msgid "Group"
 msgstr "Grupo"
 
@@ -10903,6 +10900,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "reinicialização"
+
+#~ msgid "Green FOG"
+#~ msgstr "FOG verde"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3113,9 +3113,6 @@ msgstr "图启用"
 msgid "Graphical"
 msgstr "图形"
 
-msgid "Green FOG"
-msgstr "绿雾"
-
 msgid "Group"
 msgstr "组"
 
@@ -10903,6 +10900,9 @@ msgstr ""
 #, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "重启"
+
+#~ msgid "Green FOG"
+#~ msgstr "绿雾"
 
 #, fuzzy
 #~ msgid "Group Mappings"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -3223,9 +3223,6 @@ abstract class FOGPage extends FOGBase
             $array = [];
             foreach ($globalModules as $index => $key) {
                 switch ($key) {
-                    case 'greenfog':
-                        $class='GF';
-                        continue 2;
                     case 'powermanagement':
                         $class='PM';
                         break;

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 374);
+        define('FOG_SCHEMA', 375);
         define('FOG_BCACHE_VER', 321);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4239');
+        define('FOG_VERSION', '1.6.0-beta.4242');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element


### PR DESCRIPTION
Green FOG has had no server side since `565caa40c "Remove legacy client stuff"` deleted the `GF` class. Its entry point went with the other three legacy-client orphans in #1423. What stayed behind was the configuration.

## What was actually still live — I had this wrong first time

I said earlier that Green FOG "still has per-host/per-group toggles on three pages." That was wrong, and checking it is what turned this into a smaller, more precise change. Two independent mechanisms already suppressed it:

- `FOGBase::getGlobalModuleStatus()` builds the module list from a **hardcoded** `$services` array that has never listed `greenfog`;
- the host, group and service-configuration pages each carried it in a `$notWhere` **exclusion** list on top of that.

So there has been no per-host or per-group toggle to tick.

**One part was not inert.** `FOG_CLIENT_GREENFOG_ENABLED` still had a `globalSettings` row under its own "FOG Client - Green Fog" category, so FOG Configuration rendered a real checkbox that saved a real value that nothing has read since the module was removed. Same failure `FOG_PLUGINSYS_DIR` was removed for in step 326: a setting that lies is worse than no setting.

## Schema step 375

Removes the `globalSettings` row, the `modules` row, and the `moduleStatusByHost` rows answering for it. Measured against the lab install rather than assumed:

| Target | Rows matched |
|---|---|
| `modules` where `short_name = 'greenfog'` | 1 |
| `moduleStatusByHost` where `msModuleID IN ('5','greenfog')` | **97** |
| `globalSettings` where `settingKey = 'FOG_CLIENT_GREENFOG_ENABLED'` | 1 |

So this deletes real data — 97 per-host on/off answers for a module that cannot come back, because there is no `GF` class to restore. Ordered with the per-host answers first so no window exists where a row references a module id nothing declares. Both are keyed on an exact value, so neither can take anything else with it. `msModuleID` is a VARCHAR and a server upgraded across step 34's numeric rewrite can hold either spelling, so both are matched.

**The seed steps are deliberately left alone.** `schema.php` is a replay log, and step 326 set the precedent — it deletes `FOG_PLUGINSYS_DIR` while leaving the `INSERT` that creates it (line 749) intact. A fresh install creates these and removes them one step later, which costs nothing and keeps the history readable. `FOG_SCHEMA` bumped 374 → 375 in the same commit; `schema-gate.test.php` confirms they agree.

## Why the `$notWhere` entries go in the same commit

With the `modules` row gone they have nothing to exclude. Group and host build their module keys from that **table** rather than from `$services`, which is why the row and the lists have to move together — dropping the lists without the row would put Green FOG *back* in those lists.

There is no deploy window: `DatabaseManager::init()` returns early only when `mySchema >= FOG_SCHEMA` and otherwise diverts to the schema updater, so the new code never renders against a database that still holds the row.

## Also removed

- The unreachable `case 'greenfog': $class='GF';` in `requestClientInfo()` — the last reference in the tree to a class that no longer exists. Unreachable because `$globalModules` comes from the hardcoded `$services` list; if it ever were reached it would fall to `default:` and fatal in `getClass()`.
- `$foglang['GreenFOG']`, which nothing used.

## Verification

Full suite green. `schema-executes.test.php` skips locally without `FOG_TEST_DSN` — the three CI schema jobs (mariadb 10.5, mariadb 11.8, mysql 8.0) replay step 375 for real, and that is the gate that matters here.

The language-file churn in the diff is the pre-commit hook regenerating `messages.pot` and the `.po` files after `$foglang['GreenFOG']` was dropped.