### PR TITLE
Qualify Route's entity names at instantiation

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4242');
+        define('FOG_VERSION', '1.6.0-beta.4245');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -3983,6 +3983,41 @@ class Route extends FOGBase
         }
     }
     /**
+     * Instantiates one of $validClasses by its bare route name.
+     *
+     * The route binds `:class` from a URL segment matched against
+     * $validClasses, so what arrives here is a bare lowercase name -- 'host',
+     * not 'FOG\Items\Host'. It resolves today only because every file under
+     * src/ ends in a class_alias() re-exporting itself globally (ADR 0013
+     * §2), and retiring those aliases is queued work.
+     *
+     * Qualifying at DISPATCH instead would be wrong, which is why this sits
+     * here and not in runMatches(). The same $class is an identifier as well
+     * as a class reference: every caller below computes
+     * `$classname = strtolower($class)` first, and that string feeds
+     * listem()'s validation against $validClasses, $emitClassname, the HTML
+     * name=/id= attributes, and Authorization::resolveApiPermission().
+     * $validClasses holds bare lowercase names, and 'fog\items\host' is not
+     * a member of it -- the same trap FOGManagerController's __construct
+     * documents. So the bare name stays the identifier and only the
+     * instantiation is qualified.
+     *
+     * Not used by the two `new $class($id)` calls in edit() and create()
+     * that follow a successful save(). By that point $class holds the saved
+     * OBJECT, not its name, and `new $object` is alias-independent already.
+     *
+     * @param string $class the bare class name the route matched
+     * @param mixed  $id    the id to construct with, or null for an empty one
+     *
+     * @return object
+     */
+    private static function _newEntity(string $class, $id = null)
+    {
+        $fqcn = self::qualify($class);
+
+        return null === $id ? new $fqcn() : new $fqcn($id);
+    }
+    /**
      * Displays the individual item.
      *
      * @param string $class The class to work with.
@@ -3997,7 +4032,7 @@ class Route extends FOGBase
             // Recorded for printer(): a single-entity payload is flat and does
             // not name its own class.
             self::$emitClassname = $classname;
-            $class = new $class($id);
+            $class = self::_newEntity($class, $id);
             if (!$class->isValid()) {
                 self::sendResponse(
                     HTTPResponseCodes::HTTP_NOT_FOUND
@@ -4053,7 +4088,7 @@ class Route extends FOGBase
                 '',
                 true
             );
-            $class = new $class($id);
+            $class = self::_newEntity($class, $id);
             if (!$class->isValid()) {
                 self::sendResponse(
                     HTTPResponseCodes::HTTP_NOT_FOUND
@@ -4344,7 +4379,7 @@ class Route extends FOGBase
     public static function task($class, $id)
     {
         $classname = strtolower($class);
-        $class = new $class($id);
+        $class = self::_newEntity($class, $id);
         if (!$class->isValid()) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_NOT_FOUND
@@ -4411,7 +4446,7 @@ class Route extends FOGBase
                 '',
                 true
             );
-            $class = new $class;
+            $class = self::_newEntity($class);
 
             $vars = json_decode(
                 file_get_contents(
@@ -4815,7 +4850,7 @@ class Route extends FOGBase
     {
         try {
             $classname = strtolower($class);
-            $class = new $class($id);
+            $class = self::_newEntity($class, $id);
             // The states a task can be cancelled FROM. This is the same
             // allowlist every "is this task live" test in the tree uses --
             // Host::loadTask() and getActiveTaskCount() both ask for exactly
@@ -5005,7 +5040,7 @@ class Route extends FOGBase
             );
             $find = [];
             $classname = $class;
-            $class = new $class;
+            $class = self::_newEntity($class);
             foreach ($classVars['databaseFields'] as &$key) {
                 $key = $class->key($key);
                 if (isset($vars->$key)) {

--- a/tests/getclass-resolves-without-aliases.test.php
+++ b/tests/getclass-resolves-without-aliases.test.php
@@ -210,6 +210,55 @@ if ($unresolved) {
     );
 }
 
+/*
+ * ------------------------------------------------------------------
+ * 4. Route instantiates its entities through Route::_newEntity().
+ *
+ * The router binds `:class` from a URL segment matched against
+ * $validClasses, so a bare lowercase name reaches indiv(), edit(), task(),
+ * create(), cancel() and getsearchbody(). `new $class` on that name works
+ * only through the compatibility alias.
+ *
+ * Two `new $class($id)` calls legitimately remain, in edit() and create()
+ * after a successful save(): $class holds the saved OBJECT by then, and
+ * `new $object` never consulted an alias. So this cannot be a count or a
+ * grep for `new $class` -- it has to know which of the two $class is.
+ *
+ * Resolved by walking back to the variable's last assignment inside its own
+ * function: assigned from new/_newEntity means an object and is fine;
+ * reaching the parameter list means a bare string that bypassed the helper.
+ * ------------------------------------------------------------------
+ */
+$routeFile = $web . '/src/Router/Route.php';
+$routeLines = explode("\n", file_get_contents($routeFile));
+foreach ($routeLines as $i => $line) {
+    if (!preg_match('/=\s*new\s+\$(\w+)\s*[;(]/', $line, $m)) {
+        continue;
+    }
+    $var = $m[1];
+    // Walk back to the enclosing function, noting the last assignment.
+    $origin = 'parameter';
+    for ($j = $i - 1; $j >= 0; $j--) {
+        if (preg_match('/^\s*(?:public|protected|private)\s.*function\s/', $routeLines[$j])) {
+            break;
+        }
+        if (preg_match('/\$' . $var . '\s*=\s*(new\s|self::_newEntity\()/', $routeLines[$j])) {
+            $origin = 'object';
+            break;
+        }
+    }
+    if ('object' !== $origin) {
+        $fails[] = sprintf(
+            'src/Router/Route.php:%d instantiates $%s directly from the bare '
+            . 'route name. Bare names resolve only through the compatibility '
+            . 'alias -- use self::_newEntity($%s[, $id])',
+            $i + 1,
+            $var,
+            $var
+        );
+    }
+}
+
 if (count($fails)) {
     fwrite(STDERR, 'FAIL:' . PHP_EOL);
     foreach ($fails as $fail) {
@@ -220,7 +269,8 @@ if (count($fails)) {
 
 printf(
     "ok: qualify() resolves %d cases, %d src/ classes map to the namespace "
-    . "they declare, and all %d getClass() literals resolve without an alias\n",
+    . "they declare, all %d getClass() literals resolve without an alias, and "
+    . "Route instantiates only objects directly\n",
     count($expect),
     count($srcMap),
     count($literals)


### PR DESCRIPTION
Finishes step 1 of the alias retirement inside this repo. #1424 covered `getClass()` and `getManager()`; this covers the router.

## The problem

The router binds `:class` from a URL segment matched against `$validClasses`, so a **bare lowercase name** — `host`, not `FOG\Items\Host` — reaches `indiv()`, `edit()`, `task()`, `create()`, `cancel()` and `getsearchbody()`, each of which did `new $class`. That resolves only through the compatibility alias every `src/` file re-exports itself with (ADR 0013 §2).

`Route::_newEntity()` applies `FOGBase::qualify()` at the instantiation and nothing else.

## Why not qualify at dispatch

`runMatches()` is where the name arrives and where **one** edit would have covered all six. It looks obviously better and it is wrong.

The same `$class` is an *identifier* as well as a class reference. Every one of the six computes `$classname = strtolower($class)` **first**, and that string feeds:

- `listem()`'s validation against `$validClasses`
- `self::$emitClassname`
- the HTML `name=` / `id=` attributes
- `Authorization::resolveApiPermission()`

`$validClasses` holds bare lowercase names, and `fog\items\host` is not a member of it. `FOGManagerController::__construct` already carries a comment documenting this exact trap. So the bare name stays the identifier and only the instantiation is qualified.

## Six sites, not eight

The `new $class($id)` calls in `edit()` and `create()` that follow a successful `save()` are **left exactly as they were**. By that point `$class` holds the saved *object*, not its name — `new $object` never consulted an alias, and passing one to `qualify()` would be a TypeError.

Nothing outside Route needed it either. I had flagged `FOGPageManager:381` and `Plugin.php:1086` as "the same shape"; checking what actually feeds them says otherwise:

| Site | Feeds from | Verdict |
|---|---|---|
| `FOGPageManager` `new $className` | `basename()` of a `.page.php` — a discovery-named `lib/` class | not in the src map; no-op |
| `Plugin::getManager()` `new $classManager` | `<pluginName>Manager`, behind a `class_exists()` guard | plugin class, global by design (ADR 0009); no-op |

A no-op `qualify()` call is worse than none, so both are untouched.

## Verification

Shadow tree against the live database, `class_alias` stripped from `Items/Host.php`, `Items/Image.php` and `Items/Snapin.php`:

```
global \Host declared: no
_newEntity('host', 1) => FOG\Items\Host   name=test
_newEntity('host')    => FOG\Items\Host
_newEntity('image')   => FOG\Items\Image
_newEntity('snapin')  => FOG\Items\Snapin
```

The test gains a fourth section. It **cannot** be a count or a grep for `new $class`, because two of those are correct — so it walks back to each variable's last assignment inside its own function: assigned from `new`/`_newEntity` is an object and passes; reaching the parameter list is a bare string and fails.

Mutation-confirmed in both directions — reverting `indiv()` to `new $class($id)` fails naming that exact line:

```
- src/Router/Route.php:4035 instantiates $class directly from the bare route
  name. Bare names resolve only through the compatibility alias -- use
  self::_newEntity($class[, $id])
```

and the two surviving object cases stay unflagged.

Full suite: **176 passed, 0 failed**.