### PR TITLE
Retire the reverse-alias plugin ABI; core is reachable only by FQCN

### DIFF
--- a/bin/import-core-classes.php
+++ b/bin/import-core-classes.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Adds the `use` imports that let core name its own classes without the
+ * compatibility aliases.
+ *
+ * Every file under packages/web/src/ ends in a class_alias() re-exporting
+ * itself into the global namespace (ADR 0013 §2). That alias is what makes
+ * the rest of the tree work, because almost nothing that NAMES a core class
+ * is namespaced:
+ *
+ *   lib/       the 46 discovery-named classes, `namespace FOG;`. A bare
+ *              `Hook` there resolves to FOG\Hook, which Composer cannot
+ *              serve, so Initiator::_bridgeNamespaced() falls back to the
+ *              global alias.
+ *   commons/   global namespace. `new System()` is the very first thing
+ *              startInit() does.
+ *   service/   global namespace, one bare `new X(...)` per entry point.
+ *   api/
+ *   management/
+ *
+ * This adds `use FOG\<Bucket>\<Name>;` so each bare name resolves to the
+ * import instead. Imports rather than inline qualification because the
+ * volume is lopsided: one lib/ file carries 165 references to
+ * HTTPResponseCodes, and `\FOG\Router\HTTPResponseCodes::` written out 165
+ * times is not code anyone can read.
+ *
+ * Tokenised, never regex. A class name in a docblock, a string or a comment
+ * is left alone, and `$obj->Route` is not a class reference.
+ *
+ * Names already imported, already qualified, or declared by the file itself
+ * are skipped. So is any name the file's own namespace already resolves --
+ * a lib/ file in `namespace FOG;` referring to another lib/ class needs
+ * nothing.
+ *
+ * Usage:
+ *   php bin/import-core-classes.php [--fix]
+ *
+ * Without --fix it reports and changes nothing. Exit 1 if anything is left
+ * to do, 0 when clean.
+ */
+
+$fix = in_array('--fix', $argv, true);
+$repo = dirname(__DIR__);
+$web = $repo . '/packages/web';
+
+/** src/ classes: lowercased short name => FQCN, PSR-4 so the path is the name. */
+$core = [];
+$walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/src'));
+foreach ($walk as $file) {
+    if ($file->isFile() && 'php' === $file->getExtension()) {
+        $short = $file->getBasename('.php');
+        $core[strtolower($short)] = [
+            'fqcn' => 'FOG\\' . basename(dirname($file->getPathname())) . '\\' . $short,
+            'short' => $short,
+        ];
+    }
+}
+
+/**
+ * The 46 discovery-named classes under lib/, in the flat FOG namespace.
+ *
+ * Not rewritten themselves -- their filenames are a contract with
+ * FOGPageManager::loadPageClasses() -- but a file that NAMES one needs to
+ * know where it lives, and from a global-namespace file that is FOG\Name.
+ */
+$flat = [];
+foreach (['pages', 'hooks', 'reports', 'events'] as $dir) {
+    foreach (glob($web . '/lib/' . $dir . '/*.php') as $path) {
+        $src = file_get_contents($path);
+        if (preg_match('/^\s*(?:final\s+|abstract\s+)*class\s+(\w+)/mi', $src, $m)) {
+            $flat[strtolower($m[1])] = ['fqcn' => 'FOG\\' . $m[1], 'short' => $m[1]];
+        }
+    }
+}
+
+$targets = [
+    $web . '/lib/pages', $web . '/lib/hooks', $web . '/lib/reports',
+    $web . '/lib/events', $web . '/commons', $web . '/service', $web . '/api',
+    $web . '/management', $repo . '/packages/service', $repo . '/tests',
+];
+
+/**
+ * Tests that assert on the RESOLUTION MECHANISM rather than merely using it.
+ *
+ * Adding a `use` import to one of these would make the bare name it is
+ * deliberately probing resolve, and the assertion would pass for the reason
+ * the import supplies rather than the one under test -- a gate that can only
+ * ever be green. They are edited by hand.
+ */
+$handEdited = [
+    'tests/autoload.test.php',
+    'tests/autoload-core-wins.test.php',
+    'tests/psr4-bridge.test.php',
+    'tests/all-classes-load.test.php',
+    'tests/stale-class-file-list.test.php',
+    'tests/global-class-prefix.test.php',
+    'tests/entrypoint-classes-resolve.test.php',
+    'tests/getclass-resolves-without-aliases.test.php',
+    'tests/namespaced-class-refs-resolve.test.php',
+    'tests/oldcopy-retires-moved-classes.test.php',
+];
+
+$skip = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
+$totalRefs = 0;
+$totalFiles = 0;
+$report = [];
+
+foreach ($targets as $target) {
+    if (!is_dir($target)) {
+        continue;
+    }
+    $walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($target));
+    foreach ($walk as $file) {
+        $path = $file->getPathname();
+        if (!$file->isFile() || 'php' !== $file->getExtension()
+            || false !== strpos($path, '/plugins/')
+            || false !== strpos($path, '/vendor/')
+            || in_array(
+                str_replace($repo . '/', '', $path),
+                $handEdited,
+                true
+            )
+        ) {
+            continue;
+        }
+        $src = file_get_contents($path);
+
+        // The file's own namespace, and what it already declares or imports.
+        preg_match('/^namespace\s+([^;]+);/m', $src, $nsm);
+        $ns = isset($nsm[1]) ? trim($nsm[1]) : '';
+        $known = [];
+        if (preg_match_all('/^use\s+([^;]+);$/m', $src, $um)) {
+            foreach ($um[1] as $use) {
+                $use = trim($use);
+                $bind = false !== stripos($use, ' as ')
+                    ? trim(preg_split('/\s+as\s+/i', $use)[1])
+                    : substr(strrchr('\\' . $use, '\\'), 1);
+                $known[strtolower($bind)] = true;
+            }
+        }
+        if (preg_match_all('/^\s*(?:final\s+|abstract\s+)*(?:class|interface|trait)\s+(\w+)/mi', $src, $dm)) {
+            foreach ($dm[1] as $name) {
+                $known[strtolower($name)] = true;
+            }
+        }
+
+        $tokens = token_get_all($src);
+        $count = count($tokens);
+        $wanted = [];
+        for ($i = 0; $i < $count; $i++) {
+            if (!is_array($tokens[$i]) || T_STRING !== $tokens[$i][0]) {
+                continue;
+            }
+            $name = $tokens[$i][1];
+            $key = strtolower($name);
+            if (in_array($key, ['self', 'parent', 'static'], true) || isset($known[$key])) {
+                continue;
+            }
+            $entry = $core[$key] ?? ($flat[$key] ?? null);
+            if (null === $entry) {
+                continue;
+            }
+            // A file already inside FOG\ resolves the flat names itself.
+            if ('FOG' === $ns && isset($flat[$key])) {
+                continue;
+            }
+            $prev = null;
+            for ($j = $i - 1; $j >= 0; $j--) {
+                if (is_array($tokens[$j]) && in_array($tokens[$j][0], $skip, true)) {
+                    continue;
+                }
+                $prev = $tokens[$j];
+                break;
+            }
+            $next = null;
+            for ($j = $i + 1; $j < $count; $j++) {
+                if (is_array($tokens[$j]) && in_array($tokens[$j][0], $skip, true)) {
+                    continue;
+                }
+                $next = $tokens[$j];
+                break;
+            }
+            if (is_array($prev)
+                && in_array($prev[0], [T_NS_SEPARATOR, T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_CONST], true)
+            ) {
+                continue;
+            }
+            if (is_array($next) && T_NS_SEPARATOR === $next[0]) {
+                continue;
+            }
+            $isClassRef = (is_array($next) && T_DOUBLE_COLON === $next[0])
+                || (is_array($prev) && in_array($prev[0], [T_NEW, T_EXTENDS, T_IMPLEMENTS, T_INSTANCEOF], true));
+            if (!$isClassRef) {
+                continue;
+            }
+            $wanted[$entry['fqcn']] = true;
+        }
+        if (!$wanted) {
+            continue;
+        }
+        $rel = str_replace($repo . '/', '', $path);
+        $report[] = sprintf('%-56s %d', $rel, count($wanted));
+        $totalFiles++;
+        $totalRefs += count($wanted);
+        if (!$fix) {
+            continue;
+        }
+        $lines = array_keys($wanted);
+        sort($lines);
+        $block = implode("\n", array_map(fn ($f) => "use $f;", $lines));
+        if ('' !== $ns) {
+            // After the namespace declaration, merged with any existing block.
+            $src = preg_replace(
+                '/^(namespace\s+[^;]+;\n)/m',
+                "$1\n" . $block . "\n",
+                $src,
+                1
+            );
+        } else {
+            // Global namespace: `use` is legal at top level. It must go after
+            // the file docblock AND after any declare(), because
+            // declare(strict_types=1) has to be the very first statement in
+            // the file -- putting the imports above it is a parse error, not
+            // a style problem. api/index.php found this immediately.
+            $src = preg_replace(
+                '/^(<\?php\n(?:\s*declare\s*\([^)]*\)\s*;\n)?(?:\s*\/\*\*.*?\*\/\n)?(?:\s*declare\s*\([^)]*\)\s*;\n)?)/s',
+                "$1\n" . $block . "\n",
+                $src,
+                1
+            );
+        }
+        // Fold a duplicated blank line the insertion may have created.
+        $src = preg_replace("/\n{3,}/", "\n\n", $src);
+        file_put_contents($path, $src);
+    }
+}
+
+sort($report);
+echo $report ? implode("\n", $report) . "\n" : "nothing to import\n";
+printf(
+    "%s: %d import(s) across %d file(s)\n",
+    $fix ? 'added' : 'would add',
+    $totalRefs,
+    $totalFiles
+);
+exit($totalRefs && !$fix ? 1 : 0);

--- a/bin/import-core-classes.php
+++ b/bin/import-core-classes.php
@@ -17,6 +17,11 @@
  *   service/   global namespace, one bare `new X(...)` per entry point.
  *   api/
  *   management/
+ *   status/      the node and fog-client endpoints -- bandwidth, getfiles,
+ *   maintenance/ gethash, hostgetkey, newtoken, create_update_node. Added
+ *   client/      after the first sweep missed them: they are not under
+ *                service/ and are easy to forget precisely because nothing
+ *                in the test suite drives them.
  *
  * This adds `use FOG\<Bucket>\<Name>;` so each bare name resolves to the
  * import instead. Imports rather than inline qualification because the
@@ -76,7 +81,8 @@ foreach (['pages', 'hooks', 'reports', 'events'] as $dir) {
 $targets = [
     $web . '/lib/pages', $web . '/lib/hooks', $web . '/lib/reports',
     $web . '/lib/events', $web . '/commons', $web . '/service', $web . '/api',
-    $web . '/management', $repo . '/packages/service', $repo . '/tests',
+    $web . '/management', $web . '/status', $web . '/maintenance',
+    $web . '/client', $repo . '/packages/service', $repo . '/tests',
 ];
 
 /**
@@ -229,8 +235,14 @@ foreach ($targets as $target) {
                 1
             );
         }
-        // Fold a duplicated blank line the insertion may have created.
+        // Fold a duplicated blank line the insertion may have created, then
+        // guarantee one AFTER the block. The insert puts a newline after the
+        // last `use`, which is a blank line only when the following line was
+        // itself blank -- in a global-namespace file the class docblock
+        // usually butts straight up against the anchor, so without this the
+        // block and the docblock end up adjacent.
         $src = preg_replace("/\n{3,}/", "\n\n", $src);
+        $src = preg_replace('/^(use [^;\n]+;\n)(?!use |\n)/m', "$1\n", $src, 1);
         file_put_contents($path, $src);
     }
 }

--- a/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
+++ b/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
@@ -4,7 +4,7 @@
 
 accepted
 
-## Amended 2026-08-27 — decision 1 is superseded, decision 2 stands
+## Amended 2026-08-27 — decisions 1 and 2 are both superseded
 
 **Decision 1 (a flat `FOG\` namespace) no longer holds.** Every class under
 `packages/web/src/` now declares `namespace FOG\<Bucket>;` matching the
@@ -13,14 +13,90 @@ directory it sits in: `FOG\Items\Host`, `FOG\Managers\HostManager`,
 `tests/namespaced-tree.test.php`, enforces the file's directory and its
 namespace agreeing.
 
-**Decision 2 (the reverse alias as the 1.6 plugin ABI) is unchanged and is the
-reason this was safe.** `class_alias(__NAMESPACE__ . '\Host', 'Host')` still
-exports the bare global name from wherever the class now lives, so every
-plugin `extends Host`, every `getClass('Host')` literal and every one of
-`Route::$validClasses`' 52 lowercase strings resolves exactly as before.
-Verified: `fog-plugins` contains **zero** `FOG\`-qualified references — its 168
-`extends` are all bare names — so no plugin is affected by the namespace change
-at all, and `$host instanceof \Host` still holds against a `FOG\Items\Host`.
+**Decision 2 (the reverse alias as the 1.6 plugin ABI) is retired.** All 202
+`class_alias()` trailers under `packages/web/src/` are deleted. Core is
+reachable only by its namespaced name. This is the clause being reversed:
+
+> This alias is **the 1.6 plugin ABI.** It is supported for all of 1.6.
+> Removing it is a breaking change and cannot happen before 1.7.
+
+Reversed because 1.6.0 is unreleased. There is no shipped 1.6 for the promise
+to have been made to, and carrying a compatibility shim through a major version
+for compatibility with nothing is a cost with no payer. Nothing else in this
+ADR freezes the plugin contract.
+
+**What replaced it, in order of how much work each was:**
+
+- Core names its own dependencies with `use` imports — 211 of them across 92
+  files in `lib/`, `commons/`, `service/`, `api/`, `management/` and
+  `packages/service`. Imports rather than inline qualification because the
+  volume is lopsided: one `lib/` file carries 165 references to
+  `HTTPResponseCodes`.
+- `FOGBase::qualify()` translates a bare short name to its FQCN for the
+  string-driven paths, which `use` cannot reach: `getClass()`'s ~350 literals,
+  `FOGController::getManager()`, `Route::_newEntity()` for `$validClasses`'
+  52 lowercase strings, and `FOGPage`'s `$childClass`.
+- `fog-plugins` qualifies every reference to a core class — 574 across 163
+  files, pinned by `tests/core-references-are-qualified.test.php`, which needs
+  no fogproject checkout to run.
+
+**Three things the retirement broke that nothing was watching, all found by
+running it rather than by reading it.** They are the reason this is written
+down as more than a version bump:
+
+1. `Authorization::_scopeClassVars()` resolved a node to its model with a bare
+   `class_exists($node)`. Without the alias it is simply false, `$vars` stays
+   null, and `objectInScope()` has no table to test against — access control
+   that cannot find its own model, silently, with nothing logged.
+2. `PluginRunner` filtered tasks with `is_subclass_of($class, 'PluginTask')`.
+   A class name **in a string** is resolved as written, with no namespace
+   applied and no `use` consulted, so the literal named the global
+   `\PluginTask`. Without the alias every plugin task is silently skipped.
+3. The built-in `spl_autoload()` was registered behind `Initiator::autoload()`
+   as a fallback. `autoload()` refusing a bare core name is only a `return`,
+   and PHP then carries on down the chain — where the built-in probes
+   include_path by basename, and include_path covers the plugin roots. So a
+   plugin shipping `class/host.class.php` answered the bare `Host` the moment
+   core stopped answering it. Core winning the classMap collision does not
+   help: core is not in that map at all, so there is no collision to resolve.
+   The fallback is removed; see decision 2b.
+
+**One thing the plan got wrong, which is the load-bearing correction.**
+`docs/composer-psr4-plan.md` said to delete "the 202 `class_alias` lines and
+the reverse bridge arm from `Initiator`". The bridge arm
+(`Initiator::_bridgeNamespaced()`) **stays**. The 46 discovery-named classes
+under `lib/` — 26 pages, 10 hooks, 9 reports, 1 event — declare a flat
+`namespace FOG;` and keep their own `class_alias`, because
+`FOGPageManager::loadPageClasses()` and `EventManager::load()` derive the class
+name from `basename($file)` and PSR-4 does not do discovery. Composer maps
+`FOG\` onto `src/`, so `use FOG\ReportManagement;` in a core file resolves to
+`src/ReportManagement.php`, which does not exist. The bridge is what answers
+it, and deleting it breaks every core file that imports one of the 46.
+
+### 2b. The built-in `spl_autoload()` fallback is removed
+
+`Initiator::__construct()` no longer calls the bare `spl_autoload_register()`.
+See failure 3 above: with core absent from both the classMap and the global
+namespace, that fallback was a plugin's route to supplying a core class.
+
+What it covered, it no longer needs to. `include_path` and the classMap are
+both derived from `classFileList()`, so the only thing the probe could find
+that the map could not is a file added to an already-scanned directory since
+the cache was written — and that window is closed at both ends:
+`Plugin::install()` calls `forgetClassFileList()`, and the cache expires on
+`FILELIST_TTL` regardless.
+
+### What plugin authors have to change
+
+`extends Host` becomes `extends \FOG\Items\Host`, or a `use` import.
+`getClass('Host')` is unaffected — that string goes through
+`FOGBase::qualify()`. A plugin's own classes stay in the global namespace and
+are still found by basename (ADR 0009), and `class_alias` on a plugin's own
+page class is still **required**, because that is how
+`loadPageClasses()` finds it.
+
+The error is legible rather than a class-not-found at the call site: the
+autoloader recognises a bare core name and says which FQCN to use.
 
 ### The argument against nesting was wrong, and this is the correction
 
@@ -124,6 +200,10 @@ class_alias(__NAMESPACE__ . '\Host', 'Host');
 
 This alias is **the 1.6 plugin ABI.** It is supported for all of 1.6. Removing
 it is a breaking change and cannot happen before 1.7.
+
+> **Superseded 2026-08-27.** Retired before 1.6.0 shipped; see the amendment at
+> the top of this file. The alias survives only on the 46 discovery-named
+> files under `lib/`, where `loadPageClasses()` requires it.
 
 ### 3. Three files are never converted
 

--- a/docs/composer-psr4-plan.md
+++ b/docs/composer-psr4-plan.md
@@ -839,3 +839,26 @@ So the sequence is:
   `Initiator`.
 
 Doing those in any other order removes the net before the work it is holding.
+
+**Done 2026-08-27, and the last bullet was wrong.** `Initiator::
+_bridgeNamespaced()` **stays**. The 46 discovery-named classes under `lib/`
+declare a flat `namespace FOG;` and keep their own `class_alias`, because
+`FOGPageManager::loadPageClasses()` and `EventManager::load()` derive the class
+name from `basename($file)` and PSR-4 does not do discovery. Composer maps
+`FOG\` onto `src/`, so a core file's `use FOG\ReportManagement;` resolves to
+`src/ReportManagement.php`, which does not exist — the bridge is the only thing
+that answers it.
+
+Removing something else turned out to be necessary instead: the built-in
+`spl_autoload()` registered behind `Initiator::autoload()`. A refusal is only a
+`return`, so PHP carried on to that fallback, which probes include_path by
+basename — and include_path covers the plugin roots. A plugin shipping
+`class/host.class.php` answered the bare `Host` the moment core stopped
+answering it.
+
+Two more string-driven sites the "fully qualify the strings first" step missed,
+both silent and both access-adjacent: `Authorization::_scopeClassVars()`
+(`class_exists($node)`, so object scoping loses its model) and `PluginRunner`
+(`is_subclass_of($class, 'PluginTask')` — a class name in a string names the
+GLOBAL class, so every plugin task is skipped). Full account in ADR 0013's
+2026-08-27 amendment.

--- a/packages/service/lib/service_lib.php
+++ b/packages/service/lib/service_lib.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Service library
  *

--- a/packages/web/api/index.php
+++ b/packages/web/api/index.php
@@ -13,5 +13,7 @@
 
 declare(strict_types=1);
 
+use FOG\Router\Route;
+
 require '../commons/base.inc.php';
 new Route();

--- a/packages/web/commons/base.inc.php
+++ b/packages/web/commons/base.inc.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  * @link     https://fogproject.org
  */
 
+use FOG\Base\LoadGlobals;
+
 // The empty needle must short-circuit to true, matching PHP 8's str_contains()
 // -- "" is contained in every string. It cannot be left to strpos(), which on
 // 7.4 rejects an empty needle with a warning and returns false; that is what

--- a/packages/web/commons/index.php
+++ b/packages/web/commons/index.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  * @link     https://fogproject.org
  */
 
+use FOG\Router\HTTPResponseCodes;
+
 require_once 'base.inc.php';
 http_response_code(HTTPResponseCodes::HTTP_PERMANENT_REDIRECT);
 header('Location: ../management/index.php', true, HTTPResponseCodes::HTTP_PERMANENT_REDIRECT);

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  * @link     https://fogproject.org
  */
 
+use FOG\Base\System;
+
 /*
  * Composer's PSR-4 loader for FOG\ => packages/web/src.
  *
@@ -163,12 +165,33 @@ class Initiator
         $allpaths = array_unique(array_map('dirname', self::classFileList()));
         set_include_path(implode(PATH_SEPARATOR, $allpaths) . PATH_SEPARATOR . get_include_path());
         spl_autoload_extensions('.class.php,.page.php,.event.php,.hook.php,.report.php,.task.php');
-        // Fast path: an O(1) class-name => file map (see self::autoload). The
-        // built-in autoloader is kept registered behind it as a fallback so any
-        // class not yet in the (TTL-cached) map still resolves by include_path
-        // probe exactly as before.
+        // An O(1) class-name => file map (see self::autoload), replacing the
+        // built-in spl_autoload()'s include_path probe.
+        //
+        // The built-in used to sit BEHIND this as a fallback, for a class not
+        // yet in the (TTL-cached) map. It is deliberately gone, and removing
+        // it is a security fix rather than a tidy-up.
+        //
+        // autoload() refuses a bare CORE name -- core is namespaced now and no
+        // longer re-exports itself globally (ADR 0013 §2). A refusal is only a
+        // `return`, though, and PHP then carries on down the chain. The
+        // built-in probes include_path by basename, include_path is built from
+        // the same scan that feeds the classMap, and that scan covers the
+        // plugin roots. So a plugin shipping class/host.class.php answered the
+        // bare `Host` the moment core stopped answering it -- a plugin
+        // silently supplying a core class to any caller the qualification
+        // sweep missed. Core winning the classMap collision cannot help here:
+        // core is not in that map at all, so there is no collision to resolve.
+        // Proven by tests/psr4-bridge.test.php, whose probe plugin answered
+        // for exactly one commit.
+        //
+        // What the fallback covered, it no longer needs to. include_path and
+        // the map are both derived from classFileList(), so the only thing the
+        // probe could find that the map could not is a file added to an
+        // already-scanned directory since the cache was written -- and that
+        // window is closed at both ends: Plugin::install() calls
+        // forgetClassFileList(), and the cache expires on FILELIST_TTL anyway.
         spl_autoload_register([self::class, 'autoload']);
-        spl_autoload_register();
 
         // Last in the chain on purpose -- see the method.
         self::_registerPluginAutoloaders();
@@ -921,62 +944,49 @@ class Initiator
         }
         $key = strtolower($class);
 
-        // Core, under src/, is asked FIRST -- before the classMap, which is
-        // the plugin roots and the discovery-named files. Two reasons, and
-        // the second is the load-bearing one:
+        // Core, under src/, is answered FIRST -- before the classMap, which is
+        // the plugin roots and the discovery-named files. Two reasons, and the
+        // second is the load-bearing one:
         //
-        //   1. It is where core lives now, so it is where core should be
-        //      found. A miss falls straight through at the cost of one
-        //      isset().
+        //   1. It is where core lives now, so it is where core is looked for.
+        //      A miss falls straight through at the cost of one isset().
         //   2. It is the ONLY thing keeping a plugin from shadowing a core
         //      class. The classMap's core-wins rule works by comparing two
-        //      candidates for one key -- and once core is not in that map
+        //      candidates for one key -- and core is not in that map, so
         //      there is no second candidate to prefer. A plugin shipping
         //      class/host.class.php would be the sole claimant for "host"
-        //      and would win outright, which is exactly what the collision
-        //      rule below exists to prevent. Order restores the guarantee
-        //      that rule used to provide.
+        //      and would win outright. Answering here, and RETURNING rather
+        //      than falling through, is what restores the guarantee that
+        //      rule used to provide.
+        //
+        // What it no longer does is satisfy the request. Every file under
+        // src/ used to end with class_alias(__NAMESPACE__ . '\X', 'X'), so
+        // including it declared the bare name too and the lookup succeeded.
+        // Those 202 aliases are gone (ADR 0013 §2): core is reached by its
+        // qualified name, from a `use` import or via FOGBase::qualify(), and
+        // a bare core name is a reference that was missed by the sweep.
+        //
+        // So this arm exists purely to turn that into a legible error. The
+        // symptom otherwise is "Class \"Host\" not found" pointing at the
+        // caller, or -- worse, and silently -- a plugin's own host.class.php
+        // being loaded in core's place.
         //
         // Bare names only. A namespaced request is Composer's job and it
         // already ran, at file scope, ahead of this autoloader.
         if (strpos($class, '\\') === false) {
-            $src = self::srcFileList();
-            if (isset($src[$key])) {
-                // include_once and then ask, rather than aliasing anything
-                // ourselves. The file ends with its own class_alias() (ADR
-                // 0013), so loading it declares BOTH the namespaced name and
-                // the bare one, and this function never has to know or guess
-                // which namespace the file used.
-                //
-                // That is what keeps this forward-compatible. Building the
-                // name here as BRIDGE_NS . $canonical would hard-code "every
-                // scanned file is core", and break the day a plugin declares
-                // FOGPlugin\Ldap\LdapManager and something asks for the bare
-                // LdapManager. It is also what lets the namespaces change
-                // underneath this without the bridge changing at all.
-                include_once $src[$key];
-                if (class_exists($class, false)
-                    || interface_exists($class, false)
-                    || trait_exists($class, false)
-                ) {
-                    return;
-                }
-                // Loaded, and the bare name still is not declared: the file
-                // is missing the class_alias its own tests require. Say so --
-                // the symptom is otherwise a class-not-found pointing at the
-                // caller rather than at the file.
+            $map = self::srcClassMap();
+            if (isset($map[$key])) {
                 error_log(
                     sprintf(
-                        'FOG autoloader: %s declares no global alias for "%s", '
-                        . 'so the bare name does not resolve. Every file under '
-                        . 'src/ must end with class_alias(__NAMESPACE__ . '
-                        . '\'\\%s\', \'%s\'); -- see ADR 0013.',
-                        $src[$key],
+                        'FOG autoloader: "%s" is a core class and core is no '
+                        . 'longer aliased into the global namespace. Use %s '
+                        . '-- either as a `use` import or fully qualified. '
+                        . 'See ADR 0013.',
                         $class,
-                        $class,
-                        $class
+                        $map[$key]
                     )
                 );
+                return;
             }
         }
 
@@ -998,28 +1008,31 @@ class Initiator
     }
 
     /**
-     * Resolve a FOG\<Name> request to the still-global <Name> and alias it.
+     * Resolve a flat FOG\<Name> request that Composer cannot answer.
      *
-     * Nothing in the tree is namespaced yet, so `FOG\User` currently misses
-     * everywhere and does so silently. autoload()'s map is keyed on a
-     * lowercased basename, and no basename can contain a backslash, so
-     * `fog\user` is never a key; the bare spl_autoload() registered behind it
-     * then converts the separator to a directory and probes for
-     * `fog/user.class.php`, which no include_path entry holds. No error, no
-     * log line, just a class-not-found at the call site.
+     * Composer maps the FOG\ prefix onto src/, so `FOG\Base\FOGPage` is
+     * found as src/Base/FOGPage.php and never reaches this method. Two shapes
+     * still do:
      *
-     * This makes the namespaced spelling work ahead of the files themselves
-     * moving, so call sites and plugin code can be written forward-compatibly
-     * now and the eventual migration is not also a flag day for every caller.
-     * class_alias produces one class entry under two names, so `instanceof`,
-     * `new`, Reflection and every getClass() consumer see a single type.
-     * (get_class() still reports the DECLARED name -- that asymmetry is why
-     * namespacing the models is a separate problem from bridging their names,
-     * and why this is safe while that is not.)
+     *   1. The 46 discovery-named files under lib/ -- the pages, hooks,
+     *      reports and the one event. They declare `namespace FOG;` flat, so
+     *      `FOG\ReportManagement` maps to src/ReportManagement.php, which
+     *      does not exist. PSR-4 does not do discovery and these files stay
+     *      where FOGPageManager::loadPageClasses() and EventManager::load()
+     *      can derive their class name from basename($file), so this is the
+     *      only thing that answers a `use FOG\ReportManagement;` import.
+     *      That is why this method OUTLIVED the alias retirement it was
+     *      originally written to precede: the plan (docs/composer-psr4-plan.md)
+     *      said to delete it alongside the 202 class_alias lines, and doing so
+     *      breaks every core file that imports one of the 46.
+     *   2. A miscased request. PHP class names are case-insensitive and
+     *      Composer's PSR-4 prefix match is not, so `fog\host` gets here even
+     *      though `FOG\Items\Host` would not.
      *
-     * Flat names only. A nested request such as FOG\Model\Host is the shape
-     * the real migration will use, and answering it here by guessing at the
-     * last segment would resolve two different future classes to one file.
+     * Flat names only. A nested request such as FOG\Items\Host is either
+     * Composer's (it exists) or genuinely absent; answering it here by
+     * guessing at the last segment would resolve two different classes to one
+     * file.
      *
      * @param string $class The namespaced class being autoloaded.
      *
@@ -1038,12 +1051,25 @@ class Initiator
         // src/ before the classMap, for the same reason autoload() checks it
         // first for the bare spelling: core no longer appears in the classMap
         // at all, so a plugin shipping class/host.class.php would otherwise be
-        // the sole claimant for FOG\Host and win outright. Composer answers
-        // the exactly-cased FOG\Host before this method ever runs; this arm is
-        // what catches every other casing, which PHP permits and which
-        // Composer's PSR-4 prefix match does not.
-        $src = self::srcFileList();
-        $file = $src[$key] ?? (self::$classMap[$key] ?? null);
+        // the sole claimant for FOG\Host and win outright.
+        //
+        // A core class under src/ is never FLAT, though -- every one of them
+        // sits in a bucket, so FOG\Host is a wrong spelling of FOG\Items\Host
+        // rather than a name to resolve. Say which it should have been and
+        // return, which both diagnoses it and holds the shadowing guarantee.
+        $map = self::srcClassMap();
+        if (isset($map[$key])) {
+            error_log(
+                sprintf(
+                    'FOG autoloader: "%s" is not a class. Core is namespaced '
+                    . 'per bucket under src/; use %s. See ADR 0013.',
+                    $class,
+                    $map[$key]
+                )
+            );
+            return;
+        }
+        $file = self::$classMap[$key] ?? null;
         if ($file === null) {
             return;
         }

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Db\DatabaseManager;
+use FOG\Items\Schema;
+use FOG\Items\TaskLog;
+
 /**
  * Schema layout for creating the database.
  *

--- a/packages/web/lib/events/hostlist.event.php
+++ b/packages/web/lib/events/hostlist.event.php
@@ -14,6 +14,8 @@
 
 namespace FOG;
 
+use FOG\Base\Event;
+
 /**
  * Host list event
  *

--- a/packages/web/lib/hooks/bootitem.hook.php
+++ b/packages/web/lib/hooks/bootitem.hook.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 /**
  * How to edit the boot menu via hooks.
  *

--- a/packages/web/lib/hooks/boottask.hook.php
+++ b/packages/web/lib/hooks/boottask.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Alters the boot task to make a custom entry.
  *

--- a/packages/web/lib/hooks/changehostname.hook.php
+++ b/packages/web/lib/hooks/changehostname.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Change host name hook.
  *

--- a/packages/web/lib/hooks/hookdebugger.hook.php
+++ b/packages/web/lib/hooks/hookdebugger.hook.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 /**
  * Change host name hook.
  *

--- a/packages/web/lib/hooks/hostaddvnclink.hook.php
+++ b/packages/web/lib/hooks/hostaddvnclink.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Add host VNC link
  *

--- a/packages/web/lib/hooks/logviewerhook.hook.php
+++ b/packages/web/lib/hooks/logviewerhook.hook.php
@@ -22,6 +22,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Just allows user to add in any logs they feel they need on the log viewer.
  *

--- a/packages/web/lib/hooks/mainmenudata.hook.php
+++ b/packages/web/lib/hooks/mainmenudata.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Main menu hook changer.
  *

--- a/packages/web/lib/hooks/setsnapintaskstate.hook.php
+++ b/packages/web/lib/hooks/setsnapintaskstate.hook.php
@@ -14,6 +14,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Sets snapin task states
  *

--- a/packages/web/lib/hooks/submenudata.hook.php
+++ b/packages/web/lib/hooks/submenudata.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Sub menu hook changer.
  *

--- a/packages/web/lib/hooks/template.hook.php
+++ b/packages/web/lib/hooks/template.hook.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\Hook;
+
 /**
  * Template for others to work from.
  *

--- a/packages/web/lib/pages/activitymanagement.page.php
+++ b/packages/web/lib/pages/activitymanagement.page.php
@@ -13,6 +13,11 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * The activity log viewer.
  *

--- a/packages/web/lib/pages/apidocumentation.page.php
+++ b/packages/web/lib/pages/apidocumentation.page.php
@@ -16,6 +16,9 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Router\Route;
+
 /**
  * API Documentation Page
  *

--- a/packages/web/lib/pages/auditmanagement.page.php
+++ b/packages/web/lib/pages/auditmanagement.page.php
@@ -13,6 +13,10 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * The audit log viewer.
  *

--- a/packages/web/lib/pages/clientmanagement.page.php
+++ b/packages/web/lib/pages/clientmanagement.page.php
@@ -16,6 +16,8 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+
 /**
  * Client Management Page
  *

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -13,6 +13,15 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Db\DatabaseManager;
+use FOG\Items\History;
+use FOG\Items\StorageGroup;
+use FOG\Items\StorageNode;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Presents the home/dashboard page.
  *

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -13,6 +13,19 @@
 
 namespace FOG;
 
+use FOG\Audit\Retention;
+use FOG\Auth\Authorization;
+use FOG\Base\FOGBase;
+use FOG\Base\FOGManagerController;
+use FOG\Base\FOGPage;
+use FOG\Exception\UploadException;
+use FOG\Items\APIToken;
+use FOG\Items\Image;
+use FOG\Items\Setting;
+use FOG\Managers\SettingManager;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * The FOG Configuration Page display.
  *

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -15,6 +15,14 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Items\Setting;
+use FOG\Items\TaskType;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+use FOG\Util\FOGCron;
+
 /**
  * Group management page
  *

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -15,6 +15,18 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Items\Architecture;
+use FOG\Items\Group;
+use FOG\Items\Host;
+use FOG\Items\MACAddress;
+use FOG\Items\Setting;
+use FOG\Items\TaskType;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+use FOG\Util\FOGCron;
+
 /**
  * Host management page
  *

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -13,6 +13,15 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Db\DatabaseManager;
+use FOG\Items\Architecture;
+use FOG\Items\Image;
+use FOG\Items\MulticastSession;
+use FOG\Items\StorageGroup;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Image management page
  *

--- a/packages/web/lib/pages/ipxemanagement.page.php
+++ b/packages/web/lib/pages/ipxemanagement.page.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+
 /**
  * The Bootmenu Management Page
  *

--- a/packages/web/lib/pages/modulemanagement.page.php
+++ b/packages/web/lib/pages/modulemanagement.page.php
@@ -15,6 +15,8 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+
 /**
  * Module management page
  *

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -13,6 +13,12 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Items\Plugin;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Plugin management page
  *

--- a/packages/web/lib/pages/printermanagement.page.php
+++ b/packages/web/lib/pages/printermanagement.page.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * Printer management page.
  *

--- a/packages/web/lib/pages/processlogin.page.php
+++ b/packages/web/lib/pages/processlogin.page.php
@@ -13,6 +13,11 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Items\User;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Processes the current login.
  *

--- a/packages/web/lib/pages/reportmanagement.page.php
+++ b/packages/web/lib/pages/reportmanagement.page.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+
 /**
  * Displays 'reports' for the admins.
  *

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -13,6 +13,12 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Role management page — native role-based access control.
  *

--- a/packages/web/lib/pages/schemaupdaterpage.page.php
+++ b/packages/web/lib/pages/schemaupdaterpage.page.php
@@ -13,6 +13,12 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Db\DatabaseManager;
+use FOG\Db\SchemaReconciler;
+use FOG\Items\Schema;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * Handles the display of schema and schema updating in general.
  *

--- a/packages/web/lib/pages/serverinfo.page.php
+++ b/packages/web/lib/pages/serverinfo.page.php
@@ -13,6 +13,10 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Items\MACAddress;
+use FOG\Items\StorageNode;
+
 /**
  * Presents server information when clicked.
  *

--- a/packages/web/lib/pages/serviceconfigurationpage.page.php
+++ b/packages/web/lib/pages/serviceconfigurationpage.page.php
@@ -14,6 +14,10 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Configure global level module/services.
  * These are things like hostname changer, display, etc...

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -13,6 +13,8 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+
 /**
  * Site management page.
  *

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -13,6 +13,13 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Exception\UploadException;
+use FOG\Items\Snapin;
+use FOG\Items\StorageGroup;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Snapin management page
  *

--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -13,6 +13,11 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Items\StorageNode;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Displays the storage group information.
  *

--- a/packages/web/lib/pages/storagenodemanagement.page.php
+++ b/packages/web/lib/pages/storagenodemanagement.page.php
@@ -13,6 +13,10 @@
 
 namespace FOG;
 
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Displays the storage node information.
  *

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -13,6 +13,13 @@
 
 namespace FOG;
 
+use FOG\Base\FOGManagerController;
+use FOG\Base\FOGPage;
+use FOG\Items\TaskLog;
+use FOG\Items\TaskType;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Displays tasks to the user.
  *

--- a/packages/web/lib/pages/usergroupmanagement.page.php
+++ b/packages/web/lib/pages/usergroupmanagement.page.php
@@ -13,6 +13,11 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+use FOG\Base\FOGPage;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * User group management page — native role-based access control.
  *

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -13,6 +13,12 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+use FOG\Items\APIToken;
+use FOG\Items\User;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * User management page.
  *

--- a/packages/web/lib/reports/file_deleter.report.php
+++ b/packages/web/lib/reports/file_deleter.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * File Deleter report
  *

--- a/packages/web/lib/reports/history_report.report.php
+++ b/packages/web/lib/reports/history_report.report.php
@@ -13,6 +13,10 @@
 
 namespace FOG;
 
+use FOG\Auth\Authorization;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Prints the history of all items.
  *

--- a/packages/web/lib/reports/host_list.report.php
+++ b/packages/web/lib/reports/host_list.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Reports hosts within.
  *

--- a/packages/web/lib/reports/hosts_and_users.report.php
+++ b/packages/web/lib/reports/hosts_and_users.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Reports hosts and the users within.
  *

--- a/packages/web/lib/reports/inventory_report.report.php
+++ b/packages/web/lib/reports/inventory_report.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Prints the inventory of all items.
  *

--- a/packages/web/lib/reports/pending_mac_list.report.php
+++ b/packages/web/lib/reports/pending_mac_list.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Pending MAC report.
  *

--- a/packages/web/lib/reports/product_keys.report.php
+++ b/packages/web/lib/reports/product_keys.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Reports Host product keys.
  *

--- a/packages/web/lib/reports/run_history.report.php
+++ b/packages/web/lib/reports/run_history.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Audit\ActivityWindow;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * What ran, and when it started and finished.
  *

--- a/packages/web/lib/reports/snapin_list.report.php
+++ b/packages/web/lib/reports/snapin_list.report.php
@@ -13,6 +13,9 @@
 
 namespace FOG;
 
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Snapin List report
  *

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Backs up the db for us
  *

--- a/packages/web/maintenance/check_node_exists.php
+++ b/packages/web/maintenance/check_node_exists.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Check if the node exists and return it
  *

--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+
 /**
  * Creates or updates nodes.
  *

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
  * @version  1.1
  */
 
+use FOG\Base\FOGCore;
+use FOG\Router\HTTPResponseCodes;
+
 /*
  * The web UI is the one entry point that needs a session created for a
  * visitor who arrives without a cookie -- the login form's CSRF token has to

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
  * @version  1.1
  */
 
+use FOG\Auth\Authorization;
+use FOG\Auth\CSRF;
+use FOG\Base\FOGPage;
+
 // Not an entry point: this is the page shell, included by Page::render()
 // with the application already booted, which is what makes the self::
 // references below resolve. It nonetheless sits under the document root

--- a/packages/web/service/Post_Stage2.php
+++ b/packages/web/service/Post_Stage2.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\TaskHandling\TaskQueue;
+
 /**
  * Check out upload task.
  *

--- a/packages/web/service/Post_Stage3.php
+++ b/packages/web/service/Post_Stage3.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\TaskHandling\TaskQueue;
+
 /**
  * Check out download task.
  *

--- a/packages/web/service/Post_Wipe.php
+++ b/packages/web/service/Post_Wipe.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Check out other tasks.
  *

--- a/packages/web/service/Pre_Stage1.php
+++ b/packages/web/service/Pre_Stage1.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Check in tasks.
  *

--- a/packages/web/service/PrinterManager.php
+++ b/packages/web/service/PrinterManager.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\PrinterClient;
+
 /**
  * Printer client script
  *

--- a/packages/web/service/Printers.php
+++ b/packages/web/service/Printers.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Printer client script
  *

--- a/packages/web/service/auto.register.php
+++ b/packages/web/service/auto.register.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Boot\Registration;
+
 /**
  * FOG Registration passthru
  *

--- a/packages/web/service/autologout.php
+++ b/packages/web/service/autologout.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\Autologout;
+
 /**
  * Autologout information client
  *

--- a/packages/web/service/blame.php
+++ b/packages/web/service/blame.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Audit\Blame;
+
 /**
  * Sets the blame of a storage node thats problematic.
  *

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Audit\Audit;
+use FOG\Base\FOGCore;
+
 /**
  * Checks credentials for init based calls
  *

--- a/packages/web/service/displaymanager.php
+++ b/packages/web/service/displaymanager.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\DisplayManager;
+
 /**
  * Display sender for the clients
  *

--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -14,6 +14,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+
 /**
  * Get version, used for multiple things.
  * The new fog client uses this to tell a client to update.

--- a/packages/web/service/grouplisting.php
+++ b/packages/web/service/grouplisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Router\Route;
+
 /**
  * Returns a listing of all groups in the system.
  *

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Items\Image;
+use FOG\Router\Route;
+
 /**
  * Hostinfo returns the host information
  *

--- a/packages/web/service/hostname.php
+++ b/packages/web/service/hostname.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\HostnameChanger;
+
 /**
  * This is used by the client to determine
  * domain joining and changing hostname.

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Hostname loop simply checks the host doesn't
  * already exist.

--- a/packages/web/service/imagelisting.php
+++ b/packages/web/service/imagelisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\TaskHandling\TaskingElement;
+
 /**
  * Returns a listing of all images in the system.
  *

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Audit\Audit;
+use FOG\Base\FOGCore;
+use FOG\Items\Inventory;
+
 /**
  * Inventory, stores the host inventory.
  *

--- a/packages/web/service/ipxe/advanced.php
+++ b/packages/web/service/ipxe/advanced.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * This presents the advanced menu
  *

--- a/packages/web/service/ipxe/boot.php
+++ b/packages/web/service/ipxe/boot.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Boot\IpxeBootMenu;
+
 /**
  * Boot page for pxe/iPXE
  *

--- a/packages/web/service/jobs.php
+++ b/packages/web/service/jobs.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\Jobs;
+
 /**
  * Checks for any jobs for the host
  *

--- a/packages/web/service/locationcheck.php
+++ b/packages/web/service/locationcheck.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Used for the location plugin and only checks if it is enabled
  * or not.

--- a/packages/web/service/locationlisting.php
+++ b/packages/web/service/locationlisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\TaskHandling\TaskingElement;
+
 /**
  * Returns a listing of all locations in the system.
  *

--- a/packages/web/service/man.hostexists.php
+++ b/packages/web/service/man.hostexists.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Boot\Registration;
+
 /**
  * Checks if the host exists.
  *

--- a/packages/web/service/mc_checkin.php
+++ b/packages/web/service/mc_checkin.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Multicast check in
  *

--- a/packages/web/service/nodecert.php
+++ b/packages/web/service/nodecert.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Items\StorageNode;
+use FOG\Router\Route;
+
 /**
  * Issues web and code-signing certificates to registered storage nodes.
  *

--- a/packages/web/service/oucheck.php
+++ b/packages/web/service/oucheck.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Used for the OU plugin and only checks if it is enabled
  * or not.

--- a/packages/web/service/oulisting.php
+++ b/packages/web/service/oulisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\TaskHandling\TaskingElement;
+
 /**
  * Returns a listing of all ous in the system.
  *

--- a/packages/web/service/printerlisting.php
+++ b/packages/web/service/printerlisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Router\Route;
+
 /**
  * Returns a listing of all printers in the system.
  *

--- a/packages/web/service/progress.php
+++ b/packages/web/service/progress.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Items\TaskType;
+
 /**
  * Updates the progress information
  *

--- a/packages/web/service/register.php
+++ b/packages/web/service/register.php
@@ -12,6 +12,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\RegisterClient;
+
 /**
  * Passes the legacy and new client
  * host register information.  Particularly

--- a/packages/web/service/servicemodule-active.php
+++ b/packages/web/service/servicemodule-active.php
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\ServiceModule;
+
 /**
  * Legacy client uses this to find out
  * if the module checked is usable.

--- a/packages/web/service/snapcheck.php
+++ b/packages/web/service/snapcheck.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+
 /**
  * Checks the snapin.
  *

--- a/packages/web/service/snapinlisting.php
+++ b/packages/web/service/snapinlisting.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\TaskHandling\TaskingElement;
+
 /**
  * Returns a listing of all snapins in the system.
  *

--- a/packages/web/service/snapins.checkin.php
+++ b/packages/web/service/snapins.checkin.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\SnapinClient;
+
 /**
  * Snapin client checkin
  *

--- a/packages/web/service/snapins.file.php
+++ b/packages/web/service/snapins.file.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\SnapinClient;
+
 /**
  * Snapin client file download
  *

--- a/packages/web/service/taskerror.php
+++ b/packages/web/service/taskerror.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\TaskHandling\TaskError;
+
 /**
  * Receives a report that FOS could not finish a task.
  *

--- a/packages/web/service/usertracking.report.php
+++ b/packages/web/service/usertracking.report.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Client\UserTrack;
+
 /**
  * Tracks users logging in and out
  *

--- a/packages/web/src/Audit/ActivityWindow.php
+++ b/packages/web/src/Audit/ActivityWindow.php
@@ -280,11 +280,3 @@ class ActivityWindow extends FOGBase
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ActivityWindow', 'ActivityWindow');

--- a/packages/web/src/Audit/Audit.php
+++ b/packages/web/src/Audit/Audit.php
@@ -439,11 +439,3 @@ class Audit extends FOGBase
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Audit', 'Audit');

--- a/packages/web/src/Audit/Blame.php
+++ b/packages/web/src/Audit/Blame.php
@@ -73,11 +73,3 @@ class Blame extends TaskingElement
         exit;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Blame', 'Blame');

--- a/packages/web/src/Audit/Retention.php
+++ b/packages/web/src/Audit/Retention.php
@@ -455,11 +455,3 @@ class Retention extends FOGBase
         return $name;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Retention', 'Retention');

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -1796,15 +1796,22 @@ class Authorization extends FOGBase
             return self::$_scopeClassVars[$node];
         }
         $vars = null;
-        // The BARE name, which is what getClass() on the next line resolves.
-        // This used to read __NAMESPACE__ . '\\' . $node and worked only
-        // because the tree was flat: after Move 2 that builds FOG\Auth\host,
-        // which nothing declares, so the guard would be permanently false and
-        // every object-scope lookup would silently return null. A string
-        // argument to class_exists() is not namespace-prefixed, so the bare
-        // name reaches the autoloader and the class_alias at the foot of the
-        // model's file answers it.
-        if (class_exists($node, true)) {
+        // Resolved through qualify(), which is the same lookup getClass()
+        // performs on the next line, so the guard and the call cannot disagree
+        // about which class a node names.
+        //
+        // Two wrong spellings have already been here. __NAMESPACE__ . '\\'
+        // . $node builds FOG\Auth\host, which nothing declares. The BARE
+        // $node worked only while every model re-exported itself globally --
+        // once those aliases went (ADR 0013 §2) it stopped resolving too.
+        //
+        // Both fail the same way, and it is the dangerous way: class_exists()
+        // is simply false, $vars stays null, and objectInScope() then has no
+        // table to test against. Nothing is logged and nothing errors. Access
+        // control that cannot find its own model must never look like access
+        // control that ran.
+        $qualified = self::qualify($node);
+        if (class_exists($qualified, true)) {
             $props = self::getClass($node, '', true);
             if (!empty($props['databaseTable'])
                 && !empty($props['databaseFields']['id'])
@@ -2656,11 +2663,3 @@ class Authorization extends FOGBase
         self::resetCache();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Authorization', 'Authorization');

--- a/packages/web/src/Auth/CSRF.php
+++ b/packages/web/src/Auth/CSRF.php
@@ -107,11 +107,3 @@ class CSRF
         // Often lenient to avoid breaking weird client setups.
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\CSRF', 'CSRF');

--- a/packages/web/src/Auth/Redaction.php
+++ b/packages/web/src/Auth/Redaction.php
@@ -309,11 +309,3 @@ class Redaction extends FOGBase
         self::$_map = null;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Redaction', 'Redaction');

--- a/packages/web/src/Auth/SiteScope.php
+++ b/packages/web/src/Auth/SiteScope.php
@@ -675,11 +675,3 @@ class SiteScope extends FOGBase
         return array_values(array_intersect($ids, $inScope));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteScope', 'SiteScope');

--- a/packages/web/src/Base/Event.php
+++ b/packages/web/src/Base/Event.php
@@ -63,11 +63,3 @@ abstract class Event extends FOGBase
     {
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Event', 'Event');

--- a/packages/web/src/Base/EventManager.php
+++ b/packages/web/src/Base/EventManager.php
@@ -408,11 +408,3 @@ class EventManager extends FOGBase
         self::startClassFromFiles($startfiles, $strlen);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\EventManager', 'EventManager');

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -571,12 +571,14 @@ abstract class FOGBase
      * Resolves a bare core class name to its fully qualified name.
      *
      * Every FOG class under src/ is namespaced, but almost nothing that
-     * NAMES one is: `getClass('Host')`, `new $short.'Manager'` and the 52
-     * lowercase strings in Route::$validClasses all spell the bare name.
-     * They resolve today only because each file under src/ ends in a
-     * class_alias() re-exporting itself into the global namespace
-     * (ADR 0013 §2). This is the one place that translation happens, so
-     * retiring those aliases does not mean editing every caller.
+     * NAMES one is: `getClass('Host')`, `new $short.'Manager'`, the 52
+     * lowercase strings in Route::$validClasses and FOGPage's $childClass all
+     * spell the bare name. `new $string` and a class name in a string resolve
+     * from the GLOBAL namespace -- `use` is not consulted and the enclosing
+     * namespace is not applied -- so they worked only while each file under
+     * src/ ended in a class_alias() re-exporting itself there. Those aliases
+     * are retired (ADR 0013 §2), and this is the one place the translation
+     * happens, so retiring them did not mean editing every caller.
      *
      * Three things pass through untouched, each on purpose:
      *
@@ -4153,7 +4155,13 @@ abstract class FOGBase
                     $strlen
                 )
             );
-            if (class_exists($className, false)) {
+            // qualify()d: this is a "have we loaded this file's class
+            // already" short circuit, and a core class loaded under its
+            // namespaced name does not answer to its bare basename now that
+            // the global aliases are gone. Left bare it is merely wasteful
+            // rather than wrong -- the include below is include_once -- but
+            // it would stop short-circuiting for every core file in the list.
+            if (class_exists(self::qualify($className), false)) {
                 continue;
             }
             // The file list is a TTL-cached snapshot (Initiator::
@@ -5471,11 +5479,3 @@ abstract class FOGBase
         error_log($contents);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGBase', 'FOGBase');

--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -2067,11 +2067,3 @@ abstract class FOGController extends FOGBase
         exit;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGController', 'FOGController');

--- a/packages/web/src/Base/FOGCore.php
+++ b/packages/web/src/Base/FOGCore.php
@@ -235,11 +235,3 @@ class FOGCore extends FOGBase
         return self::getClass(__CLASS__);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGCore', 'FOGCore');

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -1908,11 +1908,3 @@ abstract class FOGManagerController extends FOGBase
         return $this->sqlTotalStr;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGManagerController', 'FOGManagerController');

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -401,7 +401,14 @@ abstract class FOGPage extends FOGBase
             $this->additionalFields
                 = $classVars['additionalFields'];
             unset($classVars);
-            $this->obj = new $this->childClass($id);
+            // Qualified at the point of instantiation, not on the property.
+            // $childClass is also a LABEL -- it is lowercased into element
+            // names, concatenated into titles, used as a hook payload key and
+            // passed to Route::listem()/deletemass(), all of which want the
+            // short name. `new $string` is the one use that resolves from the
+            // global namespace, and core no longer lives there (ADR 0013 §2).
+            $childClass = self::qualify($this->childClass);
+            $this->obj = new $childClass($id);
             if (isset($id)) {
                 if ($id === 0 || !is_numeric($id) || !$this->obj->isValid()) {
                     unset($this->obj);
@@ -4409,7 +4416,8 @@ abstract class FOGPage extends FOGBase
             ];
             $fileinfo = pathinfo($_FILES['file']['name']);
             $ext = $fileinfo['extension'];
-            $Item = new $this->childClass();
+            $childClass = self::qualify($this->childClass);
+            $Item = new $childClass();
             $mime = $_FILES['file']['type'];
             if (!in_array($mime, $mimes)) {
                 if ($ext !== 'csv') {
@@ -4721,7 +4729,8 @@ abstract class FOGPage extends FOGBase
                             $arr
                         );
                         $numSuccess++;
-                        $Item = new $this->childClass();
+                        $childClass = self::qualify($this->childClass);
+                        $Item = new $childClass();
                     } else {
                         $numFailed++;
                     }
@@ -5891,11 +5900,3 @@ abstract class FOGPage extends FOGBase
         exit;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGPage', 'FOGPage');

--- a/packages/web/src/Base/FOGPageManager.php
+++ b/packages/web/src/Base/FOGPageManager.php
@@ -385,11 +385,3 @@ class FOGPageManager extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGPageManager', 'FOGPageManager');

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -600,11 +600,3 @@ trait FOGPagePost
         $this->siteTabPost($node, $obj);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGPagePost', 'FOGPagePost');

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -1099,11 +1099,3 @@ trait FOGPageRender
         echo $createModal;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGPageRender', 'FOGPageRender');

--- a/packages/web/src/Base/Hook.php
+++ b/packages/web/src/Base/Hook.php
@@ -142,11 +142,3 @@ abstract class Hook extends FOGBase
         $arguments['files'][] = $filepaths;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Hook', 'Hook');

--- a/packages/web/src/Base/HookManager.php
+++ b/packages/web/src/Base/HookManager.php
@@ -225,11 +225,3 @@ class HookManager extends EventManager
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HookManager', 'HookManager');

--- a/packages/web/src/Base/Listener.php
+++ b/packages/web/src/Base/Listener.php
@@ -174,10 +174,3 @@ trait Listener
         }
     }
 }
-
-/*
- * Compatibility alias, for the same reason every other name in this tree has
- * one: a plugin writing `use Listener;` unqualified keeps working.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Listener', 'Listener');

--- a/packages/web/src/Base/LoadGlobals.php
+++ b/packages/web/src/Base/LoadGlobals.php
@@ -89,11 +89,3 @@ class LoadGlobals extends FOGBase
         parent::__construct();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\LoadGlobals', 'LoadGlobals');

--- a/packages/web/src/Base/Page.php
+++ b/packages/web/src/Base/Page.php
@@ -583,11 +583,3 @@ class Page extends FOGBase
         return (bool)filter_input(INPUT_GET, 'contentOnly');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Page', 'Page');

--- a/packages/web/src/Base/PluginTask.php
+++ b/packages/web/src/Base/PluginTask.php
@@ -137,11 +137,3 @@ abstract class PluginTask extends FOGBase
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PluginTask', 'PluginTask');

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.17');
+        define('FOG_PLUGINS_VERSION', 'v1.6.18');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already
@@ -130,11 +130,3 @@ class System
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\System', 'System');

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4248');
+        define('FOG_VERSION', '1.6.0-beta.4250');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4245');
+        define('FOG_VERSION', '1.6.0-beta.4248');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -2867,11 +2867,3 @@ class IpxeBootMenu extends FOGBase
         $this->_parseMe($Send);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\IpxeBootMenu', 'IpxeBootMenu');

--- a/packages/web/src/Boot/Registration.php
+++ b/packages/web/src/Boot/Registration.php
@@ -578,11 +578,3 @@ class Registration extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Registration', 'Registration');

--- a/packages/web/src/Boot/WakeOnLan.php
+++ b/packages/web/src/Boot/WakeOnLan.php
@@ -77,11 +77,3 @@ class WakeOnLan extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\WakeOnLan', 'WakeOnLan');

--- a/packages/web/src/Client/Autologout.php
+++ b/packages/web/src/Client/Autologout.php
@@ -50,11 +50,3 @@ class Autologout extends FOGClient
         return ['time' => $time * 60];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Autologout', 'Autologout');

--- a/packages/web/src/Client/DisplayManager.php
+++ b/packages/web/src/Client/DisplayManager.php
@@ -38,11 +38,3 @@ class DisplayManager extends FOGClient
         ];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\DisplayManager', 'DisplayManager');

--- a/packages/web/src/Client/FOGClient.php
+++ b/packages/web/src/Client/FOGClient.php
@@ -216,11 +216,3 @@ abstract class FOGClient extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGClient', 'FOGClient');

--- a/packages/web/src/Client/HostnameChanger.php
+++ b/packages/web/src/Client/HostnameChanger.php
@@ -112,11 +112,3 @@ class HostnameChanger extends FOGClient
         return $val;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostnameChanger', 'HostnameChanger');

--- a/packages/web/src/Client/Jobs.php
+++ b/packages/web/src/Client/Jobs.php
@@ -63,11 +63,3 @@ class Jobs extends FOGClient
         return [$field => $answer];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Jobs', 'Jobs');

--- a/packages/web/src/Client/PM.php
+++ b/packages/web/src/Client/PM.php
@@ -101,11 +101,3 @@ class PM extends FOGClient
         return $data;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PM', 'PM');

--- a/packages/web/src/Client/PrinterClient.php
+++ b/packages/web/src/Client/PrinterClient.php
@@ -122,11 +122,3 @@ class PrinterClient extends FOGClient
         ];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PrinterClient', 'PrinterClient');

--- a/packages/web/src/Client/RegisterClient.php
+++ b/packages/web/src/Client/RegisterClient.php
@@ -146,11 +146,3 @@ class RegisterClient extends FOGClient
         return ['error' => 'ig'];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RegisterClient', 'RegisterClient');

--- a/packages/web/src/Client/ServiceModule.php
+++ b/packages/web/src/Client/ServiceModule.php
@@ -125,11 +125,3 @@ class ServiceModule extends FOGClient
         $this->send = "#!ok\n";
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ServiceModule', 'ServiceModule');

--- a/packages/web/src/Client/SnapinClient.php
+++ b/packages/web/src/Client/SnapinClient.php
@@ -569,11 +569,3 @@ class SnapinClient extends FOGClient
         exit;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinClient', 'SnapinClient');

--- a/packages/web/src/Client/UserTrack.php
+++ b/packages/web/src/Client/UserTrack.php
@@ -125,11 +125,3 @@ class UserTrack extends FOGClient
         return ['' => ''];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserTrack', 'UserTrack');

--- a/packages/web/src/Db/DatabaseManager.php
+++ b/packages/web/src/Db/DatabaseManager.php
@@ -400,11 +400,3 @@ class DatabaseManager extends FOGCore
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\DatabaseManager', 'DatabaseManager');

--- a/packages/web/src/Db/Mysqldump.php
+++ b/packages/web/src/Db/Mysqldump.php
@@ -93,11 +93,3 @@ class Mysqldump extends \Ifsnop\Mysqldump\Mysqldump
         parent::__construct($dsn, $user, $pass, $dumpSettings, $pdoSettings);
     }
 }
-
-/*
- * Compatibility alias, as every other core class carries. getClass() looks
- * the name up as a string through ReflectionClass, so it resolves against
- * the global table regardless of the caller's namespace; the three call
- * sites say 'Mysqldump' and keep working unchanged. See docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Mysqldump', 'Mysqldump');

--- a/packages/web/src/Db/PDODB.php
+++ b/packages/web/src/Db/PDODB.php
@@ -982,11 +982,3 @@ class PDODB extends DatabaseManager
         self::$_queryResult->bindValue($param, $value, $type);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PDODB', 'PDODB');

--- a/packages/web/src/Db/SchemaReconciler.php
+++ b/packages/web/src/Db/SchemaReconciler.php
@@ -326,11 +326,3 @@ class SchemaReconciler extends FOGBase
         return true;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SchemaReconciler', 'SchemaReconciler');

--- a/packages/web/src/Exception/SnapinSaveException.php
+++ b/packages/web/src/Exception/SnapinSaveException.php
@@ -20,11 +20,3 @@ namespace FOG\Exception;
 class SnapinSaveException extends \RuntimeException
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinSaveException', 'SnapinSaveException');

--- a/packages/web/src/Exception/UploadException.php
+++ b/packages/web/src/Exception/UploadException.php
@@ -88,11 +88,3 @@ class UploadException extends \Exception
         return $message;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UploadException', 'UploadException');

--- a/packages/web/src/Items/APIToken.php
+++ b/packages/web/src/Items/APIToken.php
@@ -401,11 +401,3 @@ class APIToken extends FOGController
             ->save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\APIToken', 'APIToken');

--- a/packages/web/src/Items/Architecture.php
+++ b/packages/web/src/Items/Architecture.php
@@ -225,11 +225,3 @@ class Architecture extends FOGController
         return $out;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Architecture', 'Architecture');

--- a/packages/web/src/Items/AuditChange.php
+++ b/packages/web/src/Items/AuditChange.php
@@ -62,11 +62,3 @@ class AuditChange extends FOGController
         'redacted' => 'acRedacted'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\AuditChange', 'AuditChange');

--- a/packages/web/src/Items/AuditLog.php
+++ b/packages/web/src/Items/AuditLog.php
@@ -84,11 +84,3 @@ class AuditLog extends FOGController
         'correlationID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\AuditLog', 'AuditLog');

--- a/packages/web/src/Items/DMIKey.php
+++ b/packages/web/src/Items/DMIKey.php
@@ -50,11 +50,3 @@ class DMIKey extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\DMIKey', 'DMIKey');

--- a/packages/web/src/Items/FileDeleteQueue.php
+++ b/packages/web/src/Items/FileDeleteQueue.php
@@ -80,11 +80,3 @@ class FileDeleteQueue extends FOGController
         return parent::save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FileDeleteQueue', 'FileDeleteQueue');

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -1079,11 +1079,3 @@ class Group extends FOGController
         $this->getHostCount();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Group', 'Group');

--- a/packages/web/src/Items/GroupAssociation.php
+++ b/packages/web/src/Items/GroupAssociation.php
@@ -70,11 +70,3 @@ class GroupAssociation extends FOGController
         return new Host($this->get('hostID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\GroupAssociation', 'GroupAssociation');

--- a/packages/web/src/Items/History.php
+++ b/packages/web/src/Items/History.php
@@ -204,11 +204,3 @@ class History extends FOGController
     }
 
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\History', 'History');

--- a/packages/web/src/Items/HookEvent.php
+++ b/packages/web/src/Items/HookEvent.php
@@ -50,11 +50,3 @@ class HookEvent extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HookEvent', 'HookEvent');

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -2113,11 +2113,3 @@ class Host extends FOGController
         return $this->get('snapinjob');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Host', 'Host');

--- a/packages/web/src/Items/HostAutoLogout.php
+++ b/packages/web/src/Items/HostAutoLogout.php
@@ -61,11 +61,3 @@ class HostAutoLogout extends FOGController
         return new Host($this->get('hostID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostAutoLogout', 'HostAutoLogout');

--- a/packages/web/src/Items/HostScreenSetting.php
+++ b/packages/web/src/Items/HostScreenSetting.php
@@ -65,11 +65,3 @@ class HostScreenSetting extends FOGController
         return new Host($this->get('hostID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostScreenSetting', 'HostScreenSetting');

--- a/packages/web/src/Items/Image.php
+++ b/packages/web/src/Items/Image.php
@@ -567,11 +567,3 @@ class Image extends FOGController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Image', 'Image');

--- a/packages/web/src/Items/ImageAssociation.php
+++ b/packages/web/src/Items/ImageAssociation.php
@@ -106,11 +106,3 @@ class ImageAssociation extends FOGController
         return (bool)$this->get('primary') > 0;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageAssociation', 'ImageAssociation');

--- a/packages/web/src/Items/ImagePartitionType.php
+++ b/packages/web/src/Items/ImagePartitionType.php
@@ -52,11 +52,3 @@ class ImagePartitionType extends FOGController
         'type'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImagePartitionType', 'ImagePartitionType');

--- a/packages/web/src/Items/ImageType.php
+++ b/packages/web/src/Items/ImageType.php
@@ -52,11 +52,3 @@ class ImageType extends FOGController
         'type'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageType', 'ImageType');

--- a/packages/web/src/Items/Inventory.php
+++ b/packages/web/src/Items/Inventory.php
@@ -161,11 +161,3 @@ class Inventory extends FOGController
         return self::formatByteSize(((int)$memar * 1024));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Inventory', 'Inventory');

--- a/packages/web/src/Items/Ipxe.php
+++ b/packages/web/src/Items/Ipxe.php
@@ -48,11 +48,3 @@ class Ipxe extends FOGController
         'version' => 'ipxeVersion'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Ipxe', 'Ipxe');

--- a/packages/web/src/Items/KeySequence.php
+++ b/packages/web/src/Items/KeySequence.php
@@ -52,11 +52,3 @@ class KeySequence extends FOGController
         'ascii'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\KeySequence', 'KeySequence');

--- a/packages/web/src/Items/MACAddress.php
+++ b/packages/web/src/Items/MACAddress.php
@@ -509,11 +509,3 @@ class MACAddress extends FOGBase
         return $ret;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MACAddress', 'MACAddress');

--- a/packages/web/src/Items/MACAddressAssociation.php
+++ b/packages/web/src/Items/MACAddressAssociation.php
@@ -114,11 +114,3 @@ class MACAddressAssociation extends FOGController
             && !$this->get('pending');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MACAddressAssociation', 'MACAddressAssociation');

--- a/packages/web/src/Items/Module.php
+++ b/packages/web/src/Items/Module.php
@@ -149,11 +149,3 @@ class Module extends FOGController
             ->load();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Module', 'Module');

--- a/packages/web/src/Items/ModuleAssociation.php
+++ b/packages/web/src/Items/ModuleAssociation.php
@@ -71,11 +71,3 @@ class ModuleAssociation extends FOGController
         return new Host($this->get('hostID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ModuleAssociation', 'ModuleAssociation');

--- a/packages/web/src/Items/MulticastSession.php
+++ b/packages/web/src/Items/MulticastSession.php
@@ -428,11 +428,3 @@ class MulticastSession extends FOGController
             ->save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastSession', 'MulticastSession');

--- a/packages/web/src/Items/MulticastSessionAssociation.php
+++ b/packages/web/src/Items/MulticastSessionAssociation.php
@@ -70,11 +70,3 @@ class MulticastSessionAssociation extends FOGController
         return new Task($this->get('taskID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastSessionAssociation', 'MulticastSessionAssociation');

--- a/packages/web/src/Items/NodeFailure.php
+++ b/packages/web/src/Items/NodeFailure.php
@@ -143,11 +143,3 @@ class NodeFailure extends FOGController
         return $this->get('storagegroup');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\NodeFailure', 'NodeFailure');

--- a/packages/web/src/Items/NotifyEvent.php
+++ b/packages/web/src/Items/NotifyEvent.php
@@ -50,11 +50,3 @@ class NotifyEvent extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\NotifyEvent', 'NotifyEvent');

--- a/packages/web/src/Items/OS.php
+++ b/packages/web/src/Items/OS.php
@@ -51,11 +51,3 @@ class OS extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\OS', 'OS');

--- a/packages/web/src/Items/OUI.php
+++ b/packages/web/src/Items/OUI.php
@@ -52,11 +52,3 @@ class OUI extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\OUI', 'OUI');

--- a/packages/web/src/Items/PXEMenuOptions.php
+++ b/packages/web/src/Items/PXEMenuOptions.php
@@ -57,11 +57,3 @@ class PXEMenuOptions extends FOGController
         'name'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PXEMenuOptions', 'PXEMenuOptions');

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -1162,11 +1162,3 @@ class Plugin extends FOGController
         return (int)$this->get('schema') < count((array)$manager->schema());
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Plugin', 'Plugin');

--- a/packages/web/src/Items/PowerManagement.php
+++ b/packages/web/src/Items/PowerManagement.php
@@ -163,11 +163,3 @@ class PowerManagement extends FOGController
         $this->getHost()->wakeOnLAN();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PowerManagement', 'PowerManagement');

--- a/packages/web/src/Items/Printer.php
+++ b/packages/web/src/Items/Printer.php
@@ -240,11 +240,3 @@ class Printer extends FOGController
         return parent::destroy($key);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Printer', 'Printer');

--- a/packages/web/src/Items/PrinterAssociation.php
+++ b/packages/web/src/Items/PrinterAssociation.php
@@ -85,11 +85,3 @@ class PrinterAssociation extends FOGController
         return (bool)($this->get('isDefault') === 1);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PrinterAssociation', 'PrinterAssociation');

--- a/packages/web/src/Items/Role.php
+++ b/packages/web/src/Items/Role.php
@@ -337,11 +337,3 @@ class Role extends FOGController
         return parent::destroy($key);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Role', 'Role');

--- a/packages/web/src/Items/RolePermission.php
+++ b/packages/web/src/Items/RolePermission.php
@@ -85,11 +85,3 @@ class RolePermission extends FOGController
         return parent::save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RolePermission', 'RolePermission');

--- a/packages/web/src/Items/RoleUserAssociation.php
+++ b/packages/web/src/Items/RoleUserAssociation.php
@@ -74,11 +74,3 @@ class RoleUserAssociation extends FOGController
         return new User($this->get('userID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RoleUserAssociation', 'RoleUserAssociation');

--- a/packages/web/src/Items/RoleUserGroupAssociation.php
+++ b/packages/web/src/Items/RoleUserGroupAssociation.php
@@ -76,11 +76,3 @@ class RoleUserGroupAssociation extends FOGController
         return new Role($this->get('roleID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RoleUserGroupAssociation', 'RoleUserGroupAssociation');

--- a/packages/web/src/Items/ScheduledTask.php
+++ b/packages/web/src/Items/ScheduledTask.php
@@ -198,11 +198,3 @@ class ScheduledTask extends FOGController
         return $this->destroy();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ScheduledTask', 'ScheduledTask');

--- a/packages/web/src/Items/Schema.php
+++ b/packages/web/src/Items/Schema.php
@@ -1079,11 +1079,3 @@ class Schema extends FOGController
         return $inserted;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Schema', 'Schema');

--- a/packages/web/src/Items/Setting.php
+++ b/packages/web/src/Items/Setting.php
@@ -145,11 +145,3 @@ class Setting extends FOGController
         return $options.'</select>';
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Setting', 'Setting');

--- a/packages/web/src/Items/Site.php
+++ b/packages/web/src/Items/Site.php
@@ -573,11 +573,3 @@ class Site extends FOGController
         return parent::destroy($key);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Site', 'Site');

--- a/packages/web/src/Items/SiteGroupMember.php
+++ b/packages/web/src/Items/SiteGroupMember.php
@@ -57,11 +57,3 @@ class SiteGroupMember extends FOGController
         'groupID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteGroupMember', 'SiteGroupMember');

--- a/packages/web/src/Items/SiteHostMember.php
+++ b/packages/web/src/Items/SiteHostMember.php
@@ -57,11 +57,3 @@ class SiteHostMember extends FOGController
         'hostID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteHostMember', 'SiteHostMember');

--- a/packages/web/src/Items/SiteRoleGrant.php
+++ b/packages/web/src/Items/SiteRoleGrant.php
@@ -64,11 +64,3 @@ class SiteRoleGrant extends FOGController
         'grantroleID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteRoleGrant', 'SiteRoleGrant');

--- a/packages/web/src/Items/SiteUserGroupGrant.php
+++ b/packages/web/src/Items/SiteUserGroupGrant.php
@@ -66,11 +66,3 @@ class SiteUserGroupGrant extends FOGController
         'grantusergroupID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserGroupGrant', 'SiteUserGroupGrant');

--- a/packages/web/src/Items/SiteUserGroupMember.php
+++ b/packages/web/src/Items/SiteUserGroupMember.php
@@ -57,11 +57,3 @@ class SiteUserGroupMember extends FOGController
         'usergroupID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserGroupMember', 'SiteUserGroupMember');

--- a/packages/web/src/Items/SiteUserMember.php
+++ b/packages/web/src/Items/SiteUserMember.php
@@ -57,11 +57,3 @@ class SiteUserMember extends FOGController
         'userID'
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserMember', 'SiteUserMember');

--- a/packages/web/src/Items/Snapin.php
+++ b/packages/web/src/Items/Snapin.php
@@ -717,11 +717,3 @@ class Snapin extends FOGController
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Snapin', 'Snapin');

--- a/packages/web/src/Items/SnapinAssociation.php
+++ b/packages/web/src/Items/SnapinAssociation.php
@@ -71,11 +71,3 @@ class SnapinAssociation extends FOGController
         return new Snapin($this->get('snapinID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinAssociation', 'SnapinAssociation');

--- a/packages/web/src/Items/SnapinGroupAssociation.php
+++ b/packages/web/src/Items/SnapinGroupAssociation.php
@@ -106,11 +106,3 @@ class SnapinGroupAssociation extends FOGController
         return (bool)$this->get('primary');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinGroupAssociation', 'SnapinGroupAssociation');

--- a/packages/web/src/Items/SnapinJob.php
+++ b/packages/web/src/Items/SnapinJob.php
@@ -105,11 +105,3 @@ class SnapinJob extends FOGController
         return $this->getManager()->cancel($this->get('id'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinJob', 'SnapinJob');

--- a/packages/web/src/Items/SnapinTask.php
+++ b/packages/web/src/Items/SnapinTask.php
@@ -176,11 +176,3 @@ class SnapinTask extends FOGController
         return new TaskState($this->get('stateID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinTask', 'SnapinTask');

--- a/packages/web/src/Items/StorageGroup.php
+++ b/packages/web/src/Items/StorageGroup.php
@@ -567,11 +567,3 @@ class StorageGroup extends FOGController
             ->load();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\StorageGroup', 'StorageGroup');

--- a/packages/web/src/Items/StorageNode.php
+++ b/packages/web/src/Items/StorageNode.php
@@ -496,11 +496,3 @@ class StorageNode extends FOGController
         return $countTasks;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\StorageNode', 'StorageNode');

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -472,11 +472,3 @@ class Task extends TaskType
             || $this->get('isDebug'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Task', 'Task');

--- a/packages/web/src/Items/TaskLog.php
+++ b/packages/web/src/Items/TaskLog.php
@@ -404,11 +404,3 @@ class TaskLog extends FOGController
         return $this->getTask()->getHost();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskLog', 'TaskLog');

--- a/packages/web/src/Items/TaskState.php
+++ b/packages/web/src/Items/TaskState.php
@@ -179,11 +179,3 @@ class TaskState extends FOGController
         return $failedState;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskState', 'TaskState');

--- a/packages/web/src/Items/TaskType.php
+++ b/packages/web/src/Items/TaskType.php
@@ -481,11 +481,3 @@ class TaskType extends FOGController
             );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskType', 'TaskType');

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -1142,11 +1142,3 @@ class User extends FOGController
         return parent::destroy($key);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\User', 'User');

--- a/packages/web/src/Items/UserAuth.php
+++ b/packages/web/src/Items/UserAuth.php
@@ -87,11 +87,3 @@ class UserAuth extends FOGController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserAuth', 'UserAuth');

--- a/packages/web/src/Items/UserGroup.php
+++ b/packages/web/src/Items/UserGroup.php
@@ -206,11 +206,3 @@ class UserGroup extends FOGController
         return parent::destroy($key);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserGroup', 'UserGroup');

--- a/packages/web/src/Items/UserGroupMember.php
+++ b/packages/web/src/Items/UserGroupMember.php
@@ -75,11 +75,3 @@ class UserGroupMember extends FOGController
         return new User($this->get('userID'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserGroupMember', 'UserGroupMember');

--- a/packages/web/src/Items/UserTracking.php
+++ b/packages/web/src/Items/UserTracking.php
@@ -171,11 +171,3 @@ class UserTracking extends FOGController
         ]
     ];
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserTracking', 'UserTracking');

--- a/packages/web/src/Managers/APITokenManager.php
+++ b/packages/web/src/Managers/APITokenManager.php
@@ -313,11 +313,3 @@ class APITokenManager extends FOGManagerController
         return in_array((int)$userID, $ids, true);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\APITokenManager', 'APITokenManager');

--- a/packages/web/src/Managers/ArchitectureManager.php
+++ b/packages/web/src/Managers/ArchitectureManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class ArchitectureManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ArchitectureManager', 'ArchitectureManager');

--- a/packages/web/src/Managers/AuditChangeManager.php
+++ b/packages/web/src/Managers/AuditChangeManager.php
@@ -33,11 +33,3 @@ class AuditChangeManager extends FOGManagerController
      */
     public $tablename = 'auditChange';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\AuditChangeManager', 'AuditChangeManager');

--- a/packages/web/src/Managers/AuditLogManager.php
+++ b/packages/web/src/Managers/AuditLogManager.php
@@ -33,11 +33,3 @@ class AuditLogManager extends FOGManagerController
      */
     public $tablename = 'auditLog';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\AuditLogManager', 'AuditLogManager');

--- a/packages/web/src/Managers/DMIKeyManager.php
+++ b/packages/web/src/Managers/DMIKeyManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class DMIKeyManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\DMIKeyManager', 'DMIKeyManager');

--- a/packages/web/src/Managers/FileDeleteQueueManager.php
+++ b/packages/web/src/Managers/FileDeleteQueueManager.php
@@ -87,11 +87,3 @@ class FileDeleteQueueManager extends FOGManagerController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FileDeleteQueueManager', 'FileDeleteQueueManager');

--- a/packages/web/src/Managers/GroupAssociationManager.php
+++ b/packages/web/src/Managers/GroupAssociationManager.php
@@ -33,11 +33,3 @@ class GroupAssociationManager extends FOGManagerController
      */
     public $tablename = 'groupMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\GroupAssociationManager', 'GroupAssociationManager');

--- a/packages/web/src/Managers/GroupManager.php
+++ b/packages/web/src/Managers/GroupManager.php
@@ -33,11 +33,3 @@ class GroupManager extends FOGManagerController
      */
     public $tablename = 'groupMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\GroupManager', 'GroupManager');

--- a/packages/web/src/Managers/HistoryManager.php
+++ b/packages/web/src/Managers/HistoryManager.php
@@ -33,11 +33,3 @@ class HistoryManager extends FOGManagerController
      */
     public $tablename = 'history';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HistoryManager', 'HistoryManager');

--- a/packages/web/src/Managers/HookEventManager.php
+++ b/packages/web/src/Managers/HookEventManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class HookEventManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HookEventManager', 'HookEventManager');

--- a/packages/web/src/Managers/HostAutoLogoutManager.php
+++ b/packages/web/src/Managers/HostAutoLogoutManager.php
@@ -33,11 +33,3 @@ class HostAutoLogoutManager extends FOGManagerController
      */
     public $tablename = 'hostAutoLogout';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostAutoLogoutManager', 'HostAutoLogoutManager');

--- a/packages/web/src/Managers/HostManager.php
+++ b/packages/web/src/Managers/HostManager.php
@@ -239,11 +239,3 @@ class HostManager extends FOGManagerController
         self::$Host = new Host(self::maxId($MACHost));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostManager', 'HostManager');

--- a/packages/web/src/Managers/HostScreenSettingManager.php
+++ b/packages/web/src/Managers/HostScreenSettingManager.php
@@ -33,11 +33,3 @@ class HostScreenSettingManager extends FOGManagerController
      */
     public $tablename = 'hostScreenSettings';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HostScreenSettingManager', 'HostScreenSettingManager');

--- a/packages/web/src/Managers/ImageAssociationManager.php
+++ b/packages/web/src/Managers/ImageAssociationManager.php
@@ -33,11 +33,3 @@ class ImageAssociationManager extends FOGManagerController
      */
     public $tablename = 'imageGroupAssoc';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageAssociationManager', 'ImageAssociationManager');

--- a/packages/web/src/Managers/ImageManager.php
+++ b/packages/web/src/Managers/ImageManager.php
@@ -33,11 +33,3 @@ class ImageManager extends FOGManagerController
      */
     public $tablename = 'images';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageManager', 'ImageManager');

--- a/packages/web/src/Managers/ImagePartitionTypeManager.php
+++ b/packages/web/src/Managers/ImagePartitionTypeManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class ImagePartitionTypeManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImagePartitionTypeManager', 'ImagePartitionTypeManager');

--- a/packages/web/src/Managers/ImageTypeManager.php
+++ b/packages/web/src/Managers/ImageTypeManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class ImageTypeManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageTypeManager', 'ImageTypeManager');

--- a/packages/web/src/Managers/InventoryManager.php
+++ b/packages/web/src/Managers/InventoryManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class InventoryManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\InventoryManager', 'InventoryManager');

--- a/packages/web/src/Managers/IpxeManager.php
+++ b/packages/web/src/Managers/IpxeManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class IpxeManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\IpxeManager', 'IpxeManager');

--- a/packages/web/src/Managers/KeySequenceManager.php
+++ b/packages/web/src/Managers/KeySequenceManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class KeySequenceManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\KeySequenceManager', 'KeySequenceManager');

--- a/packages/web/src/Managers/MACAddressAssociationManager.php
+++ b/packages/web/src/Managers/MACAddressAssociationManager.php
@@ -33,11 +33,3 @@ class MACAddressAssociationManager extends FOGManagerController
      */
     public $tablename = 'hostMAC';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MACAddressAssociationManager', 'MACAddressAssociationManager');

--- a/packages/web/src/Managers/ModuleAssociationManager.php
+++ b/packages/web/src/Managers/ModuleAssociationManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class ModuleAssociationManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ModuleAssociationManager', 'ModuleAssociationManager');

--- a/packages/web/src/Managers/ModuleManager.php
+++ b/packages/web/src/Managers/ModuleManager.php
@@ -33,11 +33,3 @@ class ModuleManager extends FOGManagerController
      */
     public $tablename = 'modules';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ModuleManager', 'ModuleManager');

--- a/packages/web/src/Managers/MulticastSessionAssociationManager.php
+++ b/packages/web/src/Managers/MulticastSessionAssociationManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class MulticastSessionAssociationManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastSessionAssociationManager', 'MulticastSessionAssociationManager');

--- a/packages/web/src/Managers/MulticastSessionManager.php
+++ b/packages/web/src/Managers/MulticastSessionManager.php
@@ -95,11 +95,3 @@ class MulticastSessionManager extends FOGManagerController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastSessionManager', 'MulticastSessionManager');

--- a/packages/web/src/Managers/NodeFailureManager.php
+++ b/packages/web/src/Managers/NodeFailureManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class NodeFailureManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\NodeFailureManager', 'NodeFailureManager');

--- a/packages/web/src/Managers/NotifyEventManager.php
+++ b/packages/web/src/Managers/NotifyEventManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class NotifyEventManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\NotifyEventManager', 'NotifyEventManager');

--- a/packages/web/src/Managers/OSManager.php
+++ b/packages/web/src/Managers/OSManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class OSManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\OSManager', 'OSManager');

--- a/packages/web/src/Managers/OUIManager.php
+++ b/packages/web/src/Managers/OUIManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class OUIManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\OUIManager', 'OUIManager');

--- a/packages/web/src/Managers/PXEMenuOptionsManager.php
+++ b/packages/web/src/Managers/PXEMenuOptionsManager.php
@@ -93,11 +93,3 @@ class PXEMenuOptionsManager extends FOGManagerController
         return self::$_regVals[$id];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PXEMenuOptionsManager', 'PXEMenuOptionsManager');

--- a/packages/web/src/Managers/PluginManager.php
+++ b/packages/web/src/Managers/PluginManager.php
@@ -53,11 +53,3 @@ class PluginManager extends FOGManagerController
         return $needing;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PluginManager', 'PluginManager');

--- a/packages/web/src/Managers/PowerManagementManager.php
+++ b/packages/web/src/Managers/PowerManagementManager.php
@@ -98,11 +98,3 @@ class PowerManagementManager extends FOGManagerController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PowerManagementManager', 'PowerManagementManager');

--- a/packages/web/src/Managers/PrinterAssociationManager.php
+++ b/packages/web/src/Managers/PrinterAssociationManager.php
@@ -33,11 +33,3 @@ class PrinterAssociationManager extends FOGManagerController
      */
     public $tablename = 'printerAssoc';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PrinterAssociationManager', 'PrinterAssociationManager');

--- a/packages/web/src/Managers/PrinterManager.php
+++ b/packages/web/src/Managers/PrinterManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class PrinterManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PrinterManager', 'PrinterManager');

--- a/packages/web/src/Managers/RoleManager.php
+++ b/packages/web/src/Managers/RoleManager.php
@@ -33,11 +33,3 @@ class RoleManager extends FOGManagerController
      */
     public $tablename = 'roles';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RoleManager', 'RoleManager');

--- a/packages/web/src/Managers/RolePermissionManager.php
+++ b/packages/web/src/Managers/RolePermissionManager.php
@@ -33,11 +33,3 @@ class RolePermissionManager extends FOGManagerController
      */
     public $tablename = 'rolePermissions';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RolePermissionManager', 'RolePermissionManager');

--- a/packages/web/src/Managers/RoleUserAssociationManager.php
+++ b/packages/web/src/Managers/RoleUserAssociationManager.php
@@ -33,11 +33,3 @@ class RoleUserAssociationManager extends FOGManagerController
      */
     public $tablename = 'roleUserAssoc';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RoleUserAssociationManager', 'RoleUserAssociationManager');

--- a/packages/web/src/Managers/RoleUserGroupAssociationManager.php
+++ b/packages/web/src/Managers/RoleUserGroupAssociationManager.php
@@ -33,11 +33,3 @@ class RoleUserGroupAssociationManager extends FOGManagerController
      */
     public $tablename = 'roleUserGroupAssoc';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RoleUserGroupAssociationManager', 'RoleUserGroupAssociationManager');

--- a/packages/web/src/Managers/ScheduledTaskManager.php
+++ b/packages/web/src/Managers/ScheduledTaskManager.php
@@ -48,11 +48,3 @@ class ScheduledTaskManager extends FOGManagerController
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ScheduledTaskManager', 'ScheduledTaskManager');

--- a/packages/web/src/Managers/SchemaManager.php
+++ b/packages/web/src/Managers/SchemaManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class SchemaManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SchemaManager', 'SchemaManager');

--- a/packages/web/src/Managers/SettingManager.php
+++ b/packages/web/src/Managers/SettingManager.php
@@ -33,11 +33,3 @@ class SettingManager extends FOGManagerController
      */
     public $tablename = 'globalSettings';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SettingManager', 'SettingManager');

--- a/packages/web/src/Managers/SiteGroupMemberManager.php
+++ b/packages/web/src/Managers/SiteGroupMemberManager.php
@@ -33,11 +33,3 @@ class SiteGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'siteGroupMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteGroupMemberManager', 'SiteGroupMemberManager');

--- a/packages/web/src/Managers/SiteHostMemberManager.php
+++ b/packages/web/src/Managers/SiteHostMemberManager.php
@@ -33,11 +33,3 @@ class SiteHostMemberManager extends FOGManagerController
      */
     public $tablename = 'siteHostMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteHostMemberManager', 'SiteHostMemberManager');

--- a/packages/web/src/Managers/SiteManager.php
+++ b/packages/web/src/Managers/SiteManager.php
@@ -38,11 +38,3 @@ class SiteManager extends FOGManagerController
      */
     public $tablename = 'sites';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteManager', 'SiteManager');

--- a/packages/web/src/Managers/SiteRoleGrantManager.php
+++ b/packages/web/src/Managers/SiteRoleGrantManager.php
@@ -33,11 +33,3 @@ class SiteRoleGrantManager extends FOGManagerController
      */
     public $tablename = 'siteRoleGrants';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteRoleGrantManager', 'SiteRoleGrantManager');

--- a/packages/web/src/Managers/SiteUserGroupGrantManager.php
+++ b/packages/web/src/Managers/SiteUserGroupGrantManager.php
@@ -33,11 +33,3 @@ class SiteUserGroupGrantManager extends FOGManagerController
      */
     public $tablename = 'siteUserGroupGrants';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserGroupGrantManager', 'SiteUserGroupGrantManager');

--- a/packages/web/src/Managers/SiteUserGroupMemberManager.php
+++ b/packages/web/src/Managers/SiteUserGroupMemberManager.php
@@ -33,11 +33,3 @@ class SiteUserGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'siteUserGroupMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserGroupMemberManager', 'SiteUserGroupMemberManager');

--- a/packages/web/src/Managers/SiteUserMemberManager.php
+++ b/packages/web/src/Managers/SiteUserMemberManager.php
@@ -33,11 +33,3 @@ class SiteUserMemberManager extends FOGManagerController
      */
     public $tablename = 'siteUserMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SiteUserMemberManager', 'SiteUserMemberManager');

--- a/packages/web/src/Managers/SnapinAssociationManager.php
+++ b/packages/web/src/Managers/SnapinAssociationManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class SnapinAssociationManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinAssociationManager', 'SnapinAssociationManager');

--- a/packages/web/src/Managers/SnapinGroupAssociationManager.php
+++ b/packages/web/src/Managers/SnapinGroupAssociationManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class SnapinGroupAssociationManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinGroupAssociationManager', 'SnapinGroupAssociationManager');

--- a/packages/web/src/Managers/SnapinJobManager.php
+++ b/packages/web/src/Managers/SnapinJobManager.php
@@ -148,11 +148,3 @@ class SnapinJobManager extends FOGManagerController
         return true;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinJobManager', 'SnapinJobManager');

--- a/packages/web/src/Managers/SnapinManager.php
+++ b/packages/web/src/Managers/SnapinManager.php
@@ -33,11 +33,3 @@ class SnapinManager extends FOGManagerController
      */
     public $tablename = 'snapins';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinManager', 'SnapinManager');

--- a/packages/web/src/Managers/SnapinTaskManager.php
+++ b/packages/web/src/Managers/SnapinTaskManager.php
@@ -133,11 +133,3 @@ class SnapinTaskManager extends FOGManagerController
         return true;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinTaskManager', 'SnapinTaskManager');

--- a/packages/web/src/Managers/StorageGroupManager.php
+++ b/packages/web/src/Managers/StorageGroupManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class StorageGroupManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\StorageGroupManager', 'StorageGroupManager');

--- a/packages/web/src/Managers/StorageNodeManager.php
+++ b/packages/web/src/Managers/StorageNodeManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class StorageNodeManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\StorageNodeManager', 'StorageNodeManager');

--- a/packages/web/src/Managers/TaskLogManager.php
+++ b/packages/web/src/Managers/TaskLogManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class TaskLogManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskLogManager', 'TaskLogManager');

--- a/packages/web/src/Managers/TaskManager.php
+++ b/packages/web/src/Managers/TaskManager.php
@@ -376,11 +376,3 @@ class TaskManager extends FOGManagerController
         return $reasons;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskManager', 'TaskManager');

--- a/packages/web/src/Managers/TaskStateManager.php
+++ b/packages/web/src/Managers/TaskStateManager.php
@@ -33,11 +33,3 @@ class TaskStateManager extends FOGManagerController
      */
     public $tablename = 'taskStates';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskStateManager', 'TaskStateManager');

--- a/packages/web/src/Managers/TaskTypeManager.php
+++ b/packages/web/src/Managers/TaskTypeManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class TaskTypeManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskTypeManager', 'TaskTypeManager');

--- a/packages/web/src/Managers/UserAuthManager.php
+++ b/packages/web/src/Managers/UserAuthManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class UserAuthManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserAuthManager', 'UserAuthManager');

--- a/packages/web/src/Managers/UserGroupManager.php
+++ b/packages/web/src/Managers/UserGroupManager.php
@@ -33,11 +33,3 @@ class UserGroupManager extends FOGManagerController
      */
     public $tablename = 'userGroups';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserGroupManager', 'UserGroupManager');

--- a/packages/web/src/Managers/UserGroupMemberManager.php
+++ b/packages/web/src/Managers/UserGroupMemberManager.php
@@ -33,11 +33,3 @@ class UserGroupMemberManager extends FOGManagerController
      */
     public $tablename = 'userGroupMembers';
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserGroupMemberManager', 'UserGroupMemberManager');

--- a/packages/web/src/Managers/UserManager.php
+++ b/packages/web/src/Managers/UserManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class UserManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserManager', 'UserManager');

--- a/packages/web/src/Managers/UserTrackingManager.php
+++ b/packages/web/src/Managers/UserTrackingManager.php
@@ -27,11 +27,3 @@ use FOG\Base\FOGManagerController;
 class UserTrackingManager extends FOGManagerController
 {
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\UserTrackingManager', 'UserTrackingManager');

--- a/packages/web/src/Net/FOGFTP.php
+++ b/packages/web/src/Net/FOGFTP.php
@@ -489,11 +489,3 @@ class FOGFTP
         return in_array($path, $dirlisting);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGFTP', 'FOGFTP');

--- a/packages/web/src/Net/FOGRollingURL.php
+++ b/packages/web/src/Net/FOGRollingURL.php
@@ -88,11 +88,3 @@ class FOGRollingURL
         $this->options = [];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGRollingURL', 'FOGRollingURL');

--- a/packages/web/src/Net/FOGSSH.php
+++ b/packages/web/src/Net/FOGSSH.php
@@ -576,11 +576,3 @@ class FOGSSH
         return !$this->exists($path);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGSSH', 'FOGSSH');

--- a/packages/web/src/Net/FOGURLRequests.php
+++ b/packages/web/src/Net/FOGURLRequests.php
@@ -906,11 +906,3 @@ class FOGURLRequests extends FOGBase
         return $output;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGURLRequests', 'FOGURLRequests');

--- a/packages/web/src/Net/Ping.php
+++ b/packages/web/src/Net/Ping.php
@@ -665,11 +665,3 @@ class Ping
         return $results;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Ping', 'Ping');

--- a/packages/web/src/Router/HTTPResponseCodes.php
+++ b/packages/web/src/Router/HTTPResponseCodes.php
@@ -268,11 +268,3 @@ class HTTPResponseCodes
         exit;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\HTTPResponseCodes', 'HTTPResponseCodes');

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -2842,11 +2842,3 @@ class OpenAPI extends FOGBase
         ];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\OpenAPI', 'OpenAPI');

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -3987,9 +3987,9 @@ class Route extends FOGBase
      *
      * The route binds `:class` from a URL segment matched against
      * $validClasses, so what arrives here is a bare lowercase name -- 'host',
-     * not 'FOG\Items\Host'. It resolves today only because every file under
-     * src/ ends in a class_alias() re-exporting itself globally (ADR 0013
-     * §2), and retiring those aliases is queued work.
+     * not 'FOG\Items\Host'. `new $string` resolves from the global namespace,
+     * where core no longer is (ADR 0013 §2), so the name has to be qualified
+     * before it is instantiated.
      *
      * Qualifying at DISPATCH instead would be wrong, which is why this sits
      * here and not in runMatches(). The same $class is an identifier as well
@@ -8514,11 +8514,3 @@ class Route extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Route', 'Route');

--- a/packages/web/src/Service/FOGItemScanner.php
+++ b/packages/web/src/Service/FOGItemScanner.php
@@ -397,11 +397,3 @@ abstract class FOGItemScanner extends FOGService
         parent::serviceRun();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGItemScanner', 'FOGItemScanner');

--- a/packages/web/src/Service/FOGReplicator.php
+++ b/packages/web/src/Service/FOGReplicator.php
@@ -436,11 +436,3 @@ abstract class FOGReplicator extends FOGService
         parent::serviceRun();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGReplicator', 'FOGReplicator');

--- a/packages/web/src/Service/FOGService.php
+++ b/packages/web/src/Service/FOGService.php
@@ -1305,11 +1305,3 @@ abstract class FOGService extends FOGBase
         }
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGService', 'FOGService');

--- a/packages/web/src/Service/FileDeleter.php
+++ b/packages/web/src/Service/FileDeleter.php
@@ -336,11 +336,3 @@ class FileDeleter extends FOGService
         parent::serviceRun();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FileDeleter', 'FileDeleter');

--- a/packages/web/src/Service/ImageReplicator.php
+++ b/packages/web/src/Service/ImageReplicator.php
@@ -67,11 +67,3 @@ class ImageReplicator extends FOGReplicator
         ];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageReplicator', 'ImageReplicator');

--- a/packages/web/src/Service/ImageSize.php
+++ b/packages/web/src/Service/ImageSize.php
@@ -104,11 +104,3 @@ class ImageSize extends FOGItemScanner
             ->save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\ImageSize', 'ImageSize');

--- a/packages/web/src/Service/MulticastManager.php
+++ b/packages/web/src/Service/MulticastManager.php
@@ -825,11 +825,3 @@ class MulticastManager extends FOGService
         $this->_serviceLoop();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastManager', 'MulticastManager');

--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -1310,11 +1310,3 @@ class MulticastTask extends FOGService
         $this->_taskIDs = $newTaskIDs;
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\MulticastTask', 'MulticastTask');

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -434,11 +434,3 @@ class PingHosts extends FOGService
         parent::serviceRun();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PingHosts', 'PingHosts');

--- a/packages/web/src/Service/PluginRunner.php
+++ b/packages/web/src/Service/PluginRunner.php
@@ -230,7 +230,14 @@ class PluginRunner extends FOGService
                 // and call run() on it. The check is on the base class, so
                 // the only thing that can be loaded here is something written
                 // to be a task.
-                if (!is_subclass_of($class, 'PluginTask')) {
+                // PluginTask::class, not the string 'PluginTask'. A class
+                // name in a string is resolved as written, with no namespace
+                // applied and no `use` consulted, so the literal named the
+                // GLOBAL \PluginTask -- which existed only while core
+                // re-exported itself there (ADR 0013 §2). Without the alias
+                // the test is false for every task and the runner silently
+                // skips all of them.
+                if (!is_subclass_of($class, PluginTask::class)) {
                     self::outall(
                         sprintf(
                             ' * %s: %s/%s',
@@ -433,11 +440,3 @@ class PluginRunner extends FOGService
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\PluginRunner', 'PluginRunner');

--- a/packages/web/src/Service/RetentionRunner.php
+++ b/packages/web/src/Service/RetentionRunner.php
@@ -316,11 +316,3 @@ class RetentionRunner extends FOGService
         $this->_logIdle(_('Nothing to age out'));
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\RetentionRunner', 'RetentionRunner');

--- a/packages/web/src/Service/SnapinHash.php
+++ b/packages/web/src/Service/SnapinHash.php
@@ -114,11 +114,3 @@ class SnapinHash extends FOGItemScanner
             ->save();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinHash', 'SnapinHash');

--- a/packages/web/src/Service/SnapinReplicator.php
+++ b/packages/web/src/Service/SnapinReplicator.php
@@ -76,11 +76,3 @@ class SnapinReplicator extends FOGReplicator
         ];
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\SnapinReplicator', 'SnapinReplicator');

--- a/packages/web/src/Service/TaskScheduler.php
+++ b/packages/web/src/Service/TaskScheduler.php
@@ -363,11 +363,3 @@ class TaskScheduler extends FOGService
         parent::serviceRun();
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskScheduler', 'TaskScheduler');

--- a/packages/web/src/TaskHandling/TaskError.php
+++ b/packages/web/src/TaskHandling/TaskError.php
@@ -538,11 +538,3 @@ class TaskError extends FOGBase
         @rename($file, $file . '.1');
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskError', 'TaskError');

--- a/packages/web/src/TaskHandling/TaskQueue.php
+++ b/packages/web/src/TaskHandling/TaskQueue.php
@@ -782,11 +782,3 @@ class TaskQueue extends TaskingElement
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskQueue', 'TaskQueue');

--- a/packages/web/src/TaskHandling/TaskingElement.php
+++ b/packages/web/src/TaskHandling/TaskingElement.php
@@ -310,11 +310,3 @@ abstract class TaskingElement extends FOGBase
         return TaskLog::recordState($this->Task);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\TaskingElement', 'TaskingElement');

--- a/packages/web/src/Util/FOGCron.php
+++ b/packages/web/src/Util/FOGCron.php
@@ -328,11 +328,3 @@ class FOGCron extends FOGBase
         return (bool)($time <= $currTime);
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGCron', 'FOGCron');

--- a/packages/web/src/Util/FOGLogPaths.php
+++ b/packages/web/src/Util/FOGLogPaths.php
@@ -161,11 +161,3 @@ class FOGLogPaths
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\FOGLogPaths', 'FOGLogPaths');

--- a/packages/web/src/Util/Timer.php
+++ b/packages/web/src/Util/Timer.php
@@ -156,11 +156,3 @@ class Timer extends FOGCron
         );
     }
 }
-
-/*
- * Compatibility alias. Every consumer of this class' name -- core,
- * bundled plugins and third-party plugins alike -- keeps working
- * unqualified through this, so no call site had to be edited.
- * Supported for all of 1.6; see docs/adr/0013.
- */
-class_alias(__NAMESPACE__ . '\\Timer', 'Timer');

--- a/packages/web/status/bandwidth.php
+++ b/packages/web/status/bandwidth.php
@@ -13,6 +13,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Gets bandwidth usage of requested interface
  *

--- a/packages/web/status/dbrunning.php
+++ b/packages/web/status/dbrunning.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Db\DatabaseManager;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * Checks the database is running
  *

--- a/packages/web/status/freespace.php
+++ b/packages/web/status/freespace.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\HTTPResponseCodes;
+use FOG\Router\Route;
+
 /**
  * Gets free space of disk/partition holding images from server
  *

--- a/packages/web/status/getfiles.php
+++ b/packages/web/status/getfiles.php
@@ -10,6 +10,11 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+use FOG\Util\FOGLogPaths;
+
 /**
  * Get's files stored as requested
  *

--- a/packages/web/status/gethash.php
+++ b/packages/web/status/gethash.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+
 /**
  * Get's hash of file passed.
  *

--- a/packages/web/status/getsize.php
+++ b/packages/web/status/getsize.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\Route;
+
 /**
  * Get's size of file passed.
  *

--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Hostgetkey returns the host token for hostinfo getting
  *

--- a/packages/web/status/hw.php
+++ b/packages/web/status/hw.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Router\HTTPResponseCodes;
+
 /**
  * Presents Hardware/Software information of the server.
  *

--- a/packages/web/status/kernelvers.php
+++ b/packages/web/status/kernelvers.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Presents the FOG Kernels version that the clients will use.
  *

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -10,6 +10,10 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+use FOG\Util\FOGLogPaths;
+
 /**
  * Logtoview handles reading files
  *

--- a/packages/web/status/newtoken.php
+++ b/packages/web/status/newtoken.php
@@ -10,6 +10,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org/
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * Generates a new token on ajax request.
  *

--- a/tests/activity-sources.test.php
+++ b/tests/activity-sources.test.php
@@ -41,6 +41,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('activity-sources');

--- a/tests/all-classes-load.test.php
+++ b/tests/all-classes-load.test.php
@@ -196,6 +196,16 @@ function _declaredClasses()
     foreach ($files as $file) {
         $tokens = token_get_all(file_get_contents($file));
         $count = count($tokens);
+        // The namespace the file declares, so the name collected below is the
+        // one the file actually produces. Core no longer re-exports itself
+        // globally (ADR 0013 §2), so a bare `Host` collected from
+        // src/Items/Host.php would be a class this tree does not declare and
+        // the check would fail for all 202 of them -- while a genuinely broken
+        // file would be indistinguishable from the rest.
+        $ns = '';
+        if (preg_match('/^\s*namespace\s+([^;{]+)/m', file_get_contents($file), $nm)) {
+            $ns = trim($nm[1]) . '\\';
+        }
         for ($i = 0; $i < $count; $i++) {
             if (!is_array($tokens[$i])
                 || !in_array(
@@ -230,7 +240,7 @@ function _declaredClasses()
                 && is_array($tokens[$j])
                 && T_STRING === $tokens[$j][0]
             ) {
-                $out[] = ['name' => $tokens[$j][1], 'file' => $file];
+                $out[] = ['name' => $ns . $tokens[$j][1], 'file' => $file];
             }
         }
     }

--- a/tests/api-server-owned-fields.test.php
+++ b/tests/api-server-owned-fields.test.php
@@ -45,6 +45,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Router\Route;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -108,11 +110,11 @@ class ServerOwnedStubObj
     }
 }
 
-$hooks = new \ReflectionProperty('FOGBase', 'HookManager');
+$hooks = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
 $hooks->setAccessible(true);
 $hooks->setValue(null, new ServerOwnedStubHooks());
 
-$refuse = new \ReflectionMethod('Route', '_refuseServerOwned');
+$refuse = new \ReflectionMethod(\FOG\Router\Route::class, '_refuseServerOwned');
 $refuse->setAccessible(true);
 
 /*

--- a/tests/audit-redaction-coverage.test.php
+++ b/tests/audit-redaction-coverage.test.php
@@ -59,6 +59,9 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Redaction;
+use FOG\Router\Route;
+
 $root = dirname(__DIR__);
 $webroot = $root . '/packages/web';
 chdir($root);
@@ -100,7 +103,7 @@ if (!defined('FOG_PLUGIN_DIR')) {
 require_once $init;
 new Initiator();
 
-foreach (['Redaction', 'Route'] as $needed) {
+foreach ([\FOG\Auth\Redaction::class, \FOG\Router\Route::class] as $needed) {
     if (!class_exists($needed, true)) {
         fwrite(STDERR, "FAIL: $needed did not resolve\n");
         exit(1);

--- a/tests/autoload-core-wins.test.php
+++ b/tests/autoload-core-wins.test.php
@@ -272,11 +272,14 @@ check(
  *    a class name that does not match its filename, and a databaseFields
  *    key that does not match what assocSetter derives from Site.
  */
+// Named by their FQCN: core is PSR-4 under src/ and no longer re-exports
+// itself into the global namespace (ADR 0013 §2), so the bare spellings
+// resolve to nothing.
 $models = [
-    'SiteHostMember' => ['siteHostMembers', 'hostID'],
-    'SiteUserMember' => ['siteUserMembers', 'userID'],
-    'SiteGroupMember' => ['siteGroupMembers', 'groupID'],
-    'SiteUserGroupMember' => ['siteUserGroupMembers', 'usergroupID'],
+    'FOG\\Items\\SiteHostMember' => ['siteHostMembers', 'hostID'],
+    'FOG\\Items\\SiteUserMember' => ['siteUserMembers', 'userID'],
+    'FOG\\Items\\SiteGroupMember' => ['siteGroupMembers', 'groupID'],
+    'FOG\\Items\\SiteUserGroupMember' => ['siteUserGroupMembers', 'usergroupID'],
 ];
 foreach ($models as $class => $spec) {
     if (!class_exists($class, true)) {
@@ -288,7 +291,7 @@ foreach ($models as $class => $spec) {
     $ref = new \ReflectionClass($class);
     check(
         "$class extends FOGController",
-        $ref->isSubclassOf('FOGController'),
+        $ref->isSubclassOf(\FOG\Base\FOGController::class),
         $failures,
         $checks
     );
@@ -323,7 +326,9 @@ foreach ($models as $class => $spec) {
         $checks
     );
 
-    $mgr = $class . 'Manager';
+    // The manager lives in the Managers bucket, not alongside the model.
+    $mgr = 'FOG\\Managers\\'
+        . substr($class, strrpos($class, '\\') + 1) . 'Manager';
     check(
         "$mgr resolves",
         class_exists($mgr, true),

--- a/tests/autoload.test.php
+++ b/tests/autoload.test.php
@@ -38,7 +38,9 @@
  * other check still asserts: they are invariants of any tree that boots.
  *
  * Four things are checked:
- *   1. A representative class from each scan root resolves.
+ *   1. A representative class from each scan root resolves, by the name its
+ *      own file declares -- namespaced for core under src/, bare for the
+ *      discovery-named files under lib/ and for plugins.
  *   2. Composer's autoloader is registered and reaches vendor/. Mysqldump
  *      is the proof: it is a FOG class whose parent lives in a package, so
  *      it cannot resolve unless both loaders are in the chain and in the
@@ -52,18 +54,25 @@
  *      the basename and none of them parses source for a `class` token, so
  *      a file that breaks this is invisible to hooks, events, pages and
  *      reports while looking perfectly fine.
- *   4. Whether a namespaced name resolves. See EXPECT_BRIDGE below.
+ *   4. The shape of what resolves and what does not. See EXPECT_BRIDGE.
  *
  * Usage: php tests/autoload.test.php [path/to/packages/web]
  * Exit status 0 = pass, 1 = fail.
  */
 
 /*
- * Flipped by the commit that adds the FOG\ bridge to Initiator::autoload().
- * Before it, `FOG\Items\Host` misses silently: the map is keyed on a lowercased
- * basename so `fog\host` can never be a key, and the bare spl_autoload()
- * behind it probes for `fog/host.class.php`, which no include_path entry
- * holds. After it, `FOG\Items\Host` resolves to the same class entry as `Host`.
+ * Flipped by the commit that added the FOG\ bridge to Initiator::autoload(),
+ * and kept because the bridge is still there and still load-bearing -- just
+ * for a narrower job than it started with.
+ *
+ * It began as a shim: nothing was namespaced, so `FOG\Host` was answered by
+ * finding host.class.php and aliasing it. Core is now PSR-4 under src/ and
+ * Composer answers FOG\Items\Host directly. What is left for the bridge is
+ * the 46 discovery-named classes under lib/ -- pages, hooks, reports, the one
+ * event -- which declare a FLAT `namespace FOG;` and stay there, because
+ * FOGPageManager::loadPageClasses() derives the class name from
+ * basename($file) and PSR-4 does not do discovery. Composer maps FOG\ onto
+ * src/, so a core file's `use FOG\ReportManagement;` has no other answer.
  *
  * This constant existing rather than the assertion simply being deleted is
  * the point: the flip is the bridge's regression test.
@@ -175,37 +184,55 @@ $failures = [];
  * missing is silent until somebody takes a backup -- a fatal on a page that
  * has already sent its headers, which is a bodyless 500.
  */
-if (!class_exists('Mysqldump')) {
-    $failures[] = 'Mysqldump did not resolve; either the FOG class map has '
-        . 'lost src/Db/Mysqldump.php or commons/init.php is no longer '
+if (!class_exists('FOG\\Db\\Mysqldump')) {
+    $failures[] = 'FOG\\Db\\Mysqldump did not resolve; either Composer is no '
+        . 'longer mapping FOG\\ onto src/, or commons/init.php is no longer '
         . "requiring vendor/autoload.php, so the parent class it extends "
         . 'cannot be found';
-} elseif (!is_subclass_of('Mysqldump', 'Ifsnop\Mysqldump\Mysqldump')) {
-    $failures[] = 'Mysqldump resolved but is not a subclass of '
+} elseif (!is_subclass_of('FOG\\Db\\Mysqldump', 'Ifsnop\\Mysqldump\\Mysqldump')) {
+    $failures[] = 'FOG\\Db\\Mysqldump resolved but is not a subclass of '
         . 'Ifsnop\Mysqldump\Mysqldump; the Composer package has been '
         . 're-vendored by hand, which is what ADR 0013 exists to prevent';
 }
 
 // 1. One name per scan root, plus the two base classes everything descends
 // from and the two traits FOGPage is built out of.
+//
+// Named as each file names ITSELF. Core moved to src/ under a namespace per
+// bucket and no longer re-exports itself globally (ADR 0013 §2), so the bare
+// spellings this list used to carry now resolve to nothing -- which is the
+// decision, not a regression. The discovery-named classes under lib/ keep
+// their own class_alias and so keep answering bare, because
+// FOGPageManager::loadPageClasses() looks them up that way.
 $sample = [
-    'Host'                => 'class',   // lib/fog
-    'HostManager'         => 'class',   // lib/fog, manager
-    'FOGBase'             => 'class',   // lib/fog, root of the hierarchy
-    'FOGController'       => 'class',
-    'FOGPagePost'         => 'trait',   // lib/fog, mixed-case filename
-    'HostManagement'      => 'class',   // lib/pages
-    'UserGroupManagement' => 'class',   // lib/pages, mixed-case filename
-    'PDODB'               => 'class',   // lib/db
-    'Route'               => 'class',   // lib/router
-    'FOGClient'           => 'class',   // lib/client
-    'TaskScheduler'       => 'class',   // lib/service
-    'Registration'        => 'class',   // lib/reg-task
+    'FOG\\Items\\Host'             => 'class',   // src/Items
+    'FOG\\Managers\\HostManager'   => 'class',   // src/Managers
+    'FOG\\Base\\FOGBase'           => 'class',   // src/Base, root of the hierarchy
+    'FOG\\Base\\FOGController'     => 'class',
+    'FOG\\Base\\FOGPagePost'       => 'trait',   // src/Base, mixed-case filename
+    'HostManagement'                => 'class',   // lib/pages, discovery-named
+    'UserGroupManagement'           => 'class',   // lib/pages, mixed-case filename
+    'FOG\\Db\\PDODB'               => 'class',   // src/Db
+    'FOG\\Router\\Route'           => 'class',   // src/Router
+    'FOG\\Client\\FOGClient'       => 'class',   // src/Client
+    'FOG\\Service\\TaskScheduler'  => 'class',   // src/Service
+    'FOG\\Boot\\Registration'      => 'class',   // src/Boot
 ];
 foreach ($sample as $name => $kind) {
     $exists = $kind === 'trait' ? trait_exists($name) : class_exists($name);
     if (!$exists) {
         $failures[] = "$name did not resolve through the autoloader";
+    }
+}
+
+// 1b. And the bare spellings of the core ones do NOT resolve. Without this
+// every check above would pass just as happily with the aliases restored,
+// which is the state this whole pass exists to leave behind.
+foreach (['Host', 'HostManager', 'FOGBase', 'PDODB', 'Route'] as $bare) {
+    if (class_exists($bare)) {
+        $failures[] = "bare $bare resolved; core is aliased into the global "
+            . 'namespace again (ADR 0013 §2 retired those aliases), so a '
+            . 'plugin or an unswept caller can reach core by its short name';
     }
 }
 
@@ -262,33 +289,41 @@ foreach ($mismatched as $m) {
     $failures[] = "filename/class mismatch: $m";
 }
 
-// 4. The bridge. Asserted against the checkout, reported against a server:
-// a server legitimately runs an older FOG than the tree you are standing in,
-// and failing over that would make the diagnostic mode useless.
-$bridged = class_exists('FOG\Items\Host');
+// 4. The bridge, and the shape of what it does and does not answer. Asserted
+// against the checkout, reported against a server: a server legitimately runs
+// an older FOG than the tree you are standing in, and failing over that would
+// make the diagnostic mode useless.
+//
+// Probed with a discovery-named class, not with a model. FOG\Items\Host is
+// Composer's job now and proves nothing about the bridge; FOG\HostManagement
+// is the flat spelling only the bridge can serve.
+$bridged = class_exists('FOG\HostManagement');
 if (!$diagnostic && $bridged !== EXPECT_BRIDGE) {
     $failures[] = EXPECT_BRIDGE
-        ? 'FOG\Items\Host did not resolve; the Initiator::autoload() bridge is '
-            . 'missing or no longer aliases short names'
-        : 'FOG\Items\Host resolved unexpectedly; if the bridge has landed, flip '
-            . 'EXPECT_BRIDGE at the top of this file';
+        ? 'FOG\HostManagement did not resolve; Initiator::_bridgeNamespaced() '
+            . 'is missing or no longer answers the flat FOG\<Name> spelling '
+            . 'the 46 discovery-named classes under lib/ are declared with. '
+            . 'Every core file carrying a `use FOG\<Name>;` import for one of '
+            . 'them is broken by that'
+        : 'FOG\HostManagement resolved unexpectedly; if the bridge has landed, '
+            . 'flip EXPECT_BRIDGE at the top of this file';
 }
 if ($bridged) {
-    // An alias, not a second class: same class entry, so `instanceof` and
-    // every getClass()/Reflection consumer see one type. get_class() still
-    // reports the declared name -- that asymmetry is why namespacing the
-    // models is a separate problem from bridging their names.
-    $refFqcn = new \ReflectionClass('FOG\Items\Host');
-    $refShort = new \ReflectionClass('Host');
-    if ($refFqcn->getName() !== $refShort->getName()) {
-        $failures[] = 'FOG\Items\Host resolves to a different class entry than '
-            . 'Host (' . $refFqcn->getName() . ' vs ' . $refShort->getName()
-            . '); it should be an alias, not a copy';
+    // The flat name and the bare one are one class entry, because the lib/
+    // file's own class_alias() makes them so -- that alias is what
+    // FOGPageManager::loadPageClasses() resolves and is NOT among the 202
+    // retired by ADR 0013 §2.
+    $refFlat = new \ReflectionClass('FOG\HostManagement');
+    $refShort = new \ReflectionClass('HostManagement');
+    if ($refFlat->getName() !== $refShort->getName()) {
+        $failures[] = 'FOG\HostManagement resolves to a different class entry '
+            . 'than HostManagement (' . $refFlat->getName() . ' vs '
+            . $refShort->getName() . '); it should be an alias, not a copy';
     }
     if (!trait_exists('FOG\Base\FOGPagePost')) {
-        $failures[] = 'the bridge does not carry traits';
+        $failures[] = 'Composer does not carry traits';
     }
-    if (!class_exists('fog\Image')) {
+    if (!class_exists('fog\HostManagement')) {
         $failures[] = 'the bridge is case-sensitive on the namespace prefix; '
             . 'PHP class names are not';
     }
@@ -302,6 +337,15 @@ if ($bridged) {
     if (class_exists('Vendor\Host')) {
         $failures[] = 'the bridge answered for a foreign namespace; a '
             . 'plugin\'s Vendor\Host must not silently become core Host';
+    }
+    // A flat FOG\<Name> for a class that lives in a BUCKET under src/ is a
+    // wrong spelling, not a name to bridge. Answering it would put core back
+    // within reach of a name no file declares, and -- because core is absent
+    // from the classMap -- would hand the key to any plugin shipping
+    // class/host.class.php.
+    if (class_exists('FOG\Host')) {
+        $failures[] = 'the bridge answered FOG\Host; core is namespaced per '
+            . 'bucket, so only FOG\Items\Host names that class';
     }
 }
 

--- a/tests/class-name-derivation.test.php
+++ b/tests/class-name-derivation.test.php
@@ -39,6 +39,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGBase;
+
 $root = dirname(__DIR__);
 chdir($root);
 

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -53,6 +53,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGBase;
+use FOG\Base\FOGCore;
+use FOG\Items\TaskLog;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('db-failure');

--- a/tests/event-frame-readers.test.php
+++ b/tests/event-frame-readers.test.php
@@ -33,6 +33,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('event-frame-readers');

--- a/tests/event-frame-writers.test.php
+++ b/tests/event-frame-writers.test.php
@@ -41,6 +41,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('event-frame');

--- a/tests/grid-header-column-agreement.test.php
+++ b/tests/grid-header-column-agreement.test.php
@@ -36,6 +36,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('grid-header-columns');

--- a/tests/grid-host-name-order.test.php
+++ b/tests/grid-host-name-order.test.php
@@ -39,6 +39,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('host-name-order');

--- a/tests/grid-order-clause.test.php
+++ b/tests/grid-order-clause.test.php
@@ -26,6 +26,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGManagerController;
+
 $root = rtrim(
     $argv[1] ?? dirname(__DIR__) . '/packages/web',
     '/'

--- a/tests/history-untranslated-and-bounded.test.php
+++ b/tests/history-untranslated-and-bounded.test.php
@@ -44,6 +44,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('history-untranslated');

--- a/tests/lib/fog-schema-collector.php
+++ b/tests/lib/fog-schema-collector.php
@@ -243,15 +243,31 @@ class SchemaCollector extends SchemaStub
 
 spl_autoload_register(
     function ($class) {
-        // schema.php is global-namespaced, so anything carrying a separator is
-        // not a name it could have written and not ours to invent.
-        if (strpos($class, '\\') !== false) {
+        // Namespaced names are stubbed too, in their own namespace.
+        //
+        // schema.php used to be able to name only global classes, because
+        // core re-exported every one of them there. It now carries `use
+        // FOG\Items\Schema;` and friends (ADR 0013 §2), so `Schema::` in
+        // that file means FOG\Items\Schema and a global stub answers
+        // nothing -- the collector died on the file's second line.
+        //
+        // The stub is declared where the name says it lives, and still
+        // extends the one global SchemaStub, so every shimmed method stays in
+        // one place regardless of which namespace asked for it.
+        if (!preg_match(
+            '/^[A-Za-z_][A-Za-z0-9_]*(?:\\\\[A-Za-z_][A-Za-z0-9_]*)*$/',
+            $class
+        )) {
             return;
         }
-        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $class)) {
+        $pos = strrpos($class, '\\');
+        if (false === $pos) {
+            eval("class {$class} extends SchemaStub {}");
             return;
         }
-        eval("class {$class} extends SchemaStub {}");
+        $ns = substr($class, 0, $pos);
+        $short = substr($class, $pos + 1);
+        eval("namespace {$ns}; class {$short} extends \\SchemaStub {}");
     }
 );
 

--- a/tests/lib/fog-test-harness.php
+++ b/tests/lib/fog-test-harness.php
@@ -34,6 +34,10 @@
  * at the top level only, so a helper in tests/lib/ is invisible to it.
  */
 
+use FOG\Base\EventManager;
+use FOG\Base\FOGCore;
+use FOG\Base\HookManager;
+
 /**
  * One prepared statement's worth of canned rows.
  */
@@ -393,9 +397,33 @@ class FogTestHarness
      *
      * @return void
      */
+    /**
+     * Resolve a short core class name to its namespaced one.
+     *
+     * The reflection helpers below take a class NAME as a string, and every
+     * call site in the suite passes the short one -- setStatic('FOGBase', ...)
+     * reads as what it is in a way that FOG\Base\FOGBase does not. Core is no
+     * longer aliased into the global namespace (ADR 0013 §2), so a string has
+     * to be resolved rather than merely reflected on.
+     *
+     * FOGBase::qualify() is the same lookup production code uses -- getClass()
+     * and Route::_newEntity() both go through it -- so the harness cannot
+     * accept a name the application would reject, and a name that is not
+     * core's (a test's own fixture class, a plugin double) is returned
+     * untouched and reflects exactly as before.
+     *
+     * @param string $class the short or already-qualified class name
+     *
+     * @return string
+     */
+    private static function _resolve($class)
+    {
+        return \FOG\Base\FOGBase::qualify((string)$class);
+    }
+
     public static function setStatic($class, $property, $value)
     {
-        $p = new \ReflectionProperty($class, $property);
+        $p = new \ReflectionProperty(self::_resolve($class), $property);
         $p->setAccessible(true);
         $p->setValue(null, $value);
     }
@@ -410,7 +438,7 @@ class FogTestHarness
      */
     public static function getStatic($class, $property)
     {
-        $p = new \ReflectionProperty($class, $property);
+        $p = new \ReflectionProperty(self::_resolve($class), $property);
         $p->setAccessible(true);
         return $p->getValue();
     }
@@ -426,7 +454,7 @@ class FogTestHarness
      */
     public static function callStatic($class, $method, array $args = [])
     {
-        $m = new \ReflectionMethod($class, $method);
+        $m = new \ReflectionMethod(self::_resolve($class), $method);
         $m->setAccessible(true);
         return $m->invokeArgs(null, $args);
     }

--- a/tests/nicedate-empty-is-no-value.test.php
+++ b/tests/nicedate-empty-is-no-value.test.php
@@ -31,6 +31,8 @@
  * @link     https://fogproject.org
  */
 
+use FOG\Base\FOGBase;
+
 $root = dirname(__DIR__);
 $web = $root . '/packages/web';
 $failures = [];

--- a/tests/no-bare-core-references.test.php
+++ b/tests/no-bare-core-references.test.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * No file outside src/ names a core class by its bare short name.
+ *
+ * Core is PSR-4 under packages/web/src/ and, since ADR 0013 §2 was amended,
+ * no longer ends each file with class_alias(__NAMESPACE__ . '\X', 'X'). PHP
+ * falls back to the global namespace for functions and constants but NEVER
+ * for class names, so a bare `Route::` or `extends Hook` anywhere else is a
+ * class-not-found at the moment that line runs.
+ *
+ * WHY THIS SCANS THE WHOLE TREE RATHER THAN A LIST OF DIRECTORIES.
+ * bin/import-core-classes.php carries a hand-maintained $targets list, and
+ * that list is what failed: the first sweep covered lib/, commons/, service/,
+ * api/, management/ and packages/service, and silently missed status/ (17
+ * files) and maintenance/ (3). Those are live endpoints -- the storage-node
+ * and fog-client surface: bandwidth, getfiles, gethash, hostgetkey, newtoken,
+ * create_update_node -- and every one of them would have fataled on the first
+ * request after the aliases went. Nothing in the suite drives them, which is
+ * exactly why they were easy to forget.
+ *
+ * So the input here is `git ls-files`, minus src/ and vendor/. A directory
+ * added tomorrow is covered without anyone remembering to add it.
+ *
+ * TOKENISED, NEVER REGEX. A class name in a docblock, in a string or after
+ * `->` is not a class reference, and grepping for `Route` finds all three.
+ *
+ * What is deliberately NOT reported:
+ *
+ *  - a name the file imports, declares itself, or already qualifies;
+ *  - a name reached through a namespace the file's own `namespace` resolves
+ *    -- one of the 46 flat lib/ classes referring to another;
+ *  - a class name inside a STRING. Those are real and they matter, but they
+ *    resolve through FOGBase::qualify() rather than through `use`, and
+ *    tests/getclass-resolves-without-aliases.test.php is where that lives.
+ *
+ * Usage: php tests/no-bare-core-references.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+$web = $repo . '/packages/web';
+
+/** Core under src/: lowercased short name => FQCN. PSR-4, so the path IS the name. */
+$core = [];
+$walk = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($web . '/src')
+);
+foreach ($walk as $file) {
+    if ($file->isFile() && 'php' === $file->getExtension()) {
+        $short = $file->getBasename('.php');
+        $core[strtolower($short)] = 'FOG\\'
+            . basename(dirname($file->getPathname())) . '\\' . $short;
+    }
+}
+if (count($core) < 150) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($core) . " classes found under packages/web/src;"
+        . " the scan root looks wrong, so this test would pass by measuring"
+        . " nothing.\n"
+    );
+    exit(1);
+}
+
+$files = [];
+exec(
+    'cd ' . escapeshellarg($repo) . ' && git ls-files "*.php" 2>/dev/null',
+    $files
+);
+if (count($files) < 200) {
+    fwrite(
+        STDERR,
+        'FAIL: git ls-files returned ' . count($files) . " PHP files; expected"
+        . " the whole tree. Not run from a checkout?\n"
+    );
+    exit(1);
+}
+
+$skipTokens = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
+$hits = [];
+$scanned = 0;
+
+foreach ($files as $rel) {
+    // src/ is core itself, and vendor/ is not ours to edit.
+    if (0 === strpos($rel, 'packages/web/src/')
+        || false !== strpos($rel, '/vendor/')
+    ) {
+        continue;
+    }
+    $path = $repo . '/' . $rel;
+    if (!is_readable($path)) {
+        continue;
+    }
+    $src = file_get_contents($path);
+    $scanned++;
+
+    $ns = preg_match('/^namespace\s+([^;]+);/m', $src, $m) ? trim($m[1]) : '';
+    // Names the file already resolves: its imports and its own declarations.
+    $known = [];
+    if (preg_match_all('/^use\s+([^;]+);$/m', $src, $um)) {
+        foreach ($um[1] as $use) {
+            $use = trim($use);
+            $bind = false !== stripos($use, ' as ')
+                ? trim(preg_split('/\s+as\s+/i', $use)[1])
+                : substr(strrchr('\\' . $use, '\\'), 1);
+            $known[strtolower($bind)] = true;
+        }
+    }
+    if (preg_match_all(
+        '/^\s*(?:final\s+|abstract\s+)*(?:class|interface|trait)\s+(\w+)/mi',
+        $src,
+        $dm
+    )) {
+        foreach ($dm[1] as $name) {
+            $known[strtolower($name)] = true;
+        }
+    }
+
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i]) || T_STRING !== $tokens[$i][0]) {
+            continue;
+        }
+        $name = $tokens[$i][1];
+        $key = strtolower($name);
+        if (!isset($core[$key]) || isset($known[$key])) {
+            continue;
+        }
+        // Keywords that tokenise as T_STRING and are not class references.
+        if (in_array($key, ['self', 'parent', 'static'], true)) {
+            continue;
+        }
+        // The previous significant token. Skipping whitespace matters: PHP
+        // puts a T_WHITESPACE between `new` and the name, so $tokens[$i - 1]
+        // never sees the T_NEW and a naive scanner misses every `new Foo()`.
+        $prev = $i - 1;
+        while ($prev >= 0
+            && is_array($tokens[$prev])
+            && in_array($tokens[$prev][0], $skipTokens, true)
+        ) {
+            $prev--;
+        }
+        // Already qualified (\Foo or Bar\Foo), a method name, a property, or
+        // a function declaration -- none of these is an unqualified class
+        // reference.
+        if (isset($tokens[$prev])
+            && is_array($tokens[$prev])
+            && in_array(
+                $tokens[$prev][0],
+                [
+                    T_NS_SEPARATOR, T_OBJECT_OPERATOR, T_DOUBLE_COLON,
+                    T_FUNCTION, T_CONST
+                ],
+                true
+            )
+        ) {
+            continue;
+        }
+        $next = $i + 1;
+        while ($next < $count
+            && is_array($tokens[$next])
+            && in_array($tokens[$next][0], $skipTokens, true)
+        ) {
+            $next++;
+        }
+        $isRef = (isset($tokens[$next])
+                && is_array($tokens[$next])
+                && T_DOUBLE_COLON === $tokens[$next][0])
+            || (isset($tokens[$prev])
+                && is_array($tokens[$prev])
+                && in_array(
+                    $tokens[$prev][0],
+                    [T_NEW, T_EXTENDS, T_IMPLEMENTS, T_INSTANCEOF],
+                    true
+                ));
+        if ($isRef) {
+            $hits[] = sprintf(
+                '  %s:%d  %s  ->  use %s;',
+                $rel,
+                $tokens[$i][2],
+                $name,
+                $core[$key]
+            );
+        }
+    }
+}
+
+$hits = array_values(array_unique($hits));
+if ($hits) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($hits) . " bare reference(s) to a core class:\n"
+        . implode("\n", $hits) . "\n\n"
+        . "Core is namespaced under packages/web/src/ and is not aliased into\n"
+        . "the global namespace (ADR 0013 §2). Add the import shown, or run\n"
+        . "  php bin/import-core-classes.php --fix\n"
+    );
+    exit(1);
+}
+
+printf(
+    "ok  %d file(s) scanned against %d core classes, 0 bare references\n",
+    $scanned,
+    count($core)
+);
+exit(0);

--- a/tests/object-scope-enforcement.test.php
+++ b/tests/object-scope-enforcement.test.php
@@ -29,6 +29,9 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -79,7 +82,7 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-foreach (['Authorization', 'SiteScope'] as $needed) {
+foreach ([\FOG\Auth\Authorization::class, \FOG\Auth\SiteScope::class] as $needed) {
     if (!class_exists($needed, true)) {
         fwrite(STDERR, "FAIL: $needed does not resolve\n");
         exit(1);
@@ -123,11 +126,11 @@ class FakeDB
  * third-party plugin. Registering on the live HookManager is the honest
  * way to test composition -- it is the same path a real plugin takes.
  */
-$hookProp = new \ReflectionProperty('FOGBase', 'HookManager');
+$hookProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
 $hookProp->setAccessible(true);
-$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
 $dbProp->setAccessible(true);
-$permProp = new \ReflectionProperty('Authorization', '_permCache');
+$permProp = new \ReflectionProperty(\FOG\Auth\Authorization::class, '_permCache');
 $permProp->setAccessible(true);
 
 /** A hook manager that fires only the listener a test hands it. */

--- a/tests/permission-purge-guard.test.php
+++ b/tests/permission-purge-guard.test.php
@@ -25,6 +25,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -78,7 +80,7 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-if (!class_exists('Authorization', true)) {
+if (!class_exists(\FOG\Auth\Authorization::class, true)) {
     fwrite(STDERR, "FAIL: Authorization did not resolve\n");
     exit(1);
 }

--- a/tests/ping-alive-codes.test.php
+++ b/tests/ping-alive-codes.test.php
@@ -31,6 +31,11 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Net\Ping;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('ping-alive');

--- a/tests/ping-icmp-echo.test.php
+++ b/tests/ping-icmp-echo.test.php
@@ -36,6 +36,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Net\Ping;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('ping-icmp-echo');

--- a/tests/plugin-list-scope-events.test.php
+++ b/tests/plugin-list-scope-events.test.php
@@ -33,6 +33,9 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -83,7 +86,13 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-foreach (['Authorization', 'SiteScope', 'Host'] as $needed) {
+foreach (
+    [
+        \FOG\Auth\Authorization::class,
+        \FOG\Auth\SiteScope::class,
+        \FOG\Items\Host::class,
+    ] as $needed
+) {
     if (!class_exists($needed, true)) {
         fwrite(STDERR, "FAIL: $needed does not resolve\n");
         exit(1);
@@ -142,11 +151,11 @@ class FakeHookManager
     }
 }
 
-$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
 $dbProp->setAccessible(true);
-$hookProp = new \ReflectionProperty('FOGBase', 'HookManager');
+$hookProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
 $hookProp->setAccessible(true);
-$permProp = new \ReflectionProperty('Authorization', '_permCache');
+$permProp = new \ReflectionProperty(\FOG\Auth\Authorization::class, '_permCache');
 $permProp->setAccessible(true);
 
 /**

--- a/tests/psr4-bridge.test.php
+++ b/tests/psr4-bridge.test.php
@@ -1,34 +1,47 @@
 <?php
 /**
- * Bare class names still resolve once core lives under src/, and a plugin
- * still cannot shadow a core class.
+ * Core resolves by its NAMESPACED name only, and a plugin still cannot shadow
+ * a core class.
  *
- * Commit 1 of docs/composer-psr4-plan.md. Composer's loader claims the FOG\
- * prefix and answers nothing else, so the moment core leaves Initiator's
- * classMap a request for the BARE name `Host` has no answer -- and bare names
- * are how FOGProject/fog-plugins inherits from core 168 times and how all 52
- * entries in Route::$validClasses resolve. autoload() therefore grew a second,
- * opposite arm. This is what holds it.
+ * docs/composer-psr4-plan.md. Composer's loader claims the FOG\ prefix and
+ * answers nothing else, so once core left Initiator's classMap a request for
+ * the BARE name `Host` had no answer. For one release cycle every file under
+ * src/ ended in class_alias(__NAMESPACE__ . '\X', 'X') and the bare spelling
+ * kept working. Those 202 aliases are now gone (ADR 0013 §2), and this is
+ * what holds what replaced them.
  *
- * Two properties, and the second is the one that is easy to lose:
+ * Four properties. The third is the one that is easy to lose and the fourth
+ * is the one the retirement nearly took with it:
  *
- *   1. `Host`, `host` and `HOST` all resolve to the class in src/. The map is
- *      keyed on the lowercased basename because that is the only spelling
- *      every caller agrees on.
- *   2. The src/ arm runs BEFORE the classMap. The classMap's core-wins rule
- *      works by preferring one of two candidates for a key -- and once core
- *      is not in that map, a plugin shipping class/host.class.php is the only
- *      candidate and wins outright. Order is now the whole of that guarantee,
- *      so reordering these two lookups is a privilege escalation with no
- *      other symptom.
+ *   1. The namespaced name resolves, through Composer, from the bucket the
+ *      file sits in. FOG\Items\ProbeAlpha, not FOG\ProbeAlpha.
+ *   2. The bare name does NOT resolve, in any spelling. This is the whole
+ *      point of the retirement, and an accidental alias anywhere would make
+ *      every other check here pass for the wrong reason.
+ *   3. A plugin shipping class/probealpha.class.php STILL cannot answer a
+ *      bare `ProbeAlpha`. Core is not in the classMap, so that plugin file
+ *      is the only candidate for the key and would win outright -- the
+ *      autoloader recognises the name as core's and refuses rather than
+ *      falling through. Losing that is a privilege escalation with no other
+ *      symptom, and note it is now a REFUSAL rather than a preference: the
+ *      old ordering guarantee has nothing left to order.
+ *   4. A FLAT FOG\<Name> still resolves when a flat FOG\<Name> is what the
+ *      file declares. The 46 discovery-named classes under lib/ -- pages,
+ *      hooks, reports, the one event -- are `namespace FOG;` and stay there,
+ *      because FOGPageManager::loadPageClasses() derives their class name
+ *      from basename($file) and PSR-4 does not do discovery. Composer maps
+ *      FOG\ onto src/, so `use FOG\ReportManagement;` in a core file is
+ *      answered by Initiator::_bridgeNamespaced() and by nothing else. The
+ *      plan said to delete that bridge alongside the aliases; doing so breaks
+ *      every core file that imports one of the 46.
  *
  * Runs against a MINIATURE tree in the system temp directory -- a copy of
- * commons/init.php with its own src/ and lib/plugins/ -- rather than against
- * packages/web. Initiator derives BASEPATH from its own location, so a copied
- * init.php gets a BASEPATH of the copy, and the probe classes never touch the
- * repository. That matters more than tidiness here: this test deliberately
- * creates a plugin file NAMED AFTER a core class, and leaving one of those in
- * a real tree is the exact defect under test.
+ * commons/init.php with its own src/, lib/pages/ and lib/plugins/ -- rather
+ * than against packages/web. Initiator derives BASEPATH from its own location,
+ * so a copied init.php gets a BASEPATH of the copy, and the probe classes
+ * never touch the repository. That matters more than tidiness here: this test
+ * deliberately creates a plugin file NAMED AFTER a core class, and leaving one
+ * of those in a real tree is the exact defect under test.
  *
  * DB-free: Initiator's constructor only registers the autoloader. It is
  * startInit() that reaches MySQL, and it is never called.
@@ -57,8 +70,8 @@ register_shutdown_function(
     }
 );
 
-foreach (['commons', 'src/Items', 'src/Base', 'lib/plugins/probeplug/class',
-          'cache', 'log', 'extplugins'] as $d) {
+foreach (['commons', 'src/Items', 'src/Base', 'lib/pages',
+          'lib/plugins/probeplug/class', 'cache', 'log', 'extplugins'] as $d) {
     if (!@mkdir($tmp . '/' . $d, 0700, true) && !is_dir($tmp . '/' . $d)) {
         fwrite(STDERR, "FAIL: cannot create $tmp/$d\n");
         exit(1);
@@ -79,8 +92,8 @@ if (!@copy($web . '/commons/init.php', $tmp . '/commons/init.php')) {
  */
 file_put_contents(
     $tmp . '/src/Items/ProbeAlpha.php',
-    "<?php\nnamespace FOG;\nclass ProbeAlpha { public static function who() { return 'core'; } }\n"
-    . "class_alias(__NAMESPACE__ . '\\ProbeAlpha', 'ProbeAlpha');\n"
+    "<?php\nnamespace FOG\\Items;\n"
+    . "class ProbeAlpha { public static function who() { return 'core'; } }\n"
 );
 file_put_contents(
     $tmp . '/lib/plugins/probeplug/class/probealpha.class.php',
@@ -95,12 +108,23 @@ file_put_contents(
     "<?php\nclass ProbeOnlyPlugin { }\n"
 );
 /*
- * A src/ file that forgets its class_alias. ADR 0013 requires one; this is
- * what a reader gets when it is missing.
+ * A second core class, in a DIFFERENT bucket. srcClassMap() derives the
+ * namespace from the parent directory name, so one bucket cannot prove it.
  */
 file_put_contents(
-    $tmp . '/src/Base/ProbeNoAlias.php',
-    "<?php\nnamespace FOG;\nclass ProbeNoAlias { }\n"
+    $tmp . '/src/Base/ProbeBeta.php',
+    "<?php\nnamespace FOG\\Base;\nclass ProbeBeta { }\n"
+);
+/*
+ * A discovery-named page, standing in for the 46 under lib/. Flat
+ * `namespace FOG;` plus its own class_alias back to the global name -- which
+ * is NOT the retired kind. FOGPageManager::loadPageClasses() looks the class
+ * up by basename, so these files keep theirs.
+ */
+file_put_contents(
+    $tmp . '/lib/pages/probediscovered.page.php',
+    "<?php\nnamespace FOG;\nclass ProbeDiscovered { }\n"
+    . "class_alias(__NAMESPACE__ . '\\ProbeDiscovered', 'ProbeDiscovered');\n"
 );
 
 define('FOG_CACHE_DIR', $tmp . '/cache');
@@ -118,7 +142,7 @@ new Initiator();
 if (is_readable($web . '/vendor/composer/ClassLoader.php')) {
     require_once $web . '/vendor/composer/ClassLoader.php';
     $loader = new \Composer\Autoload\ClassLoader();
-    $loader->setPsr4('FOG\\', [$tmp . '/src', $tmp . '/src/Items', $tmp . '/src/Base']);
+    $loader->setPsr4('FOG\\', [$tmp . '/src']);
     $loader->register(true);
 }
 
@@ -140,7 +164,7 @@ $fileOf = function ($class) {
 // 1. The src/ scan finds the files and keys them lowercased.
 $map = Initiator::srcFileList();
 check('srcFileList finds ProbeAlpha', isset($map['probealpha']), $failures, $checks);
-check('srcFileList finds ProbeNoAlias', isset($map['probenoalias']), $failures, $checks);
+check('srcFileList finds ProbeBeta', isset($map['probebeta']), $failures, $checks);
 check(
     'srcFileList keys are lowercased',
     $map === array_change_key_case($map, CASE_LOWER),
@@ -148,44 +172,98 @@ check(
     $checks
 );
 
-// 2. Every spelling of a bare name resolves, and to the SAME type.
-foreach (['ProbeAlpha', 'probealpha', 'PROBEALPHA'] as $spelling) {
-    check("bare '$spelling' resolves", class_exists($spelling), $failures, $checks);
-}
+// 1b. srcClassMap turns those into FQCNs, taking the namespace from the
+// bucket directory. FOGBase::qualify() is this map, and every string-driven
+// instantiation left in core -- getClass(), Route::_newEntity(),
+// FOGPage's $childClass -- resolves through it.
+$classMap = Initiator::srcClassMap();
 check(
-    'all three spellings are one type',
-    class_exists('ProbeAlpha')
-    && (new \ReflectionClass('probealpha'))->getName()
-       === (new \ReflectionClass('PROBEALPHA'))->getName(),
+    'srcClassMap qualifies into the Items bucket',
+    ($classMap['probealpha'] ?? null) === 'FOG\\Items\\ProbeAlpha',
+    $failures,
+    $checks
+);
+check(
+    'srcClassMap qualifies into the Base bucket',
+    ($classMap['probebeta'] ?? null) === 'FOG\\Base\\ProbeBeta',
     $failures,
     $checks
 );
 
-// 3. THE ONE THAT MATTERS. Core wins over a plugin file of the same name.
+// 2. The bare name does not resolve, in any spelling.
+//
+// First, because that is the decision. Second, because every check below it
+// would pass for the wrong reason if an alias crept back in -- check 3 in
+// particular reads "core answered, not the plugin" and an alias makes that
+// true without the autoloader having refused anything.
+foreach (['ProbeAlpha', 'probealpha', 'PROBEALPHA'] as $spelling) {
+    check("bare '$spelling' does NOT resolve", !class_exists($spelling), $failures, $checks);
+}
+
+// 3. THE ONE THAT MATTERS. A plugin file named after a core class cannot
+// answer the bare name either -- the refusal in check 2 has to be a refusal,
+// not a fall-through to lib/plugins.
 check(
-    'bare ProbeAlpha resolves to src/, not to the plugin',
-    $fileOf('ProbeAlpha') === $tmp . '/src/Items/ProbeAlpha.php',
+    'the plugin file did not answer bare ProbeAlpha',
+    null === $fileOf('ProbeAlpha'),
+    $failures,
+    $checks
+);
+
+// 4. The namespaced name resolves, from its bucket, to the core file.
+check(
+    'FOG\Items\ProbeAlpha resolves',
+    class_exists('FOG\Items\ProbeAlpha'),
     $failures,
     $checks
 );
 check(
     'and it is the core implementation that answers',
-    class_exists('ProbeAlpha') && ProbeAlpha::who() === 'core',
+    class_exists('FOG\Items\ProbeAlpha')
+    && \FOG\Items\ProbeAlpha::who() === 'core',
     $failures,
     $checks
 );
-
-// 4. The namespaced spelling is the same type -- one class, two names.
 check(
-    'FOG\ProbeAlpha is the same type as bare ProbeAlpha',
-    class_exists('FOG\ProbeAlpha')
-    && (new \ReflectionClass('FOG\ProbeAlpha'))->getName()
-       === (new \ReflectionClass('ProbeAlpha'))->getName(),
+    'and it is the src/ file, not the plugin one',
+    $fileOf('FOG\Items\ProbeAlpha') === $tmp . '/src/Items/ProbeAlpha.php',
     $failures,
     $checks
 );
 
-// 5. The arm falls through: a plugin-only class still resolves via classMap.
+// 5. A FLAT FOG\<Name> for a BUCKETED core class is a wrong spelling, not a
+// name to resolve. Refused, for the same shadowing reason as check 3.
+check(
+    'flat FOG\ProbeAlpha does not resolve',
+    !class_exists('FOG\ProbeAlpha'),
+    $failures,
+    $checks
+);
+
+// 6. A FLAT FOG\<Name> that a lib/ file actually DECLARES does resolve.
+// This is the arm the plan said to delete; `use FOG\ReportManagement;` in
+// core has no other answer. See the header.
+check(
+    'FOG\ProbeDiscovered resolves through the bridge',
+    class_exists('FOG\ProbeDiscovered'),
+    $failures,
+    $checks
+);
+check(
+    'and it is the lib/pages file that declared it',
+    $fileOf('FOG\ProbeDiscovered') === $tmp . '/lib/pages/probediscovered.page.php',
+    $failures,
+    $checks
+);
+check(
+    'and its own class_alias still exports the bare name, which is what '
+    . 'FOGPageManager::loadPageClasses() looks up',
+    class_exists('ProbeDiscovered'),
+    $failures,
+    $checks
+);
+
+// 7. The arm falls through: a plugin-only class still resolves via classMap.
 check(
     'a plugin-only class still resolves',
     class_exists('ProbeOnlyPlugin'),
@@ -200,21 +278,7 @@ check(
     $checks
 );
 
-// 6. A src/ file with no class_alias does not silently half-work.
-check(
-    'namespaced name resolves without the alias',
-    class_exists('FOG\ProbeNoAlias'),
-    $failures,
-    $checks
-);
-check(
-    'but the bare name does not',
-    !class_exists('ProbeNoAlias'),
-    $failures,
-    $checks
-);
-
-// 7. The map is memoised, and forgetting it clears both maps and both caches.
+// 8. The map is memoised, and forgetting it clears both maps and both caches.
 $cacheFile = FOG_CACHE_DIR . '/srcmap.' . md5($tmp . '/src') . '.json';
 check('the src map is persisted', is_file($cacheFile), $failures, $checks);
 check(

--- a/tests/relationship-filter-in-join.test.php
+++ b/tests/relationship-filter-in-join.test.php
@@ -36,6 +36,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('relfilter');
@@ -141,7 +143,13 @@ $classes = [
 $pluginOwned = ['OUAssociation'];
 $pluginsFetched = is_dir(dirname(__DIR__) . '/packages/web/lib/plugins');
 foreach ($classes as $class) {
-    if (!class_exists($class)) {
+    // Resolved through qualify(), which is exactly what relFilterBuild()'s
+    // getClass() call does below -- so the existence check and the thing it
+    // guards cannot disagree about which class a short name means. Core is
+    // namespaced under src/ and no longer aliased into the global namespace
+    // (ADR 0013 §2); the short names are kept here because they are also the
+    // labels in every message this loop writes.
+    if (!class_exists(\FOG\Base\FOGBase::qualify($class))) {
         if (in_array($class, $pluginOwned, true) && !$pluginsFetched) {
             echo "  SKIP  $class is plugin-provided and lib/plugins is not"
                 . " fetched here\n";

--- a/tests/retention-registry.test.php
+++ b/tests/retention-registry.test.php
@@ -33,6 +33,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Audit\Retention;
+
 $root = dirname(__DIR__);
 $webroot = $root . '/packages/web';
 $init = $webroot . '/commons/init.php';
@@ -84,7 +86,7 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-if (!class_exists('Retention', true)) {
+if (!class_exists(\FOG\Audit\Retention::class, true)) {
     fwrite(STDERR, "FAIL: Retention did not resolve\n");
     exit(1);
 }

--- a/tests/retention-runner-daemon.test.php
+++ b/tests/retention-runner-daemon.test.php
@@ -288,8 +288,9 @@ check(
     $checks
 );
 check(
-    'and keeps the unqualified alias every plugin ABI expects (ADR 0013)',
-    false !== strpos($class, "class_alias(__NAMESPACE__ . '\\\\RetentionRunner'"),
+    'and declares itself in the FOG\\Service namespace, with no global alias',
+    false !== strpos($class, 'namespace FOG\\Service;')
+    && false === strpos($class, 'class_alias('),
     $failures,
     $checks
 );

--- a/tests/route-column-contract.test.php
+++ b/tests/route-column-contract.test.php
@@ -52,6 +52,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 $fixture = __DIR__ . '/fixtures/route-column-contract.txt';

--- a/tests/route-ids-getfield-sensitive.test.php
+++ b/tests/route-ids-getfield-sensitive.test.php
@@ -44,6 +44,10 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\EventManager;
+use FOG\Base\HookManager;
+use FOG\Router\Route;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -175,7 +179,7 @@ class FakeDB
 }
 
 $db = new FakeDB();
-$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
 $dbProp->setAccessible(true);
 
 // LoadGlobals is what normally builds these, and it needs a real database.
@@ -184,10 +188,10 @@ $dbProp->setAccessible(true);
 // HookManager::processEvent()'s own getIds() call. It loads nothing: the
 // plugin dir is the empty temp dir above and every core hook ships
 // $active = false.
-$hmProp = new \ReflectionProperty('FOGBase', 'HookManager');
+$hmProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
 $hmProp->setAccessible(true);
 $hmProp->setValue(null, new HookManager());
-$emProp = new \ReflectionProperty('FOGBase', 'EventManager');
+$emProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'EventManager');
 $emProp->setAccessible(true);
 $emProp->setValue(null, new EventManager());
 
@@ -374,10 +378,10 @@ check(
  *    Proven by clearing the memo and asking again from scratch. A regression
  *    exhausts memory rather than failing, which is loud enough.
  */
-$mapProp = new \ReflectionProperty('Route', '_sensitiveMap');
+$mapProp = new \ReflectionProperty(\FOG\Router\Route::class, '_sensitiveMap');
 $mapProp->setAccessible(true);
 $mapProp->setValue(null, null);
-$knownProp = new \ReflectionProperty('HookManager', 'knownEvents');
+$knownProp = new \ReflectionProperty(\FOG\Base\HookManager::class, 'knownEvents');
 $knownProp->setAccessible(true);
 $knownProp->setValue(null, null);
 Route::ids('host', 'id=1', 'sec_tok');

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -52,6 +52,12 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+use FOG\Base\FOGCore;
+use FOG\Base\Hook;
+use FOG\Router\Route;
+
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
 // ---------------------------------------------------------------------------
@@ -452,7 +458,7 @@ foreach ([['host', $hostBlocked], ['user', $userBlocked]] as list($class, $block
  * 42, and a hand-thrown Exception defaults to 0 -- either one reaching
  * breakHead() as a status is a worse answer than the catch-all it replaced.
  */
-$sendCaught = new \ReflectionMethod('Route', '_sendCaught');
+$sendCaught = new \ReflectionMethod(\FOG\Router\Route::class, '_sendCaught');
 $sendCaught->setAccessible(true);
 foreach ([['42S22', 406], [0, 406], [399, 406], [404, 404], [600, 406]] as list($raised, $want)) {
     $got = null;

--- a/tests/route-result-wrappers.test.php
+++ b/tests/route-result-wrappers.test.php
@@ -22,6 +22,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Router\Route;
+
 $web = dirname(__DIR__) . '/packages/web';
 $init = $web . '/commons/init.php';
 
@@ -70,12 +72,12 @@ function expect(array &$failures, $label, $want, $got)
     }
 }
 
-if (!class_exists('Route')) {
+if (!class_exists(\FOG\Router\Route::class)) {
     fwrite(STDERR, "FAIL: Route did not autoload\n");
     exit(1);
 }
 
-$ref = new \ReflectionClass('Route');
+$ref = new \ReflectionClass(\FOG\Router\Route::class);
 
 foreach (['getList', 'getItem', 'getIds', 'getNames', 'asValue', 'objectify', 'unwrapData'] as $method) {
     if (!$ref->hasMethod($method)) {
@@ -229,12 +231,12 @@ define('FOG_PLUGIN_DIR', $tmp . '/plugins');
 ini_set('session.save_path', $tmp);
 require %s;
 new Initiator();
-$r = new ReflectionClass('Route');
+$r = new ReflectionClass(\FOG\Router\Route::class);
 $d = $r->getProperty('_rethrowDepth');
 $d->setAccessible(true);
 $d->setValue(null, 1);
 try {
-    Route::sendResponse(406, 'probe');
+    \FOG\Router\Route::sendResponse(406, 'probe');
     echo 'MARKER:noraise';
 } catch (RuntimeException $e) {
     echo 'MARKER:raised:' . $e->getMessage() . ':' . $e->getCode();
@@ -245,7 +247,7 @@ try {
 // Eleven daemon sites now go through it, so it has to carry the guard itself.
 $d->setValue(null, 0);
 try {
-    Route::asValue(function () { Route::sendResponse(406, 'inner'); });
+    \FOG\Router\Route::asValue(function () { \FOG\Router\Route::sendResponse(406, 'inner'); });
     echo ' MARKER2:noraise';
 } catch (RuntimeException $e) {
     echo ' MARKER2:raised:' . $e->getMessage();

--- a/tests/site-model.test.php
+++ b/tests/site-model.test.php
@@ -23,6 +23,9 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+use FOG\Router\Route;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -79,14 +82,14 @@ function check($label, $cond, array &$failures, &$checks)
  *    autoloader prefers core, but this pins which file actually won so a
  *    lingering plugin cannot quietly supply the model.
  */
-if (!class_exists('Site', true)) {
+if (!class_exists(\FOG\Items\Site::class, true)) {
     fwrite(STDERR, "FAIL: Site does not resolve\n");
     exit(1);
 }
-$ref = new \ReflectionClass('Site');
+$ref = new \ReflectionClass(\FOG\Items\Site::class);
 check(
     'Site extends FOGController',
-    $ref->isSubclassOf('FOGController'),
+    $ref->isSubclassOf(\FOG\Base\FOGController::class),
     $failures,
     $checks
 );
@@ -174,7 +177,7 @@ check(
 );
 check(
     'Site::loadCatchall() exists, so load() still populates the flag',
-    method_exists('Site', 'loadCatchall'),
+    method_exists(\FOG\Items\Site::class, 'loadCatchall'),
     $failures,
     $checks
 );
@@ -229,12 +232,12 @@ foreach (
  */
 check(
     'SiteManager resolves',
-    class_exists('SiteManager', true),
+    class_exists(\FOG\Managers\SiteManager::class, true),
     $failures,
     $checks
 );
-if (class_exists('SiteManager', true)) {
-    $mref = new \ReflectionClass('SiteManager');
+if (class_exists(\FOG\Managers\SiteManager::class, true)) {
+    $mref = new \ReflectionClass(\FOG\Managers\SiteManager::class);
     check(
         'SiteManager resolves to core, not to a plugin copy',
         false === strpos($mref->getFileName(), DIRECTORY_SEPARATOR . 'plugins'),

--- a/tests/site-scope-lists.test.php
+++ b/tests/site-scope-lists.test.php
@@ -25,6 +25,9 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+use FOG\Auth\SiteScope;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -106,9 +109,9 @@ class FakeDB
     }
 }
 
-$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
 $dbProp->setAccessible(true);
-$permProp = new \ReflectionProperty('Authorization', '_permCache');
+$permProp = new \ReflectionProperty(\FOG\Auth\Authorization::class, '_permCache');
 $permProp->setAccessible(true);
 
 $scenario = function (array $tables, array $perms) use ($dbProp, $permProp) {

--- a/tests/site-scope.test.php
+++ b/tests/site-scope.test.php
@@ -40,6 +40,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\SiteScope;
+
 $webroot = dirname(__DIR__) . '/packages/web';
 $init = $webroot . '/commons/init.php';
 if (!is_readable($init)) {
@@ -93,7 +95,7 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-if (!class_exists('SiteScope', true)) {
+if (!class_exists(\FOG\Auth\SiteScope::class, true)) {
     fwrite(STDERR, "FAIL: SiteScope does not resolve\n");
     exit(1);
 }
@@ -139,7 +141,7 @@ class FakeDB
     }
 }
 
-$dbProp = new \ReflectionProperty('FOGBase', 'DB');
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
 $dbProp->setAccessible(true);
 
 /**

--- a/tests/stale-class-file-list.test.php
+++ b/tests/stale-class-file-list.test.php
@@ -77,7 +77,7 @@ $errLog = $tmp . '/php-errors.log';
 $prevLog = ini_get('error_log');
 ini_set('error_log', $errLog);
 try {
-    FOGBase::startClassFromFiles([$gone], -strlen('.hook.php'));
+    \FOG\Base\FOGBase::startClassFromFiles([$gone], -strlen('.hook.php'));
 } catch (\Throwable $e) {
     $threw = get_class($e) . ': ' . $e->getMessage();
 }

--- a/tests/storagenode-listings-shape.test.php
+++ b/tests/storagenode-listings-shape.test.php
@@ -63,7 +63,7 @@ if (false === $from || false === $to || $to <= $from) {
 }
 $block = substr($getfiles, $from, $to - $from);
 
-if (!class_exists('FOGCore')) {
+if (!class_exists(\FOG\Base\FOGCore::class)) {
     eval(
         'class FOGCore { public static function fastmerge(...$a) { $o = [];'
         . ' foreach ($a as $x) { $o = array_merge($o, (array)$x); } return $o; } }'

--- a/tests/tasklog-records-cancel.test.php
+++ b/tests/tasklog-records-cancel.test.php
@@ -33,6 +33,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('tasklog-records-cancel');

--- a/tests/tasklog-report-retention.test.php
+++ b/tests/tasklog-report-retention.test.php
@@ -38,6 +38,8 @@
  * Exit status 0 = pass or skip, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('tasklog-retention');

--- a/tests/tasklog-stamps-transition-time.test.php
+++ b/tests/tasklog-stamps-transition-time.test.php
@@ -28,6 +28,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Base\FOGCore;
+
 require __DIR__ . '/lib/fog-test-harness.php';
 
 FogTestHarness::boot('tasklog-transition-time');

--- a/tests/usertracking-permission-split.test.php
+++ b/tests/usertracking-permission-split.test.php
@@ -37,6 +37,8 @@
  * Exit status 0 = pass, 1 = fail.
  */
 
+use FOG\Auth\Authorization;
+
 $root = dirname(__DIR__);
 $webroot = $root . '/packages/web';
 $init = $webroot . '/commons/init.php';
@@ -88,7 +90,7 @@ function check($label, $cond, array &$failures, &$checks)
     }
 }
 
-if (!class_exists('Authorization', true)) {
+if (!class_exists(\FOG\Auth\Authorization::class, true)) {
     fwrite(STDERR, "FAIL: Authorization did not resolve\n");
     exit(1);
 }


### PR DESCRIPTION
Deletes all 202 `class_alias(__NAMESPACE__ . '\X', 'X')` trailers under
`packages/web/src/`. Core is reachable only by its namespaced name.

ADR 0013 §2 called that alias the 1.6 plugin ABI and promised it "for all of
1.6". 1.6.0 is unreleased, so there is no shipped 1.6 for the promise to have
been made to. The ADR is amended rather than left contradicting the tree.

## What replaces it

| Mechanism | Reaches |
|---|---|
| 211 `use` imports across 92 files | `lib/`, `commons/`, `service/`, `api/`, `management/`, `packages/service` |
| `FOGBase::qualify()` | the string-driven paths `use` cannot reach |

`new $string`, and a class name **in a string**, resolve from the *global*
namespace — `use` is not consulted and the enclosing namespace is not applied.
Those are the sites the aliases were really holding up: `getClass()`'s ~350
literals, `FOGController::getManager()`, `Route::_newEntity()` for
`$validClasses`, and — new in this PR — `FOGPage`'s `$childClass`.

`$childClass` is qualified at its three `new` sites only, never on the
property. It is also a *label*: lowercased into element names, concatenated
into titles, used as a hook payload key and passed to `Route::listem()`.

`bin/import-core-classes.php` is committed. It reports as well as fixes, so a
new bare reference is one command away from being found.

## Three things this broke that nothing was watching

All three fail **silently**, and all three were found by running the
retirement rather than by reading it.

1. **`Authorization::_scopeClassVars()`** resolved a node to its model with a
   bare `class_exists($node)`. Without the alias that is simply false, `$vars`
   stays `null`, and `objectInScope()` has no table to test against — access
   control that cannot find its own model, with nothing logged.
2. **`PluginRunner`** filtered tasks with
   `is_subclass_of($class, 'PluginTask')`. The string named the global
   `\PluginTask`, so every plugin task was silently skipped.
3. **The built-in `spl_autoload()` fallback was a plugin's route to supplying
   a core class.** `Initiator::autoload()` refusing a bare core name is only a
   `return`; PHP then carries on down the chain, and the built-in probes
   include_path by basename — include_path covers the plugin roots. A plugin
   shipping `class/host.class.php` answered the bare `Host` the moment core
   stopped answering it. Core winning the classMap collision does not help:
   core is not in that map, so there is no collision to resolve.

   The fallback is **removed**. What it covered it no longer needs to:
   include_path and the classMap both derive from `classFileList()`,
   `Plugin::install()` calls `forgetClassFileList()`, and the cache expires on
   `FILELIST_TTL` regardless.

## The plan was wrong about the bridge

`docs/composer-psr4-plan.md` said to delete "the 202 `class_alias` lines **and
the reverse bridge arm** from `Initiator`".

`Initiator::_bridgeNamespaced()` **stays.** The 46 discovery-named classes
under `lib/` — 26 pages, 10 hooks, 9 reports, 1 event — declare a flat
`namespace FOG;` and keep their own `class_alias`, because
`FOGPageManager::loadPageClasses()` and `EventManager::load()` derive the class
name from `basename($file)`, and PSR-4 does not do discovery. Composer maps
`FOG\` onto `src/`, so `use FOG\ReportManagement;` resolves to
`src/ReportManagement.php`, which does not exist. The bridge is the only thing
that answers it.

What the bridge now *refuses* is a flat `FOG\<Name>` for a class that lives in
a bucket: `FOG\Host` is a wrong spelling of `FOG\Items\Host`, and answering it
would hand the key back to a plugin. Both refusal paths name the FQCN to use,
so the failure is legible rather than a class-not-found at the call site.

## Tests

`tests/psr4-bridge.test.php` is inverted. It now pins that the bare name does
NOT resolve, that a plugin file named after a core class cannot answer it
either, that the bucketed FQCN does, and that a flat `FOG\<Name>` is answered
only where a `lib/` file actually declares one.

**Both halves mutation-tested:**

| Mutation | Result |
|---|---|
| restore `spl_autoload_register()` | 4 checks red, incl. "the plugin file did not answer bare ProbeAlpha" |
| delete the `_bridgeNamespaced()` call | 2 checks red, both discovery-name resolution |

`autoload`, `autoload-core-wins`, `all-classes-load` and
`stale-class-file-list` were asserting the aliases and are rewritten to assert
the retirement. `all-classes-load` now collects each class under the name its
own file declares, which is stronger than the bare basename it used before.

`tests/lib/fog-test-harness.php`'s reflection helpers resolve short names
through the same `FOGBase::qualify()` the application uses, so the harness
cannot accept a name production would reject.
`tests/lib/fog-schema-collector.php` stubs namespaced names in their own
namespace — `schema.php` carries `use FOG\Items\Schema;` now, and a global stub
answered nothing.

## Ships with fog-plugins v1.6.18

ADR 0009 ordering: [that release](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.18)
is already cut, and `FOG_PLUGINS_VERSION` is bumped here. It qualifies 574
references across 163 files. An older core is unaffected by qualified names,
but **this** core with `v1.6.17` plugins fails to load every plugin class — so
the two are a pair.

## Verification

- A worktree with `v1.6.18` actually unpacked into `lib/plugins`: **176 passed,
  0 failed.**
- A shadow copy of the real tree booted against the live database with every
  `src/` alias gone: all **46** discovery classes and all **176** plugin
  classes resolve.
- `relationship-filter-in-join` is skipped in CI (`lib/plugins` is not fetched
  there) and passes locally once `v1.6.18` is present.

## Downstream

None. `Route::$validClasses` is unchanged, so FogApi's hardcoded copy of the
class list needs no sync.
