### PR TITLE
Correct the sync-scripts section: paths, staleness, and signed artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,22 +38,39 @@ from the start.
 
 ### Sync Scripts
 
-There are two scripts that sync between the **git repo** (`~/fogproject/`) and the **live web server** (`/var/www/fog/` or `/var/www/html/fog-1.6/`).
+Two scripts sync between the **git repo** (`~/fogproject/`) and the **live web
+server** (`/var/www/fog/`, symlinked to `/var/www/html/fog-1.6/`). Both live in
+[`FOGProject/fog-community-scripts`](https://github.com/FOGProject/fog-community-scripts);
+neither is part of this repo, and **what they are installed as locally is up to
+whoever installed them** — do not assume a path. `command -v` first, and check
+the machine's own notes.
 
-**`/usr/local/bin/copybacktrunk.sh`** — Git → Web (deploy for live testing)
+**`CopyBackTrunk/copybacktrunk.sh`** — Git → Web (deploy for live testing)
 - rsync's `~/fogproject/packages/web/` → `/var/www/html/fog-{ver}/`
-- Copies config, sets symlinks, permissions, and regenerates SSL cert
+- Copies the generated config into place, sets symlinks and permissions, and
+  regenerates the SSL cert
 - Use this after editing in the git repo to deploy and test changes live
 - Usage: `copybacktrunk.sh "" "" "1.6"`
 
-**`/usr/local/bin/copytosvn.sh`** — Web → Git (pull live edits back)
-- rsync's `/var/www/fog/` → `~/fogproject/packages/web/`
+**`CopyToSVN/copytosvn.sh`** — Web → Git (pull live edits back)
+- rsync's the webroot → `~/fogproject/packages/web/`
 - Use this ONLY after editing files directly on the live web server
-- Also updates language `.pot`/`.po` files via `xgettext`/`msgmerge`
-- Strips generated/runtime files (`config.class.php`, cache, ssl certs, logs)
-- **Do NOT run this after `copybacktrunk.sh`** — it will overwrite git with the web copy
+- Strips generated and runtime files: the config, cache, SSL certs, the
+  published CA, compiled `.mo` files, and the Secure Boot signed artifacts
+- **Do NOT run this after `copybacktrunk.sh`** — it will overwrite git with the
+  web copy
+- It does **not** touch the `.pot`/`.po` files, run php-cs-fixer or rewrite
+  `FOG_VERSION` any more. All three moved to `.githooks/pre-commit`, which does
+  them scoped to the files staged for that one commit instead of across the
+  whole live webroot. A doc or a memory still saying otherwise is describing a
+  copy from before 2026-08.
 
-The web root the user edits live is `/var/www/fog/` (symlinked to `/var/www/html/fog-1.6/`).
+**Neither script may move a Secure Boot signed artifact in either direction.**
+`installfog.sh` countersigns the deployed kernels and `refind*.efi` with the
+server's own key, so pulling one into the checkout publishes that key's output
+as though it were the upstream source, and deploying the repo copy over a signed
+one strips the countersignature and stops Secure Boot clients booting. Both
+scripts exclude them; `test-signed-artifacts-excluded.sh` in that repo pins it.
 
 ### Pre-commit hook (IMPORTANT — explains "files I didn't touch" in commits)
 

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4258');
+        define('FOG_VERSION', '1.6.0-beta.4261');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element


### PR DESCRIPTION
Doc only. Three corrections to **Development Workflow → Sync Scripts**, each
wrong in the direction that costs an agent a wasted round or a bad edit.

## 1. It named a path that does not exist

`/usr/local/bin/copytosvn.sh`. On the maintainer's box the web → git script is
installed under a different name, chosen deliberately: `copy<tab>` completed to
the wrong one of the two, and the wrong one silently overwrites the checkout
from the webroot.

Neither script is part of this repo — both live in
[`fog-community-scripts`](https://github.com/FOGProject/fog-community-scripts) —
and what they are installed as is a property of the machine, not the project. The
section now names them by their location in that repo and says to resolve the
local name rather than assume it.

## 2. It described behaviour removed months ago

It credited `copytosvn.sh` with regenerating the `.pot`/`.po` files. It has not
done that, run `php-cs-fixer`, or rewritten `FOG_VERSION` since all three moved
to `.githooks/pre-commit` — where they are scoped to the files staged for one
commit instead of run across the whole live webroot.

Stated with a date, so a stale copy elsewhere reads as stale rather than as a
disagreement.

## 3. It said nothing about Secure Boot

`installfog.sh` countersigns the deployed kernels **and `refind*.efi`** with the
server's own key, so neither direction may move them:

| Direction | Failure |
|---|---|
| web → git | publishes one server's signing output as the upstream source |
| git → web | strips the countersignature; Secure Boot clients stop booting, nothing on the server explains why |

This is not hypothetical — it happened on 2026-08-27 and is what prompted the
change. `sbverify` on the pulled copy showed two signatures where `HEAD` has one:

```
checkout:  /CN=Roderick W. Smith  +  /CN=FOG Project Secure Boot Signing
HEAD:      /CN=Roderick W. Smith
```

The kernels were already excluded in both scripts; `refind*.efi` never was, and
unlike the kernels it is **tracked**, so a pull is a content change to a
committed file. Fixed in fog-community-scripts#90 with
`test-signed-artifacts-excluded.sh` pinning both directions — but the constraint
belongs where someone reads about the scripts.

## Not changed

The `commons/config.class.php` row in **Key Files** and the "do not touch
`config.class.php`" line under **What NOT to Do** were both already corrected in
#1429.
