### PR TITLE
Stop shipping the generated config world-readable

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -10652,6 +10652,30 @@ class Config
     }
 }" > "${webdirdest}/commons/config.class.php"
     errorStat $?
+    # This file holds ${DB_password}, both FTP passwords (${SVC_password}, and
+    # the storage node account the same value backs) and the per-install schema
+    # bootstrap token generated above. It is written by a plain redirect, so
+    # without this it lands at whatever umask root is carrying -- 0644 on every
+    # distro we support. Every local account on the server could then read all
+    # of them, and the FTP credential is fleet-wide, not per-server.
+    #
+    # Same reasoning as .fogsettings, which is chmod 0600 for the same two
+    # passwords. This one cannot be 0600: unlike .fogsettings it is read by
+    # PHP rather than by the installer -- the web tier includes it on every
+    # request, and FOGPluginRunner and FOGRetentionRunner are the two daemons
+    # that run as ${apacheuser} instead of root. Group read is what keeps all
+    # three working, which is why the owner is set here and not left to the
+    # chown -R at the end of this function: the mode is only meaningful once
+    # the group is right, and a failure between the two should not leave a
+    # window where it is neither.
+    #
+    # Storage nodes take this path too -- configureMinHttpd() calls this
+    # function before stubbing out the management UI -- and a node's copy
+    # carries the MASTER's database password, so the node case is the one that
+    # matters most.
+    chown ${apacheuser}:${apacheuser} "${webdirdest}/commons/config.class.php" >>$error_log 2>&1
+    chmod 0640 "${webdirdest}/commons/config.class.php" >>$error_log 2>&1
+    errorStat $?
     dots "Creating paths file"
     # GH-850: hand the installer's $fogprogramdir to the PHP runtime so
     # FOG_BASE_DIR is no longer a hardcoded string in system.class.php.

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4261');
+        define('FOG_VERSION', '1.6.0-beta.4264');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/generated-config-mode.test.sh
+++ b/tests/generated-config-mode.test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Pins that the generated config.class.php is not world-readable.
+#
+# Why
+# ---
+# commons/config.class.php holds ${DB_password}, both FTP passwords and the
+# per-install schema bootstrap token. It is written by a plain shell redirect,
+# so with no chmod it inherits root's umask -- 0644 on every supported distro
+# -- and every local account on the server can read all three. The FTP
+# credential is fleet-wide rather than per-server, and a storage node's copy
+# carries the MASTER's database password.
+#
+# 0640 rather than 0600 because the web tier includes this file on every
+# request, as does any daemon running as the web user (on the 1.6 line that is
+# FOGPluginRunner and FOGRetentionRunner; on 1.5 every daemon is root). So the
+# test asserts BOTH directions: no world bit, and group read intact. A gate
+# that only checked "not 0644" would go green on 0600 and take the UI down with
+# it, which is a worse outage than the bug.
+#
+# The chown/chmod pair is EXTRACTED from lib/common/functions.sh and executed
+# against a fixture file, not grepped for. A grep passes on a line that has
+# been commented out, moved behind a false condition, or pointed at a path
+# nothing writes. Running it is the only thing that answers the question.
+#
+# Usage: bash tests/generated-config-mode.test.sh
+# Exit 0 = pass, 1 = fail.
+
+set -uo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fn="$repo/lib/common/functions.sh"
+[[ -r $fn ]] || { echo "FAIL: cannot read $fn"; exit 1; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+note() { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+# Where the installer actually writes the config, read out of the script
+# rather than named here. The path differs by branch -- commons/ on the PSR-4
+# line, lib/fog/ on 1.5 -- and a hardcoded path would make this test silently
+# measure nothing on the branch it did not expect.
+dest=$(grep -oE '^\}" > "\$\{webdirdest\}/?[a-z/]*config\.class\.php"' "$fn" \
+    | head -1 | sed -e 's/^.*\${webdirdest}\/*//' -e 's/"$//')
+[[ -n $dest ]] || { echo "FAIL: could not find the config write in $fn"; exit 1; }
+
+# Take the lines that act on that exact path. Anchored to start-of-line
+# whitespace so a commented-out line does not count as present.
+block=$work/perms.sh
+grep -E "^ *(chown|chmod) .*\\\$\{webdirdest\}/?${dest}\"" "$fn" \
+    | sed 's/>>\$error_log 2>&1//' > "$block"
+
+lines=$(grep -c . "$block")
+if [[ $lines -lt 2 ]]; then
+    note "expected a chown AND a chmod on \${webdirdest}/$dest in
+      lib/common/functions.sh; found $lines line(s). Either they were removed, or
+      the path they name no longer matches the path the config is written to."
+    echo "$failures failure(s)"; exit 1
+fi
+
+# Run them for real against a fixture standing in for the webroot.
+mkdir -p "$work/web/$(dirname "$dest")"
+target=$work/web/$dest
+printf "<?php class Config { const DB_PASS = 'secret'; }\n" > "$target"
+chmod 0644 "$target"   # what the redirect leaves behind with no chmod at all
+
+(
+    webdirdest=$work/web
+    # The installer runs as root and can chown to anyone; a test cannot, so it
+    # chowns to the user already running. What is under test is the MODE.
+    apacheuser=$(id -un)
+    # shellcheck disable=SC1090
+    source "$block"
+) >/dev/null 2>&1
+
+mode=$(stat -c '%a' "$target")
+
+# The load-bearing half: no world bit.
+if [[ $(( 8#$mode & 8#0007 )) -ne 0 ]]; then
+    note "config.class.php ended at $mode -- world-readable credentials"
+fi
+# The other half: the web user must still be able to read it.
+if [[ $(( 8#$mode & 8#0040 )) -eq 0 ]]; then
+    note "config.class.php ended at $mode -- no group read, so the web tier
+      (and any daemon running as the web user) cannot read its own config"
+fi
+# And the owner must still be able to write it, or a re-install cannot.
+if [[ $(( 8#$mode & 8#0600 )) -ne 8#0600 ]]; then
+    note "config.class.php ended at $mode -- owner lost read or write"
+fi
+
+if [[ $failures -gt 0 ]]; then
+    echo "$failures failure(s)"
+    exit 1
+fi
+echo "generated-config-mode: 0$mode -- owner rw, group r, world nothing"
+echo "PASS"
+exit 0


### PR DESCRIPTION
## The bug

`commons/config.class.php` is written by a plain shell redirect at
`lib/common/functions.sh:10653` — no `chmod`, and the installer sets no `umask`
anywhere. So it lands at root's umask, **0644**, and is then chowned to the web
user with the rest of the tree.

It holds `${DB_password}`, both FTP passwords, and the per-install schema
bootstrap token. Every local account on the server can read all three. The FTP
credential is **fleet-wide**, not per-server, and a storage node's copy carries
the **master's** database password.

Not theoretical — verified on a live install here before the fix.

## Why 0640 and not 0600

`.fogsettings` holds two of the same secrets and is `chmod 0600` (`:6752`), with
a comment explaining exactly this reasoning. It can be, because it is read by
the *installer*.

This file is read by *PHP*. The web tier includes it on every request, and
`FOGPluginRunner` and `FOGRetentionRunner` are the two daemons that run as
`${apacheuser}` rather than root — I checked both unit files. Group read is
load-bearing; `0600` would take the UI and both daemons down.

## Why the owner is set here too

Rather than left to the `chown -R ${apacheuser}:${apacheuser} $webdirdest` at
the end of the same function: a mode is only meaningful once the group is
right, and a failure between the two should not leave a window where it is
neither.

Storage nodes take the same path — `configureMinHttpd()` calls
`configureHttpd()` before stubbing out the management UI — so one change covers
both install types.

## The test

`tests/generated-config-mode.test.sh` **extracts** the chown/chmod pair from
`functions.sh` and **runs** it against a fixture. A grep for the `chmod` would
pass on a line that had been commented out, moved behind a false condition, or
pointed at a path nothing writes. It reads the write destination out of the
script too, rather than naming it, so the same file works on a branch where the
config lives somewhere else.

It asserts **both** directions on purpose — a gate that only checked "not 0644"
goes green on `0600`, which is a worse outage than the bug.

| Mutation | Result |
|---|---|
| `chmod` deleted | pair not found |
| `chmod` commented out | pair not found |
| `0600` | no group read — web tier and both daemons locked out |
| `0644` | world-readable credentials |
| `0440` | owner lost write |

## Scope

Existing installs are unaffected until the next install runs. `dev-branch` has
the same bug at `lib/fog/config.class.php` and gets the same fix separately.
