### PR TITLE
Stop the config step printing OK twice

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -10651,7 +10651,11 @@ class Config
         define('FOG_THEME', 'default/fog.css');
     }
 }" > "${webdirdest}/commons/config.class.php"
-    errorStat $?
+    # "skipOk", because this step is not finished until the permissions below
+    # are set: the OK belongs to the errorStat after them, not to this one.
+    # A failure here still aborts loudly -- that is the half skipOk does not
+    # touch.
+    errorStat $? "skipOk"
     # This file holds ${DB_password}, both FTP passwords (${SVC_password}, and
     # the storage node account the same value backs) and the per-install schema
     # bootstrap token generated above. It is written by a plain redirect, so

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4279');
+        define('FOG_VERSION', '1.6.0-beta.4283');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element


### PR DESCRIPTION
Follow-up to #1431. My bug, reported from a live install.

## Symptom

```
 * Copying new files to web folder.............................OK
 * Dropping the stale class file list..........................OK
 * Creating config file........................................OK
OK
 *
```

## Cause

#1431 added a `chown`/`chmod` after the config write with **its own**
`errorStat`, under the single `dots "Creating config file"`. `errorStat` prints
the `OK` that terminates a dots line, so two of them under one `dots` emit a
bare `OK` on its own line.

Cosmetic — nothing failed and the permissions were set correctly — but a loose
`OK` in installer output reads as something having gone sideways, which is the
opposite of what that column is for.

## Fix

The write's `errorStat` takes `"skipOk"`, the second argument the function
already has for exactly this (three existing uses at `:3503`–`:3513`). The `OK`
now belongs to the `errorStat` **after** the chown and chmod, which is also
more honest: the step is not finished until the file is secured.

`skipOk` suppresses only the success line. The failure branch is untouched, and
that matters here — a failed config write must still abort.

## Verified

Extracted the block and ran it against a fixture, both trees:

```
merged tree:   * Creating config file......OK
              OK
this branch:   * Creating config file......OK
```

And separately that `errorStat 1 "skipOk"` still prints `Failed!`, dumps the
error log and exits, while `errorStat 0 "skipOk"` prints nothing.

Same fix on `dev-branch` in the companion PR; the doubled `OK` was reproduced
there too.
