### PR TITLE
Stop the config step printing OK twice

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5285,7 +5285,11 @@ class Config
         define('FOG_THEME', 'default/fog.css');
     }
 }" > "${webdirdest}/lib/fog/config.class.php"
-    errorStat $?
+    # "skipOk", because this step is not finished until the permissions below
+    # are set: the OK belongs to the errorStat after them, not to this one.
+    # A failure here still aborts loudly -- that is the half skipOk does not
+    # touch.
+    errorStat $? "skipOk"
     # This file holds ${DB_password}, both FTP passwords (${SVC_password}, and
     # the storage node account the same value backs) and the schema bootstrap
     # token. It is written by a plain redirect, so without this it lands at


### PR DESCRIPTION
Follow-up to #1433 (the dev-branch half of #1431). My bug, reported from a live install.

## Symptom

```
 * Copying new files to web folder.............................OK
 * Dropping the stale class file list..........................OK
 * Creating config file........................................OK
OK
 *
```

## Cause

#1431 added a `chown`/`chmod` after the config write with **its own**
`errorStat`, under the single `dots "Creating config file"`. `errorStat` prints
the `OK` that terminates a dots line, so two of them under one `dots` emit a
bare `OK` on its own line.

Cosmetic — nothing failed and the permissions were set correctly — but a loose
`OK` in installer output reads as something having gone sideways, which is the
opposite of what that column is for.

## Fix

The write's `errorStat` takes `"skipOk"`, the second argument the function
already has for exactly this (three existing uses at `:3503`–`:3513`). The `OK`
now belongs to the `errorStat` **after** the chown and chmod, which is also
more honest: the step is not finished until the file is secured.

`skipOk` suppresses only the success line. The failure branch is untouched, and
that matters here — a failed config write must still abort.

## Verified

Extracted the block and ran it against a fixture, both trees:

```
merged tree:   * Creating config file......OK
              OK
this branch:   * Creating config file......OK
```

And separately that `errorStat 1 "skipOk"` still prints `Failed!`, dumps the
error log and exits, while `errorStat 0 "skipOk"` prints nothing.

Port of the working-1.6 fix; the doubled `OK` was reproduced on this branch
independently, not assumed.
