### PR TITLE
Fix the ten real bugs PHPStan found, and prune them from the baseline

### DIFF
--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -3347,6 +3347,12 @@ class GroupManagement extends FOGPage
                 $this->scheduleTypeFields($labelClass, $isdebug, $type)
             );
 
+            // $buttons is echoed below, after the rendered fields. It was
+            // passed here by reference while being neither initialised nor
+            // rendered, so the argument this hook advertises did nothing and
+            // said nothing. Empty by default -- the modal's own Create button
+            // lives in its static footer, not in this fragment.
+            $buttons = '';
             self::$HookManager->processEvent(
                 'GROUP_CREATE_TASKING',
                 [
@@ -3367,6 +3373,7 @@ class GroupManagement extends FOGPage
                 true
             );
             echo $rendered;
+            echo $buttons;
             echo '</form>';
             $msg = json_encode(
                 [

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -4405,6 +4405,12 @@ class HostManagement extends FOGPage
                 $this->scheduleTypeFields($labelClass, $isdebug, $type)
             );
 
+            // $buttons is echoed below, after the rendered fields. It was
+            // passed here by reference while being neither initialised nor
+            // rendered, so the argument this hook advertises did nothing and
+            // said nothing. Empty by default -- the modal's own Create button
+            // lives in its static footer, not in this fragment.
+            $buttons = '';
             self::$HookManager->processEvent(
                 'HOST_CREATE_TASKING',
                 [
@@ -4425,6 +4431,7 @@ class HostManagement extends FOGPage
                 true
             );
             echo $rendered;
+            echo $buttons;
             echo '</form>';
             $msg = json_encode(
                 [

--- a/packages/web/lib/pages/modulemanagement.page.php
+++ b/packages/web/lib/pages/modulemanagement.page.php
@@ -285,7 +285,7 @@ class ModuleManagement extends FOGPage
             )
         ];
 
-        $buttons .= self::makeButton(
+        $buttons = self::makeButton(
             'general-send',
             _('Update'),
             'btn btn-primary float-end'

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -14,6 +14,7 @@
 namespace FOG;
 
 use FOG\Base\FOGPage;
+use FOG\Exception\SnapinSaveException;
 use FOG\Exception\UploadException;
 use FOG\Items\Snapin;
 use FOG\Items\StorageGroup;

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -3866,11 +3866,18 @@ abstract class FOGBase
         $size = filesize($path);
         if (is_dir($path)) {
             $size = 0;
-            $di = new \RecursiveDirectoryIterator($path);
-            $rii = new \RecursiveIteratorIterator(
-                $di,
+            // SKIP_DOTS is a RecursiveDirectoryIterator flag, not a
+            // RecursiveIteratorIterator mode. Passing it as the mode left the
+            // directory iterator including '.' and '..', so their inode sizes
+            // (and every subdirectory's) were added to the total, and the
+            // mode -- 4096, not LEAVES_ONLY -- stopped the walk descending at
+            // all. A FOG image is a directory, so both errors hit image sizing
+            // and replication's size comparison.
+            $di = new \RecursiveDirectoryIterator(
+                $path,
                 \FilesystemIterator::SKIP_DOTS
             );
+            $rii = new \RecursiveIteratorIterator($di);
             foreach ($rii as $file) {
                 $size += filesize($file);
             }

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1091,6 +1091,11 @@ abstract class FOGPage extends FOGBase
                 header('Content-Type: application/json');
                 Route::listem($this->childClass);
                 $data = Route::getData();
+                // Initialised to match indexDivDisplay()'s parameter default.
+                // It was passed by reference while undeclared in this scope;
+                // nothing here reads it back, so the key is kept for the
+                // listeners that expect it rather than being made meaningful.
+                $delNeeded = false;
                 self::$HookManager->processEvent(
                     'AJAX_DATA_DISPLAY_CHANGE',
                     [
@@ -1702,14 +1707,13 @@ abstract class FOGPage extends FOGBase
                         $tablestr .= '<tr class="'
                             . strtolower($node)
                             . '" '
+                            // $id_field was never declared in this scope, so
+                            // isset($rowData[$id_field]) read $rowData[''] and
+                            // was always false -- the whole expression has only
+                            // ever been the 'id' test below. Kept as it behaved.
                             . (
-                                isset($rowData['id']) || isset($rowData[$id_field]) ?
-                                'id="'
-                                . (
-                                    isset($rowData['id']) ?
-                                    $rowData['id'] . '"' :
-                                    $rowData[$id_field] . '"'
-                                ) :
+                                isset($rowData['id']) ?
+                                'id="' . $rowData['id'] . '"' :
                                 ''
                             )
                             . '>';
@@ -2148,6 +2152,24 @@ abstract class FOGPage extends FOGBase
             return $fields;
         }
         $ucclass = strtoupper($this->childClass);
+        // Build the buttons BEFORE the hook fires. They used to be created
+        // after it and assigned with '=', so the listener was handed an
+        // undefined variable by reference and anything it contributed was
+        // unconditionally overwritten before the footer was echoed. Compare
+        // IMPORT_FIELDS below, which has always done it in this order.
+        $buttons = '';
+        if ($ownElement) {
+            $buttons = self::makeButton(
+                'ad-send',
+                _('Update'),
+                'btn btn-primary float-end'
+            )
+            . self::makeButton(
+                'ad-clear',
+                _('Clear Fields'),
+                'btn btn-danger float-start'
+            );
+        }
         self::$HookManager->processEvent(
             "{$ucclass}_EDIT_AD_FIELDS",
             [
@@ -2184,16 +2206,6 @@ abstract class FOGPage extends FOGBase
         }
         echo $rendered;
         if ($ownElement) {
-            $buttons = self::makeButton(
-                'ad-send',
-                _('Update'),
-                'btn btn-primary float-end'
-            );
-            $buttons .= self::makeButton(
-                'ad-clear',
-                _('Clear Fields'),
-                'btn btn-danger float-start'
-            );
             echo '</div>';
             echo '<div class="card-footer">';
             echo $buttons;

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -41,7 +41,11 @@ trait FOGPagePost
      * @param int    $code The HTTP status code to send.
      * @param string $body The response body (already JSON-encoded).
      *
-     * @return void
+     * Annotated void until 1.6.0-beta, which made every caller look like it
+     * fell through -- including FOGConfigurationPage::_jsonExit(), which is
+     * itself declared as never returning.
+     *
+     * @return never
      */
     protected static function jsonSend($code, $body)
     {

--- a/packages/web/src/Base/LoadGlobals.php
+++ b/packages/web/src/Base/LoadGlobals.php
@@ -13,7 +13,6 @@
 
 namespace FOG\Base;
 
-use FOG\DashboardPage;
 use FOG\Db\DatabaseManager;
 use FOG\Items\User;
 use FOG\Net\FOGFTP;
@@ -65,18 +64,18 @@ class LoadGlobals extends FOGBase
         $GLOBALS['currentUser'] = new User($userID);
         $GLOBALS['HookManager']->load();
         $GLOBALS['EventManager']->load();
-        $subs = [
-            'configure',
-            'authorize',
-            'requestClientInfo'
-        ];
-        if (in_array(isset($sub) ? $sub : '', $subs)) {
-            new DashboardPage();
-            unset($subs);
-            exit;
-        }
+        // A vestigial copy of the configure/authorize/requestClientInfo
+        // dispatch used to sit here, guarded by isset($sub) on a variable
+        // this scope never declared -- so it has never run, on this branch
+        // or on 1.5. That was load-bearing. Initiator::startInit() populates
+        // the global $sub from GET/POST *before* base.inc.php constructs
+        // LoadGlobals, so adding the `global $sub;` that the isset() invites
+        // would have made the branch live and answered all three subs with a
+        // dashboard render plus exit -- pre-empting FOGPage::_init(), which
+        // dispatches exactly these three to their real handlers
+        // (FOGPage::requestClientInfo() and friends). Removed rather than
+        // commented so the trap cannot be sprung by tidying it.
         self::$_loadedglobals = true;
-        unset($subs);
     }
     /**
      * Initializes directly.

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4283');
+        define('FOG_VERSION', '1.6.0-beta.4286');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -1557,6 +1557,18 @@ class IpxeBootMenu extends FOGBase
         $chkdsk = $chkdsk == 1 ? 0 : 1;
         $ftp = $StorageNode->get('ip');
         $port = ($mc ? $mc->get('port') : null);
+        // $mac was never assigned in this method, so every false tasking
+        // booted FOS with an empty mac= kernel argument. Resolved the same
+        // way getTasking() does it: a false tasking is by definition a host
+        // that may not be registered, and getHostItem() leaves an invalid
+        // Host(0) rather than null, so isValid() is the test.
+        $mac = self::$Host->isValid()
+            ? self::$Host->get('mac')
+            : (string) (
+                filter_input(INPUT_GET, 'mac')
+                ?: filter_input(INPUT_POST, 'mac')
+                ?: ''
+            );
         $kernelArgsArray = [
             "mac=$mac",
             "ftp=$ftp",

--- a/packages/web/src/Boot/Registration.php
+++ b/packages/web/src/Boot/Registration.php
@@ -467,10 +467,15 @@ class Registration extends FOGBase
                             0,
                             STR_PAD_LEFT
                         );
+                        // Was $autuRegSysName -- a typo, so this passed null
+                        // and the loop produced an empty hostname on the first
+                        // collision. isHostnameSafe() then rejected it and
+                        // quick registration fell back to the MAC-derived name
+                        // instead of incrementing to the next free number.
                         $hostname = str_replace(
                             $paddingString,
                             $paddedInsert,
-                            $autuRegSysName
+                            $autoRegSysName
                         );
                     }
                     self::setSetting('FOG_QUICKREG_SYS_NUMBER', ++$autoRegSysNumber);

--- a/packages/web/src/Items/Image.php
+++ b/packages/web/src/Items/Image.php
@@ -50,7 +50,6 @@ class Image extends FOGController
         'imageTypeID' => 'imageTypeID',
         'imagePartitionTypeID' => 'imagePartitionTypeID',
         'osID' => 'imageOSID',
-        'size' => 'imageSize',
         'deployed' => 'imageLastDeploy',
         'format' => 'imageFormat',
         'magnet' => 'imageMagnetUri',

--- a/packages/web/src/Items/Schema.php
+++ b/packages/web/src/Items/Schema.php
@@ -222,7 +222,10 @@ class Schema extends FOGController
             }
             fclose($fh);
             ini_set('max_execution_time', $orig_exec_time);
-            ini_set('request_terminate_timeout', $orig_term_time);
+            // No request_terminate_timeout restore: nothing here changes it,
+            // it is a php-fpm pool directive rather than a runtime-settable
+            // ini, and the line that restored it passed $orig_term_time --
+            // a variable this method never captured.
             if (file_exists($file)) {
                 unlink($file);
             }

--- a/packages/web/src/Items/StorageGroup.php
+++ b/packages/web/src/Items/StorageGroup.php
@@ -115,7 +115,17 @@ class StorageGroup extends FOGController
      */
     protected function loadUsedtasks()
     {
-        $used = explode(',', self::getSetting('FOG_USED_TASKS'));
+        // Same unreachable guard as StorageNode::loadUsedtasks() -- see the
+        // comment there. 1/15/17 are DEPLOY, DEPLOY_DEBUG and
+        // DEPLOY_NO_SNAPINS, matching the setting's shipped default.
+        $used = array_values(
+            array_filter(
+                explode(',', (string) self::getSetting('FOG_USED_TASKS')),
+                static function ($taskTypeId) {
+                    return trim($taskTypeId) !== '';
+                }
+            )
+        );
         if (count($used) < 1) {
             $used = [
                 1,

--- a/packages/web/src/Items/StorageNode.php
+++ b/packages/web/src/Items/StorageNode.php
@@ -405,11 +405,24 @@ class StorageNode extends FOGController
      */
     protected function loadUsedtasks()
     {
-        $used = explode(',', self::getSetting('FOG_USED_TASKS'));
+        // explode() always returns at least one element -- on an unset or
+        // blank setting it returns [''] -- so the old `count($used) < 1`
+        // guard could never be true and this fallback had never run. Which
+        // is just as well: TaskType::DEPLOY_CAPTURE does not exist, so
+        // reaching it would have been fatal. 1/15/17 is what the setting
+        // ships as (schema step 142) and what StorageGroup falls back to.
+        $used = array_values(
+            array_filter(
+                explode(',', (string) self::getSetting('FOG_USED_TASKS')),
+                static function ($taskTypeId) {
+                    return trim($taskTypeId) !== '';
+                }
+            )
+        );
         if (count($used) < 1) {
             $used = [
                 TaskType::DEPLOY,
-                TaskType::DEPLOY_CAPTURE,
+                TaskType::DEPLOY_DEBUG,
                 TaskType::DEPLOY_NO_SNAPINS
             ];
         }

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -572,8 +572,7 @@ class User extends FOGController
             sprintf(
                 '%s %s.',
                 $this->get('name'),
-                _('user failed to login'),
-                $this->get('name')
+                _('user failed to login')
             ),
             0,
             0,

--- a/packages/web/src/Managers/PowerManagementManager.php
+++ b/packages/web/src/Managers/PowerManagementManager.php
@@ -60,15 +60,14 @@ class PowerManagementManager extends FOGManagerController
             printf(
                 '<option value="%s"%s>%s</option>',
                 \Initiator::e(trim($val)),
+                // A $template arm used to sit in front of this, testing a
+                // variable this method never had -- getActionSelect() takes
+                // $selected, $array and $id. isset() made it permanently
+                // false, so $selected has always been the only test.
                 (
-                    (isset($template) && $template !== false)
-                    && trim($template) === trim($val) ?
+                    trim($selected) === trim($val) ?
                     ' selected' :
-                    (
-                        trim($selected) === trim($val) ?
-                        ' selected' :
-                        ''
-                    )
+                    ''
                 ),
                 \Initiator::e($text)
             );

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -31,6 +31,7 @@ use FOG\Items\Inventory;
 use FOG\Items\MACAddress;
 use FOG\Items\Plugin;
 use FOG\Items\Snapin;
+use FOG\Items\SnapinJob;
 use FOG\Items\StorageNode;
 use FOG\Items\Task;
 use FOG\Items\UserTracking;
@@ -5658,7 +5659,7 @@ class Route extends FOGBase
                     $snapinjob = $class->get('snapinjob');
                     $hasJob = is_object($snapinjob) && $snapinjob->isValid();
                     $sj = $hasJob
-                        ? new Snapinjob($snapinjob->get('id'))
+                        ? new SnapinJob($snapinjob->get('id'))
                         : null;
                     $host = $hasJob
                         ? new Host($snapinjob->get('hostID'))

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,12 +265,6 @@ parameters:
 			path: packages/web/lib/pages/dashboardpage.page.php
 
 		-
-			message: '#^Method FOG\\DashboardPage\:\:testUrls\(\) should return array but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: packages/web/lib/pages/dashboardpage.page.php
-
-		-
 			message: '#^Static property FOG\\DashboardPage\:\:\$_tftp is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
@@ -325,12 +319,6 @@ parameters:
 			path: packages/web/lib/pages/fogconfigurationpage.page.php
 
 		-
-			message: '#^Method FOG\\FOGConfigurationPage\:\:_jsonExit\(\) should always throw an exception or terminate script execution but doesn''t do that\.$#'
-			identifier: return.never
-			count: 1
-			path: packages/web/lib/pages/fogconfigurationpage.page.php
-
-		-
 			message: '#^Offset ''FOG_PXE_HIDDENMENU…''\|''FOG_PXE_MENU_TIMEOUT'' on array\{FOG_PXE_HIDDENMENU_TIMEOUT\: true, FOG_PXE_MENU_TIMEOUT\: true\} in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.offset
 			count: 1
@@ -361,19 +349,7 @@ parameters:
 			path: packages/web/lib/pages/fogconfigurationpage.page.php
 
 		-
-			message: '#^Variable \$code might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/lib/pages/fogconfigurationpage.page.php
-
-		-
 			message: '#^Variable \$ip might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/lib/pages/fogconfigurationpage.page.php
-
-		-
-			message: '#^Variable \$msg might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: packages/web/lib/pages/fogconfigurationpage.page.php
@@ -469,12 +445,6 @@ parameters:
 			path: packages/web/lib/pages/groupmanagement.page.php
 
 		-
-			message: '#^Undefined variable\: \$buttons$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/lib/pages/groupmanagement.page.php
-
-		-
 			message: '#^Variable \$printers might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -519,12 +489,6 @@ parameters:
 		-
 			message: '#^Method FOG\\HostManagement\:\:getGroupsList\(\) with return type void returns null but should not return anything\.$#'
 			identifier: return.void
-			count: 1
-			path: packages/web/lib/pages/hostmanagement.page.php
-
-		-
-			message: '#^Method FOG\\HostManagement\:\:getHostDefaultPrinters\(\) should return string but return statement is missing\.$#'
-			identifier: return.missing
 			count: 1
 			path: packages/web/lib/pages/hostmanagement.page.php
 
@@ -595,12 +559,6 @@ parameters:
 			path: packages/web/lib/pages/hostmanagement.page.php
 
 		-
-			message: '#^Undefined variable\: \$buttons$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/lib/pages/hostmanagement.page.php
-
-		-
 			message: '#^Variable \$code might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -657,12 +615,6 @@ parameters:
 		-
 			message: '#^Method FOG\\ImageManagement\:\:getHostsList\(\) with return type void returns null but should not return anything\.$#'
 			identifier: return.void
-			count: 1
-			path: packages/web/lib/pages/imagemanagement.page.php
-
-		-
-			message: '#^Method FOG\\ImageManagement\:\:getImagePrimaryStoragegroups\(\) should return string but return statement is missing\.$#'
-			identifier: return.missing
 			count: 1
 			path: packages/web/lib/pages/imagemanagement.page.php
 
@@ -747,12 +699,6 @@ parameters:
 		-
 			message: '#^Result of method FOG\\Base\\FOGPage\:\:assocItemsList\(\) \(void\) is used\.$#'
 			identifier: method.void
-			count: 1
-			path: packages/web/lib/pages/modulemanagement.page.php
-
-		-
-			message: '#^Undefined variable\: \$buttons$#'
-			identifier: variable.undefined
 			count: 1
 			path: packages/web/lib/pages/modulemanagement.page.php
 
@@ -1165,18 +1111,6 @@ parameters:
 			path: packages/web/lib/pages/snapinmanagement.page.php
 
 		-
-			message: '#^Call to method getMessage\(\) on an unknown class FOG\\SnapinSaveException\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/lib/pages/snapinmanagement.page.php
-
-		-
-			message: '#^Caught class FOG\\SnapinSaveException not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/lib/pages/snapinmanagement.page.php
-
-		-
 			message: '#^Method FOG\\SnapinManagement\:\:_maker\(\) with return type void returns string\|false but should not return anything\.$#'
 			identifier: return.void
 			count: 1
@@ -1185,12 +1119,6 @@ parameters:
 		-
 			message: '#^Method FOG\\SnapinManagement\:\:getHostsList\(\) with return type void returns null but should not return anything\.$#'
 			identifier: return.void
-			count: 1
-			path: packages/web/lib/pages/snapinmanagement.page.php
-
-		-
-			message: '#^Method FOG\\SnapinManagement\:\:getSnapinPrimaryStoragegroups\(\) should return string but return statement is missing\.$#'
-			identifier: return.missing
 			count: 1
 			path: packages/web/lib/pages/snapinmanagement.page.php
 
@@ -1263,12 +1191,6 @@ parameters:
 		-
 			message: '#^Method FOG\\StorageGroupManagement\:\:getStorageNodesList\(\) with return type void returns mixed but should not return anything\.$#'
 			identifier: return.void
-			count: 1
-			path: packages/web/lib/pages/storagegroupmanagement.page.php
-
-		-
-			message: '#^Method FOG\\StorageGroupManagement\:\:getStoragegroupMasterStoragenodes\(\) should return string but return statement is missing\.$#'
-			identifier: return.missing
 			count: 1
 			path: packages/web/lib/pages/storagegroupmanagement.page.php
 
@@ -2179,12 +2101,6 @@ parameters:
 			path: packages/web/src/Base/FOGBase.php
 
 		-
-			message: '#^Parameter \#2 \$mode of class RecursiveIteratorIterator constructor expects 0\|1\|2, 4096 given\.$#'
-			identifier: argument.type
-			count: 1
-			path: packages/web/src/Base/FOGBase.php
-
-		-
 			message: '#^Parameter \#2 \$start of function substr expects int, float given\.$#'
 			identifier: argument.type
 			count: 1
@@ -2695,24 +2611,6 @@ parameters:
 			path: packages/web/src/Base/FOGPage.php
 
 		-
-			message: '#^Undefined variable\: \$buttons$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/src/Base/FOGPage.php
-
-		-
-			message: '#^Undefined variable\: \$delNeeded$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/src/Base/FOGPage.php
-
-		-
-			message: '#^Undefined variable\: \$id_field$#'
-			identifier: variable.undefined
-			count: 2
-			path: packages/web/src/Base/FOGPage.php
-
-		-
 			message: '#^Variable \$storagegroups might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -2817,18 +2715,6 @@ parameters:
 		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: packages/web/src/Base/LoadGlobals.php
-
-		-
-			message: '#^Undefined variable\: \$sub$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/src/Base/LoadGlobals.php
-
-		-
-			message: '#^Variable \$sub in isset\(\) is never defined\.$#'
-			identifier: isset.variable
 			count: 1
 			path: packages/web/src/Base/LoadGlobals.php
 
@@ -2971,12 +2857,6 @@ parameters:
 			path: packages/web/src/Boot/IpxeBootMenu.php
 
 		-
-			message: '#^Undefined variable\: \$mac$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/src/Boot/IpxeBootMenu.php
-
-		-
 			message: '#^Variable \$chkdsk in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -3028,12 +2908,6 @@ parameters:
 			message: '#^Parameter \#3 \$pad_string of function str_pad expects string, int given\.$#'
 			identifier: argument.type
 			count: 2
-			path: packages/web/src/Boot/Registration.php
-
-		-
-			message: '#^Undefined variable\: \$autuRegSysName$#'
-			identifier: variable.undefined
-			count: 1
 			path: packages/web/src/Boot/Registration.php
 
 		-
@@ -3787,12 +3661,6 @@ parameters:
 			path: packages/web/src/Items/Host.php
 
 		-
-			message: '#^Array has 2 duplicate keys with value ''size'' \(''size'', ''size''\)\.$#'
-			identifier: array.duplicateKey
-			count: 1
-			path: packages/web/src/Items/Image.php
-
-		-
 			message: '#^Comparison operation "\<" between 1 and 1 is always false\.$#'
 			identifier: smaller.alwaysFalse
 			count: 1
@@ -4051,12 +3919,6 @@ parameters:
 			path: packages/web/src/Items/Schema.php
 
 		-
-			message: '#^Undefined variable\: \$orig_term_time$#'
-			identifier: variable.undefined
-			count: 1
-			path: packages/web/src/Items/Schema.php
-
-		-
 			message: '#^Call to function unset\(\) contains undefined variable \$viewop\.$#'
 			identifier: unset.variable
 			count: 1
@@ -4135,12 +3997,6 @@ parameters:
 			path: packages/web/src/Items/StorageGroup.php
 
 		-
-			message: '#^Comparison operation "\<" between int\<1, max\> and 1 is always false\.$#'
-			identifier: smaller.alwaysFalse
-			count: 1
-			path: packages/web/src/Items/StorageGroup.php
-
-		-
 			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
 			identifier: equal.alwaysTrue
 			count: 1
@@ -4157,18 +4013,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: packages/web/src/Items/StorageGroup.php
-
-		-
-			message: '#^Access to undefined constant FOG\\Items\\TaskType\:\:DEPLOY_CAPTURE\.$#'
-			identifier: classConstant.notFound
-			count: 1
-			path: packages/web/src/Items/StorageNode.php
-
-		-
-			message: '#^Comparison operation "\<" between int\<1, max\> and 1 is always false\.$#'
-			identifier: smaller.alwaysFalse
-			count: 1
-			path: packages/web/src/Items/StorageNode.php
 
 		-
 			message: '#^Comparison operation "\<" between object and 1 results in an error\.$#'
@@ -4345,12 +4189,6 @@ parameters:
 			path: packages/web/src/Items/User.php
 
 		-
-			message: '#^Call to sprintf contains 2 placeholders, 3 values given\.$#'
-			identifier: argument.sprintf
-			count: 1
-			path: packages/web/src/Items/User.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
@@ -4493,24 +4331,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: packages/web/src/Managers/PXEMenuOptionsManager.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 2
-			path: packages/web/src/Managers/PowerManagementManager.php
-
-		-
-			message: '#^Undefined variable\: \$template$#'
-			identifier: variable.undefined
-			count: 2
-			path: packages/web/src/Managers/PowerManagementManager.php
-
-		-
-			message: '#^Variable \$template in isset\(\) is never defined\.$#'
-			identifier: isset.variable
-			count: 1
-			path: packages/web/src/Managers/PowerManagementManager.php
 
 		-
 			message: '#^Method FOG\\Managers\\ScheduledTaskManager\:\:cancel\(\) should return bool but returns null\.$#'
@@ -5062,12 +4882,6 @@ parameters:
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 2
-			path: packages/web/src/Router/Route.php
-
-		-
-			message: '#^Instantiated class FOG\\Router\\Snapinjob not found\.$#'
-			identifier: class.notFound
-			count: 1
 			path: packages/web/src/Router/Route.php
 
 		-

--- a/tests/getfilesize-walks-directories.test.php
+++ b/tests/getfilesize-walks-directories.test.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * FOGBase::getFilesize() must total a directory tree, not its dot entries.
+ *
+ * A FOG image is a directory, so getFilesize() is called on one by the
+ * FOGImageSize daemon (src/Service/ImageSize.php), by replication's local
+ * vs remote size comparison (src/Service/FOGService.php) and by the task
+ * queue writing srvsize. It was wrong in two directions at once:
+ *
+ *   SKIP_DOTS is a RecursiveDirectoryIterator flag. It had been passed as
+ *   RecursiveIteratorIterator's $mode, whose values are LEAVES_ONLY(0),
+ *   SELF_FIRST(1), CHILD_FIRST(2) and CATCH_GET_CHILD(16). So the directory
+ *   iterator kept '.' and '..', whose inode sizes were added to the total,
+ *   and the mode -- 4096 -- was not a walk mode at all, so nothing below
+ *   the top level was ever counted.
+ *
+ * On the two-file fixture below that reported 583 bytes for a true 9.
+ * Both halves are silent: an image's reported size is simply wrong, and a
+ * replication size comparison against it decides on that wrong number.
+ *
+ * The assertion is the exact byte total, deliberately. A test that only
+ * checked "greater than zero", or that grepped for the SKIP_DOTS constant,
+ * passes with the flag back on the wrong constructor -- which is the whole
+ * defect. Adding a file to the fixture means updating EXPECTED_TOTAL.
+ *
+ * Usage: php tests/getfilesize-walks-directories.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+require_once $root . '/packages/web/vendor/autoload.php';
+
+$failures = 0;
+
+/**
+ * Report one assertion.
+ *
+ * @param string $label what is being asserted
+ * @param bool   $ok    whether it held
+ * @param string $extra detail to print on failure
+ *
+ * @return void
+ */
+function check($label, $ok, $extra = '')
+{
+    global $failures;
+    if ($ok) {
+        echo "ok   - $label\n";
+        return;
+    }
+    $failures++;
+    echo "FAIL - $label" . ($extra !== '' ? " ($extra)" : '') . "\n";
+}
+
+// a.txt 3 + sub/b.txt 6 + sub/deeper/c.txt 2. Nested two levels down so a
+// walk that does not descend cannot produce the right answer by accident.
+$files = [
+    'a.txt' => 'abc',
+    'sub/b.txt' => 'abcdef',
+    'sub/deeper/c.txt' => 'ab',
+];
+$expectedTotal = 11;
+
+$base = sys_get_temp_dir() . '/fog-getfilesize-' . getmypid();
+foreach ($files as $rel => $content) {
+    $full = $base . '/' . $rel;
+    if (!is_dir(dirname($full))) {
+        mkdir(dirname($full), 0700, true);
+    }
+    file_put_contents($full, $content);
+}
+
+/**
+ * Remove the fixture tree.
+ *
+ * @param string $dir directory to remove
+ *
+ * @return void
+ */
+function rmtree($dir)
+{
+    if (!is_dir($dir)) {
+        return;
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+        \RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $item) {
+        $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+    }
+    rmdir($dir);
+}
+
+try {
+    $total = \FOG\Base\FOGBase::getFilesize($base);
+    check(
+        "a directory totals only its files, recursively (expected $expectedTotal)",
+        $total === $expectedTotal,
+        "got " . var_export($total, true)
+    );
+
+    $one = \FOG\Base\FOGBase::getFilesize($base . '/a.txt');
+    check(
+        'a plain file still reports its own size',
+        $one === 3,
+        'got ' . var_export($one, true)
+    );
+
+} finally {
+    rmtree($base);
+}
+
+if ($failures > 0) {
+    echo "\n$failures check(s) failed\n";
+    exit(1);
+}
+echo "\nAll checks passed\n";
+exit(0);


### PR DESCRIPTION
Follow-on to #1432. The baseline landed with 2327 entries; these are the
findings from that scan that were genuine defects rather than analyser
noise. Each is fixed and its baseline entry removed, so the gate now goes
red if it comes back. **2327 -> 2293, deletions only** — no new entries.

## Live fatal or silently wrong

| Where | What |
|---|---|
| `src/Router/Route.php:5661` | `new Snapinjob` with no import resolved to `FOG\Router\Snapinjob`. **`GET /api/snapintask/{id}` fataled for every snapin task that has a job** — the normal case; only the orphaned-job path survived. |
| `lib/pages/snapinmanagement.page.php:617` | `catch (SnapinSaveException)` in a `namespace FOG;` file resolved to `FOG\SnapinSaveException` and matched nothing. It extends `\RuntimeException`, so the generic handler answered **HTTP 400 with `serverFault` false** where the exception exists to answer 500. |
| `src/Base/FOGBase.php:3869` | `SKIP_DOTS` — a `RecursiveDirectoryIterator` flag — passed as `RecursiveIteratorIterator`'s `$mode`. Dot and subdirectory inodes were added to the total **and the walk never descended**. A FOG image is a directory, so this feeds `ImageSize`, replication's size comparison and the task queue's `srvsize`. Reported **583 bytes for a true 9**. |
| `src/Base/FOGPage.php:2155` | `{CLASS}_EDIT_AD_FIELDS` got `$buttons` by reference before assignment, then overwrote it before echoing — a listener's button was discarded. Now built before the hook, matching `IMPORT_FIELDS` in the same file. |
| group/host `*_CREATE_TASKING` | Same argument, with nothing rendering it at all. Initialised and echoed after the fields; empty by default, so nothing moves for anyone not using the hook. |
| `lib/pages/modulemanagement.page.php:288` | `$buttons .=` on an undefined variable — a warning on every render of that pane. |

## Contained

`Image::$databaseFields` declared `'size'` twice · `User::login()`'s failure log gave `sprintf` three values for two slots · `StorageNode`/`StorageGroup::loadUsedtasks()` guarded their fallback with `count(explode(...)) < 1`, which cannot be true — just as well, since **`TaskType::DEPLOY_CAPTURE` does not exist** and reaching it would fatal; the guard now tests for an empty setting and the fallback is `1/15/17`, what the setting ships as · Registration's quick-reg collision loop read `$autuRegSysName`, so a name clash produced an empty hostname and **fell back to the MAC-derived name instead of incrementing** · `IpxeBootMenu::falseTasking()` never assigned `$mac`, so **every false tasking booted FOS with an empty `mac=`** · `Schema::backupDB()` restored `request_terminate_timeout` from a variable it never captured · `PowerManagementManager::getActionSelect()` tested a `$template` parameter it does not have · `FOGPage::index()` passed `$delNeeded` undeclared · `FOGPage::process()` tested `$rowData[$id_field]` on an undeclared `$id_field` · `FOGPagePost::jsonSend()` is now `@return never` — it always exits, and saying otherwise made every AJAX endpoint look like it fell through.

## One deletion, deliberately

`LoadGlobals::_init()` carried a **second** copy of the
`configure`/`authorize`/`requestClientInfo` dispatch, guarded by `isset()`
on a variable that scope never declared — so it has never run, on this
branch or on 1.5.

That was load-bearing. `Initiator::startInit()` populates the global
`$sub` **before** `base.inc.php` constructs `LoadGlobals`, so adding the
`global $sub;` the `isset()` invites would have answered all three subs
with a dashboard render plus `exit`, pre-empting `FOGPage::_init()` which
dispatches them to their real handlers. Deleted so the trap cannot be
sprung by tidying it.

## Verification

- `tests/getfilesize-walks-directories.test.php` asserts the **exact byte
  total** of a two-level fixture. A "greater than zero" check, or a grep
  for the `SKIP_DOTS` constant, passes with the flag back on the wrong
  constructor — which is the whole defect. Reintroduced it: **40263 against
  an expected 11**, exit 1.
- The pruned baseline was mutation-tested too: removing the `SnapinJob`
  import again gives `Instantiated class FOG\Router\SnapinJob not found`,
  exit 1.
- `tests/run-all.sh`: **180 passed, 0 failed**. `phpstan analyse`: no errors.

## Downstream

None — no route class added or removed, so FogApi's hardcoded list is
unaffected.