### PR TITLE
Declare FOGPage::$obj and qualify the docblock types hiding real analysis

### DIFF
--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -86,7 +86,7 @@ class ImageManagement extends FOGPage
      *
      * @param StorageGroup $StorageGroup the group to resolve a node for
      *
-     * @return StorageNode|null
+     * @return \FOG\Items\StorageNode|null
      */
     private function _displayStorageNode($StorageGroup)
     {

--- a/packages/web/lib/router/altorouter.class.php
+++ b/packages/web/lib/router/altorouter.class.php
@@ -46,6 +46,20 @@
  * tree. Left in place: they are part of the fork's shape and removing them
  * is a separate decision from correcting what this file is.
  *
+ * The seven verb methods below are provided by __call(), which prepends the
+ * uppercased verb and forwards to map(). They are declared as @method so the
+ * chained route table in Route::defineRoutes() can be analysed statically --
+ * without them every ->get()/->post() in that table reads as a call to an
+ * undefined method.
+ *
+ * @method AltoRouter get(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter put(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter head(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter post(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter patch(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter delete(string $route, mixed $target, string|null $name = null)
+ * @method AltoRouter options(string $route, mixed $target, string|null $name = null)
+ *
  * @category AltoRouter
  * @package  AltoRouter
  * @author   Danny van Kooten <no@email.given>

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1763,7 +1763,7 @@ abstract class FOGBase
      * @param mixed $date The date stamp, defaults to now if not set
      * @param bool  $utc  Whether to use utc timezone or not
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public static function niceDate($date = 'now', $utc = false)
     {
@@ -1948,7 +1948,7 @@ abstract class FOGBase
      *
      * @throws Exception
      *
-     * @return DateTime
+     * @return string
      */
     protected static function diff($start, $end, $ago = false)
     {

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -188,6 +188,21 @@ abstract class FOGPage extends FOGBase
      */
     protected $childClass = '';
     /**
+     * The entity this page is acting on -- an instance of $childClass,
+     * assigned in _init().
+     *
+     * Declared because it was previously created on the fly: PHP 8.2
+     * deprecates dynamic properties and PHP 9 makes them an error, and
+     * every page construction was hitting that. Deliberately left without
+     * a native type -- _init() calls unset($this->obj) when the id does
+     * not resolve, and a typed property would then throw on read rather
+     * than warning, which is a different behaviour from the one this code
+     * has always had.
+     *
+     * @var mixed
+     */
+    protected $obj;
+    /**
      * The report place holder
      *
      * @var string

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4283');
+        define('FOG_VERSION', '1.6.0-beta.4287');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4289');
+        define('FOG_VERSION', '1.6.0-beta.4292');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -140,7 +140,7 @@ class Task extends TaskType
     /**
      * Returns cutoff timing
      *
-     * @return DateTimeImmutable
+     * @return \DateTime|false
      */
     private static function cutoff()
     {

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -108,7 +108,7 @@ class Route extends FOGBase
     /**
      * AltoRouter object container.
      *
-     * @var AltoRouter
+     * @var \AltoRouter
      */
     public static $router = null;
     /**

--- a/packages/web/src/Util/FOGCron.php
+++ b/packages/web/src/Util/FOGCron.php
@@ -85,7 +85,7 @@ class FOGCron extends FOGBase
      * @param string $cron    the cron to parse
      * @param bool   $lastrun show the last run time
      *
-     * @return string
+     * @return int unix timestamp -- every caller feeds it to setTimestamp()
      */
     public static function parse($cron, $lastrun = false)
     {
@@ -176,8 +176,8 @@ class FOGCron extends FOGBase
                 }
             }
             return $Start->setTime(
-                $Start->format('H'),
-                $Start->format('i'),
+                (int) $Start->format('H'),
+                (int) $Start->format('i'),
                 0
             )->getTimestamp();
         } while (true);
@@ -317,7 +317,8 @@ class FOGCron extends FOGBase
     /**
      * Check the time to see if it should be run now
      *
-     * @param DateTime $time the datetime to test
+     * @param int $time unix timestamp to test -- this is what parse()
+     *                  returns and what Timer passes in, not a DateTime
      *
      * @return bool
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -229,12 +229,6 @@ parameters:
 			path: packages/web/lib/pages/clientmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\DashboardPage\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 9
-			path: packages/web/lib/pages/dashboardpage.page.php
-
-		-
 			message: '#^Call to function unset\(\) contains undefined variable \$SystemUptime\.$#'
 			identifier: unset.variable
 			count: 1
@@ -249,12 +243,6 @@ parameters:
 		-
 			message: '#^Call to function unset\(\) contains undefined variable \$tftp\.$#'
 			identifier: unset.variable
-			count: 2
-			path: packages/web/lib/pages/dashboardpage.page.php
-
-		-
-			message: '#^Call to method setTime\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
 			count: 2
 			path: packages/web/lib/pages/dashboardpage.page.php
 
@@ -292,12 +280,6 @@ parameters:
 			message: '#^Call to function unset\(\) contains undefined variable \$val\.$#'
 			identifier: unset.variable
 			count: 1
-			path: packages/web/lib/pages/fogconfigurationpage.page.php
-
-		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
 			path: packages/web/lib/pages/fogconfigurationpage.page.php
 
 		-
@@ -365,12 +347,6 @@ parameters:
 			identifier: variable.undefined
 			count: 11
 			path: packages/web/lib/pages/fogconfigurationpage.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\GroupManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 58
-			path: packages/web/lib/pages/groupmanagement.page.php
 
 		-
 			message: '#^Constructor of class FOG\\GroupManagement has an unused parameter \$name\.$#'
@@ -466,12 +442,6 @@ parameters:
 			message: '#^Access to an undefined property FOG\\HostManagement\:\:\$exitNorm\.$#'
 			identifier: property.notFound
 			count: 5
-			path: packages/web/lib/pages/hostmanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\HostManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 109
 			path: packages/web/lib/pages/hostmanagement.page.php
 
 		-
@@ -577,21 +547,9 @@ parameters:
 			path: packages/web/lib/pages/hostmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\ImageManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 40
-			path: packages/web/lib/pages/imagemanagement.page.php
-
-		-
 			message: '#^Binary operation "\*" between array\|string and 60 results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
-			path: packages/web/lib/pages/imagemanagement.page.php
-
-		-
-			message: '#^Call to method get\(\) on an unknown class FOG\\StorageNode\.$#'
-			identifier: class.notFound
-			count: 2
 			path: packages/web/lib/pages/imagemanagement.page.php
 
 		-
@@ -603,12 +561,6 @@ parameters:
 		-
 			message: '#^Expression on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.expr
-			count: 1
-			path: packages/web/lib/pages/imagemanagement.page.php
-
-		-
-			message: '#^Method FOG\\ImageManagement\:\:_displayStorageNode\(\) has invalid return type FOG\\StorageNode\.$#'
-			identifier: class.notFound
 			count: 1
 			path: packages/web/lib/pages/imagemanagement.page.php
 
@@ -667,22 +619,10 @@ parameters:
 			path: packages/web/lib/pages/imagemanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\IpxeManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 14
-			path: packages/web/lib/pages/ipxemanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\IpxeManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
 			path: packages/web/lib/pages/ipxemanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\ModuleManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 10
-			path: packages/web/lib/pages/modulemanagement.page.php
 
 		-
 			message: '#^Constructor of class FOG\\ModuleManagement has an unused parameter \$name\.$#'
@@ -701,12 +641,6 @@ parameters:
 			identifier: method.void
 			count: 1
 			path: packages/web/lib/pages/modulemanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\PluginManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 8
-			path: packages/web/lib/pages/pluginmanagement.page.php
 
 		-
 			message: '#^Constructor of class FOG\\PluginManagement has an unused parameter \$name\.$#'
@@ -751,12 +685,6 @@ parameters:
 			path: packages/web/lib/pages/pluginmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\PrinterManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 27
-			path: packages/web/lib/pages/printermanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\PrinterManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -790,12 +718,6 @@ parameters:
 			message: '#^Call to function is_array\(\) with \*NEVER\* will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
-			path: packages/web/lib/pages/processlogin.page.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
 			path: packages/web/lib/pages/processlogin.page.php
 
 		-
@@ -883,12 +805,6 @@ parameters:
 			path: packages/web/lib/pages/reportmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\RoleManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 20
-			path: packages/web/lib/pages/rolemanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\RoleManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -953,12 +869,6 @@ parameters:
 			identifier: include.fileNotFound
 			count: 1
 			path: packages/web/lib/pages/schemaupdaterpage.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\ServerInfo\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 7
-			path: packages/web/lib/pages/serverinfo.page.php
 
 		-
 			message: '#^Constructor of class FOG\\ServerInfo has an unused parameter \$name\.$#'
@@ -1051,12 +961,6 @@ parameters:
 			path: packages/web/lib/pages/serviceconfigurationpage.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\SiteManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 16
-			path: packages/web/lib/pages/sitemanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\SiteManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -1103,12 +1007,6 @@ parameters:
 			identifier: method.void
 			count: 6
 			path: packages/web/lib/pages/sitemanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\SnapinManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 42
-			path: packages/web/lib/pages/snapinmanagement.page.php
 
 		-
 			message: '#^Method FOG\\SnapinManagement\:\:_maker\(\) with return type void returns string\|false but should not return anything\.$#'
@@ -1165,12 +1063,6 @@ parameters:
 			path: packages/web/lib/pages/snapinmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\StorageGroupManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 39
-			path: packages/web/lib/pages/storagegroupmanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\StorageGroupManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -1205,12 +1097,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: packages/web/lib/pages/storagegroupmanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\StorageNodeManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 41
-			path: packages/web/lib/pages/storagenodemanagement.page.php
 
 		-
 			message: '#^Constructor of class FOG\\StorageNodeManagement has an unused parameter \$name\.$#'
@@ -1279,12 +1165,6 @@ parameters:
 			path: packages/web/lib/pages/taskmanagement.page.php
 
 		-
-			message: '#^Access to an undefined property FOG\\UserGroupManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 17
-			path: packages/web/lib/pages/usergroupmanagement.page.php
-
-		-
 			message: '#^Constructor of class FOG\\UserGroupManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -1313,12 +1193,6 @@ parameters:
 			identifier: method.void
 			count: 3
 			path: packages/web/lib/pages/usergroupmanagement.page.php
-
-		-
-			message: '#^Access to an undefined property FOG\\UserManagement\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 39
-			path: packages/web/lib/pages/usermanagement.page.php
 
 		-
 			message: '#^Constructor of class FOG\\UserManagement has an unused parameter \$name\.$#'
@@ -1391,18 +1265,6 @@ parameters:
 			identifier: method.void
 			count: 1
 			path: packages/web/lib/reports/product_keys.report.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/lib/reports/run_history.report.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/lib/reports/run_history.report.php
 
 		-
 			message: '#^Result of method FOG\\Base\\FOGPage\:\:render\(\) \(void\) is used\.$#'
@@ -1561,18 +1423,6 @@ parameters:
 			path: packages/web/management/other/index.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Audit/Blame.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Audit/Retention.php
-
-		-
 			message: '#^Call to function is_array\(\) with null will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -1661,12 +1511,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: packages/web/src/Auth/Authorization.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Base/Event.php
 
 		-
 			message: '#^Argument of an invalid type string supplied for foreach, only iterables are supported\.$#'
@@ -1795,30 +1639,6 @@ parameters:
 			path: packages/web/src/Base/FOGBase.php
 
 		-
-			message: '#^Call to method diff\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 15
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Cloning object of an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Base/FOGBase.php
-
-		-
 			message: '#^Comparison operation "\<" between int\<1, max\> and 1 is always false\.$#'
 			identifier: smaller.alwaysFalse
 			count: 1
@@ -1909,18 +1729,6 @@ parameters:
 			path: packages/web/src/Base/FOGBase.php
 
 		-
-			message: '#^Method FOG\\Base\\FOGBase\:\:diff\(\) has invalid return type FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Method FOG\\Base\\FOGBase\:\:diff\(\) should return FOG\\Base\\DateTime but returns string\.$#'
-			identifier: return.type
-			count: 7
-			path: packages/web/src/Base/FOGBase.php
-
-		-
 			message: '#^Method FOG\\Base\\FOGBase\:\:fileitems\(\) should return string but returns array\<int, list\>\.$#'
 			identifier: return.type
 			count: 1
@@ -1964,18 +1772,6 @@ parameters:
 
 		-
 			message: '#^Method FOG\\Base\\FOGBase\:\:getMasterInterface\(\) should return string but returns false\.$#'
-			identifier: return.type
-			count: 1
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Method FOG\\Base\\FOGBase\:\:niceDate\(\) has invalid return type FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Base/FOGBase.php
-
-		-
-			message: '#^Method FOG\\Base\\FOGBase\:\:niceDate\(\) should return FOG\\Base\\DateTime but returns DateTime\.$#'
 			identifier: return.type
 			count: 1
 			path: packages/web/src/Base/FOGBase.php
@@ -2407,12 +2203,6 @@ parameters:
 			path: packages/web/src/Base/FOGPage.php
 
 		-
-			message: '#^Access to an undefined property FOG\\Base\\FOGPage\:\:\$obj\.$#'
-			identifier: property.notFound
-			count: 31
-			path: packages/web/src/Base/FOGPage.php
-
-		-
 			message: '#^Call to an undefined method FOG\\Base\\FOGPage\:\:_addFields\(\)\.$#'
 			identifier: method.notFound
 			count: 2
@@ -2421,18 +2211,6 @@ parameters:
 		-
 			message: '#^Call to function unset\(\) contains undefined variable \$actionbox\.$#'
 			identifier: unset.variable
-			count: 1
-			path: packages/web/src/Base/FOGPage.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Base/FOGPage.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
 			count: 1
 			path: packages/web/src/Base/FOGPage.php
 
@@ -2686,12 +2464,6 @@ parameters:
 			message: '#^Access to an undefined property FOG\\Base\\Hook\:\:\$node\.$#'
 			identifier: property.notFound
 			count: 4
-			path: packages/web/src/Base/Hook.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
 			path: packages/web/src/Base/Hook.php
 
 		-
@@ -2977,12 +2749,6 @@ parameters:
 			path: packages/web/src/Client/FOGClient.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Client/FOGClient.php
-
-		-
 			message: '#^Instanceof between FOG\\Items\\Host and FOG\\Items\\Host will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
@@ -3037,12 +2803,6 @@ parameters:
 			path: packages/web/src/Client/ServiceModule.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Client/SnapinClient.php
-
-		-
 			message: '#^Instanceof between null and FOG\\Items\\StorageGroup will always evaluate to false\.$#'
 			identifier: instanceof.alwaysFalse
 			count: 2
@@ -3095,12 +2855,6 @@ parameters:
 			identifier: booleanAnd.alwaysFalse
 			count: 4
 			path: packages/web/src/Client/SnapinClient.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Client/UserTrack.php
 
 		-
 			message: '#^PHPDoc tag @throws with type FOG\\Client\\Exception is not subtype of Throwable$#'
@@ -3373,12 +3127,6 @@ parameters:
 			path: packages/web/src/Items/Group.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Items/Group.php
-
-		-
 			message: '#^Cannot access property \$id on int\.$#'
 			identifier: property.nonObject
 			count: 5
@@ -3484,12 +3232,6 @@ parameters:
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 2
-			path: packages/web/src/Items/Host.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 4
 			path: packages/web/src/Items/Host.php
 
 		-
@@ -3721,18 +3463,6 @@ parameters:
 			path: packages/web/src/Items/Module.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 4
-			path: packages/web/src/Items/MulticastSession.php
-
-		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/MulticastSession.php
-
-		-
 			message: '#^Method FOG\\Items\\MulticastSession\:\:cancel\(\) with return type void returns mixed but should not return anything\.$#'
 			identifier: return.void
 			count: 1
@@ -3833,12 +3563,6 @@ parameters:
 			identifier: ternary.alwaysFalse
 			count: 1
 			path: packages/web/src/Items/Role.php
-
-		-
-			message: '#^Call to method setTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/ScheduledTask.php
 
 		-
 			message: '#^Method FOG\\Items\\ScheduledTask\:\:cancel\(\) should return bool but returns object\.$#'
@@ -4117,42 +3841,6 @@ parameters:
 			path: packages/web/src/Items/StorageNode.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 7
-			path: packages/web/src/Items/Task.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/Task.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Items\\DateTimeImmutable\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/Task.php
-
-		-
-			message: '#^Cloning object of an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/Task.php
-
-		-
-			message: '#^Cloning object of an unknown class FOG\\Items\\DateTimeImmutable\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/Task.php
-
-		-
-			message: '#^Method FOG\\Items\\Task\:\:cutoff\(\) has invalid return type FOG\\Items\\DateTimeImmutable\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/Task.php
-
-		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 4
@@ -4165,28 +3853,10 @@ parameters:
 			path: packages/web/src/Items/Task.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Items/TaskLog.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 2
 			path: packages/web/src/Items/TaskLog.php
-
-		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Items/User.php
-
-		-
-			message: '#^Call to method setTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Items/User.php
 
 		-
 			message: '#^Left side of && is always true\.$#'
@@ -4229,12 +3899,6 @@ parameters:
 			identifier: isset.variable
 			count: 1
 			path: packages/web/src/Items/User.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Items/UserAuth.php
 
 		-
 			message: '#^Method FOG\\Items\\UserGroup\:\:destroy\(\) should return bool but returns object\.$#'
@@ -4321,12 +3985,6 @@ parameters:
 			path: packages/web/src/Managers/HostManager.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 3
-			path: packages/web/src/Managers/MulticastSessionManager.php
-
-		-
 			message: '#^Static property FOG\\Base\\FOGBase\:\:\$selected \(bool\|int\) does not accept string\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -4343,24 +4001,6 @@ parameters:
 			identifier: staticMethod.void
 			count: 1
 			path: packages/web/src/Managers/ScheduledTaskManager.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Managers/SnapinJobManager.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Managers/SnapinTaskManager.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Managers/TaskManager.php
 
 		-
 			message: '#^Access to an undefined property FOG\\Net\\FOGFTP\:\:\$host\.$#'
@@ -4837,30 +4477,6 @@ parameters:
 			path: packages/web/src/Router/Route.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Router/Route.php
-
-		-
-			message: '#^Call to method map\(\) on an unknown class FOG\\Router\\AltoRouter\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Router/Route.php
-
-		-
-			message: '#^Call to method match\(\) on an unknown class FOG\\Router\\AltoRouter\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Router/Route.php
-
-		-
-			message: '#^Call to method setTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Router/Route.php
-
-		-
 			message: '#^Default value of the parameter \#2 \$msg \(false\) of method FOG\\Router\\Route\:\:sendResponse\(\) is incompatible with type int\.$#'
 			identifier: parameter.defaultValue
 			count: 1
@@ -4993,12 +4609,6 @@ parameters:
 			path: packages/web/src/Router/Route.php
 
 		-
-			message: '#^Property FOG\\Router\\Route\:\:\$router has unknown class FOG\\Router\\AltoRouter as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Router/Route.php
-
-		-
 			message: '#^Result of static method FOG\\Router\\Route\:\:deletemass\(\) \(void\) is used\.$#'
 			identifier: staticMethod.void
 			count: 1
@@ -5091,12 +4701,6 @@ parameters:
 		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: packages/web/src/Service/FOGService.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
 			count: 1
 			path: packages/web/src/Service/FOGService.php
 
@@ -5221,24 +4825,6 @@ parameters:
 			path: packages/web/src/Service/FileDeleter.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 4
-			path: packages/web/src/Service/FileDeleter.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/FileDeleter.php
-
-		-
-			message: '#^Cloning object of an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/FileDeleter.php
-
-		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
@@ -5263,12 +4849,6 @@ parameters:
 			path: packages/web/src/Service/FileDeleter.php
 
 		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/MulticastManager.php
-
-		-
 			message: '#^Cannot call method getID\(\) on int\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -5277,12 +4857,6 @@ parameters:
 		-
 			message: '#^Cannot call method getTaskIDs\(\) on int\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: packages/web/src/Service/MulticastManager.php
-
-		-
-			message: '#^Cloning object of an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
 			count: 1
 			path: packages/web/src/Service/MulticastManager.php
 
@@ -5337,12 +4911,6 @@ parameters:
 		-
 			message: '#^Call to function unset\(\) contains undefined variable \$filelist\.$#'
 			identifier: unset.variable
-			count: 1
-			path: packages/web/src/Service/MulticastTask.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
 			count: 1
 			path: packages/web/src/Service/MulticastTask.php
 
@@ -5431,18 +4999,6 @@ parameters:
 			path: packages/web/src/Service/MulticastTask.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/PingHosts.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/PingHosts.php
-
-		-
 			message: '#^PHPDoc tag @throws with type FOG\\Service\\Exception is not subtype of Throwable$#'
 			identifier: throws.notThrowable
 			count: 1
@@ -5461,22 +5017,10 @@ parameters:
 			path: packages/web/src/Service/PingHosts.php
 
 		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 3
-			path: packages/web/src/Service/PluginRunner.php
-
-		-
 			message: '#^Static property FOG\\Service\\PluginRunner\:\:\$_runnerOn \(int\) does not accept array\|string\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: packages/web/src/Service/PluginRunner.php
-
-		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Service/RetentionRunner.php
 
 		-
 			message: '#^Static property FOG\\Service\\RetentionRunner\:\:\$_runnerOn \(int\) does not accept array\|string\.$#'
@@ -5509,18 +5053,6 @@ parameters:
 			'''
 			identifier: array.duplicateKey
 			count: 1
-			path: packages/web/src/TaskHandling/TaskQueue.php
-
-		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 7
-			path: packages/web/src/TaskHandling/TaskQueue.php
-
-		-
-			message: '#^Call to method getTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
 			path: packages/web/src/TaskHandling/TaskQueue.php
 
 		-
@@ -5596,30 +5128,6 @@ parameters:
 			path: packages/web/src/TaskHandling/TaskingElement.php
 
 		-
-			message: '#^Call to method format\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 3
-			path: packages/web/src/Util/FOGCron.php
-
-		-
-			message: '#^Call to method modify\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 6
-			path: packages/web/src/Util/FOGCron.php
-
-		-
-			message: '#^Call to method setTime\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Util/FOGCron.php
-
-		-
-			message: '#^Call to method setTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Util/FOGCron.php
-
-		-
 			message: '#^PHPDoc tag @throws with type FOG\\Util\\Exception is not subtype of Throwable$#'
 			identifier: throws.notThrowable
 			count: 1
@@ -5638,22 +5146,10 @@ parameters:
 			path: packages/web/src/Util/FOGCron.php
 
 		-
-			message: '#^Parameter \$time of method FOG\\Util\\FOGCron\:\:shouldRunCron\(\) has invalid type FOG\\Util\\DateTime\.$#'
-			identifier: class.notFound
-			count: 1
-			path: packages/web/src/Util/FOGCron.php
-
-		-
 			message: '#^Ternary operator condition is always true\.$#'
 			identifier: ternary.alwaysTrue
 			count: 3
 			path: packages/web/src/Util/FOGCron.php
-
-		-
-			message: '#^Call to method setTimestamp\(\) on an unknown class FOG\\Base\\DateTime\.$#'
-			identifier: class.notFound
-			count: 2
-			path: packages/web/src/Util/Timer.php
 
 		-
 			message: '#^If condition is always true\.$#'


### PR DESCRIPTION
**Stacked on #1437** — that PR is in the diff below until it merges. Merge
#1437 first, then update this branch.

**Baseline 2293 → 1629, deletions only.** Two mechanical changes account
for all of it, and correcting the docblocks turned up four genuinely wrong
type annotations on the way.

## `FOGPage::$obj` — 527 entries, one line

It was a **dynamic property**. PHP 8.2 deprecates those and PHP 9 makes
them an error, so every page construction on the versions the servers
actually run was emitting a deprecation.

Deliberately left **untyped**: `_init()` calls `unset($this->obj)` when the
id does not resolve, and a typed property would then throw on read instead
of warning — a different behaviour from the one this code has always had.

## Docblocks naming a class that does not exist in the file's namespace

`@return DateTime` inside `namespace FOG\Base;` resolves to
`FOG\Base\DateTime`. PHPStan then cannot check anything downstream of that
value, so **three annotations were costing 111 errors**. The code was always
right — it says `\DateTime` with the backslash.

Corrected: `FOGBase::niceDate()` and `FOGCron::shouldRunCron()`'s `@param`
(`\DateTime`), `Route::$router` (`\AltoRouter`), and `ImageManagement`'s
`@return` (`\FOG\Items\StorageNode|null`).

## What that unlocked

Restoring the analysis immediately reported **thirteen errors that had been
invisible behind the bad types**. All four causes were the annotation being
wrong rather than the code — which is the argument for doing this at all:

| Where | Documented | Actually |
|---|---|---|
| `FOGBase::diff()` | `DateTime` | a human-readable string — `"3 hours 5 minutes"`, `"2 years ago"`. **Seven of the thirteen were this one line.** |
| `Task::cutoff()` | `DateTimeImmutable` | clones the `\DateTime` from `niceDate()` |
| `FOGCron::parse()` | `string` | `getTimestamp()`, an **int**. Every caller feeds it straight to `setTimestamp()`, so the callers were right and the docblock was not. |
| `FOGCron::shouldRunCron()` | takes a `\DateTime` | takes that same **timestamp**. Had anyone believed the docblock and passed a DateTime, `setTimestamp()` would have raised a TypeError. |

Also cast `parse()`'s `setTime()` arguments, which were passing `format()`'s
strings into int parameters, and declared AltoRouter's seven verb methods as
`@method`. Those are provided by the fork's `__call()`, so the whole chained
route table in `Route::defineRoutes()` read as calls to undefined methods.

## Verification

Both halves mutation-tested, not just observed green:

- drop the `$obj` declaration → **527 errors**
- un-qualify `niceDate()`'s `@return` → **118 errors**
- restored → no errors

`tests/run-all.sh`: **180 passed, 0 failed**.

## Not in scope

`FOGBase::$Host` is annotated `@var Host` and initialised to `null`.
Correcting it to `Host|null` is the same class of fix but has a much wider
blast radius — every unguarded `self::$Host->` call site — so it wants its
own pass rather than riding along here.