### PR TITLE
Analyse tests/ as a second PHPStan pass with its own config and baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,3 +226,9 @@ jobs:
       # fault rather than a configuration one.
       - name: Analyse
         run: vendor/bin/phpstan analyse --memory-limit=2G --no-progress --error-format=github
+
+      # A second pass with its own config and its own baseline. Same job
+      # rather than its own, so the ruleset context stays the single name
+      # `phpstan` and neither pass can be required without the other.
+      - name: Analyse tests
+        run: vendor/bin/phpstan analyse -c phpstan-tests.neon --memory-limit=2G --no-progress --error-format=github

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4292');
+        define('FOG_VERSION', '1.6.0-beta.4296');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -1,0 +1,907 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/activity-sources.test.php
+
+		-
+			message: '#^Offset ''dt'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/activity-sources.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/all-classes-load.test.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: tests/api-nested-secret-strip.test.php
+
+		-
+			message: '#^Parameter \#3 \$failures of function check expects array, string given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/api-nested-secret-strip.test.php
+
+		-
+			message: '#^Parameter \#3 \$failures of function check is passed by reference, so it expects variables only\.$#'
+			identifier: argument.byRef
+			count: 4
+			path: tests/api-nested-secret-strip.test.php
+
+		-
+			message: '#^Call to function is_callable\(\) with array\{''FOG\\\\Auth…'', ''apiOnlyUsersGiven''\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: tests/api-only-users.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/api-server-owned-fields.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between bool and \*NEVER\* will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/arch-compatibility.test.php
+
+		-
+			message: '#^Result of \|\| is always false\.$#'
+			identifier: booleanOr.alwaysFalse
+			count: 1
+			path: tests/audit-invariants.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 5
+			path: tests/audit-invariants.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/audit-redaction-coverage.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:autoload\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/autoload-core-wins.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:classFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/autoload-core-wins.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/autoload-core-wins.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:classFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:srcFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Call to function is_subclass_of\(\) with ''FOG\\\\Db\\\\Mysqldump'' and ''Ifsnop\\\\Mysqldump…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<FOG\\HostManagement\>\|FOG\\HostManagement, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<HostManagement\>\|HostManagement, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 1
+			path: tests/autoload.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/break-glass-auth-sources.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 0 and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: tests/createtable-column-defaults.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/credentials-are-not-html-escaped.test.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: tests/db-failure-is-recorded.test.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: tests/db-failure-is-recorded.test.php
+
+		-
+			message: '#^Property FogFakeDb\:\:\$error \(bool\) does not accept string\.$#'
+			identifier: assign.propertyType
+			count: 3
+			path: tests/db-failure-is-recorded.test.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between ''the original cause'' and ''the original cause'' will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: tests/db-failure-is-recorded.test.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/db-failure-is-recorded.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 0 and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: tests/entrypoint-classes-resolve.test.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/entrypoint-classes-resolve.test.php
+
+		-
+			message: '#^Offset string on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/entrypoint-classes-resolve.test.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: tests/entrypoint-classes-resolve.test.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/event-frame-readers.test.php
+
+		-
+			message: '#^Offset ''dt'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/event-frame-readers.test.php
+
+		-
+			message: '#^Offset ''formatter'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/event-frame-readers.test.php
+
+		-
+			message: '#^Offset ''/images/part/ok\.img'' on array\{''/images/part''\: ''dir'', ''/images/part/ok\.img''\: ''file'', ''/images/part/locked\.img''\: ''file''\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/fogssh-delete-terminates.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{\} and array\{''/images/Base\-Dev\.movetmp''\: ''dir'', ''/images/Base\-Dev\.movetmp/d1\.partitions''\: ''file'', ''/images/Base\-Dev\.movetmp/d1\.img''\: ''file''\} will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/fogssh-delete-terminates.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 0 and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: tests/getfilesize-walks-directories.test.php
+
+		-
+			message: '#^Parameter \#3 \$failures of function check expects array, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/getfilesize-walks-directories.test.php
+
+		-
+			message: '#^Parameter \#3 \$failures of function check is passed by reference, so it expects variables only\.$#'
+			identifier: argument.byRef
+			count: 2
+			path: tests/getfilesize-walks-directories.test.php
+
+		-
+			message: '#^Function hostOrderColumns\(\) never returns array so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: tests/grid-host-name-order.test.php
+
+		-
+			message: '#^Parameter \#3 \$orderby of static method FOG\\Base\\FOGManagerController\:\:order\(\) expects array, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/grid-order-clause.test.php
+
+		-
+			message: '#^Call to function is_int\(\) with 0\|100 will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/history-untranslated-and-bounded.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^Offset 0 on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between '''' and ''public \$active  \=…''\|''public \$active \= …''\|''public \$active \=…''\|''public \$active\=true;'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/hook-event-contract.test.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: tests/host-site-csv-label.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/imaging-notify-events.test.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Route\:\:\$rows\.$#'
+			identifier: staticProperty.notFound
+			count: 2
+			path: tests/lib/bootmenu-harness.php
+
+		-
+			message: '#^Call to function is_numeric\(\) with \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/lib/bootmenu-harness.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/lib/bootmenu-harness.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: tests/lib/bootmenu-harness.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Base\\FOGBase\:\:\$settings\.$#'
+			identifier: staticProperty.notFound
+			count: 1
+			path: tests/lib/bootmenu-render.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Router\\Route\:\:\$rows\.$#'
+			identifier: staticProperty.notFound
+			count: 2
+			path: tests/lib/bootmenu-render.php
+
+		-
+			message: '#^Access to protected property \$HookManager of class FOG\\Base\\FOGBase\.$#'
+			identifier: staticProperty.protected
+			count: 2
+			path: tests/lib/bootmenu-render.php
+
+		-
+			message: '#^Static property FOG\\Base\\FOGBase\:\:\$Host \(FOG\\Items\\Host\) does not accept FOG\\StubHost\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: tests/lib/bootmenu-render.php
+
+		-
+			message: '#^Constructor of class SchemaStub has an unused parameter \$args\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: tests/lib/fog-schema-collector.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/lib/fog-test-harness.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Scenario\:\:\$assocCount\.$#'
+			identifier: staticProperty.notFound
+			count: 3
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Scenario\:\:\$devSetting\.$#'
+			identifier: staticProperty.notFound
+			count: 3
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Scenario\:\:\$logSetting\.$#'
+			identifier: staticProperty.notFound
+			count: 3
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Access to an undefined static property FOG\\Scenario\:\:\$primary\.$#'
+			identifier: staticProperty.notFound
+			count: 3
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between null and non\-empty\-string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/lib/replicator-transcript.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/lib/scanner-transcript.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 0 and 0 will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/logout-redirect-seam.test.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: tests/multicast-kill-contract.test.php
+
+		-
+			message: '#^Offset 0 on array\{resource\|false\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/multicast-kill-contract.test.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(lowercase\-string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/nonunique-names-match-schema.test.php
+
+		-
+			message: '#^Access to an undefined property FakeHookManager\:\:\$listener\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/object-scope-enforcement.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/object-scope-enforcement.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/page-discovery-survives-bad-file.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/permission-actions-declared.test.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/permission-purge-guard.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/permission-purge-guard.test.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments non\-empty\-string, array\{\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/php-deprecations.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/plugin-extension-points.test.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between ''/ext/'' and ''/ext/'' will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: tests/plugin-extension-points.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/plugin-list-scope-events.test.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: tests/plugin-list-scope-events.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/plugin-vendor-autoload.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:forgetClassFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/psr4-bridge.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:srcFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: tests/psr4-bridge.test.php
+
+		-
+			message: '#^Call to function class_exists\(\) with ''PROBEALPHA''\|''ProbeAlpha''\|''probealpha'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/psr4-bridge.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/psr4-bridge.test.php
+
+		-
+			message: '#^Parameter \#3 \$failures of function check is passed by reference, so it expects variables only\.$#'
+			identifier: argument.byRef
+			count: 7
+			path: tests/replication-group-scope.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/retention-registry.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''db'' and \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/route-column-contract.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''dt'' and \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/route-column-contract.test.php
+
+		-
+			message: '#^Offset ''formatter'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/route-column-contract.test.php
+
+		-
+			message: '#^Offset ''prime'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/route-column-contract.test.php
+
+		-
+			message: '#^Access to undefined constant FakeDB\:\:SENTINEL\.$#'
+			identifier: classConstant.notFound
+			count: 3
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''data'' and \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to function is_array\(\) with ''unset\-sentinel'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to function is_array\(\) with null will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Offset ''data'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Parameter \#2 \$whereItems of static method FOG\\Router\\Route\:\:getIds\(\) expects array, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Parameter \#2 \$whereItems of static method FOG\\Router\\Route\:\:ids\(\) expects array, string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between \*NEVER\* and 0 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/route-ids-getfield-sensitive.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''_lang''\|''data''\|''draw''\|''firstUrl''\|''lastUrl''\|''nextUrl''\|''prevUrl''\|''recordsFiltered''\|''recordsReturned''\|''recordsTotal''\|''truncated'' and array\{\} will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\{\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Offset ''_lang'' does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Offset ''data'' does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 5
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Offset ''data'' on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Offset ''data'' on array\{\} on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Offset ''recordsTotal'' does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 1 and 2 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 2 and 1 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 2 and 2 will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 2
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{array\{id\: 1\}, array\{id\: 2\}\} and array\{\} will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{data\: array\{array\{id\: 1\}, array\{id\: 2\}\}, recordsTotal\: 2, recordsFiltered\: 2\} and array\{data\: array\{array\{id\: 1\}, array\{id\: 2\}\}, recordsTotal\: 2, recordsFiltered\: 2\} will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/route-read-path-guards.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/route-result-wrappers.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''run_history'' and array\{hosts_and_users\: ''usertracking'', run_history\: ''task''\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/run-history-report.test.php
+
+		-
+			message: '#^Offset ''run_history'' on array\{hosts_and_users\: ''usertracking'', run_history\: ''task''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/run-history-report.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''task'' and ''task'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/run-history-report.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between false and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/schema-executes.test.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: tests/schema-manifest-consistent.test.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: tests/service-daemon-descriptors.test.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: tests/service-proclist-cleanup.test.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/service-proclist-cleanup.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/session-provenance.test.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: tests/site-grant-reverse-tabs.test.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''FOG\\\\Items\\\\Site'' and ''loadCatchall'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/site-model.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/site-model.test.php
+
+		-
+			message: '#^Offset ''site'' on array\{architecture\: ''image'', filedeletequeue\: ''task'', group\: ''group'', groupassociation\: ''group'', history\: ''report'', hookevent\: ''settings'', host\: ''host'', hostautologout\: ''host'', \.\.\.\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/site-model.test.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<SiteManagement\>\|SiteManagement, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/site-model.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''site'' and ''site'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/site-model.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/site-scope-lists.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/site-scope.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/stale-class-file-list.test.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: tests/storagenode-listings-shape.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 0 and 1 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: tests/storagenode-listings-shape.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 0 and 2 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/storagenode-listings-shape.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and '''' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/storagenode-listings-shape.test.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/storagenode-listings-shape.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/task-error-report.test.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''FOG\\\\Items\\\\TaskLog'' and ''recordState'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/tasklog-stamps-transition-time.test.php
+
+		-
+			message: '#^Function fogHostProbe not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: tests/url-requests-tls.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/usertracking-permission-split.test.php
+
+		-
+			message: '#^Offset ''getloginhist'' on array\{savegroup\?\: ''group\.create'', getloginhist\: ''usertracking\.view''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/usertracking-permission-split.test.php
+
+		-
+			message: '#^Offset ''usertracking'' on array\{architecture\: ''image'', filedeletequeue\: ''task'', group\: ''group'', groupassociation\: ''group'', history\: ''report'', hookevent\: ''settings'', host\: ''host'', hostautologout\: ''host'', \.\.\.\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/usertracking-permission-split.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''usertracking'' and ''usertracking'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/usertracking-permission-split.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''usertracking\.view'' and ''usertracking\.view'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/usertracking-permission-split.test.php

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -1,0 +1,69 @@
+# PHPStan configuration for tests/ -- a SECOND pass, separate from phpstan.neon.
+#
+# It is separate rather than another entry in the main config's `paths` because
+# the two are analysing different kinds of program and need different rules
+# about what counts as noise. The application is one program. tests/ is 180-odd
+# INDEPENDENT scripts that happen to share a directory, each run on its own by
+# run-all.sh, and PHPStan has no way to analyse them that way -- it sees one
+# global namespace containing all of them at once.
+#
+# Run it the same way, pointing at this file:
+#
+#   composer install
+#   vendor/bin/phpstan analyse -c phpstan-tests.neon --memory-limit=2G
+#
+# Regenerate its baseline with --generate-baseline=phpstan-tests-baseline.neon.
+#
+# The convention in tests/ is deliberately out of scope here: this pass adapts
+# to the tests as they are written, it does not ask them to change.
+
+parameters:
+    level: 5
+
+    # Same reasoning as phpstan.neon: without it, FIXING a baselined finding
+    # fails the build.
+    reportUnmatchedIgnoredErrors: false
+
+    # Same range as the application. A test that only runs correctly on one end
+    # of the supported range is a test that lies on the other end.
+    phpVersion:
+        min: 70400
+        max: 80300
+
+    paths:
+        - tests
+
+    ignoreErrors:
+        # Two STRUCTURAL blind spots, ignored by identifier rather than
+        # baselined, because they are permanent properties of how these tests
+        # are written and not a backlog anyone will ever burn down.
+        #
+        # 1. Fixtures are built with eval(). Several tests stand up a probe
+        #    class from a source string so they can exercise shipped code
+        #    against a stub -- ScopeProbe in setting-value-filter-oracle,
+        #    NodeSigProbe in node-signature-auth, FOGTest\Svc in
+        #    service-proclist-cleanup. PHPStan cannot see inside eval() and
+        #    never will, so every use of those classes reads as unknown. That
+        #    was 147 of the 407 findings at level 5.
+        -
+            identifier: class.notFound
+            path: tests/*
+        # 2. Each test file declares its own global helpers -- check(),
+        #    fail(), and friends -- with the signature that file needs. Run
+        #    standalone that is correct. Analysed together they collide, and
+        #    PHPStan measures every call against whichever declaration it saw
+        #    first: "Function check invoked with 2 parameters, 4 required",
+        #    59 times, none of them a real defect. Fixing this would mean
+        #    changing the tests/*.test.php convention, which is not this
+        #    pass's business.
+        -
+            identifier: arguments.count
+            path: tests/*
+
+    bootstrapFiles:
+        # So a test that names a real FOG class resolves it.
+        - packages/web/vendor/autoload.php
+        - build/phpstan/constants.stub.php
+
+includes:
+    - phpstan-tests-baseline.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,12 +58,10 @@ parameters:
         - packages/service
         - bin
 
-    # tests/ is deliberately NOT analysed yet. Its 144 files reach core by bare
-    # global name and build FOG objects without the runtime bootstrap, so at
-    # level 1 they produce 198 errors of which 104 are class.notFound and 59 are
-    # arguments.count -- all one problem ("PHPStan is not booting FOG") wearing
-    # 163 different hats. Baselining that would make the baseline actively
-    # misleading. Bring tests/ in as a second pass with its own config.
+    # tests/ is analysed by phpstan-tests.neon, not here. It needs two
+    # ignoreErrors rules this config must not carry -- see that file's header
+    # for why eval()'d fixtures and per-file global helpers make a shared
+    # config the wrong shape.
 
     excludePaths:
         analyseAndScan:


### PR DESCRIPTION
**Stacked on #1438, which is stacked on #1437.** Merge order: #1437 → #1438 →
this. Both are in the diff below until they merge.

`tests/` was left out of the first baseline deliberately. It comes in here as
`phpstan-tests.neon` + `phpstan-tests-baseline.neon`, run as a **second step
of the same `phpstan` CI job** — so the ruleset context stays the single name
`phpstan` and neither pass can be required without the other.

## Why a separate config rather than another `paths` entry

The two are analysing different **kinds of program**. The application is one
program. `tests/` is 180-odd **independent scripts** that share a directory,
each run on its own by `run-all.sh` — and PHPStan has no mode that analyses
them that way. It sees one global namespace holding all of them at once.

That produces two categories of finding that are artifacts of the viewing
angle rather than defects. They are ignored **by identifier and documented in
the config**, not baselined, because they are permanent properties of how
these tests are written and not a backlog anyone will burn down:

| Blind spot | Count | Why it is permanent |
|---|---|---|
| `eval()`'d fixtures — `ScopeProbe`, `NodeSigProbe`, `FOGTest\Svc` | 147 of 407 | PHPStan cannot see inside `eval()` and never will |
| per-file global helpers — each file declares its own `check()` | 59 | correct standalone, collides when analysed together; fixing it would mean changing the `tests/*.test.php` convention, which is explicitly not this pass's business |

That leaves **199, baselined**, so the gate is on new findings only — same
arrangement and reasoning as the application pass, `reportUnmatchedIgnoredErrors:
false` included, so fixing one does not fail the build.

## What it buys

A check on the shape of the assertions themselves. Proved by adding a file
that asserts `count([1,2,3]) === 0`, reads an undefined variable and calls a
method that does not exist:

```
4  Strict comparison using === between 3 and 0 will always evaluate to false.
5  Variable $undefinedVariableHere might not be defined.
7  Call to an undefined static method FOG\Base\FOGBase::thisMethodDoesNotExist().
[ERROR] Found 3 errors — exit 1
```

**An assertion that cannot fail** is the failure mode this suite is most
exposed to, and nothing else in it looks for one.

## The 199 were reviewed, not just captured

Several look alarming and are not, which is worth saying so the baseline is not
mistaken for a list of known-broken tests:

- `storagenode-listings-shape` `0 === 1` — PHPStan constant-folding an array
  that `eval()` fills.
- `php-deprecations` always-false `in_array()` — an intentionally empty
  exclusion list (`const VENDORED = []`).
- `audit-invariants` null checks — defensive guards against a helper whose own
  docblock says it cannot return null.

**No fake gate was found.** The value here is forward-looking.

## Out of scope, as specified

No change to the `tests/*.test.php` convention and none to `run-all.sh`. This
pass adapts to the tests as they are written.