### PR TITLE
Give the database export its own permission, and stop writing it to a predictable path

### DIFF
--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -3821,11 +3821,17 @@ class FOGConfigurationPage extends FOGPage
             . '</div>'
         ];
 
-        $buttons = self::makeButton(
-            'exportdb',
-            _('Export'),
-            'btn btn-primary float-end'
-        );
+        // The button follows the grant, the way the Login History tab does:
+        // a role that cannot export should not be shown the control that
+        // fails. The check in configPost() is the gate; this is the display.
+        $buttons = '';
+        if (Authorization::can('system.export')) {
+            $buttons = self::makeButton(
+                'exportdb',
+                _('Export'),
+                'btn btn-primary float-end'
+            );
+        }
         $buttons .= self::makeButton(
             'importdb',
             _('Import'),
@@ -3871,9 +3877,35 @@ class FOGConfigurationPage extends FOGPage
         $serverFault = false;
         try {
             if (isset($_POST['toExport'])) {
+                // The UI's own dump is the same authority as
+                // GET /system/export -- same tables, same credentials --
+                // so it takes the same permission (GH-1410). Checked here
+                // rather than by the node/sub map because this one POST
+                // endpoint serves both export and import, and only the
+                // export half is a credential census; `about` aliases to
+                // `settings`, so the map would put both on settings.edit.
+                if (!Authorization::can('system.export')) {
+                    $this->_jsonExit(
+                        HTTPResponseCodes::HTTP_FORBIDDEN,
+                        [
+                            'error' => _('You do not have permission to '
+                                . 'export the database.'),
+                            'title' => _('Export Failed')
+                        ]
+                    );
+                }
                 $backup_name = 'fog_backup_'
                     . self::formatTime('now', 'Ymd_His');
-                $tmpfile = '/tmp/' . $backup_name;
+                // Not a fixed name under the system temp dir keyed on
+                // $backup_name: that is guessable to the second,
+                // world-readable under the default umask, and fopen()
+                // follows symlinks. Same three defects as
+                // Schema::exportdb() had -- see the comment there.
+                $tmpfile = tempnam(sys_get_temp_dir(), 'fog_backup_');
+                if (false === $tmpfile) {
+                    throw new \Exception(_('Could not create tmp file.'));
+                }
+                chmod($tmpfile, 0600);
                 $data = '';
                 self::getClass('Mysqldump')->start($tmpfile);
                 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -79,7 +79,12 @@ class RoleManagement extends FOGPage
             'service' => _('Client Settings'),
             'settings' => _('FOG Settings'),
             'report' => _('Reports'),
-            'plugin' => _('Plugins')
+            'plugin' => _('Plugins'),
+            // Adding system.export puts a new row and a new one-checkbox
+            // column in this matrix. Labelled so neither reads as the
+            // ucfirst() fallback -- `install` and `manage` already rely on
+            // it, but a grant this wide should not be introduced that way.
+            'system' => _('System')
         ];
     }
     /**
@@ -94,7 +99,8 @@ class RoleManagement extends FOGPage
             'create' => _('Create'),
             'edit' => _('Edit'),
             'delete' => _('Delete'),
-            'task' => _('Task')
+            'task' => _('Task'),
+            'export' => _('Export')
         ];
     }
     /**

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -39,7 +39,15 @@ unset($_remoteIp, $_serverIp);
 
 $backup_name = 'fog_backup_'
     . FOGCore::formatTime('now', 'Ymd_His');
-$tmpfile = '/tmp/' . $backup_name;
+// Not a fixed name under the system temp dir: this dumps every credential
+// in the deployment, and a guessable path is world-readable under the
+// default umask, collides with a concurrent run, and is a symlink target
+// -- fopen() follows one. Same fix as Schema::exportdb() (GH-1410).
+$tmpfile = tempnam(sys_get_temp_dir(), 'fog_backup_');
+if (false === $tmpfile) {
+    throw new \Exception(_('Could not create tmp file.'));
+}
+chmod($tmpfile, 0600);
 $data = '';
 FOGCore::getClass('Mysqldump')->start($tmpfile);
 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1692,6 +1692,10 @@ msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "In dieser Gruppe wurde kein Speicherknoten gefunden"
 
@@ -2528,6 +2532,10 @@ msgstr "Export vollständig"
 
 msgid "Export Configuration"
 msgstr "Konfiguration exportieren"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "Image aktualisiert"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8045,6 +8053,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "System Tools"
+
+#, fuzzy
 msgid "System Log"
 msgstr "System Tools"
 
@@ -9704,6 +9716,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1694,6 +1694,10 @@ msgid "Could not create the staging directory."
 msgstr "Failed to create Snapin Job"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "Could not read tmp file."
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "Could not find a Storage Node, is there one enabled within this group?"
 
@@ -2529,6 +2533,10 @@ msgstr "Complete"
 
 msgid "Export Configuration"
 msgstr "Export Configuration"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "Image updated"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8040,6 +8048,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "System Type"
+
+#, fuzzy
 msgid "System Log"
 msgstr "System Type"
 
@@ -9699,6 +9711,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "No connection to the database"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1714,6 +1714,10 @@ msgstr "No se pudo crear Complemento de empleo"
 msgid "Could not create the staging directory."
 msgstr "No se pudo crear Complemento de empleo"
 
+#, fuzzy
+msgid "Could not create tmp file."
+msgstr "No se pudo leer el archivo tmp."
+
 msgid "Could not find a Storage Node in this group"
 msgstr ""
 
@@ -2567,6 +2571,10 @@ msgstr "impresora iPrint"
 #, fuzzy
 msgid "Export Configuration"
 msgstr "Configuración"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "imagen actualizada"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8220,6 +8228,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "Tipo de sistema"
+
+#, fuzzy
 msgid "System Log"
 msgstr "Tipo de sistema"
 
@@ -9883,6 +9895,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Haga clic en el botón para exportar la base de datos."
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1692,6 +1692,10 @@ msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "In dieser Gruppe wurde kein Speicherknoten gefunden"
 
@@ -2528,6 +2532,10 @@ msgstr "Export vollständig"
 
 msgid "Export Configuration"
 msgstr "Konfiguration exportieren"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "Image aktualisiert"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8046,6 +8054,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "System Tools"
+
+#, fuzzy
 msgid "System Log"
 msgstr "System Tools"
 
@@ -9705,6 +9717,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1696,6 +1696,10 @@ msgid "Could not create the staging directory."
 msgstr "Échec de la création d'emploi Snapin"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "Impossible de trouver un nœud de stockage, est-il un permis dans ce groupe?"
 
@@ -2531,6 +2535,10 @@ msgstr "Achevée"
 
 msgid "Export Configuration"
 msgstr "Exporter la configuration"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "image mise à jour"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8042,6 +8050,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "Type de système"
+
+#, fuzzy
 msgid "System Log"
 msgstr "Type de système"
 
@@ -9701,6 +9713,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Pas de connexion à la base de données"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1641,6 +1641,10 @@ msgstr "Impossibile creare Snapin lavoro"
 msgid "Could not create the staging directory."
 msgstr "Impossibile creare Snapin lavoro"
 
+#, fuzzy
+msgid "Could not create tmp file."
+msgstr "Impossibile leggere il file tmp."
+
 msgid "Could not find a Storage Node in this group"
 msgstr "Impossibile trovare un nodo di archiviazione in questo gruppo"
 
@@ -2461,6 +2465,10 @@ msgstr "Esportazione Completata"
 
 msgid "Export Configuration"
 msgstr "Esporta configurazione"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "immagine aggiornata"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -7776,6 +7784,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "Utilità di sistema"
+
+#, fuzzy
 msgid "System Log"
 msgstr "Utilità di sistema"
 
@@ -9380,6 +9392,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Nessuna connessione al database"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1625,6 +1625,10 @@ msgstr "スナップインジョブの作成に失敗しました"
 msgid "Could not create the staging directory."
 msgstr "スナップインジョブの作成に失敗しました"
 
+#, fuzzy
+msgid "Could not create tmp file."
+msgstr "一時ファイルを読み取れませんでした。"
+
 msgid "Could not find a Storage Node in this group"
 msgstr "このグループ内にストレージノードが見つかりません"
 
@@ -2444,6 +2448,10 @@ msgstr "エクスポートが完了しました"
 
 msgid "Export Configuration"
 msgstr "構成をエクスポート"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "インポートに失敗しました"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -7716,6 +7724,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "システムツール"
+
+#, fuzzy
 msgid "System Log"
 msgstr "システムツール"
 
@@ -9315,6 +9327,10 @@ msgstr "少なくとも 1 つのグループを関連付ける必要がありま
 
 #, fuzzy
 msgid "You do not have permission to change site grants."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
+msgid "You do not have permission to export the database."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1452,6 +1452,9 @@ msgstr ""
 msgid "Could not create the staging directory."
 msgstr ""
 
+msgid "Could not create tmp file."
+msgstr ""
+
 msgid "Could not find a Storage Node in this group"
 msgstr ""
 
@@ -2157,6 +2160,9 @@ msgid "Export Complete"
 msgstr ""
 
 msgid "Export Configuration"
+msgstr ""
+
+msgid "Export Failed"
 msgstr ""
 
 msgid "Export LDAP Servers"
@@ -6820,6 +6826,9 @@ msgstr ""
 msgid "Sync finished - "
 msgstr ""
 
+msgid "System"
+msgstr ""
+
 msgid "System Log"
 msgstr ""
 
@@ -8270,6 +8279,9 @@ msgid "You do not have permission to change provider group associations."
 msgstr ""
 
 msgid "You do not have permission to change site grants."
+msgstr ""
+
+msgid "You do not have permission to export the database."
 msgstr ""
 
 msgid "You do not have permission to issue API tokens."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1695,6 +1695,10 @@ msgid "Could not create the staging directory."
 msgstr "Falha ao criar Snapin Job"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "Não foi possível encontrar um nó de armazenamento, há um ativado dentro deste grupo?"
 
@@ -2530,6 +2534,10 @@ msgstr "Completo"
 
 msgid "Export Configuration"
 msgstr "Configuração de exportação"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "imagem atualizada"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8041,6 +8049,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "Tipo de sistema"
+
+#, fuzzy
 msgid "System Log"
 msgstr "Tipo de sistema"
 
@@ -9700,6 +9712,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "Sem conexão com o banco de dados"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1695,6 +1695,10 @@ msgid "Could not create the staging directory."
 msgstr "无法创建管理单元工作"
 
 #, fuzzy
+msgid "Could not create tmp file."
+msgstr "无法读取tmp文件。"
+
+#, fuzzy
 msgid "Could not find a Storage Node in this group"
 msgstr "找不到存储节点，有一个图像，此组内启用？"
 
@@ -2530,6 +2534,10 @@ msgstr "完成"
 
 msgid "Export Configuration"
 msgstr "导出配置"
+
+#, fuzzy
+msgid "Export Failed"
+msgstr "图片更新"
 
 #, fuzzy
 msgid "Export LDAP Servers"
@@ -8041,6 +8049,10 @@ msgid "Sync finished - "
 msgstr ""
 
 #, fuzzy
+msgid "System"
+msgstr "系统类型"
+
+#, fuzzy
 msgid "System Log"
 msgstr "系统类型"
 
@@ -9700,6 +9712,10 @@ msgstr ""
 
 msgid "You do not have permission to change site grants."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to export the database."
+msgstr "没有连接到数据库"
 
 msgid "You do not have permission to issue API tokens."
 msgstr ""

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -220,7 +220,7 @@ class Authorization extends FOGBase
         // than left to the unknown-route fallback so the intent is recorded.
         'openapi' => null,
         'openapiSwaggerAlias' => null,
-        'export' => 'settings.edit',
+        'export' => 'system.export',
         'kernelUpdate' => 'settings.view',
         'initrdUpdate' => 'settings.view',
         'logfiles' => 'settings.view',
@@ -494,7 +494,37 @@ class Authorization extends FOGBase
             // create/delete are the plugin ROW, which is how one is switched
             // on and off; they were routable and undeclared, which had the
             // effect of making the lesser power the harder one to grant.
-            'plugin' => ['view', 'create', 'edit', 'delete', 'install']
+            'plugin' => ['view', 'create', 'edit', 'delete', 'install'],
+            // The whole-database dump, split out of settings.edit (GH-1410).
+            // It is not a settings read: the dump is every row of all 70
+            // tables, so it hands over users.uPass and uAPIToken,
+            // apiTokens.atHash, userAuths' hashes, every host's
+            // hostSecToken and hostADPass, nfsGroupMembers' credentials and
+            // every globalSettings value -- FOG_NODE_API_KEY and the LDAP
+            // bind password included. It is the one route that bypasses the
+            // API's own data protection: unfilterableFields() refuses
+            // token/password filters, maskSensitiveSetting() strips values
+            // by name, and Route::$sensitiveSettings says of
+            // FOG_NODE_API_KEY that "it is a shared HMAC secret, so it must
+            // not be readable over REST". This returns it in the clear.
+            //
+            // So it is a credential multiplier rather than a data read:
+            // compromise of one token yields every credential in the
+            // deployment, plus persistence that survives rotating the token
+            // that got in. "May change a setting" is not self-evidently
+            // "may take a copy of every secret in the estate", and SIX page
+            // nodes already map onto settings.edit.
+            //
+            // Deny by default, exactly as `activity` and `audit.manage`
+            // were introduced: no schema step seeds it, so only a holder of
+            // '*' has it until an administrator grants it. A role holding
+            // settings.edit and nothing else LOSES the export on upgrade,
+            // which is the point of the change.
+            //
+            // It also fixes the audit trail as a side effect: _auditGate()
+            // records the permission string, so the row now says the whole
+            // database left the server instead of saying settings.edit.
+            'system' => ['export']
         ];
     }
     /**

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4296');
+        define('FOG_VERSION', '1.6.0-beta.4299');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Items/Schema.php
+++ b/packages/web/src/Items/Schema.php
@@ -197,7 +197,19 @@ class Schema extends FOGController
     ) {
         $orig_exec_time = ini_get('max_execution_time');
         set_time_limit(0);
-        $file = '/tmp/fog_backup_tmp.sql';
+        // A fixed path in /tmp was three bugs at once (GH-1410): the dump
+        // holds every credential in the deployment and the default umask
+        // made it world-readable for the duration; two concurrent exports
+        // clobbered each other; and fopen() follows symlinks, so a
+        // pre-planted symlink at a guessable name was a write-as-web-user
+        // primitive. tempnam() creates the file 0600 and unpredictably
+        // named, and Mysqldump's own fopen(...,'wb') truncates rather than
+        // recreating it, so the mode survives.
+        $file = tempnam(sys_get_temp_dir(), 'fog_backup_');
+        if (false === $file) {
+            throw new \Exception(_('Could not create tmp file.'));
+        }
+        chmod($file, 0600);
         if (!$backup_name) {
             $backup_name = sprintf(
                 'fog_backup_%s.sql',

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -2343,7 +2343,17 @@ class OpenAPI extends FOGBase
                                 // application/sql, application/octet-stream
                                 // and text/plain all compile once the
                                 // binary format is dropped.
-                                'application/sql' => [
+                                //
+                                // text/plain because that is what the server
+                                // actually sends (Schema::exportdb()), so
+                                // anything written against the live route has
+                                // been built around it. application/sql is the
+                                // more correct description -- it is registered,
+                                // RFC 6922 -- but changing the wire contract to
+                                // match the document breaks working consumers,
+                                // and correcting the document breaks none
+                                // (GH-1410 item 4).
+                                'text/plain' => [
                                     'schema' => [
                                         'type' => 'string'
                                     ]

--- a/tests/system-export-permission.test.php
+++ b/tests/system-export-permission.test.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * The whole-database dump takes its own permission, and leaves no
+ * predictable file behind while it runs.
+ *
+ * Three routes hand over every row of all 70 tables -- GET /system/export,
+ * the Export button on FOG Configuration, and maintenance/backup_db.php,
+ * which the installer calls before an upgrade. That means users.uPass and
+ * uAPIToken, apiTokens.atHash, userAuths' hashes, every host's hostSecToken
+ * and hostADPass, nfsGroupMembers' credentials, and every globalSettings
+ * value including FOG_NODE_API_KEY and the LDAP bind password.
+ *
+ * The first two used to resolve to settings.edit, which SIX page nodes
+ * already map onto -- so "may edit the OUI table" and "may take a copy of
+ * every secret in the estate" were the same grant. It matters more here
+ * than anywhere else in the API, because this is the one route that
+ * bypasses the data protection the rest of the router applies:
+ * unfilterableFields() refuses token/password filters,
+ * maskSensitiveSetting() strips values by name, and Route::$sensitiveSettings
+ * says of FOG_NODE_API_KEY that "it is a shared HMAC secret, so it must not
+ * be readable over REST". The dump returns it in the clear.
+ *
+ * The permission half is EXECUTED, not grepped: resolveApiPermission() is
+ * the same call the router makes, so a map entry edited back, or a registry
+ * node dropped, fails here. A grep for the string would pass on a route
+ * rewired around it.
+ *
+ * The temp-file half cannot be executed without a database, so it is
+ * asserted as the absence of the dangerous literal anywhere under
+ * packages/web. A fixed name in the system temp dir was three defects at
+ * once: the dump is world-readable under the default umask for as long as
+ * it takes to write, two concurrent exports clobber each other, and
+ * fopen() follows symlinks, so a guessable path is a write-as-web-user
+ * primitive. That third path was found by this test, not by the issue.
+ *
+ * Refs https://github.com/FOGProject/fogproject/issues/1410
+ *
+ * No FOG boot: the composer autoloader is enough, because every call below
+ * reads constant tables. Same DB-free stance as
+ * permission-actions-declared.test.php, one step lighter.
+ *
+ * Usage: php tests/system-export-permission.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$autoload = $webroot . '/vendor/autoload.php';
+if (!is_readable($autoload)) {
+    fwrite(STDERR, "FAIL: cannot read $autoload\n");
+    exit(1);
+}
+require_once $autoload;
+
+$results = [];
+
+/**
+ * Record one assertion and echo its result.
+ *
+ * Named uniquely rather than check(): tests/ is analysed as one program by
+ * phpstan-tests.neon, and a global check() collides with the dozens of
+ * other files that declare their own.
+ *
+ * @param string $label what is being asserted
+ * @param bool   $ok    whether it held
+ * @param string $extra detail printed on failure
+ *
+ * @return bool the value of $ok, for the caller to collect
+ */
+function exportCheck($label, $ok, $extra = '')
+{
+    $suffix = ('' !== $extra ? " ($extra)" : '');
+    echo ($ok ? 'ok   - ' : 'FAIL - ') . $label . ($ok ? '' : $suffix) . "\n";
+    return $ok;
+}
+
+/*
+ * 1. The router's own resolution, executed.
+ */
+$resolved = FOG\Auth\Authorization::resolveApiPermission('export');
+$results[] = exportCheck(
+    'GET /system/export resolves to system.export',
+    'system.export' === $resolved,
+    'got ' . var_export($resolved, true)
+);
+$results[] = exportCheck(
+    'it is not back on settings.edit, which six page nodes share',
+    'settings.edit' !== $resolved,
+    'got ' . var_export($resolved, true)
+);
+
+/*
+ * 2. The permission has to be grantable, or the only holder is '*' forever
+ *    and assertCanGrant() refuses to delegate it.
+ */
+$registry = FOG\Auth\Authorization::coreRegistry();
+$results[] = exportCheck(
+    "the registry declares a 'system' node",
+    array_key_exists('system', $registry),
+    'nodes: ' . implode(',', array_keys($registry))
+);
+$results[] = exportCheck(
+    "'system' offers the export action",
+    in_array('export', (array) ($registry['system'] ?? []), true),
+    'actions: ' . implode(',', (array) ($registry['system'] ?? []))
+);
+
+/*
+ * 3. No predictable dump path, on any of the three export routes.
+ *
+ * Matches the literal shape rather than one filename, so reintroducing it
+ * under any name is still a failure. tempnam() is what all three use
+ * instead; it creates the file 0600 and unguessably named.
+ */
+$offenders = [];
+$it = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($webroot, \FilesystemIterator::SKIP_DOTS)
+);
+foreach ($it as $f) {
+    $path = $f->getPathname();
+    if (substr($path, -4) !== '.php' || false !== strpos($path, '/vendor/')) {
+        continue;
+    }
+    $body = (string) file_get_contents($path);
+    if (preg_match("#'/tmp/' *\\.|'/tmp/[A-Za-z0-9_.-]*'#", $body, $m)) {
+        $offenders[] = str_replace($root . '/', '', $path) . ': ' . $m[0];
+    }
+}
+$results[] = exportCheck(
+    'no export path builds a dump filename under a fixed /tmp name',
+    [] === $offenders,
+    implode(' | ', array_slice($offenders, 0, 4))
+);
+
+/*
+ * 4. The UI export is the same authority and takes the same gate. It is
+ *    checked inside configPost() rather than by the node/sub map because
+ *    that one POST endpoint serves both export and import, and `about`
+ *    aliases onto `settings` -- so the map would put both on settings.edit.
+ */
+$src = (string) file_get_contents(
+    $webroot . '/lib/pages/fogconfigurationpage.page.php'
+);
+$results[] = exportCheck(
+    'the UI export branch checks system.export before dumping',
+    1 === preg_match(
+        "#isset\\(\\\$_POST\\['toExport'\\]\\).*?"
+        . "Authorization::can\\('system\\.export'\\).*?"
+        . "Mysqldump#s",
+        $src
+    ),
+    'the guard is missing, or no longer precedes the dump'
+);
+
+/*
+ * 5. The document describes what the server sends. Source-level for the
+ *    same reason openapi-route-coverage.test.php is: building the document
+ *    needs a boot this test deliberately does not do.
+ */
+$openapi = (string) file_get_contents($webroot . '/src/Router/OpenAPI.php');
+$exportBlock = '';
+if (preg_match("#'/system/export' => \\[.*?\\n            \\],#s", $openapi, $m)) {
+    $exportBlock = $m[0];
+}
+$results[] = exportCheck(
+    'the /system/export block was located in the OpenAPI source',
+    '' !== $exportBlock
+);
+$results[] = exportCheck(
+    'the document declares text/plain, which is what exportdb() sends',
+    false !== strpos($exportBlock, "'text/plain' => ["),
+    'block did not name text/plain'
+);
+$results[] = exportCheck(
+    'and no longer declares application/sql, which it never sent',
+    false === strpos($exportBlock, "'application/sql' => ["),
+    'application/sql is still declared'
+);
+
+$failed = count(
+    array_filter(
+        $results,
+        function ($ok) {
+            return !$ok;
+        }
+    )
+);
+
+echo "\n";
+if ($failed > 0) {
+    echo "$failed of " . count($results) . " check(s) failed\n";
+    exit(1);
+}
+echo 'All ' . count($results) . " checks passed\n";
+exit(0);


### PR DESCRIPTION
Closes #1410 — items 1, 2 and 4. **Item 3 was already fixed** by #1437, which
dropped the `$orig_term_time` line while sweeping PHPStan findings.

## Item 1 — the permission did not match the authority

The dump is every row of all 70 tables: `users.uPass`/`uAPIToken`,
`apiTokens.atHash`, `userAuths`' hashes, every host's `hostSecToken` and
`hostADPass`, `nfsGroupMembers`' credentials, and every `globalSettings` value
— `FOG_NODE_API_KEY` and the LDAP bind password included.

It is the **one route that bypasses the data protection the rest of the router
applies**. `unfilterableFields()` refuses token/password filters,
`maskSensitiveSetting()` strips values by name, and `Route::$sensitiveSettings`
says of `FOG_NODE_API_KEY` that *"it is a shared HMAC secret, so it must not be
readable over REST."* The dump returned it in the clear.

It resolved to `settings.edit`, which **six page nodes already share** — so
"may edit the OUI table" and "may take a copy of every secret in the estate"
were the same grant.

**New registry node `system` with one action, `export`.** Deny by default,
exactly as `activity` and `audit.manage` were introduced: no schema step seeds
it, so only a holder of `*` has it until an administrator grants it.

> [!WARNING]
> **Behaviour change.** A role holding `settings.edit` and nothing else
> **loses the database export on upgrade**. That is the point of the change.
> Admins (`*`) are unaffected, and the installer's own backup is unaffected
> (see below).

It also fixes the audit trail as a side effect — `_auditGate()` records the
permission string, so the row now says the whole database left the server
instead of saying `settings.edit`.

## Item 2 — the issue named one export path; there are three

All three had the predictable-tempfile defect:

| Path | Reached by |
|---|---|
| `Schema::exportdb()` | `GET /system/export` |
| `FOGConfigurationPage::configPost()` | the Export button |
| `maintenance/backup_db.php` | **the installer, before an upgrade** |

The third was found by the new test, not by the issue. A fixed name under
`/tmp` was three defects at once: world-readable under the default umask for
as long as the dump takes to write; two concurrent exports clobber each other;
and `fopen()` follows symlinks, so a guessable path is a **write-as-web-user
primitive**.

All three now use `tempnam()` plus an explicit `chmod 0600`. Mysqldump's own
`fopen(...,'wb')` truncates rather than recreating, so the mode survives.

**`backup_db.php` keeps its same-machine IP check unchanged** — it has no
session to carry a permission and the installer depends on it. Only its temp
file changed, so upgrades are unaffected.

## Item 4 — content type

The document said `application/sql`; the server has always sent `text/plain`.
**Corrected the document.** `application/sql` is the more correct description —
registered, RFC 6922 — but changing the wire contract breaks consumers built
against the live route, and correcting the document breaks none.

## Where the UI gate lives, and why

Inside `configPost()` rather than through the node/sub map. That one POST
endpoint serves **both** export and import, only the export half is a
credential census, and `about` aliases onto `settings` — so the map would have
put both straight back on `settings.edit`. The button follows the grant, the
way the Login History tab does.

Adding the node puts a new row and a one-checkbox column in the role matrix,
so both are labelled rather than left to the `ucfirst()` fallback that
`install` and `manage` currently rely on.

## Verification

The permission half is **executed, not grepped** — `resolveApiPermission('export')`
is the same call the router makes, so a map entry edited back or a registry
node dropped fails the test. A grep for the string would pass on a route
rewired around it.

All nine assertions were proved by reintroducing each defect in turn:

| Mutation | Assertions that went red |
|---|---|
| `'export' => 'settings.edit'` | 2 |
| drop the `system` registry node | 2 |
| fixed `/tmp` name back in `backup_db.php` | 1 |
| remove the `configPost()` guard | 1 |
| document back to `application/sql` | 2 |

`tests/run-all.sh`: **181 passed, 0 failed**. Both PHPStan passes: no errors.

## Follow-up

A note in fog-docs for the upgrade behaviour — a `settings.edit`-only role
losing the export — is the one piece not in this PR, since UI docs live in the
other repo.