### PR TITLE
Route::getter() must qualify the class name before its type guard

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4302');
+        define('FOG_VERSION', '1.6.0-beta.4305');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -5410,14 +5410,34 @@ class Route extends FOGBase
      * @param string $classname The name of the class.
      * @param object $class     The class to work with.
      *
-     * @return object|array
+     * @return object|array|null null when $class is not of $classname -- the
+     *                           bare `return;` in the type guard below. The
+     *                           docblock said object|array until GH-1442,
+     *                           which is why nothing downstream ever tested
+     *                           for the null it has always been able to
+     *                           return.
      */
     public static function getter($classname, $class)
     {
         self::$getterDepth++;
         try {
-            if (!$class instanceof $classname) {
-                return;
+            // qualify() before the test, because $classname is the BARE
+            // lowercase name ('storagenode') everything on this router speaks,
+            // while the entity is FOG\Items\StorageNode. A class name held in
+            // a string resolves from the GLOBAL namespace, so this guard only
+            // ever passed while each file under src/ re-exported itself there
+            // with class_alias(). Those aliases were retired (ADR 0013 §2) and
+            // this guard was missed, so from that commit it was false for every
+            // class: getter() returned null, and indiv() emitted `null` with a
+            // 200 for EVERY single-entity GET. Silent, because returning null
+            // from a serializer is indistinguishable from a serializer that ran.
+            //
+            // qualify() passes an unknown name through unchanged, so a plugin
+            // class -- global-namespace by design (ADR 0009) -- still matches
+            // itself, and so does an already-qualified name.
+            $fqcn = self::qualify($classname);
+            if (!$class instanceof $fqcn) {
+                return null;
             }
             switch ($classname) {
                 case 'host':
@@ -5847,6 +5867,11 @@ class Route extends FOGBase
             return $data;
         } catch (\Exception $e) {
             self::_sendCaught($e);
+            // Reached only when sendResponse() does not end the request --
+            // an internal caller running under _rethrowDepth. Explicit,
+            // because falling off the end here is the same silent null the
+            // type guard above used to produce.
+            return null;
         } finally {
             self::$getterDepth--;
         }

--- a/tests/route-getter-resolves-class-names.test.php
+++ b/tests/route-getter-resolves-class-names.test.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Route::getter() must resolve the bare class name before its type guard.
+ *
+ * getter() opens with a type assertion:
+ *
+ *     $fqcn = self::qualify($classname);
+ *     if (!$class instanceof $fqcn) { return; }
+ *
+ * $classname is the BARE lowercase name ('storagenode') that the whole router
+ * speaks, while the entity is FOG\Items\StorageNode. A class name held in a
+ * string resolves from the GLOBAL namespace -- `use` is not consulted -- so
+ * without the qualify() the test is false for every core class.
+ *
+ * That is not hypothetical. The guard was written in 2021 and worked only
+ * because each file under src/ re-exported itself globally with class_alias().
+ * Retiring those aliases (ADR 0013 s2) missed this one site, and from that
+ * commit getter() returned null for EVERY class. indiv() assigns its result
+ * straight to self::$data, so `GET /api/<class>/<id>` answered HTTP 200 with a
+ * literal `null` body for every entity in the API -- and Route::getItem(),
+ * embed() and expandRelations() went with it, which is why the storage node
+ * panel on the About page rendered empty.
+ *
+ * It is silent in the worst way: null out of a serializer is indistinguishable
+ * from a serializer that ran and found nothing, so nothing logs, nothing 500s,
+ * and the status code stays 200.
+ *
+ * TWO ARMS, deliberately. Checking only that a matching object survives would
+ * still pass if the guard were deleted outright, which would let getter() run
+ * on an object of the wrong class:
+ *
+ *   A. matching   -- getter(<bare>, new <FQCN>) must NOT return null.
+ *   B. mismatched -- getter(<other bare>, new <FQCN>) MUST return null.
+ *
+ * Arm A goes red if the qualify() is dropped; arm B goes red if the guard is
+ * removed. Both were confirmed by mutation before this file was committed.
+ *
+ * A Throwable counts as passing arm A. This harness deliberately boots no
+ * database -- it defines the handful of constants the autoloader needs and
+ * nothing else -- so an entity that gets PAST the guard dies reaching for one.
+ * What matters is that it got past; the guard is the only thing above the
+ * switch that can return null.
+ *
+ * Usage: php tests/route-getter-resolves-class-names.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+
+if (!is_file($web . '/vendor/autoload.php')) {
+    fwrite(STDERR, "FAIL: composer dependencies are not installed\n");
+    exit(1);
+}
+
+// The autoloader reads these three and nothing else on this path. FOG_CACHE_DIR
+// only has to be writable -- srcFileList() memoises its scan there.
+define('DS', DIRECTORY_SEPARATOR);
+define('BASEPATH', $web . DS);
+define('FOG_CACHE_DIR', sys_get_temp_dir());
+
+require $web . '/vendor/autoload.php';
+require_once $web . '/commons/init.php';
+
+/**
+ * 'NULL' when getter() short-circuited, 'past' when it did not.
+ *
+ * @param string $bare the bare class name to hand getter()
+ * @param object $obj  the entity to serialize
+ *
+ * @return string
+ */
+function getterOutcome($bare, $obj)
+{
+    try {
+        $got = \FOG\Router\Route::getter($bare, $obj);
+    } catch (\Throwable $e) {
+        return 'past';
+    }
+    return null === $got ? 'NULL' : 'past';
+}
+
+// One entity per shape of getter() case: a `default` arm, an arm with embeds,
+// and one of the tasking arms. Constructed WITHOUT an id, so nothing loads.
+$sample = ['image', 'user', 'host', 'storagenode', 'snapin'];
+
+$fails = [];
+$objects = [];
+
+foreach ($sample as $bare) {
+    $fqcn = \FOG\Base\FOGBase::qualify($bare);
+    if ($fqcn === $bare || !class_exists($fqcn)) {
+        $fails[] = sprintf(
+            'qualify(%s) did not resolve to a class under src/ (got %s) -- '
+            . 'the class map is not being read, so this gate proves nothing',
+            $bare,
+            $fqcn
+        );
+        continue;
+    }
+    $objects[$bare] = new $fqcn();
+}
+
+if (count($objects) < 2) {
+    fwrite(STDERR, "FAIL: too few entities resolved to test both arms\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+// Arm A -- a matching name must get past the guard.
+foreach ($objects as $bare => $obj) {
+    if ('NULL' === getterOutcome($bare, $obj)) {
+        $fails[] = sprintf(
+            'getter(%s, %s) returned null. The guard is testing the bare name '
+            . 'against the global namespace, so it can never match -- every '
+            . 'single-entity GET serializes to `null`.',
+            $bare,
+            get_class($obj)
+        );
+    }
+}
+
+// Arm B -- a mismatched name must still be rejected.
+$names = array_keys($objects);
+foreach ($names as $i => $bare) {
+    $other = $names[($i + 1) % count($names)];
+    if ('NULL' !== getterOutcome($other, $objects[$bare])) {
+        $fails[] = sprintf(
+            'getter(%s, %s) did not return null. The type guard is gone, so '
+            . 'getter() will serialize an object of the wrong class.',
+            $other,
+            get_class($objects[$bare])
+        );
+    }
+}
+
+if ($fails) {
+    fwrite(STDERR, "FAIL: Route::getter() type guard is wrong\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo 'PASS: Route::getter() resolves bare class names (' . count($objects)
+    . " classes, both arms)\n";
+exit(0);


### PR DESCRIPTION
**Every single-entity `GET` on the REST API has been answering HTTP 200 with a literal `null` body since yesterday.** Confirmed against the running 1.6 server (1.6.0-beta.4299):

```
GET /api/storagenode/1   200  null
GET /api/host/1          200  null
GET /api/image/1         200  null
GET /api/storagegroup/1  200  null
GET /api/storagenode/list 200 {"draw":0,"recordsTotal":4,...}   <- lists are fine
```

## Cause

`Route::getter()` opens with a type assertion:

```php
if (!$class instanceof $classname) { return; }
```

`$classname` is the bare lowercase name the whole router speaks (`storagenode`); the entity is `FOG\Items\StorageNode`. **A class name held in a string resolves from the GLOBAL namespace** — `use` is not consulted and the enclosing namespace is not applied — so this guard only ever passed because each file under `src/` re-exported itself globally with `class_alias()`.

Those aliases were retired in `1ecf0255d` (ADR 0013 §2) **yesterday**. `FOGBase::qualify()` exists precisely so retiring them did not mean editing every caller — its own docblock says as much — and `getter()` is a caller it never reached. The guard has been false for every core class ever since.

Proven on the live install, no deploy, both halves in one read:

```
asked for            : storagenode #1
actual class         : FOG\Items\StorageNode
instanceof 'storagenode'  : false   <- what getter() tests today
qualify()            : FOG\Items\StorageNode
instanceof qualified : true         <- what it should test
getter(bare)         : NULL
getter(qualified)    : array(23) keys: id,name,description,isMaster,storagegroupID,isEnabled ...
```

## Blast radius

| Path | Effect |
|---|---|
| `GET /api/<class>/<id>` | `null` body, HTTP 200, every class |
| `Route::getItem()` | returns null — the wrapper ~190 call sites moved onto |
| `embed()` | every nested object dropped |
| `expandRelations()` | every `?expand=` relation dropped |

Lists are unaffected: `listem()` builds rows from the manager, and only reaches `getter()` when `?expand` is used.

**The visible symptom that found it** — the storage node panel on *FOG Configuration → FOG Version Information* renders empty. `version()` calls `Route::getItem()` per node and `continue`s on null, so four configured nodes produced no output at all.

Nothing logs and nothing 500s: `null` out of a serializer is indistinguishable from a serializer that ran.

## Scope of the bug class

`grep -rn 'instanceof \$'` across `src/`, `lib/`, `commons/`, `packages/service` and the plugins returns **this one site**. `new $var` sites were checked too: `FOGPage` already calls `qualify()` at the point of instantiation, `_newEntity()` uses it, and the two `new $class($id)` in `edit()`/`create()` take an *object*, not a string.

**dev-branch is not affected and needs no port** — its `Route` is not namespaced, so the bare name resolves there exactly as it always did. Verified with `git show origin/dev-branch:packages/web/lib/router/route.class.php`.

## Also corrected, both exposed by the fix

- `@return object|array` was wrong. `getter()` has always been able to return null — that bare `return;` *is* the bug — and the wrong return type is why nothing downstream ever tested for it. PHPStan flagged the new test's `null === $got` as impossible, which is how this surfaced.
- Both null paths are now an explicit `return null;` rather than falling off the end.

## The gate

`tests/route-getter-resolves-class-names.test.php` boots the autoloader with **no database** (three constants and `vendor/autoload.php`) and asserts **both arms**:

- **A — matching:** `getter(<bare>, new <FQCN>)` must not return null.
- **B — mismatched:** `getter(<other bare>, new <FQCN>)` must return null.

One arm alone is not a gate: checking only that a matching object survives still passes if the guard is deleted outright, which would let `getter()` serialize an object of the wrong class.

Mutation-proven before commit:

| Mutation | Result |
|---|---|
| drop the `qualify()` (i.e. reintroduce the bug) | arm A red, exit 1 |
| delete the guard entirely | arm B red, exit 1 |
| unmutated | pass |

Full `tests/*.test.php` suite: 0 failures. Both PHPStan passes: no errors.