### PR TITLE
Carry contentOnly through a redirect so AJAX nav gets a fragment

### DIFF
--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1402,6 +1402,27 @@ abstract class FOGBase
         if (!in_array($status, [301, 302, 303, 307, 308], true)) {
             $status = 308;
         }
+        /*
+         * A redirect issued while serving an AJAX page load (?contentOnly=1)
+         * is followed by the XHR transparently, so whatever the TARGET
+         * renders is what lands in #ajaxPageWrapper. Without the flag the
+         * target renders the whole page -- sidebar, header, the lot -- inside
+         * that wrapper, and the user sees the menu twice. Reported against
+         * Reports -> History Report, which redirects to the activity viewer
+         * (ADR 0023), but it is the same for every redirect a menu click can
+         * reach: a permission denial bouncing to ?node=home, objectNotFound
+         * bouncing to a node's list, the schema updater.
+         *
+         * Relative targets only. An absolute URL is leaving this application
+         * -- OIDC single logout, a configured login/logout redirect -- and
+         * must not have a FOG query parameter bolted onto it.
+         */
+        if (filter_input(INPUT_GET, 'contentOnly')
+            && false === strpos($url, '://')
+            && false === strpos($url, 'contentOnly=')
+        ) {
+            $url .= (false === strpos($url, '?') ? '?' : '&') . 'contentOnly=1';
+        }
         header("Location: $url", true, $status);
         exit;
     }

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4318');
+        define('FOG_VERSION', '1.6.0-beta.4321');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element


### PR DESCRIPTION
## The bug

Clicking **Reports → History Report** draws the whole sidebar a second time inside the page body.

## Cause

The AJAX page loader (`.ajax-page-link` → `doPageLoad`) fetches the target with `?contentOnly=1` and drops the response straight into `#ajaxPageWrapper`.

`History_Report::file()` 302s to the activity viewer (ADR 0023), and the redirect target carried no `contentOnly`. The XHR follows the hop transparently, so what came back was a complete HTML document — sidebar, header and all — which then rendered nested inside the page.

Confirmed against the lab server before any change:

```
$ curl -sk -b jar -o /dev/null -w '%{redirect_url}\n' \
    '.../index.php?node=report&sub=file&f=aGlzdG9yeSByZXBvcnQ%3D&contentOnly=true'
https://…/index.php?node=activity&source=history      <- no contentOnly

$ curl … -L …          # 34855 bytes, contains <html> and .sidebar-menu
```

## Fix

`FOGBase::redirect()` appends the flag to a **relative** target whenever the request being served asked for content only. Absolute targets are left alone — those are leaving the application (OIDC single logout, a configured login/logout redirect) and must not have a FOG query parameter bolted on.

## Not specific to that one report

Every redirect a menu click can reach had the same result:

| Call site | Redirects to |
|---|---|
| `History_Report::file()` | `?node=activity&source=history` |
| `FOGPage::objectNotFound()` | `?node={node}` |
| `Authorization` denial | `?node=home` |
| `ImageManagement` architectures | `?node=image&sub=architectures` |
| `DatabaseManager` / `PDODB` | `?node=schema` |

## Verification

Exercised over HTTP against a shadow copy of the live tree (never the webroot), authenticated as a real UI session:

| Case | Before | After |
|---|---|---|
| History Report, `contentOnly` | 34855 B, full `<html>` + sidebar | 1414 B fragment, no `<html>`, no sidebar |
| `?node=host&sub=edit&id=99999999`, `contentOnly` | full page | 11933 B fragment, no sidebar |
| History Report, **no** `contentOnly` | 302 → `?node=activity&source=history` | unchanged |

The harness was made to go red on unpatched code first, then green with the patch applied.

## Known residual

The browser's URL bar and the sidebar highlight still show the item that was clicked (History Report), not the page the redirect landed on. That is pre-existing and cosmetic — telling the client the final URL would need a new response header and a change to `doPageLoad`, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)