### PR TITLE
Return '' from data grid columns instead of the em-dash span

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -211,7 +211,7 @@
             [('mainlink' in colIndex ? colIndex.mainlink : 0), 'asc']
         ],
         // lastping/lastcheckin need no render: both arrive already formatted
-        // by the server, or as an em dash when the host has never been seen.
+        // by the server, or empty when the host has never been seen.
         columns: columns,
         rowId: 'id',
         columnDefs: columnDefs,

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4321');
+        define('FOG_VERSION', '1.6.0-beta.4324');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -45,6 +45,12 @@ class Route extends FOGBase
      * Muted em-dash used to render an empty list cell (no value / no
      * associated entity) consistently across every entity list.
      *
+     * MARKUP -- so it belongs only in a column that already emits markup
+     * and escapes its own interpolations (the *Link anchors). A plain data
+     * column must return '' instead: its consumers escape, so the span
+     * arrives on screen as literal text, and it is the value the CSV/Excel
+     * export writes back out. See the 'mem' and date arms below.
+     *
      * @var string
      */
     const EMPTY_CELL = '<span class="text-muted">&mdash;</span>';
@@ -2538,7 +2544,25 @@ class Route extends FOGBase
                             if (self::validDate($d)) {
                                 return self::niceDate($d)->format('Y-m-d H:i:s');
                             }
-                            return self::EMPTY_CELL;
+                            // '' rather than EMPTY_CELL: these are data
+                            // columns, and every escaping consumer printed
+                            // the span as literal text instead of a dash.
+                            // registerExportTable() escapes each of these
+                            // (host, image, group, snapin and user exports
+                            // all carry createdTime, and host carries
+                            // deployed/lastping/lastcheckin), and the same
+                            // value is what the CSV/Excel export hands back
+                            // to importPost() -- which maps createdTime and
+                            // deployed straight onto datetime columns, so a
+                            // placeholder here is not round-trippable.
+                            // It also silently defeated GH-1245: the host
+                            // list blanks a never-deployed cell by testing
+                            // !data, and a span is truthy.
+                            //
+                            // The placeholder is a display decision and is
+                            // already made client-side, per column -- blank
+                            // for 'deployed', "Not yet seen" for 'arch'.
+                            return '';
                         }
                     ];
                     break;
@@ -2791,7 +2815,17 @@ class Route extends FOGBase
                         'dt' => $common,
                         'formatter' => function ($d, $row) {
                             if (!$d) {
-                                return self::EMPTY_CELL;
+                                // '' rather than EMPTY_CELL, same reason as
+                                // the date arm above. The Inventory Report
+                                // binds this column through
+                                // render.text(), so a host that has never
+                                // reported its memory printed the raw
+                                // <span class="text-muted">&mdash;</span>
+                                // in the cell -- and in the Copy/CSV/Excel
+                                // exports beside it. Blank matches every
+                                // other unreported inventory column on that
+                                // report.
+                                return '';
                             }
                             return Inventory::getMemory($d);
                         }


### PR DESCRIPTION
## Problem

The Inventory Report's **System Memory Available** column renders the literal
string `<span class="text-muted">&mdash;</span>` for any host that has never
reported its memory.

`Route::EMPTY_CELL` is markup. It is correct for the columns that already emit
markup and escape their own interpolations (the `*Link` anchors), but it was
also returned by two plain **data** arms, whose consumers escape.

One cause, three consequences:

| Where | What happens |
|---|---|
| Inventory Report (`mem`) | Bound through `render.text()`, so the span prints as literal text in the cell **and** in the Copy/CSV/Excel exports beside it. This is the reported bug. |
| Export grids (date arm) | `registerExportTable()` escapes every column it is handed. `createdTime` is on the host, image, group, snapin and user exports; `deployed`/`lastping`/`lastcheckin` are on hosts. Same literal markup on screen, and written verbatim into the exported file — which `importPost()` maps straight back onto datetime columns, so the value was not round-trippable. |
| Host list (`deployed`) | GH-1245 blanks a never-deployed cell by testing `!data`. A span is truthy, so that fix had been silently defeated and the column showed a dash. |

## Fix

Both arms return `''`. The placeholder is a display decision and the house
pattern already makes it client-side, per column — blank for `deployed`,
"Not yet seen" for `arch` — so an empty cell now matches every other empty
cell in those grids. `EMPTY_CELL`'s docblock now says which columns may use it.

## Verification

Exercised `Route::_gridColumns()` against the live lab database from a shadow
tree (no deploy), formatting an empty value, in both directions:

```
=== BEFORE (HEAD) ===
Inventory:
  mem            '<span class="text-muted">&mdash;</span>'
Host:
  createdTime    '<span class="text-muted">&mdash;</span>'
  deployed       '<span class="text-muted">&mdash;</span>'
  lastping       '<span class="text-muted">&mdash;</span>'
  lastcheckin    '<span class="text-muted">&mdash;</span>'
=== AFTER (patched) ===
Inventory:
  mem            ''
Host:
  createdTime    ''
  deployed       ''
  lastping       ''
  lastcheckin    ''
```

Not present on `dev-branch` — that line has no `EMPTY_CELL` and no grid column
table, so there is nothing to port.

## Behavior change

Grids that showed a muted em-dash for an empty date now show an empty cell.
No route, schema or API shape changed; `OpenAPI::document()` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)