### PR TITLE
Emit the iPXE header even when no storage node is valid

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4330');
+        define('FOG_VERSION', '1.6.0-beta.4332');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4327');
+        define('FOG_VERSION', '1.6.0-beta.4330');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -876,7 +876,6 @@ class IpxeBootMenu extends BootMenuBase
                     trim($StorageNode->get('ip'))
                 )
             ];
-            $this->_parseMe($Send);
             $this->_storage = sprintf(
                 'storage=%s:/%s/ storageip=%s',
                 trim($StorageNode->get('ip')),
@@ -884,6 +883,18 @@ class IpxeBootMenu extends BootMenuBase
                 trim($StorageNode->get('ip'))
             );
         }
+        /**
+         * Outside the guard above, which it used to sit inside. This is the
+         * only _parseMe() in the constructor and it flushes the whole header
+         * -- '#!ipxe' first of all, then fog-ip, fog-webroot, boot-url,
+         * setmacto and the host/inventory variables. An install with no
+         * enabled storage node therefore emitted a script with no shebang,
+         * which iPXE rejects outright: not a menu missing its imaging
+         * options, but a machine that does not boot, and no clue on screen
+         * as to why. Only storage-ip is genuinely conditional, so only
+         * storage-ip is built under the condition.
+         */
+        $this->_parseMe($Send);
         $this->_kernel = sprintf(
             'kernel %s %s initrd=%s root=/dev/ram0 rw '
             . 'ramdisk_size=%s%sweb=%s consoleblank=0%s rootfstype=ext4%s%s '

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -357,7 +357,7 @@ parameters:
 		-
 			message: '#^Access to an undefined static property FOG\\Router\\Route\:\:\$rows\.$#'
 			identifier: staticProperty.notFound
-			count: 2
+			count: 3
 			path: tests/lib/bootmenu-render.php
 
 		-

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -678,6 +678,29 @@ $checks = [
             'set nevermind',
         ],
     ],
+    /*
+     * The constructor's only _parseMe() used to sit inside
+     * `if ($StorageNode->isValid())`, so an install with no enabled storage
+     * node emitted no header at all -- no '#!ipxe', which iPXE rejects
+     * outright, so the machine does not boot rather than booting to a menu
+     * with imaging missing. Asserted on the shebang and on a host variable,
+     * because those are what the guard was swallowing; storage-ip is
+     * genuinely conditional and is refuted here to pin that the fix moved
+     * the flush out rather than moving the condition off.
+     */
+    'the header is emitted even with no storage node' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'noStorageNode' => true,
+        ],
+        'expectLine' => [
+            '#!ipxe',
+            'set hostname testhost',
+            'set boot-url ',
+        ],
+        'refuteLine' => ['set storage-ip'],
+    ],
 ];
 
 $checkFailures = [];

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -214,6 +214,15 @@ Route::$rows = [
 ];
 
 /*
+ * An install with no enabled storage node at all. Rare but reachable -- a
+ * half-finished install, or every node disabled -- and it used to decide
+ * whether the constructor emitted its header, '#!ipxe' included.
+ */
+if (!empty($scenario['noStorageNode'])) {
+    Route::$rows['storagenode'] = [];
+}
+
+/*
  * The host row Route::getItem('host', id) returns, which generateIpxeItems()
  * turns into `set ...` lines. Scenario-supplied extra columns land here too,
  * so a scenario can plant a secret field and assert it never reaches iPXE.


### PR DESCRIPTION
Follow-up to #1447, which noted this but did not fix it.

## The bug

The constructor's only `_parseMe()` sat inside `if ($StorageNode->isValid())`,
next to the `storage-ip` line that genuinely depends on a node. That flush is
what puts the entire header on the wire — `#!ipxe` first of all, then
`fog-ip`, `fog-webroot`, `boot-url`, `setmacto`, and the host and inventory
variables from #572.

So an install with no enabled master storage node — a half-finished install,
or every node disabled — emitted a script with **no shebang**. iPXE rejects
that outright, so the symptom is not "the menu is missing its imaging
options", it is a machine that will not boot, with nothing on screen saying
why.

The storage node is a dependency of *imaging*, not of rendering a menu.
Booting to hard disk, memtest and Secure Boot enrolment need no node at all,
and neither does telling the operator what machine they are looking at.

## The change

Only `storage-ip` is conditional, so only `storage-ip` is built under the
condition; the flush moves out. Emission order is untouched — the flush is
still the last thing before `$this->_kernel` is composed — and the golden is
byte-identical at 110998 bytes, which is the evidence for that.

`UbootBootMenu` carries the same `isValid()` guard but wraps only
`$this->_storage`, with no flush inside it, so there is nothing to port.

## Verification

New behaviour check with a `noStorageNode` scenario knob that empties the
`storagenode` rows: asserts the shebang and `set hostname testhost` are
present, and that `set storage-ip` is not.

Shown red twice before it was green, because each half needed its own proof:

- flush put back inside the guard → all three `expectLine`s fail;
- condition dropped instead of the flush → the `refuteLine` fails.

Neither assertion is one that could only ever pass. Full `tests/*.test.php`
suite green, php-cs-fixer `@PSR2` clean on all three files, PHPStan clean.