### PR TITLE
Document the phpstan check as two passes in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,36 @@ PR it finds nothing to do, which is expected rather than a symptom.
 
 Full reasoning: `docs/development/version-sync-automation.md` in `FOGProject/fog-docs`.
 
+### The `phpstan` check is two passes — run both, unscoped
+
+One check-run named `phpstan`, one job, **two steps**. Run both before pushing:
+
+```
+vendor/bin/phpstan analyse --memory-limit=2G --no-progress
+vendor/bin/phpstan analyse -c phpstan-tests.neon --memory-limit=2G --no-progress
+```
+
+`phpstan analyse <one file>` is not a smaller version of either. Naming a path
+overrides the config's own `paths`, so a scoped run skips the whole `tests/`
+pass and passes for reasons the real command never touches. The two live in the
+same job on purpose: the ruleset requires the single context `phpstan`, so
+neither pass can be required without the other.
+
+The second pass analyses `tests/` against `phpstan-tests-baseline.neon`, and
+**that baseline counts occurrences, not lines.** Adding a second use of an
+already-baselined pattern fails the build on an entry nobody touched:
+
+```
+Ignored error pattern ... is expected to occur 2 times, but occurred 3 times
+```
+
+Bump that entry's `count:`; don't regenerate the baseline, which would sweep up
+unrelated drift. Note this is the opposite direction from
+`reportUnmatchedIgnoredErrors: false`, which exists so that *fixing* a baselined
+error does not fail the build — nothing guards the over-count, so it is the one
+you find in CI. (#1448: one added `Route::$rows` write in
+`tests/lib/bootmenu-render.php` took a count from 2 to 3.)
+
 ### Commit authorship
 
 Commits are **authored by the maintainer and co-authored by the agent**, not the

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4332');
+        define('FOG_VERSION', '1.6.0-beta.4335');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element


### PR DESCRIPTION
Doc-only. Follow-up to #1448, where I hit both of these.

The `phpstan` context is **one job with two steps** — the application config
and `phpstan-tests.neon` — and nothing said so outside `tests.yml` itself.
Running `vendor/bin/phpstan analyse <one file>` locally looks like a smaller
version of the check and is not one: naming a path overrides the config's own
`paths`, so it skips the `tests/` pass entirely and reports OK on a change that
then fails CI.

Also records that `phpstan-tests-baseline.neon` counts *occurrences* rather
than matching lines. A second use of an already-baselined pattern fails the
build on an entry nobody edited:

```
Ignored error pattern ... is expected to occur 2 times, but occurred 3 times
```

The fix is to bump that entry's `count:`, not to regenerate the baseline —
regenerating would sweep up unrelated drift. Worth stating explicitly because
it is the *opposite* direction from `reportUnmatchedIgnoredErrors: false`,
which exists so that fixing a baselined error does not fail the build. Nothing
guards the over-count, which is why it is the one you meet in CI rather than
locally.

No code change; the note sits beside the ruleset and pre-commit-hook sections
that cover the rest of "why did CI reject this when it passed here".