### PR TITLE
Let the host win a variable its inventory also supplies

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4335');
+        define('FOG_VERSION', '1.6.0-beta.4338');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -374,10 +374,23 @@ class IpxeBootMenu extends BootMenuBase
     /**
      * Builds the std class property and value items as appropriate
      *
-     * @param object $object
+     * $seen carries the iPXE variable names already emitted, so a caller
+     * making more than one call in a row does not emit the same `set` twice.
+     * It is needed because the host and the inventory are separate records
+     * that share column names: `Route::getList('inventory')` joins the host
+     * name in as `hostname` for the Inventory grid, and the host record
+     * supplies the same variable from its own `name`. Both were emitted, and
+     * an iPXE `set` is last-wins, so the value the menu actually used came
+     * from whichever record was read second rather than from the host.
+     * First occurrence wins here, and the host is read first, which is the
+     * right precedence: the host record is the authority on its own name.
+     *
+     * @param object $object the record to build variables from
+     * @param array  $seen   variable names already emitted, updated in place
+     *
      * @return array
      */
-    public static function generateIpxeItems($object)
+    public static function generateIpxeItems($object, array &$seen = [])
     {
         $ignore_keys = [
             'description',
@@ -454,7 +467,14 @@ class IpxeBootMenu extends BootMenuBase
                     if ('' === $safe) {
                         continue;
                     }
-                    $output[] = "set {$property}{$count} {$safe}";
+                    // $count advances only on an emission, so the indices
+                    // stay contiguous for a consumer walking macs0..macsN.
+                    $name = "{$property}{$count}";
+                    if (isset($seen[$name])) {
+                        continue;
+                    }
+                    $seen[$name] = true;
+                    $output[] = "set {$name} {$safe}";
                     $count++;
                 }
             } else {
@@ -465,6 +485,10 @@ class IpxeBootMenu extends BootMenuBase
                 if ('' === $safe) {
                     continue;
                 }
+                if (isset($seen[$property])) {
+                    continue;
+                }
+                $seen[$property] = true;
                 $output[] = "set {$property} {$safe}";
             }
         }
@@ -695,8 +719,13 @@ class IpxeBootMenu extends BootMenuBase
             // reaching breakHead()'s exit, which on a boot request means the
             // machine gets a truncated iPXE script instead of a menu.
             $host = Route::getItem('host', self::$Host->get('id'));
+            // Shared across both calls, host first. The inventory list joins
+            // the host name in as `hostname` for the Inventory grid, so both
+            // records offer that variable and an iPXE `set` is last-wins --
+            // the menu was reading the inventory's copy, not the host's.
+            $seen = [];
             if ($host) {
-                $host_items = self::generateIpxeItems($host);
+                $host_items = self::generateIpxeItems($host, $seen);
                 foreach ($host_items as $item) {
                     $Send['hostinfo'][] = $item;
                 }
@@ -706,7 +735,7 @@ class IpxeBootMenu extends BootMenuBase
                 ['hostID' => self::$Host->get('id')]
             );
             if (!empty($inventory)) {
-                $inventory_items = self::generateIpxeItems($inventory[0]);
+                $inventory_items = self::generateIpxeItems($inventory[0], $seen);
                 foreach ($inventory_items as $item) {
                     $Send['inventoryinfo'][] = $item;
                 }

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -357,7 +357,7 @@ parameters:
 		-
 			message: '#^Access to an undefined static property FOG\\Router\\Route\:\:\$rows\.$#'
 			identifier: staticProperty.notFound
-			count: 3
+			count: 4
 			path: tests/lib/bootmenu-render.php
 
 		-

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -701,6 +701,35 @@ $checks = [
         ],
         'refuteLine' => ['set storage-ip'],
     ],
+    /*
+     * The host and the inventory are separate records read by the same
+     * emitter, and they share column names: Route's inventory list joins the
+     * host name in as `hostname` for the Inventory grid, and the host record
+     * supplies the same variable from its own `name`. Both were emitted.
+     *
+     * An iPXE `set` is last-wins, so this was not merely a duplicate line --
+     * the value the menu ended up using came from whichever record happened
+     * to be read second. The inventory's `hostname` is given a DIFFERENT
+     * value here on purpose: asserting only that the line appears once would
+     * pass with the wrong record winning, which is the half that actually
+     * matters.
+     */
+    'the host wins a variable the inventory also supplies' => [
+        'scenario' => [
+            'host' => ['id' => 1, 'name' => 'testhost'],
+            'request' => ['arch' => 'x86_64', 'platform' => 'bios'],
+            'inventoryRow' => [
+                'hostname' => 'staleinventoryname',
+                'sysman' => 'ACME',
+            ],
+        ],
+        'expectLine' => [
+            "\nset hostname testhost\n",
+            "\nset sysman ACME\n",
+        ],
+        'expectCount' => ['set hostname ' => 1],
+        'refuteLine' => ['staleinventoryname'],
+    ],
 ];
 
 $checkFailures = [];
@@ -744,6 +773,23 @@ foreach ($checks as $label => $check) {
     foreach ((array)($check['refuteLine'] ?? []) as $needle) {
         if (false !== strpos($raw, $needle)) {
             $checkFailures[] = "$label: '$needle' must NOT appear";
+        }
+    }
+    /*
+     * For a variable two records can both supply. expectLine only proves the
+     * right value is present somewhere; iPXE `set` is last-wins, so the
+     * count is what proves the loser was not emitted after the winner.
+     */
+    foreach ((array)($check['expectCount'] ?? []) as $needle => $want) {
+        $have = substr_count($raw, $needle);
+        if ($have !== $want) {
+            $checkFailures[] = sprintf(
+                "%s: '%s' appears %d time(s), expected %d",
+                $label,
+                $needle,
+                $have,
+                $want
+            );
         }
     }
 }

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -214,6 +214,19 @@ Route::$rows = [
 ];
 
 /*
+ * The inventory row Route::getList('inventory', ...) returns. Its columns go
+ * through the same generateIpxeItems() as the host's, and the two records
+ * share names -- the inventory list joins the host name in as `hostname` --
+ * so a scenario needs to be able to plant one to exercise that overlap.
+ */
+if (!empty($scenario['inventoryRow'])) {
+    Route::$rows['inventory'][] = (object)array_merge(
+        ['id' => 1, 'hostID' => $scenario['host']['id'] ?? 1],
+        (array)$scenario['inventoryRow']
+    );
+}
+
+/*
  * An install with no enabled storage node at all. Rare but reachable -- a
  * half-finished install, or every node disabled -- and it used to decide
  * whether the constructor emitted its header, '#!ipxe' included.


### PR DESCRIPTION
Last of the three follow-ups noted in #1447. Related: #1448.

## Not just a duplicate line

The host and the inventory are separate records read by the same emitter, and
they share a column name — `Route`'s inventory list joins the host name in as
`hostname` for the Inventory grid, and the host record supplies the same
variable from its own `name`. Both were emitted, so every registered,
inventoried machine got two `set hostname` lines.

An iPXE `set` is **last-wins**, so the value the menu actually used came from
whichever record was read second — the inventory's — rather than from the host
record, which is the authority on its own name. Today the two agree because the
joined column *is* `hosts.hostName`, so nothing visibly broke. The bug is that
the correct value was winning by luck.

## The fix

`generateIpxeItems()` takes a `$seen` array of already-emitted variable names,
threaded through both calls. First occurrence wins, and the host is read first.

Two rejected alternatives worth stating, because the obvious one is a trap:

- **Add `'hostname'` to `$ignore_keys`.** Works only by accident — the host's
  property is `name` and is renamed to `hostname` *after* that check, so the
  entry happens to catch only the inventory's. A later reorder would silently
  drop the host's own hostname, which is the most-used variable of the lot.
  Nothing would fail loudly.
- **Special-case the pair.** Keying the dedupe on the emitted *name* instead
  costs the same and means a future column shared by the two records cannot
  reintroduce this quietly.

In the array branch the index still advances only on an emission, so a consumer
walking `macs0..macsN` sees no gap.

## Verification

Gated with an inventory row whose `hostname` deliberately **disagrees** with the
host's. Asserting the line appears once is not sufficient on its own — that
passes with the wrong record winning — so the check pins the value too and
refutes the inventory's. Needed a new `expectCount` assertion in the runner,
since `expectLine` cannot express "exactly once".

Shown red twice, on different assertions:

| Mutation | Result |
|---|---|
| no dedupe (pre-change) | `set hostname ` appears 2×, stale value present |
| dedupe present, inventory read **first** | one line, but it carries the stale value |

Golden byte-identical at 110998 — the fixture carries no inventory row, which is
why this lives in the behaviour checks. Full `tests/*.test.php` green,
php-cs-fixer `@PSR2` clean, **both** phpstan passes clean.

## Downstream

The new `inventoryRow` harness knob is a fourth `Route::$rows` write, so
`phpstan-tests-baseline.neon`'s count for that pattern goes 3 → 4. That is the
occurrence-counting behaviour documented in #1449; the second phpstan pass
caught it exactly as that section says it would.