### PR TITLE
Name which object an audit change row is about

### DIFF
--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -98,7 +98,7 @@ return [
             ],
         ],
         'auditChange' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `auditChange` ( `acID` int(11) NOT NULL AUTO_INCREMENT, `acAuditID` int(11) NOT NULL, `acSubjectType` varchar(64) NOT NULL DEFAULT \'\', `acSubjectID` int(11) NOT NULL DEFAULT 0, `acField` varchar(128) NOT NULL DEFAULT \'\', `acOldValue` longtext DEFAULT NULL, `acNewValue` longtext DEFAULT NULL, `acRedacted` tinyint(1) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`acID`), KEY `acAuditID` (`acAuditID`), KEY `acSubject` (`acSubjectType`,`acSubjectID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `auditChange` ( `acID` int(11) NOT NULL AUTO_INCREMENT, `acAuditID` int(11) NOT NULL, `acSubjectType` varchar(64) NOT NULL DEFAULT \'\', `acSubjectID` int(11) NOT NULL DEFAULT 0, `acField` varchar(128) NOT NULL DEFAULT \'\', `acOldValue` longtext DEFAULT NULL, `acNewValue` longtext DEFAULT NULL, `acRedacted` tinyint(1) unsigned NOT NULL DEFAULT 0, `acSubjectLabel` varchar(200) NOT NULL DEFAULT \'\', PRIMARY KEY (`acID`), KEY `acAuditID` (`acAuditID`), KEY `acSubject` (`acSubjectType`,`acSubjectID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'acID' => 'int(11) NOT NULL',
                 'acAuditID' => 'int(11) NOT NULL',
@@ -108,6 +108,7 @@ return [
                 'acOldValue' => 'longtext DEFAULT NULL',
                 'acNewValue' => 'longtext DEFAULT NULL',
                 'acRedacted' => 'tinyint(1) unsigned NOT NULL DEFAULT 0',
+                'acSubjectLabel' => 'varchar(200) NOT NULL DEFAULT \'\'',
             ],
         ],
         'auditLog' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -8397,3 +8397,54 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 378
+$this->schema[] = [
+    // auditChange.acSubjectLabel -- which OBJECT a change row is about.
+    //
+    // A change row said WHICH FIELD moved and never WHICH OBJECT: it carries
+    // acSubjectType and acSubjectID, so the modal printed `setting#496`. For
+    // most models the field name carries enough of the sense to survive that
+    // -- `name`, `mac`, `ip` -- but globalSettings has exactly one editable
+    // column, so every settings edit in the install read `value | 1 | 0` and
+    // named nothing at all. The identity of a setting is its key, and the
+    // key was in hand at write time and thrown away.
+    //
+    // Denormalized rather than resolved when the page is read, which is the
+    // decision `history` already made for the same reason one table over:
+    // hSubjectLabel, ADR 0020 phase 3, docblocked "so the row still names
+    // its subject after the subject is deleted". A join goes blank the day
+    // the host is removed, which is the day the row matters most.
+    //
+    // VARCHAR(200) matching hSubjectLabel exactly, and sized the same way --
+    // to the widest name column a subject can have (snapins.sName
+    // varchar(200)), not to hosts.hostName varchar(16).
+    //
+    // No index. It is read only alongside the rows for one header, which
+    // acAuditID already indexes.
+    //
+    // Additive and inert: existing rows keep '' and the modal falls back to
+    // the type#id it prints today. Guarded closure, same shape as 376/377.
+    function () {
+        $have = self::$DB->query(
+            "SELECT `COLUMN_NAME` AS `c` FROM `information_schema`.`COLUMNS` "
+            . "WHERE `TABLE_SCHEMA` = DATABASE() "
+            . "AND `TABLE_NAME` = 'auditChange' "
+            . "AND `COLUMN_NAME` = 'acSubjectLabel'"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $cols = [];
+        foreach ((array)$have as $row) {
+            if (isset($row['c'])) {
+                $cols[] = $row['c'];
+            }
+        }
+        if (!in_array('acSubjectLabel', $cols)) {
+            self::$DB->query(
+                "ALTER TABLE `auditChange` "
+                . "ADD `acSubjectLabel` VARCHAR(200) NOT NULL DEFAULT ''"
+            );
+        }
+
+        return true;
+    },
+];

--- a/packages/web/lib/pages/auditmanagement.page.php
+++ b/packages/web/lib/pages/auditmanagement.page.php
@@ -169,6 +169,12 @@ class AuditManagement extends FOGPage
     /**
      * Serves the change rows for one header.
      *
+     * Each row names its own subject. A header can cover many of them --
+     * an iterating save writes change rows for every object it touched --
+     * and for a settings edit the subject is the only identifying part
+     * there is, because globalSettings has one editable column and so
+     * every such row's field reads `value`.
+     *
      * A redacted row carries NULL in both value columns and `redacted = 1`;
      * the page says so rather than showing an empty cell, because "this
      * changed and you may not see what to" and "this changed to nothing" are
@@ -190,8 +196,8 @@ class AuditManagement extends FOGPage
             // ORM route would materialize an object per row to hand back
             // the six columns printed below.
             $rows = self::$DB->query(
-                'SELECT `acSubjectType`, `acSubjectID`, `acField`, '
-                . '`acOldValue`, `acNewValue`, `acRedacted` '
+                'SELECT `acSubjectType`, `acSubjectID`, `acSubjectLabel`, '
+                . '`acField`, `acOldValue`, `acNewValue`, `acRedacted` '
                 . 'FROM `auditChange` WHERE `acAuditID` = :id '
                 . 'ORDER BY `acID` ASC LIMIT ' . self::MAX_CHANGES,
                 [],
@@ -203,6 +209,11 @@ class AuditManagement extends FOGPage
             $out[] = [
                 'subjectType' => (string) ($row['acSubjectType'] ?? ''),
                 'subjectID' => (int) ($row['acSubjectID'] ?? 0),
+                // Empty on every row written before the label column
+                // existed, and on a model with no `name` field. The page
+                // falls back to type#id there, which is what it printed
+                // for everything before this.
+                'subjectLabel' => (string) ($row['acSubjectLabel'] ?? ''),
                 'field' => (string) ($row['acField'] ?? ''),
                 // NOT cast: NULL is the value a redacted row carries and it
                 // has to survive to the browser as null, not as ''.

--- a/packages/web/management/js/fog/audit/fog.audit.list.js
+++ b/packages/web/management/js/fog/audit/fog.audit.list.js
@@ -151,7 +151,8 @@
     }
     html = '<h5>' + $.escapeHtml('Changes') + '</h5>'
       + '<div class="table-responsive"><table class="table table-sm">'
-      + '<thead><tr><th>Field</th><th>From</th><th>To</th></tr></thead>'
+      + '<thead><tr><th>Subject</th><th>Field</th><th>From</th>'
+      + '<th>To</th></tr></thead>'
       + '<tbody>';
     $.each(rows, function(i, c) {
       var from, to;
@@ -169,7 +170,13 @@
         to = (c.newValue === null || c.newValue === '') ? '<em>empty</em>'
           : $.escapeHtml(String(c.newValue));
       }
-      html += '<tr><td>' + $.escapeHtml(c.field || '') + '</td>'
+      // Subject first, because it is the part that says WHICH object this
+      // row is about and the header can only name one of them. For a
+      // settings edit it is the only identifying part there is:
+      // globalSettings has one editable column, so Field reads `value` on
+      // every settings row in the install.
+      html += '<tr><td>' + $.escapeHtml(subjectText(c)) + '</td>'
+        + '<td>' + $.escapeHtml(c.field || '') + '</td>'
         + '<td>' + from + '</td><td>' + to + '</td></tr>';
     });
     html += '</tbody></table></div>';

--- a/packages/web/src/Audit/Audit.php
+++ b/packages/web/src/Audit/Audit.php
@@ -352,19 +352,41 @@ class Audit extends FOGBase
      * is exactly how a credential ends up in a log -- twice in one week, by
      * two different subsystems (ADR 0021 Context 4).
      *
-     * @param object $audit       the header returned by record()
-     * @param mixed  $class       the model, or its name, the fields belong to
-     * @param int    $subjectID   which object these changes are for
-     * @param array  $diff        friendly key => [old, new]
+     * THE LABEL IS WHAT MAKES A ROW READABLE, and it is denormalized here
+     * for the reason history's hSubjectLabel is (ADR 0020 phase 3): resolved
+     * at read time it goes blank the day the subject is deleted, which is
+     * the day the row matters most. Read from the model when the caller
+     * hands one over, because that is where the name is already in hand and
+     * costs nothing -- get() returns false for a model with no `name` field,
+     * which casts to the same empty string an unlabeled row already stored.
+     *
+     * Without it a settings edit named nothing at all. globalSettings has
+     * one editable column, so `field` is `value` for every setting in the
+     * install and the identifying part -- the key -- had nowhere to go.
+     *
+     * @param object $audit        the header returned by record()
+     * @param mixed  $class        the model, or its name, the fields belong to
+     * @param int    $subjectID    which object these changes are for
+     * @param array  $diff         friendly key => [old, new]
+     * @param string $subjectLabel names the subject when $class is a name,
+     *                             not a model, and so carries no label
      *
      * @return int how many change rows stored
      */
-    public static function changes($audit, $class, $subjectID, array $diff)
-    {
+    public static function changes(
+        $audit,
+        $class,
+        $subjectID,
+        array $diff,
+        $subjectLabel = ''
+    ) {
         if (!$audit instanceof AuditLog || !$audit->isValid()) {
             return 0;
         }
         $subjectType = strtolower(self::shortName($class));
+        if ('' === (string)$subjectLabel && is_object($class)) {
+            $subjectLabel = (string)$class->get('name');
+        }
         $stored = 0;
         foreach ($diff as $field => $pair) {
             $values = Redaction::values(
@@ -378,6 +400,7 @@ class Audit extends FOGBase
                     ->set('auditID', (int)$audit->get('id'))
                     ->set('subjectType', $subjectType)
                     ->set('subjectID', (int)$subjectID)
+                    ->set('subjectLabel', (string)$subjectLabel)
                     ->set('field', (string)$field)
                     ->set('oldValue', $values['old'])
                     ->set('newValue', $values['new'])

--- a/packages/web/src/Audit/Retention.php
+++ b/packages/web/src/Audit/Retention.php
@@ -272,11 +272,24 @@ class Retention extends FOGBase
             // reader builds the sentence, in its own locale, from the parts
             // (ADR 0020 Decision 5). It also puts the old and new windows in
             // the same columns every other before/after lands in.
+            //
+            // The key is the LABEL and `value` is the field, which is what
+            // every other settings edit in the install now stores. This used
+            // to pass the key AS the field to get it on screen at all --
+            // accurate to read and a lie about the column, since the column
+            // that moved is globalSettings.settingValue like any other. The
+            // label column exists now, so the workaround comes out.
+            //
+            // subjectID 0 because this caller has the key and not the row:
+            // it is handed a settings POST, not a Setting. It used to store
+            // the AUDIT row's own id here, which is not a setting id and
+            // pointed at whatever setting happened to hold that number.
             $stored = Audit::changes(
                 $audit,
                 'Setting',
-                (int)$audit->get('id'),
-                [$key => [(int)$old, (int)$new]]
+                0,
+                ['value' => [(int)$old, (int)$new]],
+                $key
             ) > 0;
         }
         if ($shrink && !$stored) {

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4347');
+        define('FOG_VERSION', '1.6.0-beta.4350');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,8 +94,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 377);
-        define('FOG_BCACHE_VER', 323);
+        define('FOG_SCHEMA', 378);
+        define('FOG_BCACHE_VER', 324);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Items/AuditChange.php
+++ b/packages/web/src/Items/AuditChange.php
@@ -56,6 +56,7 @@ class AuditChange extends FOGController
         'auditID' => 'acAuditID',
         'subjectType' => 'acSubjectType',
         'subjectID' => 'acSubjectID',
+        'subjectLabel' => 'acSubjectLabel',
         'field' => 'acField',
         'oldValue' => 'acOldValue',
         'newValue' => 'acNewValue',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$DB outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 80
+			count: 82
 			path: packages/web/commons/schema.php
 
 		-
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 347
+			count: 348
 			path: packages/web/commons/schema.php
 
 		-

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -63,7 +63,7 @@ parameters:
 		-
 			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
-			count: 5
+			count: 6
 			path: tests/audit-invariants.test.php
 
 		-

--- a/tests/audit-invariants.test.php
+++ b/tests/audit-invariants.test.php
@@ -28,8 +28,15 @@
  *      logHistory(); without the guard every audited action would also write
  *      a history row, doubling the volume of the table audit exists to
  *      replace.
+ *   5. A CHANGE ROW NAMES ITS SUBJECT. acSubjectLabel is denormalized at
+ *      write time for the reason history's hSubjectLabel is: resolved at
+ *      read time it goes blank the day the subject is deleted. The chain is
+ *      four links -- the manifest column, the model's field map, the writer
+ *      setting it, the page selecting it -- and breaking any one of them
+ *      degrades silently to the `setting#496` this replaced, because every
+ *      reader falls back to type#id by design.
  *
- * Textual, and DB-free, because all four are properties of the source.
+ * Textual, and DB-free, because all five are properties of the source.
  *
  * Usage: php tests/audit-invariants.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -159,6 +166,48 @@ if (null === $changes || false === strpos($changes, 'Redaction::values')) {
     $failures[] = 'Audit::changes() does not call Redaction::values(). '
         . 'Without it every credential a changed object carries is written '
         . 'to auditChange in clear.';
+}
+
+/*
+ * 2b. The subject label survives end to end.
+ *
+ * Every link is checked rather than just the writer, because the failure is
+ * silent at each of them: a row with no label renders as type#id, which is
+ * precisely the unreadable state the column was added to end. A settings
+ * edit is the worst case and the reason it exists -- globalSettings has one
+ * editable column, so `field` reads `value` for every setting in the install
+ * and the key is the only identifying part there is.
+ */
+$checks++;
+if (null === $changes || false === strpos($changes, "->set('subjectLabel'")) {
+    $failures[] = 'Audit::changes() does not set subjectLabel on the change '
+        . 'row, so every row falls back to type#id and a settings edit reads '
+        . '`value | old | new` naming no setting.';
+}
+$checks++;
+$acModel = (string) file_get_contents($web . '/src/Items/AuditChange.php');
+if (false === strpos($acModel, "'subjectLabel' => 'acSubjectLabel'")) {
+    $failures[] = 'AuditChange does not map subjectLabel to acSubjectLabel. '
+        . 'set() on an unmapped key is silently dropped by the ORM, so the '
+        . 'writer above would store nothing and report success.';
+}
+$checks++;
+$manifest = (string) file_get_contents($web . '/commons/schema-expected.php');
+if (false === strpos($manifest, "'acSubjectLabel' =>")) {
+    $failures[] = 'schema-expected.php does not carry auditChange.'
+        . 'acSubjectLabel, so the column the writer depends on is not part '
+        . 'of the schema an install is checked against.';
+}
+$checks++;
+$auditPage = (string) file_get_contents(
+    $web . '/lib/pages/auditmanagement.page.php'
+);
+if (false === strpos($auditPage, 'acSubjectLabel')
+    || false === strpos($auditPage, "'subjectLabel' =>")
+) {
+    $failures[] = 'AuditManagement::getChanges() does not select and emit '
+        . 'the subject label, so it is stored and never shown -- which looks '
+        . 'identical to it never having been stored.';
 }
 
 /*


### PR DESCRIPTION
## The problem

Open any settings edit in the Audit Log and the detail modal says this:

```
Subject     setting#496
Changes
Field   From   To
value   1      0
```

Nothing in that row says *which* setting. `globalSettings` has exactly one
editable column, so `acField` reads `value` for every settings edit in the
install, and the identifying part -- the key -- had nowhere to go: a change
row carries `acSubjectType` and `acSubjectID` and no label.

Most models hide the hole because their field name carries enough sense on
its own (`name`, `mac`, `ip`). Settings make it total.

## The fix

`auditChange` gains `acSubjectLabel varchar(200)`, denormalized at write
time from the model's own `name`.

That is the decision `history` already made for the same reason one table
over -- `hSubjectLabel`, ADR 0020 phase 3, docblocked *"so the row still
names its subject after the subject is deleted."* Resolving the label at
read time instead would go blank the day the subject is removed, which is
the day the row matters most. Same width, sized the same way (to
`snapins.sName varchar(200)`, the widest name a subject can have).

The modal grows a **Subject** column, first, reusing the same
`subjectText()` fallback the header already uses -- so a row written before
the column existed still renders as `type#id` rather than as a blank.

`Field` is left alone. `value` is *true*; it just is not the identifying
part.

### Retention loses its workaround

`Retention::permitSettingChange()` had already hit this and worked around
it by passing the setting key **as the field name**, which reads correctly
and lies about the column -- what moved is `settingValue` like any other
settings edit. It also stored the audit row's own id in `acSubjectID`,
which is not a setting id and pointed at whatever setting happened to hold
that number. Both come out: the key is the label, the field is `value`, and
`acSubjectID` is 0 because that caller holds the key and not the row.

## Schema

Step **378**, `FOG_SCHEMA` 377 -> 378. Additive, guarded and inert: existing
rows keep `''` and render exactly as they do today. `FOG_BCACHE_VER` 323 ->
324 for the JS.

## Verification

Against a **throwaway podman copy of a live 1.6 database** at schemaVersion
377, with a shadow webroot -- nothing touched the live install:

```
ok    the lab database starts without acSubjectLabel
      lab schemaVersion is 377, auditChange has 8 column(s)
ok    step 378 adds acSubjectLabel -- varchar(200)|NO|''
ok    step 378 is idempotent -- a second run is a no-op
      editing FOG_USE_SLOPPY_NAME_LOOKUPS (id 7), currently '1'
      newest auditChange row: {"acSubjectType":"setting","acSubjectID":7,
      "acSubjectLabel":"FOG_USE_SLOPPY_NAME_LOOKUPS","acField":"value",
      "acOldValue":"1","acNewValue":"0"}
ok    the change row carries the setting key as its label
ok    the field column still says which column moved (`value`)
ok    from/to are unchanged by any of this
ok    getChanges() emits the label
```

Deleting the one `->set('subjectLabel', ...)` puts `acSubjectLabel: ""` --
and so `setting#496` -- straight back, which is what makes that a gate
rather than a green tick.

Four new invariants in `tests/audit-invariants.test.php` pin the chain end
to end (manifest column, model field map, writer, page), because breaking
any single link degrades **silently** to the `type#id` this replaces. Each
was mutation-tested to red individually.

Local: full suite green, both `phpstan` passes green (three baseline counts
bumped, none regenerated).

Not verified here: the browser render of the new column, which needs a
deploy.