### PR TITLE
Use US spelling in the Secure Boot ledger

### DIFF
--- a/docs/adr/0029-the-secure-boot-ledger-is-observed-and-asserted-and-neither-is-a-control.md
+++ b/docs/adr/0029-the-secure-boot-ledger-is-observed-and-asserted-and-neither-is-a-control.md
@@ -6,11 +6,11 @@ accepted
 
 ## Context
 
-ADR 0008 scopes the Secure Boot enrolment task to machines that are **not
+ADR 0008 scopes the Secure Boot enrollment task to machines that are **not
 currently enforcing Secure Boot**, and states why in the task's own
 description: a machine that is enforcing does not trust this server's kernel,
 so it cannot boot FOS, so it cannot run the task that would make it trust us.
-The task that would enrol the key cannot run on the machine that needs it.
+The task that would enroll the key cannot run on the machine that needs it.
 
 That constraint was written down and then had nowhere to live. Nothing in FOG
 recorded what state any machine was in, so finding the eligible machines meant
@@ -43,9 +43,9 @@ conflating them is how a record stops meaning anything.
 | | Observed (`hostSbState`, `hostSbStateTime`) | Asserted (`hostSbEnrolled`, `hostSbEnrollCert`, `hostSbEnrollVia`) |
 |---|---|---|
 | What it is | what a machine said about itself | a record that somebody enrolled something |
-| Written by | iPXE on every PXE boot; FOS when the enrolment task runs | FOS for the `db` and MOK paths; a human for the USB path |
+| Written by | iPXE on every PXE boot; FOS when the enrollment task runs | FOS for the `db` and MOK paths; a human for the USB path |
 | Editable | **never**, in the UI or over the API | **yes**, and it has to be |
-| Timestamp | stamped by the server from its own clock | the date of the enrolment, which may be historical |
+| Timestamp | stamped by the server from its own clock | the date of the enrollment, which may be historical |
 
 The observed half is never editable because there is no such thing as a
 correct manual value for it: it is a report of what happened on a boot, and a
@@ -55,7 +55,7 @@ refuses the write with a 400 and is pinned by
 `tests/api-server-owned-fields.test.php` — plus disabled (not readonly) inputs
 on the host form, because a disabled input is not submitted at all.
 
-The asserted half is editable because enrolment happens three ways and only
+The asserted half is editable because enrollment happens three ways and only
 two of them can write it themselves. A technician at the machine with a USB
 stick reports nothing; leaving the field hand-editable is the only thing that
 makes that path recordable at all.
@@ -75,8 +75,8 @@ The property that makes this safe is the asymmetry of what a lie buys:
 - Spoofing `disabled` (or leaving the state unknown) gets a host a task that
   cannot work. That is a wasted task — which is exactly what happens today, on
   every host, with no record at all. Nothing regresses.
-- Spoofing `enforcing` gets a host *excluded* from an enrolment it would
-  otherwise receive. It costs nothing, because the enrolment is not a
+- Spoofing `enforcing` gets a host *excluded* from an enrollment it would
+  otherwise receive. It costs nothing, because the enrollment is not a
   privilege and the host is denying it to itself.
 
 There is no third case, and there must not be. Specifically: the boot decision
@@ -96,7 +96,7 @@ vocabularies for one fact; `unknown` is the sixth and is server-side only.
 | `unknown` | nothing has reported yet |
 | `nonefi` | booted BIOS/CSM; Secure Boot is not a concept here |
 | `noefivars` | UEFI, but the variables could not be read |
-| `setup` | Setup Mode — `db` is writable, enrolment is unattended |
+| `setup` | Setup Mode — `db` is writable, enrollment is unattended |
 | `enforcing` | User Mode, Secure Boot ON — the task cannot run |
 | `disabled` | User Mode, Secure Boot OFF — the ADR 0008 case |
 
@@ -104,7 +104,7 @@ vocabularies for one fact; `unknown` is the sixth and is server-side only.
 Boot off leaves the platform key in place, so `db` still refuses a write; only
 Setup Mode accepts one. The Secure Boot configuration page already says this in
 as many words, and `fog.enrollsb` branches on exactly it. It is the difference
-between an enrolment that finishes with nobody at the keyboard and one that
+between an enrollment that finishes with nobody at the keyboard and one that
 needs a human at the MokManager screen — which is the single most useful thing
 an administrator can know before scheduling, and a four-state model throws it
 away.
@@ -144,7 +144,7 @@ legacy BIOS, and it is why the classifier treats the two separately.
 
 ### 5. The record references what was enrolled, not just when
 
-`hostSbEnrollCert` holds the SHA-256 of the enrolled certificate. An enrolment
+`hostSbEnrollCert` holds the SHA-256 of the enrolled certificate. An enrollment
 date alone goes stale in silence: FOG has PKI zones, a multi-server CA and
 certificates that expire, so "enrolled 2026-03-14" says nothing about whether
 the machine trusts what this server is serving today — which is the question
@@ -159,7 +159,7 @@ configuration page hashes. The check is string equality.
 rendering it beside nothing does not answer the question above — it asks an
 administrator to check 95 hex characters against a different page by eye, which
 is how a fleet ends up with nobody having checked. `SecureBootState` owns the
-comparison: `enrolmentFreshness()` returns `current`, `stale`, or `''`, the host
+comparison: `enrollmentFreshness()` returns `current`, `stale`, or `''`, the host
 form renders a read-only Certificate Status row, and the host grid badges the
 stale rows so one glance over a fleet finds them.
 
@@ -177,9 +177,9 @@ The fingerprint FORMAT lives in `SecureBootState::normalizeFingerprint()` for
 the same reason the state format does. It was written out longhand in four
 files; any two of them drifting turns every comparison into a silent false,
 which does not read as a bug — it reads as "this host trusts an older
-certificate", and sends somebody to re-enrol a machine that was already correct.
+certificate", and sends somebody to re-enroll a machine that was already correct.
 
-### 6. A staged MOK request is not an enrolment
+### 6. A staged MOK request is not an enrollment
 
 `fog.enrollsb` has three exits — already-trusted, enrolled-via-`db`, and
 staged-a-MOK — and all three end with the same argument-free completion POST.
@@ -197,7 +197,7 @@ through MokManager, which is the only point at which it is true.
 Nothing observes the human at the MokManager screen, so `mok-pending` does not
 clear itself — and it deliberately gets no clever inference to make it. FOS's
 `sbCertTrusted()` already answers the question definitively, checking both `db`
-and MokList, so re-running the enrolment task on a confirmed host reports
+and MokList, so re-running the enrollment task on a confirmed host reports
 `trusted` and the record corrects itself. That path already exists, already
 works, and is an observation rather than a guess. `mok` is left for a human
 recording that they were there.
@@ -226,7 +226,7 @@ claims.
 
 ### 8. The task refuses a target it cannot run on — but not a guess
 
-`Host::createImagePackage()` refuses a single-host enrolment task whose target
+`Host::createImagePackage()` refuses a single-host enrollment task whose target
 last reported `enforcing`, `nonefi` or `noefivars`. This is the payoff: it
 turns ADR 0008's constraint from something a technician remembers into
 something the server checks.
@@ -264,7 +264,7 @@ group path useless for the case it exists for. Both call the same
   machine reported has no business being echoed back at that machine, and
   nothing in the menu consumes it.
 - A new machine entry point, `service/secureboot.report.php`. It is narrowed to
-  hosts with a Secure Boot enrolment task actually in flight — true by
+  hosts with a Secure Boot enrollment task actually in flight — true by
   construction when FOS calls it — so that "advisory" does not become "writable
   by anyone who knows a MAC". It answers 200 in every case including refusal,
   because a non-2xx from a FOS script is invisible to the caller.
@@ -276,6 +276,6 @@ group path useless for the case it exists for. Both call the same
 - Companion changes in `FOGProject/fos` are required for the automatic half:
   `fog.enrollsb` must report which of its three branches it took, plus the
   fingerprint it already computes and prints. Until that ships, the observed
-  half works on its own and the enrolment record is hand-entered only.
+  half works on its own and the enrollment record is hand-entered only.
 - ADR 0008 is unchanged and remains the authority on what the task is for. This
   ADR is the record, not the task.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2336,10 +2336,10 @@ configureDefaultiPXEfile() {
     # both params empty and the chain is unaffected. Verified 2026-08-28 by
     # running FOG's own ipxe.lkrn under SeaBIOS through this exact script.
     #
-    # BOTH are sent, because SecureBoot alone cannot tell the two enrolment
+    # BOTH are sent, because SecureBoot alone cannot tell the two enrollment
     # routes apart. A machine with Secure Boot merely switched off still has a
     # platform key and still refuses a db write; only Setup Mode accepts one.
-    # That is the difference between an enrolment that completes unattended and
+    # That is the difference between an enrollment that completes unattended and
     # one that needs a human at the MokManager screen.
     #
     # An older default.ipxe sends neither param, and that is deliberately

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -8201,7 +8201,7 @@ $this->schema[] = [
     // hosts.hostSbState -- what this machine last told us about its own
     // Secure Boot posture, and when we heard it.
     //
-    // ADR 0008 scopes the Secure Boot enrolment task to machines that are
+    // ADR 0008 scopes the Secure Boot enrollment task to machines that are
     // NOT currently enforcing, because a machine that is enforcing will not
     // boot FOS and so cannot run the task that would make it trust us. Until
     // now there was no way to find those machines: an admin guessed, and a
@@ -8223,21 +8223,21 @@ $this->schema[] = [
     //   unknown    nothing has reported yet -- server-side only
     //   nonefi     booted BIOS/CSM; Secure Boot is not a concept here
     //   noefivars  UEFI, but the variables could not be read
-    //   setup      Setup Mode -- db is writable, enrolment is unattended
+    //   setup      Setup Mode -- db is writable, enrollment is unattended
     //   enforcing  User Mode, Secure Boot ON  -- the task cannot run
     //   disabled   User Mode, Secure Boot OFF -- the ADR 0008 case
     //
     // setup and disabled are NOT collapsed into one "off". Turning Secure
     // Boot off leaves the platform key in place, so db still refuses a
     // write; only Setup Mode accepts one. fog.enrollsb branches on exactly
-    // that, and it is the difference between an enrolment that finishes with
+    // that, and it is the difference between an enrollment that finishes with
     // nobody at the keyboard and one that needs a human at MokManager.
     //
     // NULL, not a default, and read as "unknown". An existing fleet starts
     // unreported and fills in as machines boot. Defaulting to anything else
     // would assert a fact nobody observed -- and "disabled" is the dangerous
     // direction specifically, because it is the value that makes a host look
-    // like a valid enrolment target.
+    // like a valid enrollment target.
     //
     // VARCHAR, not ENUM: ENUM makes every new state a schema migration, and
     // an int written to an ENUM is a member INDEX rather than a value, which
@@ -8297,7 +8297,7 @@ $this->schema[] = [
 // 377
 $this->schema[] = [
     // hosts.hostSbEnrolled / hostSbEnrollCert / hostSbEnrollVia -- the record
-    // of an enrolment having been PERFORMED.
+    // of an enrollment having been PERFORMED.
     //
     // The other half of 376, and a different kind of fact. 376 is an
     // observation: the machine said what it was, and nobody may edit it.
@@ -8328,7 +8328,7 @@ $this->schema[] = [
     // formatted and upper case -- 95 characters. It is here because "was
     // this machine ever enrolled" is not the question an admin has. The
     // question is "does this machine trust the certificate I am serving
-    // today", and an enrolment date alone goes stale in silence when the
+    // today", and an enrollment date alone goes stale in silence when the
     // certificate rotates: FOG has PKI zones, a multi-server CA, and certs
     // that expire.
     //

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -495,7 +495,7 @@ class FOGConfigurationPage extends FOGPage
         // compare against.
         //
         // Read through SecureBootState rather than computed here, so that the
-        // string on this page and the string each host's enrolment record is
+        // string on this page and the string each host's enrollment record is
         // compared against are the same string by construction. They agreed
         // when both were written out longhand; "they agree today" is not the
         // same property as "they cannot disagree".

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -141,7 +141,7 @@ class HostManagement extends FOGPage
             // Image Management. See schema step 369.
             _('Architecture'),
             // The observed half of the Secure Boot ledger (schema step 376),
-            // and the record of an enrolment having been performed (377).
+            // and the record of an enrollment having been performed (377).
             // Beside Architecture because they answer the same shape of
             // question -- what is this machine, and can the thing I am about
             // to schedule actually run on it.
@@ -149,7 +149,7 @@ class HostManagement extends FOGPage
             // Both default to hidden in the column picker's sense of the
             // word only in that most fleets will not look at them daily;
             // they are emitted always, because the one time they matter is
-            // when someone is picking enrolment targets and needs to sort by
+            // when someone is picking enrollment targets and needs to sort by
             // them. Sorting is the filter here -- this grid has no
             // per-column search UI, so the global box matches the STORED
             // word ('disabled', 'setup') rather than the rendered label.
@@ -1216,7 +1216,7 @@ class HostManagement extends FOGPage
                 $sbStateTime
             );
         }
-        // The enrolment record IS posted back -- a technician who enrolled
+        // The enrollment record IS posted back -- a technician who enrolled
         // from a USB stick is the only source for it and has to be able to
         // type it. filter_input first, object second, exactly like every
         // other editable value on this form.
@@ -1260,9 +1260,9 @@ class HostManagement extends FOGPage
         // post re-renders whatever was typed, and running the comparison on
         // that would report the freshness of a value the database does not
         // hold. Empty when there is nothing to compare -- see
-        // enrolmentFreshness() for why that is not the same as stale.
+        // enrollmentFreshness() for why that is not the same as stale.
         $sbEnrollFresh = SecureBootState::freshnessLabel(
-            SecureBootState::enrolmentFreshness(
+            SecureBootState::enrollmentFreshness(
                 $this->obj->get('sbenrollcert')
             )
         );
@@ -1470,7 +1470,7 @@ class HostManagement extends FOGPage
             ),
             // ASSERTED -- editable, and the three below are one record.
             //
-            // Enrolment happens three ways and only two of them can write
+            // Enrollment happens three ways and only two of them can write
             // this themselves: fog.enrollsb reports the db and MOK paths, and
             // a technician at the machine with a USB stick reports nothing at
             // all. Leaving these hand-editable is what makes the third path
@@ -1502,7 +1502,7 @@ class HostManagement extends FOGPage
             ),
             // The certificate that was enrolled, not merely the date. This
             // is the field that answers the question an admin actually has:
-            // an enrolment date alone says nothing once the certificate has
+            // an enrollment date alone says nothing once the certificate has
             // rotated, and FOG has PKI zones, a multi-server CA and certs
             // that expire. Compare it against the SHA-256 on the Secure Boot
             // configuration page -- the two are computed identically, so the
@@ -1673,7 +1673,7 @@ class HostManagement extends FOGPage
             (string)filter_input(INPUT_POST, 'archID')
         );
         $archID = '' === $archID ? null : (int)$archID;
-        // The enrolment record (schema step 377). Editable, unlike the
+        // The enrollment record (schema step 377). Editable, unlike the
         // reported state above it on the form, because a technician who
         // enrolled from a USB stick is the only source for it.
         //
@@ -1682,7 +1682,7 @@ class HostManagement extends FOGPage
         // VARCHARs, and an unparseable date written to a DATETIME is the
         // GH-1243/GH-1245 family -- it stores as the zero date and the
         // display layer then reads "never enrolled" as "enrolled in year
-        // zero". An empty box is how an enrolment is cleared, and must stay
+        // zero". An empty box is how an enrollment is cleared, and must stay
         // distinguishable from a bad one: '' stores NULL, garbage is
         // refused out loud.
         $sbEnrolled = trim(
@@ -1694,7 +1694,7 @@ class HostManagement extends FOGPage
             $sbEnrolled = self::niceDate($sbEnrolled)->format('Y-m-d H:i:s');
         } else {
             throw new \Exception(
-                _('Secure Boot enrolment date is not a valid date')
+                _('Secure Boot enrollment date is not a valid date')
             );
         }
         // Whitelisted against the same five words fog.enrollsb and the host
@@ -1708,7 +1708,7 @@ class HostManagement extends FOGPage
         // it got there -- db, a MOK confirmed months ago, or an image that
         // shipped with it. Folding it into 'db' would assert a mechanism
         // nobody watched happen, which is the same mistake as recording a
-        // staged MOK as an enrolment, just quieter.
+        // staged MOK as an enrollment, just quieter.
         $sbEnrollVia = strtolower(
             trim((string)filter_input(INPUT_POST, 'sbenrollvia'))
         );
@@ -1729,7 +1729,7 @@ class HostManagement extends FOGPage
             );
         }
         // Shape-checked, not merely trimmed, and through the same
-        // normaliser service/secureboot.report.php uses -- this format was
+        // normalizer service/secureboot.report.php uses -- this format was
         // written out longhand in four files, which is three places for it
         // to drift. Accepts the colon-formatted form the Secure Boot page
         // displays and the bare hex a copy-paste tends to produce, and

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -213,9 +213,9 @@
                 if (type !== 'display') {
                     return data;
                 }
-                // Colour carries the same meaning the enrolment task acts on,
+                // Color carries the same meaning the enrollment task acts on,
                 // so the grid and the refusal cannot tell different stories:
-                // green is ready to enrol unattended, blue is enrollable with
+                // green is ready to enroll unattended, blue is enrollable with
                 // someone at the machine, red cannot run the task at all, and
                 // grey is "we have never heard from this host" -- which is
                 // deliberately not the same grey-as-harmless as the others,
@@ -247,13 +247,13 @@
                 if (type !== 'display') {
                     return data;
                 }
-                // Blank, not "Never": an empty enrolment cell next to a
+                // Blank, not "Never": an empty enrollment cell next to a
                 // populated Secure Boot cell already reads as "not enrolled",
                 // and the word would crowd a column most fleets never look at.
                 if (!data) {
                     return '';
                 }
-                // A staged MOK request is NOT an enrolment and must not read
+                // A staged MOK request is NOT an enrollment and must not read
                 // as one -- the machine will not boot with Secure Boot on
                 // until someone confirms it at the MokManager screen. The
                 // date alone would say the opposite.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2264,7 +2264,7 @@ msgstr "Nicht im Menü aufführen"
 msgid "Documentation"
 msgstr "Ort"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7153,7 +7153,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Es gibt keine Images auf diesem Server."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7353,7 +7353,7 @@ msgstr "Einstellungen erfolgreich gespeichert!"
 msgid "Settings update failed!"
 msgstr "Update der Einstellungen fehlgeschlagen"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8778,10 +8778,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2266,7 +2266,7 @@ msgstr "Do not list on menu"
 msgid "Documentation"
 msgstr "Location"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5491,7 +5491,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7150,7 +7150,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "There are no images on this server."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7350,7 +7350,7 @@ msgstr "has been successfully updated"
 msgid "Settings update failed!"
 msgstr "Settings Updated"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8772,10 +8772,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Documentation"
 msgstr "Acción"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5616,7 +5616,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7300,7 +7300,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "No hay grupos en este servidor."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7503,7 +7503,7 @@ msgstr "se ha actualizado correctamente"
 msgid "Settings update failed!"
 msgstr "Servicio de Actualización!"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8959,10 +8959,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2264,7 +2264,7 @@ msgstr "Nicht im Menü aufführen"
 msgid "Documentation"
 msgstr "Ort"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5494,7 +5494,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7154,7 +7154,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Es gibt keine Images auf diesem Server."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7354,7 +7354,7 @@ msgstr "Einstellungen erfolgreich gespeichert!"
 msgid "Settings update failed!"
 msgstr "Update der Einstellungen fehlgeschlagen"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8779,10 +8779,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2268,7 +2268,7 @@ msgstr "Ne pas inscrire sur le menu"
 msgid "Documentation"
 msgstr "Emplacement"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7152,7 +7152,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Il n'y a pas d'images sur ce serveur."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7352,7 +7352,7 @@ msgstr "a été mis à jour avec succès"
 msgid "Settings update failed!"
 msgstr "Paramètres mis à jour"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8774,10 +8774,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2200,7 +2200,7 @@ msgstr "Non elencare nel menu"
 msgid "Documentation"
 msgstr "Luogo"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -6926,7 +6926,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Non ci sono immagini su questo server"
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7121,7 +7121,7 @@ msgstr "Le impostazioni sono state memorizzate correttamente!"
 msgid "Settings update failed!"
 msgstr "Aggiornamento Impostazioni non riuscito"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8486,10 +8486,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2183,7 +2183,7 @@ msgstr "メニューに表示しない"
 msgid "Documentation"
 msgstr "詳細ドキュメント"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5278,7 +5278,7 @@ msgstr "\"snapinfiles[]\" マルチパートフィールドを使用して、1 �
 msgid "No groups are being created or selected"
 msgstr "削除するグループが選択されていません"
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -6880,7 +6880,7 @@ msgstr ""
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr ""
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7072,7 +7072,7 @@ msgstr "設定を正常に保存しました！"
 msgid "Settings update failed!"
 msgstr "設定の更新に失敗しました"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8424,10 +8424,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 msgid "Domain Admins"
@@ -4664,7 +4664,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -6085,7 +6085,7 @@ msgstr ""
 msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
 msgstr ""
 
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr ""
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -6252,7 +6252,7 @@ msgstr ""
 msgid "Settings update failed!"
 msgstr ""
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -7468,10 +7468,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2267,7 +2267,7 @@ msgstr "Não lista de menus"
 msgid "Documentation"
 msgstr "Localização"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5492,7 +5492,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7151,7 +7151,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Não há imagens neste servidor."
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7351,7 +7351,7 @@ msgstr "foi atualizado com sucesso"
 msgid "Settings update failed!"
 msgstr "Configurações atualizadas"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8773,10 +8773,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2267,7 +2267,7 @@ msgstr "不要列出菜单上"
 msgid "Documentation"
 msgstr "位置"
 
-msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrolment task on it."
+msgid "Does NOT match this server's current certificate -- this host trusts a superseded one and will stop booting under Secure Boot once it is retired. Re-run the Secure Boot enrollment task on it."
 msgstr ""
 
 #, fuzzy
@@ -5492,7 +5492,7 @@ msgstr ""
 msgid "No groups are being created or selected"
 msgstr ""
 
-msgid "No host in this group can run Secure Boot enrolment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
+msgid "No host in this group can run Secure Boot enrollment. Every member last reported a firmware state the task cannot work on -- see the Secure Boot column on the host list."
 msgstr ""
 
 msgid "No hosts are assigned an image"
@@ -7151,7 +7151,7 @@ msgid "Secure Boot does not need to be enabled on a client to enrol its key -- e
 msgstr ""
 
 #, fuzzy
-msgid "Secure Boot enrolment date is not a valid date"
+msgid "Secure Boot enrollment date is not a valid date"
 msgstr "有此服务器上没有图像。"
 
 msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
@@ -7351,7 +7351,7 @@ msgstr "已成功更新"
 msgid "Settings update failed!"
 msgstr "设置更新"
 
-msgid "Setup Mode (unattended enrolment)"
+msgid "Setup Mode (unattended enrollment)"
 msgstr ""
 
 msgid "Setup Mode -- shown as \"Custom\" or \"Custom mode\" in most firmware menus -- is the state a machine is in when its platform key has been cleared, and it is the only state in which these databases can be written. Turning Secure Boot OFF is not the same thing and does not help: a machine with Secure Boot disabled still has a platform key, and still refuses the write. Look for \"Custom mode\", \"Erase all Secure Boot settings\" or \"Clear Secure Boot keys\" in the firmware."
@@ -8773,10 +8773,10 @@ msgstr ""
 msgid "This host has finished deploying image %s."
 msgstr ""
 
-msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enrol into."
+msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
 msgstr ""
 
-msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enrol from local media."
+msgid "This host last reported Secure Boot as ON. It does not trust this server's kernel yet, so it cannot boot FOS to run the task at all. Turn Secure Boot off in its firmware first, or enroll from local media."
 msgstr ""
 
 msgid "This host last reported UEFI firmware whose Secure Boot state could not be read, so FOS has nowhere to write the certificate."

--- a/packages/web/service/secureboot.report.php
+++ b/packages/web/service/secureboot.report.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * FOS reports what a Secure Boot enrolment actually did.
+ * FOS reports what a Secure Boot enrollment actually did.
  *
  * PHP version 7.4+
  *
@@ -18,7 +18,7 @@ use FOG\Items\TaskType;
 use FOG\Router\Route;
 
 /**
- * FOS reports what a Secure Boot enrolment actually did.
+ * FOS reports what a Secure Boot enrollment actually did.
  *
  * WHY THIS EXISTS AND IS NOT PART OF THE COMPLETION POST
  *
@@ -38,7 +38,7 @@ use FOG\Router\Route;
  * So the outcome is reported explicitly, by the only party that knows it,
  * before the completion POST. A separate endpoint rather than extra fields on
  * Post_Wipe.php because that script is shared by every non-imaging task and
- * has no business growing an enrolment vocabulary.
+ * has no business growing an enrollment vocabulary.
  *
  * ADVISORY, like every other machine entry point. This writes the editable
  * half of the ledger (schema step 377), which an administrator can type into
@@ -47,10 +47,10 @@ use FOG\Router\Route;
  *
  * It is still narrowed to what it needs to be, because "advisory" is not a
  * reason to accept a write from anywhere: the host must have a Secure Boot
- * enrolment task actually in flight. That is true by construction when FOS
+ * enrollment task actually in flight. That is true by construction when FOS
  * calls this -- the task is what booted it -- and it means an arbitrary
- * caller who knows a MAC cannot stamp an enrolment onto a host that was never
- * asked to enrol.
+ * caller who knows a MAC cannot stamp an enrollment onto a host that was never
+ * asked to enroll.
  *
  * Answers 200 with a plain-text body in every case, including refusal. A
  * non-2xx from a FOS script is invisible to the caller and reads as a
@@ -109,7 +109,7 @@ if (!$Task->isValid()
 //
 // 'trusted' stays 'trusted' rather than collapsing into 'db': it means the
 // machine already trusted this certificate when the task ran, and nothing
-// observed how it got there. It is an enrolment fact worth keeping -- it is
+// observed how it got there. It is an enrollment fact worth keeping -- it is
 // the one result that would otherwise be lost entirely -- but it is not a
 // record of this server enrolling anything.
 //
@@ -128,7 +128,7 @@ if (!array_key_exists($result, $map)) {
 }
 
 // Shape-checked for the same reason the form is, and through the same
-// normaliser: this value's whole purpose is to be compared against the
+// normalizer: this value's whole purpose is to be compared against the
 // server's own fingerprint, and a comparison against something that is not a
 // SHA-256 can only ever be false -- silently, and looking exactly like "this
 // host trusts an older certificate".

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4350');
+        define('FOG_VERSION', '1.6.0-beta.4354');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -221,7 +221,7 @@ class IpxeBootMenu extends BootMenuBase
      *
      * The same seam as _recordHostArch() and for the same reason: this is the
      * only moment FOG hears it. FOS could report it too -- and does, when the
-     * enrolment task runs -- but FOS runs when someone schedules a task, which
+     * enrollment task runs -- but FOS runs when someone schedules a task, which
      * for most hosts is never. iPXE runs on every PXE boot.
      *
      * The classification lives in SecureBootState so that the one place the

--- a/packages/web/src/Boot/SecureBootState.php
+++ b/packages/web/src/Boot/SecureBootState.php
@@ -22,7 +22,7 @@ namespace FOG\Boot;
  *   - iPXE, on every PXE boot, via `${efi/SecureBoot}` and `${efi/SetupMode}`
  *     posted by default.ipxe. Cheap, early, and it happens whether or not
  *     FOS ever runs.
- *   - FOS, when the enrolment task runs, via sbState() in
+ *   - FOS, when the enrollment task runs, via sbState() in
  *     usr/share/fog/lib/secureboot-funcs.sh.
  *
  * The five machine states below are FOS's names, taken verbatim from that
@@ -110,7 +110,7 @@ class SecureBootState
      *
      * A column read is not a promise: a value could have been written by an
      * older build, by a plugin, or by hand in the database. Anything
-     * unrecognised is treated as UNKNOWN by the callers rather than trusted.
+     * unrecognized is treated as UNKNOWN by the callers rather than trusted.
      *
      * @param mixed $state the value to test
      *
@@ -154,7 +154,7 @@ class SecureBootState
      * Compared case-insensitively and after a trim anyway: the format is
      * iPXE's to change, and a comparison that breaks on '00 ' would fail
      * open into "not off", which is the direction that silently stops the
-     * enrolment task working.
+     * enrollment task working.
      *
      * SetupMode is tested BEFORE SecureBoot, matching sbState(). A machine in
      * Setup Mode has no platform key, so it cannot be enforcing, but the
@@ -195,11 +195,11 @@ class SecureBootState
         // value that is neither 00 nor 01 is a byte nothing here understands.
         // NOEFIVARS rather than DISABLED, because "we could not read this"
         // must never collapse into the one answer that makes a host look
-        // like a valid enrolment target.
+        // like a valid enrollment target.
         return self::NOEFIVARS;
     }
     /**
-     * Whether the enrolment task can do anything useful on this host.
+     * Whether the enrollment task can do anything useful on this host.
      *
      * True for the two states where FOS can boot and has somewhere to put
      * the certificate. SETUP is the good one -- fog.enrollsb writes db and
@@ -224,7 +224,7 @@ class SecureBootState
      *
      * @return bool
      */
-    public static function isEnrolmentTarget($state)
+    public static function isEnrollmentTarget($state)
     {
         if (!self::isKnown($state)) {
             return true;
@@ -239,7 +239,7 @@ class SecureBootState
     /**
      * Whether scheduling against this host is a guess rather than a decision.
      *
-     * Separate from isEnrolmentTarget() on purpose: UNKNOWN is allowed
+     * Separate from isEnrollmentTarget() on purpose: UNKNOWN is allowed
      * through and still has to be said out loud, and the two answers are
      * needed in different places -- the refusal, and the warning next to it.
      *
@@ -252,7 +252,7 @@ class SecureBootState
         return !self::isKnown($state) || self::UNKNOWN === (string)$state;
     }
     /**
-     * Why the enrolment task will not run here, or '' if it will.
+     * Why the enrollment task will not run here, or '' if it will.
      *
      * Lives here rather than at either call site because there ARE two call
      * sites and they are not on the same code path: a single-host task goes
@@ -273,7 +273,7 @@ class SecureBootState
      */
     public static function refusalReason($state)
     {
-        if (self::isEnrolmentTarget($state)) {
+        if (self::isEnrollmentTarget($state)) {
             return '';
         }
         switch ((string)$state) {
@@ -282,13 +282,13 @@ class SecureBootState
                     'This host last reported Secure Boot as ON. It does not '
                     . 'trust this server\'s kernel yet, so it cannot boot FOS '
                     . 'to run the task at all. Turn Secure Boot off in its '
-                    . 'firmware first, or enrol from local media.'
+                    . 'firmware first, or enroll from local media.'
                 );
             case self::NONEFI:
                 return _(
                     'This host last booted in legacy BIOS mode, where Secure '
                     . 'Boot does not exist. There is nothing for this task to '
-                    . 'enrol into.'
+                    . 'enroll into.'
                 );
             default:
                 return _(
@@ -317,7 +317,7 @@ class SecureBootState
             case self::NOEFIVARS:
                 return _('UEFI, state unreadable');
             case self::SETUP:
-                return _('Setup Mode (unattended enrolment)');
+                return _('Setup Mode (unattended enrollment)');
             case self::ENFORCING:
                 return _('Secure Boot ON');
             case self::DISABLED:
@@ -375,7 +375,7 @@ class SecureBootState
         return BASEPATH . 'service/secureboot' . DS . 'MOK.der';
     }
     /**
-     * Canonicalise a SHA-256 fingerprint, or reject it.
+     * Canonicalize a SHA-256 fingerprint, or reject it.
      *
      * One format, one place. The colon-separated upper-case form is what
      * FOGConfigurationPage::secureBoot() displays and what FOS's
@@ -387,7 +387,7 @@ class SecureBootState
      * column's only use is an equality test, and a comparison against
      * something that is not a SHA-256 can only ever be false -- silently, and
      * looking exactly like "this host trusts an older certificate", which is
-     * the one wrong answer that sends somebody to re-enrol a machine that is
+     * the one wrong answer that sends somebody to re-enroll a machine that is
      * already fine.
      *
      * @param mixed $value bare or colon-separated hex, any case
@@ -432,7 +432,7 @@ class SecureBootState
         return self::$_serverPrint;
     }
     /**
-     * Whether a host's enrolment record matches what this server serves.
+     * Whether a host's enrollment record matches what this server serves.
      *
      * Returns '' -- not STALE -- for every case where the question cannot be
      * answered: nothing recorded against the host, an unparseable stored
@@ -447,7 +447,7 @@ class SecureBootState
      *
      * @return string FRESH, STALE, or '' when it cannot be answered
      */
-    public static function enrolmentFreshness($stored, $server = null)
+    public static function enrollmentFreshness($stored, $server = null)
     {
         $stored = self::normalizeFingerprint($stored);
         if ('' === $stored) {
@@ -485,7 +485,7 @@ class SecureBootState
                     'Does NOT match this server\'s current certificate -- '
                     . 'this host trusts a superseded one and will stop '
                     . 'booting under Secure Boot once it is retired. Re-run '
-                    . 'the Secure Boot enrolment task on it.'
+                    . 'the Secure Boot enrollment task on it.'
                 );
             default:
                 return '';

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -813,7 +813,7 @@ class Group extends FOGController
         } else {
             if ($TaskType->id != TaskType::WAKE_UP) {
                 $hostIDs = $this->get('hosts');
-                // Drop members the Secure Boot enrolment task cannot run on.
+                // Drop members the Secure Boot enrollment task cannot run on.
                 //
                 // The same refusal Host::createImagePackage() makes, at the
                 // only other place it can be made: a non-imaging group task
@@ -829,7 +829,7 @@ class Group extends FOGController
                 // from a firmware change with Secure Boot already on would
                 // make the group path useless for the case it exists for.
                 //
-                // Unreported members are KEPT, matching isEnrolmentTarget():
+                // Unreported members are KEPT, matching isEnrollmentTarget():
                 // nothing is known until a host PXE boots, and silently
                 // dropping every not-yet-seen host would empty the group on
                 // the first day this shipped.
@@ -840,7 +840,7 @@ class Group extends FOGController
                 //
                 // One row-load per member, matching setSnapinOrder() above
                 // rather than reaching for a lighter query. Deliberate: this
-                // runs only for an explicitly scheduled enrolment, which is a
+                // runs only for an explicitly scheduled enrollment, which is a
                 // rare and considered operation, and the batch insert that
                 // follows dominates it on any group big enough to notice.
                 if (TaskType::ENROLL_SECUREBOOT == $TaskType->id) {
@@ -850,7 +850,7 @@ class Group extends FOGController
                         if (!$Host->isValid()) {
                             continue;
                         }
-                        if (SecureBootState::isEnrolmentTarget(
+                        if (SecureBootState::isEnrollmentTarget(
                             $Host->get('sbstate')
                         )) {
                             $eligible[] = $hostID;
@@ -860,7 +860,7 @@ class Group extends FOGController
                         throw new \Exception(
                             _(
                                 'No host in this group can run Secure Boot '
-                                . 'enrolment. Every member last reported a '
+                                . 'enrollment. Every member last reported a '
                                 . 'firmware state the task cannot work on -- '
                                 . 'see the Secure Boot column on the host '
                                 . 'list.'

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -104,7 +104,7 @@ class Host extends FOGController
         // to either field.
         //
         // sbenrolled and its two companions are ASSERTED: a record that an
-        // enrolment happened, which IS editable because a technician with a
+        // enrollment happened, which IS editable because a technician with a
         // USB stick is one of the three ways it happens and the only one FOG
         // cannot observe. sbenrollcert is the SHA-256 of what was enrolled,
         // so "does this host trust the certificate I serve today" is
@@ -1127,7 +1127,7 @@ class Host extends FOGController
                         break;
                 }
             }
-            // Refuse a Secure Boot enrolment the target cannot run.
+            // Refuse a Secure Boot enrollment the target cannot run.
             //
             // This is the payoff for schema step 376, and it is the same
             // shape of argument as the architecture check further down: the
@@ -1148,7 +1148,7 @@ class Host extends FOGController
             // spoofed "disabled" earns itself a task that cannot work, which
             // is exactly what happens today with no record at all. See ADR
             // 0029. What it is NOT allowed to do is refuse on a guess:
-            // isEnrolmentTarget() lets UNKNOWN through, so an upgraded server
+            // isEnrollmentTarget() lets UNKNOWN through, so an upgraded server
             // whose fleet has not PXE booted yet behaves exactly as it does
             // now, and only a positively-reported bad state is refused.
             if (TaskType::ENROLL_SECUREBOOT == $TaskType->id) {

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -423,7 +423,7 @@ class Route extends FOGBase
             // The observed half of the Secure Boot ledger (schema step 376).
             // This is the field the HARD constraint in ADR 0029 is about: it
             // is a REPORT of what a machine said, so a caller asserting it
-            // would be asserting an observation nobody made. The enrolment
+            // would be asserting an observation nobody made. The enrollment
             // record next to it -- sbenrolled, sbenrollcert, sbenrollvia --
             // is deliberately NOT here, because a technician who enrolled a
             // certificate from a USB stick is the only source for that fact
@@ -2598,7 +2598,7 @@ class Route extends FOGBase
                     // pingstatus uses. It carries no header, so it is data in
                     // the JSON rather than a visible column (primac_vendor
                     // rides along the same way), and it exists because the
-                    // client needs the value to colour the badge: a DataTables
+                    // client needs the value to color the badge: a DataTables
                     // row is keyed by the `dt` names, so the db column is not
                     // reachable there, and deriving the state back out of a
                     // TRANSLATED label would break in every locale but one.
@@ -2620,16 +2620,16 @@ class Route extends FOGBase
                             // registerExportTable() escapes each cell, so a
                             // <span> here is printed as literal markup in
                             // the CSV -- the GH-1446 failure exactly. The
-                            // colour is a display decision and is made
+                            // color is a display decision and is made
                             // client-side in fog.host.list.js, which is
                             // where the existing comment on the datetime
                             // formatter above says such decisions belong.
                             //
-                            // label() renders NULL and any unrecognised
+                            // label() renders NULL and any unrecognized
                             // value as "Never reported" rather than as a
                             // blank cell. A blank would read as "no Secure
                             // Boot", which is the one wrong answer that
-                            // makes a host look like a valid enrolment
+                            // makes a host look like a valid enrollment
                             // target.
                             //
                             // Note the search box matches the STORED word
@@ -2661,7 +2661,7 @@ class Route extends FOGBase
                         'db' => $real,
                         'dt' => 'sbenrollfresh',
                         'formatter' => function ($d, $row) {
-                            return SecureBootState::enrolmentFreshness($d);
+                            return SecureBootState::enrollmentFreshness($d);
                         }
                     ];
                     $columns[] = [

--- a/tests/netboot-host.test.sh
+++ b/tests/netboot-host.test.sh
@@ -208,7 +208,7 @@ has "$written" "http://10.0.0.1/fog/service/ipxe/boot.php" \
 # O2. The Secure Boot ledger's whole supply of data is these two lines. Nothing
 #     else asks a machine what its firmware state is, so if they are dropped --
 #     by a rebase, or by someone tidying the echo -- every host silently reads
-#     "never reported" for ever, the enrolment task's target check goes back to
+#     "never reported" for ever, the enrollment task's target check goes back to
 #     allowing everything, and there is no error anywhere to say so.
 #
 #     Asserted against the WRITTEN FILE and against the exact iPXE spelling,
@@ -219,7 +219,7 @@ has "$written" "http://10.0.0.1/fog/service/ipxe/boot.php" \
 has "$written" 'param secureboot ${efi/SecureBoot}' \
     "O2: default.ipxe reports the Secure Boot variable"
 has "$written" 'param setupmode ${efi/SetupMode}' \
-    "O2b: ...and Setup Mode, which is what says whether enrolment is unattended"
+    "O2b: ...and Setup Mode, which is what says whether enrollment is unattended"
 
 # O3. Order matters for one reason: the mac1..mac7 chain below short-circuits
 #     to :bootme on the first absent interface, so anything emitted after it is

--- a/tests/secureboot-enrolvia-vocabulary.test.php
+++ b/tests/secureboot-enrolvia-vocabulary.test.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The enrolment-provenance vocabulary must be the same in both writers.
+ * The enrollment-provenance vocabulary must be the same in both writers.
  *
- * `hostSbEnrollVia` records HOW a Secure Boot enrolment happened, and two
+ * `hostSbEnrollVia` records HOW a Secure Boot enrollment happened, and two
  * unrelated files write it:
  *
  *   - `service/secureboot.report.php` maps the word FOS sends onto the word
@@ -13,7 +13,7 @@
  * Neither can see the other, and the failure when they drift is silent in the
  * direction that matters. If the endpoint learns to store a word the form does
  * not accept, an administrator who opens that host and presses Update --
- * having changed nothing about the enrolment -- gets an exception on a value
+ * having changed nothing about the enrollment -- gets an exception on a value
  * the server itself wrote. The reverse, a form word the endpoint never emits,
  * is harmless, so only one direction is a hard failure here.
  *
@@ -122,16 +122,16 @@ foreach ($stored as $word) {
 // point of the asserted half of ADR 0029.
 if (!in_array('manual', $allowed, true)) {
     $problems[] = "the host form no longer accepts 'manual'. That is the only"
-        . ' value recording an enrolment done by hand at the machine, which is'
+        . ' value recording an enrollment done by hand at the machine, which is'
         . ' the path ADR 0029 makes the asserted half editable for.';
 }
 
 // 'mok-pending' must be storable, and a staged request must not become 'mok'.
-// A staged MOK is not an enrolment (ADR 0029 decision 6), and the host grid
+// A staged MOK is not an enrollment (ADR 0029 decision 6), and the host grid
 // keys its "pending" badge on exactly this string.
 if (!in_array('mok-pending', $stored, true)) {
     $problems[] = 'service/secureboot.report.php no longer stores'
-        . " 'mok-pending'. A staged MOK request recorded as an enrolment is a"
+        . " 'mok-pending'. A staged MOK request recorded as an enrollment is a"
         . ' lie an administrator acts on -- they turn Secure Boot on and the'
         . ' machine stops booting.';
 }

--- a/tests/secureboot-state-classifier.test.php
+++ b/tests/secureboot-state-classifier.test.php
@@ -4,7 +4,7 @@
  *
  * SecureBootState::fromBootRequest() turns three strings out of an
  * unauthenticated POST body into one of six words. Every consumer -- the host
- * grid, the host form, and the enrolment task's refusal -- reads that word and
+ * grid, the host form, and the enrollment task's refusal -- reads that word and
  * nothing else, so a wrong classification is not a wrong label: it is either a
  * host that can never be enrolled, or a host that looks enrollable and is not.
  *
@@ -34,7 +34,7 @@
  * It is asserted from iPXE's own formatter -- efi_settings.c assigns
  * setting_type_hex, which is two hex digits per byte -- and the classifier is
  * built so that being wrong about it fails CLOSED: anything that is not
- * recognisably "off" is not an enrolment target.
+ * recognizably "off" is not an enrollment target.
  *
  * DB-free. SecureBootState touches no globals and no database.
  *
@@ -172,7 +172,7 @@ foreach ($cases as $case) {
 // ------------------------------------------------------------- eligibility --
 // The refusal reads this and nothing else. UNKNOWN is true by decision, not by
 // omission: nothing is reported until a host PXE boots, so refusing it outright
-// would make the enrolment task unusable on every existing fleet until a full
+// would make the enrollment task unusable on every existing fleet until a full
 // boot cycle had happened. The host list filter is what keeps an unknown host
 // from LOOKING eligible.
 $eligible = [
@@ -185,21 +185,21 @@ $eligible = [
 ];
 foreach ($eligible as $state => $expected) {
     $sbCheck(
-        "isEnrolmentTarget('$state')",
+        "isEnrollmentTarget('$state')",
         $expected,
-        SecureBootState::isEnrolmentTarget($state)
+        SecureBootState::isEnrollmentTarget($state)
     );
 }
 
-// A value this build does not recognise -- written by an older build, a
+// A value this build does not recognize -- written by an older build, a
 // plugin, or by hand in the database -- is treated as unreported rather than
 // trusted, so it is allowed with the same warning UNKNOWN gets.
-$sbCheck('isEnrolmentTarget(null)', true, SecureBootState::isEnrolmentTarget(null));
-$sbCheck('isEnrolmentTarget("")', true, SecureBootState::isEnrolmentTarget(''));
+$sbCheck('isEnrollmentTarget(null)', true, SecureBootState::isEnrollmentTarget(null));
+$sbCheck('isEnrollmentTarget("")', true, SecureBootState::isEnrollmentTarget(''));
 $sbCheck(
-    'isEnrolmentTarget("wat")',
+    'isEnrollmentTarget("wat")',
     true,
-    SecureBootState::isEnrolmentTarget('wat')
+    SecureBootState::isEnrollmentTarget('wat')
 );
 $sbCheck('isUnreported(null)', true, SecureBootState::isUnreported(null));
 $sbCheck('isUnreported("wat")', true, SecureBootState::isUnreported('wat'));
@@ -245,7 +245,7 @@ foreach ($reasons as $reason => $count) {
     $sbCheck('each refused state has its own message', 1, $count);
 }
 // The states that must NOT be refused, asserted through the same function the
-// call sites use rather than through isEnrolmentTarget() alone -- the two have
+// call sites use rather than through isEnrollmentTarget() alone -- the two have
 // to agree, and only checking one lets them drift.
 foreach (
     [
@@ -262,7 +262,7 @@ foreach (
 }
 $sbCheck('refusalReason(null) permits', '', SecureBootState::refusalReason(null));
 $sbCheck(
-    'refusalReason("wat") permits an unrecognised stored value',
+    'refusalReason("wat") permits an unrecognized stored value',
     '',
     SecureBootState::refusalReason('wat')
 );
@@ -291,11 +291,11 @@ foreach ($labels as $label => $count) {
 }
 
 // ------------------------------------------------------- fingerprint format --
-// One normaliser, because this format was written out longhand in four files
+// One normalizer, because this format was written out longhand in four files
 // before it had a home: the host form, the report endpoint, the Secure Boot
 // configuration page and FOS. Any two of them drifting turns every comparison
 // into a silent false, which does not read as a bug -- it reads as "this host
-// trusts an older certificate", and sends somebody to re-enrol a machine that
+// trusts an older certificate", and sends somebody to re-enroll a machine that
 // was already correct.
 $canonical = 'AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99'
     . ':AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99';
@@ -346,19 +346,19 @@ $other = implode(':', str_split(str_repeat('11', 32), 2));
 $sbCheck(
     'an identical fingerprint is current',
     SecureBootState::FRESH,
-    SecureBootState::enrolmentFreshness($canonical, $canonical)
+    SecureBootState::enrollmentFreshness($canonical, $canonical)
 );
-// The case the normaliser is FOR: the same certificate written two ways must
+// The case the normalizer is FOR: the same certificate written two ways must
 // not read as two certificates.
 $sbCheck(
     'bare hex against colon form is still the same certificate',
     SecureBootState::FRESH,
-    SecureBootState::enrolmentFreshness(strtolower($bare), $canonical)
+    SecureBootState::enrollmentFreshness(strtolower($bare), $canonical)
 );
 $sbCheck(
     'a different fingerprint is stale',
     SecureBootState::STALE,
-    SecureBootState::enrolmentFreshness($canonical, $other)
+    SecureBootState::enrollmentFreshness($canonical, $other)
 );
 
 // Three different kinds of "cannot answer", none of which is evidence that a
@@ -376,7 +376,7 @@ foreach ($unanswerable as $why => $pair) {
     $sbCheck(
         "freshness is unanswerable when $why",
         '',
-        SecureBootState::enrolmentFreshness($pair[0], $pair[1])
+        SecureBootState::enrollmentFreshness($pair[0], $pair[1])
     );
 }
 
@@ -391,7 +391,7 @@ $sbCheck('the stale label says something', true, '' !== $stale);
 $sbCheck('the two labels differ', true, $fresh !== $stale);
 $sbCheck("an unanswerable freshness has no label", '', SecureBootState::freshnessLabel(''));
 $sbCheck(
-    'an unrecognised freshness has no label',
+    'an unrecognized freshness has no label',
     '',
     SecureBootState::freshnessLabel('wat')
 );
@@ -399,7 +399,7 @@ $sbCheck(
 // tell anyone anything: the machine boots fine until the old kernels stop
 // being served, and then stops booting with no apparent cause.
 $sbCheck(
-    'the stale label says to re-run the enrolment task',
+    'the stale label says to re-run the enrollment task',
     true,
     false !== stripos($stale, 're-run')
 );


### PR DESCRIPTION
The Secure Boot ledger (#1451) shipped **147 UK spellings**, almost all of them `enrolment`.

The project's own identifiers have always been US — `hostSbEnrolled`, `hostSbEnrollVia`, `hostSbEnrollCert`, `fog.enrollsb`, `sbEnrollDb` — so the prose was disagreeing with the columns it described. Two methods coined in that PR carried it into the API surface:

| was | now |
|---|---|
| `isEnrolmentTarget()` | `isEnrollmentTarget()` |
| `enrolmentFreshness()` | `enrollmentFreshness()` |

Also `recognised` / `recognise` / `recognisably`, `normaliser`, `canonicalise` and `colour`.

Three user-visible strings change with it — "Setup Mode (unattended enrollment)", the enrollment-task refusal text, and the stale-certificate warning — so the `.pot` and `.po` files move too. Those are regenerated by the pre-commit hook from source rather than hand-edited.

## Scoped by the diff, not by the word

**160 files in this repo carried UK spellings before any of this landed**, including `docs/adr/0008-secure-boot-enrolment-task-type.md` — in its *filename*. Rewriting those is a separate pass that would dominate any diff it rode in, and the house convention is to leave surrounding text alone.

So only lines #1451 added were rewritten. That does leave a mixture inside `Route.php`, `IpxeBootMenu.php`, `schema.php`, `fogconfigurationpage.page.php` and `lib/common/functions.sh` (82 pre-existing hits in that last one) — deliberately, and called out here rather than left to be discovered.

## No behavior change

The stored column values are untouched. `db`, `trusted`, `mok`, `mok-pending` and `manual` were already US, and are what `service/secureboot.report.php` writes and the host form whitelists. No data migration, no schema bump, no `FOG_SCHEMA` change.

## Verification

- `tests/run-all.sh` — 185 passed, 0 failed
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/phpstan analyse -c phpstan-tests.neon` — no errors

Companion: FOGProject/fos#167, which does the same for `sbReport` and renames `tests/checks/secureboot-enrolment-report.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2gFRQ3Khhx24FNYMZhW6N
