### PR TITLE
Name the setting a retention window change is about

### DIFF
--- a/packages/web/src/Audit/Retention.php
+++ b/packages/web/src/Audit/Retention.php
@@ -234,6 +234,41 @@ class Retention extends FOGBase
         return $new < $old;
     }
     /**
+     * The globalSettings row id behind a settings key.
+     *
+     * The audit rows here name a SETTING, and a subject is a type, an id and
+     * a label -- so `setting#496` and the key belong together, the same way
+     * every other audited edit carries both. This caller is handed a
+     * settings POST rather than a Setting, so the id has to be read.
+     *
+     * One indexed lookup on settingKey, and only on a path that runs when a
+     * retention window actually moves -- not on every settings save.
+     *
+     * IT MAY NOT THROW, and that is the whole reason it is a method. This
+     * runs inside Decision 10's HARD constraint: a shrink that cannot be
+     * recorded must be REFUSED, so an exception raised while decorating the
+     * record would turn a settings save into a 500 and, worse, do it from
+     * the code that exists to protect the record. An unresolvable key
+     * degrades to 0, which reads as "id unknown" -- the label still names
+     * the setting, so nothing identifying is lost.
+     *
+     * @param string $key the globalSettings key
+     *
+     * @return int the setting's id, or 0 when it could not be read
+     */
+    private static function _settingID($key)
+    {
+        try {
+            $setting = self::getClass('Setting')
+                ->set('name', $key)
+                ->load('name');
+
+            return (int)$setting->get('id');
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
+    /**
      * May this retention window change go ahead?
      *
      * ADR 0021 Decision 10, and the HARD constraint behind it: anything that
@@ -259,9 +294,11 @@ class Retention extends FOGBase
             return true;
         }
         $shrink = self::isShrink($old, $new);
+        $settingID = self::_settingID($key);
         $audit = Audit::record([
             'type' => self::WINDOW_CHANGE,
             'subjectType' => 'setting',
+            'subjectID' => $settingID,
             'subjectLabel' => $key,
             'permission' => 'audit.manage',
             'renderable' => 1
@@ -280,14 +317,15 @@ class Retention extends FOGBase
             // that moved is globalSettings.settingValue like any other. The
             // label column exists now, so the workaround comes out.
             //
-            // subjectID 0 because this caller has the key and not the row:
-            // it is handed a settings POST, not a Setting. It used to store
-            // the AUDIT row's own id here, which is not a setting id and
-            // pointed at whatever setting happened to hold that number.
+            // subjectID is the globalSettings row's own id, looked up from
+            // the key -- the SUBJECT'S id, not the audit row's. It used to
+            // store the audit row's id here, which is a number from a
+            // different table that happens to fit the column and so points
+            // at whatever setting holds it.
             $stored = Audit::changes(
                 $audit,
                 'Setting',
-                0,
+                $settingID,
                 ['value' => [(int)$old, (int)$new]],
                 $key
             ) > 0;

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4354');
+        define('FOG_VERSION', '1.6.0-beta.4360');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4350');
+        define('FOG_VERSION', '1.6.0-beta.4353');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/retention-registry.test.php
+++ b/tests/retention-registry.test.php
@@ -321,6 +321,47 @@ check(
 );
 
 /*
+ * 5b. The audit rows name the SETTING, by its own id.
+ *
+ * Scoped to permitSettingChange()'s body. It used to store the audit row's
+ * own id as the subject id -- a number from a different table that fits the
+ * column and so points at whatever setting happens to hold it, which is
+ * wrong in a way nothing can detect after the fact. The subject id must come
+ * from the lookup, and the lookup must not be able to throw: this runs inside
+ * Decision 10, where an exception raised while decorating the record would
+ * turn a settings save into a 500 from the code protecting the record.
+ */
+$permitStart = strpos($src, 'public static function permitSettingChange(');
+$permitEnd = $permitStart === false
+    ? false
+    : strpos($src, "\n    /**", $permitStart);
+$permit = ($permitStart === false || $permitEnd === false)
+    ? ''
+    : substr($src, $permitStart, $permitEnd - $permitStart);
+check(
+    'permitSettingChange() reads the setting id from the key',
+    '' !== $permit
+    && false !== strpos($permit, '$settingID = self::_settingID($key)'),
+    $failures,
+    $checks
+);
+check(
+    'permitSettingChange() never uses the audit row id as the subject id',
+    '' !== $permit && false === strpos($permit, "\$audit->get('id')"),
+    $failures,
+    $checks
+);
+check(
+    '_settingID() cannot throw',
+    false !== strpos($src, 'private static function _settingID($key)')
+    && false !== strpos($src, '} catch (\\Exception $e) {
+            return 0;
+        }'),
+    $failures,
+    $checks
+);
+
+/*
  * 6. The settings page gates the windows on audit.manage, both ways: the
  *    field is not rendered without it and a post is refused without it.
  */


### PR DESCRIPTION
Follow-on to #1452.

## The problem

`Retention::permitSettingChange()` wrote its audit rows with
`subjectType => 'setting'` and a label, and no id — so they read `setting`
where every other audited edit reads `setting#496`. The id is part of the
subject, not decoration: it says *which* row, and for a subject with no
name (an association row, say) it is the only thing that says anything at
all.

Worse, before #1452 the change row stored **the audit row's own id** in
`acSubjectID`. That is a number from a different table that happens to fit
the column, so it silently points at whatever setting holds it. The row the
audit is *discussing* is not the row the audit *is*.

## The fix

Both the header and the change row now carry the real `globalSettings` id,
resolved from the key through the pattern already used for exactly this
(`serviceconfigurationpage.page.php:269`, `FOGBase::nodeSecret()`):

```php
self::getClass('Setting')->set('name', $key)->load('name');
```

One indexed read, on a path that runs only when a retention window actually
moves — not on every settings save.

### Why it is a method

`_settingID()` exists to be unable to throw. This runs inside ADR 0021
Decision 10's HARD constraint — a shrink that cannot be recorded must be
refused — so an exception raised while *decorating* the record would turn a
settings save into a 500, thrown from the code whose whole job is
protecting the record. An unresolvable key degrades to `0`; the label still
names the setting, so nothing identifying is lost.

## Verification

Against a throwaway podman copy of a live 1.6 database — nothing touched
the live install:

```
      FOG_AUDIT_RETENTION_DAYS is globalSettings id 1036, currently '732'
ok    a growth is permitted
      newest header: {"alID":522,"alType":"audit.retention.window",
      "alSubjectType":"setting","alSubjectID":1036,
      "alSubjectLabel":"FOG_AUDIT_RETENTION_DAYS"}
ok    the header names the setting by its real id (1036)
ok    the header id and the subject id are different numbers
      its change row: {"acAuditID":522,"acSubjectID":1036,
      "acSubjectLabel":"FOG_AUDIT_RETENTION_DAYS","acField":"value",
      "acOldValue":"30","acNewValue":"0"}
ok    the change row carries the same real id
ok    the change row still reads key-as-label, `value` as field
ok    from/to are the window either side
ok    an unresolvable key reads 0 and does not throw
```

Header id 522 vs subject id 1036 is the assertion that would have caught
the original bug.

Three invariants added to `tests/retention-registry.test.php` — the lookup
is used, the audit row's id is never the subject id, and the catch is still
there. Each mutation-tested to red on its own, including by putting the
original bug back.

Local: full suite green, both `phpstan` passes green. No schema change.