### PR TITLE
Use US spellings throughout the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ pass and passes for reasons the real command never touches. The two live in the
 same job on purpose: the ruleset requires the single context `phpstan`, so
 neither pass can be required without the other.
 
-The second pass analyses `tests/` against `phpstan-tests-baseline.neon`, and
+The second pass analyzes `tests/` against `phpstan-tests-baseline.neon`, and
 **that baseline counts occurrences, not lines.** Adding a second use of an
 already-baselined pattern fails the build on an entry nobody touched:
 
@@ -267,7 +267,7 @@ The REST API is routed separately from the `?node=` UI above: `Route::defineRout
 (`lib/router/route.class.php`) maps the URIs, and `OpenAPI::document()`
 (`lib/fog/openapi.class.php`) describes them, served at `system/openapi` and `swagger.json`
 and rendered by the API Documentation page. The document is generated per request, but only
-*partly* from the router — so **a route change can change behaviour without changing the
+*partly* from the router — so **a route change can change behavior without changing the
 document**. Treat the spec as part of the route commit, not as follow-up.
 
 Updates itself, nothing to do:
@@ -390,9 +390,9 @@ reasoning and the rejected alternatives:
 - **Newer files**: `declare(strict_types=1)` at top; older files do not have this — don't add it retroactively
 - **Avoid `new` directly**: use `FOGBase::getClass()` or `FOGBase::getManager()` as appropriate
 
-### Button colour and alignment
+### Button color and alignment
 
-Position carries the meaning, colour follows it. Don't pick a colour to make a
+Position carries the meaning, color follows it. Don't pick a color to make a
 button stand out — pick the one that matches what kind of action it is.
 
 | Action | Class | Side |
@@ -428,7 +428,7 @@ nothing inside a flex container**, and most of the containers here are flex:
   the auto margin only pushes the slack to one side — #919 shipped the margin
   alone and the buttons stayed in emission order, just left-packed instead of
   right-packed. Keep tagging the dismiss `float-start`; that class is what both
-  the position and the plain (non type-coloured) fill key off.
+  the position and the plain (non type-colored) fill key off.
 
 That flex/float mismatch has bitten twice: the task panes wrapped their buttons
 in a bare `.btn-group`, which silently killed `float-start`/`float-end` and
@@ -443,7 +443,7 @@ Three consequences worth remembering:
   They were `btn-info` and read as a different one.
 - Don't override `renderAssocTab()`'s `$sendClass`. Every association tab's
   "Add selected" is primary; nine tabs used to pass `btn-success` and the two
-  colours got mixed inside a single page.
+  colors got mixed inside a single page.
 - Adjacent right-side buttons that are *already* distinguishable are fine as
   they are — e.g. image replication's `[Resume Reload (success)][Create
   (primary)]`, where green marks a genuinely different operation. The rule is

--- a/bin/fog-node-key.php
+++ b/bin/fog-node-key.php
@@ -24,7 +24,7 @@
  *     never run there and no row exists.
  *   - validNodeSignature() deliberately never mints, so the peer cannot
  *     heal itself on the first signed request either. That is the correct
- *     behaviour -- a verifier that invents keys verifies nothing -- and it
+ *     behavior -- a verifier that invents keys verifies nothing -- and it
  *     is what makes this a manual step.
  *
  * Deliberately does NOT boot FOG. It reads the DB constants straight out of

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -471,7 +471,7 @@ while :; do
             sWEB_root="${sWEB_root%'/'}"
             # Store the FINAL "/x/" form here rather than the bare "x". Two
             # separate bugs came out of not doing so, both because the
-            # normalisation further down only runs on the upgrade path (it is
+            # normalization further down only runs on the upgrade path (it is
             # gated on grepping an existing .fogsettings):
             #
             #   -W /      stripped to "", and the application tested `-n
@@ -639,7 +639,7 @@ while :; do
                 # The Secure Boot zone's anchor: what gets ENROLLED in
                 # firmware. Pairs with --secure-boot-key/--secure-boot-cert,
                 # which name the leaf that actually signs. Supplying only the
-                # leaf pair (the historic form) still works and enrols that
+                # leaf pair (the historic form) still works and enrolls that
                 # certificate, exactly as before.
                 --secureboot-ca-cert) sPKI_sb_ca_cert="$2" ;;
             esac
@@ -1485,9 +1485,9 @@ while [[ -z $blGo ]]; do
                     # Also downstream of _publishSecureBootKit and
                     # _publishSecureBootAuthVars, which run inside configureHttpd
                     # above via downloadfiles(). Each archive carries whatever
-                    # enrolment material those two actually published -- MOK.der
+                    # enrollment material those two actually published -- MOK.der
                     # and the PK/KEK/db variable updates -- so one archive on a
-                    # USB stick holds every enrolment route. Taken by existence,
+                    # USB stick holds every enrollment route. Taken by existence,
                     # so a server that published neither simply ships neither.
                     _publishLocalBootFiles
                     configureFTP

--- a/bin/restorekernel.sh
+++ b/bin/restorekernel.sh
@@ -115,7 +115,7 @@ migrateDeprecatedKeys
 # .fogsettings records docroot and webroot but NOT webdirdest -- config.sh
 # derives that ("${WEB_docroot}fog/"). Sourcing .fogsettings alone therefore left
 # $webdirdest empty and $ipxedir as the relative string "service/ipxe", so
-# --list mislabelled everything and --generation would have copied the restore
+# --list mislabeled everything and --generation would have copied the restore
 # into a stray directory under bin/ instead of the live tree.
 #
 # Same ordering as bin/updatefog.sh, and for the same reason: .fogsettings

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -271,7 +271,7 @@ if [[ -z $autoYes ]]; then
     case $confirmGo in
         [Yy] | [Yy][Ee][Ss]) ;;
         *)
-            echo " * Update cancelled."
+            echo " * Update canceled."
             exit 0
             ;;
     esac

--- a/bin/verify-plugin-install-nondestructive.php
+++ b/bin/verify-plugin-install-nondestructive.php
@@ -45,7 +45,7 @@
  * docs/adr/0008). This needs a live database and a deployed plugin tree, which
  * is the same reason bin/schema-manifest.php lives here. The static half of the
  * contract IS covered by CI, in fog-plugins' tests/tables-carry-column-defaults
- * .test.php; what cannot be covered there is the behaviour of the DDL against a
+ * .test.php; what cannot be covered there is the behavior of the DDL against a
  * real server, which is what this is for.
  *
  * SAFETY

--- a/docs/CSV_IMPORT_EXPORT.md
+++ b/docs/CSV_IMPORT_EXPORT.md
@@ -46,9 +46,9 @@ maps each subsequent row **by name**:
 - **Partial** — include only the columns you want to set; omitted columns keep
   their defaults. (The identity columns are still required: `name` for every
   class, plus `primac` for hosts.)
-- **Auto‑detected** — a first row whose cells are *all* recognised column names
+- **Auto‑detected** — a first row whose cells are *all* recognized column names
   is treated as a header automatically. The *"First row is a header"* checkbox
-  forces header mode (and reports any unrecognised header names as ignored).
+  forces header mode (and reports any unrecognized header names as ignored).
 - **Names are matched case‑insensitively** (`ProductKey` == `productkey`).
 - **Export emits a header row** by default, so an Export file re‑imports
   by name with no editing of column positions.
@@ -83,7 +83,7 @@ position**, in the exact order Export produces (the per‑class tables below).
 
 ### A note on sensitive / special fields
 
-| Field | Class | Behaviour |
+| Field | Class | Behavior |
 |-------|-------|-----------|
 | `primac` | Host | **Required**, first column. Pipe‑separated MAC list; the first MAC becomes primary, the rest are added as additional MACs. |
 | `productKey` | Host | Auto‑detected: accepts plaintext, base64, or the AES‑encrypted form an export produces. |

--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -145,7 +145,7 @@ source (permalinks below, pinned to
 **Net effect:** a FOG web vhost with a real Let's Encrypt certificate validates
 fine for iPXE's netboot fetches (`boot.php`, kernel, initrd) with **no FOG-side
 change**, on both FOG's own `buildipxe.sh` binaries and the republished
-Secure-Boot-signed binaries, and independent of Secure Boot enrolment status.
+Secure-Boot-signed binaries, and independent of Secure Boot enrollment status.
 This assumes the booting client can reach `ca.ipxe.org`, which holds for most
 sites — outbound internet access is the common case, not the exception. Only
 on a fully air-gapped network does that fallback not fire, in which case FOG's

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -199,7 +199,7 @@ This branch exists because the merge above *cannot* do that run. On it every old
 key is deprecated and every new key is absent, so the merge would strip all 79
 lines and append 66 at the end: the category blocks and the `## Derived` marker
 would describe nothing, and the file would read as a pile of appended keys after
-its own footer. The rewrite carries every **unrecognised** line through into a
+its own footer. The rewrite carries every **unrecognized** line through into a
 trailing section — hand-set keys and an admin's own comments survive only because
 something preserves what it does not manage, and a plain fresh write does not.
 
@@ -290,7 +290,7 @@ disabled one.
 `_normalizeBool()` maps `yes|y|1|true|on|enabled` and the negatives, in any
 case, onto `yes`/`no`. Two things it deliberately does not do:
 
-- **An unrecognised value is left alone**, not guessed at. Turning a typo into
+- **An unrecognized value is left alone**, not guessed at. Turning a typo into
   `no` is how a deliberate setting disappears with nothing to show why.
 - **Empty stays empty.** The prompt loops are `while [[ -z ${KEY} ]]`, so
   collapsing unset into `no` would stop every prompt firing.

--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -462,7 +462,7 @@ Four further defects in the same path, all fixed on this branch:
 4. **Fix `input.sh` alongside the default.** ✅ Its HTTPS question was removed
    rather than repaired: it set `httpproto`, which no longer varies. The four
    `--install-mode` presets are asked once instead, with their costs shown.
-   *"Asked once" was the intent but not the behaviour for a while:* moving the
+   *"Asked once" was the intent but not the behavior for a while:* moving the
    question out of `input.sh` also moved it out of that file's upgrade gate, and
    `promptInstallMode` guarded only on this run's flags, so every interactive
    upgrade got the menu again — where a bare Enter takes `standard` and

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -109,7 +109,7 @@ secureboot/MOK.{key,pem}          the flat, no-intermediate fallback signing
                                   anchor an intermediate, or before one has
                                   been minted
 secureboot/PK.{key,pem}           the platform key, if automatic PK/KEK/db
-secureboot/KEK.{key,pem}          enrolment is configured. Never regenerated.
+secureboot/KEK.{key,pem}          enrollment is configured. Never regenerated.
 secureboot/admin-MOK.{key,pem}    an admin-supplied --secure-boot-key/-cert
                                   pair, copied in so it survives independent
                                   of wherever the admin originally put it
@@ -262,7 +262,7 @@ The helper copies the key, verifies the copy still matches the certificate
 that stays behind, and only then shreds the original.
 
 **Leave the certificate in place.** Everything chains to it, and the installer
-uses its presence to recognise that a CA already exists. Removing the
+uses its presence to recognize that a CA already exists. Removing the
 certificate is what makes the next run mint a fresh one, orphaning every
 intermediate beneath it — which is precisely the mistake the obvious manual
 version ("move the CA out of the way") makes.
@@ -403,7 +403,7 @@ Each zone is independently replaceable.
                 --web-ca-key  /etc/pki/web-int.key \
                 --web-ca-root /etc/pki/root.pem
 
-# Secure Boot zone -- your own intermediate is what firmware enrols
+# Secure Boot zone -- your own intermediate is what firmware enrolls
 ./installfog.sh --secureboot-ca-cert /etc/pki/sb-int.pem \
                 --secure-boot-key    /etc/pki/sb-leaf.key \
                 --secure-boot-cert   /etc/pki/sb-leaf.pem
@@ -490,7 +490,7 @@ web PKI zone directory means the leaf is yours, so it stops regenerating it and
 leaves the permissions on your key alone.
 
 There is no key to set. GH-1120 retired `acmeLeaf`, `webCertFile` and
-`webKeyFile` in favour of asking the filesystem, because a hand-set flag that
+`webKeyFile` in favor of asking the filesystem, because a hand-set flag that
 nothing re-checked was exactly what got forgotten -- and forgetting it meant the
 installer re-issued the leaf from the original CSR against your ACME key,
 leaving a mismatched pair and a web server that would not start.
@@ -643,7 +643,7 @@ $ sbverify --list bzImage
    issuer:  /CN=FOG Server CA
 ```
 
-**Confirmed on real UEFI hardware, both enrolment routes:** machines boot
+**Confirmed on real UEFI hardware, both enrollment routes:** machines boot
 FOG's leaf-signed kernels while trusting only the **intermediate** — whether
 that intermediate is enrolled as `MOK.der` through MokManager, or written into
 `db` through the Setup Mode PK/KEK/db path. Firmware and shim both accept a
@@ -658,7 +658,7 @@ chain terminating at the enrolled CA rather than demanding the exact signer.
 ### Servers that already enrolled a MOK
 
 A server that generated a self-signed MOK under an earlier build **is moved
-onto the intermediate**, and any machine that enrolled the old key must enrol
+onto the intermediate**, and any machine that enrolled the old key must enroll
 once more. The installer says so, prominently, and leaves the old
 `MOK.{key,pem}` on disk so anything signed with it can still be re-signed.
 
@@ -666,7 +666,7 @@ This is deliberate, and it is why the change landed when it did. The flat MOK
 is a signing certificate that can issue nothing, so a server left on it can
 never rotate a signing key and never let a storage node sign, without a
 firmware trip to every machine. Doing it before Secure Boot reached a stable
-release costs one enrolment; doing it after costs a fleet.
+release costs one enrollment; doing it after costs a fleet.
 
 ### efitools
 
@@ -701,7 +701,7 @@ install -m 0755 cert-to-efi-sig-list sign-efi-sig-list efi-updatevar /usr/bin/
 **intermediate** — beside Microsoft's CAs, with the signing leaf's CN absent.
 That is what makes leaf rotation safe for Setup-Mode-enrolled clients too.
 
-MOK enrolment via MokManager is unaffected either way; only the unattended
+MOK enrollment via MokManager is unaffected either way; only the unattended
 Setup Mode path needs those tools.
 
 ## Known follow-up: which certificate fog-client installs

--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -133,7 +133,7 @@ rebuilds, such as under the web root: without the copy it would be deleted
 mid-install.
 
 >[!note]
->**`--no-secure-boot` declines enrolment, not signatures.** It stops the server
+>**`--no-secure-boot` declines enrollment, not signatures.** It stops the server
 >publishing `MOK.der` and the `PK`/`KEK`/`db` variable updates, and with them the
 >*Enroll Secure Boot Key* PXE menu entry, which is gated on `MOK.der` existing.
 >The signing key is still generated and the binaries are still signed.
@@ -141,7 +141,7 @@ mid-install.
 >That is deliberate: an appended PE signature is inert on a machine booting with
 >Secure Boot **off** — which is every machine on a server that passed this flag —
 >so signing costs nothing. Leaving the binaries unsigned instead would only mean
->that the day you do enrol, or move one of these files onto a machine that
+>that the day you do enroll, or move one of these files onto a machine that
 >already has Secure Boot on, the file is useless and nothing on the server can
 >fix it short of a re-install.
 
@@ -170,7 +170,7 @@ contents are its top level, and holds one folder per boot route —
 `fog-ipxe\`, `secureboot-upstream\`, `secureboot-fog\`, `refind\`, plus
 `-customca\` variants where this server rebuilt iPXE with its own CA.
 
-**How to choose a folder, boot it, and enrol this server's certificate is
+**How to choose a folder, boot it, and enroll this server's certificate is
 documented at [Local ESP boot](https://docs.fogproject.org/local-esp-boot)**, with
 the capability matrix per Secure Boot state. This page covers only what the
 installer does to these files, which is the part that concerns preservation.

--- a/docs/adr/0006-site-object-scope-boundary.md
+++ b/docs/adr/0006-site-object-scope-boundary.md
@@ -31,7 +31,7 @@ consulted *after* the verb check has already passed. Core owns the seam; the
   `$id < 1` (list/create/mass — nothing to scope yet), true for unrestricted
   users, otherwise fires the `OBJECT_SCOPE_CHECK` hook with a
   `&$allowed` (default true) and returns it. With no listener the boundary
-  does not exist and behaviour is unchanged.
+  does not exist and behavior is unchanged.
 - "Unrestricted" (`Authorization::isUnrestricted`) = an implicit admin (no
   role) **or** a holder of global `*`. These bypass scoping entirely.
 - Four choke points enforce it:

--- a/docs/adr/0008-secure-boot-enrolment-task-type.md
+++ b/docs/adr/0008-secure-boot-enrolment-task-type.md
@@ -1,4 +1,4 @@
-# The Secure Boot enrolment task type, and the narrow case it is actually for
+# The Secure Boot enrollment task type, and the narrow case it is actually for
 
 The client-side mechanics and the full reasoning live in
 [fos ADR-0009](https://github.com/FOGProject/fos/blob/master/docs/adr/0009-secure-boot-enrolment-paths.md).
@@ -17,7 +17,7 @@ yet trusted, `bzImage` and `init.xz` are both refused with
 `Verification failed: Security Policy Violation`. FOS never starts, so a FOG task
 running inside FOS cannot possibly be what establishes trust in FOG's key.
 
-The task that would enrol the key cannot run on the machine that needs it.
+The task that would enroll the key cannot run on the machine that needs it.
 
 ## What the task type IS for
 
@@ -43,7 +43,7 @@ Two things will mislead an admin if the task description omits them, and both
 cost a wasted trip to a machine:
 
 1. The MokManager confirmation **cannot** be automated. shim's `MokList` is
-   boot-services-only; nothing FOG does can enrol a key unattended.
+   boot-services-only; nothing FOG does can enroll a key unattended.
 2. The task **cannot run at all** if Secure Boot is already enforcing.
 
 An admin who schedules this against 200 enforcing machines and watches every one
@@ -67,7 +67,7 @@ chain observed in testing was `secureboot/snponly-shimx64.efi` →
 **Microsoft Corporation UEFI CA 2011**. Ship a `db` without it and FOG's own
 Secure Boot PXE boot stops working.
 
-These are public certificates Microsoft publishes so people can enrol them;
+These are public certificates Microsoft publishes so people can enroll them;
 Debian, Fedora, `sbctl` and `efitools` all redistribute them. An earlier concern
 about a licensing barrier was mistaken.
 
@@ -91,10 +91,10 @@ visit at all.
 
 `_ensureSecureBootPlatformKeys()` generates a second and third keypair alongside
 the MOK signing key. They sign nothing that ever executes; they exist only to
-authorise updates to a client's Secure Boot databases.
+authorize updates to a client's Secure Boot databases.
 
 The reason to generate them properly rather than reuse the MOK key or throw one
-away after enrolment: once a client leaves Setup Mode it is in **User Mode with
+away after enrollment: once a client leaves Setup Mode it is in **User Mode with
 our PK**, and the UEFI spec then requires a KEK-signed update to touch `db` and a
 PK-signed update to touch `KEK`. Holding those keys is what lets this same server
 push a `db` change to an already-enrolled fleet later without another firmware
@@ -137,7 +137,7 @@ to say why.
 
 Two guards, because the first one alone is what already failed:
 
-1. Every certificate is normalised to PEM before the tool sees it, whatever
+1. Every certificate is normalized to PEM before the tool sees it, whatever
    format it arrived in.
 2. The result is size-checked. An ESL is exactly a 28-byte header plus a 16-byte
    owner GUID plus the DER certificate, so its size must be `DER + 44`; anything
@@ -159,7 +159,7 @@ partition path — here it just wears a zero exit status instead of a warning.
   absent the installer skips the build with a warning and the MOK paths keep
   working — it does not fail the install.
 - The Secure Boot configuration page gains a card that says whether automatic
-  enrolment is available, and spells out that Setup Mode is *not* the same as
+  enrollment is available, and spells out that Setup Mode is *not* the same as
   "Secure Boot turned off". An admin who has never heard the term will not find
   "clear the Secure Boot keys" in their firmware menu on their own.
 - Verified end to end on 2026-08-03: `boot.php` emits `mode=enrollsb` on the

--- a/docs/adr/0011-route-result-wrappers.md
+++ b/docs/adr/0011-route-result-wrappers.md
@@ -40,7 +40,7 @@ That mistake has shipped three times:
 | Site | Consequence |
 |---|---|
 | `ou` plugin's check-in hook | `ADOU` never set on any client check-in, one warning per check-in on a client endpoint |
-| `route.class.php` group task cancel | cancelling a group's tasks cancelled **nothing** — eleven nulls passed to `getClass('Task', null)->cancel()` while the real tasks kept running |
+| `route.class.php` group task cancel | canceling a group's tasks canceled **nothing** — eleven nulls passed to `getClass('Task', null)->cancel()` while the real tasks kept running |
 | `bootitem.hook.php` | the iPXE menu never applied its `fog.local` boot-to-disk label |
 
 All three were verified against a live 1.6 database before being fixed. They are

--- a/docs/adr/0012-self-rescheduling-polls-guard-on-their-own-widget.md
+++ b/docs/adr/0012-self-rescheduling-polls-guard-on-their-own-widget.md
@@ -114,7 +114,7 @@ complete that request and draw into nothing before the next wake-up stops it.
 That is one request, not an unbounded stream, and eliminating it would require
 the central cancellation this ADR rejects.
 
-`setInterval` needs none of this. It is already tracked and cancelled. This ADR
+`setInterval` needs none of this. It is already tracked and canceled. This ADR
 is not a reason to convert intervals to timeout chains, and if a poll can be
 written as an interval, prefer it.
 

--- a/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
+++ b/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
@@ -96,7 +96,7 @@ page class is still **required**, because that is how
 `loadPageClasses()` finds it.
 
 The error is legible rather than a class-not-found at the call site: the
-autoloader recognises a bare core name and says which FQCN to use.
+autoloader recognizes a bare core name and says which FQCN to use.
 
 ### The argument against nesting was wrong, and this is the correction
 
@@ -256,7 +256,7 @@ $this->childClass = preg_replace('#_?Manager$#', '', self::shortName($this));
 
 Under a flat namespace, `Host` + `'Manager'` gives `HostManager`, which resolves.
 Under a split one it gives `Model\HostManager`, which does not exist — on the
-most-travelled path in the ORM, run by every model and every manager.
+most-traveled path in the ORM, run by every model and every manager.
 
 That could be fixed, by teaching both derivations to move between namespaces.
 But doing so would *create* two new instances of the exact bug class Phase 3

--- a/docs/adr/0014-authentication-seams-in-core-identity-providers-as-plugins.md
+++ b/docs/adr/0014-authentication-seams-in-core-identity-providers-as-plugins.md
@@ -76,7 +76,7 @@ tables and no OIDC attack surface, and a provider bug is a plugin release
 rather than a FOG release.
 
 The scope is OIDC only. SAML is excluded on **shape**, not on dependency
-weight: SAML's security rests on XML canonicalisation and XML signature
+weight: SAML's security rests on XML canonicalization and XML signature
 verification, a class of parsing whose vulnerabilities (XXE, signature
 wrapping, comment truncation) live in the parser rather than the protocol.
 Building the seam properly is what makes SAML somebody's plugin later instead
@@ -112,7 +112,7 @@ owned by LDAP can still be signed in by something else, and after an incident
 precisely the question asked. The break-glass rules below also have to count
 sessions by how they were *made*.
 
-### 5. Break-glass is a core invariant, not a plugin's good behaviour
+### 5. Break-glass is a core invariant, not a plugin's good behavior
 
 **Local password login cannot be disabled.** Not a setting with a scary label —
 no setting at all. `User::passwordValidate()` reads none, and

--- a/docs/adr/0015-install-settings-are-independent-keys.md
+++ b/docs/adr/0015-install-settings-are-independent-keys.md
@@ -18,7 +18,7 @@ visible, not less. Only the spellings moved.
 
 Nothing in its name says the last two, and an admin setting `-S/--force-https`
 was not choosing them. The bindings were an accident of implementation that
-hardened into behaviour, and each one caused a distinct failure:
+hardened into behavior, and each one caused a distinct failure:
 
 - `downloadipxe()` skipped the release asset on any HTTPS install, so such a
   server never had a pristine copy of the published binaries.

--- a/docs/adr/0016-ipxe-enforces-x509-name-constraints.md
+++ b/docs/adr/0016-ipxe-enforces-x509-name-constraints.md
@@ -39,7 +39,7 @@ verifier FOG can patch, and UEFI firmware is not.
 table knows five extensions: `basicConstraints`, `keyUsage`, `extKeyUsage`,
 `authorityInfoAccess` and `subjectAltName`. `nameConstraints` is not among them,
 and `x509_parse_extension()` refuses any critical extension it does not
-recognise:
+recognize:
 
 ```c
 if ( ! extension ) {
@@ -78,7 +78,7 @@ The patch lives in `FOGProject/fog-ipxe` under `patches/`, applied by
 `buildipxe.sh` after its `git reset --hard`, against the pinned upstream tag.
 fog-ipxe overlays configuration onto a pristine upstream checkout rather than
 forking it; `patches/` is the one place a C change may live, and it earns that
-only when upstream cannot yet supply the behaviour and FOG cannot ship without
+only when upstream cannot yet supply the behavior and FOG cannot ship without
 it. Because the pin is a fixed tag the patch cannot rot between builds.
 
 ### Enforcement is per path, not per issuer

--- a/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
+++ b/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
@@ -6,7 +6,7 @@ accepted -- all five phases of the Migration section are implemented on
 `working-1.6`
 
 Phases 0 and 1 are the ones the ADR marks as worth doing whatever happens to
-the rest, and neither touches the database or changes behaviour: phase 0 was two
+the rest, and neither touches the database or changes behavior: phase 0 was two
 live defects found while writing this (`UserTrack::json()` setting a key no
 model declares, and the list formatter falling out of its switch into a blank
 cell), and phase 1 writes the convention down -- the six frame keys are
@@ -80,7 +80,7 @@ alternative that reads as equivalent and is not:
   The activity viewer's detail pane shows the stored line whenever it differs
   from the summary, which is exactly the failure rows and nothing else.
 - **Legacy rows are not parsed.** A row with no type, a `TYPE_LOG` row, a row
-  with no subject id and a type nothing recognises all fall back to the stored
+  with no subject id and a type nothing recognizes all fall back to the stored
   prose verbatim. See "The old `history` rows" below for why parsing them was
   rejected.
 
@@ -239,7 +239,7 @@ answer in three ways, and each of the three changes what should be built.
 
 The column names really are three vocabularies. But `FOGController` does not
 address columns; it addresses *friendly keys*, and `save()` gives two of those
-keys behaviour that no other key has:
+keys behavior that no other key has:
 
 ```php
 // fogcontroller.class.php:762
@@ -626,7 +626,7 @@ adding nullable or `DEFAULT ''` columns only:
 - `userTracking`: `utCreatedBy`, `utIP`, `utHostName`.
 - `history`: `hType`, `hSubjectType`, `hSubjectID`, `hSubjectLabel`.
 
-An install that stops here is unchanged in behaviour. This is the only phase
+An install that stops here is unchanged in behavior. This is the only phase
 that touches `ALTER TABLE`, and it is the reversible half of the DDL.
 
 **Phase 3 — writers fill them; readers still read the old columns.** Two
@@ -730,9 +730,9 @@ third-party plugin reading them — a rewrite, in exchange for a table whose row
 are mostly `NULL`.
 
 **A shared base class (`EventController extends FOGController`).** Rejected as
-premature rather than wrong. The only behaviour to share is the frame's
+premature rather than wrong. The only behavior to share is the frame's
 defaults, and `save()` already implements the two that exist. A base class
-becomes worth it when there is behaviour to put in it — append-only
+becomes worth it when there is behavior to put in it — append-only
 enforcement, retention, the deletion policy of Decision 4. That is the audit
 ADR's decision to make, with three tables already conforming; taking it now
 sets the shape of a class before knowing what goes in it.

--- a/docs/adr/0021-the-audit-trail.md
+++ b/docs/adr/0021-the-audit-trail.md
@@ -343,7 +343,7 @@ disclosure with extra steps.
 is what failed:
 
 1. **Default closed by name.** A pattern over the friendly key —
-   `PASS|PWD|SECRET|TOKEN|KEY` — redacts by default, modelled directly on
+   `PASS|PWD|SECRET|TOKEN|KEY` — redacts by default, modeled directly on
    `SENSITIVE_SETTING_PATTERN`, which exists so "a credential setting added
    later is masked by default instead of silently leaking until someone
    remembers". A field matching the pattern that is *not* a credential goes

--- a/docs/adr/0022-spans-and-work-items.md
+++ b/docs/adr/0022-spans-and-work-items.md
@@ -177,7 +177,7 @@ without finishing" distinguishable today?
 
 - In `imagingLog`: **no**, and worse, the second is not retained at all.
 - In the five state-carrying tables: **yes**, and only because of the state
-  column — `Failed` (state 6) and `Cancelled` (5) are distinct from
+  column — `Failed` (state 6) and `Canceled` (5) are distinct from
   `In Progress` (3). The timestamps cannot tell them apart in any of them
   either.
 
@@ -225,7 +225,7 @@ is two different questions answered by two different columns, and the fix is to
 say so rather than to delete one:
 
 - **`<x>State` answers "what is this doing now"**, and it is the only column
-  that can distinguish finished, cancelled and failed. It is authoritative for
+  that can distinguish finished, canceled and failed. It is authoritative for
   lifecycle.
 - **The timestamps answer "when"**, and they are authoritative for duration
   and for time-range queries. A completion timestamp is set *because* the state
@@ -237,7 +237,7 @@ both in one call and is the model. Where the two disagree today, state wins and
 the timestamp is the bug.
 
 Reconciling them into one representation is rejected in both directions.
-Dropping state loses the failed/cancelled distinction (see Context). Dropping
+Dropping state loses the failed/canceled distinction (see Context). Dropping
 the timestamps loses duration, and `taskStateChangedTime` — which the prompt
 correctly identifies as a partial one-slot span — cannot substitute, because it
 is overwritten by every transition and so records only the last one.

--- a/docs/adr/0023-activity-is-a-view-and-retention-is-a-registry.md
+++ b/docs/adr/0023-activity-is-a-view-and-retention-is-a-registry.md
@@ -252,7 +252,7 @@ The request asked whether applying a default on upgrade is "exactly what a
 privacy control should do, or a nasty surprise". It is both, and the split is
 along install age:
 
-- **New installs default to a bounded value.** Data minimisation is the right
+- **New installs default to a bounded value.** Data minimization is the right
   default for data nobody has chosen to keep, and an admin who wants forever
   can say so.
 - **Upgrades default to `0`, keep forever**, and surface a dashboard notice
@@ -263,7 +263,7 @@ Silently deleting on upgrade is wrong for a specific reason, not a squeamish
 one: the administrator never chose to hold this data *or* to delete it, and
 some of them are under a legal obligation to retain it. A privacy control that
 destroys evidence someone is required to keep is not a privacy win. Making the
-choice visible and unavoidable achieves minimisation without making it for
+choice visible and unavoidable achieves minimization without making it for
 them.
 
 The recommended new-install default is **365 days**. It is long enough to

--- a/docs/adr/0024-fogsettings-unified-key-model.md
+++ b/docs/adr/0024-fogsettings-unified-key-model.md
@@ -39,7 +39,7 @@ would not start — silently, under `-y`. `caCreated` said "the CA exists" and b
 of its readers already paired it with an `-e`/`-f` test on the very file it stood
 in for.
 
-Renaming this was discussed as a risk to be minimised. That framing was wrong and
+Renaming this was discussed as a risk to be minimized. That framing was wrong and
 is worth recording as such: because a key name is a variable name, a spot check of
 25 of the 79 keys found 753 references in `bin/` and `lib/` alone. The full sweep
 is around 2500 real variable references. The model only pays off once the code
@@ -137,7 +137,7 @@ mapping to `storageNode` DB columns. Only the values moved.
 
 One installer run, and it is **two halves that must land and stay together**:
 
-1. A one-shot rename-seed block in `bin/installfog.sh`, modelled on the
+1. A one-shot rename-seed block in `bin/installfog.sh`, modeled on the
    `httpproto`→`httpsRedirect` precedent. It runs after `.fogsettings` is sourced
    and before the flag shadows, so the order stays *explicit flag > persisted
    value > migrated value*. Each pair is guarded on the new key, so it fires
@@ -156,7 +156,7 @@ that still carries only old keys. The in-place merge cannot do that run: it
 rewrites managed keys in the position they already occupy and appends the ones it
 did not find, so with every old key deprecated and every new key absent it would
 strip all 79 lines and append 66 at the end — leaving the category blocks and the
-`## Derived` marker describing nothing. The rewrite carries every *unrecognised*
+`## Derived` marker describing nothing. The rewrite carries every *unrecognized*
 line through, because hand-set keys and an admin's own comments survive only
 because something preserves what it does not manage.
 
@@ -185,16 +185,16 @@ because something preserves what it does not manage.
 
 ## Deliberately not done
 
-- **Boolean encoding and polarity normalisation.** Deferred here, and the
+- **Boolean encoding and polarity normalization.** Deferred here, and the
   encoding half has since been done — see
   [ADR 0025](0025-one-boolean-encoding-normalised-on-load.md). The reasoning
   below is what it had to answer: fixing encodings changes *values*, not names,
   and would have made this migration a translation rather than a copy.
-  0025 resolves that by normalising on **load** every run rather than rewriting
+  0025 resolves that by normalizing on **load** every run rather than rewriting
   once, which leaves the migration a copy. **Polarity is still not done** —
   `BOOT_external_tftp_server` keeps `noTftpBuild`'s polarity precisely so the
   value carries across untouched and still reads correctly against the firewall
-  behaviour.
+  behavior.
 - **`FOG_update_channel`'s values.** `branchToChannel()` produces
   `stable`/`staging`/`dev` while `FOG_CHANNEL` is stamped
   `Patches`/`Beta`/`Release Candidate`/`Feature`. Reconciling them touches

--- a/docs/adr/0025-one-boolean-encoding-normalised-on-load.md
+++ b/docs/adr/0025-one-boolean-encoding-normalised-on-load.md
@@ -1,4 +1,4 @@
-# One boolean encoding in `.fogsettings`, normalised on load
+# One boolean encoding in `.fogsettings`, normalized on load
 
 ## Status
 
@@ -44,7 +44,7 @@ against 79 old keys, is a much riskier thing to get wrong than a rename.
 
 ## Decision
 
-**Every boolean key holds `yes` or `no`, and the value is normalised on load,
+**Every boolean key holds `yes` or `no`, and the value is normalized on load,
 every run.**
 
 `_normalizeBool()` maps `yes|y|1|true|on|enabled` and the corresponding
@@ -53,13 +53,13 @@ to the twelve keys.
 
 Two things it deliberately does not do:
 
-- **An unrecognised value is left alone**, not coerced. Silently turning a typo
+- **An unrecognized value is left alone**, not coerced. Silently turning a typo
   into `no` is how a deliberate setting disappears with nothing to show why.
 - **Empty stays empty.** The interactive prompts are `while [[ -z ${KEY} ]]`
   loops; collapsing unset into `no` would stop every prompt firing and answer for
   the admin.
 
-Normalisation runs **after** the flag shadows in `bin/installfog.sh`. Every
+Normalization runs **after** the flag shadows in `bin/installfog.sh`. Every
 source of a value has fed in by that point — the value `.fogsettings` persisted,
 the value the rename seed block copied off a pre-1.6 key, and the value a flag
 set this run — and the flag layer was itself the worst offender for mixed
@@ -95,7 +95,7 @@ off the list, so a later sweep cannot quietly fold them.
 
 `BOOT_external_tftp_server` keeps the sense it inherited from `noTftpBuild`. Only
 the encoding moves, so values carry across untouched — which is what lets this be
-a normalisation rather than a migration.
+a normalization rather than a migration.
 
 ## Consequences
 

--- a/docs/adr/0026-retention-runs-in-a-daemon-named-for-retention.md
+++ b/docs/adr/0026-retention-runs-in-a-daemon-named-for-retention.md
@@ -111,7 +111,7 @@ Decision 5 is the answer to it: this daemon says something on every pass,
 including when it finds nothing to do.
 
 **No upgrade migration is needed, and nothing changes for a default install.**
-The settings default to enabled, `installfog.sh` installs and enrols the new
+The settings default to enabled, `installfog.sh` installs and enrolls the new
 unit like any other, and the windows themselves are untouched. A site that had
 deliberately disabled `FOGPluginRunner` to stop retention — which nothing
 documented, so it is unlikely anyone did — starts pruning again on upgrade;
@@ -124,7 +124,7 @@ audit-before-delete refusal all stand exactly as written.
 
 **The general rule this is an instance of**, and the reason it is worth an ADR
 rather than a commit message: *a shared host for a piece of work inherits its
-name to every operator who reads it.* Putting core behaviour inside a component
-named for something optional gives that behaviour a second off switch nobody
+name to every operator who reads it.* Putting core behavior inside a component
+named for something optional gives that behavior a second off switch nobody
 documented — and the person who trips it will report a bug against the feature,
 not against the placement.

--- a/docs/adr/0027-api-tokens-are-a-separate-hashed-credential.md
+++ b/docs/adr/0027-api-tokens-are-a-separate-hashed-credential.md
@@ -117,7 +117,7 @@ that must reach the tokens.
 ## Alternatives considered
 
 **Hash `uAPIToken` in place.** Rejected. It stops the UI re-displaying the
-token, which is a behaviour change to a credential people rely on being able to
+token, which is a behavior change to a credential people rely on being able to
 re-read, and it forces the migration choice described above. It also conflates
 "make the API transport modern" with "make token storage safe" — two changes
 with different risk profiles.

--- a/docs/adr/0028-booleans-are-tinyint-not-enum.md
+++ b/docs/adr/0028-booleans-are-tinyint-not-enum.md
@@ -39,7 +39,7 @@ server as an integer rather than a string. FOG survives that only because
 `PDODB::_bind()` binds every parameter as `PDO::PARAM_STR`. That is not a design;
 it is a load-bearing accident, and it has already cost real work:
 
-- `PDODB::_bind()` cannot normalise a PHP boolean with `PDO::PARAM_BOOL`, because
+- `PDODB::_bind()` cannot normalize a PHP boolean with `PDO::PARAM_BOOL`, because
   bound as an integer `false` would be index 0 and `true` index 1 — refused and
   inverted respectively. It has to produce the *strings* `'0'`/`'1'` (#1361).
 - `Schema::defaultLiteral()` exists because `createTable()` callers pass values
@@ -72,7 +72,7 @@ one rule in it that must not be re-derived per plugin (below), so it is written
 once and the plugins call it. It reads nullability and default out of
 `information_schema` and carries them across rather than assuming `NOT NULL` —
 `LDAPServers`.`lsAllowAPI` is nullable and `lsUseGroupMatch` has no default at
-all, and rewriting either would be a behaviour change smuggled in by a type
+all, and rewriting either would be a behavior change smuggled in by a type
 change. It also skips any column that is not still exactly `enum('0','1')`, so a
 re-run is a read.
 

--- a/docs/composer-psr4-plan.md
+++ b/docs/composer-psr4-plan.md
@@ -413,7 +413,7 @@ Commit 1 does not preclude it.
 | | Count | Where |
 |---|---|---|
 | Move | **202** | `lib/{fog,db,client,service,reg-task,router}/*.class.php` → `src/<same>/<Class>.php`, `System` included |
-| Stay — ADR 0013 exclusions | 2 | `lib/router/altorouter.class.php`, `altotransformer.class.php` — upstream name, authorship, MIT licence |
+| Stay — ADR 0013 exclusions | 2 | `lib/router/altorouter.class.php`, `altotransformer.class.php` — upstream name, authorship, MIT license |
 | Stay — HARD, discovery-named | 46 | 26 `.page.php`, 10 `.hook.php`, 9 `.report.php`, 1 `.event.php` |
 | Stay — generated | 1 | `lib/fog/config.class.php` |
 
@@ -830,7 +830,7 @@ The gate, in order of what is most likely to break quietly:
 It is **not** part of this work, and landing it first would mislead rather than
 help.
 
-The premise behind "a static analyser watches while 202 files move" is that the
+The premise behind "a static analyzer watches while 202 files move" is that the
 move breaks references that then have to be chased. It does not: no caller is
 edited anywhere, because no class name changes. What PHPStan would report is
 whatever `scanDirectories` told it to — point it at `lib/` and it loses every

--- a/docs/hook-event-brief.md
+++ b/docs/hook-event-brief.md
@@ -50,7 +50,7 @@ independently before relying on it; if any is wrong, say so.
 checks** (`eventmanager.class.php:218-225`). `HookManager extends EventManager`,
 so a HookManager satisfies both branches. The correct file extension and
 directory are reached only because the second assignment overwrites the first.
-Reordering the two blocks changes behaviour.
+Reordering the two blocks changes behavior.
 
 **2. Whether a class is active is decided by a regular expression run over the
 file's source text**, line by line (`eventmanager.class.php:248-252`), matching
@@ -73,7 +73,7 @@ total registration failure once during the namespace migration.
 **5. `notify()` treats "no listeners registered" as an exception**
 (`eventmanager.class.php:175-177`) that is caught, logged, and returns false.
 `processEvent()` handles the same condition with a bare `return`
-(`hookmanager.class.php:89-91`). Same situation, two behaviours, one of which
+(`hookmanager.class.php:89-91`). Same situation, two behaviors, one of which
 writes a log line on what is probably the common case.
 
 **6. `processEvent()` force-activates any listener whose file path contains the
@@ -99,8 +99,8 @@ embedded in the payload; `notify()` calls `onEvent()` and discards the result.
 shapes of listener are actually passed, what payloads are actually mutated. The
 contract is what the callers do, not what the docblocks say.
 
-**Characterize current behaviour before changing it.** Write tests that pin what
-happens today, including the parts that are wrong. Then a behaviour change shows
+**Characterize current behavior before changing it.** Write tests that pin what
+happens today, including the parts that are wrong. Then a behavior change shows
 up as a test that has to be edited, deliberately, rather than as a silent
 difference.
 
@@ -137,7 +137,7 @@ Plus, and separately from the plan:
 1. **The defect list as you found it**, including anything above that turns out
    to be wrong or that you found and I did not.
 2. **The decisions that are mine, not yours.** Where fixing a defect would
-   change behaviour something might rely on, do not pick. Present the options
+   change behavior something might rely on, do not pick. Present the options
    and what each costs. Bugs that are load-bearing for somebody are not
    automatically bugs to fix.
 3. **The measurement**, per goal 3 above.

--- a/docs/hook-event-plan.md
+++ b/docs/hook-event-plan.md
@@ -236,8 +236,8 @@ Tree green after every commit. `sh tests/run-all.sh` is the gate throughout.
 One new `tests/hook-event-contract.test.php`, following the standalone-script
 convention (`tests/plugin-extension-points.test.php` is the closest model:
 `require commons/init.php`, `new Initiator()`, no database, exit 0/1). Pins
-today's behaviour **including the parts that are wrong**, so every later
-behaviour change shows up as a test that must be edited on purpose.
+today's behavior **including the parts that are wrong**, so every later
+behavior change shows up as a test that must be edited on purpose.
 
 Pins: the four `register()` shapes and their outcomes; the six-row activation
 table; `Hook` accepted by `EventManager::register()`; `HookManager::notify()`
@@ -297,7 +297,7 @@ the crash.
 Replace the line-by-line regex with
 `(new \ReflectionClass($class))->getDefaultProperties()['active']` — the
 declared default, which is exactly what the regex was trying to approximate, so
-a value set in a constructor is still not consulted and behaviour is unchanged
+a value set in a constructor is still not consulted and behavior is unchanged
 for every shipped file (F-12). Autoloading the class is an include, not a
 construction; the class map is already O(1).
 
@@ -352,7 +352,7 @@ Decision 5. One `instanceof Hook` guard in `EventManager::register()`, plus
 `Event::onEvent()`'s default body changing from `printf` to a no-op. Every
 bundled plugin event overrides `onEvent()`; the one shipped file that does not,
 `lib/events/hostlist.event.php`, is inactive (F-11) and its author plainly did
-not intend "print the event name into the page" as behaviour.
+not intend "print the event name into the page" as behavior.
 
 ### H.10 — The dead event names · **split out, not part of this work**
 
@@ -374,7 +374,7 @@ recommendations below originally leaned on "ADR 0013 promised the plugin ABI
 holds for all of 1.6." That is not what ADR 0013 says. Its §2 makes one
 promise — the reverse `class_alias` in each namespaced file is supported for
 all of 1.6 and cannot be removed before 1.7 — about *the alias*, not about every
-behaviour a plugin can observe. And 1.6.0 has not been released: `working-1.6`
+behavior a plugin can observe. And 1.6.0 has not been released: `working-1.6`
 stamps `1.6.0-beta.NNNN`, so there is no installed base of third-party 1.6
 plugins to keep faith with. Nothing here should be deferred to a "1.7" that is
 two releases away from existing. Where a recommendation survived the correction

--- a/docs/nodecert-test-results.md
+++ b/docs/nodecert-test-results.md
@@ -157,7 +157,7 @@ have helped. Three changes:
   silently rewrite the other node's row rather than fail — and hostnames are not
   unique across a fleet (two default RHEL installs are both
   `localhost.localdomain`). Anything unusable falls back to the address, which
-  is the old behaviour exactly;
+  is the old behavior exactly;
 - `nodecert.php` refuses to put an IP literal in a DNS SAN. `FILTER_VALIDATE_DOMAIN`
   accepts `10.0.0.5` as a hostname, so without an explicit `FILTER_VALIDATE_IP`
   test the request reached the signer and died at verify. Existing IP-named nodes
@@ -338,7 +338,7 @@ if [[ -z $cacert || ! -f $cacert ]]; then
 fi
 ```
 
-The endpoint authenticated the node, authorised it, staged the CSR and invoked the helper
+The endpoint authenticated the node, authorized it, staged the CSR and invoked the helper
 through sudo correctly. The helper then found no CA to sign with.
 
 ### Root cause
@@ -443,7 +443,7 @@ if ($recorded && $recorded !== $remoteIP) {
 }
 ```
 
-And putting a hostname in the `ip` field instead makes things worse: the authorisation
+And putting a hostname in the `ip` field instead makes things worse: the authorization
 lookup is `Route::getIds('storagenode', ['ip' => $remoteIP], 'id')`, and `$remoteIP` is
 always an address literal, so the record stops matching and the request fails one step
 earlier with `403 no storage node is registered at <ip>`.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -575,7 +575,7 @@ why none of the bundled plugins do.
 
 ### What the failure looks like
 
-A bare core name does not fail quietly. `Initiator::autoload()` recognises it
+A bare core name does not fail quietly. `Initiator::autoload()` recognizes it
 and writes one line before giving up:
 
 ```

--- a/docs/refactor-brief.md
+++ b/docs/refactor-brief.md
@@ -75,7 +75,7 @@ Plan three independent changes, as separate PRs, in this order:
 `packages/web`. `\Exception`, `\DateTime`, `\DateTimeZone`, `\PharData`,
 `\ReflectionClass`, `\PDO`, `\RecursiveIteratorIterator`, and anything else
 you find. In the global namespace this is a no-op, which is the point: it
-must be reviewable as a purely mechanical diff with zero behaviour change.
+must be reviewable as a purely mechanical diff with zero behavior change.
 Give me the exact count per class before proposing the change.
 
 This exists because inside a namespace, `catch (Exception $e)` silently
@@ -119,7 +119,7 @@ Plan moving site's scope enforcement into core alongside RBAC.
 
 **Design constraint I have already decided: no enable flag.** Sites are
 unconditional. Zero sites defined means one implicit site containing
-everything, which is today's behaviour and today's out-of-box experience.
+everything, which is today's behavior and today's out-of-box experience.
 Defining a site is what makes the boundary start to mean something. A
 boundary that exists only when a boolean is true is still a boundary that
 can be absent. Argue against this if you think I am wrong, but argue

--- a/docs/refactor-facts.md
+++ b/docs/refactor-facts.md
@@ -39,7 +39,7 @@ numbers in that document as approximate until individually confirmed.
 grep -n 'cp -Rf \$webdirsrc' lib/common/functions.sh    # 6592
 ```
 
-### C-02 — UNKNOWN #4 is closed, and the answer is favourable
+### C-02 — UNKNOWN #4 is closed, and the answer is favorable
 
 Ordering at `functions.sh:6579-6593` is: restore `fog_web_*.BACKUP` first (inside
 the `copybackold` block), then `cp -Rf $webdirsrc/* $webdirdest/`. **New files
@@ -88,7 +88,7 @@ could find it. `lib/router/altorouter.class.php` is the same story
 
 So PR 0.3 is not only groundwork for a future JWT library. It is the mechanism
 that **retires existing hand-vendored code** which currently has no version, no
-lockfile, no licence metadata and no upgrade path. That is a materially stronger
+lockfile, no license metadata and no upgrade path. That is a materially stronger
 argument for Composer than the one in the plan, and it belongs in the ADR.
 
 **Action:** add this to 0.3's rationale. Do **not** do the swaps inside 0.3.
@@ -240,7 +240,7 @@ git restore --staged packages/web/vendor
 `$active\s?=\s?true;`. All eleven files under `packages/web/lib/hooks` and
 `packages/web/lib/events` declare `public $active = false;` and none matches.
 So every listener that runs on a stock server comes from a plugin; the eleven
-core files are examples an admin opts into, not shipped behaviour. Anything
+core files are examples an admin opts into, not shipped behavior. Anything
 that reasons about "core hooks" as live code is reasoning about dead code.
 ```
 cd packages/web/lib
@@ -429,7 +429,7 @@ HookManager load `.event.php` files, and neither PHP nor any test would say so.
 sed -n '218,225p' packages/web/lib/fog/eventmanager.class.php
 ```
 
-### F-23 — ADR 0013's promise is about the alias, not about every plugin-observable behaviour
+### F-23 — ADR 0013's promise is about the alias, not about every plugin-observable behavior
 Its §2 says the reverse `class_alias` "is supported for all of 1.6" and cannot
 be removed before 1.7. Nothing in it freezes the hook contract, the `$active`
 semantics or `register()`'s accepted listener shapes. Combined with 1.6.0 being
@@ -500,11 +500,11 @@ restored from a copy between runs. All eight: `72 passed, 0 failed`. Deleting
 `_applySiteScope()` from `listem()` -- the one line that stops one site's users
 seeing another site's hosts -- is among them, as is renaming `_lang`, which
 disables `stripSensitivePayload()` for every list payload. The suite pins
-symbols, not behaviour: `sensitive-fields-unfilterable.test.php` greps for the
+symbols, not behavior: `sensitive-fields-unfilterable.test.php` greps for the
 strings `_assertNoSensitiveFilter(`, `HTTP_BAD_REQUEST` and `'nosearch'`, and an
 inserted `return;` leaves all three in place; `site-scope-lists.test.php` tests
 `Authorization::scopedObjectIDs()` and never names `Route`. Consequence: no
-decomposition of this file may begin before a behavioural net exists.
+decomposition of this file may begin before a behavioral net exists.
 ```
 cp packages/web/lib/router/route.class.php /tmp/route.bak
 sed -i 's|self::_applySiteScope($classname);|// removed|' packages/web/lib/router/route.class.php
@@ -635,7 +635,7 @@ returns to `listem()`. Under the ADR 0011 result-wrapper path it is not: there
 `sendResponse()` throws, `listem()` catches, and the caller gets 406 for a
 refusal the source raised as 400. Every service and client endpoint reading
 through `asValue()`/`getX()` sees one status for all failures, and a
-behavioural test written against that seam will observe 406 where the source
+behavioral test written against that seam will observe 406 where the source
 says 400.
 ```
 # lab: Route::asValue(function () { Route::listem('host', 'sec_tok=x', true); });
@@ -684,7 +684,7 @@ sh tests/run-all.sh | tail -1          # 73 passed, 0 failed
 php tests/route-ids-getfield-sensitive.test.php   # ok  41 checks passed
 ```
 
-### F-39 — The read path's access controls now have a behavioural net, and it turns fourteen mutations red
+### F-39 — The read path's access controls now have a behavioral net, and it turns fourteen mutations red
 
 `tests/route-read-path-guards.test.php` (93 checks) drives the real functions
 against `tests/lib/fog-test-harness.php`, a fake PDODB with no database behind
@@ -703,7 +703,7 @@ reader would assume the obvious assertion already covered:
   `API_MASSDATA_MAPPING` — protecting only rows a plugin **added** to the
   payload, since `listem()` already scoped. Removing it leaves every
   listem()-driven scope assertion green.
-- Pinning `stripSensitivePayload()`'s behaviour does not pin `printer()`'s
+- Pinning `stripSensitivePayload()`'s behavior does not pin `printer()`'s
   call to it.
 
 Two facts the net depends on. `DatabaseManager::getLink()` is

--- a/docs/refactor-phase1-site-inheritance-plan.md
+++ b/docs/refactor-phase1-site-inheritance-plan.md
@@ -175,7 +175,7 @@ sh tests/run-all.sh
 
 ### PR B — the four-arm query
 
-`SiteScope::userSiteIDs()` only. This is the commit that changes behaviour, and
+`SiteScope::userSiteIDs()` only. This is the commit that changes behavior, and
 it is one method so a bisect lands on it.
 
 Extend `tests/site-scope.test.php`, which already asserts the **issued SQL and
@@ -245,7 +245,7 @@ can't-lose-access change in the same PR as a might-lose-access one.
 **None.** Two `CREATE TABLE IF NOT EXISTS` and no data movement — nothing is
 read, rewritten or deleted. A revert leaves two unused tables.
 
-There is no upgrade-day behaviour change: both tables start empty, every arm but
+There is no upgrade-day behavior change: both tables start empty, every arm but
 the first returns nothing, and `userSiteIDs()` answers exactly what it answers
 today until an administrator creates a grant.
 

--- a/docs/refactor-phase2-plan.md
+++ b/docs/refactor-phase2-plan.md
@@ -49,7 +49,7 @@ route table: `API_VALID_CLASSES` (`route.class.php:537`),
 `API_TASKING_CLASSES` (`:541`), `API_ACTIVE_TASK_CLASSES` (`:545`), plus
 `API_REMOVE_COLUMNS`, `API_MASSDATA_MAPPING`, `API_UNISEARCH_RESULTS`,
 `API_INDIVDATA_MAPPING`, `API_GETTER`, `API_SENSITIVE_FIELDS`. Each of those
-shapes the **generic CRUD** behaviour of a class that already exists.
+shapes the **generic CRUD** behavior of a class that already exists.
 
 `defineRoutes()` (`route.class.php:793`) builds its patterns by `implode`-ing
 those class lists into a regex. There is no hook between the lists and
@@ -145,7 +145,7 @@ repository size, not install-time risk.
 
 The stronger reason is **shape**. OIDC is a browser redirect plus two HTTPS
 calls returning JSON, verified with a signature over a well-known key set.
-SAML is XML, and its security depends on XML canonicalisation and XML
+SAML is XML, and its security depends on XML canonicalization and XML
 signature verification — a class of parsing where the vulnerabilities
 (XXE, signature wrapping, comment truncation) live in the parser rather than
 the protocol. `INFERRED`: that is a materially harder thing to ship safely in
@@ -311,7 +311,7 @@ Three seams, each closing one gap, each independently useful:
 
 Landed with a fourth thing the plan did not anticipate, and which turned out
 to matter more than any of the three: `resolveApiPermission()` **already**
-returned `null` — no check — for a route name it did not recognise, described
+returned `null` — no check — for a route name it did not recognize, described
 in a comment as matching the unregistered-page stance that had since been
 tightened everywhere else. Harmless while nothing could add a route; an open
 default the moment something could. Flipped to deny first, in its own commit,
@@ -353,17 +353,17 @@ sh tests/run-all.sh
 
 An IdP-established session must be distinguishable from a password one, for
 audit and for break-glass. Extends the login history entry and the session
-with the auth source. No behaviour change for the password path.
+with the auth source. No behavior change for the password path.
 
 Landed as `establishSession($source = self::AUTH_SOURCE_PASSWORD)`, writing
 `$_SESSION['FOG_AUTH_SOURCE']` and appending `(<source>)` to the history
 entry. Two things the plan did not spell out and that the implementation
 had to settle:
 
-- **The value is normalised, not trusted.** A provider plugin supplies it and
+- **The value is normalized, not trusted.** A provider plugin supplies it and
   it lands in an audit trail, so anything that is not a plain slug
   (`^[a-z0-9][a-z0-9_-]{0,31}$`, case-folded and trimmed) is recorded as
-  `unknown` rather than passed through. The normalisation is a separate
+  `unknown` rather than passed through. The normalization is a separate
   public static — `User::normalizeAuthSource()` — purely so it can be tested
   without a database; `establishSession()` itself writes a history row and
   cannot be exercised DB-free.
@@ -382,7 +382,7 @@ proved it this time). Break-glass in 2.5 needs the second one.
 ```bash
 grep -n 'function establishSession' -A5 packages/web/lib/fog/user.class.php
 php tests/session-provenance.test.php
-# 13 normaliser cases + the 32-char boundary; static pins on the session
+# 13 normalizer cases + the 32-char boundary; static pins on the session
 # stamp, on validatePw() still taking the default, and on logout()'s
 # wholesale clear
 # verified failing with: normalizeAuthSource() bypassed in establishSession()

--- a/docs/refactor-phase3-plan.md
+++ b/docs/refactor-phase3-plan.md
@@ -232,7 +232,7 @@ $this->childClass = preg_replace('#_?Manager$#', '', get_class($this));
 
 Under flat, `FOG\Host` + `'Manager'` → `FOG\HostManager`, which exists —
 `VERIFIED` by prototype. Under nested, it produces `FOG\Model\HostManager`, which
-does not exist, and `new $man` is a fatal on the single most-travelled path in the
+does not exist, and `new $man` is a fatal on the single most-traveled path in the
 ORM.
 
 You could fix it — rewrite both derivations to move between namespaces. But that

--- a/docs/route-listem-access-control-map.md
+++ b/docs/route-listem-access-control-map.md
@@ -23,7 +23,7 @@
 >   list-half amendment.
 >
 > What this document still gets right, and is worth reading for, is §6: the
-> catalogue of single-line deletions that remove a control without failing a
+> catalog of single-line deletions that remove a control without failing a
 > test, and why `tests/route-read-path-guards.test.php` exists.
 
 This document answers one question: **which lines in the read path remove or
@@ -217,7 +217,7 @@ restored from a scratchpad copy.
 green.**
 
 The reason is consistent, and it is the failure documented in
-`docs/lessons/` as pinning a symbol's *use* instead of its *behaviour*:
+`docs/lessons/` as pinning a symbol's *use* instead of its *behavior*:
 
 - `site-scope-lists.test.php` tests `Authorization::scopedObjectIDs()` — the
   **supplier** of scope ids, exhaustively and well. It contains no reference to

--- a/docs/route-listem-brief.md
+++ b/docs/route-listem-brief.md
@@ -69,12 +69,12 @@ responsibilities. My expectation is that it is several functions wearing a
 trenchcoat: request parsing, permission resolution, scope filtering, query
 building, joining, pagination, sorting, search, field selection, result
 shaping. Confirm or correct that, and say which responsibilities are entangled
-such that they cannot be separated without changing behaviour.
+such that they cannot be separated without changing behavior.
 
 **3. Whether the existing tests are a net or a comfort.**
 `route-filter-fields.test.php`, `route-result-wrappers.test.php`,
 `routed-query-string.test.php` and `openapi-route-coverage.test.php` exist. Do
-they actually pin the behaviour a refactor could break — scope filtering in
+they actually pin the behavior a refactor could break — scope filtering in
 particular — or do they cover the edges and leave the middle open? Answer with
 what they assert, not with a count. If they are not a sufficient net, then
 building one is the first commit and the decomposition is the second.
@@ -108,7 +108,7 @@ Separately from the plan:
 1. **The access-control map**, as its own document. This outlives the refactor.
 2. **The defect list**, with anything that would need a `dev-branch` decision
    split into its own section, severity-rated, no port proposed.
-3. **The decisions that are mine.** Where a fix changes observable behaviour,
+3. **The decisions that are mine.** Where a fix changes observable behavior,
    present the options and their costs rather than picking. Some of what looks
    wrong in a nine-year-old API is load-bearing for somebody.
 4. **The measurement.**
@@ -125,7 +125,7 @@ Ask me questions before planning if the code does not answer something.
 ## One thing I am not asking for
 
 Do not propose splitting `route.class.php` into multiple files as a first step.
-Moving 6,470 lines between files produces an enormous diff that hides behaviour
+Moving 6,470 lines between files produces an enormous diff that hides behavior
 changes inside apparent relocations, and it is exactly the shape of change I
 cannot review. If the end state wants several files, that is the last commit in
 the sequence, not the first.

--- a/docs/route-listem-defects.md
+++ b/docs/route-listem-defects.md
@@ -17,7 +17,7 @@ Severity is mine; the decisions in §3 are yours.
 > `unfilterableFields()` before the existence test. Serving a request it
 > answers 400; off-request (the daemons) it returns no rows and logs, because
 > `sendResponse()` exits and a daemon that exits is a restart loop. Verified
-> under both SAPIs against the lab database, and pinned behaviourally by
+> under both SAPIs against the lab database, and pinned behaviorally by
 > `tests/route-ids-getfield-sensitive.test.php` (41 checks), which fails 20 of
 > them when the guard is removed. Landing it required REENTRANCY-1 below.
 > The description that follows is the defect as found.
@@ -60,7 +60,7 @@ Not confirmed over HTTP: this sandbox blocks the request. The code path above
 is complete and each link is cited; a one-line `curl` would settle it, and the
 probe script says which.
 
-**Fix shape (one line, no behaviour change for legitimate callers):** run
+**Fix shape (one line, no behavior change for legitimate callers):** run
 `$getField` through `unfilterableFields($classname)` in the same loop that
 already validates it, and refuse the same way. Nothing in-repo asks `ids()` for
 a sensitive field — `getIds()`'s internal callers ask for `id`, `name` and
@@ -155,7 +155,7 @@ caller does it.
 
 This does **not** leak — it hides. But it means nobody can be running the site
 feature at fleet scale today, which is itself worth knowing before the
-decomposition assumes the current behaviour is load-bearing for somebody.
+decomposition assumes the current behavior is load-bearing for somebody.
 
 ---
 
@@ -171,7 +171,7 @@ kept-row count.
 |---|---|---|
 | `recordsTotal` = total in-scope objects, `recordsFiltered` = in-scope matching the filter | DataTables' "Showing 1 to 25 of N" is correct; paging works | changes the number every existing client sees on a scoped server. On an unscoped server (the overwhelming majority) nothing changes. |
 | leave both as the unscoped SQL counts | no client-visible change at all | the count answers the question the row-filtering refuses to; a scoped user learns how many hosts exist outside their site |
-| keep today's behaviour | nothing | the grid stays broken |
+| keep today's behavior | nothing | the grid stays broken |
 
 My read: option 1. It is the only one where the envelope describes the payload,
 and the client-visible change lands only on scoped servers, where the current
@@ -189,7 +189,7 @@ scope in `ids()` would deny-all every daemon.
 | Option | Gains | Costs |
 |---|---|---|
 | scope only when a request is being served (`'cli' !== PHP_SAPI` and a route matched), as `ids()` already does for its error branch | closes the hole, daemons unaffected | a second "am I serving a request" test in the file; that predicate becomes load-bearing |
-| scope in the router, not in the handler — one filter applied to `self::$data` for any route whose name resolves to `<entity>.view` | one place, covers routes added later | needs each handler's payload shape to be recognisable; `ids()`'s bare scalar array carries no ids to filter on when `getField != 'id'` |
+| scope in the router, not in the handler — one filter applied to `self::$data` for any route whose name resolves to `<entity>.view` | one place, covers routes added later | needs each handler's payload shape to be recognizable; `ids()`'s bare scalar array carries no ids to filter on when `getField != 'id'` |
 | refuse these four routes outright for scoped users | trivially correct | breaks the UI's own type-ahead for scoped users |
 
 My read: option 1 for `count()` and `unisearch()` now (both already produce
@@ -221,7 +221,7 @@ Each formatter now resolves the row's own group through a per-id memo (the
 leaves a group in a state `getMasterStorageNode()` answers differently on, so
 priming here trades one wrong answer for another.
 
-This is a **behaviour change and the point of the commit**: the grid now
+This is a **behavior change and the point of the commit**: the grid now
 reports each group's own enabled nodes and master node.
 
 `:2645-2673`. A single `new StorageGroup()` is shared by two formatters: the
@@ -232,7 +232,7 @@ left behind. It works only because `dataOutput()`
 `enablednodes` is emitted first. This is the same shape as F-22 — correct by
 an ordering accident, and neither PHP nor any test would say so if the two were
 swapped. Fixing it changes no output; it is listed here because "make each
-formatter self-contained" is a behaviour-preserving change that a reviewer
+formatter self-contained" is a behavior-preserving change that a reviewer
 should be told is deliberate.
 
 ### DEC-5 — `listem()`'s catch relabels every failure as HTTP 406
@@ -255,14 +255,14 @@ Route::asValue(function () { Route::listem('host', 'sec_tok=x', true); });
 
 Matters twice over. For consumers: every service and client endpoint that reads
 through `asValue()`/`getX()` sees one status for all failures. For the
-decomposition: any behavioural test written against the wrapper seam (which is
+decomposition: any behavioral test written against the wrapper seam (which is
 how the net in the plan is built) will observe 406 where the source says 400,
-and a test written to the source rather than to the observed behaviour will
+and a test written to the source rather than to the observed behavior will
 fail for the wrong reason.
 
-Preserving today's wire behaviour while fixing the wrapper means re-raising with
+Preserving today's wire behavior while fixing the wrapper means re-raising with
 `$e->getCode()` when the code is a real HTTP status and falling back to 406
-otherwise. That is a behaviour change for wrapper callers, so it is yours.
+otherwise. That is a behavior change for wrapper callers, so it is yours.
 
 **DECIDED 2026-08-19: re-raise the inner code. FIXED 2026-08-19.** All 17
 catches in the class now call one helper, `Route::_sendCaught()`, which re-raises
@@ -465,7 +465,7 @@ idiom appears four more times (`:2519`, `:2547`, `:2594`).
 
 The `dev-branch` question is therefore not "port SEC-1's fix" but "does the
 1.5.x line get sensitive-field stripping at all". That is a much larger
-decision than this scan, it is a shipped-behaviour change on a patches line,
+decision than this scan, it is a shipped-behavior change on a patches line,
 and it is entirely yours. I have not shaped anything in §1–§5 to make it
 easier.
 

--- a/docs/route-listem-plan.md
+++ b/docs/route-listem-plan.md
@@ -49,7 +49,7 @@ sorting, search, field selection, result shaping." Mostly right. Corrections:
 |---|---|---|
 | request parsing (body + `?length`/`?start` fold-in) | `:1523-1543` | yes, cleanly |
 | expand-clamp | `:1545-1561` | yes — and it is broken (DEAD-2) |
-| filter normalisation **and refusal** | `:1567-1581` | yes, but this is guard #1 and #2 |
+| filter normalization **and refusal** | `:1567-1581` | yes, but this is guard #1 and #2 |
 | **permission resolution** | *not here* | already extracted — `runMatches()` `:1191` |
 | column removal (secrets) | `:1614-1633` | yes, but this is guard #3 |
 | **column table** | `:1645-2478` | **yes, trivially — 834 of 1,103 lines, zero guards** |
@@ -145,7 +145,7 @@ cp /tmp/route.bak packages/web/lib/router/route.class.php
 ```
 
 Why every one of these passes: the existing route tests pin *symbols*, not
-*behaviour*. `sensitive-fields-unfilterable.test.php` greps for the strings
+*behavior*. `sensitive-fields-unfilterable.test.php` greps for the strings
 `_assertNoSensitiveFilter(`, `HTTP_BAD_REQUEST` and `'nosearch'`; inserting
 `return;` above the `HTTP_BAD_REQUEST` line leaves all three present.
 `site-scope-lists.test.php` exercises `Authorization::scopedObjectIDs()`
@@ -193,7 +193,7 @@ existing conventions (standalone, exit 0/1, no framework, no DB):
 2. the same through the JSON search body (`getsearchbody`);
 3. `stripSensitivePayload` removes both tiers from a `_lang`-stamped list
    payload, and only tier 2 from an unstamped single-entity payload;
-4. an unstamped payload is returned **unchanged** — pinning today's behaviour
+4. an unstamped payload is returned **unchanged** — pinning today's behavior
    so SEC-1's fix is understood as an input-side fix, not an emitter change;
 5. `_applySiteScope` with `scopedObjectIDs` → `null` leaves the payload
    byte-identical (`===`), with `[]` empties it, with `[a,b]` keeps exactly
@@ -207,8 +207,8 @@ existing conventions (standalone, exit 0/1, no framework, no DB):
    literal key list, because that list is the API contract (ADR 0011) and
    nothing pins it today;
 9. `listem()` calls `_applySiteScope` — a source-level assertion, kept
-   **alongside** the behavioural ones and not instead of them, because a
-   decomposition can preserve the behaviour of a method nobody calls.
+   **alongside** the behavioral ones and not instead of them, because a
+   decomposition can preserve the behavior of a method nobody calls.
 
 **Each assertion must be mutation-verified as it is written.** The mutation
 table above is the acceptance criterion: re-run all eight with the net in
@@ -260,7 +260,7 @@ covered, and each cost an assertion that would not otherwise have been written:
   they can. Section 6b registers a hook that appends an out-of-scope row and
   asserts it never reaches the wire. This is the line a decomposition drops on
   the grounds that `listem()` already did it.
-- **M4.** Pinning `stripSensitivePayload()`'s behaviour does not pin the
+- **M4.** Pinning `stripSensitivePayload()`'s behavior does not pin the
   emitter's **call** to it — the exact failure mode this file exists to
   prevent, reproduced while writing the file that prevents it. Closed by
   driving `printer()` itself through `asValue()` and asserting on the wire
@@ -515,7 +515,7 @@ there (`fogmanagercontroller.class.php:685,713-718`), already ANDed into both
 the row query and the filter count, and already feeds `$whereAllSql` into the
 total count. That is what it was built for; nothing new is invented.
 
-`_applySiteScope`'s row loop then becomes a **defence in depth** assertion
+`_applySiteScope`'s row loop then becomes a **defense in depth** assertion
 rather than the enforcement — keep it, and have it log if it ever removes a row
 the SQL should already have excluded.
 
@@ -752,7 +752,7 @@ part of what it pins: `f:StorageGroup` became `f:groupFor`.
 ## Commit 8 — extract the pipeline phases
 
 Only now, and only if commits 1–7 have left something worth extracting. After
-commit 3, `listem()` is ~260 lines: parse request → normalise filters →
+commit 3, `listem()` is ~260 lines: parse request → normalize filters →
 build columns → query → hooks → scope → shape. Each phase is a private method
 returning a value.
 
@@ -762,7 +762,7 @@ the net, and by here the net has been mutation-verified twice.
 **Alternative rejected — and this is your constraint, restated so a later
 reader does not re-litigate it:** splitting `route.class.php` into several
 files. If the end state wants that, it is the commit after this one, never
-before. A 6,470-line move hides behaviour changes inside apparent relocations.
+before. A 6,470-line move hides behavior changes inside apparent relocations.
 
 ---
 
@@ -789,7 +789,7 @@ path pattern, a method, a parameter or a response body desynchronises silently.
 directions — `VERIFIED` by mutation: changing the `/names` route's *path* while
 keeping its name leaves the suite green.
 
-For this plan that cuts a favourable way: **nothing in `listem()` is described
+For this plan that cuts a favorable way: **nothing in `listem()` is described
 by the document at all.** `_entitySchema()` reflects `$databaseFields`, so the
 grid's own `dt` columns — `mainlink`, `imagename`, `primac`, `primac_vendor`,
 `hostLink`, `taskstateicon`, `diff`, `members`, `hostcount` — are undocumented
@@ -849,7 +849,7 @@ remove rows a user should not see, never leave one in.**
 
 Everything else in this plan is arranged around that. It is why SCOPE-2 is
 rated a *functional* defect and not a disclosure, why commit 5 is sequenced
-sixth instead of first, and why I was willing to keep the row loop as a defence
+sixth instead of first, and why I was willing to keep the row loop as a defense
 in depth rather than treating it as the hole.
 
 It rests on one line, `:5676`:

--- a/docs/superpowers/CONTEXT-1013-pki-and-customizations.md
+++ b/docs/superpowers/CONTEXT-1013-pki-and-customizations.md
@@ -95,13 +95,13 @@ renamed backgrounds / custom kernel names surviving repeated installs.
 
 ## NOT verified — read this before shipping
 
-1. **Secure Boot with name constraints, on hardware.** Both enrolment routes
+1. **Secure Boot with name constraints, on hardware.** Both enrollment routes
    (MokManager and Setup Mode `db`) were confirmed on real UEFI hardware
    *before* `nameConstraints` was added to the Secure Boot CA. That extension
    is critical, and it sits in the one certificate firmware and shim actually
    parse. **This is the release gate.** `--no-sb-name-constraints` exists so a
    rejection is a flag flip and a re-issue of one intermediate, not a
-   re-enrolment of a fleet.
+   re-enrollment of a fleet.
 
    Measured, and the reason the signing leaf now carries a DNS SAN: OpenSSL
    applies DNS constraints to the subject CN when a certificate has no DNS SAN.
@@ -110,7 +110,7 @@ renamed backgrounds / custom kernel names surviving repeated installs.
    hostname. Depending on that quirk would mean renaming that CN stops the
    fleet booting.
 
-2. **Existing servers that enrolled the old self-signed MOK must re-enrol.**
+2. **Existing servers that enrolled the old self-signed MOK must re-enroll.**
    Deliberate, and the reason this landed before Secure Boot reached stable —
    after that, the same change costs a firmware trip to every machine. The
    installer prints a prominent notice and leaves `MOK.{key,pem}` on disk.
@@ -213,7 +213,7 @@ per-host/group only, which may be part of the gap.
 ## Still open
 
 - The dev-branch port: the PKI hierarchy, key isolation and Secure Boot
-  intermediate, but **not** the node endpoint and **not** the db/KEK enrolment
+  intermediate, but **not** the node endpoint and **not** the db/KEK enrollment
   task (1.6 only). dev-branch lacks `--external-ca`, the managed vhost block
   and `_pkiZoneDir`/`_linkCanonical`, and `createSSLCA` there hardcodes
   `/opt/fog/snapins/ssl/`, so this is a port rather than a cherry-pick.

--- a/docs/superpowers/plans/2026-08-11-pxe-unattended-secureboot-enroll.md
+++ b/docs/superpowers/plans/2026-08-11-pxe-unattended-secureboot-enroll.md
@@ -36,7 +36,7 @@ Create `tests/pxe-secureboot-menu-schema.test.php`:
 ```php
 <?php
 /**
- * Guards the two pxeMenu schema changes for unattended Secure Boot enrol:
+ * Guards the two pxeMenu schema changes for unattended Secure Boot enroll:
  *  - pxeID 14 ("Enroll Secure Boot Key") gets relabeled to distinguish it
  *    from the new unattended item, via a new UPDATE step (321 already ran
  *    on existing installs, so it cannot be edited in place).
@@ -111,7 +111,7 @@ $this->schema[] = [
     // Distinguishes pxeID 14 from the unattended item added in step 325
     // below. It has always chained straight to MokManager for a technician
     // to drive by hand; the plain "Enroll Secure Boot Key" name stopped
-    // being enough once there is a second, unattended way to enrol from
+    // being enough once there is a second, unattended way to enroll from
     // the same menu.
     //
     // A new step, not an edit to step 321: that INSERT has already run on
@@ -138,7 +138,7 @@ $this->schema[] = [
     //
     // BootMenu::printDefault() additionally hides this item unless
     // PK.auth/KEK.auth/db.auth all exist in service/secureboot/ -- without
-    // them mode=enrollsb's auto-enrol path has nothing valid to write.
+    // them mode=enrollsb's auto-enroll path has nothing valid to write.
     "INSERT IGNORE INTO `pxeMenu` "
     . "(`pxeID`,`pxeName`,`pxeDesc`,`pxeDefault`,`pxeRegOnly`,`pxeArgs`) "
     . "VALUES "
@@ -157,7 +157,7 @@ Expected: `PASS`
 
 ```bash
 git add packages/web/commons/schema.php tests/pxe-secureboot-menu-schema.test.php
-git commit -m "Add pxeMenu schema step for unattended Secure Boot enrol, relabel attended item"
+git commit -m "Add pxeMenu schema step for unattended Secure Boot enroll, relabel attended item"
 ```
 
 (The pre-commit hook will also touch `languages/messages.pot`/`.po` files and `system.class.php`'s version — expected.)
@@ -185,7 +185,7 @@ Create `tests/pxe-secureboot-menu-gating.test.php`:
  * Secure Boot Key (Unattended...)", mode=enrollsb): it must stay hidden on
  * non-EFI platforms exactly like pxeID 14, and must additionally stay
  * hidden unless PK.auth/KEK.auth/db.auth all exist in service/secureboot/
- * -- without them mode=enrollsb's auto-enrol path has nothing valid to
+ * -- without them mode=enrollsb's auto-enroll path has nothing valid to
  * write.
  *
  * Static source check (no DB, no server) -- BootMenu needs the full FOG
@@ -250,7 +250,7 @@ In `packages/web/lib/fog/bootmenu.class.php`, replace the existing comment + fil
         // pxeID 14 ("Enroll Secure Boot Key (MOK attended setup)") and
         // pxeID 15 ("Enroll Secure Boot Key (Unattended...)") are both
         // meaningless on a legacy BIOS boot: there is no UEFI variable
-        // store to enrol into, so every route out of them -- MokManager,
+        // store to enroll into, so every route out of them -- MokManager,
         // and the FOS task behind mode=enrollsb -- can only fail. Both
         // carry pxeRegOnly=2 so a technician never has to repoint a
         // client's boot file to reach them, and that "always shown" is
@@ -285,7 +285,7 @@ In `packages/web/lib/fog/bootmenu.class.php`, replace the existing comment + fil
                 )
             );
         }
-        // pxeID 15's unattended enrol (mode=enrollsb) only auto-enrols when
+        // pxeID 15's unattended enroll (mode=enrollsb) only auto-enrolls when
         // PK.auth, KEK.auth and db.auth all exist in service/secureboot/ --
         // fog-build-sb-authvars' output, the same directory MOK.der already
         // lives in. Without all three the task type itself has nothing
@@ -323,7 +323,7 @@ Expected: `PASS`
 
 ```bash
 git add packages/web/lib/fog/bootmenu.class.php tests/pxe-secureboot-menu-gating.test.php
-git commit -m "Hide unattended Secure Boot enrol PXE item until .auth files exist"
+git commit -m "Hide unattended Secure Boot enroll PXE item until .auth files exist"
 ```
 
 ---
@@ -333,6 +333,6 @@ git commit -m "Hide unattended Secure Boot enrol PXE item until .auth files exis
 Not automatable in this environment (no DB/live iPXE client) — call this out to whoever runs the plan rather than skipping it silently:
 
 1. With no `.auth` files in `service/secureboot/`: PXE menu on a UEFI test client shows only "Enroll Secure Boot Key (MOK attended setup)". No unattended item.
-2. Run `fog-build-sb-authvars` (or otherwise populate `PK.auth`/`KEK.auth`/`db.auth`) and reload the menu: both items now appear, correctly labelled.
-3. Select the unattended item on a client currently in UEFI Setup Mode: it boots FOS with `mode=enrollsb` in the kernel command line and completes the enrol automatically.
+2. Run `fog-build-sb-authvars` (or otherwise populate `PK.auth`/`KEK.auth`/`db.auth`) and reload the menu: both items now appear, correctly labeled.
+3. Select the unattended item on a client currently in UEFI Setup Mode: it boots FOS with `mode=enrollsb` in the kernel command line and completes the enroll automatically.
 4. On a BIOS/CSM client (`platform != efi`): neither item appears, regardless of `.auth`/`MOK.der` state.

--- a/docs/superpowers/plans/2026-08-22-fogsettings-key-rename.md
+++ b/docs/superpowers/plans/2026-08-22-fogsettings-key-rename.md
@@ -21,7 +21,7 @@ thing. **79 managed keys → 66.**
 **Architecture:** `.fogsettings` is *sourced*, so a key name **is** a shell
 variable name — the rename is necessarily a codebase-wide variable rewrite
 (753 references across just 25 of the 79 keys; expect 1000+ in total). That
-rewrite is the deliverable, not a cost to minimise. The organising idea is
+rewrite is the deliverable, not a cost to minimize. The organizing idea is
 `_linkCanonical()` (`lib/common/functions.sh`), already documented as *"Make $2
 resolve to $1, so FOG can keep referencing a fixed path while the real file lives
 wherever the admin keeps it."* Each setting names a **canonical path in FOG's own
@@ -46,7 +46,7 @@ Tests are standalone shell harnesses under `tests/`, run via `tests/run-all.sh`.
   sourced. Writing the real variable directly is silently discarded on upgrade —
   that bug has shipped at least three times (`-E`, `-s`/`-e`, `-S`).
 - Adding a key to `managedKeys` turns a hand-set key into a managed one, so the
-  admin's value starts being overwritten. That is a behaviour change even when it
+  admin's value starts being overwritten. That is a behavior change even when it
   looks like documentation.
 - Related: `docs/FOGSETTINGS.md` (mechanics and the four key kinds),
   `docs/adr/0015-install-settings-are-independent-keys.md`,
@@ -206,14 +206,14 @@ is back on the table. Not decided; flagged.
 ## Sequencing across sessions
 
 Real parallelism is narrow: the rename is concentrated in `functions.sh` and
-`installfog.sh`, and most behaviour changes land in `functions.sh` too. Splitting
+`installfog.sh`, and most behavior changes land in `functions.sh` too. Splitting
 the rename by category would have every session fighting the same file.
 
 | Track | Files | When |
 |---|---|---|
 | 1 — `-K`/`-C` client break | `functions.sh`, one function | **Merge before track 2 branches** |
 | 2 — mechanical rename | `functions.sh`, `installfog.sh`, `newinput.sh`, distro configs, tests | Alone |
-| 3 — behaviour changes | same | After 2 merges |
+| 3 — behavior changes | same | After 2 merges |
 | 4 — fog-docs | different repo | Fully parallel |
 | 5 — PHP whoami + OpenAPI | `route.class.php`, `openapi.class.php` | Parallel; contract is the five new pub-file names |
 
@@ -341,7 +341,7 @@ strips all 79 lines and appends 66 at the end. The category blocks and the
 as a pile of appended keys after its own footer.
 
 So a recognizable file carrying only pre-rename keys now gets a **one-time
-canonical rewrite**, which also carries every *unrecognised* line through. That
+canonical rewrite**, which also carries every *unrecognized* line through. That
 second half matters as much: hand-set keys (`inetConnectTimeout`,
 `storageLocationCapture`, `ftppasvmin`/`max`, `mcastportmin`/`max`) and an admin's
 own comments survive only because something preserves what it does not manage,
@@ -379,7 +379,7 @@ membership half of what it was for is covered properly instead:
 - `tests/fogsettings-migration.test.sh` (new) **extracts the seed block from the
   installer and evaluates it** rather than replaying it by hand, then runs
   `writeUpdateFile()` over a synthesized pre-rename file. A hand-copied replay is
-  how a test passes while the behaviour is wrong.
+  how a test passes while the behavior is wrong.
 - `tests/whoami-keys-in-step.test.php` (new) binds `Route::WHOAMI_KEYS` to the
   pub-file loop — `docs/FOGSETTINGS.md` said in as many words that nothing did.
 

--- a/docs/superpowers/specs/2026-08-11-pxe-unattended-secureboot-enroll-design.md
+++ b/docs/superpowers/specs/2026-08-11-pxe-unattended-secureboot-enroll-design.md
@@ -55,7 +55,7 @@ schedule a task, and come back.
 - With no `.auth` files present: PXE menu on a UEFI client shows only item 14
   ("...MOK attended setup)"). Item 15 absent.
 - With all three `.auth` files present: PXE menu on a UEFI client shows both
-  items, correctly labelled. Item 15 boots FOS with `mode=enrollsb` in the
+  items, correctly labeled. Item 15 boots FOS with `mode=enrollsb` in the
   kernel line.
 - On a BIOS/CSM client (`platform != efi`): neither item 14 nor 15 appears,
   regardless of `.auth`/`MOK.der` state.

--- a/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
+++ b/docs/superpowers/specs/2026-08-15-secureboot-local-esp-boot-design.md
@@ -46,13 +46,13 @@ ships are only ever a first-and-second stage that chainloads onward, never the
 binary that actually drives the NIC.
 
 Once shim has run, its security policy override stays installed for the rest of
-the boot, so a MOK-signed binary loads. FOG already publishes and enrols a MOK
+the boot, so a MOK-signed binary loads. FOG already publishes and enrolls a MOK
 (`_publishSecureBootKit`, `service/secureboot/MOK.der`). Nothing is missing but
 a signature on the binaries FOG already ships.
 
 ## Non-goals
 
-**This must never be on the netboot path.** The enrolment workflow depends on an
+**This must never be on the netboot path.** The enrollment workflow depends on an
 un-enrolled machine reaching the FOG menu: upstream signed shim, upstream signed
 snponly, `autoexec.ipxe`, `default.ipxe`, then *Enroll Secure Boot Key* →
 MokManager. A MOK-signed binary anywhere in that chain cannot load, because the
@@ -130,7 +130,7 @@ that made the default install fast.
 
 ### 1. `_signLocalIpxe()`
 
-New function in `lib/common/functions.sh`, modelled directly on
+New function in `lib/common/functions.sh`, modeled directly on
 `_resignRefind()` (7915) — same shape, same guards, same failure messaging.
 
 ```
@@ -333,7 +333,7 @@ folder or only the variant their hardware needs.
 | Sign only a hand-picked local-boot subset | Signing is in place under `$tftpdirdst` and costs nothing per file, so restricting it would only make a variant fetched by hand off TFTP useless. *Publishing* is curated — see Design §2 — because there the list is advice, not just bytes. |
 | Publish every `*.efi` in the tree | The first implementation. 55 files and 27MB, including `snponly.efi`, which cannot work from an ESP, and the `autoexec/` builds, which arrive inert without an `autoexec.ipxe` beside them. A directory that offers a wrong answer next to the right one is worse than a shorter directory. |
 | Gate signing behind a flag | Signing was never the expensive part. A flag means a Secure Boot site that wants local ESP boot has to know it exists. |
-| Symlink `service/secureboot/…` to `$tftpdirdst` | The original design. 403s under SELinux, needed ~40 lines of vhost changes across nine sites, and depended on GH-529 behaviour that fails open. Replaced by copies — see Design §3. |
+| Symlink `service/secureboot/…` to `$tftpdirdst` | The original design. 403s under SELinux, needed ~40 lines of vhost changes across nine sites, and depended on GH-529 behavior that fails open. Replaced by copies — see Design §3. |
 | Relabel the TFTP tree `public_content_t` | Would make the symlink work, but widens the tree to ftpd/rsync/samba for a feature needing none of them, and means editing GH-963's recent fix. |
 | ~~Defer the ESP `autoexec.ipxe`~~ | **Reversed.** Testing showed it is load-bearing, not a convenience: the chain does not work without it, so a published directory lacking it is an incomplete kit. Now shipped as part of `esp/` — see Design §4. |
 | Drop upstream's `ipxe-shimx64.efi` + `ipxe.efi` as redundant | Raised in review on the grounds that both shim pairs only ever chain onward, so `snponly` alone would do. Rejected: shim resolves its second stage from its own filename, so each pair is indivisible, and an admin whose boot manager is already pointed at one of them needs that one present. Ten files is not worth the sharp edge. |
@@ -441,7 +441,7 @@ another tenant's files — never enters into it.
 was.
 
 **HTTP is the recommended transport here**, not a downgrade — iPXE's own docs
-favour it over TFTP, and UEFI HTTP Boot is a firmware standard. No CVE exists for
+favor it over TFTP, and UEFI HTTP Boot is a firmware standard. No CVE exists for
 exposing PXE artifacts over HTTP; FOG's actual CVEs are elsewhere (command
 injection in `export.php`, auth bypass, world-readable `.fogsettings`).
 
@@ -552,10 +552,10 @@ runs.
 | Was | Now | Why |
 | --- | --- | --- |
 | FOG's `snponly.efi` excluded | published as `fogsnponly.efi`, tried **last** in the ladder | The exclusion was only forced because `snponly.efi` is a shim-reserved name. Under the `fog` prefix there is no collision, the manifest note carries the disk-not-NIC caveat, and there is hardware where it works. |
-| `MOK.der` not in the kit | in every archive | MokManager enrols by browsing the ESP for a certificate. Shipping MokManager without one is still a dead end — it just fails one screen later. §4 missed this. |
+| `MOK.der` not in the kit | in every archive | MokManager enrolls by browsing the ESP for a certificate. Shipping MokManager without one is still a dead end — it just fails one screen later. §4 missed this. |
 | No `.auth` blobs in the kit | `PK`/`KEK`/`db.auth` in every archive | They are signed EFI variable updates a machine in Setup Mode writes to put this server's certificate straight into `db`, after which firmware verifies a signed `fogipxe.efi` **directly** — no shim, no MokManager, no MOK. |
 | "i386 has no Secure Boot chain to assemble" (§4) | **wrong, and corrected** | True that upstream signs no shim for ia32. But the `db` route needs no shim, so i386 Secure Boot local boot works. The conclusion followed from treating the shim chain as the only route. |
-| Publishing gated on nothing; **signing** gated on `--no-secure-boot` | signing always runs; the opt-out declines **enrolment** | A PE signature is inert with Secure Boot off, so signing costs nothing, while an unsigned binary is useless the day anyone enrols with nothing on the server able to fix it. The flag now stops `MOK.der`, the `.auth` blobs, and so the PXE enrol entry — applied in `_ensureSecureBootPlatformKeys` and `_publishSecureBootKit` instead of by blanking `$secureBootKey`. |
+| Publishing gated on nothing; **signing** gated on `--no-secure-boot` | signing always runs; the opt-out declines **enrollment** | A PE signature is inert with Secure Boot off, so signing costs nothing, while an unsigned binary is useless the day anyone enrolls with nothing on the server able to fix it. The flag now stops `MOK.der`, the `.auth` blobs, and so the PXE enroll entry — applied in `_ensureSecureBootPlatformKeys` and `_publishSecureBootKit` instead of by blanking `$secureBootKey`. |
 | ~~Curated list of loose files~~ | archives only | See the trade below. |
 
 ### Traded away, deliberately
@@ -592,7 +592,7 @@ really did replace is copied through untouched, so that file stays protected.
 | Bundle `bzImage`/`init.xz` per arch | 60–80MB per architecture, and it would not produce a working local boot on its own: FOS reads per-host, per-task kernel arguments that `boot.php` generates. Listed in the manifest's `kernels` section instead — no bytes moved, and the manifest becomes the single index. |
 | Grab `.usb`/`.iso` if present | A coherent but *different* feature (boot iPXE off a USB stick without touching the ESP), with its own layout question. Not published, and not silently dropped — say so if it is wanted. |
 | Build the manifest with `jq` | `jq` is in the install list, so it is normally there — but a missing package would mean publishing no manifest at all, which is the whole feature. Hand-written through a `_jsonStr` escaper instead: everything encoded here is content this file produced, so the escaping problem is bounded. Same reasoning as the `tar` fallback for `zip`. |
-| Symlink the enrolment material from `../secureboot/` | `_publishSecureBootKit()` `rm -rf`s that directory when there is no MOK, so a link inside an archive could dangle. Copies keep each archive self-contained, and the files are a few KB. |
+| Symlink the enrollment material from `../secureboot/` | `_publishSecureBootKit()` `rm -rf`s that directory when there is no MOK, so a link inside an archive could dangle. Copies keep each archive self-contained, and the files are a few KB. |
 
 ### Verification (in addition to the list above)
 
@@ -607,14 +607,14 @@ Also covered: the manifest parses as JSON under an independent implementation
 bytes; no BIOS artifact and no EMBED-less `autoexec/` build leaks in; upstream
 keeps the two shim-reserved names; the HTTPS-only shape publishes six archives
 and correctly omits an `autoexec.ipxe` no loader could read; a server with no
-enrolment material still succeeds; an empty tree reports `Failed` rather than
+enrollment material still succeeds; an empty tree reports `Failed` rather than
 publishing silently; a re-run is stable; and the `.fog-ipxe-manifest` regression
 is pinned end to end.
 
 Steps 3/3b of the original verification list are replaced by: fetch
 `manifest.json`, check each archive's sha256 against it, and confirm the
 directory itself 404s. Step 4 becomes: extract `fog-esp-x86_64.zip` and point the
-boot manager at `snponly-shimx64.efi`. New step: enrol `db.auth` from
+boot manager at `snponly-shimx64.efi`. New step: enroll `db.auth` from
 `fog-esp-i386.zip` through firmware Setup Mode and boot `fogipxe.efi` directly,
 with no shim — the path this spec originally said did not exist.
 
@@ -654,7 +654,7 @@ That invalidated two things this spec asserted:
    treats a missing source as fine by design (an HTTPS install stages no
    `secureboot/`), and `copied` stayed non-zero from the shim set, so three
    archives were staged, checksummed and advertised in `manifest.json` holding a
-   shim, MokManager, enrolment material, and a README telling the admin to boot a
+   shim, MokManager, enrollment material, and a README telling the admin to boot a
    file that was not in them.
 
 ### What replaced it
@@ -710,7 +710,7 @@ directory it was loaded from. x86_64 follows `bootmenu.class.php`'s
 `refind.efi`-over-`refind_x64.efi` preference so the ESP and the netboot path
 agree on which binary is canonical.
 
-### The iPXE behaviour this rests on
+### The iPXE behavior this rests on
 
 `efi_autoexec_filesystem()` tries `file:autoexec.ipxe` — resolved against the
 directory of the running image's `FilePath` — and then `file:/autoexec.ipxe` at
@@ -726,10 +726,10 @@ resolves through `LocateDevicePath()`, which matches the longest device-path
 prefix and so lands on that synthetic handle. That virtual filesystem serves
 registered images by flat name only — no directories, no passthrough — and
 `image_exec()` unregisters the running script for the duration, so on paper the
-chained binary should find nothing. Observed behaviour on hardware is the sibling
+chained binary should find nothing. Observed behavior on hardware is the sibling
 read, for the chained case as well as the firmware-loaded one.
 
-Hardware wins, and the layout is built on the observed behaviour. Do not
+Hardware wins, and the layout is built on the observed behavior. Do not
 "correct" it on the strength of the source read. If a client ever does dead-end
 on the chained route specifically — reaching iPXE's bare `autoboot()` instead of
 FOG's script — that synthetic handle is where to look, and the fix would be for
@@ -753,7 +753,7 @@ under-reporting manifest reads exactly like a correct one.
 `tests/localboot-publish.test.sh` grew from 62 to 87 assertions. The mock tree's
 "every file's content is its own path" mechanism carried over unchanged and is
 what proves rEFInd came from the web tree and matches its archive's architecture.
-All 50 of the assertions touching the new behaviour were confirmed to fail against
+All 50 of the assertions touching the new behavior were confirmed to fail against
 the pre-fix `functions.sh` before being relied on.
 
 Hardware step still owed, and the only one that cannot be faked: boot an ESP

--- a/lib/common/config.sh
+++ b/lib/common/config.sh
@@ -68,7 +68,7 @@ fog_udpversion="20250223"
 [[ -z $servicelogs ]] && servicelogs="$fogprogramdir/log"
 # Secure Boot signing is on by default: _ensureSecureBootKeys generates a
 # signing key when the admin has not supplied one, so a stock server always has
-# a fingerprint and an enrolment kit to hand out. --no-secure-boot sets this to
+# a fingerprint and an enrollment kit to hand out. --no-secure-boot sets this to
 # 0, and because .fogsettings is sourced before this file, that choice survives
 # an upgrade rather than being silently re-enabled.
 [[ -z ${PKI_sb_enabled} ]] && PKI_sb_enabled="yes"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -93,7 +93,7 @@ channelToBranch() {
     esac
 }
 # Folds a channel name to its canonical spelling, so exactly one place knows the
-# retired names. Returns 1 for anything unrecognised rather than echoing it
+# retired names. Returns 1 for anything unrecognized rather than echoing it
 # back: a caller asking "is this a channel" needs a no, and a typo silently
 # passed through would be resolved as a branch name later and fail further from
 # the cause.
@@ -506,7 +506,7 @@ checkDatabaseConnection() {
 # does not depend on which path got us here.
 #
 # Anything that cannot serve as a certificate name falls back to the address,
-# which is exactly the old behaviour. Rejected: an empty value, an IP literal,
+# which is exactly the old behavior. Rejected: an empty value, an IP literal,
 # localhost (the RHEL/Rocky minimal default, and identical on every node), and
 # anything outside the hostname grammar fog-sign-node-cert enforces.
 # The first argument that can actually serve as a certificate/vhost name, or
@@ -801,7 +801,7 @@ applyNewInstallDefaults() {
 recordGitUpdateSettings() {
     dots "Recording fog_git_path/update channel/extra server names"
     mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_GIT_PATH', 'Filesystem path of the FOG git checkout on this server. Recorded automatically by installfog.sh/updatefog.sh -- editing it here has no effect on the next update.', \"${FOG_git_path}\", 'FOG Update') ON DUPLICATE KEY UPDATE settingValue=\"${FOG_git_path}\"" ${DB_name} >>$error_log 2>&1
-    # settingDesc is refreshed too, unlike its two neighbours. The channel
+    # settingDesc is refreshed too, unlike its two neighbors. The channel
     # vocabulary changed (GH-1279), and ON DUPLICATE KEY UPDATE touching only
     # settingValue would leave every server installed before that change showing
     # "stable, staging, or dev" in the FOG Settings UI forever -- which is the
@@ -2005,7 +2005,7 @@ installFOGServices() {
     # prints its own "Setting SELinux context" line, so calling it between them
     # ran that line into ours ("...directory.... * Setting SELinux context...OK"
     # with our OK stranded on the next line) AND left errorStat reporting the
-    # labelling result instead of whether the directory was created -- a failed
+    # labeling result instead of whether the directory was created -- a failed
     # mkdir or chown here would have printed OK.
     setSELinuxContext "$servicelogs/plugins" httpd_sys_rw_content_t
     # FOGRetentionRunner is the second non-root daemon and needs the same
@@ -2088,8 +2088,8 @@ installFOGServices() {
     # nothing fails until something tries to write, so the install looks clean
     # and the settings-cache flush silently never happens.
     #
-    # Labelled where the directory is created rather than in a sweep at the end,
-    # so a relocated $fogprogramdir (GH-850) is labelled wherever it landed.
+    # Labeled where the directory is created rather than in a sweep at the end,
+    # so a relocated $fogprogramdir (GH-850) is labeled wherever it landed.
     setSELinuxContext "$fogprogramdir/cache" httpd_sys_rw_content_t
     # FOG's own PHP session store (FOG_SESSION_DIR in commons/init.php, which
     # points session.save_path here at runtime). FOG used to share the distro's
@@ -2112,7 +2112,7 @@ installFOGServices() {
     chmod 0700 $fogprogramdir/sessions >>$error_log 2>&1
     errorStat $?
     # Same GH-964 reasoning as the cache directory above: /opt/fog inherits
-    # usr_t and httpd_t may read but not write it. Unlabelled, PHP cannot write
+    # usr_t and httpd_t may read but not write it. Unlabeled, PHP cannot write
     # a session file on an enforcing host -- which does not degrade, it means
     # nobody can log in at all, with only an AVC denial to say so.
     setSELinuxContext "$fogprogramdir/sessions" httpd_sys_rw_content_t
@@ -2151,7 +2151,7 @@ installFOGServices() {
     errorStat $?
     # Outside the dots/errorStat pair above: setSELinuxContext prints its own
     # "Setting SELinux context" line, so calling it between them interleaved
-    # the two and left errorStat reporting the labelling result rather than
+    # the two and left errorStat reporting the labeling result rather than
     # whether the directory was created. Matches the cache block above.
     #
     # httpd_sys_content_t by default, not the _rw_ variant the cache uses: the
@@ -2571,7 +2571,7 @@ _needsLocalIpxeBuild() {
 # the installer with the rebuild off.
 #
 # Copied inside $tftpdirsrc so the normal copy loop carries it to $tftpdirdst
-# with everything else, and so it inherits the same ownership, SELinux labelling
+# with everything else, and so it inherits the same ownership, SELinux labeling
 # and signing sweep. No separate path to keep in step.
 #
 # secureboot/ is excluded, and that exclusion is load-bearing rather than tidy:
@@ -2670,7 +2670,7 @@ _sbChainStaged() {
 # "signed vs not".
 #
 # No 32-bit case on purpose: there is no Microsoft-signed ia32 shim to start a
-# chain from and no 32-bit MokManager to enrol one with, so i386-efi clients must
+# chain from and no 32-bit MokManager to enroll one with, so i386-efi clients must
 # have Secure Boot disabled to netboot at all.
 #
 # --boot-delay needs no handling here either. EFI takes its delay from
@@ -3189,7 +3189,7 @@ configureTFTPandPXE() {
     # a regular file to every daemon.
     #
     # Relinked unconditionally on every run: the copy loop truncates in place
-    # and the link usually survives, but that is cp's behaviour rather than a
+    # and the link usually survives, but that is cp's behavior rather than a
     # guarantee, and an editor that writes-and-renames breaks it. ln -f is
     # idempotent.
     # Before the links, so every path picks the delay up from one rewrite.
@@ -3479,7 +3479,7 @@ installPackages() {
     # _resignKernels degrades to its existing warning.
     FOG_packages="${FOG_packages} sbsigntool"
     # efitools builds the signed PK/KEK/db variable updates that the automatic
-    # Secure Boot enrolment path writes on the client (_publishSecureBootAuthVars).
+    # Secure Boot enrollment path writes on the client (_publishSecureBootAuthVars).
     # Same baseline reasoning as sbsigntool: the feature is on by default, so the
     # tooling it needs is not something the admin should have to know to install
     # first. Named "efitools" on every distro that packages it, so it needs no
@@ -3841,7 +3841,7 @@ setSELinuxContext() {
     # boot failed as a bare "file not found", with nothing in FOG's own logs and
     # only an AVC denial in the audit log to explain it. FOG's answer until now
     # was checkSELinux() offering to switch SELinux off machine-wide, which is a
-    # very large hammer for one mislabelled directory.
+    # very large hammer for one mislabeled directory.
     #
     # Policy almost always already knows the correct label -- FOG simply never
     # asked for it. So ask (restorecon), and only register a rule when policy
@@ -3890,7 +3890,7 @@ setSELinuxContext() {
             local chconis=$(ls -Zd "$dir" 2>>$error_log | awk '{print $1}' | cut -d: -f3)
             if [[ $acceptable == *" $chconis "* ]]; then
                 echo "OK"
-                echo " * Labelled with chcon only -- a filesystem relabel will undo this."
+                echo " * Labeled with chcon only -- a filesystem relabel will undo this."
                 echo " * Install policycoreutils-python-utils and re-run to make it permanent."
                 return 0
             fi
@@ -3915,7 +3915,7 @@ setSELinuxContext() {
     # install that otherwise succeeded should not be aborted over a label. But
     # it must be loud, because the symptom it causes has no other explanation.
     echo "Failed!"
-    echo " * $dir is labelled '$nowis', which the daemon using it cannot read."
+    echo " * $dir is labeled '$nowis', which the daemon using it cannot read."
     echo " * Under SELinux enforcing this presents as a bare file-not-found at"
     echo " *   the client with nothing in FOG's logs -- check for AVC denials:"
     echo " *   ausearch -m avc -ts recent"
@@ -3934,9 +3934,9 @@ checkSELinux() {
     # machine-wide without anyone deciding to. That was defensible only while
     # FOG genuinely did not work enforcing. It now does:
     #
-    #   GH-963       $tftpdirdst is labelled, so PXE boots
+    #   GH-963       $tftpdirdst is labeled, so PXE boots
     #   GH-966/967   $fogprogramdir/cache, $snapindir and ${STORAGE_image_share_path} are
-    #                labelled, so the web tier can write
+    #                labeled, so the web tier can write
     #   GH-968/969   fog_share_t, so vsftpd can read and write image and
     #                snapin storage as well as the web tier
     #   GH-966/967   packages/selinux/fog.te, so httpd_t may reach its own
@@ -4301,7 +4301,7 @@ migrateDeprecatedKeys() {
     # this run the new name is persisted and the old line is gone, and a flag that
     # already set the new key on this run correctly wins over the persisted value.
     #
-    # Modelled on the httpproto/httpsRedirect seeding immediately below, which is
+    # Modeled on the httpproto/httpsRedirect seeding immediately below, which is
     # the same shape for a single key.
     # FOG
     [[ -z ${FOG_install_type} ]] && FOG_install_type="$installtype"
@@ -4571,7 +4571,7 @@ enableInitScript() {
                         #
                         # The runlevel is named rather than left to default to
                         # the current one: an install run from a rescue or
-                        # single-user shell would otherwise enrol the daemons
+                        # single-user shell would otherwise enroll the daemons
                         # in a runlevel that never comes up on boot.
                         dots "Enabling $serviceItem Service"
                         rc-update add $serviceItem default >>$error_log 2>&1
@@ -5752,7 +5752,7 @@ _resolveSelfCacert() {
 #
 # FOG's PKI already reaches every consumer it can address directly: fog-client
 # pins ca.cert.der, iPXE gets the CA compiled into the binary at build time,
-# Secure Boot enrols a MOK. The host's own TLS clients were the gap. curl,
+# Secure Boot enrolls a MOK. The host's own TLS clients were the gap. curl,
 # wget, PHP's stream wrapper and the node-to-master status calls all read the
 # system store, and nothing had ever told that store about the CA this
 # installer mints -- so on the FOG server itself every HTTPS call to the FOG
@@ -6218,7 +6218,7 @@ configureStorage() {
     # `file_type` attribute that fog_share_t carries. The lab's audit log
     # agrees -- zero nfsd_t denials across months of imaging.
     #
-    # $storageLocationCapture is labelled separately because .fogsettings can
+    # $storageLocationCapture is labeled separately because .fogsettings can
     # relocate it out from under ${STORAGE_image_share_path}, in which case the recursive
     # fcontext registered for ${STORAGE_image_share_path} would not cover it.
     setSELinuxContext "${STORAGE_image_share_path}" fog_share_t
@@ -6427,7 +6427,7 @@ writeUpdateFile() {
         # its polarity, so the migration copies the value across with no
         # inversion. It names the reason rather than the mechanic: yes means TFTP
         # lives elsewhere, so skip the rebuild -- and it still reads correctly
-        # against the firewall behaviour, where an external TFTP server means
+        # against the firewall behavior, where an external TFTP server means
         # 69/udp stays closed.
         BOOT_external_tftp_server BOOT_tftp_options
         # Seconds of pre-DHCP sleep written into autoexec.ipxe, for switches
@@ -6696,7 +6696,7 @@ writeUpdateFile() {
             # marker would end up describing nothing, and the file would read as
             # a pile of appended keys after "## End of FOG Settings".
             #
-            # Unrecognised lines still have to survive. Hand-set keys
+            # Unrecognized lines still have to survive. Hand-set keys
             # (inetConnectTimeout, inetMaxTime, storageLocationCapture,
             # ftppasvmin/max, mcastportmin/max) work ONLY because the merge
             # preserves lines it does not know about; a plain fresh write would
@@ -6988,7 +6988,7 @@ validateExternalCA() {
             ;;
         *)
             echo
-            echo "  Note: the imported CA uses ${certalgorithm:-an unrecognised algorithm}${certcurve:+ (${certcurve})}."
+            echo "  Note: the imported CA uses ${certalgorithm:-an unrecognized algorithm}${certcurve:+ (${certcurve})}."
             echo "  iPXE can only verify RSA and ECDSA P-256/P-384 signatures, so HTTPS"
             echo "  netboot will fail against this CA. The web UI and fog-client are"
             echo "  unaffected. Use HTTP netboot, serve netboot from a publicly-trusted"
@@ -7013,7 +7013,7 @@ validateExternalCA() {
     fi
 }
 # GH-529: the vhost templates and the docroot symlink both need ${WEB_root} in a
-# form other than the "/x/" one installfog.sh normalises to, so derive them in
+# form other than the "/x/" one installfog.sh normalizes to, so derive them in
 # one place rather than in each consumer. Idempotent -- callers invoke it
 # without caring whether an earlier one already has.
 #
@@ -7023,7 +7023,7 @@ validateExternalCA() {
 #                          dot is a legitimate path character but a wildcard
 #
 # The default is repeated here because functions.sh is also sourced by the
-# utils scripts, which never run installfog.sh's normalisation.
+# utils scripts, which never run installfog.sh's normalization.
 normalizeWebroot() {
     [[ -z ${WEB_root} ]] && WEB_root="/fog/"
     webrootbare="${WEB_root#/}"
@@ -7730,7 +7730,7 @@ _collectPkiNames() {
 # ASKED ONCE, which is what $priorInstall enforces. Everything else here is
 # run-scoped -- the s* shadows are this run's flags -- so before that line there
 # was nothing in the guard that could remember an answer, and every interactive
-# upgrade got the menu again. That was not merely repetitive: any unrecognised
+# upgrade got the menu again. That was not merely repetitive: any unrecognized
 # reply including a bare Enter takes the `standard` default below, and
 # _applyInstallMode then wrote it straight over a public-cert or embed-ca
 # server's keys, which writeUpdateFile persisted. The prompt reverted the very
@@ -7886,7 +7886,7 @@ _reportNetbootProto() {
     echo "   network."
     echo
     echo " * Secure Boot binaries ARE staged on this server, in every mode."
-    echo "   That used to be skipped on any HTTPS install. To enrol a machine,"
+    echo "   That used to be skipped on any HTTPS install. To enroll a machine,"
     echo "   boot it and choose 'Enroll Secure Boot Key' from the FOG menu."
     echo
     echo " * To move netboot onto HTTPS, tell FOG which is true:"
@@ -8050,7 +8050,7 @@ $(_nameConstraints)" "FOG Web UI"
         #
         # The -s fallback keeps a fresh install working when there is no chain
         # on disk yet: a chain built from the wrong root is still better than
-        # no chain at all, and that is the pre-existing behaviour.
+        # no chain at all, and that is the pre-existing behavior.
         if _rootIssuedWebCA || [[ ! -s ${PKI_web_trust_chain} ]]; then
             cat "${PKI_web_ca_cert}" "${PKI_root_ca_cert}" > "${PKI_web_trust_chain}" 2>>$error_log
             chmod 0644 "${PKI_web_trust_chain}" >>$error_log 2>&1
@@ -9016,7 +9016,7 @@ createSSLCA() {
     # leave the web server unable to start.
     #
     # No prompt. Under -y there is nobody to ask, and that is exactly the run
-    # that used to do the damage silently, so the safe behaviour has to be the
+    # that used to do the damage silently, so the safe behavior has to be the
     # DEFAULT rather than an answer. Everything needed is already on disk: the
     # vhost names the files and the certificate names itself.
     if ! _externallyManagedLeaf; then
@@ -9266,7 +9266,7 @@ EOF
     errorStat $?
     # "Forced SSL" describes the REDIRECT, so it follows httpsRedirect. Left on
     # httpproto it would print on every install, since httpproto is https for
-    # everyone now -- labelling a plain HTTPS-available server as one that
+    # everyone now -- labeling a plain HTTPS-available server as one that
     # forces HTTPS, which is the opposite of what this line is for.
     [[ ${WEB_https_redirect} == yes ]] && sslenabled=" (Forced SSL)" || sslenabled=" (normal)"
     # ${PKI_san_dns_names} is a space-joined string (see --extra-server-name).
@@ -9476,7 +9476,7 @@ EOF
                         #                       relative to boot.php's own URI),
                         #                       refind, grub, the menu artwork.
                         #   service/secureboot/ MOK.der, which IpxeBootMenu imgfetches
-                        #                       so MokManager can enrol it from
+                        #                       so MokManager can enroll it from
                         #                       memory, and mmx64.efi /
                         #                       arm64-efi/mmaa64.efi, which it
                         #                       chains. See IpxeBootMenu's Secure
@@ -10344,7 +10344,7 @@ configureHttpd() {
         # the new tree is about to be written over that exact path.
         # $priorwebdir is somewhere else the admin chose, and it was already
         # being left behind before this fix -- backing it up is the gain here,
-        # and deleting it would be a new behaviour nobody asked for.
+        # and deleting it would be a new behavior nobody asked for.
         cp -RT "$priorwebdir" "${DB_backup_path}/fog_web_${version}.BACKUP" >>$error_log 2>&1
         webbackedup=1
         rm -rf ${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol
@@ -10733,7 +10733,7 @@ class Config
     #
     # Regenerated on every install/upgrade. If it is missing (pre-850 install,
     # or a hand-copied web tree) the PHP side falls back to /opt/fog, which is
-    # exactly the behaviour before this change.
+    # exactly the behavior before this change.
     echo "<?php
 /**
  * Filesystem paths chosen at install time.
@@ -10999,7 +10999,7 @@ downloadfiles() {
 # The gap this closes: --secure-boot-key/--secure-boot-cert are persisted to
 # .fogsettings verbatim and _ensureSecureBootKeys() then trusts that path
 # forever, but nothing ever copies the file anywhere. An admin who parks the
-# pair under $webdirdest -- not unreasonable, it is where the enrolment kit is
+# pair under $webdirdest -- not unreasonable, it is where the enrollment kit is
 # published -- loses it to configureHttpd()'s rm -rf $webdirdest, in the SAME
 # run that first accepted the flags, before _resignKernels() ever reads it.
 #
@@ -11043,7 +11043,7 @@ preserveSecureBootAdminFiles() {
     fi
     chown root:root "$destkey" "$destcert" >>$error_log 2>&1
     # Key restricted, certificate public by design -- it is the thing handed
-    # out for enrolment. Mirrors _ensureSecureBootKeys()'s own permissions.
+    # out for enrollment. Mirrors _ensureSecureBootKeys()'s own permissions.
     chmod 0600 "$destkey" >>$error_log 2>&1
     chmod 0644 "$destcert" >>$error_log 2>&1
     PKI_sb_codesign_key="$destkey"
@@ -11054,14 +11054,14 @@ preserveSecureBootAdminFiles() {
 #
 # Signing used to require --secure-boot-key/--secure-boot-cert, which meant it
 # was off unless someone already knew to ask for it -- so on a stock server the
-# Secure Boot page had no fingerprint to show and no enrolment kit to hand out,
+# Secure Boot page had no fingerprint to show and no enrollment kit to hand out,
 # and the feature was effectively invisible. Generating a key by default makes
 # it present everywhere; enrolling it on a client is still a deliberate act by
 # someone physically at the machine, so defaulting this on grants no trust by
 # itself.
 #
 # The key NEVER regenerates once it exists. A fresh key silently invalidates
-# enrolment on every machine that already trusted the old one, and nothing
+# enrollment on every machine that already trusted the old one, and nothing
 # surfaces that until a client fails to boot -- long after the install that
 # caused it. So an existing pair is always reused, and --recreate-keys
 # deliberately does not reach this.
@@ -11265,7 +11265,7 @@ _ensureSecureBootKeys() {
     # appended PE signature is inert on a machine booting with Secure Boot off
     # -- which is every machine on an opted-out server -- and costs nothing.
     # Leaving the binaries unsigned instead only means that the day anyone does
-    # enrol, or moves one of these files onto a machine that already has Secure
+    # enroll, or moves one of these files onto a machine that already has Secure
     # Boot on, the file is useless and nothing on this server can fix it without
     # a re-install.
     #
@@ -11273,7 +11273,7 @@ _ensureSecureBootKeys() {
     # now answers yes on every server, and _signLocalIpxe/_resignRefind/
     # _resignKernels/_resignCustomKernels sign unconditionally. The opt-out is
     # re-applied in _ensureSecureBootPlatformKeys and _publishSecureBootKit,
-    # which are the two functions that publish enrolment material.
+    # which are the two functions that publish enrollment material.
     #
     # An admin-supplied pair always wins and is never touched or overwritten.
     # Their certificate is also what gets enrolled, exactly as before -- an
@@ -11317,7 +11317,7 @@ _ensureSecureBootKeys() {
     #
     # Deliberately NOT guarded on the flat MOK's absence. A server that already
     # generated a self-signed MOK is moved onto the intermediate too, and any
-    # machine that enrolled the old key has to enrol once more -- which is the
+    # machine that enrolled the old key has to enroll once more -- which is the
     # whole reason this lands before Secure Boot reaches a stable release. The
     # flat MOK is a signing certificate that can issue nothing, so leaving a
     # server on it means it can never rotate a signing key, and never let a
@@ -11331,7 +11331,7 @@ _ensureSecureBootKeys() {
         # no "Enroll Secure Boot Key" menu item, so both routes this names are
         # absent and the notice would only send an admin looking for a 404. The
         # keys are still minted and the binaries still signed -- see the top of
-        # this function -- there is simply nothing to enrol them with yet.
+        # this function -- there is simply nothing to enroll them with yet.
         if [[ -f $key && -f $cert && ${PKI_sb_enabled:-yes} == yes ]]; then
             echo
             echo "  ###################################################################"
@@ -11340,7 +11340,7 @@ _ensureSecureBootKeys() {
             echo "  # rotated and storage nodes can sign without holding the fleet's  #"
             echo "  # one trusted key.                                                #"
             echo "  #                                                                 #"
-            echo "  # Any machine that already enrolled the previous MOK must enrol    #"
+            echo "  # Any machine that already enrolled the previous MOK must enroll    #"
             echo "  # once more. After that, no future signing-key change needs a     #"
             echo "  # firmware trip.                                                  #"
             echo "  #                                                                 #"
@@ -11410,11 +11410,11 @@ EOF
     chown root:root "$key" "$cert" >>$error_log 2>&1
     chmod 0600 "$key" >>$error_log 2>&1
     # The certificate is public by design -- it is the thing published in the
-    # enrolment kit -- so only the key is restricted.
+    # enrollment kit -- so only the key is restricted.
     chmod 0644 "$cert" >>$error_log 2>&1
     PKI_sb_codesign_key="$key"
     PKI_sb_codesign_cert="$cert"
-    # Flat: the signing certificate IS what firmware enrols.
+    # Flat: the signing certificate IS what firmware enrolls.
     PKI_sb_ca_cert="$cert"
     echo "Done"
 }
@@ -11422,8 +11422,8 @@ EOF
 #
 # Separate from _ensureSecureBootKeys because these are a different kind of key
 # doing a different job. MOK.key signs FOS kernels. PK/KEK sign nothing that ever
-# executes -- they exist only to authorise updates to a client's own Secure Boot
-# databases, which is what makes the automatic (Setup Mode) enrolment path in
+# executes -- they exist only to authorize updates to a client's own Secure Boot
+# databases, which is what makes the automatic (Setup Mode) enrollment path in
 # fos ADR-0009 possible at all.
 #
 # Why the server needs its own PK when a client in Setup Mode enforces nothing:
@@ -11453,12 +11453,12 @@ _ensureSecureBootPlatformKeys() {
     # The platform keys exist for one job -- signing the PK/KEK/db variable
     # updates a client writes in Setup Mode -- so this is one of the two places
     # the ${PKI_sb_enabled} opt-out is applied. Signing keys are minted regardless
-    # (see _ensureSecureBootKeys); enrolment material is not. Blanked rather
+    # (see _ensureSecureBootKeys); enrollment material is not. Blanked rather
     # than merely skipped so _publishSecureBootAuthVars takes its "no platform
     # keys" branch and clears any blobs a previous, non-opted-out run left.
     [[ ${PKI_sb_enabled:-yes} != yes ]] && return 0
     # No signing key means the whole feature is opted out; there is nothing for
-    # a platform key to authorise.
+    # a platform key to authorize.
     [[ -z ${PKI_sb_codesign_key} || -z ${PKI_sb_codesign_cert} ]] && return 0
 
     # An install that already ran the flat ${fogprogramdir}/secureboot layout
@@ -11503,7 +11503,7 @@ _ensureSecureBootPlatformKeys() {
             -keyout "$kekKey" -out "$kekCert" >>$error_log 2>&1; then
         echo "Failed"
         echo " * Could not generate the Secure Boot platform keys. Automatic"
-        echo "   enrolment will be unavailable; the MOK paths are unaffected."
+        echo "   enrollment will be unavailable; the MOK paths are unaffected."
         echo "   See $error_log."
         rm -f "$pkKey" "$pkCert" "$kekKey" "$kekCert" >>$error_log 2>&1
         return 0
@@ -11517,7 +11517,7 @@ _ensureSecureBootPlatformKeys() {
     secureBootKEKCert="$kekCert"
     echo "Done"
 }
-# Publish the MOK enrolment kit under the web root.
+# Publish the MOK enrollment kit under the web root.
 #
 # Only the *certificate* is published -- it is public by design, and is the
 # thing you are meant to distribute. The private key stays where the admin put
@@ -11529,7 +11529,7 @@ _publishSecureBootKit() {
 
     # MOK.der publishes the certificate to be ENROLLED, which is not always the
     # one that signs. In split mode that is the Secure Boot intermediate, so a
-    # rotated signing leaf never invalidates an enrolment; in flat mode
+    # rotated signing leaf never invalidates an enrollment; in flat mode
     # ${PKI_sb_ca_cert} is the same file as ${PKI_sb_codesign_cert} and this is
     # byte-identical to before.
     #
@@ -11544,7 +11544,7 @@ _publishSecureBootKit() {
         return 0
     fi
 
-    dots "Publishing Secure Boot enrolment kit"
+    dots "Publishing Secure Boot enrollment kit"
     mkdir -p "$kitdir" >>$error_log 2>&1
     # The intermediate case already has a canonical DER sibling next to
     # .fogSBCA.pem in the PKI zone dir (see createSecureBootIntermediateCA) --
@@ -11663,7 +11663,7 @@ _ensureEfitools() {
 }
 # Build and publish the signed PK/KEK/db variable updates.
 #
-# These are what a client in Setup Mode writes to enrol this server's
+# These are what a client in Setup Mode writes to enroll this server's
 # certificate automatically -- no MokManager, no password, no USB stick. See fos
 # ADR-0009 for why Setup Mode is the only path that scales.
 #
@@ -11690,12 +11690,12 @@ _publishSecureBootAuthVars() {
     fi
 
     # No platform keys means no automatic path. Clear any blobs from a previous
-    # install rather than leaving stale ones a client would happily enrol: an
-    # .auth signed by a key this server no longer holds enrols a platform the
+    # install rather than leaving stale ones a client would happily enroll: an
+    # .auth signed by a key this server no longer holds enrolls a platform the
     # server can never update again.
     #
     # This used to return in silence, which made it the ONE cause of "automatic
-    # enrolment is unavailable" that produced no diagnostic anywhere -- and it
+    # enrollment is unavailable" that produced no diagnostic anywhere -- and it
     # is the likeliest cause on a server that has efitools installed. An admin
     # re-running the installer to fix it therefore saw nothing at all, then read
     # a web page confidently naming a different cause (GH-1266). It says which
@@ -11705,20 +11705,20 @@ _publishSecureBootAuthVars() {
         dots "Publishing Secure Boot variable updates"
         echo "Skipped"
         if [[ ${PKI_sb_enabled:-yes} != yes ]]; then
-            echo " * Secure Boot enrolment material is switched off for this"
+            echo " * Secure Boot enrollment material is switched off for this"
             echo "   install (PKI_sb_enabled is not \"yes\"), so no platform keys"
-            echo "   were minted and the automatic enrolment blobs were not"
+            echo "   were minted and the automatic enrollment blobs were not"
             echo "   built. FOS kernels are still signed."
         elif [[ -z ${PKI_sb_codesign_key} || -z ${PKI_sb_codesign_cert} ]]; then
             echo " * No Secure Boot signing key is configured, so there is"
-            echo "   nothing for a platform key to authorise and the automatic"
-            echo "   enrolment blobs were not built."
+            echo "   nothing for a platform key to authorize and the automatic"
+            echo "   enrollment blobs were not built."
         else
             echo " * The Secure Boot platform keys (PK/KEK) are missing, so the"
-            echo "   automatic enrolment blobs were not built. Generating them"
+            echo "   automatic enrollment blobs were not built. Generating them"
             echo "   failed earlier in this run -- see $error_log."
         fi
-        echo "   The MOK enrolment paths are unaffected."
+        echo "   The MOK enrollment paths are unaffected."
         return 0
     fi
 
@@ -11728,8 +11728,8 @@ _publishSecureBootAuthVars() {
        ! command -v sign-efi-sig-list >/dev/null 2>&1; then
         echo "Skipped"
         echo " * efitools is not installed and could not be built from source,"
-        echo "   so the automatic Secure Boot enrolment blobs were not built."
-        echo "   See ${error_log}. The MOK enrolment paths are unaffected."
+        echo "   so the automatic Secure Boot enrollment blobs were not built."
+        echo "   See ${error_log}. The MOK enrollment paths are unaffected."
         rm -f "${kitdir}"/{PK,KEK,db}.auth >>$error_log 2>&1
         return 0
     fi
@@ -11753,7 +11753,7 @@ _publishSecureBootAuthVars() {
         # The only arm here that used to print a bare "Failed" with no cause,
         # which is the same complaint as GH-1266 one line down.
         echo " * Could not install the Secure Boot variable builder to $helper,"
-        echo "   so automatic enrolment will be unavailable. The MOK enrolment"
+        echo "   so automatic enrollment will be unavailable. The MOK enrollment"
         echo "   paths are unaffected. See $error_log."
         return 0
     }
@@ -11768,7 +11768,7 @@ _publishSecureBootAuthVars() {
     if ! "$helper" >>$error_log 2>&1; then
         echo "Failed"
         echo " * Could not build the Secure Boot variable updates, so automatic"
-        echo "   enrolment will be unavailable. The MOK enrolment paths are"
+        echo "   enrollment will be unavailable. The MOK enrollment paths are"
         echo "   unaffected. See $error_log."
         rm -f "${kitdir}"/{PK,KEK,db}.auth >>$error_log 2>&1
         return 0
@@ -11777,7 +11777,7 @@ _publishSecureBootAuthVars() {
     chmod 0644 "${kitdir}"/{PK,KEK,db}.auth >>$error_log 2>&1
     echo "Done"
 }
-# Normalise --secure-boot-cert to PEM and echo the path.
+# Normalize --secure-boot-cert to PEM and echo the path.
 #
 # sbsign and sbverify read certificates with PEM_read_bio_X509 and reject DER
 # outright:
@@ -11793,7 +11793,7 @@ _publishSecureBootAuthVars() {
 #
 # Convert once here rather than pushing the distinction onto the user: the flag
 # accepts either, _resignKernels and the signing helper get PEM, and
-# _publishSecureBootKit still converts to DER for enrolment.
+# _publishSecureBootKit still converts to DER for enrollment.
 _secureBootCertPem() {
     local pem="${fogprogramdir}/.fog-secureboot.pem"
     [[ -z ${PKI_sb_codesign_cert} ]] && return 1
@@ -11871,7 +11871,7 @@ _installSecureBootSigner() {
     fi
     # Root-owned, root-readable only: the web user learns nothing about where
     # the key lives, and cannot rewrite these paths to point somewhere else.
-    # SECUREBOOT_CERT is the normalised PEM -- sbsign cannot read DER.
+    # SECUREBOOT_CERT is the normalized PEM -- sbsign cannot read DER.
     #
     # The PK/KEK/mscerts/authvars lines are for fog-build-sb-authvars, not for
     # fog-sign-kernel, which ignores them. They live in the same file because
@@ -12039,7 +12039,7 @@ _resignKernels() {
 # signature to a file that grows forever.
 #
 # secureBootMokCert may be the DER copy an admin passed to --secureboot-ca-cert,
-# and sbverify takes PEM only -- same normalisation _secureBootCertPem() does
+# and sbverify takes PEM only -- same normalization _secureBootCertPem() does
 # for the signing cert, against a separate filename so the two cannot clobber
 # each other.
 _secureBootAnchorPem() {
@@ -12172,9 +12172,9 @@ _restampIpxeManifest() {
 # binary carrying iPXE's own NIC drivers, and that one is ours. Once shim has run
 # its security policy override stays installed for the rest of the boot, so a
 # MOK-signed image loads, and the MOK is the one _publishSecureBootKit() already
-# publishes and clients already enrol.
+# publishes and clients already enroll.
 #
-# This is NOT on the netboot path and must not become one. Enrolment depends on
+# This is NOT on the netboot path and must not become one. Enrollment depends on
 # an un-enrolled machine reaching the FOG menu to run MokManager, and a
 # MOK-signed binary there could not load, because the MOK is not enrolled yet.
 # Signing in place is safe for the same reason it is invisible: an appended PE
@@ -12188,7 +12188,7 @@ _restampIpxeManifest() {
 # an HTTPS-with-your-own-CA install has already compiled locally before this runs.
 #
 # Runs on every server, including one that passed --no-secureboot: that flag
-# declines enrolment, not signatures. See _ensureSecureBootKeys.
+# declines enrollment, not signatures. See _ensureSecureBootKeys.
 _signLocalIpxe() {
     [[ -z ${PKI_sb_codesign_key} || -z ${PKI_sb_codesign_cert} ]] && return 0
     local tftproot="${tftpdirdst%/}"
@@ -12331,7 +12331,7 @@ _signLocalIpxe() {
 # the volume fallback, for an ESP whose contents were unpacked at the top level.
 #
 # A folder that exists but holds no *.efi does NOT get one: on an HTTPS-only
-# install the enrolment material still lands in secureboot-upstream/ while no shim
+# install the enrollment material still lands in secureboot-upstream/ while no shim
 # does, and a script beside no binary implies a route the archive does not have.
 #
 # EVERY COPY IS IDENTICAL, from _espAutoexecScript(). That is the fix for what
@@ -12357,7 +12357,7 @@ _signLocalIpxe() {
 # made at download time. With the script on disk it is two lines of text, so
 # every copy carries them commented out, and --boot-delay writes them live --
 # exactly what _applyBootDelay() already does to the TFTP copy for netboot
-# clients. Six archives become three, one behaviour, one place to look.
+# clients. Six archives become three, one behavior, one place to look.
 #
 # ---------------------------------------------------------------------------
 #
@@ -12412,14 +12412,14 @@ _signLocalIpxe() {
 # configuration, so no SNP device existed. See the README's troubleshooting note.
 #
 # MokManager ships too. shim launches mm<arch>.efi FROM ITS OWN DIRECTORY when
-# it cannot verify the next stage, and that is the only way to enrol a MOK --
+# it cannot verify the next stage, and that is the only way to enroll a MOK --
 # shim's MokList is a boot-services-only variable, so nothing in a running OS
 # can write it. Without mmx64.efi beside the shim, an ESP that has not been
 # enrolled yet is a dead end with no route out of it. Found the hard way: it had
 # to be downloaded by hand.
 #
 # MOK.der ships WITH it, which the first implementation missed. MokManager
-# enrols by browsing the ESP for a certificate, so shipping MokManager without
+# enrolls by browsing the ESP for a certificate, so shipping MokManager without
 # one is still a dead end -- it just fails one screen later.
 #
 # PK/KEK/db.auth ship as well, and they are what make the i386 archive worth
@@ -12470,7 +12470,7 @@ _signLocalIpxe() {
 #   fog-ipxe-customca/        the same builds with this server's CA embedded.
 #                             Only exists where --rebuild-ipxe-with-my-ca ran.
 #   secureboot-upstream/      upstream's Microsoft-signed shim and the loader it
-#                             hands to, unmodified. Nothing to enrol.
+#                             hands to, unmodified. Nothing to enroll.
 #   secureboot-fog/           upstream's shims with FOG's build standing in as
 #                             the second stage. For Secure Boot with the MOK
 #                             enrolled, or Secure Boot off, keeping the shim.
@@ -12488,7 +12488,7 @@ _signLocalIpxe() {
 # Secure Boot signing decides whether firmware or shim will load the image at all.
 # _signLocalIpxe() signs every *.efi under the TFTP root with the same key,
 # stock/ included, so both variants behave identically under Secure Boot and one
-# enrolment covers either.
+# enrollment covers either.
 #
 # WHAT THIS COSTS: roughly 16MB against the ~7MB of the two-folder layout, from
 # five FOG binaries duplicated for the CA variant plus two shims and a binary in
@@ -12501,7 +12501,7 @@ _espKitFiles() {
         i386)
             fogdir="i386-efi/"
             # No shim, loader or MokManager: upstream signs none for ia32. The
-            # archive is still built, because db enrolment needs no shim -- see
+            # archive is still built, because db enrollment needs no shim -- see
             # the header.
             sbdir=""
             ;;
@@ -12635,8 +12635,8 @@ _espFileRole() {
         autoexec.ipxe|*/autoexec.ipxe)    echo "boot-script" ;;
         refind/*.efi)                     echo "chainloader" ;;
         refind/refind.conf)               echo "config" ;;
-        */MOK.der)                        echo "enrolment-cert" ;;
-        */PK.auth|*/KEK.auth|*/db.auth)   echo "enrolment-var" ;;
+        */MOK.der)                        echo "enrollment-cert" ;;
+        */PK.auth|*/KEK.auth|*/db.auth)   echo "enrollment-var" ;;
         */fog-enroll-mok.*)               echo "helper" ;;
         README.txt|MANIFEST.json)         echo "doc" ;;
         *)                                echo "other" ;;
@@ -12667,7 +12667,7 @@ _espFileNote() {
         secureboot-fog*/snponly.efi|secureboot-fog*/ipxe.efi)
             echo "FOG's own all-drivers build, carrying an upstream filename so that the shim beside it will load it -- shim picks its second stage by name, and on many firmwares falls back to ipxe.efi whichever shim you launched, so the binary ships under both names. Needs FOG's certificate in MokList or db; with nothing enrolled shim rejects it. NOT upstream's loader despite the name." ;;
         secureboot-upstream/mmx64.efi|secureboot-upstream/mmaa64.efi|secureboot-fog*/mmx64.efi|secureboot-fog*/mmaa64.efi)
-            echo "MokManager. shim launches it from this directory when it cannot verify the next stage; enrol MOK.der beside it. Not optional -- nothing in a running OS can write shim's MokList. Note it is only invoked when a MOK request is already pending, so a first boot with nothing enrolled simply fails rather than offering to enrol." ;;
+            echo "MokManager. shim launches it from this directory when it cannot verify the next stage; enroll MOK.der beside it. Not optional -- nothing in a running OS can write shim's MokList. Note it is only invoked when a MOK request is already pending, so a first boot with nothing enrolled simply fails rather than offering to enroll." ;;
         fog-ipxe/fogipxe.efi)
             echo "FOG's build with all of iPXE's own NIC drivers. Start here on firmware that offers no PXE boot option at all -- such firmware usually provides no UEFI SNP protocol either, so a binary needing one is no use to it. Boots directly with Secure Boot off, or with this server's certificate in db. A MOK does NOT help here: firmware never reads shim's MokList." ;;
         fog-ipxe-customca/fogipxe.efi)
@@ -12687,11 +12687,11 @@ _espFileNote() {
         refind/*.efi)
             echo "rEFInd, signed by this server. A boot manager that finds and boots whatever OS is installed locally. Not needed by the default exit type (sanboot hands straight back to firmware), but it is what the refind_efi exit type chainloads, and it is here so an ESP assembled from this archive carries every route off FOG rather than only the configured one." ;;
         */MOK.der)
-            echo "This server's certificate in DER form, and it does TWO jobs. MokManager enrols it, which makes the shim routes work. It is also the certificate to put in db, which is what lets FOG's binaries boot directly with no shim -- and when you enrol through the FIRMWARE's own tool, or a hypervisor setting, db on its own is enough because that write is unauthenticated. Enrolling from a running OS instead (FOG's task, a Linux tool, PowerShell) is a User Mode write that must be authenticated by a KEK-signed update, so that route needs the full PK/KEK/db set. It is the intermediate that FOG's signatures carry via sbsign --addcert, so this one certificate covers every FOG binary and the signing leaf can rotate without re-enrolling." ;;
+            echo "This server's certificate in DER form, and it does TWO jobs. MokManager enrolls it, which makes the shim routes work. It is also the certificate to put in db, which is what lets FOG's binaries boot directly with no shim -- and when you enroll through the FIRMWARE's own tool, or a hypervisor setting, db on its own is enough because that write is unauthenticated. Enrolling from a running OS instead (FOG's task, a Linux tool, PowerShell) is a User Mode write that must be authenticated by a KEK-signed update, so that route needs the full PK/KEK/db set. It is the intermediate that FOG's signatures carry via sbsign --addcert, so this one certificate covers every FOG binary and the signing leaf can rotate without re-enrolling." ;;
         */PK.auth|*/KEK.auth|*/db.auth)
-            echo "Signed EFI variable update, for FOG's unattended enrolment task, which writes all of them from a client in Setup/Custom Mode. NOT what a firmware menu or a hypervisor wants -- those take a plain DER certificate, so use MOK.der there. Replacing db with this keeps Microsoft's CAs and so still boots Windows, but appending MOK.der to the existing db is the lower-risk operation." ;;
+            echo "Signed EFI variable update, for FOG's unattended enrollment task, which writes all of them from a client in Setup/Custom Mode. NOT what a firmware menu or a hypervisor wants -- those take a plain DER certificate, so use MOK.der there. Replacing db with this keeps Microsoft's CAs and so still boots Windows, but appending MOK.der to the existing db is the lower-risk operation." ;;
         */fog-enroll-mok.sh|*/fog-enroll-mok.desktop)
-            echo "Enrols MOK.der via mokutil from a booted Linux OS. Not read by firmware; it is here so one folder carries every enrolment route." ;;
+            echo "Enrolls MOK.der via mokutil from a booted Linux OS. Not read by firmware; it is here so one folder carries every enrollment route." ;;
         README.txt)
             echo "What this archive is and how to use it." ;;
         *)  echo "" ;;
@@ -12828,7 +12828,7 @@ ESPWALK
 # root, which is what motivated the ladder originally. That script and this one
 # are byte-identical; three variables were uncontrolled across those runs and all
 # three have since been individually eliminated -- mounted install media, db/KEK
-# enrolment state, and which shim/loader pair was used. Treat that failure as
+# enrollment state, and which shim/loader pair was used. Treat that failure as
 # unexplained rather than as evidence for a chain.
 _espAutoexecScript() {
     cat <<'ESPAUTOEXEC'
@@ -12889,7 +12889,7 @@ ESPINTRO
 WHICH FOLDER
 ------------
   Machine PXE boots normally
-      -> secureboot-upstream\   Upstream's shim and loader, nothing to enrol.
+      -> secureboot-upstream\   Upstream's shim and loader, nothing to enroll.
 
   No PXE boot option, or firmware provides no SNP
       -> fog-ipxe\              FOG's builds carry iPXE's own NIC drivers and
@@ -12925,9 +12925,9 @@ TWO THINGS THAT SURPRISE PEOPLE
   A MOK does nothing for fog-ipxe\. MokList belongs to shim; firmware never
   reads it. Booting FOG's binary directly under Secure Boot needs db.
 
-  With nothing enrolled, secureboot-fog\ does not offer to enrol -- it just
+  With nothing enrolled, secureboot-fog\ does not offer to enroll -- it just
   fails. shim only launches MokManager when a request is already pending, and
-  nothing here stages one. Enrol first, then boot.
+  nothing here stages one. Enroll first, then boot.
 ESPPICK
     else
         cat <<'ESPPICKNOSB'
@@ -12959,7 +12959,7 @@ THE FOLDERS
 $(if [[ $haveloader -eq 1 ]]; then cat <<'ESPFLD1'
   secureboot-upstream\   Upstream's Microsoft-signed shims and the loaders they
                          hand to, unmodified, plus MokManager and this server's
-                         enrolment material. Boot snponly-shimx64.efi or
+                         enrollment material. Boot snponly-shimx64.efi or
                          ipxe-shimx64.efi.
   secureboot-fog\        The same shims, but FOG's own build stands in as the
                          second stage. It appears twice, as ipxe.efi and as
@@ -13049,7 +13049,7 @@ fi)
         so nothing has to vouch for it. Confirmed: MOK.der added to db by itself,
         then FOG's signed binary booted directly with no shim.
 
-        From a running OS -- FOG's enrolment task, a Linux tool, PowerShell's
+        From a running OS -- FOG's enrollment task, a Linux tool, PowerShell's
         Secure Boot cmdlets -- expect to need PK, KEK and db together. In User
         Mode a db write must be authenticated by a KEK-signed update, and the
         machine only trusts FOG's KEK if FOG's PK is enrolled too. That is what
@@ -13074,7 +13074,7 @@ fi)
       Changing db is measured into TPM PCR 7, so it can trigger BitLocker
       recovery. Suspend BitLocker first on machines that use it.
 
-PK.auth, KEK.auth and db.auth are for FOG's own unattended enrolment task, which
+PK.auth, KEK.auth and db.auth are for FOG's own unattended enrollment task, which
 writes all of them from a client in Setup/Custom Mode. They are not what a
 firmware menu or a hypervisor wants.
 $(if [[ $haverefind -eq 1 ]]; then cat <<'ESPREFIND'
@@ -13205,9 +13205,9 @@ _espKernelsJson() {
 # That is also why this lives at service/localboot/ rather than under
 # service/secureboot/: _publishSecureBootKit() rm -rf's its whole kit directory
 # when it has no MOK to publish, which would take this with it on exactly the
-# servers that still want it. The enrolment material it publishes is COPIED into
+# servers that still want it. The enrollment material it publishes is COPIED into
 # each archive rather than linked, so an archive stays self-contained and a
-# server that later opts out of enrolment cannot dangle a reference inside one.
+# server that later opts out of enrollment cannot dangle a reference inside one.
 #
 # COPIES, never a symlink to $tftpdirdst, which was the first design. SELinux
 # labels the TFTP tree tftpdir_t and httpd_t has no rule permitting it to read
@@ -13309,13 +13309,13 @@ _publishLocalBootFiles() {
             rm -rf "$staged" >>$error_log 2>&1
             continue
         fi
-        # Whatever enrolment material this server actually published. Taken
+        # Whatever enrollment material this server actually published. Taken
         # by existence rather than by asking whether Secure Boot is
         # configured, so an opted-out server ships neither and a server with
         # only a MOK ships only that.
         #
         # The .auth set goes to secureboot-upstream/ only -- they belong to FOG's
-        # unattended enrolment task and are nothing a shim reads.
+        # unattended enrollment task and are nothing a shim reads.
         #
         # MOK.der goes to EVERY folder that holds a shim, because MokManager
         # browses for it and shim launches MokManager out of its own directory. A
@@ -13351,7 +13351,7 @@ _publishLocalBootFiles() {
         #
         # Driven off the folder holding a BOOTABLE BINARY, not merely existing.
         # The distinction is load-bearing: on an HTTPS-only install no shim
-        # stages, but the enrolment material still lands in secureboot-upstream/,
+        # stages, but the enrollment material still lands in secureboot-upstream/,
         # so that folder exists while containing nothing that could read a script.
         # A script beside no binary is a file that implies a route the archive
         # does not have.
@@ -13386,7 +13386,7 @@ _publishLocalBootFiles() {
         #
         # Both writers change directory into the staged tree, which means
         # $bootdir has to be absolute. It always is -- ${WEB_docroot} is a distro
-        # default under / and --docroot is normalised with a leading slash
+        # default under / and --docroot is normalized with a leading slash
         # (installfog.sh) -- but that is the dependency to keep in mind if
         # docroot handling changes. Both recurse, so local/, secureboot/ and
         # refind/ need nothing extra here.

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -170,7 +170,7 @@ case ${FOG_install_type} in
                 *)
                     # Cleared so the loop re-prompts. Before the read targeted
                     # this key it was always empty here and always matched ""
-                    # above, so an unrecognised answer could not survive; now it
+                    # above, so an unrecognized answer could not survive; now it
                     # can, and a non-empty one would end the loop.
                     DHCP_enabled=""
                     echo "  Invalid input, please try again."
@@ -268,7 +268,7 @@ case ${FOG_install_type} in
                     ;;
                 *)
                     # See the DHCP_enabled loop above: cleared so an
-                    # unrecognised answer re-prompts instead of ending the loop.
+                    # unrecognized answer re-prompts instead of ending the loop.
                     FOG_install_lang=""
                     echo "  Invalid input, please try again."
                     ;;
@@ -311,5 +311,5 @@ esac
 # consequences instead of hidden behind one yes/no. Two prompts covering the
 # same ground could also contradict each other.
 #
-# (The old text pointed at wiki.fogproject.org, which has been retired in favour
+# (The old text pointed at wiki.fogproject.org, which has been retired in favor
 # of docs.fogproject.org.)

--- a/lib/common/newinput.sh
+++ b/lib/common/newinput.sh
@@ -64,7 +64,7 @@ fi
 [[ -z $systemHostname ]] && hostnameNeedsSystemSet=1
 while [[ -z ${NET_hostname} ]]; do
     if [[ -n $systemHostname ]]; then
-        # This machine knows its own name. Unchanged behaviour: suggest it,
+        # This machine knows its own name. Unchanged behavior: suggest it,
         # offer to override, and default to accepting it.
         if [[ -n $autoaccept ]]; then
             NET_hostname="$systemHostname"

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -115,7 +115,7 @@ class Initiator
         // being assumed. It is a bare define-only file precisely so it can be
         // pulled in here -- before the autoloader exists. Absent on a pre-850
         // install or a hand-copied web tree, in which case the /opt/fog
-        // fallback below keeps the previous behaviour.
+        // fallback below keeps the previous behavior.
         $fogPaths = __DIR__ . DS . 'fogpaths.php';
         if (is_readable($fogPaths)) {
             require_once $fogPaths;
@@ -316,7 +316,7 @@ class Initiator
         }
         // A directory we cannot write is worse than the shared one: every
         // session_start() would fail and nobody could log in at all. Fall back
-        // to PHP's configured path, which is exactly today's behaviour, and say
+        // to PHP's configured path, which is exactly today's behavior, and say
         // why -- a silent fallback here would look identical to the bug being
         // fixed.
         if (!is_dir(FOG_SESSION_DIR) || !is_writable(FOG_SESSION_DIR)) {
@@ -799,7 +799,7 @@ class Initiator
      * Namespace prefixes and classmap entries both, because a package can be
      * autoloaded either way -- PSR-4 for the normal case, a classmap for one
      * that predates it. `optimize-autoloader` adds a classmap without
-     * dropping the prefixes, so an optimised tree is caught by either.
+     * dropping the prefixes, so an optimized tree is caught by either.
      *
      * @param \Composer\Autoload\ClassLoader $loader The loader to inspect.
      *
@@ -883,7 +883,7 @@ class Initiator
      * replace core's Authorization on some installs and not others.
      *
      * Core winning makes the two plugin roots behave the same way, which is
-     * the behaviour the external-plugin case already had, and it is the only
+     * the behavior the external-plugin case already had, and it is the only
      * safe direction: a plugin must never be able to shadow a core class by
      * naming a file after it. Verified against the shipped tree at the time
      * of writing -- 396 scanned files, zero colliding basenames -- so this

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -4317,7 +4317,7 @@ $this->schema[] = [
 // 300
 $this->schema[] = [
     // Tasks never recorded when they reached their current state, so the
-    // task list's Recent view had nothing to sort completed/cancelled work
+    // task list's Recent view had nothing to sort completed/canceled work
     // by. Stamped on every state transition (Task::set + the mass-update
     // cancel/complete paths). NULL for rows that last changed state before
     // this upgrade; readers fall back to
@@ -4679,7 +4679,7 @@ $this->schema[] = [
     . "join credentials and the product key). Enter a comma separated list of "
     . "imaging networks in CIDR form and/or individual addresses, for example "
     . "10.0.0.0/8,192.168.5.20. Leave empty to allow any source, which is the "
-    . "default and matches the behaviour of earlier versions.','','Security')",
+    . "default and matches the behavior of earlier versions.','','Security')",
 ];
 // 316
 $this->schema[] = [
@@ -4772,7 +4772,7 @@ $this->schema[] = count($columnhostSecTokenPrev ?: []) ? [] : [
     // exit was an administrator pressing Reset Encryption Data.
     //
     // One generation of history closes that gap. A client whose reply went
-    // missing re-presents its previous token, is recognised, and is handed the
+    // missing re-presents its previous token, is recognized, and is handed the
     // current one again. The grace is retired as soon as the client proves it
     // holds the current token, so a stolen token does not stay valid
     // indefinitely.
@@ -4922,8 +4922,8 @@ $this->schema[] = [
     . "`ttKernelArgs`,`ttType`,`ttIsAdvanced`,`ttIsAccess`) "
     . "VALUES "
     . "(25, 'Enroll Secure Boot Key', 'Enroll Secure Boot Key will "
-    . "chain the client straight to the Secure Boot enrolment menu "
-    . "so a technician can enrol this FOG server\'s MOK without "
+    . "chain the client straight to the Secure Boot enrollment menu "
+    . "so a technician can enroll this FOG server\'s MOK without "
     . "hunting for it in the PXE boot menu. A technician still has "
     . "to be at the console: MokManager gives up after about 10 "
     . "seconds with no keypress and boots normally, and reboots if "
@@ -4932,7 +4932,7 @@ $this->schema[] = [
 ];
 // 323
 $this->schema[] = [
-    // Redefines task type 25 so it BOOTS FOS and performs the enrolment, rather
+    // Redefines task type 25 so it BOOTS FOS and performs the enrollment, rather
     // than chaining the client to MokManager and leaving it there.
     //
     // Step 322 above shipped it as "Enroll Secure Boot Key": a schedulable
@@ -4941,7 +4941,7 @@ $this->schema[] = [
     // answer before FOS could touch EFI variables at all. It can now, and the
     // two are for the same job, so this supersedes it rather than sitting
     // alongside it -- two near-identically named task types with different
-    // behaviour is a support burden nobody needs.
+    // behavior is a support burden nobody needs.
     //
     // Updated in a NEW step rather than by editing 322 in place: 322 has already
     // run on every 1.6 beta server, and a server does not re-run a step it has
@@ -4959,7 +4959,7 @@ $this->schema[] = [
     // _enrollSecureBootChoice() special case for this type is gone. PXE menu
     // item 14 and _enrollSecureBootChoice() itself both stay: chaining straight
     // to MokManager is still how a technician answers a pending request, or
-    // enrols from local FAT media on a machine FOS cannot boot.
+    // enrolls from local FAT media on a machine FOS cannot boot.
     //
     // ttIsAdvanced drops from '1' to '0': the old row hid behind Advanced
     // because it stranded the client at a firmware screen. This one completes on
@@ -4990,7 +4990,7 @@ $this->schema[] = [
     // Distinguishes pxeID 14 from the unattended item added in step 325
     // below. It has always chained straight to MokManager for a technician
     // to drive by hand; the plain "Enroll Secure Boot Key" name stopped
-    // being enough once there is a second, unattended way to enrol from
+    // being enough once there is a second, unattended way to enroll from
     // the same menu.
     //
     // A new step, not an edit to step 321: that INSERT has already run on
@@ -5025,7 +5025,7 @@ $this->schema[] = [
     //
     // IpxeBootMenu::printDefault() additionally hides this item unless
     // PK.auth/KEK.auth/db.auth all exist in service/secureboot/ -- without
-    // them mode=enrollsb's auto-enrol path has nothing valid to write.
+    // them mode=enrollsb's auto-enroll path has nothing valid to write.
     "INSERT IGNORE INTO `pxeMenu` "
     . "(`pxeID`,`pxeName`,`pxeDesc`,`pxeDefault`,`pxeRegOnly`,`pxeArgs`) "
     . "VALUES "
@@ -5706,7 +5706,7 @@ $this->schema[] = [
     //
     // It is a foreign key to `tasks`.`taskID`, an int(11), but the column
     // was mediumtext. The values are numeric only because
-    // FOGController::save() coerces them on the way in -- a behaviour of the
+    // FOGController::save() coerces them on the way in -- a behavior of the
     // PHP layer, not a constraint of the database -- and three things follow
     // from the type:
     //
@@ -5878,7 +5878,7 @@ $this->schema[] = [
     // was working on it, and the host could not be re-tasked because it still
     // held an active task. Somebody had to notice and cancel it by hand.
     //
-    // Not reusing Cancelled (5), which was the alternative. Cancelled means
+    // Not reusing Canceled (5), which was the alternative. Canceled means
     // an administrator stopped it; losing the difference between "somebody
     // stopped this" and "this broke" costs the operator the one fact they are
     // looking at the task list to find.
@@ -6277,7 +6277,7 @@ $this->schema[] = [
     //
     // Inert at this step. Nothing writes either table and neither is in
     // Route::$validClasses, so this ships as storage and a setting and
-    // changes no behaviour anywhere. The writers arrive in later merges.
+    // changes no behavior anywhere. The writers arrive in later merges.
     //
     // Every column is named explicitly rather than derived, because a
     // schema step that does not name its columns has broken the
@@ -6290,7 +6290,7 @@ $this->schema[] = [
     // and it is the reason that table cannot be trusted -- two identical
     // actions in the same second collapse into one row, silently, through
     // save()'s INSERT ... ON DUPLICATE KEY UPDATE. An audit trail that
-    // discards a row because it resembles its neighbour is not one. The
+    // discards a row because it resembles its neighbor is not one. The
     // volume argument that key was invented for is answered by retention
     // (FOG_AUDIT_RETENTION_DAYS below) and by not auditing reads at all.
     //
@@ -6490,7 +6490,7 @@ $this->schema[] = [
     // WHY THIS CANNOT BREAK A WORKING WRITE. An INSERT that names the column
     // is unaffected; a default applies only to an omitted column. An INSERT
     // that omits it currently FAILS outright on a strict server, so there is
-    // no working behaviour to change. On a non-strict server it currently
+    // no working behavior to change. On a non-strict server it currently
     // gets the server's implicit coercion -- and the defaults chosen here are
     // exactly that coercion ('' for text, 0 for integers, the first member
     // for an enum), which is the same rule FOGBase::emptyValueFor() applies.
@@ -7332,7 +7332,7 @@ $this->schema[] = [
     // An opt-out, not an opt-in. ICMP is the better probe -- it asks "is
     // this machine up" rather than "does this machine run the one service
     // we guessed at" -- so it is on by default and a server that wants the
-    // old behaviour turns it off.
+    // old behavior turns it off.
     //
     // The reason to have the switch at all is that a fleet-wide echo sweep
     // every PINGHOSTSLEEPTIME seconds looks like a host sweep to an IDS,
@@ -7906,7 +7906,7 @@ $this->schema[] = [
     // `archIsAccess` is `taskTypes.ttIsAccess` wearing different values. There
     // it says whether a task type may be started from a host, from a group, or
     // from both; here it says whether an architecture may be picked on a host,
-    // on an image, or on both. It is what makes the table worth normalising
+    // on an image, or on both. It is what makes the table worth normalizing
     // rather than just adding a CHECK constraint: an architecture FOS can
     // capture but no host in this fleet can boot (or the reverse) is a real
     // state, and the flag is where an admin says so.

--- a/packages/web/lib/pages/dashboardpage.page.php
+++ b/packages/web/lib/pages/dashboardpage.page.php
@@ -709,10 +709,10 @@ class DashboardPage extends FOGPage
         // a task type name that a site can rename. It is NOT sufficient on its
         // own: TaskLog::recordState() writes that column on every transition
         // of an imaging task, cancellation included, so a deploy that was
-        // queued and then cancelled without ever starting carries an image
+        // queued and then canceled without ever starting carries an image
         // name on its only row. Counting it says an image was deployed when
-        // no machine was ever touched, so the cancelled state is excluded --
-        // a task cancelled MID-image still has its In-Progress row and still
+        // no machine was ever touched, so the canceled state is excluded --
+        // a task canceled MID-image still has its In-Progress row and still
         // counts, which is the answer we want.
         //
         // MIN() rather than each row's own date, because a run that starts
@@ -730,7 +730,7 @@ class DashboardPage extends FOGPage
                    FROM `taskLog`
                   WHERE `createTime` BETWEEN :start AND :end
                     AND `logImageName` <> ''
-                    AND `taskStateID` <> :cancelled
+                    AND `taskStateID` <> :canceled
                   GROUP BY `taskID`
                ) AS `runs`
               GROUP BY DATE(`started`)",
@@ -738,7 +738,7 @@ class DashboardPage extends FOGPage
             [
                 ':start' => $start->format('Y-m-d H:i:s'),
                 ':end' => $end->format('Y-m-d H:i:s'),
-                ':cancelled' => self::getCancelledState()
+                ':canceled' => self::getCancelledState()
             ]
         )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $counts = [];

--- a/packages/web/lib/pages/fogconfigurationpage.page.php
+++ b/packages/web/lib/pages/fogconfigurationpage.page.php
@@ -455,9 +455,9 @@ class FOGConfigurationPage extends FOGPage
         echo $this->_box(_('Certificates'), $body, ['color' => 'info']);
     }
     /**
-     * Show the Secure Boot enrolment page.
+     * Show the Secure Boot enrollment page.
      *
-     * Displays the certificate fingerprint and links to the enrolment kit, so
+     * Displays the certificate fingerprint and links to the enrollment kit, so
      * a technician has something to check the key against before trusting it
      * on a machine. Nothing here is secret: the kit contains the public
      * certificate only, which is the thing you are meant to distribute.
@@ -503,7 +503,7 @@ class FOGConfigurationPage extends FOGPage
         // MokManager's own "View key" screen -- the only thing shown when
         // enrolling from the PXE menu, which never runs fog-enroll-mok.sh --
         // prints a SHA-1 fingerprint, not SHA-256. Show both so either
-        // enrolment route has a value on this page to check against.
+        // enrollment route has a value on this page to check against.
         $fingerprintSha1 = strtoupper(
             implode(':', str_split(hash_file('sha1', $certfile), 2))
         );
@@ -518,7 +518,7 @@ class FOGConfigurationPage extends FOGPage
         $body .= '<p><strong>' . _('Certificate SHA-256') . '</strong></p>';
         $body .= '<pre>' . \Initiator::e($fingerprint) . '</pre>';
         $body .= '<p>' . _(
-            'Check this value against what the enrolment tool shows before '
+            'Check this value against what the enrollment tool shows before '
             . 'confirming, whether the certificate reached the client on a '
             . 'USB stick or over the network. That comparison is what stops '
             . 'the wrong key being trusted.'
@@ -530,9 +530,9 @@ class FOGConfigurationPage extends FOGPage
             . 'enrolling from the PXE menu -- that route never runs the '
             . 'script above, so check it against this value instead.'
         ) . '</p>';
-        $body .= '<p><strong>' . _('Enrolment kit') . '</strong></p>';
+        $body .= '<p><strong>' . _('Enrollment kit') . '</strong></p>';
         $body .= '<p>' . _(
-            'For a live-USB enrolment, copy all three files onto a USB '
+            'For a live-USB enrollment, copy all three files onto a USB '
             . 'stick, boot the client from a stock Ubuntu or Debian live '
             . 'image with Secure Boot left ON, and run the launcher. No '
             . 'firmware changes are needed.'
@@ -562,7 +562,7 @@ class FOGConfigurationPage extends FOGPage
         ) . '</p>';
         echo $this->_box(_('Secure Boot'), $body, ['color' => 'info']);
 
-        // Automatic enrolment card, placed above the manual steps because it is
+        // Automatic enrollment card, placed above the manual steps because it is
         // the path that scales: it finishes on the client with nobody at the
         // keyboard. Its one precondition -- Setup Mode -- is a firmware setting
         // an admin has to know to look for, and stating it here is the only
@@ -585,13 +585,13 @@ class FOGConfigurationPage extends FOGPage
             // so on every run, so this points there instead of guessing.
             $auto = '<p>' . _(
                 'This server has not published the automatic Secure Boot '
-                . 'enrolment blobs (PK.auth, KEK.auth and db.auth), so '
-                . 'automatic enrolment is unavailable. There are three '
+                . 'enrollment blobs (PK.auth, KEK.auth and db.auth), so '
+                . 'automatic enrollment is unavailable. There are three '
                 . 'reasons that happens:'
             ) . '</p>';
             $auto .= '<ul>';
             $auto .= '<li>' . _(
-                'Secure Boot enrolment material is switched off for this '
+                'Secure Boot enrollment material is switched off for this '
                 . 'install, or no signing key is configured -- so no platform '
                 . 'keys were minted.'
             ) . '</li>';
@@ -614,10 +614,10 @@ class FOGConfigurationPage extends FOGPage
                 . 'which of the three applied here.'
             ) . '</p>';
             $auto .= '<p>' . _(
-                'The manual enrolment steps below are unaffected.'
+                'The manual enrollment steps below are unaffected.'
             ) . '</p>';
             echo $this->_box(
-                _('Automatic enrolment (Setup/Custom Mode)'),
+                _('Automatic enrollment (Setup/Custom Mode)'),
                 $auto,
                 ['color' => 'warning']
             );
@@ -668,7 +668,7 @@ class FOGConfigurationPage extends FOGPage
                 . 'steps below for those.'
             ) . '</p>';
             echo $this->_box(
-                _('Automatic enrolment (Setup/Custom Mode)'),
+                _('Automatic enrollment (Setup/Custom Mode)'),
                 $auto,
                 ['color' => 'success']
             );
@@ -676,13 +676,13 @@ class FOGConfigurationPage extends FOGPage
 
         // Second card: the actual procedure. The card above answers "is this
         // configured and what is the key", which is the reference half. Full
-        // per-client steps for both enrolment routes live in the linked guide
+        // per-client steps for both enrollment routes live in the linked guide
         // now rather than being duplicated here -- this card is the summary
         // and the gotchas that matter regardless of which route is used.
         $steps = '<p>' . _(
             'Signing is already done on this server. The remaining work is '
             . 'per-client and has to be done by someone at the machine -- that '
-            . 'is what makes enrolment a deliberate act rather than something '
+            . 'is what makes enrollment a deliberate act rather than something '
             . 'a server can do to a client remotely.'
         ) . '</p>';
         $steps .= '<p>' . _(
@@ -692,22 +692,22 @@ class FOGConfigurationPage extends FOGPage
             . 'network on its own, with no USB stick needed.'
         ) . '</p>';
         $steps .= '<p>' . _(
-            'Secure Boot does not need to be enabled on a client to enrol '
+            'Secure Boot does not need to be enabled on a client to enroll '
             . 'its key -- either route works the same way with it off, '
-            . 'which lets you stage enrolment fleet-wide before ever '
+            . 'which lets you stage enrollment fleet-wide before ever '
             . 'turning it on.'
         ) . '</p>';
         $steps .= '<p>' . _(
             'The Enroll Secure Boot task type does all of this for you: '
             . 'schedule it against a host or a group from Task Scheduling '
             . 'and the client boots FOS, which stages the request itself -- '
-            . 'or enrols outright with nothing to confirm, if the machine is '
+            . 'or enrolls outright with nothing to confirm, if the machine is '
             . 'in Setup Mode. The Enroll Secure Boot Key menu item stays for '
             . 'answering a pending request by hand, or for enrolling from '
             . 'local media on a machine FOS cannot boot.'
         ) . '</p>';
         $steps .= '<p>' . _(
-            'Whichever route is used, MokManager -- the blue enrolment '
+            'Whichever route is used, MokManager -- the blue enrollment '
             . 'screen -- has its own timeouts FOG cannot change: it gives '
             . 'up and boots normally if nothing is pressed within about 10 '
             . 'seconds of appearing, and reboots if left idle partway '
@@ -1855,7 +1855,7 @@ class FOGConfigurationPage extends FOGPage
                     'error' => sprintf(
                         _('%s already has a token called "%s". Names have to '
                             . 'be unique per user so a token can be told '
-                            . 'apart from its neighbours when it comes time '
+                            . 'apart from its neighbors when it comes time '
                             . 'to revoke one.'),
                         $user->get('name'),
                         $name
@@ -2790,7 +2790,7 @@ class FOGConfigurationPage extends FOGPage
             // $combined can be empty, so a post that changes nothing left
             // $items undefined -- and the count below reads it, which is a
             // warning rather than a silent 0. `?:` there was papering over
-            // the missing initialisation; `??` would have hidden it too.
+            // the missing initialization; `??` would have hidden it too.
             $items = [];
             foreach ($combined as $key => &$val) {
                 // Resolved into its own variable: $key stays the posted key

--- a/packages/web/lib/pages/groupmanagement.page.php
+++ b/packages/web/lib/pages/groupmanagement.page.php
@@ -3348,7 +3348,7 @@ class GroupManagement extends FOGPage
             );
 
             // $buttons is echoed below, after the rendered fields. It was
-            // passed here by reference while being neither initialised nor
+            // passed here by reference while being neither initialized nor
             // rendered, so the argument this hook advertises did nothing and
             // said nothing. Empty by default -- the modal's own Create button
             // lives in its static footer, not in this fragment.

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -4689,7 +4689,7 @@ class HostManagement extends FOGPage
             );
 
             // $buttons is echoed below, after the rendered fields. It was
-            // passed here by reference while being neither initialised nor
+            // passed here by reference while being neither initialized nor
             // rendered, so the argument this hook advertises did nothing and
             // said nothing. Empty by default -- the modal's own Create button
             // lives in its static footer, not in this fragment.

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1732,8 +1732,8 @@ class ImageManagement extends FOGPage
         //
         // The card idiom below is the one the Images and Hosts cards on this
         // same page already use. The theme styles cards in both modes, so this
-        // needs no colour of its own and cannot drift from the rest of the
-        // page. Only the warning tile takes a colour, and it takes it from
+        // needs no color of its own and cannot drift from the rest of the
+        // page. Only the warning tile takes a color, and it takes it from
         // card-danger, which forces its own contrast.
         echo '<div class="col-sm-6 col-md-3">';
         echo '<div class="card '
@@ -1753,7 +1753,7 @@ class ImageManagement extends FOGPage
      * reads as x86 to anyone scanning a list, which is the exact assumption
      * these columns exist to stop.
      *
-     * @param string $arch    the normalised architecture, '' when unknown
+     * @param string $arch    the normalized architecture, '' when unknown
      * @param string $unknown what to say when it is unknown
      *
      * @return string
@@ -2005,7 +2005,7 @@ class ImageManagement extends FOGPage
                     break;
                 case 'session-cancel':
                     $this->sessionCancel();
-                    $msgSuccess = _('Sessions cancelled!');
+                    $msgSuccess = _('Sessions canceled!');
                     $titleSuccess = _('Session Cancel Success');
                     $titleFail = _('Session Cancel Fail');
             }

--- a/packages/web/lib/pages/rolemanagement.page.php
+++ b/packages/web/lib/pages/rolemanagement.page.php
@@ -81,7 +81,7 @@ class RoleManagement extends FOGPage
             'report' => _('Reports'),
             'plugin' => _('Plugins'),
             // Adding system.export puts a new row and a new one-checkbox
-            // column in this matrix. Labelled so neither reads as the
+            // column in this matrix. Labeled so neither reads as the
             // ucfirst() fallback -- `install` and `manage` already rely on
             // it, but a grant this wide should not be introduced that way.
             'system' => _('System')

--- a/packages/web/lib/pages/sitemanagement.page.php
+++ b/packages/web/lib/pages/sitemanagement.page.php
@@ -575,7 +575,7 @@ class SiteManagement extends FOGPage
         // as an object; "Granted To User Groups" puts its members in scope
         // for it. Same picker, same list of names, and mixing them into one
         // row of tabs is how somebody grants a site while meaning to
-        // catalogue one.
+        // catalog one.
         $tabData[] = [
             'tabs' => [
                 'name' => _('Granted To'),

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -646,7 +646,7 @@ class SnapinManagement extends FOGPage
         // Mirrors handleAddPost(): fire the hook, then attach the created
         // object so a caller can act on the result without a second request.
         // This endpoint is hand-rolled rather than using that helper (the file
-        // upload does not fit the closure), so the behaviour is repeated here
+        // upload does not fit the closure), so the behavior is repeated here
         // deliberately -- a create should answer the same way whichever
         // scaffold built it.
         $args = [

--- a/packages/web/lib/pages/taskmanagement.page.php
+++ b/packages/web/lib/pages/taskmanagement.page.php
@@ -404,7 +404,7 @@ class TaskManagement extends FOGPage
         );
     }
     /**
-     * Renders the recent (completed/cancelled) tasks pane.
+     * Renders the recent (completed/canceled) tasks pane.
      *
      * @return void
      */
@@ -450,7 +450,7 @@ class TaskManagement extends FOGPage
             . '">';
         // 'all' rather than 'both': there are three finished states since
         // schema 339 added Failed, so a two-way label was about to start
-        // lying. getRecentTasks() still treats any unrecognised value as
+        // lying. getRecentTasks() still treats any unrecognized value as
         // all-of-them, so a page cached before this keeps working.
         echo '<input type="radio" class="btn-check" name="recent-state-filter"'
             . ' id="recent-state-all" value="all" autocomplete="off" checked/>';
@@ -465,7 +465,7 @@ class TaskManagement extends FOGPage
         echo '<input type="radio" class="btn-check" name="recent-state-filter"'
             . ' id="recent-state-cancelled" value="cancelled" autocomplete="off"/>';
         echo '<label class="btn btn-outline-primary" for="recent-state-cancelled">'
-            . _('Cancelled')
+            . _('Canceled')
             . '</label>';
         echo '<input type="radio" class="btn-check" name="recent-state-filter"'
             . ' id="recent-state-failed" value="failed" autocomplete="off"/>';
@@ -804,10 +804,10 @@ class TaskManagement extends FOGPage
         ));
     }
     /**
-     * Get recently completed/cancelled tasks.
+     * Get recently completed/canceled tasks.
      *
      * The Recent tab posts two extra filter vars alongside the
-     * DataTables request: states (both|complete|cancelled) and
+     * DataTables request: states (both|complete|canceled) and
      * typegroup (imaging|snapins|wipes|other|all).
      *
      * @return void
@@ -1265,7 +1265,7 @@ class TaskManagement extends FOGPage
         echo Route::getData();
     }
     /**
-     * For cancelling/forcing tasks.
+     * For canceling/forcing tasks.
      *
      * @return void
      */
@@ -1294,7 +1294,7 @@ class TaskManagement extends FOGPage
             $hook = 'TASK_CANCEL_SUCCESS';
             $msg = json_encode(
                 [
-                    'msg' => _('Selected tasks cancelled!'),
+                    'msg' => _('Selected tasks canceled!'),
                     'title' => _('Task Cancel Success')
                 ]
             );
@@ -1356,7 +1356,7 @@ class TaskManagement extends FOGPage
             $hook = 'TASK_CANCEL_SUCCESS';
             $msg = json_encode(
                 [
-                    'msg' => _('Selected tasks cancelled!'),
+                    'msg' => _('Selected tasks canceled!'),
                     'title' => _('Task Cancel Success')
                 ]
             );
@@ -1410,7 +1410,7 @@ class TaskManagement extends FOGPage
             $hook = 'TASK_CANCEL_SUCCESS';
             $msg = json_encode(
                 [
-                    'msg' => _('Selected tasks cancelled!'),
+                    'msg' => _('Selected tasks canceled!'),
                     'title' => _('Task Cancel Success')
                 ]
             );
@@ -1464,7 +1464,7 @@ class TaskManagement extends FOGPage
             $hook = 'TASK_CANCEL_SUCCESS';
             $msg = json_encode(
                 [
-                    'msg' => _('Selected tasks cancelled!'),
+                    'msg' => _('Selected tasks canceled!'),
                     'title' => _('Task Cancel Success')
                 ]
             );
@@ -1518,7 +1518,7 @@ class TaskManagement extends FOGPage
             $hook = 'QUEUED_DELETION_CANCEL_SUCCESS';
             $msg = json_encode(
                 [
-                    'msg' => _('Selected tasks cancelled!'),
+                    'msg' => _('Selected tasks canceled!'),
                     'title' => _('Queue Deletion Cancel Success')
                 ]
             );

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -1364,7 +1364,7 @@ class UserManagement extends FOGPage
      * Issues one API token and returns its plaintext, once.
      *
      * Its own endpoint rather than part of the tab form, for the reasons set
-     * out where the Issue Token button is emitted. Modelled on the Reset
+     * out where the Issue Token button is emitted. Modeled on the Reset
      * Token control beside it, which has always been a direct AJAX call.
      *
      * The plaintext is written to this response and nowhere else -- not the

--- a/packages/web/lib/router/altorouter.class.php
+++ b/packages/web/lib/router/altorouter.class.php
@@ -48,7 +48,7 @@
  *
  * The seven verb methods below are provided by __call(), which prepends the
  * uppercased verb and forwards to map(). They are declared as @method so the
- * chained route table in Route::defineRoutes() can be analysed statically --
+ * chained route table in Route::defineRoutes() can be analyzed statically --
  * without them every ->get()/->post() in that table reads as a call to an
  * undefined method.
  *

--- a/packages/web/management/js/fog/about/fog.about.apitokens.js
+++ b/packages/web/management/js/fog/about/fog.about.apitokens.js
@@ -2,7 +2,7 @@
   // The estate-wide API token pane. Auto-loaded by the js/fog/<node>/
   // fog.<node>.<sub>.js convention, so nothing registers this file.
   //
-  // Driven by registerTable() -- the same initialiser every list page uses
+  // Driven by registerTable() -- the same initializer every list page uses
   // -- rather than registerListPage(), which hardwires its ajax url to
   // '?node=' + Common.node + '&sub=list'. This grid lives at node=about,
   // sub=apitokens and its rows come from sub=apitokenlist, so it wires the

--- a/packages/web/management/js/fog/about/fog.about.logviewer.js
+++ b/packages/web/management/js/fog/about/fog.about.logviewer.js
@@ -103,7 +103,7 @@
     getLogData(ip, file, selectedLines, reverseChecked);
   });
 
-  // Pause/resume the tail. One button, relabelled by the shared helper.
+  // Pause/resume the tail. One button, relabeled by the shared helper.
   $.registerReloadToggle(reloadToggle, {
     onPause: function() {
       if (logTimer) {

--- a/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
+++ b/packages/web/management/js/fog/apidocs/fog.apidocs.snippets.js
@@ -26,8 +26,8 @@
  * On highlighting: the bundle registers only bash, http, javascript, json,
  * powershell, xml and yaml with highlight.js. An unregistered `syntax` value
  * does not throw -- react-syntax-highlighter falls back to highlightAuto() --
- * so Python is declared honestly as 'python' and gets auto-detected colouring
- * rather than being mislabelled as something that happens to be registered.
+ * so Python is declared honestly as 'python' and gets auto-detected coloring
+ * rather than being mislabeled as something that happens to be registered.
  *
  * The request object handed to a generator is an Immutable Map with `url`,
  * `method`, `headers` and `body`. Nothing here reaches for Immutable itself,
@@ -151,7 +151,7 @@
             }
         }
         // Anything else is already a structure; treat it as the JSON it will
-        // be serialised to.
+        // be serialized to.
         return { kind: 'json', value: body, raw: JSON.stringify(body, null, 2) };
     }
 
@@ -392,7 +392,7 @@
         if (body.kind === 'json') {
             lines.push('payload = ' + pythonValue(body.value, ''));
             lines.push('');
-            // json= rather than data=json.dumps(...): requests serialises it
+            // json= rather than data=json.dumps(...): requests serializes it
             // and the shape stays readable and editable in the snippet.
             args.push('json=payload');
         } else if (body.kind === 'raw') {

--- a/packages/web/management/js/fog/audit/fog.audit.list.js
+++ b/packages/web/management/js/fog/audit/fog.audit.list.js
@@ -38,7 +38,7 @@
     };
   }
 
-  // allowed / denied / failed / partial, coloured because scanning a page of
+  // allowed / denied / failed / partial, colored because scanning a page of
   // these for the denials is the whole reason somebody opens this grid.
   var outcomeClass = {
     allowed: 'text-bg-success',

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -866,8 +866,8 @@ $.registerAssociationTab = function(opts) {
 //      is in the DOM. Some create forms are not inert markup: the printer form's
 //      type sections and the snapin form's command builder are driven by JS that
 //      normally runs on the node's own page, and that JS does not travel with a
-//      fetched fragment. The tab passes its node's initialiser here rather than
-//      this helper carrying a node->initialiser map, which would make a shared
+//      fetched fragment. The tab passes its node's initializer here rather than
+//      this helper carrying a node->initializer map, which would make a shared
 //      helper grow a branch per node and put plugin nodes out of reach.
 // opts.validate - optional processForm() validate filter, mirroring
 //      wireCreateForm({selector}). The printer form needs ':input:visible'
@@ -926,7 +926,7 @@ function wireCreateModal(slug, opts) {
           el.attr('id', newId);
         });
         holder.html(form);
-        // Before the keypress/focus wiring below, because an initialiser can
+        // Before the keypress/focus wiring below, because an initializer can
         // change which fields are even visible -- the printer one hides every
         // type section but the selected one -- and focusing a hidden field or
         // binding Enter to it would be wrong.
@@ -940,7 +940,7 @@ function wireCreateModal(slug, opts) {
             sendBtn.trigger('click');
           }
         });
-        // :visible so a form whose initialiser hid sections still opens with the
+        // :visible so a form whose initializer hid sections still opens with the
         // caret in a field the user can actually see.
         holder.find(':input:visible:first').trigger('focus');
       }
@@ -989,7 +989,7 @@ function wireCreateModal(slug, opts) {
         if (form[0]) {
           form[0].reset();
           // reset() restores field VALUES but fires no events, so any UI an
-          // initialiser drives off a select -- the printer type sections, the
+          // initializer drives off a select -- the printer type sections, the
           // snapin pack mode -- would be left displaying the previous choice
           // against a reset select. Re-fire change so those handlers re-sync;
           // they only read the current value, so running them again is safe.
@@ -1043,7 +1043,7 @@ $.registerCreateAndAssociate = function(slug, table, opts) {
 // the path it would have taken had the admin picked the value by hand.
 //
 // Clicking the real button rather than POSTing here is deliberate: these tabs
-// carry plugin-specific behaviour on that button (site/location on a GROUP fans
+// carry plugin-specific behavior on that button (site/location on a GROUP fans
 // the choice out to every member host), and duplicating the submit would mean
 // duplicating whatever the plugin does around it.
 //
@@ -1120,9 +1120,9 @@ $.registerSelectTab = function(opts) {
 // One button relabels itself instead: it always shows the action you can take.
 //
 // Both labels come off the button's own data attributes rather than being
-// written here, so the strings stay inside gettext on the PHP side. The colour
+// written here, so the strings stay inside gettext on the PHP side. The color
 // class is deliberately not touched - state is carried by the label alone, so
-// the button does not change colour under the cursor and cannot end up as a
+// the button does not change color under the cursor and cannot end up as a
 // second btn-primary next to a real one (the multicast pane's Create).
 //
 // btn   - the toggle button, a jQuery object or selector.
@@ -1179,11 +1179,11 @@ $.registerReloadToggle = function(btn, opts) {
 //
 // So: attach the strips to whichever header is visible, and on drag rewrite
 // the matching <col> on every colgroup involved. Width is moved from one
-// column to its neighbour, so the table's total width never changes and
+// column to its neighbor, so the table's total width never changes and
 // nothing reflows sideways.
 //
 // The last column is skipped on purpose -- it is the one absorbing whatever
-// the others leave, so there is no neighbour to take width from.
+// the others leave, so there is no neighbor to take width from.
 
 // Resolve the pieces of a DataTable that resizing needs to talk to.
 function fogTableParts(node) {
@@ -1301,7 +1301,7 @@ function fogRememberColWidths(parts, widths) {
 // Rebuild a width row from what was remembered, or null when this table has
 // nothing stored for any column currently showing.
 //
-// The shares are renormalised over the showing columns, and that renormalising
+// The shares are renormalized over the showing columns, and that renormalizing
 // is the whole trick for carrying a layout across a breakpoint: hide two of
 // five columns and the surviving three keep the same proportions to each other
 // that the user gave them, spread over the full table width.
@@ -1362,7 +1362,7 @@ function fogRestoredColWidths(parts, widths) {
   return out;
 }
 
-// Write a column and its neighbour in one go, on every colgroup involved.
+// Write a column and its neighbor in one go, on every colgroup involved.
 function fogSetColPair(parts, i, widthA, widthB) {
   parts.tables.each(function() {
     var cols = $(this).find('colgroup > col');
@@ -1388,9 +1388,9 @@ function fogSetCols(parts, widths) {
 }
 
 // Resize column i to `want`, paying for it out of ALL the other columns rather
-// than only its right-hand neighbour.
+// than only its right-hand neighbor.
 //
-// A drag takes width from the neighbour because the neighbour's border is the
+// A drag takes width from the neighbor because the neighbor's border is the
 // thing being dragged. A fit has no such anchor, and charging the whole cost
 // to one column flattened it to the floor -- fitting the plugin Description
 // took 238px straight out of Location and left it unreadable.
@@ -1642,7 +1642,7 @@ $.fn.makeColumnsResizable = function() {
       // same gesture a spreadsheet uses.
       //
       // The cost is spread across the other columns rather than charged to the
-      // neighbour (see fogFitColumn), so the table's total width still never
+      // neighbor (see fogFitColumn), so the table's total width still never
       // changes but no single column gets flattened to pay for the fit.
       handle.on('dblclick', function(ev) {
         ev.preventDefault();
@@ -1709,16 +1709,16 @@ var TOAST_DELAY = 8000;
 // problem: under `[data-bs-theme=dark]` Bootstrap filters `.btn-close` white
 // again, so those two go invisible for anyone using FOG's dark theme instead.
 //
-// These backgrounds are fixed colours in BOTH themes, so the header is pinned
+// These backgrounds are fixed colors in BOTH themes, so the header is pinned
 // to the theme its own background belongs to. That is enough for the text and
-// the icon, which read their colour from the scoped variables.
+// the icon, which read their color from the scoped variables.
 //
 // It is NOT enough for the close button, and the reason is worth writing down
 // because the markup looks correct either way: Bootstrap dims it with
 // `[data-bs-theme=dark] .btn-close`, a DESCENDANT selector, so it matches any
 // close button anywhere under <html data-bs-theme="dark"> and a nearer `light`
 // scope does not call it off. Verified by reading the computed filter -- all
-// five were identical while the title colours had scoped correctly. So a light
+// five were identical while the title colors had scoped correctly. So a light
 // header clears the filter itself, below.
 var TOAST_TYPES = {
   success: ['success', 'fas fa-circle-check', 'dark'],
@@ -2791,7 +2791,7 @@ $.fn.registerTable = function(onSelect, opts) {
     // that reason, which today means long text simply overflows its column.
     // Clipping is what turns that into something readable. A paged or grouped
     // table has no such constraint and keeps wrapping, which is the better
-    // behaviour when rows are allowed to be tall.
+    // behavior when rows are allowed to be tall.
     $(this).addClass('fog-table-clip');
   }
 
@@ -3270,7 +3270,7 @@ function reinitialize() {
 /**
  * Keep the edit page's info card in step with the form under it.
  *
- * The card summarises the record you are editing, and it used to be rendered
+ * The card summarizes the record you are editing, and it used to be rendered
  * once and left alone -- so changing Max Clients on the General tab left the
  * card still showing the old number until a full page reload. It is sticky, so
  * that stale number follows you down the page.
@@ -3283,7 +3283,7 @@ function reinitialize() {
  *
  * Deliberately no initial repaint: until you touch a control, the server's
  * value is the truthful one. Painting on load would let a client-side reading
- * of the control quietly replace a value the server had normalised (the image
+ * of the control quietly replace a value the server had normalized (the image
  * path, for one, comes back with its trailing slash trimmed).
  */
 function setupInfoCard() {
@@ -3788,7 +3788,7 @@ function clearAllIntervals(){
     var commonScripts = JSON.parse(req.getResponseHeader('X-FOG-Common-JavaScripts'));
     // Libraries that must execute at most once per session. Defaults to empty
     // so a response from an older server (or any handler that does not send
-    // the header) keeps exactly the previous behaviour.
+    // the header) keeps exactly the previous behavior.
     var onceHeader = req.getResponseHeader('X-FOG-Once-JavaScripts');
     var onceScripts = onceHeader ? JSON.parse(onceHeader) : [];
 

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -45,7 +45,7 @@
         resetEncryptionModal.modal('show');
     });
 
-    // Modal cancelled
+    // Modal canceled
     resetEncryptionCancelBtn.on('click', function(e) {
         e.preventDefault();
 

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -39,7 +39,7 @@
         resetEncryptionModal.modal('show');
     });
 
-    // Modal cancelled
+    // Modal canceled
     resetEncryptionCancelBtn.on('click', function(e) {
         e.preventDefault();
 
@@ -631,7 +631,7 @@
     });
     // The printer create form is not inert markup -- it hides every type
     // section but the selected one -- and that JS lives on the printer pages,
-    // which do not load here. onForm runs the same initialiser against the
+    // which do not load here. onForm runs the same initializer against the
     // fetched form; node:'printer' because the helper would otherwise ask
     // ?node=host for getPrinterInfo. validate matches what the printer pages
     // pass, so the hidden sections are not validated.

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -217,8 +217,8 @@
                 // so the grid and the refusal cannot tell different stories:
                 // green is ready to enroll unattended, blue is enrollable with
                 // someone at the machine, red cannot run the task at all, and
-                // grey is "we have never heard from this host" -- which is
-                // deliberately not the same grey-as-harmless as the others,
+                // gray is "we have never heard from this host" -- which is
+                // deliberately not the same gray-as-harmless as the others,
                 // because unknown is allowed through with a warning.
                 var raw = String(row.sbstatecode || '');
                 var tone = 'secondary';

--- a/packages/web/management/js/fog/task/fog.task.list.js
+++ b/packages/web/management/js/fog/task/fog.task.list.js
@@ -79,7 +79,7 @@
     return $('#active-tasks-table').registerTable(paneOnSelect(pane), {
       // Infinite-scroll (Scroller) for UI consistency with the other lists, but
       // with deferRender explicitly OFF for this table only. It polls every 5s and
-      // frequently transitions to zero rows (task cancelled/completed); with
+      // frequently transitions to zero rows (task canceled/completed); with
       // deferRender on, DataTables caches the last window's row node and Scroller
       // leaves it -- striped progress bar and all -- orphaned in the fixed-height
       // scroll body on the empty draw, beneath "No data available in table".

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -143,7 +143,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1120,7 +1120,7 @@ msgstr "Integritätseinstellungen"
 msgid "Auto Logout Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1344,10 +1344,11 @@ msgid "Cancel the selected tasks."
 msgstr "Ausgewählte löschen"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "Stornierter Task"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
 #, fuzzy
@@ -1522,7 +1523,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2438,7 +2439,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2958,7 +2959,7 @@ msgstr "FOG Einstellungen"
 msgid "Flush the settings cache"
 msgstr "FOG Einstellungen"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5882,7 +5883,7 @@ msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6637,7 +6638,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
 msgid "RESOURCES"
@@ -7149,14 +7150,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Es gibt keine Images auf diesem Server."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7186,7 +7187,7 @@ msgid "Selectable on"
 msgstr "Wählen Sie einen Crontyp"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7301,7 +7302,7 @@ msgid "Session with that name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
 msgid "Set Printer as Default for Hosts"
@@ -7406,7 +7407,7 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8315,7 +8316,7 @@ msgid "Task finished"
 msgstr "Task gestartet"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "Image ist geschützt und kann nicht gelöscht werden"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8431,7 +8432,7 @@ msgstr "Es gibt keine Gruppen auf diesem Server."
 msgid "The CA private key is on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8583,7 +8584,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8871,7 +8872,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9682,7 +9683,7 @@ msgstr "Wo bekomme ich Hilfe?"
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9945,7 +9946,7 @@ msgid "confirm"
 msgstr "Bestätige Task"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy
@@ -10009,7 +10010,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10071,7 +10072,7 @@ msgid "group claim"
 msgstr "Gruppenname"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy
@@ -10253,7 +10254,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1124,7 +1124,7 @@ msgstr "Settings"
 msgid "Auto Logout Time"
 msgstr "Default log out time (in minutes)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1348,10 +1348,11 @@ msgid "Cancel the selected tasks."
 msgstr "Delete Selected"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "Cancelled task"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Cancelled due to new tasking."
 
 #, fuzzy
@@ -1525,7 +1526,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "No FOGPage Class found for this node"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2439,7 +2440,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2959,7 +2960,7 @@ msgstr "FOG Settings"
 msgid "Flush the settings cache"
 msgstr "FOG Settings"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5879,7 +5880,7 @@ msgstr "Error, Is an image associated with this host"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6634,7 +6635,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin is protected and cannot be deleted"
 
 msgid "RESOURCES"
@@ -7146,14 +7147,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "There are no images on this server."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7183,7 +7184,7 @@ msgid "Selectable on"
 msgstr "Select a cron type"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "has been successfully updated"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7298,7 +7299,7 @@ msgid "Session with that name already exists!"
 msgstr "A hostname with that name already exists."
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "has been successfully updated"
 
 msgid "Set Printer as Default for Hosts"
@@ -7403,7 +7404,7 @@ msgstr "Load failed: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8310,7 +8311,7 @@ msgid "Task finished"
 msgstr "Task Started"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "Image is protected and cannot be deleted"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8426,7 +8427,7 @@ msgstr "There are no groups on this server."
 msgid "The CA private key is on this server"
 msgstr "There are no groups on this server."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8578,7 +8579,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8865,7 +8866,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9676,7 +9677,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9938,7 +9939,7 @@ msgid "confirm"
 msgstr "Invalid task"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "has been successfully updated"
 
 #, fuzzy
@@ -10002,7 +10003,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10064,7 +10065,7 @@ msgid "group claim"
 msgstr "Group Name"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "has been successfully updated"
 
 #, fuzzy
@@ -10246,7 +10247,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "has been successfully updated"
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -146,7 +146,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1138,7 +1138,7 @@ msgstr "Configuración Tecla"
 msgid "Auto Logout Time"
 msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1366,10 +1366,11 @@ msgid "Cancel the selected tasks."
 msgstr "Eliminar seleccionado"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "tarea Cancelado"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Cancelada debido a las nuevas tareas a la vez."
 
 #, fuzzy
@@ -1541,7 +1542,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr ""
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -3011,7 +3012,7 @@ msgstr "Ajustes del sistema FOG"
 msgid "Flush the settings cache"
 msgstr "Ajustes del sistema FOG"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -6008,7 +6009,7 @@ msgstr "Error, es una imagen asociada con este anfitrión"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6777,7 +6778,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "está protegido, no se permite la eliminación"
 
 msgid "RESOURCES"
@@ -7296,14 +7297,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "No hay grupos en este servidor."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7333,7 +7334,7 @@ msgid "Selectable on"
 msgstr "Seleccione un tipo de cron"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "se ha actualizado correctamente"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7450,7 +7451,7 @@ msgid "Session with that name already exists!"
 msgstr "Sesión con ese nombre ya existe"
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "se ha actualizado correctamente"
 
 msgid "Set Printer as Default for Hosts"
@@ -7556,7 +7557,7 @@ msgstr "Carga ha fallado: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8496,7 +8497,7 @@ msgid "Task finished"
 msgstr "Nombre de la tarea"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "está protegido, no se permite la eliminación"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8611,7 +8612,7 @@ msgstr "No hay grupos en este servidor."
 msgid "The CA private key is on this server"
 msgstr "No hay grupos en este servidor."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8763,7 +8764,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -9050,7 +9051,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9860,7 +9861,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -10122,7 +10123,7 @@ msgid "confirm"
 msgstr "tarea no válido"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "se ha actualizado correctamente"
 
 #, fuzzy
@@ -10186,7 +10187,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10249,7 +10250,7 @@ msgid "group claim"
 msgstr "Nombre del grupo"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "se ha actualizado correctamente"
 
 #, fuzzy
@@ -10432,7 +10433,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "se ha actualizado correctamente"
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -143,7 +143,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1120,7 +1120,7 @@ msgstr "Integritätseinstellungen"
 msgid "Auto Logout Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1344,10 +1344,11 @@ msgid "Cancel the selected tasks."
 msgstr "Ausgewählte löschen"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "Stornierter Task"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Abgebrochen aufgrund neuer Aufgabe (Task)"
 
 #, fuzzy
@@ -1522,7 +1523,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "Keine FOGPage-Klasse für diesen Knoten gefunden"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2438,7 +2439,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2958,7 +2959,7 @@ msgstr "FOG Einstellungen"
 msgid "Flush the settings cache"
 msgstr "FOG Einstellungen"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5883,7 +5884,7 @@ msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6638,7 +6639,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
 msgid "RESOURCES"
@@ -7150,14 +7151,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Es gibt keine Images auf diesem Server."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7187,7 +7188,7 @@ msgid "Selectable on"
 msgstr "Wählen Sie einen Crontyp"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7302,7 +7303,7 @@ msgid "Session with that name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
 
 msgid "Set Printer as Default for Hosts"
@@ -7407,7 +7408,7 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8316,7 +8317,7 @@ msgid "Task finished"
 msgstr "Task gestartet"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "Image ist geschützt und kann nicht gelöscht werden"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8432,7 +8433,7 @@ msgstr "Es gibt keine Gruppen auf diesem Server."
 msgid "The CA private key is on this server"
 msgstr "Es gibt keine Gruppen auf diesem Server."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8584,7 +8585,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8872,7 +8873,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9683,7 +9684,7 @@ msgstr "Wo bekomme ich Hilfe?"
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9946,7 +9947,7 @@ msgid "confirm"
 msgstr "Bestätige Task"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy
@@ -10010,7 +10011,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10072,7 +10073,7 @@ msgid "group claim"
 msgstr "Gruppenname"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy
@@ -10254,7 +10255,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "wurde abgebrochen"
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -149,7 +149,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1125,7 +1125,7 @@ msgstr "Paramètres"
 msgid "Auto Logout Time"
 msgstr "Par défaut déconnecter le temps (en minutes)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1349,10 +1349,11 @@ msgid "Cancel the selected tasks."
 msgstr "Supprimer sélectionnée"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "tâche Annulé"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Annulé en raison de nouvelles tâches."
 
 #, fuzzy
@@ -1526,7 +1527,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "Non FOGPage Classe trouvé pour ce noeud"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2441,7 +2442,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2961,7 +2962,7 @@ msgstr "Paramètres BROUILLARD"
 msgid "Flush the settings cache"
 msgstr "Paramètres BROUILLARD"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5881,7 +5882,7 @@ msgstr "Erreur, est une image associée à cet hôte"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6636,7 +6637,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin est protégé et ne peut être supprimé"
 
 msgid "RESOURCES"
@@ -7148,14 +7149,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Il n'y a pas d'images sur ce serveur."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7185,7 +7186,7 @@ msgid "Selectable on"
 msgstr "Sélectionnez un type de cron"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "a été mis à jour avec succès"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7300,7 +7301,7 @@ msgid "Session with that name already exists!"
 msgstr "Un nom d'hôte avec ce nom existe déjà."
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "a été mis à jour avec succès"
 
 msgid "Set Printer as Default for Hosts"
@@ -7405,7 +7406,7 @@ msgstr "Échec du chargement: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8312,7 +8313,7 @@ msgid "Task finished"
 msgstr "Tâche Started"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "L'image est protégée et ne peut être supprimé"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8428,7 +8429,7 @@ msgstr "Il n'y a pas de groupes sur ce serveur."
 msgid "The CA private key is on this server"
 msgstr "Il n'y a pas de groupes sur ce serveur."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8580,7 +8581,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8867,7 +8868,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9678,7 +9679,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9940,7 +9941,7 @@ msgid "confirm"
 msgstr "tâche non valide"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "a été mis à jour avec succès"
 
 #, fuzzy
@@ -10004,7 +10005,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10066,7 +10067,7 @@ msgid "group claim"
 msgstr "Nom de groupe"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "a été mis à jour avec succès"
 
 #, fuzzy
@@ -10248,7 +10249,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "a été mis à jour avec succès"
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1093,7 +1093,7 @@ msgstr "Impostazioni di integrità"
 msgid "Auto Logout Time"
 msgstr "Predefinito disconnettersi tempo (in minuti)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1309,10 +1309,11 @@ msgid "Cancel the selected tasks."
 msgstr "Elimina selezionato"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "compito Annullato"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Annullato a causa della nuova tasking."
 
 msgid "Cannot bind to the LDAP server"
@@ -1482,7 +1483,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "Nessun FOGPage Classe trovato per questo nodo"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2374,7 +2375,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2878,7 +2879,7 @@ msgstr "Impostazioni FOG"
 msgid "Flush the settings cache"
 msgstr "Impostazioni FOG"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5692,7 +5693,7 @@ msgstr "Uno o più MAC sono associati a questo host"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6427,7 +6428,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin è protetto e non può essere cancellato"
 
 msgid "RESOURCES"
@@ -6922,14 +6923,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Non ci sono immagini su questo server"
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -6959,7 +6960,7 @@ msgid "Selectable on"
 msgstr "Selezionare un tipo di cron"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "Attività pianificate create con successo"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7073,7 +7074,7 @@ msgid "Session with that name already exists!"
 msgstr "Un nome host con questo nome esiste già"
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "Attività pianificate create con successo"
 
 msgid "Set Printer as Default for Hosts"
@@ -7174,7 +7175,7 @@ msgstr "Caricamento non riuscito"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8033,7 +8034,7 @@ msgid "Task finished"
 msgstr "Attività iniziata"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "L'immagine è protetta e non può essere cancellato"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8145,7 +8146,7 @@ msgstr "Non ci sono gruppi su questo server"
 msgid "The CA private key is on this server"
 msgstr "Non ci sono gruppi su questo server"
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8296,7 +8297,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8578,7 +8579,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9361,7 +9362,7 @@ msgstr "Dove ottenere aiuto"
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9613,7 +9614,7 @@ msgid "confirm"
 msgstr "Conferma il task"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "è stato cancellato"
 
 #, fuzzy
@@ -9675,7 +9676,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -9733,7 +9734,8 @@ msgstr "gruppo"
 msgid "group claim"
 msgstr "Nome del gruppo"
 
-msgid "has been cancelled"
+#, fuzzy
+msgid "has been canceled"
 msgstr "è stato cancellato"
 
 msgid "has been completed"
@@ -9903,7 +9905,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "è stato cancellato"
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -139,7 +139,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1078,7 +1078,7 @@ msgstr "整合性設定"
 msgid "Auto Logout Time"
 msgstr "ホスト自動ログアウト"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1292,10 +1292,11 @@ msgid "Cancel the selected tasks."
 msgstr "キャンセルされたタスク"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "キャンセルされたタスク"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "新しいタスクによりキャンセルされました。"
 
 msgid "Cannot bind to the LDAP server"
@@ -1466,7 +1467,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "このノードの FOGPage クラスが見つかりません"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2358,7 +2359,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2852,7 +2853,7 @@ msgstr "FOG 設定"
 msgid "Flush the settings cache"
 msgstr "FOG 設定"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5652,7 +5653,7 @@ msgstr "1 つ以上の MAC アドレスがホストに関連付けられてい�
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6389,7 +6390,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "スナップインは保護されているため削除できません"
 
 msgid "RESOURCES"
@@ -6877,13 +6878,13 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr ""
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 msgid "Secure Boot kernel signing is not configured on this server"
@@ -6911,7 +6912,7 @@ msgid "Selectable on"
 msgstr "選択したログイン"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "スケジュール済みタスクを作成しました"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7025,7 +7026,7 @@ msgid "Session with that name already exists!"
 msgstr "その名前のセッションは既に存在します"
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "キャンセルされました"
 
 msgid "Set Printer as Default for Hosts"
@@ -7126,7 +7127,7 @@ msgstr "イメージ処理に失敗しました。"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -7969,7 +7970,7 @@ msgid "Task finished"
 msgstr "タスク実行に失敗しました"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "イメージは保護されているため削除できません"
 
 #, fuzzy
@@ -8081,7 +8082,7 @@ msgstr "このサーバーにはグループがありません"
 msgid "The CA private key is on this server"
 msgstr "このサーバーにはグループがありません"
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8231,7 +8232,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 #, fuzzy
@@ -8515,7 +8516,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9300,7 +9301,7 @@ msgstr "ヘルプの入手先"
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9549,7 +9550,8 @@ msgstr "クライアント"
 msgid "confirm"
 msgstr ""
 
-msgid "could not be cancelled"
+#, fuzzy
+msgid "could not be canceled"
 msgstr "キャンセルできませんでした"
 
 msgid "could not be completed"
@@ -9609,7 +9611,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -9670,7 +9672,8 @@ msgstr "グループ"
 msgid "group claim"
 msgstr "グループ名"
 
-msgid "has been cancelled"
+#, fuzzy
+msgid "has been canceled"
 msgstr "キャンセルされました"
 
 msgid "has been completed"
@@ -9842,7 +9845,8 @@ msgstr "現在は実行されていません"
 msgid "is not currently online"
 msgstr "ホストトークンは現在使用中です"
 
-msgid "is now cancelled"
+#, fuzzy
+msgid "is now canceled"
 msgstr "キャンセルされました"
 
 msgid "is now completed"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -124,7 +124,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Auto Logout Time"
 msgstr ""
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1154,10 +1154,10 @@ msgstr ""
 msgid "Cancel the selected tasks."
 msgstr ""
 
-msgid "Cancelled"
+msgid "Canceled"
 msgstr ""
 
-msgid "Cancelled due to new tasking."
+msgid "Canceled due to new tasking."
 msgstr ""
 
 msgid "Cannot bind to the LDAP server"
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr ""
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, php-format
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "Flush the settings cache"
 msgstr ""
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -4997,7 +4997,7 @@ msgstr ""
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Queued Path Deletions"
 msgstr ""
 
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr ""
 
 msgid "RESOURCES"
@@ -6082,13 +6082,13 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr ""
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 msgid "Secure Boot kernel signing is not configured on this server"
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "Selectable on"
 msgstr ""
 
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -6210,7 +6210,7 @@ msgstr ""
 msgid "Session with that name already exists!"
 msgstr ""
 
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr ""
 
 msgid "Set Printer as Default for Hosts"
@@ -6299,7 +6299,7 @@ msgstr ""
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 msgid "Signs In With"
@@ -7049,7 +7049,7 @@ msgstr ""
 msgid "Task finished"
 msgstr ""
 
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr ""
 
 msgid "Task not created as there are no associated Tasks"
@@ -7147,7 +7147,7 @@ msgstr ""
 msgid "The CA private key is on this server"
 msgstr ""
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 msgid "The FOG account could not be created"
@@ -7289,7 +7289,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -7557,7 +7557,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -8257,7 +8257,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -8489,7 +8489,7 @@ msgstr ""
 msgid "confirm"
 msgstr ""
 
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr ""
 
 msgid "could not be completed"
@@ -8544,7 +8544,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 msgid "failed to execute, image file"
@@ -8598,7 +8598,7 @@ msgstr ""
 msgid "group claim"
 msgstr ""
 
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr ""
 
 msgid "has been completed"
@@ -8748,7 +8748,7 @@ msgstr ""
 msgid "is not currently online"
 msgstr ""
 
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr ""
 
 msgid "is now completed"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1124,7 +1124,7 @@ msgstr "Configurações"
 msgid "Auto Logout Time"
 msgstr "Padrão log out tempo (em minutos)"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1348,10 +1348,11 @@ msgid "Cancel the selected tasks."
 msgstr "Delete Selected"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "tarefa cancelada"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "Cancelado devido à nova tarefa."
 
 #, fuzzy
@@ -1525,7 +1526,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "Sem FOGPage classe encontrada para este nó"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2440,7 +2441,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2960,7 +2961,7 @@ msgstr "Configurações FOG"
 msgid "Flush the settings cache"
 msgstr "Configurações FOG"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5880,7 +5881,7 @@ msgstr "Erro, é uma imagem associada com este anfitrião"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6635,7 +6636,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin está protegido e não pode ser excluído"
 
 msgid "RESOURCES"
@@ -7147,14 +7148,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "Não há imagens neste servidor."
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7184,7 +7185,7 @@ msgid "Selectable on"
 msgstr "Selecione um tipo de cron"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "foi atualizado com sucesso"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7299,7 +7300,7 @@ msgid "Session with that name already exists!"
 msgstr "Um nome de host com esse nome já existe."
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "foi atualizado com sucesso"
 
 msgid "Set Printer as Default for Hosts"
@@ -7404,7 +7405,7 @@ msgstr "Carga falhou: %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8311,7 +8312,7 @@ msgid "Task finished"
 msgstr "tarefa iniciada"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "A imagem está protegida e não pode ser excluído"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8427,7 +8428,7 @@ msgstr "Não existem grupos neste servidor."
 msgid "The CA private key is on this server"
 msgstr "Não existem grupos neste servidor."
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8579,7 +8580,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8866,7 +8867,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9677,7 +9678,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9939,7 +9940,7 @@ msgid "confirm"
 msgstr "tarefa inválido"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "foi atualizado com sucesso"
 
 #, fuzzy
@@ -10003,7 +10004,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10065,7 +10066,7 @@ msgid "group claim"
 msgstr "Nome do grupo"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "foi atualizado com sucesso"
 
 #, fuzzy
@@ -10247,7 +10248,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "foi atualizado com sucesso"
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgid "%s added. Install it to set up its database."
 msgstr ""
 
 #, php-format
-msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbours when it comes time to revoke one."
+msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
 msgstr ""
 
 #, php-format
@@ -1124,7 +1124,7 @@ msgstr "设置"
 msgid "Auto Logout Time"
 msgstr "默认注销时间（分钟）"
 
-msgid "Automatic enrolment (Setup/Custom Mode)"
+msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
 msgid "BIOS Date"
@@ -1348,10 +1348,11 @@ msgid "Cancel the selected tasks."
 msgstr "删除所选"
 
 #, fuzzy
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "取消任务"
 
-msgid "Cancelled due to new tasking."
+#, fuzzy
+msgid "Canceled due to new tasking."
 msgstr "由于新的任务取消。"
 
 #, fuzzy
@@ -1525,7 +1526,7 @@ msgstr ""
 msgid "Check the password stored for this node"
 msgstr "没有FOGPage类中找到此节点"
 
-msgid "Check this value against what the enrolment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
+msgid "Check this value against what the enrollment tool shows before confirming, whether the certificate reached the client on a USB stick or over the network. That comparison is what stops the wrong key being trusted."
 msgstr ""
 
 msgid "Checking for expired checked-in tasks..."
@@ -2440,7 +2441,7 @@ msgstr ""
 msgid "Enrolled certificate must be a SHA-256 fingerprint (64 hex characters)"
 msgstr ""
 
-msgid "Enrolment kit"
+msgid "Enrollment kit"
 msgstr ""
 
 #, fuzzy, php-format
@@ -2960,7 +2961,7 @@ msgstr "FOG设置"
 msgid "Flush the settings cache"
 msgstr "FOG设置"
 
-msgid "For a live-USB enrolment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
+msgid "For a live-USB enrollment, copy all three files onto a USB stick, boot the client from a stock Ubuntu or Debian live image with Secure Boot left ON, and run the launcher. No firmware changes are needed."
 msgstr ""
 
 msgid "For a network/SMB share use its path, e.g."
@@ -5880,7 +5881,7 @@ msgstr "错误，与此主机关联的图像"
 msgid "Online"
 msgstr ""
 
-msgid "Only a task in a queued or in-progress state can be cancelled. Naming a resource whose task has already finished -- Complete, Cancelled or Failed -- answers 409 rather than reporting a success it did not perform."
+msgid "Only a task in a queued or in-progress state can be canceled. Naming a resource whose task has already finished -- Complete, Canceled or Failed -- answers 409 rather than reporting a success it did not perform."
 msgstr ""
 
 msgid "Only administrators may use it until the plugin declares a permission for the route."
@@ -6635,7 +6636,7 @@ msgid "Queued Path Deletions"
 msgstr ""
 
 #, fuzzy
-msgid "Queued deletion is not active and cannot be cancelled"
+msgid "Queued deletion is not active and cannot be canceled"
 msgstr "管理单元被保护，不能被删除"
 
 msgid "RESOURCES"
@@ -7147,14 +7148,14 @@ msgstr ""
 msgid "Secure Boot ON"
 msgstr ""
 
-msgid "Secure Boot does not need to be enabled on a client to enrol its key -- either route works the same way with it off, which lets you stage enrolment fleet-wide before ever turning it on."
+msgid "Secure Boot does not need to be enabled on a client to enroll its key -- either route works the same way with it off, which lets you stage enrollment fleet-wide before ever turning it on."
 msgstr ""
 
 #, fuzzy
 msgid "Secure Boot enrollment date is not a valid date"
 msgstr "有此服务器上没有图像。"
 
-msgid "Secure Boot enrolment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
+msgid "Secure Boot enrollment material is switched off for this install, or no signing key is configured -- so no platform keys were minted."
 msgstr ""
 
 #, fuzzy
@@ -7184,7 +7185,7 @@ msgid "Selectable on"
 msgstr "选择一个cron类型"
 
 #, fuzzy
-msgid "Selected tasks cancelled!"
+msgid "Selected tasks canceled!"
 msgstr "已成功更新"
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7299,7 +7300,7 @@ msgid "Session with that name already exists!"
 msgstr "使用此名称的主机名已经存在。"
 
 #, fuzzy
-msgid "Sessions cancelled!"
+msgid "Sessions canceled!"
 msgstr "已成功更新"
 
 msgid "Set Printer as Default for Hosts"
@@ -7404,7 +7405,7 @@ msgstr "加载失败： %s"
 msgid "Signed in as %s."
 msgstr ""
 
-msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrolment a deliberate act rather than something a server can do to a client remotely."
+msgid "Signing is already done on this server. The remaining work is per-client and has to be done by someone at the machine -- that is what makes enrollment a deliberate act rather than something a server can do to a client remotely."
 msgstr ""
 
 #, fuzzy
@@ -8311,7 +8312,7 @@ msgid "Task finished"
 msgstr "任务开始"
 
 #, fuzzy
-msgid "Task is not active and cannot be cancelled"
+msgid "Task is not active and cannot be canceled"
 msgstr "图像被保护，不能被删除"
 
 msgid "Task not created as there are no associated Tasks"
@@ -8427,7 +8428,7 @@ msgstr "有此服务器上没有组。"
 msgid "The CA private key is on this server"
 msgstr "有此服务器上没有组。"
 
-msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrols outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
+msgid "The Enroll Secure Boot task type does all of this for you: schedule it against a host or a group from Task Scheduling and the client boots FOS, which stages the request itself -- or enrolls outright with nothing to confirm, if the machine is in Setup Mode. The Enroll Secure Boot Key menu item stays for answering a pending request by hand, or for enrolling from local media on a machine FOS cannot boot."
 msgstr ""
 
 #, fuzzy
@@ -8579,7 +8580,7 @@ msgstr ""
 msgid "The manifest calls this plugin '%s' but the directory is '%s'. They must match."
 msgstr ""
 
-msgid "The manual enrolment steps below are unaffected."
+msgid "The manual enrollment steps below are unaffected."
 msgstr ""
 
 msgid "The node did not answer on the network"
@@ -8866,7 +8867,7 @@ msgstr ""
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
-msgid "This server has not published the automatic Secure Boot enrolment blobs (PK.auth, KEK.auth and db.auth), so automatic enrolment is unavailable. There are three reasons that happens:"
+msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9677,7 +9678,7 @@ msgstr ""
 msgid "Which side of a deploy each architecture may be picked on. An architecture set to Hosts only is not offered on an image, and one set to Images only is not offered on a host. This never affects what a host reports at boot or what a capture records -- only what a person may choose."
 msgstr ""
 
-msgid "Whichever route is used, MokManager -- the blue enrolment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
+msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has its own timeouts FOG cannot change: it gives up and boots normally if nothing is pressed within about 10 seconds of appearing, and reboots if left idle partway through for a few minutes. Be at the console before starting."
 msgstr ""
 
 msgid "Who"
@@ -9939,7 +9940,7 @@ msgid "confirm"
 msgstr "任务无效"
 
 #, fuzzy
-msgid "could not be cancelled"
+msgid "could not be canceled"
 msgstr "已成功更新"
 
 #, fuzzy
@@ -10003,7 +10004,7 @@ msgid "every column on this table will be treated as untyped"
 msgstr ""
 
 #, php-format
-msgid "exited abnormally with code %d; cancelling task"
+msgid "exited abnormally with code %d; canceling task"
 msgstr ""
 
 #, fuzzy
@@ -10065,7 +10066,7 @@ msgid "group claim"
 msgstr "组名称"
 
 #, fuzzy
-msgid "has been cancelled"
+msgid "has been canceled"
 msgstr "已成功更新"
 
 #, fuzzy
@@ -10247,7 +10248,7 @@ msgid "is not currently online"
 msgstr ""
 
 #, fuzzy
-msgid "is now cancelled"
+msgid "is now canceled"
 msgstr "已成功更新"
 
 #, fuzzy

--- a/packages/web/service/nodecert.php
+++ b/packages/web/service/nodecert.php
@@ -112,7 +112,7 @@ if (!hash_equals($expect, (string) $mac)) {
     nodecertRespond(403, ['error' => 'authentication failed']);
 }
 
-// Authenticated, but not yet authorised: holding the storage password proves
+// Authenticated, but not yet authorized: holding the storage password proves
 // membership of this FOG installation, not which node is calling. The source
 // address decides that, and it must match a node this master already knows --
 // which is why a node registers before it asks for a certificate.

--- a/packages/web/service/uboot/boot.php
+++ b/packages/web/service/uboot/boot.php
@@ -49,7 +49,7 @@ require '../../commons/base.inc.php';
 header("Content-type: text/plain");
 /*
  * No explicit mac argument: getHostItem() reads POST then GET on its own, so
- * a board that can only GET is served, and the normalisation (separators,
+ * a board that can only GET is served, and the normalization (separators,
  * URL-encoding) stays in the one place that already does it.
  */
 FOGCore::getHostItem(

--- a/packages/web/src/Audit/ActivityWindow.php
+++ b/packages/web/src/Audit/ActivityWindow.php
@@ -188,7 +188,7 @@ class ActivityWindow extends FOGBase
         $map = self::_map();
         if (count($sources) > 0) {
             // Whitelisted rather than filtered into the SQL: a source name
-            // becomes a table name here, so an unrecognised one is dropped
+            // becomes a table name here, so an unrecognized one is dropped
             // and never reaches the query.
             $map = array_intersect_key($map, array_flip($sources));
         }

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -2435,7 +2435,7 @@ class Authorization extends FOGBase
      * has to sit on the operations rather than on a model method, which is
      * what makes it a standing property rather than a UI courtesy.
      *
-     * Unrecognised classes are not RBAC-relevant and pass through
+     * Unrecognized classes are not RBAC-relevant and pass through
      * untouched.
      *
      * @param string $classname the model class being deleted from

--- a/packages/web/src/Auth/Redaction.php
+++ b/packages/web/src/Auth/Redaction.php
@@ -44,7 +44,7 @@ use FOG\Router\Route;
  *
  * THREE LAYERS, because one was what failed:
  *
- *   1. CREDENTIAL_PATTERN over the friendly key. Modelled directly on
+ *   1. CREDENTIAL_PATTERN over the friendly key. Modeled directly on
  *      Route::SENSITIVE_SETTING_PATTERN, which exists so a credential
  *      setting added later is masked by default instead of leaking until
  *      somebody remembers. A field that matches and is NOT a credential goes

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -592,7 +592,7 @@ abstract class FOGBase
      *    the map is keyed on lowercased SHORT names, so 'fog\items\host'
      *    matches nothing and falls through. An explicit early return for it
      *    was written first and removed -- mutation testing showed deleting
-     *    it changed no behaviour, which is the definition of a branch
+     *    it changed no behavior, which is the definition of a branch
      *    describing a case that cannot happen.
      *
      * Passing an unknown name through rather than failing is what keeps this
@@ -1140,7 +1140,7 @@ abstract class FOGBase
     /**
      * How long a single fault line may get, in bytes, before it is cut.
      *
-     * A backstop, not the main defence: logFault() drops PDODB's debug tail
+     * A backstop, not the main defense: logFault() drops PDODB's debug tail
      * outright (see there). This catches what has no tail to drop -- a
      * driver message that is itself enormous, or a caller that built its
      * own. One fault stays one readable line either way.
@@ -1297,7 +1297,7 @@ abstract class FOGBase
      * The directory is never created here. It is the installer's, which gives
      * it to the web user with the right SELinux label (GH-964: /opt/fog
      * inherits usr_t and httpd_t may read it but not write it, so an
-     * unlabelled mkdir would produce a directory that looks right and
+     * unlabeled mkdir would produce a directory that looks right and
      * silently swallows every write on an enforcing host).
      *
      * @return string
@@ -2178,7 +2178,7 @@ abstract class FOGBase
      * it breaks a DHCP re-lease between PXE and FOS, a PXE NIC that differs from
      * the OS NIC, a VLAN hop, a relayed DHCP, or a NAT'd storage node. So the
      * policy is admin-declared instead, and DEFAULTS TO EMPTY = no restriction,
-     * which is exactly the behaviour before this setting existed. Sites that can
+     * which is exactly the behavior before this setting existed. Sites that can
      * state their imaging networks opt in; nobody's upgrade breaks.
      *
      * Accepts a comma/whitespace separated list of IPv4 CIDR ranges and/or
@@ -2192,7 +2192,7 @@ abstract class FOGBase
     {
         $allowed = trim((string)self::getSetting('FOG_HOSTKEY_ALLOWED_SOURCES'));
         if ($allowed === '') {
-            // Unconfigured: preserve pre-existing behaviour.
+            // Unconfigured: preserve pre-existing behavior.
             return true;
         }
         $ip = trim((string)$ip);
@@ -3053,9 +3053,9 @@ abstract class FOGBase
     }
     /**
      * Load every global setting from the database in a single query, applying
-     * the same normalisation as getSetting().
+     * the same normalization as getSetting().
      *
-     * @return array Map of settingKey => normalised value.
+     * @return array Map of settingKey => normalized value.
      */
     private static function _loadAllSettings()
     {
@@ -3103,7 +3103,7 @@ abstract class FOGBase
      * world-writable; executing code from it would be a local RCE vector.
      * Sensitive values (passwords, tokens, secrets) are stripped before writing
      * and are served from the database instead, so they never touch disk. The
-     * file is still mode 0600 (defence in depth) and read only by the web user;
+     * file is still mode 0600 (defense in depth) and read only by the web user;
      * daemons do not read it.
      *
      * @param array $data Map of settingKey => value.
@@ -3327,7 +3327,7 @@ abstract class FOGBase
             ['value' => trim($value)]
         );
 
-        // Only refresh the cache on a successful write, and normalise exactly
+        // Only refresh the cache on a successful write, and normalize exactly
         // as getSetting() would so cached reads match a fresh database read.
         if ($result) {
             self::$_settingsCache[$key] = [
@@ -3479,7 +3479,7 @@ abstract class FOGBase
         return TaskState::getCompleteState();
     }
     /**
-     * Get cancelled state id.
+     * Get canceled state id.
      *
      * @return int
      */
@@ -4674,7 +4674,7 @@ abstract class FOGBase
      * FOG_STORAGENODE_MYSQLPASS, which is what service/nodecert.php signs
      * with -- but that password is direct database access. Leaking it during
      * transport hands an attacker the whole schema; leaking this hands them
-     * the ability to list directories on a node, which is all it authorises.
+     * the ability to list directories on a node, which is all it authorizes.
      *
      * INSERT IGNORE rather than setSetting(), for two reasons. setSetting()
      * is an UPDATE through SettingManager and does nothing at all when the
@@ -4894,7 +4894,7 @@ abstract class FOGBase
     /**
      * Is this request signed by a FOG component that holds the node key?
      *
-     * Authentication, not authorisation: it says the caller is part of this
+     * Authentication, not authorization: it says the caller is part of this
      * installation, and nothing about what it may do. Endpoints accepting it
      * must still be ones a node is entitled to reach -- the same split
      * service/nodecert.php makes when it checks the HMAC and then separately
@@ -5210,7 +5210,7 @@ abstract class FOGBase
      * commons/schema-expected.php carries per-column types and is what
      * OpenAPI::_entitySchema() reads for the same question, so this adds no
      * new source of truth. A missing or unreadable manifest returns '', which
-     * emptyValueFor() treats as "assume a string column" -- the behaviour that
+     * emptyValueFor() treats as "assume a string column" -- the behavior that
      * shipped before any of this.
      *
      * @param string $table  the database table
@@ -5287,7 +5287,7 @@ abstract class FOGBase
             )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         } catch (\Exception $e) {
             // A catalog FOG cannot read leaves every column looking unknown,
-            // which is the behaviour that shipped before GH-1245 rather than
+            // which is the behavior that shipped before GH-1245 rather than
             // a broken one.
             self::logFault(
                 sprintf(
@@ -5308,7 +5308,7 @@ abstract class FOGBase
          * table went back to being untyped, which is exactly the GH-1245 bug
          * this method exists to prevent, reappearing with nothing said.
          *
-         * Behaviour is unchanged: still an empty map, still asked once per
+         * Behavior is unchanged: still an empty map, still asked once per
          * table per request. Only now it is written down.
          */
         if (self::$DB->error) {
@@ -5356,7 +5356,7 @@ abstract class FOGBase
      * Everywhere else the server either refuses it under a strict sql_mode or
      * coerces it without one, and FOG only ever saw the second, because
      * PDODB::_connect() cleared sql_mode on every connection. So this is not
-     * new behaviour being introduced -- it is the coercion the server was
+     * new behavior being introduced -- it is the coercion the server was
      * already performing, written down and made legal:
      *
      *   date/time  ->  NULL          (was '0000-00-00 00:00:00')

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -620,7 +620,7 @@ abstract class FOGManagerController extends FOGBase
     }
     /**
      * Perform the SQL queries needed for an server-side processing requested,
-     * utilising the helper functions of this class, limit(), order() and
+     * utilizing the helper functions of this class, limit(), order() and
      * filter() among others. The returned array is ready to be encoded as JSON
      * in response to an SSP request, or can be modified if needed before
      * sending back to the client.
@@ -928,7 +928,7 @@ abstract class FOGManagerController extends FOGBase
      * that ends every imaging task via ->set('tokenlock', false). And an
      * array -- a nested IN () list is one -- is a TypeError on PHP 8.
      *
-     * A boolean is left as a boolean and normalised once, in PDODB::_bind(),
+     * A boolean is left as a boolean and normalized once, in PDODB::_bind(),
      * so save() and the two builders here cannot disagree about what false
      * stores. See GH-1245 and forum topic 18227.
      *
@@ -968,7 +968,7 @@ abstract class FOGManagerController extends FOGBase
      *
      *  - Only columns the caller NAMED. A required column the batch is silent
      *    about is left to columnsRequiringValue() below, which is the
-     *    behaviour every one of those call sites already relies on; turning
+     *    behavior every one of those call sites already relies on; turning
      *    silence into an error is a different change with a different blast
      *    radius.
      *  - Only *ID columns. They are the ones whose zero is indistinguishable
@@ -1080,7 +1080,7 @@ abstract class FOGManagerController extends FOGBase
          * statement does not name is error 1364 and the whole batch is
          * rejected; without one the server invents a zero value and says
          * nothing. PDODB cleared sql_mode until GH-1245, so every such call
-         * site had been relying on the second behaviour without knowing it --
+         * site had been relying on the second behavior without knowing it --
          * saving FOG settings omits settingDesc and settingCategory, and
          * tasking a group's snapins omits stReturnCode and stReturnDetails.
          *

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -196,7 +196,7 @@ abstract class FOGPage extends FOGBase
      * every page construction was hitting that. Deliberately left without
      * a native type -- _init() calls unset($this->obj) when the id does
      * not resolve, and a typed property would then throw on read rather
-     * than warning, which is a different behaviour from the one this code
+     * than warning, which is a different behavior from the one this code
      * has always had.
      *
      * @var mixed
@@ -303,7 +303,7 @@ abstract class FOGPage extends FOGBase
      *
      * Deliberately keyed on self::$ajax (the X-Requested-With header jQuery
      * sets) rather than on a list of known JSON subs: a sub added later gets
-     * the right behaviour without anyone remembering to register it.
+     * the right behavior without anyone remembering to register it.
      *
      * @param string $node the node whose list page a browser is sent to
      * @param mixed  $id   the id that could not be resolved
@@ -1232,7 +1232,7 @@ abstract class FOGPage extends FOGBase
      * '/fog/', so nothing reached a FOG installed anywhere else. The webroot
      * reaches us in every shape -- '/fog/', 'fog', '/fog', '' -- because it is
      * written by the installer, edited by hand in FOG Settings, and carried
-     * per-node in ngmWebroot, so normalise rather than trust the stored form.
+     * per-node in ngmWebroot, so normalize rather than trust the stored form.
      *
      * Returns the bare form ('fog', 'apps/fog') because every caller supplies
      * its own surrounding slashes.
@@ -1352,8 +1352,8 @@ abstract class FOGPage extends FOGBase
      * means the only thing on screen is the action you can actually take.
      *
      * Both labels ride along as data attributes so gettext stays server-side
-     * and the JS only has to swap text. The colour is fixed for the life of
-     * the button -- state is carried by the label, not by a colour change --
+     * and the JS only has to swap text. The color is fixed for the life of
+     * the button -- state is carried by the label, not by a color change --
      * so callers pass whatever class fits their footer (primary when it is
      * the rightmost right-side button, secondary when something else there
      * already holds primary). Wire it up with $.registerReloadToggle().
@@ -1531,7 +1531,7 @@ abstract class FOGPage extends FOGBase
             $actionbox = '';
             $modals = '';
             if ($sub == 'list') {
-                // Tasks are cancelled per-pane, never deleted; the tabbed
+                // Tasks are canceled per-pane, never deleted; the tabbed
                 // task page hits sub=list via the no-sub default, so keep
                 // the delete actionbox off it. Activity and the audit log
                 // are read-only views of the event logs -- ?node=X&sub=list
@@ -2583,7 +2583,7 @@ abstract class FOGPage extends FOGBase
         // web server naming its own key or its own file, so the shared name
         // cannot be made per-request. Instead each download keeps its own
         // private file (see _downloadPost) and borrows the shared name only for
-        // the moment it is being signed, serialised here. That window is a
+        // the moment it is being signed, serialized here. That window is a
         // single sbsign inside a single request, which is short enough for a
         // lock to cover -- unlike the whole download, which spans three.
         //
@@ -4355,20 +4355,20 @@ abstract class FOGPage extends FOGBase
      *
      * When $force is true (the user ticked "First row is a header") the row
      * is always treated as a header. Otherwise it is auto-detected: every
-     * cell must be non-empty, unique, and a recognised column token.
-     * Recognised tokens are the class field keys plus 'primac' (hosts) and
+     * cell must be non-empty, unique, and a recognized column token.
+     * Recognized tokens are the class field keys plus 'primac' (hosts) and
      * 'associations' (where supported).
      *
      * Returns true when the row is a header; $map is filled with
-     * lowercased-token => column-index for recognised tokens, and $unknown
-     * collects any header cells that were not recognised (only meaningful
+     * lowercased-token => column-index for recognized tokens, and $unknown
+     * collects any header cells that were not recognized (only meaningful
      * when $force is true, since auto-detect rejects unknown tokens).
      *
      * @param mixed $row         the first CSV row
-     * @param array $validTokens recognised tokens, lowercased
+     * @param array $validTokens recognized tokens, lowercased
      * @param bool  $force       treat the row as a header unconditionally
      * @param array $map         out: token => column index
-     * @param array $unknown     out: unrecognised header cells
+     * @param array $unknown     out: unrecognized header cells
      *
      * @return bool
      */
@@ -4491,7 +4491,7 @@ abstract class FOGPage extends FOGBase
             // import) so the file is portable between servers.
             $fkConfig = self::getFkConfig($this->childClass);
 
-            // Recognised header tokens (lowercased) for this class: the field
+            // Recognized header tokens (lowercased) for this class: the field
             // keys, plus 'primac' for hosts and 'associations' where supported.
             $headerTokens = array_map('strtolower', $dbkeys);
             if ($isHost) {
@@ -5880,7 +5880,7 @@ abstract class FOGPage extends FOGBase
      * FOGManagerController::simple(); forcing length=-1 drops the SQL LIMIT.
      *
      * The header row uses the friendly column keys, which are exactly the
-     * tokens the CSV importer recognises, so the file round-trips through
+     * tokens the CSV importer recognizes, so the file round-trips through
      * import unchanged.
      *
      * @return void

--- a/packages/web/src/Base/FOGPageManager.php
+++ b/packages/web/src/Base/FOGPageManager.php
@@ -152,7 +152,7 @@ class FOGPageManager extends FOGBase
                 // below, which called get_class($class) with $class still
                 // unassigned -- on PHP 8 a TypeError, uncaught, so an unknown
                 // node returned a bare HTTP 500 with an empty body. Matching
-                // the old 308-to-dashboard keeps the behaviour users and any
+                // the old 308-to-dashboard keeps the behavior users and any
                 // stale bookmarks already expect.
                 self::redirect('../management/index.php');
             }

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -7,7 +7,7 @@
  * Extracted verbatim from FOGPage so the controller base stops growing
  * without bound. A trait's methods compile into the using class exactly as
  * if declared there (same $this, same access to inherited statics like
- * self::$HookManager), so behaviour is identical and every existing call
+ * self::$HookManager), so behavior is identical and every existing call
  * site keeps resolving unchanged. The file carries the `.class.php` suffix
  * so the existing filename-keyed autoloader resolves `use FOGPagePost;`
  * with no autoloader change. Its basename is lowercase like every other

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -7,7 +7,7 @@
  * Extracted verbatim from FOGPage so the controller base stops growing
  * without bound. A trait's methods compile into the using class exactly as
  * if declared there (same $this, same access to inherited statics like
- * self::$HookManager), so behaviour is identical and every existing call
+ * self::$HookManager), so behavior is identical and every existing call
  * site keeps resolving unchanged. The file carries the `.class.php` suffix
  * so the existing filename-keyed autoloader resolves `use FOGPageRender;`
  * with no autoloader change. Its basename is lowercase like every other
@@ -46,7 +46,7 @@ trait FOGPageRender
      *                          an escape hatch, but every association tab now
      *                          takes the primary default: green read as a
      *                          different KIND of action on tabs that are doing
-     *                          the same thing as their blue neighbours, and the
+     *                          the same thing as their blue neighbors, and the
      *                          two were mixed even within one page (host printer
      *                          vs host group). Green stays for genuinely
      *                          different actions like Resume.
@@ -534,7 +534,7 @@ trait FOGPageRender
      * are the only shared bookends, so they live here.
      *
      * The $obj argument is passed straight through to tabFields() with
-     * the same -1 default, preserving its three behaviours: -1 rebuilds
+     * the same -1 default, preserving its three behaviors: -1 rebuilds
      * the entity from the node/id globals, an explicit object uses it as
      * given, and false skips the TABDATA/plugin hook injection. The page
      * title always derives from $this->obj regardless of $obj.
@@ -996,7 +996,7 @@ trait FOGPageRender
      * The membership tables are many-to-many though, and the site page's
      * association grids can genuinely put one object in several sites --
      * at which point saving this tab replaces all of them with the one
-     * selected. That is the plugin's behaviour and it is kept, but it is
+     * selected. That is the plugin's behavior and it is kept, but it is
      * no longer SILENT: when an object is in more than one site the tab
      * says so and names them, so the replacement is a choice rather than a
      * surprise. Losing a membership with no message is the failure worth

--- a/packages/web/src/Base/Page.php
+++ b/packages/web/src/Base/Page.php
@@ -145,9 +145,9 @@ class Page extends FOGBase
      * The bar for this list is that the script has NO side effects at
      * execution time. jscolor.js deliberately is NOT here despite looking
      * similar: it scans the DOM for .jscolor inputs when it runs, so loading
-     * it once would leave the storage node edit page with no colour pickers
+     * it once would leave the storage node edit page with no color pickers
      * the second time it is opened. If in doubt, leave a script out -- the
-     * cost of being wrong is silent, and it is missing behaviour rather than
+     * cost of being wrong is silent, and it is missing behavior rather than
      * a visible error.
      *
      * @var array

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4363');
+        define('FOG_VERSION', '1.6.0-beta.4367');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -75,12 +75,12 @@ class System
         // at all, so the precise check never gets to run and the step sits
         // there applying to nobody.
         //
-        // That is not hypothetical: 18edea94f appended the element labelled
+        // That is not hypothetical: 18edea94f appended the element labeled
         // 330 without touching this constant, leaving it at 329, and task
         // type 26 reached no install until this bump. An earlier revision of
         // this comment said the constant had "drifted well above" the count
         // (289 at the time) and that nothing required the two to agree, which
-        // read as licence not to bump. They do have to agree, so tests/
+        // read as license not to bump. They do have to agree, so tests/
         // schema-gate.test.php now fails the build when they do not.
         //
         // The invariant the test pins, and the one to keep when appending:

--- a/packages/web/src/Boot/BootMenuBase.php
+++ b/packages/web/src/Boot/BootMenuBase.php
@@ -430,13 +430,13 @@ abstract class BootMenuBase extends FOGBase
                 // Memtest, chaining straight to _enrollSecureBootChoice() so a
                 // scheduled task landed on the same MokManager screen as PXE
                 // menu item 14. It now boots FOS instead (mode=enrollsb, schema
-                // step 323), which is what lets it enrol automatically in Setup
+                // step 323), which is what lets it enroll automatically in Setup
                 // Mode and stage a request non-interactively otherwise -- so it
                 // takes the ordinary kernel-chain path like any other task.
                 //
                 // _enrollSecureBootChoice() and pxeID 14 both stay: chaining
                 // directly to MokManager is still how a technician answers a
-                // pending request, or enrols from local FAT media on a machine
+                // pending request, or enrolls from local FAT media on a machine
                 // FOS cannot boot.
                 $this->_printTasking($kernelArgsArray);
             }

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -153,7 +153,7 @@ class IpxeBootMenu extends BootMenuBase
      * 'warn' is set only when the client named an architecture FOG ships no
      * FOS kernel for. An ABSENT arch is not that -- plenty of internal
      * chains post no arch at all -- so it resolves to x86_64 silently, the
-     * behaviour that has always been in place.
+     * behavior that has always been in place.
      *
      * @return array the profile for this request
      */
@@ -321,7 +321,7 @@ class IpxeBootMenu extends BootMenuBase
                     // been emitted rather than "corrected" to match the x86
                     // spelling: which one grub_aa64.exe accepts is a property
                     // of that binary, and changing it here would be a silent
-                    // behaviour change on the one path that cannot be tested
+                    // behavior change on the one path that cannot be tested
                     // from an x86 machine.
                     'grubConfigFlag' => '--configfile',
                     'refindBinary' => 'refind_aa64.efi',
@@ -646,7 +646,7 @@ class IpxeBootMenu extends BootMenuBase
          * to default to refind_efi instead, because iPXE's sanboot could not then
          * boot the next UEFI boot entry and leaving FOG meant chainloading rEFInd
          * over HTTP to do it. It can now, so the third-party boot manager buys
-         * nothing -- see the migration labelled 337 in commons/schema.php.
+         * nothing -- see the migration labeled 337 in commons/schema.php.
          * reset console to detected display resolution first to avoid graphical anamolies
          * --drive 0 will boot the first drive found with an efi boot file at the default file path of \EFI\Boot\bootx64.efi (side note, removable install media is found before local disks)
          * could add additional linux detections per distro like `sanboot --drive 0 --no-describe --extra \EFI\rocky` and EFI\centos and EFI\debian etc. but need an || entry for every distro.
@@ -714,7 +714,7 @@ class IpxeBootMenu extends BootMenuBase
          * literal '/fog/', so every boot URL handed to iPXE ignored the setting
          * -- this is why a custom webroot broke PXE booting (GH-502).
          *
-         * Normalise instead of trusting the stored form: the value has been
+         * Normalize instead of trusting the stored form: the value has been
          * written by the installer, by hand in FOG Settings, and by older
          * versions, so it turns up with and without either slash. $curroot is
          * the path form ('/fog/') used to build absolute URLs; $bootroot is the
@@ -2233,7 +2233,7 @@ class IpxeBootMenu extends BootMenuBase
         // id 14 already, the seeding INSERT was silently ignored (INSERT
         // IGNORE against a taken primary key does nothing), and the item never
         // appeared -- while a fresh install got it every time. Worse in the
-        // other direction: keying the behaviour on the id meant that site's
+        // other direction: keying the behavior on the id meant that site's
         // OWN custom entry would have started chaining to MokManager.
         //
         // Matching on the name removes the id from the contract entirely, so
@@ -2287,7 +2287,7 @@ class IpxeBootMenu extends BootMenuBase
      * _filterMenus() normally keeps the menu entry off an ARM screen
      * entirely, so the refusal is only reached by a scheduled memtest task
      * (which is created server-side, where the host's architecture is not
-     * knowable) or by a site that pointed a custom entry at this behaviour.
+     * knowable) or by a site that pointed a custom entry at this behavior.
      *
      * @param string $onFail what to append when the boot fails or is refused
      *
@@ -2379,7 +2379,7 @@ class IpxeBootMenu extends BootMenuBase
             'echo FAT-formatted USB stick in this machine instead.',
             'sleep 8',
             "chain -ar $mmTarget || "
-            . "echo Could not load the Secure Boot enrolment menu. && "
+            . "echo Could not load the Secure Boot enrollment menu. && "
             . "sleep 5 && goto MENU"
         ];
     }
@@ -2405,7 +2405,7 @@ class IpxeBootMenu extends BootMenuBase
         /**
          * "Enroll Secure Boot Key (MOK attended setup)" and its unattended
          * sibling are both meaningless on a legacy BIOS boot: there is no
-         * UEFI variable store to enrol into, so every route out of them --
+         * UEFI variable store to enroll into, so every route out of them --
          * MokManager, and the FOS task behind mode=enrollsb -- can only
          * fail. Both carry pxeRegOnly=2 so a technician never has to
          * repoint a client's boot file to reach them, and that "always
@@ -2437,7 +2437,7 @@ class IpxeBootMenu extends BootMenuBase
             $hide[] = 'fog.enrollsecurebootunattended';
         }
         /**
-         * The unattended enrol (mode=enrollsb) only auto-enrols when
+         * The unattended enroll (mode=enrollsb) only auto-enrolls when
          * PK.auth, KEK.auth and db.auth all exist in service/secureboot/ --
          * fog-build-sb-authvars' output, the same directory MOK.der already
          * lives in. Without all three the task type itself has nothing
@@ -2460,7 +2460,7 @@ class IpxeBootMenu extends BootMenuBase
          * here rather than refused inside _menuOpt() for the same reason
          * the Secure Boot items are: an option that cannot work should not
          * be on the menu. _menuOpt() keeps its own guard for the case where
-         * a site has pointed a custom entry at the same behaviour.
+         * a site has pointed a custom entry at the same behavior.
          */
         if (!self::_arch()['memdisk']) {
             $hide[] = 'fog.memtest';

--- a/packages/web/src/Boot/UbootBootMenu.php
+++ b/packages/web/src/Boot/UbootBootMenu.php
@@ -107,7 +107,7 @@ class UbootBootMenu extends BootMenuBase
             ]
         );
 
-        // Same normalisation as IpxeBootMenu: the value has been written by
+        // Same normalization as IpxeBootMenu: the value has been written by
         // the installer, by hand in FOG Settings, and by older versions, so
         // it turns up with and without either slash, and a nested webroot
         // such as '/apps/fog/' has to keep every segment.

--- a/packages/web/src/Client/SnapinClient.php
+++ b/packages/web/src/Client/SnapinClient.php
@@ -110,7 +110,7 @@ class SnapinClient extends FOGClient
                     'jobID' => $SnapinJob->get('id')
                 ];
                 // getList() sets inputoverride, which the old call left off.
-                // That is the one behaviour change here and it is deliberate:
+                // That is the one behavior change here and it is deliberate:
                 // this runs inside the client's POST, so without it listem()
                 // parses php://input -- and folds in ?length/?start -- and a
                 // request carrying either would silently truncate the snapin

--- a/packages/web/src/Db/PDODB.php
+++ b/packages/web/src/Db/PDODB.php
@@ -956,7 +956,7 @@ class PDODB extends DatabaseManager
          * 'sShutdown' at row 1", on any server with STRICT_TRANS_TABLES.
          *
          * It is the same defect as GH-1245 arriving by a different door.
-         * save()'s emptyValueFor() only recognises null and '' as empty, so
+         * save()'s emptyValueFor() only recognizes null and '' as empty, so
          * a boolean walks straight past it, and the manager UPDATE path
          * (HostManager::update() writing `hosts`.`hostInfoLock` from
          * ->set('tokenlock', false) at the end of every imaging task) never

--- a/packages/web/src/Items/APIToken.php
+++ b/packages/web/src/Items/APIToken.php
@@ -41,7 +41,7 @@ class APIToken extends FOGController
     /**
      * Prefix every issued token carries.
      *
-     * Present so a token is recognisable on sight -- in a log, a pasted
+     * Present so a token is recognizable on sight -- in a log, a pasted
      * config, a support ticket -- and so leaked-credential scanners have
      * something to match. It is part of the token: the hash covers the whole
      * string, so there is nothing to parse at verification time.

--- a/packages/web/src/Items/Architecture.php
+++ b/packages/web/src/Items/Architecture.php
@@ -90,7 +90,7 @@ class Architecture extends FOGController
      * compatibility test below compares two names that are equal in fact and
      * different as strings, and refuses a deploy that would have worked.
      *
-     * An architecture this does not recognise is returned unchanged rather
+     * An architecture this does not recognize is returned unchanged rather
      * than guessed at. idFromName() then finds no row and answers 0, which
      * reads as "not recorded" -- see canRun() for why that must never refuse.
      *

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -1014,7 +1014,7 @@ class Group extends FOGController
                 // absent and the task lands with a jobID of 0 -- and range()
                 // makes that worse, because range(0, -1) counts DOWN and hands
                 // back [0, -1]. A task is only reachable through its job, so
-                // such a row can never be shown, run or cancelled; it just
+                // such a row can never be shown, run or canceled; it just
                 // sits there, and until #895 it took the snapin task list down
                 // with it. One jobID-0 row on the 1.6 lab box is what put us
                 // onto this.

--- a/packages/web/src/Items/History.php
+++ b/packages/web/src/Items/History.php
@@ -145,7 +145,7 @@ class History extends FOGController
      *     boundary instead.
      *   - a TYPE_LOG row, which has no subject: FOGBase::log() takes a
      *     string and has no object in hand.
-     *   - a type this does not recognise, which is what a plugin writing
+     *   - a type this does not recognize, which is what a plugin writing
      *     its own code looks like.
      *
      * The failure types deliberately do not try to carry the error text.
@@ -154,7 +154,7 @@ class History extends FOGController
      *
      * The subject's class is NOT translated. It is an identifier, it is
      * what the prose has always shown, and it is not in any message
-     * catalogue.
+     * catalog.
      *
      * @param array $row The raw database row.
      *
@@ -172,7 +172,7 @@ class History extends FOGController
         }
         $class = ucfirst($class);
         // Each arm spells its whole msgid out. A format string built from a
-        // variable never reaches the catalogue -- xgettext reads source, not
+        // variable never reaches the catalog -- xgettext reads source, not
         // runtime -- so the sentence has to be a literal per case.
         if ('' !== $label) {
             switch ($type) {

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -68,7 +68,7 @@ class Host extends FOGController
         // The token superseded by the most recent rotation. authorize()
         // commits a rotated sec_tok before the client can possibly have
         // received it, so a response lost in flight used to strand the client
-        // on a token the server no longer recognised -- an unrecoverable
+        // on a token the server no longer recognized -- an unrecoverable
         // #!ist. Keeping one generation lets that client re-present its old
         // token once and be handed the current one again.
         'prev_sec_tok' => 'hostSecTokenPrev',
@@ -899,7 +899,7 @@ class Host extends FOGController
                 '',
                 [
                     'return' => -9999,
-                    'details' => _('Cancelled due to new tasking.'),
+                    'details' => _('Canceled due to new tasking.'),
                     'stateID' => self::getCancelledState()
                 ]
             );
@@ -989,7 +989,7 @@ class Host extends FOGController
             }
             // The job id gets the same treatment as the snapin id above. A
             // task is only reachable through its job, so one inserted against
-            // a jobID of 0 can never be shown, run or cancelled -- it is a row
+            // a jobID of 0 can never be shown, run or canceled -- it is a row
             // nothing can ever act on. save() failing is already caught above;
             // this catches a save that reported success without leaving an id
             // behind. See the matching guard in Group::createImagePackage().
@@ -2150,7 +2150,7 @@ class Host extends FOGController
      *
      * Named accessor for the same reason getImage() and getOS() are ones:
      * Route::getter() calls it alongside getImageType()/getOS()/
-     * getStorageGroup() on its neighbouring lines. It was written there
+     * getStorageGroup() on its neighboring lines. It was written there
      * before it existed here, which is the fatal that led to this. The value
      * comes from loadArch(), not from a join.
      *

--- a/packages/web/src/Items/MACAddress.php
+++ b/packages/web/src/Items/MACAddress.php
@@ -31,7 +31,7 @@ class MACAddress extends FOGBase
      *
      * Accepts the three formats a mac may arrive in: colon or hyphen
      * separated octets, twelve bare hex digits, or dot separated quads.
-     * Public so code that needs to recognise a mac without building a
+     * Public so code that needs to recognize a mac without building a
      * MACAddress (see FOGBase::stripAndDecodeMac) shares this one definition.
      *
      * @var string

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -510,10 +510,10 @@ class Plugin extends FOGController
         }
         // The archive is copied under a .tar.gz name before it is opened.
         // PharData decides the format from the FILE EXTENSION and refuses
-        // anything it does not recognise -- passing Phar::TAR|Phar::GZ does not
+        // anything it does not recognize -- passing Phar::TAR|Phar::GZ does not
         // override that -- and PHP's upload temp file is /tmp/phpXXXXXX with no
         // extension at all, so opening it in place always threw "file
-        // extension (or combination) not recognised".
+        // extension (or combination) not recognized".
         $token = bin2hex(random_bytes(16));
         $made = self::stagingRoot() . $token . DS;
         if (!self::_makeStagingDir($made)) {
@@ -563,7 +563,7 @@ class Plugin extends FOGController
                 if (count($parts) < 2) {
                     // Everything must live under one directory named for the
                     // plugin. A file at the root would extract straight into
-                    // the plugin root and could land on a neighbour.
+                    // the plugin root and could land on a neighbor.
                     if (!$entry->isDir()) {
                         return $fail(
                             sprintf(
@@ -651,7 +651,7 @@ class Plugin extends FOGController
             return $fail(sprintf('%s %s', $top, $compat));
         }
 
-        // The copy is only needed to give PharData a recognisable extension.
+        // The copy is only needed to give PharData a recognizable extension.
         // Removed once extraction is done so commitStaged() moves a directory
         // holding the plugin and nothing else. The handle goes first: it is
         // still open on the file being deleted.

--- a/packages/web/src/Items/Schema.php
+++ b/packages/web/src/Items/Schema.php
@@ -636,10 +636,10 @@ class Schema extends FOGController
      * which tinyint refuses, so without it the upgrade fails hard on exactly
      * the databases that most need repairing.
      *
-     * Nullability and default are read from the catalogue and carried across
+     * Nullability and default are read from the catalog and carried across
      * rather than assumed -- LDAPServers.lsAllowAPI is nullable and
      * lsUseGroupMatch has no default at all, and rewriting either would be a
-     * behaviour change smuggled in by a type change.
+     * behavior change smuggled in by a type change.
      *
      * Re-running is a read: a column that is not still exactly
      * enum('0','1') is skipped, so a converted column is left alone and so is
@@ -677,7 +677,7 @@ class Schema extends FOGController
                     && 0 === strcasecmp((string) $row['n'], 'YES');
                 // MariaDB reports a string default quoted ('1') and reports
                 // "no default" as SQL NULL; MySQL 8 reports the member
-                // unquoted. Trimming the quotes normalises both.
+                // unquoted. Trimming the quotes normalizes both.
                 $raw = $row['d'];
                 $hasDefault = null !== $raw
                     && 0 !== strcasecmp((string) $raw, 'NULL');

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -308,10 +308,10 @@ class Task extends TaskType
                 );
         }
         // Recorded only if the save actually happened, so the log cannot
-        // claim a transition the database never took. Before this, cancelling
+        // claim a transition the database never took. Before this, canceling
         // wrote nothing to taskLog at all: the row for the In-Progress
         // transition stayed the last word on the task, and Task Management's
-        // log pane showed a cancelled task as still running.
+        // log pane showed a canceled task as still running.
         if ($this->set('stateID', self::getCancelledState())->save()) {
             TaskLog::recordState($this);
         }

--- a/packages/web/src/Items/TaskLog.php
+++ b/packages/web/src/Items/TaskLog.php
@@ -175,7 +175,7 @@ class TaskLog extends FOGController
      * The single definition of what a state row looks like. It used to live
      * inline in TaskingElement::taskLog(), which meant only the two callers
      * that go through a TaskingElement -- checkIn() and checkout() -- could
-     * write one. Cancellation does not go through either, so a cancelled task
+     * write one. Cancellation does not go through either, so a canceled task
      * left no row at all and the last thing the log said about it was
      * In-Progress, forever.
      *
@@ -303,8 +303,8 @@ class TaskLog extends FOGController
             (array)$TaskType->isCapture(true)
         );
         // `ip` and `type` as well: recordState() gets both from TaskLog's
-        // constructor, which a batched INSERT never runs, and a bulk-cancelled
-        // row must not be distinguishable from a singly-cancelled one.
+        // constructor, which a batched INSERT never runs, and a bulk-canceled
+        // row must not be distinguishable from a singly-canceled one.
         $fields = [
             'taskID',
             'stateID',
@@ -350,7 +350,7 @@ class TaskLog extends FOGController
          * insertBatch() THROWS where FOGController::save() returns false, and
          * the only caller sits inside Route::cancel()'s try -- so an
          * unhandled failure here would answer a caller whose tasks really were
-         * cancelled with an error, which is the same class of lie the rest of
+         * canceled with an error, which is the same class of lie the rest of
          * this change exists to remove. recordState() cannot do this to its
          * caller and neither should this.
          *

--- a/packages/web/src/Items/TaskState.php
+++ b/packages/web/src/Items/TaskState.php
@@ -132,7 +132,7 @@ class TaskState extends FOGController
         return $completeState;
     }
     /**
-     * Gets the literal cancelled stated
+     * Gets the literal canceled stated
      *
      * @return int
      */
@@ -154,8 +154,8 @@ class TaskState extends FOGController
      * and the host could not be re-tasked because it still held an active
      * task.
      *
-     * Not Cancelled, which was the alternative and is the one thing this
-     * must not be confused with -- Cancelled means an administrator stopped
+     * Not Canceled, which was the alternative and is the one thing this
+     * must not be confused with -- Canceled means an administrator stopped
      * it. Losing the difference between "somebody stopped this" and "this
      * broke" is exactly the distinction an operator needs at the moment
      * they are looking at the task list.

--- a/packages/web/src/Items/TaskType.php
+++ b/packages/web/src/Items/TaskType.php
@@ -204,7 +204,7 @@ class TaskType extends FOGController
             // The character itself, not an `&#x...` entity. Initiator::e()
             // html-escapes what it is given, and the old code passed it an
             // entity with no trailing semicolon -- which htmlspecialchars
-            // cannot recognise as one even with double_encode off, so every
+            // cannot recognize as one even with double_encode off, so every
             // option rendered the literal text `&#xf02b` rather than a glyph.
             printf(
                 '<option value="%s"%s>%s %s</option>',

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -419,7 +419,7 @@ class User extends FOGController
     /**
      * Reduce a caller-supplied auth source to something safe to record.
      *
-     * Normalised, not trusted: the value reaches the history table and a
+     * Normalized, not trusted: the value reaches the history table and a
      * session key, and a provider plugin supplies it. Anything that is not a
      * plain slug is recorded as unknown rather than passed through, because
      * "we do not know how this session was made" is a fact worth keeping and

--- a/packages/web/src/Managers/MulticastSessionManager.php
+++ b/packages/web/src/Managers/MulticastSessionManager.php
@@ -41,7 +41,7 @@ class MulticastSessionManager extends FOGManagerController
          */
         $findWhere = ['id' => (array)$multicastsessionids];
         /**
-         * Get the current id for cancelled state.
+         * Get the current id for canceled state.
          */
         $cancelled = self::getCancelledState();
         /**
@@ -53,7 +53,7 @@ class MulticastSessionManager extends FOGManagerController
             'taskID'
         );
         /**
-         * Set tasks to cancelled as the main session was cancelled.
+         * Set tasks to canceled as the main session was canceled.
          */
         self::getClass('TaskManager')
             ->update(
@@ -66,7 +66,7 @@ class MulticastSessionManager extends FOGManagerController
                 ]
             );
         /*
-         * Set our cancelled state
+         * Set our canceled state
          */
         $this->update(
             $findWhere,

--- a/packages/web/src/Managers/SnapinJobManager.php
+++ b/packages/web/src/Managers/SnapinJobManager.php
@@ -40,10 +40,10 @@ class SnapinJobManager extends FOGManagerController
      * This used to cancel only the job's TASKS and let the job's own state
      * follow from them: it worked out the task ids, handed them to
      * SnapinTaskManager::cancel(), and returned. That delegate is what marked
-     * the job cancelled, by counting the tasks each job had left once it had
-     * cancelled the ones it was given.
+     * the job canceled, by counting the tasks each job had left once it had
+     * canceled the ones it was given.
      *
-     * Which meant a job with no tasks could not be cancelled at all. Deleting
+     * Which meant a job with no tasks could not be canceled at all. Deleting
      * a snapin removes its snapintask rows and then asks for the cancel, so
      * there was nothing left to count and the job sat Queued forever against a
      * snapin that no longer exists. Both delete paths hit this --
@@ -52,7 +52,7 @@ class SnapinJobManager extends FOGManagerController
      * $cancelled were both computed and then thrown away, which is the direct
      * job update that was meant to be here and never was.
      *
-     * So the job is now cancelled directly. That works with or without tasks,
+     * So the job is now canceled directly. That works with or without tasks,
      * and on the path where tasks do exist it is a harmless re-write of a state
      * the delegate has already set.
      *
@@ -73,8 +73,8 @@ class SnapinJobManager extends FOGManagerController
             (array) self::getQueuedStates(),
             (array) self::getProgressState()
         );
-        // Tasks first, where there still are any -- unchanged behaviour, and
-        // what callers cancelling a live job still rely on.
+        // Tasks first, where there still are any -- unchanged behavior, and
+        // what callers canceling a live job still rely on.
         $snapintaskids = Route::getIds(
             'snapintask',
             ['jobID' => $snapinjobids]
@@ -84,7 +84,7 @@ class SnapinJobManager extends FOGManagerController
                 ->cancel($snapintaskids);
         }
         // Only jobs still queued or running, so a job that already finished is
-        // not rewritten to Cancelled after the fact.
+        // not rewritten to Canceled after the fact.
         $toCancel = Route::getIds(
             'snapinjob',
             [
@@ -101,10 +101,10 @@ class SnapinJobManager extends FOGManagerController
             ['stateID' => $cancelled]
         );
         // A host sitting on a snapin-ONLY task has nothing left to do once its
-        // job is cancelled, so the task goes with it. SnapinTaskManager already
+        // job is canceled, so the task goes with it. SnapinTaskManager already
         // does this on the path where tasks exist; mirrored here for the path
         // where they have been deleted, or the host would keep an active task
-        // pointing at a cancelled job.
+        // pointing at a canceled job.
         //
         // Guarded rather than trusted: get('host') on a job whose host row is
         // gone returns a string, and calling into that is the same fatal that

--- a/packages/web/src/Managers/SnapinTaskManager.php
+++ b/packages/web/src/Managers/SnapinTaskManager.php
@@ -44,7 +44,7 @@ class SnapinTaskManager extends FOGManagerController
             'id' => (array)$snapintaskids
         ];
         /**
-         * Get our cancelled state id
+         * Get our canceled state id
          */
         $cancelled = self::getCancelledState();
         /**
@@ -63,7 +63,7 @@ class SnapinTaskManager extends FOGManagerController
             (array) self::getProgressState()
         );
         /**
-         * Update our entry to be cancelled
+         * Update our entry to be canceled
          */
         $this->update(
             $findWhere,
@@ -76,7 +76,7 @@ class SnapinTaskManager extends FOGManagerController
         $hostTasksToCancel = [];
         /**
          * Iterate our jobID's to find out if
-         * the job needs to be cancelled or not
+         * the job needs to be canceled or not
          */
         foreach ((array)$snapinJobIDs as $i => &$jobID) {
             /**

--- a/packages/web/src/Managers/TaskManager.php
+++ b/packages/web/src/Managers/TaskManager.php
@@ -66,7 +66,7 @@ class TaskManager extends FOGManagerController
             $updateFields
         );
         // Enumerated BEFORE the update, because $findWhere selects on the
-        // states being cancelled out of and matches nothing once they are
+        // states being canceled out of and matches nothing once they are
         // gone. Route::cancel() sends the group arm and the task arm here, so
         // without this a bulk cancel left every one of its tasks reading
         // In-Progress in the log -- the same hole Task::cancel() had.
@@ -84,7 +84,7 @@ class TaskManager extends FOGManagerController
         );
         if ($updated) {
             // Read back from `tasks` after the update, so each row records the
-            // state the task is now in rather than the one it was cancelled
+            // state the task is now in rather than the one it was canceled
             // out of -- and in one SELECT plus one batched INSERT, because
             // this arm cancels a whole group and rebuilding a Task per id to
             // write its row cost five queries apiece.
@@ -175,7 +175,7 @@ class TaskManager extends FOGManagerController
      * such rows -- two All Snapins, one Enroll Secure Boot -- every one of
      * them correct. So the image is only asked about for an imaging type.
      *
-     * FAILED, NOT CANCELLED. Cancelled means an administrator stopped it.
+     * FAILED, NOT CANCELLED. Canceled means an administrator stopped it.
      * Losing the difference between "somebody stopped this" and "this broke"
      * is exactly the distinction an operator needs at the moment they are
      * looking at the task list. Same reasoning as TaskState::getFailedState()

--- a/packages/web/src/Net/FOGURLRequests.php
+++ b/packages/web/src/Net/FOGURLRequests.php
@@ -610,7 +610,7 @@ class FOGURLRequests extends FOGBase
          * the signed-in administrator's PHP session id was handed to
          * api.github.com on every kernel listing and to fogproject.org on
          * every version check. It is here because a node's status endpoint
-         * needs the caller's session to authorise the request -- that is a
+         * needs the caller's session to authorize the request -- that is a
          * reason to send it to a node, and not a reason to send it anywhere
          * else.
          */

--- a/packages/web/src/Net/Ping.php
+++ b/packages/web/src/Net/Ping.php
@@ -654,7 +654,7 @@ class Ping
             $gotSeq = self::echoReplySeq($buf, $raw, $id);
             if (null === $gotSeq || !isset($seqOf[$gotSeq])) {
                 // Not ours, or a duplicate. Keep waiting -- the deadline is
-                // what ends this loop, not the first unrecognised packet.
+                // what ends this loop, not the first unrecognized packet.
                 continue;
             }
             $results[$seqOf[$gotSeq]] = true;

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -840,7 +840,7 @@ class OpenAPI extends FOGBase
         // own classes and its own joined fields at runtime, and a client
         // generated from a pinned snapshot meets fields added after it was
         // generated. Both are normal here, so tolerating unknown keys is the
-        // correct standing behaviour for a FOG response, not a workaround.
+        // correct standing behavior for a FOG response, not a workaround.
         $out = [
             'type' => 'object',
             'x-fog-table' => $table,
@@ -880,7 +880,7 @@ class OpenAPI extends FOGBase
             // The sentence above is accurate and stays -- it carries the
             // "not settable through create/edit" nuance that no keyword
             // expresses. But a generated client cannot read English. Every
-            // generator builds its deserialiser from `properties`, so a
+            // generator builds its deserializer from `properties`, so a
             // field named only in a description is a field the generated
             // model does not have: AutoRest copies this very sentence into
             // a doc comment and then emits a model that reads none of the
@@ -1487,8 +1487,8 @@ class OpenAPI extends FOGBase
                     // _errorResponses() map every path picks up.
                     _(
                         'Only a task in a queued or in-progress state can be '
-                        . 'cancelled. Naming a resource whose task has already '
-                        . 'finished -- Complete, Cancelled or Failed -- answers '
+                        . 'canceled. Naming a resource whose task has already '
+                        . 'finished -- Complete, Canceled or Failed -- answers '
                         . '409 rather than reporting a success it did not '
                         . 'perform.'
                     ),

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -339,7 +339,7 @@ class Route extends FOGBase
             'key',
         ],
         // The remember-me validator hash. userauth is not in $validClasses,
-        // so no route emits it and this changes no API behaviour -- it is
+        // so no route emits it and this changes no API behavior -- it is
         // here because the registry is now read by the audit trail as well
         // as the emitter (ADR 0021 Decision 6), and a credential column that
         // no route happens to expose is still a credential column.
@@ -750,7 +750,7 @@ class Route extends FOGBase
         /**
          * GH-529: the paths below were written as literal '/fog/...', so at a
          * custom webroot none of them matched. Anchor them to the configured
-         * webroot instead, normalised the same way IpxeBootMenu does since the
+         * webroot instead, normalized the same way IpxeBootMenu does since the
          * setting turns up with and without either slash.
          *
          * Every mismatch here fails closed -- a wrong or empty setting makes
@@ -906,7 +906,7 @@ class Route extends FOGBase
         self::printer(self::$data);
     }
     /**
-     * The configured webroot, normalised with a leading and trailing slash.
+     * The configured webroot, normalized with a leading and trailing slash.
      *
      * Exposed so OpenAPI can build servers[].url from the same value the
      * router anchors its paths to, rather than reconstructing it from the
@@ -1197,7 +1197,7 @@ class Route extends FOGBase
         return $whereItems;
     }
     /**
-     * Routes contributed by plugins, validated and normalised.
+     * Routes contributed by plugins, validated and normalized.
      *
      * Closes ADR 0009's first gap: every plugin-facing router hook until now
      * mutated a CLASS LIST, so a plugin could add a resource but never a
@@ -1220,7 +1220,7 @@ class Route extends FOGBase
      *   ]
      *
      * Everything about the validation below fails closed. A malformed entry
-     * is dropped, an unrecognised 'auth' becomes 'required', and a route that
+     * is dropped, an unrecognized 'auth' becomes 'required', and a route that
      * declares no permission is still registered but resolves to a
      * permission no role can hold (see Authorization::resolveApiPermission),
      * so it answers 403 with a log line naming the fix rather than 404 with
@@ -1257,7 +1257,7 @@ class Route extends FOGBase
      * @param array $entry The declaration as the plugin supplied it.
      * @param array $seen  Names already taken, as name => true.
      *
-     * @return array|null The normalised route, or null to drop it.
+     * @return array|null The normalized route, or null to drop it.
      */
     private static function _validatePluginRoute(array $entry, array $seen)
     {
@@ -2713,7 +2713,7 @@ class Route extends FOGBase
                             // stamps hostLastPing, so the badge and the
                             // timestamp cannot disagree.
                             //
-                            // Refused gets its own colour rather than
+                            // Refused gets its own color rather than
                             // borrowing success: the machine is up, which
                             // is what was asked, but "the port is shut" is
                             // the fact behind every "why is my Linux host
@@ -3421,7 +3421,7 @@ class Route extends FOGBase
                         }
                         // Spelled out per shape rather than assembled from
                         // fragments: a format string built from a variable
-                        // never reaches the catalogue.
+                        // never reaches the catalog.
                         if ('' !== $image && '' !== $host) {
                             return sprintf(
                                 _('%1$s of %2$s on %3$s: %4$s'),
@@ -3607,7 +3607,7 @@ class Route extends FOGBase
                     'db' => 'utAction',
                     'dt' => 'action',
                     'formatter' => function ($d, $row) {
-                        // An unrecognised code renders as itself, so this can
+                        // An unrecognized code renders as itself, so this can
                         // carry a value written by an endpoint. Plain text
                         // like every other data column -- see the note on
                         // `summary` below.
@@ -3635,7 +3635,7 @@ class Route extends FOGBase
                         // deleted before phase 3 has no name to fall back
                         // on. Each msgid is spelled out because a format
                         // string built from a variable never reaches the
-                        // catalogue.
+                        // catalog.
                         if ('' !== $who && '' !== $host) {
                             return sprintf(
                                 _('%1$s: %2$s on %3$s'),
@@ -4911,7 +4911,7 @@ class Route extends FOGBase
                 // setErrorMessage(), not sendResponse(): every error this
                 // route can answer with is documented as the Error schema,
                 // and sendResponse() writes the bare string into a body
-                // labelled application/json. A generated client parses
+                // labeled application/json. A generated client parses
                 // that and gets a syntax error instead of the reason.
                 self::setErrorMessage(
                     _('Plugin not found'),
@@ -4998,11 +4998,11 @@ class Route extends FOGBase
         try {
             $classname = strtolower($class);
             $class = self::_newEntity($class, $id);
-            // The states a task can be cancelled FROM. This is the same
+            // The states a task can be canceled FROM. This is the same
             // allowlist every "is this task live" test in the tree uses --
             // Host::loadTask() and getActiveTaskCount() both ask for exactly
             // it -- so anything outside it is already finished: Complete,
-            // Cancelled, and Failed since schema 339.
+            // Canceled, and Failed since schema 339.
             $states = self::fastmerge(
                 (array)self::getQueuedStates(),
                 (array)self::getProgressState()
@@ -5018,7 +5018,7 @@ class Route extends FOGBase
                     // listem(). Two separate faults lived in that call:
                     //
                     //  - It passed NO state filter, and every row that came
-                    //    back was cancelled regardless of state. The listing
+                    //    back was canceled regardless of state. The listing
                     //    is not state-scoped either: the same host filter
                     //    matches 29 rows for group 2 on the development
                     //    server, none of them active. How much of that a real
@@ -5028,7 +5028,7 @@ class Route extends FOGBase
                     //    29 as the exposure, not as a measured outcome.
                     //  - listem() returns a PAGINATED envelope, so the work
                     //    was bounded by a page either way. (Iterating the
-                    //    envelope rather than ->data once cancelled nothing at
+                    //    envelope rather than ->data once canceled nothing at
                     //    all -- that half was already fixed.)
                     //
                     // TaskManager::cancel() is the established bulk path and
@@ -5075,7 +5075,7 @@ class Route extends FOGBase
                     // Has no stateID at all -- it carries isActive -- so it
                     // fell into the default arm below, failed the state test
                     // and returned 200 having done nothing. The endpoint has
-                    // therefore never cancelled a scheduled task. Its model
+                    // therefore never canceled a scheduled task. Its model
                     // cancel() is a destroy(), which is what the management
                     // page does too, and there is no state to be wrong about.
                     if (!$class->isValid()) {
@@ -5100,7 +5100,7 @@ class Route extends FOGBase
                     }
                     if (!in_array($class->get('stateID'), $states)) {
                         self::_notCancellable(
-                            _('Queued deletion is not active and cannot be cancelled')
+                            _('Queued deletion is not active and cannot be canceled')
                         );
                     }
                     $class->getManager()->cancel([$class->get('id')]);
@@ -5122,7 +5122,7 @@ class Route extends FOGBase
                     } else {
                         // Falling out of this test used to be silent: the
                         // method returned normally and the router answered 200
-                        // "cancelled" with the state untouched. That is how a
+                        // "canceled" with the state untouched. That is how a
                         // Failed task came back from the API reporting success
                         // and stayed Failed.
                         if (!in_array($class->get('stateID'), $states)) {
@@ -5133,7 +5133,7 @@ class Route extends FOGBase
                             self::_notCancellable(
                                 sprintf(
                                     '%s: %s',
-                                    _('Task is not active and cannot be cancelled'),
+                                    _('Task is not active and cannot be canceled'),
                                     ($stateName ?: $class->get('stateID'))
                                 )
                             );
@@ -5156,7 +5156,7 @@ class Route extends FOGBase
      * breaking anyone. Same `{"msg": ...}` shape the 200 already uses, which
      * is what $.notifyFromAPI() reads.
      *
-     * @param string $msg Why the resource cannot be cancelled.
+     * @param string $msg Why the resource cannot be canceled.
      *
      * @return void
      */
@@ -5199,8 +5199,8 @@ class Route extends FOGBase
             // the class's own fields, which is all this used to do, admits
             // every sensitive field -- they ARE the class's fields. Only
             // _assertNoSensitiveFilter() is called, not the full key check:
-            // this body has always ignored keys it does not recognise, and
-            // starting to 400 on them would be a separate behaviour change.
+            // this body has always ignored keys it does not recognize, and
+            // starting to 400 on them would be a separate behavior change.
             self::_assertNoSensitiveFilter($find, $classname);
 
             // Request-supplied, so the caller-facing '*'/'+' wildcards apply
@@ -5719,12 +5719,12 @@ class Route extends FOGBase
                     /*
                      * images/snapinfiles/logfiles are not columns. Each one
                      * is an outbound HTTP GET to status/getfiles.php on that
-                     * node, so serialising a node used to cost two round
+                     * node, so serializing a node used to cost two round
                      * trips to a machine that may be down -- paid by every
                      * caller, including ones that never look at the answer.
                      * FOGMulticastManager re-reads its master nodes every
                      * MULTICASTSLEEPTIME (10s), and the storagegroup grid
-                     * serialises a master node per row.
+                     * serializes a master node per row.
                      *
                      * logfiles was already commented out for exactly this
                      * cost, which is the tell that the other two should have
@@ -6609,7 +6609,7 @@ class Route extends FOGBase
             }
             // Same empty-identifier trap as an unknown filter key, but on the
             // selected column: getField is a URL segment ("/ids/id=1/name")
-            // or a JSON body field, so an unrecognised value compiled to
+            // or a JSON body field, so an unrecognized value compiled to
             // `SELECT `` FROM ...` and returned HTTP 200 with [].
             //
             // Only answered when actually serving a request. Unlike a filter
@@ -6619,7 +6619,7 @@ class Route extends FOGBase
             // which passes it in a variable. sendResponse() exits, so
             // answering unconditionally would turn a bad field into a dead
             // daemon (cf. 2d199fa4b). Off-request, log and leave the
-            // pre-existing rejected-query behaviour alone.
+            // pre-existing rejected-query behavior alone.
             // $getField may be an array, in which case each row comes back as
             // a map of friendly name => value instead of a bare scalar. Only
             // ever passed internally -- a URL segment or JSON body can only
@@ -6916,7 +6916,7 @@ class Route extends FOGBase
         // A code this does not know renders as itself, not as an empty
         // cell. utAction has no lookup table and nothing constrains the
         // column to the three codes UserTracking declares, so an
-        // unrecognised one is a real possibility (a plugin writing its own,
+        // unrecognized one is a real possibility (a plugin writing its own,
         // or the '' that save() wrote into every unset column before
         // GH-1245). Falling out of the switch returned null, so the row
         // still listed with a blank Action and nothing said why.
@@ -7146,8 +7146,8 @@ class Route extends FOGBase
      * iterates the envelope instead walks its eleven scalar members (draw,
      * recordsTotal, the page URLs...) and gets null for every field. It does
      * not error, it warns. That mistake has shipped three times: the ou
-     * plugin never set ADOU on any client check-in, cancelling a group's tasks
-     * cancelled nothing, and the iPXE menu never applied its fog.local label.
+     * plugin never set ADOU on any client check-in, canceling a group's tasks
+     * canceled nothing, and the iPXE menu never applied its fog.local label.
      *
      * This returns the rows, so there is no envelope for a caller to hold
      * wrongly. Every permission filter, hook, expand and pluginItems step
@@ -7228,7 +7228,7 @@ class Route extends FOGBase
      *
      * The indiv() counterpart of getIds(). indiv()'s payload is flat -- there
      * is no envelope on a single entity -- so this exists for the round-trip
-     * and for the not-found behaviour rather than for unwrapping.
+     * and for the not-found behavior rather than for unwrapping.
      *
      * Existence is established first with an id-only query, deliberately.
      * indiv() answers a row it cannot find with sendResponse(404), which
@@ -7448,7 +7448,7 @@ class Route extends FOGBase
                     // and the row shows "() -" with no name to act on.
                     // Reported as "null tasks" in forum topics 18228/18230.
                     //
-                    // Cancelled rather than added to $removeItems, which is
+                    // Canceled rather than added to $removeItems, which is
                     // where the host case puts its tasks. Deleting a host
                     // takes its history with it because the subject of that
                     // history is gone; deleting an image does not -- the
@@ -8502,7 +8502,7 @@ class Route extends FOGBase
                     $k_i_type = trim($k_hint, ' ()');
                     if ($k_i_type === '') {
                         // The default arm of the switch above means "prefix not
-                        // recognised", which is an unknown, not a promise of
+                        // recognized", which is an unknown, not a promise of
                         // stability -- so show the release's own name rather
                         // than an empty cell. It filters and sorts usefully too.
                         $k_i_type = $release->name;

--- a/packages/web/src/Service/MulticastManager.php
+++ b/packages/web/src/Service/MulticastManager.php
@@ -319,7 +319,7 @@ class MulticastManager extends FOGService
                 // Common string used for logging.
                 $startStr = ' | ' . _('Task ID') . ': %s '. _('Name') . ': %s %s';
 
-                // A session that leaves the active set -- cancelled from the
+                // A session that leaves the active set -- canceled from the
                 // UI, completed elsewhere, or deleted outright -- vanishes
                 // from the per-node task list before it can ever be matched
                 // below, so the sender it owns was never killed and ran on
@@ -676,7 +676,7 @@ class MulticastManager extends FOGService
                                             $runningTask->getID(),
                                             $runningTask->getName(),
                                             sprintf(
-                                                _('exited abnormally with code %d; cancelling task'),
+                                                _('exited abnormally with code %d; canceling task'),
                                                 $exitcode
                                             )
                                         )
@@ -704,7 +704,7 @@ class MulticastManager extends FOGService
                                         $startStr,
                                         $runningTask->getID(),
                                         $runningTask->getName(),
-                                        _('has been cancelled')
+                                        _('has been canceled')
                                     )
                                 );
                                 $cancelTasks[] = $runningTask;
@@ -768,8 +768,8 @@ class MulticastManager extends FOGService
                             $Task->getName(),
                             (
                                 $Session->cancel() ?
-                                _('is now cancelled') :
-                                _('could not be cancelled')
+                                _('is now canceled') :
+                                _('could not be canceled')
                             )
                         )
                     );

--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -688,7 +688,7 @@ class MulticastTask extends FOGService
             // one directly, which is what guarantees two sessions cannot
             // land on the same address. Without a pool this falls back to
             // deriving an offset from the portbase, wrapped by the session
-            // cap -- the historical behaviour, and the reason
+            // cap -- the historical behavior, and the reason
             // FOG_MULTICAST_MAX_SESSIONS ended up doubling as a modulus.
             $pool = MulticastSession::portPool();
             $index = array_search((int)$this->getPortBase(), $pool, true);
@@ -1048,7 +1048,7 @@ class MulticastTask extends FOGService
         // MulticastTask, so any subclass override is silently ignored. No
         // subclass ships today, but it makes the method untestable in
         // isolation -- an override is skipped and the real one queries
-        // whatever session is loaded. Behaviour in the daemon is unchanged.
+        // whatever session is loaded. Behavior in the daemon is unchanged.
         $partid = $this->getPartitions();
         if ($partid < 1) {
             $filelist = array_values((array)$filelist);
@@ -1228,7 +1228,7 @@ class MulticastTask extends FOGService
     /**
      * Clears the persisted sender ownership for this session.
      *
-     * Called once the sender is gone (killed, completed or cancelled) so
+     * Called once the sender is gone (killed, completed or canceled) so
      * startup reconciliation does not later mistake a stale row for a live
      * orphan. senderstart is deliberately left alone: nothing reads it while
      * senderpid is 0, and keeping it records when the sender last ran.

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -182,7 +182,7 @@ class PingHosts extends FOGService
             //
             // getIds() answers [] rather than raising if the read fails, so
             // a failure here skips nothing and every host gets pinged --
-            // which is the old behaviour, and the safe direction to fail in.
+            // which is the old behavior, and the safe direction to fail in.
             $cutoff = self::niceDate()
                 ->modify(sprintf('-%d seconds', (int)static::$zzz))
                 ->format('Y-m-d H:i:s');

--- a/packages/web/src/TaskHandling/TaskError.php
+++ b/packages/web/src/TaskHandling/TaskError.php
@@ -43,7 +43,7 @@ use FOG\Items\TaskState;
  * The state is written for every task type, not just imaging ones: a Memtest
  * the host died on is as finished as a deploy. Only the notification is
  * imaging-specific. See TaskState::getFailedState() for why this is a sixth
- * state rather than Cancelled, and why adding one did not mean editing the
+ * state rather than Canceled, and why adding one did not mean editing the
  * places that enumerate states.
  *
  * Apart from that one field it writes nothing about the task. The endpoint is
@@ -101,7 +101,7 @@ class TaskError extends FOGBase
      *
      * A warning is a report that FOS carried on after, so it is worth a row
      * and a log line but is not a failure and must not fire HOST_IMAGE_FAIL.
-     * Anything unrecognised is treated as an error: a report FOG cannot
+     * Anything unrecognized is treated as an error: a report FOG cannot
      * classify is not a reason to throw it away.
      *
      * @var array
@@ -319,7 +319,7 @@ class TaskError extends FOGBase
     /**
      * Reads the report type, as a TaskLog type constant.
      *
-     * Unrecognised input becomes an error rather than being rejected. The
+     * Unrecognized input becomes an error rather than being rejected. The
      * caller is a machine that has already failed at something; the report
      * is worth more than the label on it, and a stricter reading would throw
      * away the report of a FOS newer than this server.
@@ -375,7 +375,7 @@ class TaskError extends FOGBase
         // to _flatten(), which those two destinations call and the stored
         // row does not.
         //
-        // Normalised first so only one line ending has to survive the class
+        // Normalized first so only one line ending has to survive the class
         // below, and so a CRLF report does not store stray carriage returns.
         $raw = preg_replace('#\r\n?#', "\n", (string) $raw);
         // [^\P{C}\n] is "in \p{C} but not a newline": every Unicode control
@@ -499,7 +499,7 @@ class TaskError extends FOGBase
      * The directory is never created here. It is the installer's, which
      * gives it to the web user with the right SELinux label (GH-964:
      * /opt/fog inherits usr_t and httpd_t may read it but not write it, so
-     * an unlabelled mkdir would produce a directory that looks right and
+     * an unlabeled mkdir would produce a directory that looks right and
      * silently swallows every write on an enforcing host).
      *
      * @return string

--- a/packages/web/src/TaskHandling/TaskQueue.php
+++ b/packages/web/src/TaskHandling/TaskQueue.php
@@ -44,8 +44,8 @@ class TaskQueue extends TaskingElement
      *
      * If the host's most recent matching-type task is already in the Complete
      * state and was checked in recently, reply with '##' (the success token
-     * the client waits for) and stop. Genuinely cancelled tasks move to the
-     * Cancelled state - not Complete - so real cancellations still fall
+     * the client waits for) and stop. Genuinely canceled tasks move to the
+     * Canceled state - not Complete - so real cancellations still fall
      * through and error exactly as before.
      *
      * Must be static: it is called before TaskQueue is constructed, because
@@ -589,7 +589,7 @@ class TaskQueue extends TaskingElement
         // image captured before schema step 370 is already in.
         //
         // The id copies straight across (schema step 372): both sides point
-        // at the same `architectures` row, so there is nothing to normalise
+        // at the same `architectures` row, so there is nothing to normalize
         // here any more and no way for the two to spell it differently.
         $capturedArchID = (int)self::$Host->get('archID');
         if ($capturedArchID > 0) {

--- a/packages/web/src/TaskHandling/TaskingElement.php
+++ b/packages/web/src/TaskHandling/TaskingElement.php
@@ -302,7 +302,7 @@ abstract class TaskingElement extends FOGBase
         // Cancellation reaches the tasks table through Task::cancel() and
         // TaskManager::cancel(), neither of which has a TaskingElement, and so
         // wrote no row at all -- leaving In-Progress as the last thing the log
-        // ever said about a cancelled task.
+        // ever said about a canceled task.
         //
         // recordState() resolves the host from the task instead of from
         // self::$Host. For this caller they are the same host; for the cancel

--- a/tests/alpine-openrc-services.test.sh
+++ b/tests/alpine-openrc-services.test.sh
@@ -21,10 +21,10 @@
 #
 # The properties pinned here:
 #
-#   A-C  enableInitScript() enrols every FOG daemon with rc-update, into a
+#   A-C  enableInitScript() enrolls every FOG daemon with rc-update, into a
 #        NAMED runlevel, and does not reach for chkconfig/sysv-rc-conf.
 #   D-G  the four service blocks each carry an osid 3 arm. Structural rather
-#        than behavioural: they live inside functions that rewrite /etc, so
+#        than behavioral: they live inside functions that rewrite /etc, so
 #        running them here would mean writing to the developer's own box.
 #   H    TFTP's existing osid 3 arm enables as well as starts -- it started
 #        in.tftpd and never enrolled it, so PXE worked until the first reboot.

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -322,7 +322,7 @@ $jsSrc = file_get_contents(
 //     only suppresses the native submit; every card is wired by hand in its
 //     page's JS, and an unwired one renders perfectly and does nothing.
 $t->check(
-    'the token grid is initialised in JS',
+    'the token grid is initialized in JS',
     false !== strpos($jsSrc, "$('#user-apitoken-table').registerTable(")
 );
 $t->check(

--- a/tests/arch-compatibility.test.php
+++ b/tests/arch-compatibility.test.php
@@ -97,7 +97,7 @@ $t->check(
     \FOG\Items\Architecture::canRun('', '') === true
 );
 
-// --- normalisation --------------------------------------------------------
+// --- normalization --------------------------------------------------------
 // FOS reports uname -m; iPXE reports ${buildarch}. Only iPXE's spelling is
 // stored, so anything arriving from elsewhere has to fold onto it or an
 // arm64 host would read as incompatible with its own arm64 image.
@@ -121,7 +121,7 @@ $t->check(
     \FOG\Items\Architecture::normalizeName('riscv64') === 'riscv64'
 );
 $t->check(
-    'an aarch64 image is compatible with an arm64 host after normalisation',
+    'an aarch64 image is compatible with an arm64 host after normalization',
     \FOG\Items\Architecture::canRun('aarch64', 'arm64') === true
 );
 
@@ -290,11 +290,11 @@ $t->check(
     \FOG\Items\Image::parseSectorSize("# note: sector-size: 4096 was seen\n") === 0
 );
 $t->check(
-    '4096 is labelled 4Kn',
+    '4096 is labeled 4Kn',
     false !== strpos(\FOG\Items\Image::sectorSizeLabel(4096), '4Kn')
 );
 $t->check(
-    '512 is labelled 512n/512e -- the two are not separable from a capture',
+    '512 is labeled 512n/512e -- the two are not separable from a capture',
     false !== strpos(\FOG\Items\Image::sectorSizeLabel(512), '512n/512e')
 );
 $t->check(

--- a/tests/audit-redaction-coverage.test.php
+++ b/tests/audit-redaction-coverage.test.php
@@ -337,7 +337,7 @@ foreach ($exempt as $class => $keys) {
  *    will. Outside a booted FOG, declaredFor() falls back to Route's core
  *    tiers -- which is what makes this callable here at all.
  */
-$behaviour = [
+$behavior = [
     // Declared in a core tier, and does not match the pattern on its own:
     // "tok" is not "token". This is the case the registry exists for.
     ['host', 'sec_tok', true],
@@ -348,7 +348,7 @@ $behaviour = [
     ['user', 'password', true],
     ['userauth', 'password', true],
     // Matches the pattern and is declared nowhere: withheld anyway. This is
-    // the default-closed behaviour that makes a forgotten column safe.
+    // the default-closed behavior that makes a forgotten column safe.
     ['host', 'someNewApiToken', true],
     ['image', 'sharedSecret', true],
     // Exempt: matches the pattern, is not a credential.
@@ -366,7 +366,7 @@ $behaviour = [
     // Nothing is not a secret.
     ['host', '', false],
 ];
-foreach ($behaviour as $case) {
+foreach ($behavior as $case) {
     list($class, $field, $want) = $case;
     $checks++;
     $got = Redaction::isSensitive($class, $field);

--- a/tests/boolean-encoding.test.sh
+++ b/tests/boolean-encoding.test.sh
@@ -60,9 +60,9 @@ done
 # unset into "no" would stop every prompt firing and silently answer for the
 # admin.
 is "$(_normalizeBool "")" "" "empty stays empty (prompt loops depend on it)"
-# An unrecognised value is left alone rather than guessed at. Turning a typo
+# An unrecognized value is left alone rather than guessed at. Turning a typo
 # into "no" is how a deliberate setting disappears with nothing to show why.
-is "$(_normalizeBool "maybe")" "maybe" "an unrecognised value is left untouched"
+is "$(_normalizeBool "maybe")" "maybe" "an unrecognized value is left untouched"
 is "$(_normalizeBool "2")" "2" "an out-of-range number is left untouched"
 
 # --- C. idempotence ----------------------------------------------------------

--- a/tests/booleans-are-tinyint.test.php
+++ b/tests/booleans-are-tinyint.test.php
@@ -158,7 +158,7 @@ btCheck(
 btCheck(
     'enumToTinyint() carries the column\'s nullability across rather than '
     . 'assuming NOT NULL -- LDAPServers.lsAllowAPI is nullable, and rewriting '
-    . 'that would be a behaviour change smuggled in by a type change',
+    . 'that would be a behavior change smuggled in by a type change',
     false !== strpos($method, 'IS_NULLABLE'),
     $failures,
     $checks

--- a/tests/booleans-store-as-zero-or-one.test.php
+++ b/tests/booleans-store-as-zero-or-one.test.php
@@ -14,7 +14,7 @@
  * with STRICT_TRANS_TABLES.
  *
  * It is GH-1245 arriving by a different door. save()'s emptyValueFor() only
- * recognises null and '' as empty, so a boolean walks past it untouched; and
+ * recognizes null and '' as empty, so a boolean walks past it untouched; and
  * the two builders in FOGManagerController called trim() first, which casts
  * before it trims, so false was already '' by the time it reached the binder.
  * The manager path is the one that ends every imaging task -- TaskQueue does
@@ -25,7 +25,7 @@
  * ->set() calls that currently pass a boolean would go green the moment
  * someone wrote another one, which is precisely how this arrived.
  *
- *   1. PDODB::_bind() normalises a boolean, as a STRING, before binding.
+ *   1. PDODB::_bind() normalizes a boolean, as a STRING, before binding.
  *   2. It does not reach for PDO::PARAM_BOOL/PARAM_INT to do it: bound as an
  *      integer, 0 against an ENUM is an *index*, and index 0 is the error
  *      value -- the same trap Schema::defaultLiteral() exists for.
@@ -35,7 +35,7 @@
  *      the boolean survives as far as the binder.
  *
  * DB-free: this reads the source, like insertbatch-required-columns. The
- * behaviour is proved against a live strict server, through the real ORM,
+ * behavior is proved against a live strict server, through the real ORM,
  * by background_scripts/prove_boolean_column_writes.php.
  *
  * Usage: php tests/booleans-store-as-zero-or-one.test.php
@@ -100,7 +100,7 @@ $ctlSrc = bStripComments(
     )
 );
 
-// --- 1. the binder normalises, and does it before bindValue() -------------
+// --- 1. the binder normalizes, and does it before bindValue() -------------
 $bindBody = '';
 if (preg_match(
     '#private static function _bind\([^)]*\)\s*\{(.*?)\n    \}#s',
@@ -128,7 +128,7 @@ bcheck(
 $boolPos = strpos($bindBody, 'is_bool($value)');
 $callPos = strpos($bindBody, 'bindValue(');
 bcheck(
-    'PDODB::_bind() normalises BEFORE it binds',
+    'PDODB::_bind() normalizes BEFORE it binds',
     $boolPos !== false && $callPos !== false && $boolPos < $callPos,
     $failures,
     $checks

--- a/tests/bootmenu-ipxe-output.test.php
+++ b/tests/bootmenu-ipxe-output.test.php
@@ -521,7 +521,7 @@ if ($broken) {
 }
 
 /*
- * Behaviour checks the golden cannot express.
+ * Behavior checks the golden cannot express.
  *
  * Each renders a scenario and asserts on something other than the exact bytes:
  * what a plugin was handed, whether a plugin's value survived, or whether a
@@ -794,14 +794,14 @@ foreach ($checks as $label => $check) {
     }
 }
 if ($checkFailures) {
-    fwrite(STDERR, "\nFAIL: behaviour checks\n");
+    fwrite(STDERR, "\nFAIL: behavior checks\n");
     foreach ($checkFailures as $f) {
         fwrite(STDERR, "  $f\n");
     }
     exit(1);
 }
 printf(
-    "bootmenu-ipxe-output: %d behaviour checks passed\n",
+    "bootmenu-ipxe-output: %d behavior checks passed\n",
     count($checks)
 );
 

--- a/tests/bootmenu-uboot-output.test.php
+++ b/tests/bootmenu-uboot-output.test.php
@@ -286,7 +286,7 @@ if ($fails) {
     exit(1);
 }
 
-printf("bootmenu-uboot-output: %d behaviour checks passed\n", count($expect));
+printf("bootmenu-uboot-output: %d behavior checks passed\n", count($expect));
 
 $expected = file_get_contents($golden);
 if ($expected === $actual) {

--- a/tests/cancel-route-reports-truthfully.test.php
+++ b/tests/cancel-route-reports-truthfully.test.php
@@ -7,15 +7,15 @@
  * than was asked:
  *
  *  - a task in a finished state fell out of the state test and answered
- *    "cancelled" with its state untouched (the reason this file exists: a
+ *    "canceled" with its state untouched (the reason this file exists: a
  *    Failed task did exactly that);
- *  - a group cancelled by no state filter at all and by a paginated listing,
- *    so whatever came back was cancelled whatever state it was in -- and the
+ *  - a group canceled by no state filter at all and by a paginated listing,
+ *    so whatever came back was canceled whatever state it was in -- and the
  *    listing covers every task the member hosts have ever run;
  *  - a host with nothing running reached Task::save() on an empty Task and
  *    answered 406 "Required database field is empty: typeID";
  *  - scheduledtask carries no stateID, so it failed a test it could never
- *    pass and the endpoint never once cancelled a scheduled task;
+ *    pass and the endpoint never once canceled a scheduled task;
  *  - filedeletequeue has no model cancel(), so a valid id raised an Error,
  *    which is not an \Exception and so escaped the catch as a bodyless 500.
  *
@@ -76,7 +76,7 @@ if (!preg_match(
     $cancel
 )) {
     $fails[] = 'a named task outside the active states does not answer 409,'
-        . ' so cancelling a Complete/Cancelled/Failed task reports success';
+        . ' so canceling a Complete/Canceled/Failed task reports success';
 }
 
 // ------------------------------------------------------------- the group
@@ -89,7 +89,7 @@ if (!preg_match(
     $cancel
 )) {
     $fails[] = 'the group arm does not filter its task ids by state, so'
-        . ' cancelling a group rewrites every task its hosts ever ran';
+        . ' canceling a group rewrites every task its hosts ever ran';
 }
 // listem() is paginated, so it was also the reason only one page of the
 // intended work happened. Reading ids has no page.
@@ -107,7 +107,7 @@ if (!preg_match('#case \'group\':(.*?)\n                    break;#s', $cancel, 
     $grp[1]
 )) {
     $fails[] = 'a group with no active tasks does not answer 409, so'
-        . ' cancelling an idle group reports success';
+        . ' canceling an idle group reports success';
 }
 
 // --------------------------------------------------------------- the host

--- a/tests/class-name-derivation.test.php
+++ b/tests/class-name-derivation.test.php
@@ -181,7 +181,7 @@ if ($converted < MIN_CONVERTED) {
     $fail = true;
 }
 
-// The helper's own behaviour, on the two shapes every call site uses.
+// The helper's own behavior, on the two shapes every call site uses.
 require_once $root . '/packages/web/src/Base/FOGBase.php';
 
 $cases = [
@@ -215,7 +215,7 @@ if ($fail) {
 
 printf(
     "ok: %d derivation site(s) via shortName(), %d marked consumer(s), "
-    . "%d file(s) scanned, 6 behaviour case(s)\n",
+    . "%d file(s) scanned, 6 behavior case(s)\n",
     $converted,
     $consumers,
     count($files)

--- a/tests/client-cert-flags.test.sh
+++ b/tests/client-cert-flags.test.sh
@@ -9,7 +9,7 @@
 # at their own files -- the exception a model whose premise is "say where the
 # cert is" cannot have.
 #
-# Three behaviours, and the difference between them is the whole point:
+# Three behaviors, and the difference between them is the whole point:
 #
 #   half a pair          REFUSED. A certificate without its key locks out every
 #                        registered host, and the failure surfaces per host as a

--- a/tests/client-zone-migration.test.sh
+++ b/tests/client-zone-migration.test.sh
@@ -167,7 +167,7 @@ is "$(cat "$ZONE/.srvpublic.crt")" "the-deployed-cert" \
 is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" \
    "$(readlink -f "$ZONE/.srvprivate.key")" \
    "upgrade: the canonical name still resolves to the key"
-is "$(neighboursIntact)" "" "upgrade: every neighbouring file is untouched"
+is "$(neighboursIntact)" "" "upgrade: every neighboring file is untouched"
 
 # --- C2. and the rest of the material lands in its own new home -------------
 # Asserting where each file WENT, not merely that it left $snapindir/ssl. The

--- a/tests/createtable-column-defaults.test.php
+++ b/tests/createtable-column-defaults.test.php
@@ -233,7 +233,7 @@ if (false !== $empty) {
                 'emptyDefaultFor(%s) returned %s on MariaDB, wanted %s. This '
                 . 'is the value the server used to substitute silently while '
                 . 'sql_mode was cleared; writing down a different one changes '
-                . 'behaviour rather than recording it.',
+                . 'behavior rather than recording it.',
                 var_export($type, true),
                 var_export($got, true),
                 var_export($want, true)

--- a/tests/event-frame-readers.test.php
+++ b/tests/event-frame-readers.test.php
@@ -192,7 +192,7 @@ if (is_callable($summary)) {
             'hSubjectType' => '',
             'hSubjectID' => null
         ],
-        'a type nothing recognises' => ['hType' => 'somepluginscode'],
+        'a type nothing recognizes' => ['hType' => 'somepluginscode'],
         'a typed row with no subject id' => ['hSubjectID' => null]
     ];
     foreach ($cases as $what => $overrides) {

--- a/tests/event-frame-writers.test.php
+++ b/tests/event-frame-writers.test.php
@@ -4,7 +4,7 @@
  * the ones the ADR fixed.
  *
  * Phase 2 added seven columns and mapped none of them, which was the point:
- * "an install that stops here is unchanged in behaviour". Phase 3 is the
+ * "an install that stops here is unchanged in behavior". Phase 3 is the
  * inverse claim -- rows written after the upgrade carry both the prose and
  * the structure -- and it has a failure mode phase 2 did not: a column that
  * is mapped but never set looks exactly like a column that is filled, from

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -102,7 +102,7 @@ out=$(_detectExternalCertManagement) && ok "D: fires on a leaf that does not cha
 #
 #    This one assertion is necessarily structural: it is about the ORDER
 #    createSSLCA consults things in, and the only way to observe that
-#    behaviourally is to run createSSLCA, which mints the vhost, writes under
+#    behaviorally is to run createSSLCA, which mints the vhost, writes under
 #    /etc and restarts services. The predicate itself is exercised for real
 #    below -- which is the part that used to be missing entirely.
 if awk '/Detect-then-LINK/,/_warnExternalCertTooling/' "$FUNCS" | grep -q '! _externallyManagedLeaf'; then
@@ -213,7 +213,7 @@ for k in PKI_web_vhost_cert PKI_web_vhost_key; do
 done
 
 # J. No prompt on the detect path. Under -y there is nobody to answer, and that
-#    is precisely the run that used to do the damage, so the safe behaviour must
+#    is precisely the run that used to do the damage, so the safe behavior must
 #    be the default rather than an answer to a question.
 if awk '/Detect-then-LINK/,/_warnExternalCertTooling/' "$FUNCS" | grep -qE '(^|[^_[:alnum:]])read($|[[:space:]])'; then
     bad "J: the detect path prompts, so an unattended run cannot benefit"

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -189,7 +189,7 @@ echo be ready before it appears.
 echo If it is not listed there, have MOK.der on a
 echo FAT-formatted USB stick in this machine instead.
 sleep 8
-chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrollment menu. && sleep 5 && goto MENU
 :bootme
 chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
 goto MENU
@@ -262,7 +262,7 @@ echo be ready before it appears.
 echo If it is not listed there, have MOK.der on a
 echo FAT-formatted USB stick in this machine instead.
 sleep 8
-chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrollment menu. && sleep 5 && goto MENU
 :fog.enrollsecurebootunattended
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=enrollsb
 imgfetch init.xz
@@ -1011,7 +1011,7 @@ echo be ready before it appears.
 echo If it is not listed there, have MOK.der on a
 echo FAT-formatted USB stick in this machine instead.
 sleep 8
-chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrolment menu. && sleep 5 && goto MENU
+chain -ar http://10.0.0.1/fog/service/secureboot/mmx64.efi || echo Could not load the Secure Boot enrollment menu. && sleep 5 && goto MENU
 :fog.enrollsecurebootunattended
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=enrollsb
 imgfetch init.xz

--- a/tests/fogsettings-key-migration.test.sh
+++ b/tests/fogsettings-key-migration.test.sh
@@ -183,7 +183,7 @@ harness() {
         [ "$mode" = "skip" ] || migrateDeprecatedKeys
 
         # Step 4a: what doOSSpecificIncludes does with FOG_os_id. Same shape as
-        # the real case statement -- a recognised id picks a distro, anything
+        # the real case statement -- a recognized id picks a distro, anything
         # else is the "Sorry, answer not recognized" arm.
         case ${FOG_os_id} in
             1) distro="Redhat"; webdirdest="${WEB_docroot}fog/"; tftpdirdst="/tftpboot" ;;
@@ -233,7 +233,7 @@ IFS='|' read -r distro guard osid osname iface dbuser docroot guard_glob <<EOF
 $out
 EOF
 
-is  'old format: the distro is recognised'          "$distro" "Redhat"
+is  'old format: the distro is recognized'          "$distro" "Redhat"
 is  'old format: FOG_os_id migrates from $osid'     "$osid"   "1"
 is  'old format: FOG_os_name migrates from $osname' "$osname" "Redhat"
 is  'old format: NET_interface migrates'            "$iface"  "eno1"
@@ -254,7 +254,7 @@ IFS='|' read -r distro guard osid osname iface dbuser docroot guard_glob <<EOF
 $(harness "$tmp/new.fogsettings")
 EOF
 
-is  'new format: the distro is recognised'  "$distro" "Redhat"
+is  'new format: the distro is recognized'  "$distro" "Redhat"
 is  'new format: FOG_os_id is untouched'    "$osid"   "1"
 is  'new format: DB_user is untouched'      "$dbuser" "fogmaster"
 is  'new format: WEB_docroot is untouched'  "$docroot" "/var/www/html/"
@@ -291,7 +291,7 @@ is  'the guarded form does not'                                     "$guard"    
 # The consumer is doOSSpecificIncludes, which cases on ${FOG_os_id} -- not
 # merely the first line that MENTIONS the key. installfog.sh defaults
 # FOG_os_id to "" near its top, long before .fogsettings is read, and that is
-# an initialisation rather than a read of a migrated value. Anchoring on the
+# an initialization rather than a read of a migrated value. Anchoring on the
 # real consumer keeps this lint precise instead of merely strict.
 # ---------------------------------------------------------------------------
 

--- a/tests/fogsettings-migration.test.sh
+++ b/tests/fogsettings-migration.test.sh
@@ -19,7 +19,7 @@
 # only runs at the very end of an install.
 #
 # The migration is EXTRACTED FROM lib/common/functions.sh AND EVALUATED here
-# rather than copied. A hand-copied replay is how a test passes while the behaviour is
+# rather than copied. A hand-copied replay is how a test passes while the behavior is
 # wrong, which is the failure mode install-settings-resolution.test.sh already
 # documents for the httpsRedirect migration.
 #

--- a/tests/fogupdater-update-source.test.sh
+++ b/tests/fogupdater-update-source.test.sh
@@ -94,7 +94,7 @@ fi
 
 # Per call site, not once for the file. A second fetch helper added later
 # without the flags is exactly how --no-check-certificate spread in the first
-# place: by copying a neighbouring call that had it.
+# place: by copying a neighboring call that had it.
 curls=0
 unpinned=0
 while IFS= read -r line; do

--- a/tests/fontawesome7-icon-names.test.php
+++ b/tests/fontawesome7-icon-names.test.php
@@ -468,7 +468,7 @@ if (false !== $from && false !== $to && $to > $from) {
 
     // The glyph beside each name has to be a character. The previous code
     // emitted `&#xf02b` with no trailing semicolon and then html-escaped it,
-    // so htmlspecialchars could not recognise it as an entity even with
+    // so htmlspecialchars could not recognize it as an entity even with
     // double_encode off and every row rendered the literal text.
     $t->check(
         'the picker renders glyphs, not escaped entity text',

--- a/tests/getclass-resolves-without-aliases.test.php
+++ b/tests/getclass-resolves-without-aliases.test.php
@@ -6,7 +6,7 @@
  * Core is addressed by string in ~440 places -- ~380 `getClass('Literal')`
  * calls, FOGController::getManager()'s `new $short.'Manager'`, and all of
  * Route::$validClasses, which spells its entries in lowercase. None of that
- * is visible to a static analyser or to a compiler: it resolves at runtime,
+ * is visible to a static analyzer or to a compiler: it resolves at runtime,
  * from the global namespace, ignoring `use` imports entirely.
  *
  * Every file under packages/web/src/ USED to end in a class_alias()
@@ -18,7 +18,7 @@
  *
  * That makes this test load-bearing rather than transitional. A rename under
  * src/ that misses a string call site cannot fail to compile and cannot be
- * caught by PHPStan -- phpstan.neon analyses this tree and is blind to all
+ * caught by PHPStan -- phpstan.neon analyzes this tree and is blind to all
  * of it. It fails here or it fails in production.
  *
  * Usage: php tests/getclass-resolves-without-aliases.test.php

--- a/tests/hook-event-contract.test.php
+++ b/tests/hook-event-contract.test.php
@@ -7,7 +7,7 @@
  * through HookManager::processEvent(). So the bar for changing it is not "the
  * tests pass", it is "no plugin needs editing" -- and the only way to hold that
  * bar is to write down what happens now, including the parts that are wrong, so
- * that a behaviour change shows up as a case somebody had to edit on purpose
+ * that a behavior change shows up as a case somebody had to edit on purpose
  * rather than as a silent difference.
  *
  * Findings pinned here are recorded as F-11..F-26 in docs/refactor-facts.md and

--- a/tests/host-site-csv-label.test.php
+++ b/tests/host-site-csv-label.test.php
@@ -25,7 +25,7 @@
  *      'addSite' would find no such field and silently export nothing.
  *
  * Source-level: the config is built by a static on a class whose file
- * pulls in the whole FOG hierarchy, and the behaviour under test needs a
+ * pulls in the whole FOG hierarchy, and the behavior under test needs a
  * database. Live proof is
  * ~/scripts/background_scripts/verify_host_site_csv.php, which runs the
  * round trip against a real install.

--- a/tests/imaging-count-excludes-cancels.test.php
+++ b/tests/imaging-count-excludes-cancels.test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The dashboard's imaging chart counts imaging RUNS, not cancelled intentions.
+ * The dashboard's imaging chart counts imaging RUNS, not canceled intentions.
  *
  * DashboardPage::get30day() feeds the "imaging history" graph. Since ADR 0022
  * decision 3 retired imagingLog it reads taskLog, and taskLog holds one row
@@ -12,15 +12,15 @@
  * TaskingElement::taskLog(), which runs on check-in -- so a row existed only
  * for a task that had actually started. TaskLog::recordState() now writes one
  * on EVERY transition of an imaging task, cancellation included. A deploy that
- * is queued and cancelled before any machine boots therefore has exactly one
+ * is queued and canceled before any machine boots therefore has exactly one
  * taskLog row, carrying an image name, and counting it reports an image
  * deployed on a day nothing was imaged.
  *
  * Two things this pins, both of which are silent when wrong -- the chart
  * renders either way and simply shows the wrong number:
  *
- * 1. **The cancelled state is excluded.** Not the Failed state and not the
- *    queued ones: a task cancelled part-way through imaging still has its
+ * 1. **The canceled state is excluded.** Not the Failed state and not the
+ *    queued ones: a task canceled part-way through imaging still has its
  *    In-Progress row from check-in and still counts, which is correct -- it
  *    did image. Only a task whose sole rows are cancellations drops out.
  *
@@ -81,17 +81,17 @@ $t->check(
 );
 
 /*
- * 1. Cancelled rows are excluded, and the state is resolved rather than
+ * 1. Canceled rows are excluded, and the state is resolved rather than
  *    written as a literal 5 -- CANCELLED_STATE is a hook, so a plugin can
  *    move it and a hardcoded id would quietly exclude the wrong state.
  */
 $t->check(
-    'cancelled rows are excluded',
-    false !== strpos($sql, '`taskStateID` <> :cancelled')
+    'canceled rows are excluded',
+    false !== strpos($sql, '`taskStateID` <> :canceled')
 );
 $t->check(
-    'the cancelled state is resolved, not hardcoded',
-    false !== strpos($body, "':cancelled' => self::getCancelledState()")
+    'the canceled state is resolved, not hardcoded',
+    false !== strpos($body, "':canceled' => self::getCancelledState()")
 );
 $t->check(
     'no other state is excluded with it',

--- a/tests/insertbatch-required-columns.test.php
+++ b/tests/insertbatch-required-columns.test.php
@@ -24,7 +24,7 @@
  * would be fixing, and one nothing else here would catch.
  *
  * DB-free: this reads the source, like usertracking-permission-split and
- * permission-purge-guard. The behaviour itself is proved against a live
+ * permission-purge-guard. The behavior itself is proved against a live
  * strict server by background_scripts/prove_insertbatch_backfill.php.
  *
  * Usage: php tests/insertbatch-required-columns.test.php

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -110,7 +110,7 @@ is "${WEB_url_proto}|${BOOT_url_proto}|${PKI_web_cert_publicly_trusted}|${BOOT_r
 # --- the mode is answered ONCE ------------------------------------------------
 #
 # promptInstallMode() used to key only on the run-scoped s* shadows, so every
-# interactive upgrade got the four-mode menu again -- and any unrecognised reply
+# interactive upgrade got the four-mode menu again -- and any unrecognized reply
 # INCLUDING A BARE ENTER takes the `standard` default, which _applyInstallMode
 # then wrote over a public-cert or embed-ca server's keys and writeUpdateFile
 # persisted. The prompt reverted the very choice it was asking about.
@@ -187,8 +187,8 @@ is "${FOG_install_mode}|${BOOT_rebuild_ipxe_with_my_ca}" "|no" \
 
 # The backstop for the one upgrade the seed cannot cover -- a pre-1.6 server,
 # which has no ${FOG_install_mode} to seed from. Asserted on the source because
-# the behaviour cannot be reached from a test: promptInstallMode also returns
-# early when stdin is not a tty, which it never is here, so a behavioural check
+# the behavior cannot be reached from a test: promptInstallMode also returns
+# early when stdin is not a tty, which it never is here, so a behavioral check
 # would pass whether the guard existed or not.
 guard=$(sed -n '/^promptInstallMode() {/,/^$/p' "$FUNCS" | grep -c 'priorInstall')
 is "$guard" "1" "promptInstallMode is guarded on priorInstall"
@@ -200,7 +200,7 @@ is "$guard" "1" "promptInstallMode is guarded on priorInstall"
 # $3 and $4 used to be the same argument, which is precisely the bug this
 # function's caller was reported for: a value the resolver DERIVED on one run is
 # persisted, and was then indistinguishable from one an admin forced. Modelling
-# them as one thing is how a test can pass while the behaviour is wrong.
+# them as one thing is how a test can pass while the behavior is wrong.
 nb() {
     PKI_web_cert_publicly_trusted="$1"; BOOT_rebuild_ipxe_with_my_ca="$2"
     sBOOT_url_proto="$3"; BOOT_url_proto="$4"; BOOT_url_proto_forced="$5"
@@ -254,7 +254,7 @@ else
     bad "no notice printed when netboot fell back to HTTP"
 fi
 if [[ "$(report http no no)" == *"Secure Boot binaries ARE staged"* ]]; then
-    ok "the notice says Secure Boot is available and how to enrol"
+    ok "the notice says Secure Boot is available and how to enroll"
 else
     bad "the HTTP notice does not mention Secure Boot onboarding"
 fi
@@ -298,7 +298,7 @@ done
 
 # All 67 keys of the model are managed, and NOTHING ELSE is: adding a key to
 # this array turns a hand-set key into a managed one, and the admin's value
-# starts being overwritten. That is a behaviour change even though it looks
+# starts being overwritten. That is a behavior change even though it looks
 # like documentation, so the count is asserted as well as the membership.
 modelKeys="
     BOOT_dhcp_delay_seconds BOOT_external_tftp_server BOOT_kernel_backups_kept BOOT_rebuild_ipxe_with_my_ca

--- a/tests/installer-schema-deploy.test.php
+++ b/tests/installer-schema-deploy.test.php
@@ -232,7 +232,7 @@ if (null === $done) {
     if (false === $tokenAt) {
         $fails[] = $schemaFile . ' no longer checks validSchemaBootstrap()'
             . ' before deciding what to do with an already-current schema,'
-            . ' so the installer is bounced to a page whose behaviour'
+            . ' so the installer is bounced to a page whose behavior'
             . ' belongs to whatever plugins are installed';
     }
     if (false === $redirectAt) {

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -42,7 +42,7 @@
 # that its own documentation satisfies is not a gate. (Same failure the
 # no-session-for-browserless and network-fetch-bounded gates hit.)
 #
-# No root, no network, no FOG install. The behavioural section builds a
+# No root, no network, no FOG install. The behavioral section builds a
 # throwaway CA in a temp directory and points $fogprogramdir at it.
 #
 # Exit status 0 = pass, 1 = fail.
@@ -248,7 +248,7 @@ else
 fi
 
 echo
-echo "4. the helper behaves (behavioural)"
+echo "4. the helper behaves (behavioral)"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT

--- a/tests/installer-tmpdir.test.sh
+++ b/tests/installer-tmpdir.test.sh
@@ -128,7 +128,7 @@ rm -f "$WORK/tmp"
 
 # --- no call site resolves ../tmp against the cwd any more ------------------
 #
-# Grep rather than behaviour, because the failure being guarded is a call site
+# Grep rather than behavior, because the failure being guarded is a call site
 # quietly reintroducing the relative form. Comments are excluded, and the
 # helper's own definition is the one legitimate use.
 stray="$(grep -nE '(^|[^#])\.\./tmp' "$FUNCS" \

--- a/tests/ipxe-auth-no-session.test.php
+++ b/tests/ipxe-auth-no-session.test.php
@@ -19,7 +19,7 @@
  * third-party callers are unaffected.
  *
  * This gate pins the property that makes the split worth having. It is
- * static on purpose: the behaviour needs a database, a populated
+ * static on purpose: the behavior needs a database, a populated
  * FOG_PXE_ADVANCED and FOG_ADVANCED_MENU_LOGIN toggled on to observe, and a
  * test that needs all three is a test nobody runs.
  *

--- a/tests/lib/bootmenu-harness.php
+++ b/tests/lib/bootmenu-harness.php
@@ -311,7 +311,7 @@ class Image extends StubModel
  * Storage group stub.
  *
  * Both getters return the same node deliberately: which one getTasking()
- * calls is the behaviour under test, and the golden shows it through the
+ * calls is the behavior under test, and the golden shows it through the
  * storage= argument rather than through the node's identity.
  */
 class StorageGroup extends StubModel

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -38,7 +38,7 @@ if (!is_file($classFile)) {
 
 /*
  * BASEPATH decides which Secure Boot branches render: MOK.der gates the
- * attended enrol inside _enrollSecureBootChoice(), and PK/KEK/db.auth gate
+ * attended enroll inside _enrollSecureBootChoice(), and PK/KEK/db.auth gate
  * whether _filterMenus() shows the unattended one at all. Point it at a
  * scenario-owned temp directory so every combination is reachable without
  * touching a real install.

--- a/tests/listem-envelope.test.php
+++ b/tests/listem-envelope.test.php
@@ -12,7 +12,7 @@
  * time it failed silently rather than loudly:
  *   - ou plugin: ADOU never set on any client check-in
  *   - bootitem.hook.php: the fog.local boot-to-disk label never applied
- *   - route.class.php: cancelling a group's tasks cancelled nothing
+ *   - route.class.php: canceling a group's tasks canceled nothing
  *
  * Static source check (no DB, no server) -- these call sites need the full FOG
  * bootstrap to run, so this parses them instead.

--- a/tests/local-login-entrypoint.test.php
+++ b/tests/local-login-entrypoint.test.php
@@ -265,7 +265,7 @@ if (null === $body) {
             . ' lockout';
     }
     if (false === strpos($body, "\$loginRedirect='';")) {
-        $fails[] = 'index.php no longer initialises $loginRedirect, so an'
+        $fails[] = 'index.php no longer initializes $loginRedirect, so an'
             . ' install with no listener redirects on whatever was left in'
             . ' scope';
     }

--- a/tests/localboot-publish.test.sh
+++ b/tests/localboot-publish.test.sh
@@ -45,7 +45,7 @@
 #      and the binary in each archive matches the arch the archive is named for.
 #   4. The degraded shapes still produce something useful rather than failing:
 #      an HTTPS-only install stages no secureboot/, and a server may hold no
-#      enrolment material.
+#      enrollment material.
 #   5. _restampIpxeManifest keeps .fog-ipxe-manifest matching the bytes on disk
 #      after signing rewrites them. Without it _copyIpxeTree reports all 45
 #      .efi as admin-modified on the SECOND install of a Secure Boot server and
@@ -278,7 +278,7 @@ is "$(mq "$MAN" paths | tr '\n' ' ')" \
    "fog-esp-arm64${EXT} fog-esp-i386${EXT} fog-esp-x86_64${EXT} " \
    "one archive per architecture, and no delay variants"
 
-# Nothing loose. The whole point of the reorganisation.
+# Nothing loose. The whole point of the reorganization.
 is "$(find "$BOOT" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" "0" \
    "the published directory has no subdirectories at all"
 is "$(find "$BOOT" -name '*.efi' | wc -l | tr -d ' ')" "0" \
@@ -376,7 +376,7 @@ is "$(cat "$X/secureboot-fog/snponly.efi")" "ipxe.efi" \
 is "$(cat "$X/secureboot-fog/snponly-shimx64.efi")" "secureboot/snponly-shimx64.efi" \
    "secureboot-fog/ still carries upstream's real shims"
 [[ -f $X/secureboot-fog/mmx64.efi && -f $X/secureboot-fog/MOK.der ]] \
-    && ok "secureboot-fog/ carries MokManager and MOK.der, so enrolment is possible from it"
+    && ok "secureboot-fog/ carries MokManager and MOK.der, so enrollment is possible from it"
 is "$(cat "$X/fog-ipxe/fogsnponly.efi")" "snponly.efi" \
    "FOG's snponly ships under the fog prefix in fog-ipxe/ instead"
 
@@ -516,8 +516,8 @@ for s in autoexec.ipxe fog-ipxe/autoexec.ipxe secureboot-upstream/autoexec.ipxe;
 done
 is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" secureboot-upstream/snponly-shimx64.efi)" "shim" \
    "the shim is still described as a shim from its new path"
-is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" secureboot-upstream/MOK.der)" "enrolment-cert" \
-   "MOK.der is still described as the enrolment certificate from its new path"
+is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" secureboot-upstream/MOK.der)" "enrollment-cert" \
+   "MOK.der is still described as the enrollment certificate from its new path"
 is "$(mq "$MAN" filerole "fog-esp-x86_64${EXT}" refind/refind.efi)" "chainloader" \
    "rEFInd is described as the local-boot chainloader"
 is "$(mq "$MAN" filesigned "fog-esp-x86_64${EXT}" refind/refind.conf)" "False" \
@@ -692,16 +692,16 @@ fi
 is "$(cat "$WORK/nostock/fog-ipxe/fogipxe.efi" 2>/dev/null)" "ipxe.efi" \
    "without a rebuild fog-ipxe/ takes the tree root, which is then the generic set"
 
-# --- a server with no enrolment material at all ------------------------------
+# --- a server with no enrollment material at all ------------------------------
 mk_web "$webdirdest" no
 _publishLocalBootFiles >/dev/null
-is "$(mq "$MAN" count)" "3" "a server publishing no enrolment material still succeeds"
+is "$(mq "$MAN" count)" "3" "a server publishing no enrollment material still succeeds"
 rm -rf "$WORK/e"; extract "$BOOT/fog-esp-x86_64${EXT}" "$WORK/e"
 E="$WORK/e"
 if [[ -e $E/secureboot-upstream/MOK.der || -e $E/secureboot-upstream/db.auth ]]; then
-    bad "enrolment material appeared on a server that publishes none"
+    bad "enrollment material appeared on a server that publishes none"
 else
-    ok "no enrolment material when the server has none to give"
+    ok "no enrollment material when the server has none to give"
 fi
 [[ -f $E/fog-ipxe/fogipxe.efi ]] && ok "the boot binaries ship regardless"
 

--- a/tests/logout-redirect-seam.test.php
+++ b/tests/logout-redirect-seam.test.php
@@ -175,7 +175,7 @@ if (preg_match('#preg_match\s*\(\s*\'\#\^https\?://\#i\'\s*,\s*\$logoutRedirect\
 if (preg_match('#function\s+redirect\s*\(\s*\$url\s*=\s*\'\'\s*,\s*\$status\s*=\s*308\s*\)#', $baseSrc)) {
     ok('FOGCore::redirect() still defaults to 308');
 } else {
-    bad('FOGCore::redirect() no longer defaults to 308 -- every existing caller changes behaviour');
+    bad('FOGCore::redirect() no longer defaults to 308 -- every existing caller changes behavior');
 }
 if (preg_match('#in_array\s*\(\s*\$status\s*,\s*\[\s*301\s*,\s*302\s*,\s*303\s*,\s*307\s*,\s*308\s*\]\s*,\s*true\s*\)#', $baseSrc)) {
     ok('FOGCore::redirect() rejects a status that is not a redirect');

--- a/tests/model-key-literals.test.php
+++ b/tests/model-key-literals.test.php
@@ -75,7 +75,7 @@ const MIN_LITERALS = 400;
  * passed `new StorageNode()` -- an EMPTY object -- so correcting the key
  * would replace a working lazy load with an invalid one.
  *
- * Removing them is the real fix and is a behaviour change to the task
+ * Removing them is the real fix and is a behavior change to the task
  * creation path, which is not this test's call to make.
  */
 $exempt = [

--- a/tests/multicast-kill-contract.test.php
+++ b/tests/multicast-kill-contract.test.php
@@ -48,7 +48,7 @@ if (!defined('SIGTERM') || !defined('SIGKILL')) {
     exit(0);
 }
 // killAll() shells out to ps to walk the process tree, and returns without
-// signalling anything if it is missing.
+// signaling anything if it is missing.
 exec('command -v ps', $psOut, $psRet);
 if (0 !== $psRet) {
     fwrite(STDERR, "SKIP: no ps on PATH\n");

--- a/tests/network-fetch-bounded.test.sh
+++ b/tests/network-fetch-bounded.test.sh
@@ -257,7 +257,7 @@ for h in httpbin.org neverssl.com fogproject.org; do
 done
 
 echo
-echo "6. an unroutable host fails fast (behavioural)"
+echo "6. an unroutable host fails fast (behavioral)"
 
 error_log=$(mktemp)
 trap 'rm -f "$error_log"' EXIT

--- a/tests/nicedate-empty-is-no-value.test.php
+++ b/tests/nicedate-empty-is-no-value.test.php
@@ -11,7 +11,7 @@
  *
  * That matters now because the date columns are moving to NULL (GH-1245), and
  * FOGController::get() hands back '' for a NULL column -- isset() is false for
- * null. Without this normalisation, making a column nullable would silently
+ * null. Without this normalization, making a column nullable would silently
  * turn every "No Data" into the current timestamp: no error, no log line, a
  * plausible value in every grid. It is already wrong for the three columns
  * that are nullable today, tasks.stateChangedTime among them.
@@ -39,7 +39,7 @@ $failures = [];
 $checks = 0;
 
 // ---------------------------------------------------------------
-// 1. Behaviour: empty, null and the zero date all mean the same thing.
+// 1. Behavior: empty, null and the zero date all mean the same thing.
 // ---------------------------------------------------------------
 require_once $web . '/src/Base/FOGBase.php';
 

--- a/tests/no-session-for-browserless.test.php
+++ b/tests/no-session-for-browserless.test.php
@@ -15,7 +15,7 @@
  *
  * Static on purpose: proving it over HTTP needs a running server with a
  * database, and a test that needs those is a test nobody runs. The HTTP
- * behaviour was verified by hand when the change landed -- see the PR.
+ * behavior was verified by hand when the change landed -- see the PR.
  *
  * Usage: php tests/no-session-for-browserless.test.php
  * Exit status 0 = pass, 1 = fail.

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -28,7 +28,7 @@
  * branch it did not know about, which is exactly how this arrived.
  *
  * DB-free: this reads the source, like insertbatch-required-columns. The
- * behaviour is proved against the live database by
+ * behavior is proved against the live database by
  * background_scripts/prove_batch_fk_guard.php and
  * background_scripts/prove_image_delete_cancels_tasks.php -- the second of
  * which fails on an unpatched tree, which is what makes it a gate.
@@ -224,7 +224,7 @@ check(
 );
 
 /*
- * TaskManager::cancel() rather than a bare state update: cancelling a task
+ * TaskManager::cancel() rather than a bare state update: canceling a task
  * also has to reissue the host's token, unwind any multicast session behind
  * it and record the transition in the task log. A state UPDATE does none of
  * those and looks identical in the list.

--- a/tests/openapi-route-coverage.test.php
+++ b/tests/openapi-route-coverage.test.php
@@ -90,7 +90,7 @@ if ($handlers !== count($m[1])) {
     fwrite(STDERR, "FAIL: parser missed a route registration\n");
     fwrite(STDERR, "  handler arrays: $handlers, names read: " . count($m[1]) . "\n");
     fwrite(STDERR, "  A route is probably registered in a shape this test does\n");
-    fwrite(STDERR, "  not recognise. Fix the pattern here, not the router.\n");
+    fwrite(STDERR, "  not recognize. Fix the pattern here, not the router.\n");
     exit(1);
 }
 if (count($served) < 1) {

--- a/tests/optional-columns-carry-defaults.test.php
+++ b/tests/optional-columns-carry-defaults.test.php
@@ -29,7 +29,7 @@
  * a real "no subject" (ADR 0021), multicastSessions.msSenderPID defaults to 0
  * meaning "not running", and nfsFailures.nfDateTime defaults to the current
  * timestamp. In each the default is unreachable through the ORM, which
- * refuses the write first, so it is defence in depth rather than a hole.
+ * refuses the write first, so it is defense in depth rather than a hole.
  * An earlier revision of this test failed on all four, which is how the
  * distinction got noticed.
  *

--- a/tests/permission-actions-declared.test.php
+++ b/tests/permission-actions-declared.test.php
@@ -45,7 +45,7 @@
  * The page surface is not covered here and does not need to be: its only
  * undeclared resolutions are POSTs to a read-only page's renderer (activity,
  * audit and task index), which are not operations -- _subToAction() falls
- * through to 'edit' for any POST it does not recognise, and refusing those is
+ * through to 'edit' for any POST it does not recognize, and refusing those is
  * the point rather than a regression.
  *
  * Usage: php tests/permission-actions-declared.test.php

--- a/tests/permission-purge-guard.test.php
+++ b/tests/permission-purge-guard.test.php
@@ -16,7 +16,7 @@
  *
  * DB-free, so it runs in tests/run-all.sh. Possible because the guard is
  * pure: coreRegistry() is a literal and isCoreOwnedNode() is an array
- * lookup. The behavioural half of the test leans on that deliberately --
+ * lookup. The behavioral half of the test leans on that deliberately --
  * with no database configured, purgePermissions() can only return without
  * throwing if it bailed out BEFORE reaching Route::getIds(). If the guard
  * is ever removed, this stops passing rather than silently doing nothing.
@@ -120,7 +120,7 @@ foreach (['capone', 'ldap', 'wolbroadcast', 'definitelynotanode', ''] as $node) 
 }
 
 /*
- * 3. Case and whitespace are normalised. The callers pass strtolower() of a
+ * 3. Case and whitespace are normalized. The callers pass strtolower() of a
  *    database value, but the guard must not depend on its callers being
  *    careful -- it is the last thing standing between a stray uninstall and
  *    a silent revocation.
@@ -133,7 +133,7 @@ check(
 );
 
 /*
- * 4. The behavioural half: with no database configured, purgePermissions()
+ * 4. The behavioral half: with no database configured, purgePermissions()
  *    on a core node must return without throwing, which it can only do by
  *    returning before it reaches Route::getIds().
  */

--- a/tests/ping-alive-codes.test.php
+++ b/tests/ping-alive-codes.test.php
@@ -204,7 +204,7 @@ if (is_callable($badge)) {
     };
 
     check(
-        'code 0 renders as Online, in the success colour',
+        'code 0 renders as Online, in the success color',
         false !== strpos($render(0), 'Online')
         && false !== strpos($render(0), 'bg-success'),
         $failures,

--- a/tests/ping-icmp-echo.test.php
+++ b/tests/ping-icmp-echo.test.php
@@ -157,7 +157,7 @@ check(
 );
 
 // Identifier and sequence are 16-bit fields. A caller handing over a larger
-// int must not corrupt the neighbouring field. Note that pack('n') truncates
+// int must not corrupt the neighboring field. Note that pack('n') truncates
 // to 16 bits by itself, so REMOVING the explicit mask in echoPacket() is an
 // equivalent mutation and these checks will not catch it -- what they pin is
 // that the value round-trips, which is what reply matching depends on. A

--- a/tests/pki-idempotence.test.sh
+++ b/tests/pki-idempotence.test.sh
@@ -166,7 +166,7 @@ artefacts() {
     # with no Secure Boot CA -- _ensureSecureBootKeys returns early here because
     # createSecureBootIntermediateCA has already pointed ${PKI_sb_codesign_key} at the
     # signing leaf -- so it is genuinely absent in this configuration rather
-    # than missing. sign.key/sign.pem above are what this install enrols.
+    # than missing. sign.key/sign.pem above are what this install enrolls.
 }
 
 sumof() {

--- a/tests/plugin-extension-points.test.php
+++ b/tests/plugin-extension-points.test.php
@@ -83,7 +83,7 @@ $cache->setAccessible(true);
  *
  * @param array $routes Declarations as a plugin would supply them.
  *
- * @return array Normalised routes, keyed by their registered name.
+ * @return array Normalized routes, keyed by their registered name.
  */
 $offer = function (array $routes) use ($stub, $cache) {
     $stub->routes = $routes;
@@ -187,7 +187,7 @@ foreach (['ext:silent', 'ext:guarded', 'ext:callback'] as $name) {
     }
 }
 if (isset($got['ext:guarded']) && 'POST' !== $got['ext:guarded']['method']) {
-    $fails[] = 'method was not normalised to upper case';
+    $fails[] = 'method was not normalized to upper case';
 }
 foreach (['ext:silent', 'ext:typo', 'ext:paramPublic'] as $name) {
     if (isset($got[$name]) && 'required' !== $got[$name]['auth']) {

--- a/tests/psr4-bridge.test.php
+++ b/tests/psr4-bridge.test.php
@@ -21,7 +21,7 @@
  *   3. A plugin shipping class/probealpha.class.php STILL cannot answer a
  *      bare `ProbeAlpha`. Core is not in the classMap, so that plugin file
  *      is the only candidate for the key and would win outright -- the
- *      autoloader recognises the name as core's and refuses rather than
+ *      autoloader recognizes the name as core's and refuses rather than
  *      falling through. Losing that is a privilege escalation with no other
  *      symptom, and note it is now a REFUSAL rather than a preference: the
  *      old ordering guarantee has nothing left to order.

--- a/tests/pxe-secureboot-menu-gating.test.php
+++ b/tests/pxe-secureboot-menu-gating.test.php
@@ -4,7 +4,7 @@
  * Secure Boot Key (Unattended...)", mode=enrollsb): it must stay hidden on
  * non-EFI platforms exactly like pxeID 14, and must additionally stay
  * hidden unless PK.auth/KEK.auth/db.auth all exist in service/secureboot/
- * -- without them mode=enrollsb's auto-enrol path has nothing valid to
+ * -- without them mode=enrollsb's auto-enroll path has nothing valid to
  * write.
  *
  * Static source check (no DB, no server) -- IpxeBootMenu needs the full FOG

--- a/tests/pxe-secureboot-menu-schema.test.php
+++ b/tests/pxe-secureboot-menu-schema.test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Guards the two pxeMenu schema changes for unattended Secure Boot enrol:
+ * Guards the two pxeMenu schema changes for unattended Secure Boot enroll:
  *  - pxeID 14 ("Enroll Secure Boot Key") gets relabeled to distinguish it
  *    from the new unattended item, via a new UPDATE step (321 already ran
  *    on existing installs, so it cannot be edited in place).

--- a/tests/relationship-filter-in-join.test.php
+++ b/tests/relationship-filter-in-join.test.php
@@ -29,7 +29,7 @@
  * is what this file is. It is STRUCTURAL and needs no database: the defect is
  * in the SQL text, so the SQL text is what it reads -- and so it runs in CI,
  * where there is no server to drive rows through. dev-branch, which got the
- * same fix later, carries this file plus a behavioural counterpart that does
+ * same fix later, carries this file plus a behavioral counterpart that does
  * drive real rows.
  *
  * Usage: php tests/relationship-filter-in-join.test.php

--- a/tests/retention-runner-daemon.test.php
+++ b/tests/retention-runner-daemon.test.php
@@ -25,7 +25,7 @@
  *
  *   A  a unit/init script exists in all four trees, and is executable in the
  *      three where the installer copies a script rather than a unit file
- *   B  $serviceList carries it, so enableInitScript() enrols it -- being in
+ *   B  $serviceList carries it, so enableInitScript() enrolls it -- being in
  *      $initdsrc gets it COPIED, not started, and not started at boot
  *   C  it runs as the web user, via the FOGWEBUSER placeholder the installer
  *      rewrites. A missing placeholder means a daemon issuing DELETEs as root
@@ -37,7 +37,7 @@
  *      daemon nobody can check on, which is the whole point of the split
  *
  * Textual and filesystem checks only: these live in functions that rewrite
- * /etc and enrol system services, so running them would mean writing to the
+ * /etc and enroll system services, so running them would mean writing to the
  * developer's own box. Same convention as
  * tests/alpine-openrc-services.test.sh.
  *

--- a/tests/route-ids-getfield-sensitive.test.php
+++ b/tests/route-ids-getfield-sensitive.test.php
@@ -323,7 +323,7 @@ foreach ([['host', 'id'], ['host', 'name'], ['host', 'ip'], ['user', 'name']] as
  *     None of them error on the wrong shape. They read null and carry on,
  *     which is the failure mode getRows() was written to end.
  *
- *     Asserted behaviourally, against the same FakeDB: the row that comes
+ *     Asserted behaviorally, against the same FakeDB: the row that comes
  *     back is the SENTINEL the fake produced, so a wrapper that returned the
  *     envelope, an empty list, or a hard-coded value cannot pass.
  */

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -17,7 +17,7 @@
  * `return;` inserted above the refusal leaves all three in place.
  * `site-scope-lists.test.php` exercises `Authorization::scopedObjectIDs()`
  * exhaustively -- the SUPPLIER of scope ids -- and never names `Route`.
- * `listem-envelope.test.php` is a caller-side lint. So the behaviour was
+ * `listem-envelope.test.php` is a caller-side lint. So the behavior was
  * unpinned in exactly the file nobody can review by reading.
  *
  * This drives the real functions against `tests/lib/fog-test-harness.php`,
@@ -40,7 +40,7 @@
  *     `API_MASSDATA_MAPPING`. Section 6 stays green without it, because
  *     listem() already scoped. It only protects rows a plugin added in
  *     between -- so that is what section 6b asserts.
- *   - Pinning `stripSensitivePayload()`'s behaviour does not pin the
+ *   - Pinning `stripSensitivePayload()`'s behavior does not pin the
  *     emitter's CALL to it. That mutation went uncaught until `printer()`
  *     itself was driven through `asValue()`.
  *
@@ -621,7 +621,7 @@ $t->check(
 // lookups this DB-free fixture cannot serve. It no longer has to be: the
 // strip happens at the emitter now, over the class registry embed() fills
 // in, and stripSensitivePayload() takes plain arrays. So this is the real
-// behaviour rather than a regex over the shape of a line.
+// behavior rather than a regex over the shape of a line.
 //
 // Why the move: getter()'s per-level strip only ever reached embeds built
 // by recursing into getter(). The ones that were a plain ->get() -- task's
@@ -745,7 +745,7 @@ FogTestHarness::setStatic('Route', 'emitClassname', '');
  * And the EMITTER actually calls it. Everything above pins what
  * stripSensitivePayload() does; none of it notices if printer() stops calling
  * it, which is the whole failure mode this file was written for -- pinning a
- * function's behaviour is not pinning its use.
+ * function's behavior is not pinning its use.
  *
  * printer() ends the response, so it is driven through asValue(): with a
  * result wrapper on the stack sendResponse() raises instead of exiting, and
@@ -779,7 +779,7 @@ $t->check(
 
 /*
  * An UNSTAMPED payload is returned untouched. This is not an aspiration, it
- * is today's behaviour, and it is pinned deliberately: it is why SEC-1 --
+ * is today's behavior, and it is pinned deliberately: it is why SEC-1 --
  * ids() handing back any column named in the URL -- had to be closed at the
  * input rather than at the emitter. If this ever starts stripping, the
  * argument in docs/route-listem-plan.md's commit 0 changes and someone should
@@ -813,7 +813,7 @@ $t->check('an ordinary setting keeps its value', 'bzImage' === ($plainSetting['v
  * 6. Row side: the site boundary, driven end to end through listem().
  *
  *    Through listem() and not by calling _applySiteScope() directly, because
- *    a decomposition can preserve the behaviour of a method nobody calls any
+ *    a decomposition can preserve the behavior of a method nobody calls any
  *    more. That is the mutation this whole file exists for.
  *
  *    scopedObjectIDs() answers three ways and two of them are falsy:

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,7 +4,7 @@
 #
 # The convention these tests already follow -- standalone scripts, exit 0 for
 # pass and non-zero for fail, no framework and no database (docs/adr/0008
-# -secure-boot-enrolment-task-type.md:103,144) -- was documented but had no
+# -secure-boot-enrollment-task-type.md:103,144) -- was documented but had no
 # runner, so "the test suite passes" meant a human remembering four commands.
 # That is the same reason .githooks/lib/update-language.sh exists: one copy of
 # the invocation, so the hook, CI and a developer all run the identical thing.

--- a/tests/run-history-report.test.php
+++ b/tests/run-history-report.test.php
@@ -18,7 +18,7 @@
  *     resolve to `task`. Getting that wrong widens access silently.
  *   - the menu label must be registered for xgettext, because the labels are
  *     built from filenames at runtime and a runtime-built msgid never
- *     reaches the catalogue.
+ *     reaches the catalog.
  *
  * What this canNOT check is that getList() RUNS. It did not, the first time:
  * `TaskStateManager->find()` does not exist in 1.6 and a call to it is a
@@ -113,7 +113,7 @@ $t->check(
 );
 
 /*
- * 4. The menu label reaches the catalogue. The labels are built from
+ * 4. The menu label reaches the catalog. The labels are built from
  *    filenames at runtime, so xgettext sees nothing unless the literal is
  *    written out in _reportNamesForTranslation().
  */

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -16,7 +16,7 @@
  * world, which is a thing you find out about months later from a bug report.
  *
  * This is not a hypothetical failure. 18edea94f appended the element
- * labelled 330 (task type 26) and left FOG_SCHEMA at 329, so that step
+ * labeled 330 (task type 26) and left FOG_SCHEMA at 329, so that step
  * reached no install until the bump alongside this test. The comment on the
  * constant at the time said it had "drifted well above" the element count
  * and that nothing required the two to agree, which is exactly the kind of
@@ -56,7 +56,7 @@
  *     while the label counts as a new one. That is exactly what happened
  *     with `// 347` on 2026-08-21, and it broke three lab servers.
  *
- * Together they close it: you cannot append without labelling, and you cannot
+ * Together they close it: you cannot append without labeling, and you cannot
  * label without appending.
  *
  * Counting the array for real was rejected here, on the grounds that
@@ -71,7 +71,7 @@
  *
  * This test stays as it is, because the two fail on different things. A real
  * count is label-independent and catches shapes the text cannot see; these
- * checks cover the LABEL hygiene a count cannot -- an unlabelled append, or a
+ * checks cover the LABEL hygiene a count cannot -- an unlabeled append, or a
  * label with no append -- and they are what keeps the file's own numbering
  * meaning what it says. Neither subsumes the other.
  *
@@ -116,7 +116,7 @@ if (!count($labels[1])) {
 $highest = max(array_map('intval', $labels[1]));
 
 /*
- * No unlabelled appends. Every top-level `$this->schema[] =` must have a
+ * No unlabeled appends. Every top-level `$this->schema[] =` must have a
  * `// N` line somewhere between it and the append before it -- true of all
  * 296 of them today, and the thing that lets the highest label stand in for
  * the element count.
@@ -136,7 +136,7 @@ $highest = max(array_map('intval', $labels[1]));
  * here.
  */
 $lines = preg_split('/\r?\n/', $schemaSrc);
-$unlabelled = [];
+$unlabeled = [];
 $seenLabel = false;
 foreach ($lines as $i => $line) {
     if (preg_match('/^\/\/ \d+(?:\D.*)?$/', $line)) {
@@ -148,7 +148,7 @@ foreach ($lines as $i => $line) {
     }
     if (!$seenLabel) {
         // Reported 1-indexed, to match what an editor shows.
-        $unlabelled[] = $i + 1;
+        $unlabeled[] = $i + 1;
     }
     $seenLabel = false;
 }
@@ -205,13 +205,13 @@ if (count($emptyLabels)) {
     exit(1);
 }
 
-if (count($unlabelled)) {
+if (count($unlabeled)) {
     fwrite(
         STDERR,
-        'FAIL: ' . count($unlabelled) . " append(s) in commons/schema.php\n"
+        'FAIL: ' . count($unlabeled) . " append(s) in commons/schema.php\n"
         . "  carry no `// N` step label, at line(s) "
-        . implode(', ', $unlabelled) . ".\n"
-        . "  An unlabelled element does not raise the highest label, so the\n"
+        . implode(', ', $unlabeled) . ".\n"
+        . "  An unlabeled element does not raise the highest label, so the\n"
         . "  FOG_SCHEMA check below would still pass while that element sat\n"
         . "  above the gate and applied to nobody. Put the step's number on\n"
         . "  a line of its own above the append, as every other step does,\n"
@@ -259,7 +259,7 @@ $schema = (int)$const[1];
  * spot with no symptom: append your closures inside the previous step's array
  * and label them `    // 369`, and every check here still passes. The highest
  * column-zero label has not moved, so FOG_SCHEMA already matches it; there is
- * no unlabelled append, because there is no append at all.
+ * no unlabeled append, because there is no append at all.
  *
  * What you get is a migration that runs on a FRESH install -- the containing
  * step still executes, so CI is green on every engine -- and never runs on an

--- a/tests/secureboot-authvars.test.sh
+++ b/tests/secureboot-authvars.test.sh
@@ -149,7 +149,7 @@ grep -qx "$(sha256sum "$WORK/keys/KEK.der" | awk '{print $1}')" "$WORK/kcerts" |
 
 # --- 4. the signing chain the UEFI spec requires ---
 #
-# db must be authorised by KEK and KEK by PK, or this server can never update an
+# db must be authorized by KEK and KEK by PK, or this server can never update an
 # already-enrolled client's db again -- it would have stranded every machine it
 # enrolled. Checked by which signer certificate the PKCS#7 blob carries.
 python3 - "$WORK" > "$WORK/chain" 2>/dev/null <<'PY'

--- a/tests/secureboot-enrolment-diagnostics.test.sh
+++ b/tests/secureboot-enrolment-diagnostics.test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
 # Guards the "narrow check reported as a broad conclusion" bug class in the
-# Secure Boot enrolment path (#1266).
+# Secure Boot enrollment path (#1266).
 #
 #   tests/secureboot-enrolment-diagnostics.test.sh
 #
 # Two faults, filed and fixed together because they share a shape. Between them
-# they made db/Setup-Mode enrolment look unavailable on a server that was fully
+# they made db/Setup-Mode enrollment look unavailable on a server that was fully
 # configured for it.
 #
 #   1. _publishSecureBootAuthVars()'s "no platform keys" branch RETURNED IN
@@ -141,7 +141,7 @@ command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not installed"; exit
 
 mkdir -p "$WORK/kit" "$WORK/bin"
 openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 1 \
-    -subj "/CN=FOG enrol-mok test/" -keyout "$WORK/mok.key" \
+    -subj "/CN=FOG enroll-mok test/" -keyout "$WORK/mok.key" \
     -out "$WORK/mok.pem" 2>/dev/null
 openssl x509 -in "$WORK/mok.pem" -outform der -out "$WORK/kit/MOK.der" 2>/dev/null
 # The script re-execs itself through sudo when not root. A passthrough stub

--- a/tests/secureboot-enrolvia-vocabulary.test.php
+++ b/tests/secureboot-enrolvia-vocabulary.test.php
@@ -46,7 +46,7 @@ $page = $webroot . '/lib/pages/hostmanagement.page.php';
  *
  * A plain array appended to inline, rather than a counter incremented inside a
  * closure. A counter mutated through a closure or `global` is invisible to the
- * second PHPStan pass -- which analyses all of tests/ as one unit -- so every
+ * second PHPStan pass -- which analyzes all of tests/ as one unit -- so every
  * `$failures > 0` after the first one reads as "always false", and the file
  * would report a pass whatever it found.
  *

--- a/tests/secureboot-state-classifier.test.php
+++ b/tests/secureboot-state-classifier.test.php
@@ -57,14 +57,14 @@ $checks = 0;
  *
  * A CLOSURE over the two counters, not a global function with `global`
  * statements, and both halves of that matter for the second PHPStan pass --
- * which analyses all of tests/ as one unit:
+ * which analyzes all of tests/ as one unit:
  *
  *   - fourteen other files here declare a global check() with four different
  *     signatures, and a fifteenth merges with them into errors about
  *     parameters this file does not have;
  *   - a counter mutated through `global` is invisible to PHPStan, so the
  *     final `$failures > 0` reads as "always false" -- which would have made
- *     this file report a pass whatever it found, had the analyser not said so.
+ *     this file report a pass whatever it found, had the analyzer not said so.
  *
  * @param string $what     what is being asserted
  * @param mixed  $expected the expected value

--- a/tests/session-provenance.test.php
+++ b/tests/session-provenance.test.php
@@ -20,7 +20,7 @@
  *   account reaching a break-glass path still made this particular session
  *   somehow, and that is the fact being recorded here.
  *
- * The behavioural half of establishSession() cannot be exercised without a
+ * The behavioral half of establishSession() cannot be exercised without a
  * database -- it writes a history row and runs the logged-in bookkeeping --
  * so the pure part was pulled out into User::normalizeAuthSource() and is
  * tested for real below. The rest is pinned statically.
@@ -94,7 +94,7 @@ function methodSource($file, $method)
 }
 
 // 1. establishSession() stamps the session with the provenance, and does it
-//    through the normaliser rather than with whatever it was handed.
+//    through the normalizer rather than with whatever it was handed.
 $body = methodSource($userFile, 'establishSession');
 if (null === $body) {
     $fails[] = 'User::establishSession() is missing';
@@ -113,7 +113,7 @@ if (null === $body) {
 }
 
 // 2. validatePw() must still call establishSession() with no argument. That
-//    default is the whole no-behaviour-change claim for the password path:
+//    default is the whole no-behavior-change claim for the password path:
 //    every existing caller keeps the meaning it already had.
 $pw = methodSource($userFile, 'validatePw');
 if (null !== $pw && false === strpos($pw, 'establishSession()')) {
@@ -140,7 +140,7 @@ if (null !== $out
 }
 
 /*
- * 4. The normaliser, for real. Booting the autoloader is enough to reach it
+ * 4. The normalizer, for real. Booting the autoloader is enough to reach it
  *    -- Initiator's constructor only registers the autoloader, and this is
  *    a pure static method, so no database is involved. FOG_CACHE_DIR and
  *    friends are redirected into a throwaway directory first; see the long

--- a/tests/setting-value-filter-oracle.test.php
+++ b/tests/setting-value-filter-oracle.test.php
@@ -26,7 +26,7 @@
  *
  * Executable, not just a source gate: the shipped filtering logic is lifted
  * out of route.class.php and run against synthetic rows, so a change that
- * keeps the shape and breaks the behaviour still fails.
+ * keeps the shape and breaks the behavior still fails.
  *
  * DB-free: reads the source, executes the lifted method.
  *

--- a/tests/site-new-account-default.test.php
+++ b/tests/site-new-account-default.test.php
@@ -30,7 +30,7 @@
  * would see every site. That is an access-control default, not a tidiness
  * preference.
  *
- * DB-free: reads the source. The behaviour of the SiteScope helpers these
+ * DB-free: reads the source. The behavior of the SiteScope helpers these
  * call is covered against a fake database in site-scope.test.php.
  *
  * Usage: php tests/site-new-account-default.test.php

--- a/tests/site-scope.test.php
+++ b/tests/site-scope.test.php
@@ -167,7 +167,7 @@ $scenario = function (array $tables) use ($dbProp) {
                 $hit = in_array($uid, (array)($tables['catchAll'] ?? []), true);
                 return ['cnt' => $hit ? 1 : 0];
             }
-            // The catch-all's id. Recognised before the plain count for the
+            // The catch-all's id. Recognized before the plain count for the
             // same reason -- both read `sites`.
             if (false !== strpos($sql, 'IS NOT NULL LIMIT 1')) {
                 return ['cnt' => (int)($tables['catchAllID'] ?? 0)];
@@ -306,7 +306,7 @@ check(
     $checks
 );
 check(
-    'joinCatchAll enrols the user',
+    'joinCatchAll enrolls the user',
     SiteScope::joinCatchAll(4) === true,
     $failures,
     $checks
@@ -343,7 +343,7 @@ $db = $scenario(
     ['siteCount' => 0, 'catchAllID' => 11, 'insertErrors' => true]
 );
 check(
-    'a failed enrolment reports failure rather than claiming success',
+    'a failed enrollment reports failure rather than claiming success',
     SiteScope::joinCatchAll(4) === false,
     $failures,
     $checks
@@ -677,7 +677,7 @@ check(
 /*
  * 12. Inherited membership. A site reaches a user directly, through a user
  *     group, or through a role -- and a role reaches a user two ways, so
- *     four arms. These cases prove the behaviour; case 13 pins the SQL,
+ *     four arms. These cases prove the behavior; case 13 pins the SQL,
  *     because the fake answers one union query and cannot tell which arm
  *     produced a row.
  */

--- a/tests/storage-node-probe-advisory.test.php
+++ b/tests/storage-node-probe-advisory.test.php
@@ -134,7 +134,7 @@ if ($fallback === '') {
     $checks++;
     if (strpos($fallback, 'error_log(') === false) {
         $failures[] = '_fallbackNode() no longer logs, so a degraded pick is '
-            . 'silent -- which is the 1.5 behaviour this replaced';
+            . 'silent -- which is the 1.5 behavior this replaced';
     }
     $checks++;
     if (strpos($fallback, 'self::error(') !== false) {

--- a/tests/system-export-permission.test.php
+++ b/tests/system-export-permission.test.php
@@ -57,7 +57,7 @@ $results = [];
 /**
  * Record one assertion and echo its result.
  *
- * Named uniquely rather than check(): tests/ is analysed as one program by
+ * Named uniquely rather than check(): tests/ is analyzed as one program by
  * phpstan-tests.neon, and a global check() collides with the dozens of
  * other files that declare their own.
  *

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -95,7 +95,7 @@ if (2 !== substr_count($multi, "\n")) {
 // CRLF into "space + newline": a trailing space on every line of a report
 // from a machine that ends lines the DOS way, which is most of them.
 if ("a\nb" !== $clean("a\r\nb")) {
-    $fails[] = 'a CRLF report is not normalised to a bare newline, so every'
+    $fails[] = 'a CRLF report is not normalized to a bare newline, so every'
         . ' line of it is stored with trailing whitespace';
 }
 // The invalid-UTF-8 fallback has to keep the newline too. [[:cntrl:]] --
@@ -405,7 +405,7 @@ if (false === strpos($inst, 'mkdir -p $servicelogs/' . $subdir)) {
         . ' web tier has nowhere to write';
 }
 if (false === strpos($inst, 'setSELinuxContext "$servicelogs/' . $subdir . '" httpd_sys_rw_content_t')) {
-    $fails[] = 'the report log directory is not relabelled, so every report is'
+    $fails[] = 'the report log directory is not relabeled, so every report is'
         . ' dropped by SELinux with nothing but an AVC to say so';
 }
 

--- a/tests/task-log-view.test.php
+++ b/tests/task-log-view.test.php
@@ -31,7 +31,7 @@ if (!preg_match("#'id' => 'logs'#", $page)) {
 }
 if (!preg_match('#logs:\s*\{[^}]*build:\s*buildLogs#s', $js)) {
     $fails[] = 'the logs pane is not in the JS pane registry, so the tab'
-        . ' renders an empty table that never initialises';
+        . ' renders an empty table that never initializes';
 }
 
 // The table id is the only thing tying the rendered markup to the builder.
@@ -172,7 +172,7 @@ preg_match('#function buildLogs\(.*?function showLogDetail\(#s', $jsBare, $lb);
 $logsFn = $lb[0] ?? '';
 $msgCol = '' === $logsFn ? false : strpos($logsFn, 'targets: 5');
 // Bounded below by the PREVIOUS `targets:`, so the window cannot reach into
-// the neighbouring columnDef. A fixed character count did: deleting the
+// the neighboring columnDef. A fixed character count did: deleting the
 // render outright still passed, on column 4's escapeHtml.
 $prevCol = false === $msgCol
     ? false

--- a/tests/tasklog-records-cancel.test.php
+++ b/tests/tasklog-records-cancel.test.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Cancelling a task says so in the log.
+ * Canceling a task says so in the log.
  *
  * taskLog was written from exactly two places, TaskQueue::checkIn() and
  * TaskQueue::checkout(), both reached through a TaskingElement -- which exists
  * only for a machine that has checked in. Cancellation has no TaskingElement:
  * Task::cancel() set stateID and saved, TaskManager::cancel() ran a bulk UPDATE,
- * and neither wrote a row. So the last thing the log ever said about a cancelled
+ * and neither wrote a row. So the last thing the log ever said about a canceled
  * task was that it was In-Progress, and Task Management's log pane showed it
  * that way for good.
  *
@@ -14,7 +14,7 @@
  * TaskManager->cancel($taskIDs), the host arm to $Task->cancel(), and the
  * default task arm reaches each of them. Covering these two therefore covers
  * every arm of the endpoint. Cancellations that happen as a SIDE EFFECT of
- * something else -- host.class.php's "Cancelled due to new tasking", multicast
+ * something else -- host.class.php's "Canceled due to new tasking", multicast
  * teardown, the file-delete queue -- go straight to TaskManager->update() and
  * are deliberately out of scope here.
  *
@@ -25,7 +25,7 @@
  *   TaskManager::cancel()  SOURCE. It is a bulk UPDATE whose correctness is an
  *                          ORDERING -- the ids have to be collected before the
  *                          update, because the WHERE selects on the states
- *                          being cancelled out of and matches nothing after.
+ *                          being canceled out of and matches nothing after.
  *                          An ordering is what is checked, so the check is on
  *                          the order of the statements.
  *
@@ -152,7 +152,7 @@ if ($t->check('Task::cancel() is found', '' !== $cancelBody)) {
  * belongs on the row, and a snapin one carrying a stale image name that must
  * not reach it -- recordState() gates that on isImagingTask(), and a second
  * definition of "imaging" living in this method is exactly the drift that
- * would make one cancelled task's row disagree with another's.
+ * would make one canceled task's row disagree with another's.
  */
 $bulkInsert = '';
 $bulkBound = [];
@@ -172,7 +172,7 @@ $db->responder = function ($sql, $params) use (
     }
     if (false !== stripos($sql, 'FROM `tasks`')) {
         $bulkSelect = $sql;
-        // What the join yields AFTER the update: state 5 (Cancelled) is read
+        // What the join yields AFTER the update: state 5 (Canceled) is read
         // off the row, never passed in, which is what lets a task whose state
         // moved concurrently log the truth instead of the caller's assumption.
         return [
@@ -265,7 +265,7 @@ if ($t->check('recordStates() writes to taskLog', '' !== $bulkInsert)) {
     // A failed log write must not fail the cancel. insertBatch() throws where
     // FOGController::save() returns false, and the only caller sits inside
     // Route::cancel()'s try -- so without a catch here a caller whose tasks
-    // really were cancelled would be answered with an error.
+    // really were canceled would be answered with an error.
     $t->check(
         'a failed batch does not escape to the caller',
         (bool)preg_match(
@@ -317,11 +317,11 @@ if ($t->check('TaskManager::cancel() is found', '' !== $bulkBody)) {
     // five queries apiece against a statement that cancels a whole group at
     // once, which is what recordStates() exists to avoid.
     $t->check(
-        'it does not rebuild a Task per cancelled id',
+        'it does not rebuild a Task per canceled id',
         false === strpos($bulkBody, 'TaskLog::recordState(new Task')
     );
 
-    // The ids of the tasks being cancelled have to be read while the WHERE
+    // The ids of the tasks being canceled have to be read while the WHERE
     // still matches them. Positions, because this is the whole correctness
     // argument: getIds -> update -> recordStates, in that order.
     //

--- a/tests/unrunnable-tasks-are-reaped.test.php
+++ b/tests/unrunnable-tasks-are-reaped.test.php
@@ -26,7 +26,7 @@
  *     legitimately stores taskImageID 0.
  *   - The image is therefore only asked about for an IMAGING task type.
  *
- * DB-free: this reads the source. The behaviour is proved against a live
+ * DB-free: this reads the source. The behavior is proved against a live
  * database by background_scripts/prove_unrunnable_task_reaper.php, which fails
  * on an unpatched tree.
  *
@@ -162,7 +162,7 @@ check(
 /* ---------------------------------------------------- 3. what it writes */
 
 /*
- * Failed, not Cancelled. Cancelled means an administrator stopped it; losing
+ * Failed, not Canceled. Canceled means an administrator stopped it; losing
  * the difference between "somebody stopped this" and "this broke" is the
  * distinction an operator needs at the moment they are reading the task list.
  */
@@ -173,7 +173,7 @@ check(
     $checks
 );
 check(
-    'and never to Cancelled',
+    'and never to Canceled',
     false === strpos($reap, 'getCancelledState()'),
     $failures,
     $checks

--- a/tests/upgrade-proto-and-os-prompt.test.sh
+++ b/tests/upgrade-proto-and-os-prompt.test.sh
@@ -68,7 +68,7 @@ grep -q '^WEB_url_proto="https"$' "$INSTALLER" \
     && ok "A: WEB_url_proto is still assigned unconditionally afterwards" \
     || bad "A: nothing sets WEB_url_proto after the migration -- removing the default would leave it empty"
 
-# --- B. behaviour: a pre-1.6 server that had -S keeps its redirect ----------
+# --- B. behavior: a pre-1.6 server that had -S keeps its redirect ----------
 # migrateDeprecatedKeys is the real thing (#1297); this drives it exactly as the
 # installer does, then applies the redirect migration verbatim.
 # shellcheck source=/dev/null
@@ -76,7 +76,7 @@ grep -q '^WEB_url_proto="https"$' "$INSTALLER" \
 if ! declare -F migrateDeprecatedKeys >/dev/null; then
     bad "B: migrateDeprecatedKeys is not defined by lib/common/functions.sh"
 else
-    # Whatever the installer initialises WEB_url_proto to before sourcing
+    # Whatever the installer initializes WEB_url_proto to before sourcing
     # .fogsettings, applied here too -- otherwise this harness starts from a
     # clean slate the real run never has, and would keep passing with the
     # pre-source default put back. There should be no such line; the eval is
@@ -124,7 +124,7 @@ printf '%s\n' "$prompt" | grep -q 'case ${FOG_os_id} in' \
     && ok "C: and the case still tests FOG_os_id" \
     || bad "C: the case no longer tests FOG_os_id -- re-check what the read should name"
 
-# --- D. behaviour: the answer actually reaches the case --------------------
+# --- D. behavior: the answer actually reaches the case --------------------
 # Replays the prompt's own logic against piped input, which is the only way to
 # see that a typed choice survives. A wrong wiring is invisible otherwise: the
 # suggestion is a valid answer, so the install succeeds for the wrong distro.

--- a/tests/url-requests-tls.test.php
+++ b/tests/url-requests-tls.test.php
@@ -18,7 +18,7 @@
  *      machine that images afterwards.
  *   2. The signed-in administrator's PHP session id (and the CSRF token)
  *      were attached to every request. They are there so a node's status
- *      endpoint can authorise the call; sending them to a third party is a
+ *      endpoint can authorize the call; sending them to a third party is a
  *      credential handed over for no purpose.
  *
  * Both are now decided by the URL's host rather than by the caller, so a

--- a/tests/usertracking-permission-split.test.php
+++ b/tests/usertracking-permission-split.test.php
@@ -164,7 +164,7 @@ $cases = [
     // A real request carries it in the query string; the sub is bare. The
     // query string is unreadable from CLI, so this asserts the fallback.
     'file' => 'report',
-    // Case: the decoded name is normalised before lookup.
+    // Case: the decoded name is normalized before lookup.
     'file&f=' . base64_encode('HOSTS AND USERS') => 'usertracking',
     // Any other report keeps the report node.
     'file&f=' . base64_encode('imaging log') => 'report',

--- a/tests/vhost-netboot-exclusion.test.sh
+++ b/tests/vhost-netboot-exclusion.test.sh
@@ -24,7 +24,7 @@
 #   1. Every netboot-reachable directory is excluded, in BOTH web servers.
 #      service/ipxe/ is the obvious one. service/secureboot/ is not, and was
 #      missing: IpxeBootMenu imgfetches MOK.der and chains mmx64.efi /
-#      arm64-efi/mmaa64.efi out of it, so Secure Boot enrolment was being
+#      arm64-efi/mmaa64.efi out of it, so Secure Boot enrollment was being
 #      redirected onto an HTTPS iPXE could not validate. service/uboot/ is
 #      the third, and the least forgiving of the three: U-Boot's `wget` is
 #      HTTP-only with no TLS at all, so it cannot fail a validation -- a 308


### PR DESCRIPTION
The tree carried a mix of UK and US spellings — most visibly `enrolment`
beside `enrollment` in the Secure Boot ledger work that just landed, but
also `behaviour`, `normalise`, `recognise`, `neighbour`, `cancelled`,
`colour`, `analyse`, `licence` and `centre` scattered through comments,
docblocks, test descriptions and ADRs.

**Prose only.** The rewrite works from an explicit word list rather than a
blanket `-ise` → `-ize`, which would have corrupted `advertise`,
`exercise`, `surprise` and a dozen others that are `-ise` in both
dialects, and it skips every `$`-prefixed token so no identifier moves.

Thirteen user-facing `_()` strings change (`Selected tasks cancelled!` →
`canceled!`, `Automatic enrolment` → `enrollment`, and so on). The
pre-commit hook regenerated `messages.pot` and msgmerged the `.po` files
accordingly, so those thirteen fall back to English until a translator
picks them up.

## What is deliberately left alone

Each of these is read by a machine, so a rename would break something:

| Left as-is | Why |
|---|---|
| `colour --rgb`, `cpair --` | iPXE's **own** command names. There is no `color` command — rewriting these silently breaks every boot menu's appearance. |
| `(colour)` in the `FOG_IPXE_*` help text | It gives the admin iPXE's spelling on purpose. |
| `FOG_IPXE_MAIN_COLOURS` and siblings | `globalSettings` **row names** inserted by `schema.php`. Renaming orphans the setting on every existing install. |
| `taskStates` seed `(5,'Cancelled',…)` | A **database value**. Changing it here changes fresh installs only, so an upgraded server reads "Cancelled" and a new one "Canceled" — and the label is translated by its own text, so the new spelling loses every locale's string. Converging them needs a schema step, which is a migration and not a spelling fix. |
| `value="cancelled"` / `case 'cancelled':` | Sender and receiver for the task list's Recent pane, in the same file. Rewriting one without the other empties the pane. |
| `getCancelledState()`, `CANCELLED_STATE` | Public method and hook name — plugin ABI. |
| ADR filenames | Referenced by name from other files here and from one file in `fos`. Renaming them is its own change. |

The first three were found by reading the diff, not by guessing — the
first cut of this sweep did rewrite `colour --rgb 0x00567a 1 ||` in the
`FOG_IPXE_MAIN_COLOURS` default.

## Verification

- `tests/run-all.sh` — 185 passed, 0 failed
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/phpstan analyse -c phpstan-tests.neon` — no errors
- Every protected token above was counted before and after; all counts match.

## Downstream

None. No route class, `$databaseFields` key, API field or REST path changes.

The matching prose sweep for FOS is FOGProject/fos#168.