### PR TITLE
Derive the retention fixture count instead of writing it down twice

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4370');
+        define('FOG_VERSION', '1.6.0-beta.4373');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/tasklog-report-retention.test.php
+++ b/tests/tasklog-report-retention.test.php
@@ -207,33 +207,48 @@ $pdo->exec("INSERT INTO `taskStates` VALUES (3,'In Progress','fa-play'),(7,'Fail
 $pdo->exec("INSERT INTO `taskTypes` VALUES (1,'Deploy','fa-download'),(2,'Upload','fa-upload')");
 $pdo->exec("INSERT INTO `hosts` VALUES (100,'alpha'),(102,'gamma')");
 $pdo->exec("INSERT INTO `tasks` VALUES (10,100,1)");
-$pdo->exec(
-    "INSERT INTO `taskLog`"
-    . " (`taskID`,`taskStateID`,`ip`,`createdBy`,`logType`,`logText`,"
-    . "`logHostID`,`logHostName`,`logTaskTypeName`) VALUES"
+// ONE ARRAY, not one SQL literal, so the row count is DERIVED rather than
+// written down a second time and left to drift. It drifted: the count below
+// said six while seven rows were inserted -- the "renamed" row was added
+// without bumping it -- and the assertion had been red on every machine with
+// a database since. Nothing caught it because CI runs this file with no
+// FOG_TEST_DSN, so only the writer half has ever run there.
+// createdBy carried per row rather than hardcoded: FOS writes the error
+// reports and FOG writes the state rows, and flattening that would lose a
+// distinction the fixture is documenting.
+$fixtures = [
     // task alive, host alive
-    . " (10,7,'127.0.0.1','fos','error','live',100,'alpha','Deploy'),"
+    [10, 7, 'fos', 'error', 'live', 100, 'alpha', 'Deploy'],
     // task deleted, host still there -- the link must survive
-    . " (55,7,'127.0.0.1','fos','error','task gone',102,'gamma','Upload'),"
+    [55, 7, 'fos', 'error', 'task gone', 102, 'gamma', 'Upload'],
     // task deleted and host deleted -- the report is all that is left
-    . " (56,7,'127.0.0.1','fos','error','both gone',999,'deadhost','Deploy'),"
+    [56, 7, 'fos', 'error', 'both gone', 999, 'deadhost', 'Deploy'],
     // written before schema 341: nothing stored, joins must still answer
-    . " (10,7,'127.0.0.1','fos','error','pre-341',NULL,'',''),"
+    [10, 7, 'fos', 'error', 'pre-341', null, '', ''],
     // a state row written before schema 373: no identity of its own, because
     // 341's backfill excluded logType='state' explicitly
-    . " (10,3,'127.0.0.1','fog','state',NULL,NULL,'',''),"
+    [10, 3, 'fog', 'state', null, null, '', ''],
     // a state row written by TaskLog::recordState(): carries its own identity,
     // and here BOTH its task (11) and its host (101) are gone. This is the row
     // 341 said could not exist and 373 exists to produce -- the log pane shows
     // state rows and the dashboard counts them, so one that cannot name its
     // host or say whether it was a capture is not readable.
-    . " (11,3,'127.0.0.1','fog','state',NULL,101,'beta','Upload'),"
+    [11, 3, 'fog', 'state', null, 101, 'beta', 'Upload'],
     // the host has since been RENAMED: host 100 is 'alpha' now and the
     // report was written when it was 'oldname'. The stored copy has to win,
     // or the fallback is really just a null-check and the record is not
     // historical at all.
-    . " (10,7,'127.0.0.1','fos','error','renamed',100,'oldname','Deploy')"
+    [10, 7, 'fos', 'error', 'renamed', 100, 'oldname', 'Deploy'],
+];
+$ins = $pdo->prepare(
+    "INSERT INTO `taskLog`"
+    . " (`taskID`,`taskStateID`,`ip`,`createdBy`,`logType`,`logText`,"
+    . "`logHostID`,`logHostName`,`logTaskTypeName`)"
+    . " VALUES (?,?,'127.0.0.1',?,?,?,?,?,?)"
 );
+foreach ($fixtures as $row) {
+    $ins->execute($row);
+}
 
 $fromMethod = new \ReflectionMethod('FOG\TaskManagement', '_logQueryFrom');
 $fromMethod->setAccessible(true);
@@ -248,7 +263,11 @@ foreach ($rows as $row) {
     $by[$row['logText']] = $row;
 }
 
-$t->check('all six fixture rows came back', 6 === count($rows));
+// Against the fixture list rather than a literal, for the reason above.
+$t->check(
+    'every fixture row came back',
+    count($fixtures) === count($rows)
+);
 
 // The ordering inside the COALESCE, not just its presence.
 $t->check(


### PR DESCRIPTION
## The bug

`tests/tasklog-report-retention.test.php` inserts **seven** `taskLog` rows and asserts that **six** came back.

```
DEBUG rows=7 texts=["live","task gone","both gone","pre-341",null,null,"renamed"]
FAIL (1 of 25):
  - all six fixture rows came back
```

The seventh is the `renamed` row — it pins that a report keeps the host name it was written *with* rather than the current one — and whoever added it didn't bump the count. Everything else in the file passes; this was the only red check.

## Why nobody noticed

**Nothing runs it.** The `suite` job executes `tests/run-all.sh` with no database and no `FOG_TEST_DSN`, so this file's read half *skips* there and the job reports green on the writer half that did run. The one CI job that has a database server — `schema on <server>` — runs a single test, `schema-executes.test.php`.

So the read half has never run anywhere except on a developer's own box, and the assertion cannot have been red for less than the entire time since that row was added.

## The fix

Removing the second copy of the number rather than correcting it. The fixture rows are a PHP array now and the assertion compares against `count($fixtures)`, so adding an eighth row cannot desync it again.

The rows themselves are unchanged — including `createdBy` per row. FOS writes the error reports and FOG writes the state rows; folding that into one hardcoded value would have lost a distinction the fixture is documenting.

## Verification

Run against a live database, the assertion now passes (25 checks).

Mutation-verified by making the reader drop rows — the `hosts` `LEFT OUTER JOIN` made `INNER`, which removes the deleted-host rows — and watching the count check go red at exit 1, then restoring:

```
--- MUTATION: hosts join made INNER (drops the deleted-host rows)
    exit=1
      - every fixture row came back
      - a report whose host is gone keeps the name it had
      ...
```

The `taskStates` join was mutated the same way and correctly stayed green: every fixture row carries a state that exists, so an inner join there drops nothing. That is the check behaving, not a gap.

## Not in this PR

The CI gap itself — that no DB-backed test has ever been gated on any workflow — is a `fog-workflows` change and is proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBigm29JVHwk2zmTTgey9a