### PR TITLE
Run History: address getList, not the page it was called from

### DIFF
--- a/packages/web/management/js/fog/report/fog.report.file.js
+++ b/packages/web/management/js/fog/report/fog.report.file.js
@@ -393,11 +393,26 @@
           serverSide: false,
           select: false,
           ajax: {
-            url: '../management/index.php?node=report&sub=getList&f='
-            + Common.f
-            + (window.location.search
-              ? '&' + window.location.search.replace(/^\?/, '')
-              : ''),
+            // The page's OWN query string carries the window (start, end,
+            // sources[]) and getList has to see it -- but it also carries
+            // node, sub and f, and appending it wholesale put `sub=file`
+            // AFTER `sub=getList`. PHP takes the last occurrence of a
+            // repeated key, so every request re-rendered the report page
+            // and DataTables was handed HTML at HTTP 200. That is what the
+            // "runhistory-table / HTTP 200 - <div class=..." toast was.
+            //
+            // Built through URLSearchParams so there are no repeated keys
+            // to resolve at all: the window params ride along untouched
+            // (set() replaces only the three named, and sources[] is left
+            // as the repeated key it is), and the three that address the
+            // endpoint are stated once.
+            url: (function () {
+              var params = new URLSearchParams(window.location.search);
+              params.set('node', 'report');
+              params.set('sub', 'getList');
+              params.set('f', Common.f);
+              return '../management/index.php?' + params.toString();
+            })(),
             type: 'post'
           }
         });

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4389');
+        define('FOG_VERSION', '1.6.0-beta.4392');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 379);
-        define('FOG_BCACHE_VER', 325);
+        define('FOG_BCACHE_VER', 326);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/report-getlist-url.test.php
+++ b/tests/report-getlist-url.test.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * A report's getList URL addresses getList, and does not repeat a key.
+ *
+ * Run History needs the page's own query string on its AJAX call -- the
+ * window (start, end, sources[]) lives in the URL by design, so getList
+ * cannot see it any other way. It got there by appending
+ * `window.location.search` wholesale, which also carries `node`, `sub` and
+ * `f`. The result was:
+ *
+ *   ?node=report&sub=getList&f=X&node=report&sub=file&f=X
+ *
+ * PHP resolves a repeated key to its LAST occurrence, so every request asked
+ * for `sub=file` and got the report page back. DataTables was handed HTML at
+ * HTTP 200 and showed "No data available in table" under an error toast
+ * reading `HTTP 200 - <div class="card">`. The table had never loaded since
+ * the report shipped.
+ *
+ * Nothing caught it because everything that checked this checked the SERVER.
+ * ADR 0022's lab harness drove the real getList() against a lab database and
+ * the row came back; tests/run-history-report.test.php pins the four names
+ * that must agree and the column keys. Both are correct and neither can see
+ * a URL the browser builds. The endpoint worked perfectly and nothing ever
+ * reached it.
+ *
+ * So this asserts the shape of the URL rather than the behavior of the
+ * endpoint, and it asserts the PREMISE too -- that a repeated key resolves
+ * to the last one -- because that is the fact the rule rests on and it is
+ * not obvious.
+ *
+ * Usage: php tests/report-getlist-url.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('report-getlist-url');
+
+$t = new FogChecks();
+
+$root = dirname(__DIR__) . '/packages/web';
+$js = (string)file_get_contents(
+    $root . '/management/js/fog/report/fog.report.file.js'
+);
+
+$t->check('the report JS is readable', '' !== $js);
+
+/*
+ * 1. The premise. parse_str -- and PHP's own superglobal parsing, which
+ *    filter_input reads -- take the LAST occurrence of a repeated key. If
+ *    that ever stopped being true the rule below would still be right, but
+ *    for a different reason, and the docblock above would be wrong.
+ */
+$parsed = [];
+parse_str('sub=getList&sub=file', $parsed);
+$t->check(
+    'a repeated query key resolves to its LAST value',
+    'file' === ($parsed['sub'] ?? null)
+);
+
+/*
+ * 2. The defect shape, named directly: no URL is built by concatenating the
+ *    page's raw query string. That is the whole bug, and a future report
+ *    needing the window has to go through URLSearchParams like this one.
+ */
+$t->check(
+    'no report URL appends window.location.search as a string',
+    1 !== preg_match(
+        '/\+\s*(?:\'&\'\s*\+\s*)?window\.location\.search/',
+        $js
+    )
+);
+
+/*
+ * 3. The replacement, positively: the search is PARSED, and the three keys
+ *    that address the endpoint are set on it rather than appended beside
+ *    whatever it already held.
+ */
+$t->check(
+    'the search is parsed rather than pasted',
+    false !== strpos($js, 'new URLSearchParams(window.location.search)')
+);
+foreach (['node', 'sub', 'f'] as $key) {
+    $t->check(
+        "`$key` is set on the parsed params, not concatenated",
+        1 === preg_match(
+            '/params\.set\(\s*\'' . preg_quote($key, '/') . '\'\s*,/',
+            $js
+        )
+    );
+}
+$t->check(
+    'and it still asks for getList',
+    1 === preg_match("/params\.set\(\s*'sub'\s*,\s*'getList'\s*\)/", $js)
+);
+
+/*
+ * 4. Every AJAX url in the file reaches index.php through a query string
+ *    that names the sub exactly once. Checked over the file's url:
+ *    expressions rather than the whole text, so an unrelated mention of
+ *    `sub=` in a comment cannot satisfy or break it.
+ */
+$urls = [];
+if (preg_match_all('/url:\s*(.+?),\n\s*type:/s', $js, $m)) {
+    $urls = $m[1];
+}
+$t->check('every report table declares a url', count($urls) > 0);
+foreach ($urls as $i => $url) {
+    // A literal `sub=` inside the string is fine as long as it appears once
+    // and the raw search is not glued on after it.
+    $literals = substr_count($url, 'sub=');
+    $t->check(
+        "url #$i names its sub at most once",
+        $literals <= 1
+    );
+    $t->check(
+        "url #$i does not paste the page's query string",
+        false === strpos($url, '+ window.location.search')
+            && false === strpos($url, "'&' + window.location.search")
+    );
+}
+
+$t->finish();


### PR DESCRIPTION
Reported from the browser: `runhistory-table` — `HTTP 200 - <div class="card">`, with "No data available in table" underneath.

## The bug

**The Run History table has never loaded since the report shipped.**

Its AJAX call appends the page's own query string, because the window (`start`, `end`, `sources[]`) lives in the URL by design and `getList` cannot see it any other way. But it appended the whole thing, and that also carries `node`, `sub` and `f`:

```
?node=report&sub=getList&f=X&node=report&sub=file&f=X
```

PHP resolves a repeated key to its **last** occurrence:

```php
parse_str('node=report&sub=getList&f=AAA&node=report&sub=file&f=BBB', $o);
// ['node' => 'report', 'sub' => 'file', 'f' => 'BBB']
```

So every request asked for `sub=file` and got the report page back. DataTables was handed HTML at HTTP 200 and drew an empty table under an error toast.

## The fix

Built through `URLSearchParams`, so there are no repeated keys to resolve at all. The window params ride along untouched — `set()` replaces only the three named, and `sources[]` stays the repeated key it is — and the three that address the endpoint are stated once.

Verified by resolving both forms the way PHP would:

```
BEFORE effective: {"node":"report","sub":"file","f":"cnVuIGhpc3Rvcnk=","start":"2026-08-28T08:33","sources":["task","snapinjob"]}
AFTER  effective: {"node":"report","sub":"getList","f":"cnVuIGhpc3Rvcnk=","start":"2026-08-28T08:33","sources":["task","snapinjob"]}
AFTER  has duplicate sub? false
```

## Why nothing caught it

This is the part worth keeping. **Everything that checked this checked the server.**

- ADR 0022's lab harness drove the real `getList()` against a lab database and the row came back.
- `tests/run-history-report.test.php` pins the four names that must agree and the column keys between `getList()` and the DataTables definition.

Both are correct, both still pass, and **neither can see a URL the browser builds**. The endpoint worked perfectly and nothing ever reached it.

`tests/report-getlist-url.test.php` closes that gap by asserting the shape of the URL rather than the behavior of the endpoint: no report URL pastes `window.location.search`, the search is parsed instead, `node`/`sub`/`f` are set on the parsed params, and every `url:` expression in the file names its sub at most once. It also pins the **premise** — that a repeated key resolves to the last value — because that is the fact the rule rests on and it is not obvious from reading either side.

**Mutation-verified against the code that actually shipped**: restoring the original concatenation reddens seven checks at exit 1.

## Also

`FOG_BCACHE_VER` bumped, without which the browser keeps serving the broken copy and the fix looks like it did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBigm29JVHwk2zmTTgey9a